### PR TITLE
GVST: init at 0.0.1-beta

### DIFF
--- a/pkgs/applications/audio/GVST/default.nix
+++ b/pkgs/applications/audio/GVST/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, lib
+, libX11
+, libXt
+, cairo
+, unzip
+, fetchurl
+, autoPatchelfHook
+}:
+
+let
+  pname = "GVST";
+  version = "0.0.1-beta";
+  owner = "ezemtsov";
+  vst_path = "/run/current-system/sw/lib/vst";
+in
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    curlOpts = [ "-O" "-H" "Referer: https://www.gvst.co.uk/portpage.htm"];
+    url = "https://www.gvst.co.uk/dl/AllGVSTLinux64Beta.zip";
+    sha256 = "0nv64pyyjz3inxsd0grcp5sjckrx6p84zyl08jjrmzwyha4ic420";
+  };
+
+  nativeBuildInputs = [ unzip autoPatchelfHook ];
+
+  buildInputs = [ libX11 libXt cairo ];
+
+  unpackPhase = ''
+    unzip $src
+  '';
+
+  installPhase = ''
+    find ./*.so -type f -exec install -m 755 -D "{}" $out/lib/vst/{} \;
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.gvst.co.uk;
+    description = "Collection of open-source audio plugins";
+
+    longDescription = ''
+      Contains the following plugins:
+
+        Effects
+        - GBand - Band-pass filter.
+        - GChorus - Chorus effect.
+        - GClip - Wave-shaping signal clipper.
+        - GComp - Compressor.
+        - GComp2 - Compressor.
+        - GDelay - Delay effect.
+        - GDuckDly - Ducking delay effect.
+        - GFader - Signal gain (-100 to 0 dB).
+        - GGain - Signal gain (-12 to 12 dB).
+        - GGate - Gate.
+        - GGrain - Granular resynthesis.
+        - GHi - High-pass filter.
+        - GLow - Low-pass filter.
+        - GLFO - Triple LFO effect.
+        - GMax - Limiter.
+        - GMonoBass - Bass stereo imaging effect.
+        - GMulti - Multi-band compressor and stereo enhancer.
+        - GNormal - Noise generator for avoiding denormal problems.
+        - GRevDly - Reverse delay effect.
+        - GSnap - Pitch-correction.
+        - GTune - Chromatic tuner.
+
+        Instruments
+        - GSinth - Mono synth using three continuous portamento sine generators.
+        - GSinth2 - Extends GSinth by adding triangle, square and saw-tooth wave.
+    '';
+    platforms = platforms.linux;
+    maintainers = [ maintainers.ezemtsov ];
+    license = licenses.unfree;
+  };
+}


### PR DESCRIPTION
Collection of free audio plugins

Contains the following plugins:

  Effects
  - GBand - Band-pass filter.
  - GChorus - Chorus effect.
  - GClip - Wave-shaping signal clipper.
  - GComp - Compressor.
  - GComp2 - Compressor.
  - GDelay - Delay effect.
  - GDuckDly - Ducking delay effect.
  - GFader - Signal gain (-100 to 0 dB).
  - GGain - Signal gain (-12 to 12 dB).
  - GGate - Gate.
  - GGrain - Granular resynthesis.
  - GHi - High-pass filter.
  - GLow - Low-pass filter.
  - GLFO - Triple LFO effect.
  - GMax - Limiter.
  - GMonoBass - Bass stereo imaging effect.
  - GMulti - Multi-band compressor and stereo enhancer.
  - GNormal - Noise generator for avoiding denormal problems.
  - GRevDly - Reverse delay effect.
  - GSnap - Pitch-correction.
  - GTune - Chromatic tuner.

  Instruments
  - GSinth - Mono synth using three continuous portamento sine generators.
  - GSinth2 - Extends GSinth by adding triangle, square and saw-tooth wave.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
