### PR TITLE
red: 0.6.3 -> 0.6.4

### DIFF
--- a/pkgs/development/interpreters/red/default.nix
+++ b/pkgs/development/interpreters/red/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "red";
-  version = "0.6.3";
+  version = "0.6.4";
   src = fetchFromGitHub {
-    rev = "6a43c767fa2e85d668b83f749158a18e62c30f70";
+    rev = "755eb943ccea9e78c2cab0f20b313a52404355cb";
     owner = "red";
     repo = "red";
-    sha256 = "1zh6xc728bs7r4v5jz1jjrdk0xd838xsxmvy9gfg75a3zffm0slr";
+    sha256 = "sha256:045rrg9666zczgrwyyyglivzdzja103s52b0fzj7hqmr1fz68q37";
   };
 
   rebol = fetchurl {
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     ${r2} -qw red.r tests/hello.red
 
     # Compiling the Red console...
-    ${r2} -qw red.r -r environment/console/console.red
+    ${r2} -qw red.r -r environment/console/CLI/console.red
 
     # Generating docs...
     cd docs


### PR DESCRIPTION
###### Motivation for this change

Update redlang version. This version is still quite old and at some point I'll try to PR a red-git package, but for now, a bump is ok.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
