### PR TITLE
stage-1 find-libs: initialise left to empty array

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -36,7 +36,7 @@ let
     set -euo pipefail
 
     declare -A seen
-    declare -a left
+    left=()
 
     patchelf="${pkgs.buildPackages.patchelf}/bin/patchelf"
 
@@ -48,7 +48,7 @@ let
       done
     }
 
-    add_needed $1
+    add_needed "$1"
 
     while [ ''${#left[@]} -ne 0 ]; do
       next=''${left[0]}


### PR DESCRIPTION
###### Motivation for this change
declare -a is not sufficient to make the array variable actually
exist, which resulted in the script failing when the target object did
not have any DT_NEEDED entries. This in turn resulted in some
initramfs libraries not having their rpaths patched to point to
extra-utils, which in turn broke the extra-utils tests.

cc @vcunat who pointed this out

###### Things done

- [x] Tested building iso_minimal, which was failing before (`nix-build nixos/release.nix -A iso_minimal.x86_64-linux`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
