### PR TITLE
libsodium: feed c2hs dependency

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1331,7 +1331,7 @@ self: super: {
   monad-dijkstra = dontCheck (doJailbreak super.monad-dijkstra);
 
   libsodium = overrideCabal super.libsodium (drv: {
-    libraryToolDepends = drv.libraryToolDepends or [self.c2hs];
+    libraryToolDepends = (drv.libraryToolDepends or []) ++ [self.c2hs];
   });
 
   # https://github.com/kowainik/policeman/issues/57

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1330,6 +1330,10 @@ self: super: {
   # https://github.com/ennocramer/monad-dijkstra/issues/4
   monad-dijkstra = dontCheck (doJailbreak super.monad-dijkstra);
 
+  libsodium = overrideCabal super.libsodium (drv: {
+    libraryToolDepends = drv.libraryToolDepends or [self.c2hs];
+  });
+
   # https://github.com/kowainik/policeman/issues/57
   policeman = doJailbreak super.policeman;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1330,6 +1330,8 @@ self: super: {
   # https://github.com/ennocramer/monad-dijkstra/issues/4
   monad-dijkstra = dontCheck (doJailbreak super.monad-dijkstra);
 
+  # Fixed upstream but not released to Hackage yet:
+  # https://github.com/k0001/hs-libsodium/issues/2
   libsodium = overrideCabal super.libsodium (drv: {
     libraryToolDepends = (drv.libraryToolDepends or []) ++ [self.c2hs];
   });

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -7265,7 +7265,6 @@ broken-packages:
   - libraft
   - librandomorg
   - librato
-  - libsodium
   - libssh2
   - libssh2-conduit
   - libsystemd-daemon


### PR DESCRIPTION
Unbreaks haskellPackages.libsodium

Builds:
```
λ ~/git/nixpkgs/ unbreak-libsodium nix-build --no-out-link -A haskellPackages.libsodium --arg config '{ allowBroken = true; }'                  ~/git/nixpkgs
/nix/store/mp9wndxz5icwmvjf05sf5fi9if9scq5i-libsodium-1.0.18.1
```

The reason we need to do this is because the author neglected to include c2hs in build-tool-depends in the package uploaded to hackage. It's fixed in the git repo already, but this has not yet been published to hackage yet.