### PR TITLE
nixos/test: colour machine names

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -3,6 +3,7 @@ import argparse
 import atexit
 import base64
 import io
+import itertools
 import logging
 import os
 import pathlib
@@ -92,10 +93,17 @@ logging.basicConfig(format="%(message)s")
 logger = logging.getLogger("test-driver")
 logger.setLevel(logging.INFO)
 
+machine_colours_iter = (
+    "\x1b[{}m".format(x) for x in itertools.cycle(reversed(range(31, 37)))
+)
+
 
 class MachineLogAdapter(logging.LoggerAdapter):
     def process(self, msg: str, kwargs: Any) -> Tuple[str, Any]:
-        return f"{self.extra['machine']}: {msg}", kwargs
+        return (
+            f"{self.extra['colour_code']}{self.extra['machine']}\x1b[39m: {msg}",
+            kwargs,
+        )
 
 
 def make_command(args: list) -> str:
@@ -172,7 +180,10 @@ class Machine:
         self.socket = None
         self.monitor: Optional[socket.socket] = None
         self.allow_reboot = args.get("allowReboot", False)
-        self.logger = MachineLogAdapter(logger, extra=dict(machine=self.name))
+        self.logger = MachineLogAdapter(
+            logger,
+            extra=dict(machine=self.name, colour_code=next(machine_colours_iter)),
+        )
 
     @staticmethod
     def create_startcommand(args: Dict[str, str]) -> str:


### PR DESCRIPTION
###### Motivation for this change

This makes NixOS Test output involving many machines a lot easier to visually parse:

![2020-08-24-200736_1929x1264_scrot](https://user-images.githubusercontent.com/691552/91019707-8e22d200-e645-11ea-96f3-a7e73d2b2a94.png)

The machine-readable XML output is unaffected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
