### PR TITLE
qtdeclarative: revert "Patch for scrollbar regression"

### DIFF
--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -12,13 +12,13 @@ let
   ;
 in pythonPackages.buildPythonApplication rec {
   pname = "picard";
-  version = "2.4.1";
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "metabrainz";
     repo = pname;
     rev = "release-${version}";
-    sha256 = "0s4jmcg1n6ayxf7x0amq67rgn6y127h98s2k4fcna6n9477krrwf";
+    sha256 = "0sbccsisk9w0gnblvhg7wk1c5ydppldjbvaa0zhl3yrid5a363ah";
   };
 
   nativeBuildInputs = [ gettext qt5.wrapQtAppsHook qt5.qtbase ]

--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -1,4 +1,4 @@
-{ qtModule, lib, fetchpatch, python3, qtbase, qtsvg }:
+{ qtModule, lib, python3, qtbase, qtsvg }:
 
 with lib;
 
@@ -23,12 +23,4 @@ qtModule {
     "bin/qmlscene"
     "bin/qmltestrunner"
   ];
-  patches =
-    # https://mail.kde.org/pipermail/kde-distro-packagers/2020-June/000419.html
-    lib.optional (lib.versionAtLeast qtbase.version "5.14.2")
-      (fetchpatch {
-        url = "https://codereview.qt-project.org/gitweb?p=qt/qtdeclarative.git;a=patch;h=3e47ac319b0f53c43cc02a8356c2dec4f0daeef4";
-        sha256 = "0wvncg7047q73nm0svc6kb14sigwk7sc53r4778kn033aj0qqszj";
-        name = "qtdeclarative-QQuickItemView-fix-max-extent.patch";
-      });
 }


### PR DESCRIPTION
This reverts commit 5530043208f0bef7. The change breaks the build of
qtquickcontrols. Fixes https://github.com/NixOS/nixpkgs/issues/96159.