### PR TITLE
softmaker-office, freeoffice: make it easy to override versions

### DIFF
--- a/pkgs/applications/office/softmaker/freeoffice.nix
+++ b/pkgs/applications/office/softmaker/freeoffice.nix
@@ -1,14 +1,26 @@
-{ callPackage, fetchurl, ... } @ args:
+{ callPackage
+, fetchurl
 
-callPackage ./generic.nix (args // rec {
-  pname = "freeoffice";
+  # This is a bit unusual, but makes version and hash easily
+  # overridable. This is useful when the upstream archive was replaced
+  # and nixpkgs is not in sync yet.
+, officeVersion ? {
   version = "976";
   edition = "2018";
+  sha256 = "13yh4lyqakbdqf4r8vw8imy5gwpfva697iqfd85qmp3wimqvzskl";
+}
+
+, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  inherit (officeVersion) version edition;
+
+  pname = "freeoffice";
   suiteName = "FreeOffice";
 
   src = fetchurl {
+    inherit (officeVersion) sha256;
     url = "https://www.softmaker.net/down/softmaker-freeoffice-${version}-amd64.tgz";
-    sha256 = "13yh4lyqakbdqf4r8vw8imy5gwpfva697iqfd85qmp3wimqvzskl";
   };
 
   archive = "freeoffice${edition}.tar.lzma";

--- a/pkgs/applications/office/softmaker/softmaker_office.nix
+++ b/pkgs/applications/office/softmaker/softmaker_office.nix
@@ -1,14 +1,27 @@
-{ callPackage, fetchurl, ... } @ args:
+{ callPackage
+, fetchurl
 
-callPackage ./generic.nix (args // rec {
-  pname = "softmaker-office";
+  # This is a bit unusual, but makes version and hash easily
+  # overridable. This is useful when people have an older version of
+  # Softmaker Office or when the upstream archive was replaced and
+  # nixpkgs is not in sync yet.
+, officeVersion ? {
   version = "1018";
   edition = "2021";
+  sha256 = "1g9mcn0z7s3xw7d5bcjxbnamh6knzndcysahydskfcds6czdxg0c";
+}
+
+, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  inherit (officeVersion) version edition;
+
+  pname = "softmaker-office";
   suiteName = "SoftMaker Office";
 
   src = fetchurl {
+    inherit (officeVersion) sha256;
     url = "https://www.softmaker.net/down/softmaker-office-${edition}-${version}-amd64.tgz";
-    sha256 = "1g9mcn0z7s3xw7d5bcjxbnamh6knzndcysahydskfcds6czdxg0c";
   };
 
   archive = "office${edition}.tar.lzma";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Make the edition, version, and hash easier to override to support
users who have a license for an older version of Softmaker Office.
With this change one can e.g. use Softmaker Office 2018 with:

```
softmaker-office.override {
  officeVersion = {
    edition = "2018";
    version = "976";
    sha256 = "0j6zm0cbxrcgm7glk84hvvbp4z0ys6v8bkwwhl5r7dbphyi72fw8";
  };
}
```

This also helps people fix things when upstream has replaced the
previous version's tarball and this hasn't been fixed in nixpkgs yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
