### PR TITLE
aspectj: 1.5.2 -> 1.9.6

### DIFF
--- a/pkgs/development/compilers/aspectj/default.nix
+++ b/pkgs/development/compilers/aspectj/default.nix
@@ -1,12 +1,15 @@
 {stdenv, fetchurl, jre}:
 
 stdenv.mkDerivation rec {
-  name = "aspectj-1.5.2";
+  pname = "aspectj";
+  version = "1.9.6";
   builder = ./builder.sh;
 
-  src = fetchurl {
-    url = "http://archive.eclipse.org/tools/aspectj/${name}.jar";
-    sha256 = "1b3mx248dc1xka1vgsl0jj4sm0nfjsqdcj9r9036mvixj1zj3nmh";
+  src = let
+    versionSnakeCase = builtins.replaceStrings ["."] ["_"] version;
+  in fetchurl {
+    url = "https://github.com/eclipse/org.aspectj/releases/download/V${versionSnakeCase}/aspectj-${version}.jar";
+    sha256 = "02jh66l3vw57k9a4dxlga3qh3487r36gyi6k2z2mmqxbpqajslja";
   };
 
   inherit jre;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The package version was quite behind the current stable release. Also, as discussed on the mailing list (see [here](https://www.eclipse.org/lists/aspectj-dev/msg03311.html)), the url is now pointed at the github project release because the previous eclipse archive link was not kept up-to-date anymore.

I have tested the new version with [Larva runtime verification](https://github.com/ccol002/larva-rv-tool) tool and there were no problems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
