### PR TITLE
nixos/tests/os-prober.nix: port to python

### DIFF
--- a/nixos/tests/os-prober.nix
+++ b/nixos/tests/os-prober.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({pkgs, lib, ...}:
+import ./make-test-python.nix ({pkgs, lib, ...}:
 let
   # A filesystem image with a (presumably) bootable debian
   debianImage = pkgs.vmTools.diskImageFuns.debian9i386 {
@@ -34,9 +34,6 @@ let
     '';
   };
 
-  # options to add the disk to the test vm
-  QEMU_OPTS = "-drive index=2,file=${debianImage}/disk-image.qcow2,read-only,if=virtio";
-
   # a part of the configuration of the test vm
   simpleConfig = {
     boot.loader.grub = {
@@ -71,7 +68,7 @@ in {
   machine = { config, pkgs, ... }: (simpleConfig // {
       imports = [ ../modules/profiles/installation-device.nix
                   ../modules/profiles/base.nix ];
-      virtualisation.memorySize = 1024;
+      virtualisation.memorySize = 1300;
       # The test cannot access the network, so any packages
       # nixos-rebuild needs must be included in the VM.
       system.extraDependencies = with pkgs;
@@ -99,22 +96,28 @@ in {
 
   testScript = ''
     # hack to add the secondary disk
-    $machine->{startCommand} = "QEMU_OPTS=\"\$QEMU_OPTS \"${lib.escapeShellArg QEMU_OPTS} ".$machine->{startCommand};
+    os.environ[
+        "QEMU_OPTS"
+    ] = "-drive index=2,file=${debianImage}/disk-image.qcow2,read-only,if=virtio"
 
-    $machine->start;
-    $machine->succeed("udevadm settle");
-    $machine->waitForUnit("multi-user.target");
+    machine.start()
+    machine.succeed("udevadm settle")
+    machine.wait_for_unit("multi-user.target")
+    print(machine.succeed("lsblk"))
 
     # check that os-prober works standalone
-    $machine->succeed("${pkgs.os-prober}/bin/os-prober | grep /dev/vdb1");
+    machine.succeed(
+        "${pkgs.os-prober}/bin/os-prober | grep /dev/vdb1"
+    )
 
     # rebuild and test that debian is available in the grub menu
-    $machine->succeed("nixos-generate-config");
-    $machine->copyFileFromHost(
+    machine.succeed("nixos-generate-config")
+    machine.copy_from_host(
         "${configFile}",
-        "/etc/nixos/configuration.nix");
-    $machine->succeed("nixos-rebuild boot >&2");
+        "/etc/nixos/configuration.nix",
+    )
+    machine.succeed("nixos-rebuild boot >&2")
 
-    $machine->succeed("egrep 'menuentry.*debian' /boot/grub/grub.cfg");
+    machine.succeed("egrep 'menuentry.*debian' /boot/grub/grub.cfg")
   '';
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
#72828 

This is a simple rebase of @symphorien's code from [this branch](https://github.com/symphorien/nixpkgs/tree/os-prober-python) onto recent master, which seems to build just fine on my machine.

I also cannot reproduce the problems observed in [this comment](https://github.com/NixOS/nixpkgs/issues/72828#issuecomment-674403183) by @flokli.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
