### PR TITLE
treewide: convert patch series files to Nix expressions

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -689,14 +689,15 @@ rec {
             "/prefix/nix-profiles-library-paths.patch"
             "/prefix/compose-search-path.patch" ]
   */
-  readPathsFromFile = rootPath: file:
-    let
-      lines = lib.splitString "\n" (builtins.readFile file);
-      removeComments = lib.filter (line: line != "" && !(lib.hasPrefix "#" line));
-      relativePaths = removeComments lines;
-      absolutePaths = builtins.map (path: rootPath + "/${path}") relativePaths;
-    in
-      absolutePaths;
+  readPathsFromFile = lib.warn "lib.readPathsFromFile is deprecated, use a list instead"
+    (rootPath: file:
+      let
+        lines = lib.splitString "\n" (builtins.readFile file);
+        removeComments = lib.filter (line: line != "" && !(lib.hasPrefix "#" line));
+        relativePaths = removeComments lines;
+        absolutePaths = builtins.map (path: rootPath + "/${path}") relativePaths;
+      in
+        absolutePaths);
 
   /* Read the contents of a file removing the trailing \n
 

--- a/pkgs/applications/kde/akonadi/default.nix
+++ b/pkgs/applications/kde/akonadi/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, copyPathsToStore, lib, kdepimTeam,
+  mkDerivation, lib, kdepimTeam,
   extra-cmake-modules, shared-mime-info,
   boost, kcompletion, kconfigwidgets, kcrash, kdbusaddons, kdesignerplugin,
   ki18n, kiconthemes, kio, kitemmodels, kwindowsystem, mysql, qttools,

--- a/pkgs/applications/kde/grantleetheme/default.nix
+++ b/pkgs/applications/kde/grantleetheme/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, copyPathsToStore, lib, kdepimTeam,
+  mkDerivation, lib, kdepimTeam,
   extra-cmake-modules, kdoctools,
   grantlee, ki18n, kiconthemes, knewstuff, kservice, kxmlgui, qtbase,
 }:

--- a/pkgs/applications/kde/kdepim-apps-libs/default.nix
+++ b/pkgs/applications/kde/kdepim-apps-libs/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, copyPathsToStore, lib, kdepimTeam,
+  mkDerivation, lib, kdepimTeam,
   extra-cmake-modules, kdoctools,
   akonadi, akonadi-contacts, grantlee, grantleetheme, kconfig, kconfigwidgets,
   kcontacts, ki18n, kiconthemes, kio, libkleo, pimcommon, prison,

--- a/pkgs/applications/kde/kdepim-runtime/default.nix
+++ b/pkgs/applications/kde/kdepim-runtime/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, copyPathsToStore, lib, kdepimTeam,
+  mkDerivation, lib, kdepimTeam,
   extra-cmake-modules, kdoctools,
   shared-mime-info,
   akonadi, akonadi-calendar, akonadi-contacts, akonadi-mime, akonadi-notes,

--- a/pkgs/desktops/plasma-5/breeze-plymouth/default.nix
+++ b/pkgs/desktops/plasma-5/breeze-plymouth/default.nix
@@ -1,7 +1,6 @@
 {
   mkDerivation,
   lib,
-  copyPathsToStore,
   extra-cmake-modules,
   plymouth,
   nixos-icons,
@@ -28,7 +27,9 @@ mkDerivation {
   name = "breeze-plymouth";
   nativeBuildInputs = [ extra-cmake-modules ] ++ lib.optionals (logoFile != null) [ imagemagick netpbm perl ];
   buildInputs = [ plymouth ];
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = [
+    ./install-paths.patch
+  ];
   cmakeFlags = []
     ++ lib.optional (osName      != null) "-DDISTRO_NAME=${osName}"
     ++ lib.optional (osVersion   != null) "-DDISTRO_VERSION=${osVersion}"

--- a/pkgs/desktops/plasma-5/breeze-plymouth/default.nix
+++ b/pkgs/desktops/plasma-5/breeze-plymouth/default.nix
@@ -15,13 +15,13 @@
   bottomColor ? "black"
 }:
 
-let 
+let
   validColors = [ "black" "cardboard_grey" "charcoal_grey" "icon_blue" "paper_white" "plasma_blue" "neon_blue" "neon_green" ];
   resolvedLogoName = if (logoFile != null && logoName == null) then lib.strings.removeSuffix ".png" (baseNameOf(toString logoFile)) else logoName;
 in
   assert lib.asserts.assertOneOf "topColor" topColor validColors;
   assert lib.asserts.assertOneOf "bottomColor" bottomColor validColors;
-  
+
 
 mkDerivation {
   name = "breeze-plymouth";
@@ -37,7 +37,7 @@ mkDerivation {
     ++ lib.optional (topColor    != null) "-DBACKGROUND_TOP_COLOR=${topColor}"
     ++ lib.optional (bottomColor != null) "-DBACKGROUND_BOTTOM_COLOR=${bottomColor}"
   ;
-  
+
   postPatch = ''
       substituteInPlace cmake/FindPlymouth.cmake --subst-var out
   '' + lib.optionalString (logoFile != null) ''

--- a/pkgs/desktops/plasma-5/breeze-plymouth/series
+++ b/pkgs/desktops/plasma-5/breeze-plymouth/series
@@ -1,1 +1,0 @@
-install-paths.patch

--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore,
+  mkDerivation, lib,
   extra-cmake-modules, kdoctools,
 
   epoxy,libICE, libSM, libinput, libxkbcommon, udev, wayland, xcb-util-cursor,

--- a/pkgs/desktops/plasma-5/libkscreen/default.nix
+++ b/pkgs/desktops/plasma-5/libkscreen/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore, propagate,
+  mkDerivation, lib, propagate,
   extra-cmake-modules,
   kwayland, libXrandr, qtbase, qtx11extras
 }:
@@ -12,7 +12,9 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kwayland libXrandr qtx11extras ];
   outputs = [ "out" "dev" ];
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = [
+    ./libkscreen-backends-path.patch
+  ];
   preConfigure = ''
     NIX_CFLAGS_COMPILE+=" -DNIXPKGS_LIBKSCREEN_BACKENDS=\"''${!outputBin}/$qtPluginPrefix/kf5/kscreen\""
   '';

--- a/pkgs/desktops/plasma-5/libkscreen/series
+++ b/pkgs/desktops/plasma-5/libkscreen/series
@@ -1,1 +1,0 @@
-libkscreen-backends-path.patch

--- a/pkgs/desktops/plasma-5/plasma-desktop/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-desktop/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore,
+  mkDerivation, lib,
   extra-cmake-modules, kdoctools,
 
   boost, fontconfig, ibus, libXcursor, libXft, libcanberra_kde, libpulseaudio,
@@ -30,7 +30,10 @@ mkDerivation {
     ksysguard kwallet kwin plasma-framework plasma-workspace qqc2-desktop-style
   ];
 
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = [
+    ./hwclock-path.patch
+    ./tzdir.patch
+  ];
   postPatch = ''
     sed '1i#include <cmath>' -i kcms/touchpad/src/backends/x11/synapticstouchpad.cpp
   '';

--- a/pkgs/desktops/plasma-5/plasma-desktop/series
+++ b/pkgs/desktops/plasma-5/plasma-desktop/series
@@ -1,2 +1,0 @@
-hwclock-path.patch
-tzdir.patch

--- a/pkgs/development/libraries/grantlee/5/default.nix
+++ b/pkgs/development/libraries/grantlee/5/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, copyPathsToStore, fetchurl, qtbase, qtscript, cmake }:
+{ mkDerivation, lib, fetchurl, qtbase, qtscript, cmake }:
 
 mkDerivation rec {
   pname = "grantlee";
@@ -14,7 +14,10 @@ mkDerivation rec {
   buildInputs = [ qtbase qtscript ];
   nativeBuildInputs = [ cmake ];
 
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = [
+    ./grantlee-nix-profiles.patch
+    ./grantlee-no-canonicalize-filepath.patch
+  ];
 
   outputs = [ "out" "dev" ];
   postFixup =

--- a/pkgs/development/libraries/grantlee/5/series
+++ b/pkgs/development/libraries/grantlee/5/series
@@ -1,2 +1,0 @@
-grantlee-nix-profiles.patch
-grantlee-no-canonicalize-filepath.patch

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/default.nix
@@ -1,9 +1,11 @@
-{ mkDerivation, lib, copyPathsToStore, cmake, pkgconfig }:
+{ mkDerivation, lib, cmake, pkgconfig }:
 
 mkDerivation {
   name = "extra-cmake-modules";
 
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = [
+    ./nix-lib-path.patch
+  ];
 
   outputs = [ "out" ];  # this package has no runtime components
 

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/series
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/series
@@ -1,1 +1,0 @@
-nix-lib-path.patch

--- a/pkgs/development/libraries/kde-frameworks/kauth/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kauth/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore, propagate,
+  mkDerivation, lib, propagate,
   extra-cmake-modules, kcoreaddons, polkit-qt, qttools
 }:
 
@@ -9,7 +9,9 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ polkit-qt qttools ];
   propagatedBuildInputs = [ kcoreaddons ];
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = [
+    ./cmake-install-paths.patch
+  ];
   # library stores reference to plugin path,
   # separating $out from $bin would create a reference cycle
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/kauth/series
+++ b/pkgs/development/libraries/kde-frameworks/kauth/series
@@ -1,1 +1,0 @@
-cmake-install-paths.patch

--- a/pkgs/development/libraries/kde-frameworks/kcmutils/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcmutils/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore,
+  mkDerivation, lib,
   extra-cmake-modules,
   kconfigwidgets, kcoreaddons, kdeclarative, ki18n, kiconthemes, kitemviews,
   kpackage, kservice, kxmlgui, qtdeclarative,

--- a/pkgs/development/libraries/kde-frameworks/kdelibs4support/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdelibs4support/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore,
+  mkDerivation, lib,
   docbook_xml_dtd_45, extra-cmake-modules, kdoctools,
   kauth, karchive, kcompletion, kconfig, kconfigwidgets, kcoreaddons, kcrash,
   kdbusaddons, kded, kdesignerplugin, kemoticons, kglobalaccel, kguiaddons,
@@ -11,7 +11,9 @@
 mkDerivation {
   name = "kdelibs4support";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = [
+    ./nix-kde-include-dir.patch
+  ];
   setupHook = ./setup-hook.sh;
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   propagatedNativeBuildInputs = [ kdoctools ];

--- a/pkgs/development/libraries/kde-frameworks/kdelibs4support/series
+++ b/pkgs/development/libraries/kde-frameworks/kdelibs4support/series
@@ -1,1 +1,0 @@
-nix-kde-include-dir.patch

--- a/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore,
+  mkDerivation, lib,
   extra-cmake-modules,
   attr, ebook_tools, exiv2, ffmpeg_3, karchive, kcoreaddons, ki18n, poppler, qtbase, qtmultimedia, taglib
 }:
@@ -12,5 +12,7 @@ mkDerivation {
     attr ebook_tools exiv2 ffmpeg_3 karchive kcoreaddons ki18n poppler qtbase qtmultimedia
     taglib
   ];
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = [
+    ./cmake-install-paths.patch
+  ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kfilemetadata/series
+++ b/pkgs/development/libraries/kde-frameworks/kfilemetadata/series
@@ -1,1 +1,0 @@
-cmake-install-paths.patch

--- a/pkgs/development/libraries/kde-frameworks/kiconthemes/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kiconthemes/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore,
+  mkDerivation, lib,
   extra-cmake-modules,
   breeze-icons, karchive, kcoreaddons, kconfigwidgets, ki18n, kitemviews,
   qtbase, qtsvg, qttools,
@@ -8,7 +8,9 @@
 mkDerivation {
   name = "kiconthemes";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = [
+    ./default-theme-breeze.patch
+  ];
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     breeze-icons karchive kcoreaddons kconfigwidgets ki18n kitemviews

--- a/pkgs/development/libraries/kde-frameworks/kiconthemes/series
+++ b/pkgs/development/libraries/kde-frameworks/kiconthemes/series
@@ -1,1 +1,0 @@
-default-theme-breeze.patch

--- a/pkgs/development/libraries/kde-frameworks/kinit/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kinit/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore, writeScript,
+  mkDerivation, lib, writeScript,
   extra-cmake-modules, kdoctools,
   kconfig, kcrash, ki18n, kio, kparts, kservice, kwindowsystem, plasma-framework
 }:

--- a/pkgs/development/libraries/kde-frameworks/kinit/series
+++ b/pkgs/development/libraries/kde-frameworks/kinit/series
@@ -1,3 +1,0 @@
-kinit-libpath.patch
-start_kdeinit-path.patch
-kdeinit-extra_libs.patch

--- a/pkgs/development/libraries/kde-frameworks/kio/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kio/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore,
+  mkDerivation, lib,
   extra-cmake-modules, kdoctools, qttools,
   karchive, kbookmarks, kcompletion, kconfig, kconfigwidgets, kcoreaddons,
   kdbusaddons, ki18n, kiconthemes, kitemviews, kjobwidgets, knotifications,
@@ -21,5 +21,8 @@ mkDerivation {
     kxmlgui qtbase qttools solid
   ];
   outputs = [ "out" "dev" ];
-  patches = (copyPathsToStore (lib.readPathsFromFile ./. ./series));
+  patches = [
+    ./samba-search-path.patch
+    ./kio-debug-module-loader.patch
+  ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kio/series
+++ b/pkgs/development/libraries/kde-frameworks/kio/series
@@ -1,2 +1,0 @@
-samba-search-path.patch
-kio-debug-module-loader.patch

--- a/pkgs/development/libraries/kde-frameworks/kpackage/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kpackage/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore,
+  mkDerivation, lib,
   extra-cmake-modules, kdoctools,
   karchive, kconfig, kcoreaddons, ki18n, qtbase,
 }:
@@ -9,5 +9,8 @@ mkDerivation {
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ karchive kconfig kcoreaddons ki18n qtbase ];
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = [
+    ./allow-external-paths.patch
+    ./qdiriterator-follow-symlinks.patch
+  ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kpackage/series
+++ b/pkgs/development/libraries/kde-frameworks/kpackage/series
@@ -1,2 +1,0 @@
-allow-external-paths.patch
-qdiriterator-follow-symlinks.patch

--- a/pkgs/development/libraries/kde-frameworks/kservice/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kservice/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore,
+  mkDerivation, lib,
   bison, extra-cmake-modules, flex,
   kconfig, kcoreaddons, kcrash, kdbusaddons, kdoctools, ki18n, kwindowsystem,
   qtbase, shared-mime-info,
@@ -15,5 +15,8 @@ mkDerivation {
   ];
   propagatedBuildInputs = [ kconfig kcoreaddons ];
   propagatedUserEnvPkgs = [ shared-mime-info ]; # for kbuildsycoca5
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = [
+    ./qdiriterator-follow-symlinks.patch
+    ./no-canonicalize-path.patch
+  ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kservice/series
+++ b/pkgs/development/libraries/kde-frameworks/kservice/series
@@ -1,2 +1,0 @@
-qdiriterator-follow-symlinks.patch
-no-canonicalize-path.patch

--- a/pkgs/development/libraries/kde-frameworks/kwindowsystem/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwindowsystem/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, copyPathsToStore,
+  mkDerivation, lib,
   extra-cmake-modules,
   libpthreadstubs, libXdmcp,
   qtbase, qttools, qtx11extras
@@ -14,7 +14,9 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ libpthreadstubs libXdmcp qttools qtx11extras ];
   propagatedBuildInputs = [ qtbase ];
-  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
+  patches = [
+    ./platform-plugins-path.patch
+  ];
   preConfigure = ''
     NIX_CFLAGS_COMPILE+=" -DNIXPKGS_QT_PLUGIN_PATH=\"''${!outputBin}/$qtPluginPrefix\""
   '';

--- a/pkgs/development/libraries/kde-frameworks/kwindowsystem/series
+++ b/pkgs/development/libraries/kde-frameworks/kwindowsystem/series
@@ -1,1 +1,0 @@
-platform-plugins-path.patch


### PR DESCRIPTION
`lib.readPathsFromFile` is slow, unidiomatic, and barely used throughout nixpkgs.
It exists to read patch series files in the [Quilt](https://git.savannah.nongnu.org/cgit/quilt.git/plain/doc/quilt.pdf) format, something made completely
redundant by the Nix expression language having full support for lists and comments.

This proposes to remove usage of these, opting to instead use Nix lists for the task,
which both removes indirection (patch series are now visible directly in the derivation),
and is more efficient. There were not many instances of `lib.readPathsFromFile` being
used, mostly localised to KDE software.

This also adds a warning notice to users of `lib.readPathsFromFile`. I didn't modify
its documentation, and am unsure whether it should just be removed entirely. There
doesn't seem to be any documentation for process or deprecating things, so I just
took the most reasonable conservative approach I could.

By the way, is there a convenient way of testing if a particular commit changed the
derivation of an expression or not? It would be useful for refactors like this, where
there shouldn't be any difference between the two. nixpkgs-review just crashed.
I ended up checking each package manually; am I missing a simpler way?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
