### PR TITLE
rust-analyzer: 2020-08-17 -> 2020-08-24

### DIFF
--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -2,10 +2,10 @@
 
 {
   rust-analyzer-unwrapped = callPackage ./generic.nix rec {
-    rev = "2020-08-17";
+    rev = "2020-08-24";
     version = "unstable-${rev}";
-    sha256 = "1lkqhaygl6wak3hypmn3zb2h0v4n082xbpaywmzqr53vhw678sp0";
-    cargoSha256 = "00a2fxq1kwybng3gp33lkad4c7wrz0gypigxkalqkyy4nbg3qil4";
+    sha256 = "11q5shrq55krgpj7rjfqw84131j5g55zyrwww3cxcbr8ndi3xdnf";
+    cargoSha256 = "15kjcgxmigm0lwbp8p0kdxax86ldjqq9q8ysj6khfhqd0173184n";
   };
 
   rust-analyzer = callPackage ./wrapper.nix {} {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bump version.

Seems update script is broken due to failed `nix-prefetch`. Maybe it has something changed. Not checked yet.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
