### PR TITLE
nixos/sssd: fix the module

### DIFF
--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -69,7 +69,7 @@ in {
         mode = "0400";
       };
 
-      system.nssModules = pkgs.sssd;
+      system.nssModules = [ pkgs.sssd ];
       system.nssDatabases = {
         group = [ "sss" ];
         passwd = [ "sss" ];
@@ -92,4 +92,6 @@ in {
     services.openssh.authorizedKeysCommand = "/etc/ssh/authorized_keys_command";
     services.openssh.authorizedKeysCommandUser = "nobody";
   })];
+
+  meta.maintainers = with maintainers; [ bbigras ];
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -320,6 +320,7 @@ in
   spike = handleTest ./spike.nix {};
   sonarr = handleTest ./sonarr.nix {};
   sslh = handleTest ./sslh.nix {};
+  sssd = handleTestOn ["x86_64-linux"] ./sssd.nix {};
   strongswan-swanctl = handleTest ./strongswan-swanctl.nix {};
   sudo = handleTest ./sudo.nix {};
   switchTest = handleTest ./switch-test.nix {};

--- a/nixos/tests/sssd.nix
+++ b/nixos/tests/sssd.nix
@@ -1,0 +1,17 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+{
+  name = "sssd";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ bbigras ];
+  };
+  machine = { pkgs, ... }: {
+    services.sssd.enable = true;
+  };
+
+  testScript = ''
+      start_all()
+      machine.wait_for_unit("multi-user.target")
+      machine.wait_for_unit("sssd.service")
+    '';
+})


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

'system.nssModules' was not set correctly

fix #91242

###### Things done

I added a simple test just to make sure the service builds and starts when using `services.sssd.enable`. I'm interested in making that test better eventually.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @e-user 