### PR TITLE
rakudo: 2020.07 -> 2020.08.1

### DIFF
--- a/pkgs/development/interpreters/rakudo/default.nix
+++ b/pkgs/development/interpreters/rakudo/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "rakudo";
-  version = "2020.07";
+  version = "2020.08.1";
 
   src = fetchurl {
     url    = "https://www.rakudo.org/dl/rakudo/rakudo-${version}.tar.gz";
-    sha256 = "1f6ay09k4n7dbcvvla45yg1lfb7vk2ssymmll2xiagjb77hlsqir";
+    sha256 = "1jwlqppm2g6ivzpipkcyihsxzsii3qyx1f35n7wj5dsf99b3hkfm";
   };
 
   buildInputs = [ icu zlib gmp perl ];

--- a/pkgs/development/interpreters/rakudo/moarvm.nix
+++ b/pkgs/development/interpreters/rakudo/moarvm.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "moarvm";
-  version = "2020.07";
+  version = "2020.08";
 
   src = fetchurl {
     url = "https://www.moarvm.org/releases/MoarVM-${version}.tar.gz";
-    sha256 = "1kzp76vqvny8gpp0b4xg1hg4vih4gmic4w1lddc9gqz03dx8hj6s";
+    sha256 = "1gq7z4z5lnkai01721waawkkal82sdmyra05nnbfb1986mq5xpiy";
    };
 
   buildInputs = [ perl ] ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices ApplicationServices ];

--- a/pkgs/development/interpreters/rakudo/nqp.nix
+++ b/pkgs/development/interpreters/rakudo/nqp.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nqp";
-  version = "2020.07";
+  version = "2020.08.1";
 
   src = fetchurl {
     url    = "https://github.com/perl6/nqp/releases/download/${version}/nqp-${version}.tar.gz";
-    sha256 = "0kian8xsyj51m120nh68c9q359l7iipkddph3r8yzvn41zql3y8v";
+    sha256 = "0pxmg22dx6rhfgrxq4gbwqf6d2nahw6iprjvrg8brkbcbyj3ryhd";
   };
 
   buildInputs = [ perl ];


### PR DESCRIPTION
###### Motivation for this change

rakudo: 2020.07 -> 2020.08.1

dependencies:

nqp: 2020.07 -> 2020.08.1
moarvm: 2020.07 -> 2020.08

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
