### PR TITLE
Init cargo-embed and cargo-flash at 0.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2873,6 +2873,12 @@
     githubId = 5918766;
     name = "Franz Thoma";
   };
+  fooker = {
+    email = "fooker@lab.sh";
+    github = "fooker";
+    githubId = 405105;
+    name = "Dustin Frisch";
+  };
   forkk = {
     email = "forkk@forkk.net";
     github = "forkk";

--- a/pkgs/development/tools/rust/cargo-embed/default.nix
+++ b/pkgs/development/tools/rust/cargo-embed/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib
+, rustPlatform, fetchFromGitHub
+, libusb1, pkg-config, rustfmt }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-embed";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "probe-rs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0klkgl7c42vhqxj6svw26lcr7rccq89bl17jn3p751x6281zvr35";
+  };
+
+  cargoSha256 = "0w21q2fpr077m8jr24ld3qjimwk1m4fy9dh14fq9nv5xd4f5s8n8";
+
+  nativeBuildInputs = [ pkg-config rustfmt ];
+  buildInputs = [ libusb1 ];
+
+  meta = with lib; {
+    description = "A cargo extension for working with microcontrollers.";
+    homepage = "http://probe.rs/";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ fooker ];
+  };
+}

--- a/pkgs/development/tools/rust/cargo-flash/default.nix
+++ b/pkgs/development/tools/rust/cargo-flash/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib
+, rustPlatform, fetchFromGitHub
+, libusb1, pkg-config, rustfmt }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-flash";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "probe-rs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1bcpv1r4pdpp22w7za7kdy7jl487x3nlwxiz6sqq3iq6wq3j9zj0";
+  };
+
+  cargoSha256 = "1pf117fgw9x9diksqv58cw7i0kzmp25yj73y5ll69sk46b6z4j90";
+
+  nativeBuildInputs = [ pkg-config rustfmt ];
+  buildInputs = [ libusb1 ];
+
+  meta = with lib; {
+    description = "A cargo extension for working with microcontrollers.";
+    homepage = "http://probe.rs/";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ fooker ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9527,6 +9527,7 @@ in
   };
   cargo-embed = callPackage ../development/tools/rust/cargo-embed { };
   cargo-expand = callPackage ../development/tools/rust/cargo-expand { };
+  cargo-flash = callPackage ../development/tools/rust/cargo-flash { };
   cargo-fund = callPackage ../development/tools/rust/cargo-fund {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9525,6 +9525,7 @@ in
   cargo-deny = callPackage ../development/tools/rust/cargo-deny {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  cargo-embed = callPackage ../development/tools/rust/cargo-embed { };
   cargo-expand = callPackage ../development/tools/rust/cargo-expand { };
   cargo-fund = callPackage ../development/tools/rust/cargo-fund {
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
###### Motivation for this change

The goal of this library is to provide a toolset to interact with a variety of embedded MCUs and debug probes.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
