### PR TITLE
gopls: remove unnecessary `go` input

### DIFF
--- a/pkgs/development/tools/gopls/default.nix
+++ b/pkgs/development/tools/gopls/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, go, buildGoModule, fetchgit }:
+{ stdenv, buildGoModule, fetchgit }:
 
 buildGoModule rec {
   pname = "gopls";


### PR DESCRIPTION

###### Motivation for this change
The dependency seems not necessary, so we can remove it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @mic92 @zimbatm