### PR TITLE
Add Cocoa to propagatedBuildInputs for tk

### DIFF
--- a/pkgs/development/libraries/tk/generic.nix
+++ b/pkgs/development/libraries/tk/generic.nix
@@ -32,9 +32,10 @@ stdenv.mkDerivation {
     ++ stdenv.lib.optional enableAqua "--enable-aqua";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = lib.optional enableAqua (with darwin.apple_sdk.frameworks; [ Cocoa ]);
 
-  propagatedBuildInputs = [ tcl libXft ];
+  propagatedBuildInputs = [
+    tcl libXft
+  ] ++ lib.optional enableAqua (with darwin.apple_sdk.frameworks; [ Cocoa ]);
 
   doCheck = false; # fails. can't find itself
 


### PR DESCRIPTION
Otherwise packages using tk will not link correctly

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I am trying to compile KiCad for macOS. Both tk and opencascade-occt are dependencies. opencascade-occt was not linking correctly for me because Cocoa was missing. So I added Cocoa to opencascade-occt buildInputs via an overlay. Upon closer inspection I found that opencascade-occt does not depend on Cocoa, but only tk. tk in turn depends on Cocoa on macOS and has Cocoa as buildInput set.

I believe the correct thing is to set Cocoa in propagatedBuildInputs of tk to allow packages depending on tk (such as opencascade-occt) to link correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
