### PR TITLE
linux_testing_bcachefs: 5.3 -> 5.7

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -1,13 +1,14 @@
-{ stdenv, buildPackages, fetchgit, fetchpatch, perl, buildLinux, ... } @ args:
+{ stdenv, buildPackages, fetchFromGitHub, fetchpatch, perl, buildLinux, ... } @ args:
 
 buildLinux (args // {
-  version = "5.3.2020.04.04";
-  modDirVersion = "5.3.0";
+  version = "5.7.2020.08.12";
+  modDirVersion = "5.7.0";
 
-  src = fetchgit {
-    url = "https://evilpiepirate.org/git/bcachefs.git";
-    rev = "a27d7265e75f6d65c2b972ce4ac27abfc153c230";
-    sha256 = "0wnjl4xs7073d5ipcsplv5qpcxb7zpfqd5gqvh3mhqc5j3qn816x";
+  src = fetchFromGitHub {
+    owner = "koverstreet";
+    repo = "bcachefs";
+    rev = "86fa1258a3ef59adccdd1534e55ef773b82c4cb7";
+    sha256 = "0g1yd9ga9p0l3hiyvsp9hhzfhvl0h7jzh0rsg6xjf0f001jlfpmb";
   };
 
   extraConfig = "BCACHEFS_FS m";

--- a/pkgs/tools/filesystems/bcachefs-tools/default.nix
+++ b/pkgs/tools/filesystems/bcachefs-tools/default.nix
@@ -1,17 +1,18 @@
-{ stdenv, fetchgit, pkgconfig, attr, libuuid, libscrypt, libsodium, keyutils
-, liburcu, zlib, libaio, zstd, lz4, valgrind, python3Packages
+{ stdenv, fetchFromGitHub, pkgconfig, attr, libuuid, libscrypt, libsodium, keyutils
+, liburcu, zlib, libaio, libudev, zstd, lz4, valgrind, python3Packages
 , fuseSupport ? false, fuse3 ? null }:
 
 assert fuseSupport -> fuse3 != null;
 
 stdenv.mkDerivation {
   pname = "bcachefs-tools";
-  version = "2020-04-04";
+  version = "2020-08-24";
 
-  src = fetchgit {
-    url = "https://evilpiepirate.org/git/bcachefs-tools.git";
-    rev = "5d6e237b728cfb7c3bf2cb1a613e64bdecbd740d";
-    sha256 = "1syym9k3njb0bk2mg6832cbf6r42z6y8b6hjv7dg4gmv2h7v7l7g";
+  src = fetchFromGitHub {
+    owner = "koverstreet";
+    repo = "bcachefs-tools";
+    rev = "da730dc67c1bd10842c49a1534fe23e0d8fdb4be";
+    sha256 = "0mqa3l9xs2dygiv3cgdzv31i9h92j42b71jwdrh114lb471jvw4l";
   };
 
   postPatch = ''
@@ -29,7 +30,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     libuuid libscrypt libsodium keyutils liburcu zlib libaio
-    zstd lz4 python3Packages.pytest
+    zstd lz4 python3Packages.pytest libudev
   ] ++ stdenv.lib.optional fuseSupport fuse3;
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change
Updates linux_testing_bcachefs to 5.7
Updates accompaning bcachefs-tools to latest commit.

This brings lots of fixes on the bcachefs side and also is needed to bring kernel up to date.

This PR duplicates https://github.com/NixOS/nixpkgs/pull/91749 however it has fixed the issues preventing the merging of the previous one - namely tests failing on bcachefs-tools as tests upstream have now been fixed.

I have been running these versions on 2 of my machines.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
