### PR TITLE
venta: init at 2020-08-20

### DIFF
--- a/pkgs/data/themes/venta/default.nix
+++ b/pkgs/data/themes/venta/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, fetchFromGitHub
+, gdk-pixbuf
+, gtk-engine-murrine
+, gtk_engines
+, librsvg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "venta";
+  version = "2020-08-20";
+
+  src = fetchFromGitHub {
+    owner = "darkomarko42";
+    repo = pname;
+    rev = "f9b7ea560def5c9d25a14015d265ba559d3501ca";
+    sha256 = "13rdavspz1q3zk2h04jpd77hxdcifg42kd71qq13ryg4b5yzqqgb";
+  };
+
+  buildInputs = [
+    gdk-pixbuf
+    gtk_engines
+    librsvg
+  ];
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/themes
+    cp -a Venta* $out/share/themes
+    rm $out/share/themes/*/COPYING
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Gtk theme based on windows 10 style";
+    homepage = "https://www.pling.com/p/1386774/";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19163,6 +19163,8 @@ in
 
   vegeta = callPackage ../tools/networking/vegeta { };
 
+  venta = callPackage ../data/themes/venta { };
+
   victor-mono = callPackage ../data/fonts/victor-mono { };
 
   vimix-gtk-themes = callPackage ../data/themes/vimix {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [venta](https://github.com/darkomarko42/Venta), a Gtk theme base on windows 10 style also supporting Xfce and Mate desktop.

See also https://www.pling.com/p/1386774/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
