### PR TITLE
kmod: add patch to correct behaviour with --field

### DIFF
--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
     "--with-modulesdirs=${modulesDirs}"
   ] ++ lib.optional withStatic "--enable-static";
 
-  patches = [ ./module-dir.patch ]
+  patches = [ ./module-dir.patch ./no-name-field.patch ]
     ++ lib.optional stdenv.isDarwin ./darwin.patch
     ++ lib.optional withStatic ./enable-static.patch;
 

--- a/pkgs/os-specific/linux/kmod/no-name-field.patch
+++ b/pkgs/os-specific/linux/kmod/no-name-field.patch
@@ -1,0 +1,24 @@
+
+---
+ tools/modinfo.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/tools/modinfo.c b/tools/modinfo.c
+index 0231bb0..7b2259e 100644
+--- a/tools/modinfo.c
++++ b/tools/modinfo.c
+@@ -178,7 +178,10 @@ static int modinfo_do(struct kmod_module *mod)
+ 	is_builtin = (filename == NULL);
+ 
+ 	if (is_builtin) {
+-		printf("%-16s%s%c", "name:", kmod_module_get_name(mod), separator);
++		if (field == NULL || field != NULL && streq(field, "name")){
++			printf("%-16s%s%c", "name:",
++			       kmod_module_get_name(mod), separator);
++		}
+ 		filename = "(builtin)";
+ 	}
+ 
+-- 
+2.28.0
+


### PR DESCRIPTION
#96123 targeted at staging

---
This came up in https://github.com/NixOS/nixpkgs/pull/96008.
Without this patch modinfo always prints the module name for builtin
modules, even if an explicit --field is passed.

(I also posted this patch upstream, waiting for feedback there)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
