### PR TITLE
Fixing/adding python27 derivations

### DIFF
--- a/pkgs/development/libraries/protobuf/3.3.nix
+++ b/pkgs/development/libraries/protobuf/3.3.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... }:
+
+callPackage ./generic-v3.nix {
+  version = "3.3.0";
+  sha256 = "0qlvpsmqgh9nw0k4zrxlxf75pafi3p0ahz99v6761b903y8qyv4i";
+}

--- a/pkgs/development/libraries/tremor/default.nix
+++ b/pkgs/development/libraries/tremor/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "tremor-unstable-2018-03-16";
 
   src = fetchgit {
-    url = https://git.xiph.org/tremor.git;
+    url = https://gitlab.xiph.org/xiph/tremor.git;
     rev = "562307a4a7082e24553f3d2c55dab397a17c4b4f";
     sha256 = "0m07gq4zfgigsiz8b518xyb19v7qqp76qmp7lb262825vkqzl3zq";
   };
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = https://xiph.org/tremor/;
+    homepage = https://xiph.org/vorbis/;
     description = "Fixed-point version of the Ogg Vorbis decoder";
     license = stdenv.lib.licenses.bsd3;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/python-modules/GitPython/2.nix
+++ b/pkgs/development/python-modules/GitPython/2.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k, substituteAll, git, gitdb2, mock, nose, ddt }:
+
+buildPythonPackage rec {
+  version = "2.1.15";
+  pname = "GitPython";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ip1j6jalj6adz0f8r5axdjwnmzqmadypm6v8v8jyyx9hbc3i343";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./hardcode-git-path.patch;
+      inherit git;
+    })
+  ];
+
+  checkInputs = [ nose ] ++ lib.optional isPy3k mock;
+  propagatedBuildInputs = [ gitdb2 ddt ];
+
+  # Tests require a git repo
+  doCheck = false;
+
+  meta = {
+    description = "Python Git Library";
+    maintainers = [ ];
+    homepage = https://github.com/gitpython-developers/GitPython;
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/sphinxcontrib-blockdiag/1.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-blockdiag/1.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, python
+, mock
+, sphinx-testing
+, sphinx
+, blockdiag
+}:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-blockdiag";
+  version = "1.5.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1w7q2hhpzk159wd35hlbwkh80hnglqa475blcd9vjwpkv1kgkpvw";
+  };
+
+  buildInputs = [ mock sphinx-testing ];
+  propagatedBuildInputs = [ sphinx blockdiag ];
+
+  # Seems to look for files in the wrong dir
+  doCheck = false;
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover -s tests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Sphinx blockdiag extension";
+    homepage = "https://github.com/blockdiag/sphinxcontrib-blockdiag";
+    maintainers = with maintainers; [ nand0p ];
+    license = licenses.bsd2;
+  };
+
+}

--- a/pkgs/development/python-modules/uritools/2.nix
+++ b/pkgs/development/python-modules/uritools/2.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, ipaddress }:
+
+buildPythonPackage rec {
+  pname = "uritools";
+  version = "2.2.0";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0awyz44yqpll6wwirii7awzr6parzjh9np8vh62zsm5dmwyf5s40";
+  };
+
+  propagatedBuildInputs = [ ipaddress ];
+
+  meta = with stdenv.lib; {
+    description = "RFC 3986 compliant, Unicode-aware, scheme-agnostic replacement for urlparse";
+    license = licenses.mit;
+    maintainers = [ maintainers.rvolosatovs ];
+  };
+}

--- a/pkgs/development/python-modules/venusian/2.nix
+++ b/pkgs/development/python-modules/venusian/2.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pytestcov
+}:
+
+buildPythonPackage rec {
+  pname = "venusian";
+  version = "2.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0i012bf3d30kq13zjr45fxvn7a99jdjw4ica9kzaiw96hh1myi5k";
+  };
+
+  checkInputs = [ pytest pytestcov ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A library for deferring decorator actions";
+    homepage = https://pylonsproject.org/;
+    license = licenses.bsd0;
+    maintainers = with maintainers; [ domenkozar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2698,7 +2698,10 @@ in {
 
   gitdb2 = callPackage ../development/python-modules/gitdb2 { };
 
-  GitPython = callPackage ../development/python-modules/GitPython { };
+  GitPython = if isPy3k then
+                callPackage ../development/python-modules/GitPython { }
+              else
+                callPackage ../development/python-modules/GitPython/2.nix { };
 
   git-annex-adapter = callPackage ../development/python-modules/git-annex-adapter {
     inherit (pkgs.gitAndTools) git-annex;
@@ -3227,7 +3230,10 @@ in {
 
   validate-email = callPackage ../development/python-modules/validate-email { };
 
-  venusian = callPackage ../development/python-modules/venusian { };
+  venusian = if isPy27 then
+               callPackage ../development/python-modules/venusian/2.nix { }
+             else
+               callPackage ../development/python-modules/venusian { };
 
   chameleon = callPackage ../development/python-modules/chameleon { };
 
@@ -5676,7 +5682,10 @@ in {
 
   umemcache = callPackage ../development/python-modules/umemcache {};
 
-  uritools = callPackage ../development/python-modules/uritools { };
+  uritools = if isPy3k then
+               callPackage ../development/python-modules/uritools { }
+             else
+               callPackage ../development/python-modules/uritools/2.nix { };
 
   update_checker = callPackage ../development/python-modules/update_checker {};
 
@@ -5975,7 +5984,8 @@ in {
 
   sphinx_rtd_theme = callPackage ../development/python-modules/sphinx_rtd_theme { };
 
-  sphinxcontrib-blockdiag = callPackage ../development/python-modules/sphinxcontrib-blockdiag { };
+  sphinxcontrib-blockdiag = if isPy3k then callPackage ../development/python-modules/sphinxcontrib-blockdiag { }
+                            else callPackage ../development/python-modules/sphinxcontrib-blockdiag/1.nix { };
 
   sphinxcontrib-openapi = callPackage ../development/python-modules/sphinxcontrib-openapi { };
 
@@ -7038,3 +7048,4 @@ in {
 });
 
 in fix' (extends overrides packages)
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

As the channel keeps supporting python27 some derivations need to be fixed or added to still working is this python version.

###### Things done

- Add python27 support for the following derivations:    

    GitPython
    Venusian
    Uritools
    Sphinxcontrib-blockdiag

- Adding Protobuf 3.3.0 derivation

- Fix tremor repository which was moved to GitLab

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
