### PR TITLE
python3Packages.rising: init at 0.2.0post0

### DIFF
--- a/pkgs/development/python-modules/rising/default.nix
+++ b/pkgs/development/python-modules/rising/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchFromGitHub
+, pytestCheckHook
+, pytestcov
+, dill
+, numpy
+, pytorch
+, threadpoolctl
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "rising";
+  version = "0.2.0post0";
+
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "PhoenixDL";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0fb9894ppcp18wc2dhhjizj8ja53gbv9wpql4mixxxdz8z2bn33c";
+  };
+
+  propagatedBuildInputs = [ numpy pytorch threadpoolctl tqdm ];
+  checkInputs = [ dill pytestcov pytestCheckHook ];
+
+  disabledTests = [ "test_affine" ];  # deprecated division operator '/'
+
+  meta = {
+    description = "High-performance data loading and augmentation library in PyTorch";
+    homepage = "https://rising.rtfd.io";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6090,6 +6090,8 @@ in {
 
   ripser = callPackage ../development/python-modules/ripser { };
 
+  rising = callPackage ../development/python-modules/rising { };
+
   rivet = disabledIf (!isPy3k) (toPythonModule (pkgs.rivet.override { python3 = python; }));
 
   rjsmin = callPackage ../development/python-modules/rjsmin { };


### PR DESCRIPTION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
