### PR TITLE
nixos/tests: use ::1 instead of anycast address 

### DIFF
--- a/nixos/tests/systemd-networkd-ipv6-prefix-delegation.nix
+++ b/nixos/tests/systemd-networkd-ipv6-prefix-delegation.nix
@@ -31,7 +31,7 @@ import ./make-test-python.nix ({pkgs, ...}: {
         firewall.enable = false;
         interfaces.eth1.ipv4.addresses = lib.mkForce []; # no need for legacy IP
         interfaces.eth1.ipv6.addresses = lib.mkForce [
-          { address = "2001:DB8::"; prefixLength = 64; }
+          { address = "2001:DB8::1"; prefixLength = 64; }
         ];
       };
 
@@ -260,7 +260,7 @@ import ./make-test-python.nix ({pkgs, ...}: {
     client.wait_until_succeeds("ping -6 -c 1 FD42::1")
 
     # the global IP of the ISP router should still not be a reachable
-    router.fail("ping -6 -c 1 2001:DB8::")
+    router.fail("ping -6 -c 1 2001:DB8::1")
 
     # Once we have internal connectivity boot up the ISP
     isp.start()
@@ -273,11 +273,11 @@ import ./make-test-python.nix ({pkgs, ...}: {
 
     # wait until the uplink interface has a good status
     router.wait_for_unit("network-online.target")
-    router.wait_until_succeeds("ping -6 -c1 2001:DB8::")
+    router.wait_until_succeeds("ping -6 -c1 2001:DB8::1")
 
     # shortly after that the client should have received it's global IPv6
     # address and thus be able to ping the ISP
-    client.wait_until_succeeds("ping -6 -c1 2001:DB8::")
+    client.wait_until_succeeds("ping -6 -c1 2001:DB8::1")
 
     # verify that we got a globally scoped address in eth1 from the
     # documentation prefix


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

According to RFC4291[1], 2001:db8:: is the anycast address for the
prefix and will be answered by all routers responsible for this prefix.
This means that before the iputils bump, the ping from client to isp was
answered by the router and not by the ISP machine. Switching away from
the anycast address fixes this issue.

Credits for finding this go to @primeos.

[1]: https://tools.ietf.org/html/rfc4291#section-2.6.1

Fixes #96188

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
