### PR TITLE
ginkgo: init at 1.14.0

### DIFF
--- a/pkgs/development/tools/ginkgo/default.nix
+++ b/pkgs/development/tools/ginkgo/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "ginkgo";
+  version = "1.14.0";
+
+  src = fetchFromGitHub {
+    owner = "onsi";
+    repo = "ginkgo";
+    rev = "v${version}";
+    sha256 = "0nwvz0pqk2jqscq88fhppad4flrr8avkxfgbci4xklbar4g8i32v";
+  };
+  vendorSha256 = "072amyw1ir18v9vk268j2y7dhw3lfwvxzvzsdqhnp50rxsa911bx";
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "BDD Testing Framework for Go";
+    homepage = "https://github.com/onsi/ginkgo";
+    license = licenses.mit;
+    maintainers = with maintainers; [ saschagrunert ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17998,6 +17998,8 @@ in
 
   iferr = callPackage ../development/tools/iferr { };
 
+  ginkgo = callPackage ../development/tools/ginkgo { };
+
   go-bindata = callPackage ../development/tools/go-bindata { };
 
   go-bindata-assetfs = callPackage ../development/tools/go-bindata-assetfs { };


### PR DESCRIPTION
###### Motivation for this change
Add ginkgo CLI wich is required by some tools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
