### PR TITLE
nixos: wpa_supplicant: warn on unused config

### DIFF
--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -233,6 +233,9 @@ in {
       path = [ pkgs.wpa_supplicant ];
 
       script = ''
+        if [ -f /etc/wpa_supplicant.conf -a "/etc/wpa_supplicant.conf" != "${configFile}" ]
+        then echo >&2 "<3>/etc/wpa_supplicant.conf present but ignored. Generated ${configFile} is used instead."
+        fi
         iface_args="-s -u -D${cfg.driver} -c ${configFile}"
         ${if ifaces == [] then ''
           for i in $(cd /sys/class/net && echo *); do


### PR DESCRIPTION
###### Motivation for this change

After https://github.com/NixOS/nixpkgs/commit/71ea6a9a41f1340e6821812f8b7e331072dbd020 there are additional cases, where wpa_supplicant uses an auto-generated config.

Because it can't use multiple config files, and the config format doesn't permit includes, that will silently ignore a present `/etc/wpa_supplicant.conf`. There are valid reasons for keeping that file outside of `extraConfig`, because it may contain secrets.

This is intended to avoid silently breaking people's config in 20.09

see https://github.com/NixOS/nixpkgs/issues/59959#issuecomment-678681134

###### Things done

Implemented a run-time warning, that will detect a condition of `/etc/wpa_supplicant.conf` being present, but ignored in favor of a a generated config file.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
