### PR TITLE
nixos/cage: supply pamEnvironment

### DIFF
--- a/nixos/modules/services/wayland/cage.nix
+++ b/nixos/modules/services/wayland/cage.nix
@@ -82,6 +82,7 @@ in {
       auth    required pam_unix.so nullok
       account required pam_unix.so
       session required pam_unix.so
+      session required pam_env.so conffile=${config.system.build.pamEnvironment} readenv=0
       session required ${pkgs.systemd}/lib/security/pam_systemd.so
     '';
 


### PR DESCRIPTION
Without this, you don’t get any of the sessionVariables in the cage
application. Things like XDG_DATA_DIRS, XCURSOR_PATH, etc. are
missing.
