### PR TITLE
papermc: cleanup

### DIFF
--- a/pkgs/games/papermc/default.nix
+++ b/pkgs/games/papermc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre }:
+{ stdenv, fetchurl, bash, jre }:
 let
   mcVersion = "1.16.2";
   buildNum = "141";
@@ -13,22 +13,23 @@ in stdenv.mkDerivation {
   preferLocalBuild = true;
 
   dontUnpack = true;
-  installPhase = ''
-    mkdir -p $out/bin
-    cp ${jar} $out/papermc.jar
-    cat > $out/bin/minecraft-server << EOF
-    #!/bin/sh
-    exec ${jre}/bin/java \$@ -jar $out/papermc.jar nogui
-    EOF
-    chmod +x $out/bin/minecraft-server
+  dontConfigure = true;
+
+  buildPhase = ''
+    cat > minecraft-server << EOF
+    #!${bash}/bin/sh
+    exec ${jre}/bin/java \$@ -jar $out/share/papermc/papermc.jar nogui
   '';
 
-  phases = "installPhase";
+  installPhase = ''
+    install -Dm444 ${jar} $out/share/papermc/papermc.jar
+    install -Dm555 -t $out/bin minecraft-server
+  '';
 
   meta = {
     description = "High-performance Minecraft Server";
     homepage    = "https://papermc.io/";
-    license     = stdenv.lib.licenses.gpl3;
+    license     = stdenv.lib.licenses.gpl3Only;
     platforms   = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ aaronjanse ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Use Nix store path for the shebang to make this work on systems
  without /bin/sh.
- Replace phases by dont*.
- Install jar file to $out/share/papermc rather than $out.
- License gpl3 -> gpl3Only (couldn't find any evidence that this is
  gpl3Plus).

I don't use this, so I cannot really verify if this server works correctly.

cc @aaronjanse  @TheUserCreated

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
