### PR TITLE
i3lock-fancy-rapid: init at 2019-10-09

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-fancy-rapid.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy-rapid.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, xorg, i3lock }:
+
+stdenv.mkDerivation rec {
+  pname = "i3lock-fancy-rapid";
+  version = "2019-10-09";
+  src = fetchFromGitHub {
+    owner = "yvbbrjdr";
+    repo = "i3lock-fancy-rapid";
+    rev = "c67f09bc8a48798c7c820d7d4749240b10865ce0";
+    sha256 = "0jhvlj6v6wx70239pgkjxd42z1s2bzfg886ra6n1rzsdclf4rkc6";
+  };
+
+  buildInputs = [ xorg.libX11 ];
+  propagatedBuildInputs = [ i3lock ];
+
+  postPatch = ''
+    substituteInPlace i3lock-fancy-rapid.c \
+      --replace '"i3lock"' '"${i3lock}/bin/i3lock"'
+  '';
+
+  installPhase = ''
+    install -D i3lock-fancy-rapid $out/bin/i3lock-fancy-rapid
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A faster implementation of i3lock-fancy";
+    homepage = "https://github.com/yvbbrjdr/i3lock-fancy-rapid";
+    maintainers = with maintainers; [ nickhu ];
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20907,6 +20907,8 @@ in
 
   i3lock-fancy = callPackage ../applications/window-managers/i3/lock-fancy.nix { };
 
+  i3lock-fancy-rapid = callPackage ../applications/window-managers/i3/lock-fancy-rapid.nix { };
+
   i3lock-pixeled = callPackage ../misc/screensavers/i3lock-pixeled { };
 
   betterlockscreen = callPackage ../misc/screensavers/betterlockscreen {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The other `i3lock-*` packages are *way* **way** too slow at pixelating my
screen; this one only takes 150ms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).