### PR TITLE
netsurf: 3.9 → 3.10

### DIFF
--- a/pkgs/applications/misc/netsurf/browser/0001-Fix-GTK-2-icons-since-commit-11aa6821.patch
+++ b/pkgs/applications/misc/netsurf/browser/0001-Fix-GTK-2-icons-since-commit-11aa6821.patch
@@ -1,0 +1,115 @@
+From 7ce0c989c8486f6f454a47e8459db149e2cf77c8 Mon Sep 17 00:00:00 2001
+From: Maxim Krivchikov <maxim.krivchikov@gmail.com>
+Date: Sat, 29 Aug 2020 11:24:08 +0300
+Subject: [PATCH] Fix GTK+2 icons since commit 11aa6821
+
+After 11aa6821 a lot of "missing icons" appeared in GTK+2 UI
+due to using stock name in functions which expect icon name.
+
+This commit restores icons in toolbar and in some menu items.
+Before 11aa6821 menu didn't have any icons, so it's not a regression.
+To add more icons to GTK+2 menu one can translate more icon names
+from toolbar_items.h to NSGTK_STOCK_* in compat.h
+---
+ frontends/gtk/compat.h        | 4 ++++
+ frontends/gtk/scaffolding.c   | 6 +++---
+ frontends/gtk/toolbar.c       | 9 +++++++++
+ frontends/gtk/toolbar_items.h | 4 ++--
+ 4 files changed, 18 insertions(+), 5 deletions(-)
+
+diff --git a/frontends/gtk/compat.h b/frontends/gtk/compat.h
+index 3b2f55094..76af0ef34 100644
+--- a/frontends/gtk/compat.h
++++ b/frontends/gtk/compat.h
+@@ -41,6 +41,8 @@
+ #define NSGTK_STOCK_CANCEL "_Cancel"
+ #define NSGTK_STOCK_CLEAR "edit-clear"
+ #define NSGTK_STOCK_CLOSE "window-close"
++#define NSGTK_STOCK_GO_BACK "go-previous"
++#define NSGTK_STOCK_GO_FORWARD "go-next"
+ #define NSGTK_STOCK_HOME "go-home"
+ #define NSGTK_STOCK_INFO "dialog-information"
+ #define NSGTK_STOCK_REFRESH "view-refresh"
+@@ -55,6 +57,8 @@
+ #define NSGTK_STOCK_CANCEL GTK_STOCK_CANCEL
+ #define NSGTK_STOCK_CLEAR GTK_STOCK_CLEAR
+ #define NSGTK_STOCK_CLOSE GTK_STOCK_CLOSE
++#define NSGTK_STOCK_GO_BACK GTK_STOCK_GO_BACK
++#define NSGTK_STOCK_GO_FORWARD GTK_STOCK_GO_FORWARD
+ #define NSGTK_STOCK_HOME GTK_STOCK_HOME
+ #define NSGTK_STOCK_INFO GTK_STOCK_INFO
+ #define NSGTK_STOCK_REFRESH GTK_STOCK_REFRESH
+diff --git a/frontends/gtk/scaffolding.c b/frontends/gtk/scaffolding.c
+index f08d5d0d0..75a2f59d8 100644
+--- a/frontends/gtk/scaffolding.c
++++ b/frontends/gtk/scaffolding.c
+@@ -1157,17 +1157,17 @@ static void nsgtk_menu_set_icons(struct nsgtk_scaffolding *g)
+ 		}
+ 
+ 		if (g->menus[i].main != NULL) {
+-		img = gtk_image_new_from_icon_name(g->menus[i].iconname,
++			img = nsgtk_image_new_from_stock(g->menus[i].iconname,
+ 						   GTK_ICON_SIZE_MENU);
+ 			nsgtk_image_menu_item_set_image(GTK_WIDGET(g->menus[i].main), img);
+ 		}
+ 		if (g->menus[i].burger != NULL) {
+-		img = gtk_image_new_from_icon_name(g->menus[i].iconname,
++			img = nsgtk_image_new_from_stock(g->menus[i].iconname,
+ 						   GTK_ICON_SIZE_MENU);
+ 			nsgtk_image_menu_item_set_image(GTK_WIDGET(g->menus[i].burger), img);
+ 		}
+ 		if (g->menus[i].popup != NULL) {
+-		img = gtk_image_new_from_icon_name(g->menus[i].iconname,
++			img = nsgtk_image_new_from_stock(g->menus[i].iconname,
+ 						   GTK_ICON_SIZE_MENU);
+ 			nsgtk_image_menu_item_set_image(GTK_WIDGET(g->menus[i].popup), img);
+ 		}
+diff --git a/frontends/gtk/toolbar.c b/frontends/gtk/toolbar.c
+index 32adabc5b..d537b254e 100644
+--- a/frontends/gtk/toolbar.c
++++ b/frontends/gtk/toolbar.c
+@@ -478,7 +478,11 @@ make_toolbar_item_button(const char *labelmsg,
+ 	}
+ 
+ 	if (item != NULL) {
++#if GTK_CHECK_VERSION(3,0,0)
+ 		gtk_tool_button_set_icon_name(GTK_TOOL_BUTTON(item), iconname);
++#else
++		gtk_tool_button_set_stock_id(GTK_TOOL_BUTTON(item), iconname);
++#endif
+ 
+ 		gtk_widget_set_sensitive(GTK_WIDGET(item), sensitivity);
+ 		if (edit) {
+@@ -1205,8 +1209,13 @@ static nserror set_item_action(struct nsgtk_toolbar *tb, int itemid, bool alt)
+ 	gtk_tool_button_set_label(GTK_TOOL_BUTTON(tb->items[itemid].button),
+ 				  label);
+ 
++	#if GTK_CHECK_VERSION(3,0,0)
+ 	gtk_tool_button_set_icon_name(GTK_TOOL_BUTTON(tb->items[itemid].button),
+ 				      iconname);
++	#else
++	gtk_tool_button_set_stock_id(GTK_TOOL_BUTTON(tb->items[itemid].button),
++				      iconname);
++	#endif
+ 
+ 	gtk_widget_set_sensitive(GTK_WIDGET(tb->items[itemid].button), TRUE);
+ 
+diff --git a/frontends/gtk/toolbar_items.h b/frontends/gtk/toolbar_items.h
+index b4bed371f..af098788e 100644
+--- a/frontends/gtk/toolbar_items.h
++++ b/frontends/gtk/toolbar_items.h
+@@ -98,9 +98,9 @@ typedef enum {
+ #define TOOLBAR_ITEM_SET
+ #endif
+ 
+-TOOLBAR_ITEM(BACK_BUTTON, back, false, b, p, gtkBack, "go-previous")
++TOOLBAR_ITEM(BACK_BUTTON, back, false, b, p, gtkBack, NSGTK_STOCK_GO_BACK)
+ TOOLBAR_ITEM(HISTORY_BUTTON, history, true, y, n, , "local-history")
+-TOOLBAR_ITEM(FORWARD_BUTTON, forward, false, b, p, gtkForward, "go-next")
++TOOLBAR_ITEM(FORWARD_BUTTON, forward, false, b, p, gtkForward, NSGTK_STOCK_GO_FORWARD)
+ TOOLBAR_ITEM(STOP_BUTTON, stop, false, t, p, gtkStop, NSGTK_STOCK_STOP)
+ TOOLBAR_ITEM(RELOAD_BUTTON, reload, true, t, p, Reload, NSGTK_STOCK_REFRESH)
+ TOOLBAR_ITEM(HOME_BUTTON, home, true, b, p, gtkHome, NSGTK_STOCK_HOME)
+-- 
+2.25.4
+

--- a/pkgs/applications/misc/netsurf/browser/default.nix
+++ b/pkgs/applications/misc/netsurf/browser/default.nix
@@ -61,13 +61,7 @@ stdenv.mkDerivation rec {
   ++ optional (uilib == "gtk2") gtk2
   ;
 
-  preConfigure = ''
-    cat <<EOF > Makefile.conf
-    override NETSURF_GTK_RES_PATH  := $out/share/netsurf/
-    override NETSURF_GTK_MAJOR := ${if uilib == "gtk3" then "3" else "2"}
-    override NETSURF_USE_GRESOURCE := YES
-    EOF
-  '';
+  patches = [ ./0001-Fix-GTK-2-icons-since-commit-11aa6821.patch ];
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"

--- a/pkgs/applications/misc/netsurf/browser/default.nix
+++ b/pkgs/applications/misc/netsurf/browser/default.nix
@@ -11,6 +11,7 @@
 
 # uilib-specific dependencies
 
+, gtk3 # GTK 3
 , gtk2 # GTK 2
 , SDL  # Framebuffer
 
@@ -31,21 +32,12 @@ in
 stdenv.mkDerivation rec {
 
   pname = "netsurf";
-  version = "3.9";
+  version = "3.10";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/netsurf/releases/source/netsurf-${version}-src.tar.gz";
-    sha256 = "1hzcm2s2wh5sapgr000lg63hcdbj6hyajxl43xa1x80kc5piqbyp";
+    sha256 = "0plra64c5xyiw12yx2q13brxsv8apmany97zqa2lcqckw4ll8j1n";
   };
-
-  patches = [
-    # GTK: prefer using curl's intrinsic defaults for CURLOPT_CA*
-    (fetchpatch {
-	  name = "0001-GTK-prefer-using-curl-s-intrinsic-defaults-for-CURLO.patch";
-      url = "http://source.netsurf-browser.org/netsurf.git/patch/?id=87177d8aa109206d131e0d80a2080ce55dab01c7";
-      sha256 = "08bc60pc5k5qpckqv21zgmgszj3rpwskfc84shs8vg92vkimv2ai";
-    })
-  ];
 
   nativeBuildInputs = [
     makeWrapper
@@ -54,7 +46,7 @@ stdenv.mkDerivation rec {
     pkgconfig
     xxd
   ]
-  ++ optional (uilib == "gtk") wrapGAppsHook
+  ++ optional (uilib == "gtk3" || uilib == "gtk2") wrapGAppsHook
   ;
 
   buildInputs = [ 
@@ -65,12 +57,14 @@ stdenv.mkDerivation rec {
     libutf8proc
   ]
   ++ optionals (uilib == "framebuffer") [ expat SDL ]
-  ++ optional (uilib == "gtk") gtk2
+  ++ optional (uilib == "gtk3") gtk3
+  ++ optional (uilib == "gtk2") gtk2
   ;
 
   preConfigure = ''
     cat <<EOF > Makefile.conf
-    override NETSURF_GTK_RES_PATH  := $out/share/
+    override NETSURF_GTK_RES_PATH  := $out/share/netsurf/
+    override NETSURF_GTK_MAJOR := ${if uilib == "gtk3" then "3" else "2"}
     override NETSURF_USE_GRESOURCE := YES
     EOF
   '';

--- a/pkgs/applications/misc/netsurf/buildsystem/default.nix
+++ b/pkgs/applications/misc/netsurf/buildsystem/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
 
   pname = "netsurf-buildsystem";
-  version = "1.8";
+  version = "1.9";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/buildsystem-${version}.tar.gz";
-    sha256 = "0ffdjwskxlnh8sk40qqfgksbb1nrdzfxsshrscra0p4nqpkj98z6";
+    sha256 = "0alsmaig9ln8dgllb3z63gq90fiz75jz0ic71fi0k0k898qix14k";
   };
 
   makeFlags = [

--- a/pkgs/applications/misc/netsurf/libcss/default.nix
+++ b/pkgs/applications/misc/netsurf/libcss/default.nix
@@ -8,11 +8,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libcss";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "1vw9j3d2mr4wbvs8fyqmgslkbxknvac10456775hflxxcivbm3xr";
+    sha256 = "1p66sdiiqm7w4jkq23hsf08khsnmq93hshh9f9m8sbirjdpf3p6j";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -26,8 +26,6 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)"
     "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
   ];
-
-  NIX_CFLAGS_COMPILE= "-Wno-error=implicit-fallthrough";
 
   meta = with stdenv.lib; {
     homepage = "http://www.netsurf-browser.org/";

--- a/pkgs/applications/misc/netsurf/libdom/default.nix
+++ b/pkgs/applications/misc/netsurf/libdom/default.nix
@@ -9,11 +9,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libdom";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "1ixkqsl3f7dl1kajksm0c231w1v5xy8z6hm3v67hgm9nh4qcvfcy";
+    sha256 = "0jpg5hx3y0mdxk5szd47dyijqimd2321brbqk2620pp5f4j0gvlq";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libhubbub/default.nix
+++ b/pkgs/applications/misc/netsurf/libhubbub/default.nix
@@ -7,11 +7,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libhubbub";
-  version = "0.3.6";
+  version = "0.3.7";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "1x3v7xvagx85v9h3pypzc86rcxs4mij87mmcqkp8pq50q6awfmnp";
+    sha256 = "1dimfyblmym98qa1b80c5jslv2zk8r44xbdrgrsrw1n9wr9y4yly";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libnsfb/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsfb/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libnsfb";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "09qag9lgn5ahanbcyf2rvfmsz15vazfwnl8xpn8f1iczd44b0bv0";
+    sha256 = "16m3kv8x8mlic4z73h2s3z8lqmyp0z8i30x95lzr1pslxfinqi5y";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libnslog/default.nix
+++ b/pkgs/applications/misc/netsurf/libnslog/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libnslog";
-  version = "0.1.2";
+  version = "0.1.3";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "1ggs6xvxp8fbg5w8pifalipm458ygr9ab6j2yvj8fnnmxwvdh4jd";
+    sha256 = "1l2k0kdv9iv18svhv360vszjavhl4g09cp8a8yb719pgsylxr67w";
   };
 
   nativeBuildInputs = [ pkgconfig bison flex ];

--- a/pkgs/applications/misc/netsurf/libnspsl/default.nix
+++ b/pkgs/applications/misc/netsurf/libnspsl/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libnspsl";
-  version = "0.1.5";
+  version = "0.1.6";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "0siq8zjfxv75i9fw6q5hkaijpdm1w3zskd5qk6vsvz8cqan4vifd";
+    sha256 = "02q28n5i6fwqcz1nn167rb71k1q95mx38mfah6zi1lvqrc2q5ifk";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libnsutils/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsutils/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libnsutils";
-  version = "0.0.5";
+  version = "0.1.0";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "09w1rixps1iiq6wirjwxmd6h87llvjzvw565rahjb3rlyhcplfqf";
+    sha256 = "1w5fyy2i60a3v3if3iqcn9sy9sycx6966rcx53v85gja6hb6a33r";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libwapcaplet/default.nix
+++ b/pkgs/applications/misc/netsurf/libwapcaplet/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libwapcaplet";
-  version = "0.4.2";
+  version = "0.4.3";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "1fjwzbn7j8bi1b9bvwxsy3i2cr6byq2s2d29866801pjnf528g86";
+    sha256 = "0p0c2q9lsj4vs97aa7vjllfhw33zv3dpysdkjblzhib6dpfs2alv";
   };
 
   buildInputs = [ buildsystem ];
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)"
     "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
   ];
-
-  NIX_CFLAGS_COMPILE = "-Wno-error=cast-function-type";
 
   meta = with stdenv.lib; {
     homepage = "http://www.netsurf-browser.org/";

--- a/pkgs/applications/misc/netsurf/nsgenbind/default.nix
+++ b/pkgs/applications/misc/netsurf/nsgenbind/default.nix
@@ -6,11 +6,11 @@
 stdenv.mkDerivation rec {
 
   pname = "netsurf-nsgenbind";
-  version = "0.7";
+  version = "0.8";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/nsgenbind-${version}-src.tar.gz";
-    sha256 = "0rplmky4afsjwiwh7grkmcdmzg86zksa55j93dvq92f91yljwqqq";
+    sha256 = "1cqwgwca49jvmijwiyaab2bwxicgxdrnlpinf8kp3nha02nm73ad";
   };
 
   buildInputs = [ buildsystem flex bison ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4956,7 +4956,7 @@ in
     # or xterm -ti 340
     ui = "sixel";
 
-    uilib = if ui == "gtk" then "gtk" else "framebuffer";
+    uilib = if ui == "gtk" then "gtk3" else "framebuffer";
 
     SDL = if ui == "gtk" then null else if ui == "sixel" then SDL_sixel else SDL;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update Netsurf to latest public release.
GTK+3 backend is usable in native Wayland. It is the default GTK backend upstream.
I use GTK+3 backend in Wayland occasionally for a few months without any problems.
For this PR I checked also GTK+2 (toolbar icons are missing; I tried updating NETSURF_GTK_RES_PATH as in docs, without any luck) and framebuffer/sixel (as in https://github.com/NixOS/nixpkgs/pull/65360#issuecomment-515283366 ) backends.

I'd like to ask @samueldr  and @S-NA who updated netsurf to 3.9 to review these changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

nixpkgs-review fails:

```
jvzpgfxwj79nka6lb8cids7pgyvb-qtquickcontrols-5.14.2/lib/qt-5.14.2/qml/QtQuick/Controls/Styles/Base/images/needle.png
  mkdir: cannot create directory '/nix/store/w8k3lq0mxlwkjxqvak956p3jfrhhbmx7-qtdeclarative-5.14.2-bin/lib/qt-5.14.2/qml/QtQuick/Controls': Permission denied
  make[2]: *** [Makefile:1642: install_qmlcacheinst] Error 1
  make[2]: Leaving directory '/build/qtquickcontrols-everywhere-src-5.14.2/src/controls'
  make[1]: *** [Makefile:64: sub-controls-install_subtargets] Error 2
  make[1]: Leaving directory '/build/qtquickcontrols-everywhere-src-5.14.2/src'
  make: *** [Makefile:61: sub-src-install_subtargets] Error 2
cannot build derivation '/nix/store/7h32a8mlw3y566swsk5m6v4an2pqx22n-qtwayland-5.14.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/fgb7yzfif8j363xx95yzj7cl63385mdb-hook.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/gr6syv50qvlf9kc43m8fg3zkmyh0nvc2-gmic-qt-gimp-2.7.1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/mmc5baix6wf81wmq64b9b73i8f26vil2-gimp-with-plugins-2.10.20.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/7ahcvxy0iqhkzpcm0yg2l4lvwxxql9ji-env.drv': 4 dependencies couldn't be built
[0 built (3 failed), 0.0 MiB DL]
error: build of '/nix/store/7ahcvxy0iqhkzpcm0yg2l4lvwxxql9ji-env.drv' failed
4 packages failed to build:
gimp-with-plugins gimpPlugins.focusblur gimpPlugins.gmic gimpPlugins.texturize

29 packages built:
gegl_0_4 gimp gimpPlugins.exposureBlend gimpPlugins.fourier gimpPlugins.gap gimpPlugins.gimplensfun gimpPlugins.lightning gimpPlugins.lqrPlugin gimpPlugins.resynthesizer gimpPlugins.ufraw gimpPlugins.waveletSharpen gnome-photos netsurf.browser netsurf.buildsystem netsurf.libcss netsurf.libdom netsurf.libhubbub netsurf.libnsbmp netsurf.libnsfb netsurf.libnsgif netsurf.libnslog netsurf.libnspsl netsurf.libnsutils netsurf.libparserutils netsurf.libsvgtiny netsurf.libutf8proc netsurf.libwapcaplet netsurf.nsgenbind ufraw
```

But it could be because of staging merge, I can't see anything related to netsurf libraries in output. Found these packages as broken in staging:

qtquickcontrols was failing in staging https://hydra.nixos.org/build/125404486 mentioned in #95492
gimpPlugins.gmic was failing in staging https://hydra.nixos.org/build/125459331
gimpPlugins.texturize is broken https://github.com/NixOS/nixpkgs/blob/84cf00f98031e93f389f1eb93c4a7374a33cc0a9/pkgs/applications/graphics/gimp/plugins/default.nix#L136
gimpPlugins.focusblur is broken https://github.com/NixOS/nixpkgs/blob/84cf00f98031e93f389f1eb93c4a7374a33cc0a9/pkgs/applications/graphics/gimp/plugins/default.nix#L101
