### PR TITLE
Make pkgsStatic set "static" argument to true

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -76,6 +76,7 @@ rec {
          # uname -r
          release = null;
       };
+      isStatic = final.isWasm || final.isRedox;
 
       kernelArch =
         if final.isAarch32 then "arm"

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -215,6 +215,7 @@ let
       crossOverlays = [ (import ./static.nix) ];
     } // lib.optionalAttrs stdenv.hostPlatform.isLinux {
       crossSystem = {
+        isStatic = true;
         parsed = stdenv.hostPlatform.parsed // {
           abi = {
             gnu = lib.systems.parse.abis.musl;


### PR DESCRIPTION
This change allows derivations to define "static ? false" arguments to
have way to distinguish dynamic musl build and static musl build in
cases where upstream build system can't detect it by itself.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).