### PR TITLE
qtbase: Move libtiff dependency from qtbase to qtimageformats

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -8,7 +8,7 @@
   darwin, libiconv,
 
   dbus, fontconfig, freetype, glib, harfbuzz, icu, libX11, libXcomposite,
-  libXcursor, libXext, libXi, libXrender, libinput, libjpeg, libpng, libtiff,
+  libXcursor, libXext, libXi, libXrender, libinput, libjpeg, libpng,
   libxcb, libxkbcommon, libxml2, libxslt, openssl, pcre16, pcre2, sqlite, udev,
   xcbutil, xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, xcbutilwm,
   zlib,
@@ -48,7 +48,7 @@ stdenv.mkDerivation {
       harfbuzz icu
 
       # Image formats
-      libjpeg libpng libtiff
+      libjpeg libpng
       (if compareVersion "5.9.0" < 0 then pcre16 else pcre2)
     ]
     ++ (

--- a/pkgs/development/libraries/qt-5/modules/qtimageformats.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtimageformats.nix
@@ -1,6 +1,7 @@
-{ qtModule, qtbase }:
+{ qtModule, qtbase, libtiff }:
 
 qtModule {
   name = "qtimageformats";
   qtInputs = [ qtbase ];
+  propagatedBuildInputs = [ libtiff ];
 }


### PR DESCRIPTION
###### Motivation for this change
`qbase` is declared to depend upon `libtiff`, but doesn't appear to actually depend upon it.

This caused pain in #88591, in which a package requires its own version of libtiff, clashing with qtbase's phantom libtiff.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
       This affects 1406 packages, which is a lot to build for me.  Also, #96159 is currently blocking many of them.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
