### PR TITLE
Octoprint: 1.4.0 -> 1.4.2

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -1,114 +1,171 @@
-{ pkgs, stdenv, lib, fetchFromGitHub, python3
-# To include additional plugins, pass them here as an overlay.
+{ pkgs
+, stdenv
+, lib
+, fetchFromGitHub
+, python3
+  # To include additional plugins, pass them here as an overlay.
 , packageOverrides ? self: super: {}
 }:
 let
   mkOverride = attrname: version: sha256:
-    self: super: {
-      ${attrname} = super.${attrname}.overridePythonAttrs (oldAttrs: {
+  self: super: {
+    ${attrname} = super.${attrname}.overridePythonAttrs (
+      oldAttrs: {
         inherit version;
         src = oldAttrs.src.override {
           inherit version sha256;
         };
-      });
-    };
+      }
+    );
+  };
 
   py = python3.override {
     self = py;
-    packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([
-      (mkOverride "flask"            "0.12.5" "fac2b9d443e49f7e7358a444a3db5950bdd0324674d92ba67f8f1f15f876b14f")
-      (mkOverride "flask_assets"     "0.12"   "0ivqsihk994rxw58vdgzrx4d77d7lpzjm4qxb38hjdgvi5xm4cb0")
-      (mkOverride "flaskbabel"       "0.12.2" "11jwp8vvq1gnm31qh6ihy2h393hy18yn9yjp569g60r0wj1x2sii")
-      (mkOverride "flask_login"      "0.4.1"  "1v2j8zd558xfmgn3rfbw0xz4vizjcnk8kqw52q4f4d9ygfnc25f8")
-      (mkOverride "markdown"         "3.1.1"  "2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a")
-      (mkOverride "tornado"          "4.5.3"  "02jzd23l4r6fswmwxaica9ldlyc2p6q8dk6dyff7j58fmdzf853d")
-      (mkOverride "psutil"           "5.6.7"  "ffad8eb2ac614518bbe3c0b8eb9dffdb3a8d2e3a7d5da51c5b974fb723a5c5aa")
-      (mkOverride "watchdog"         "0.9.0"  "07cnvvlpif7a6cg4rav39zq8fxa5pfqawchr46433pij0y6napwn")
-      (mkOverride "werkzeug"         "0.16.1" "010zmhyfbp4d56c1rgalwi188imjlkv9g7rm25jrvify6xnqalxk")
-      (mkOverride "websocket_client" "0.56.0" "0fpxjyr74klnyis3yf6m54askl0h5dchxcwbfjsq92xng0455m8z")
-      (mkOverride "wrapt"            "1.11.2" "1q81762dgsgrd12f8qc39zk8s5wll3m5xc32jdmlf6cls4gh4njn")
+    packageOverrides = lib.foldr lib.composeExtensions (self: super: {}) (
+      [
+        # the following dependencies are non trivial to update since later versions introduce backwards incompatible
+        # changes that might affect plugins, or due to other observed problems
+        (mkOverride "markupsafe" "1.1.1" "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b")
+        (mkOverride "rsa" "4.0" "1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487")
+        (mkOverride "markdown" "3.1.1" "2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a")
+        (mkOverride "tornado" "5.1.1" "4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409")
+        (mkOverride "unidecode" "0.04.21" "280a6ab88e1f2eb5af79edff450021a0d3f0448952847cd79677e55e58bad051")
 
-      # Octoprint holds back jinja2 to 2.8.1 due to breaking changes.
-      # This old version does not have updated test config for pytest 4,
-      # and pypi tarball doesn't contain tests dir anyways.
-      (self: super: {
-        jinja2 = super.jinja2.overridePythonAttrs (oldAttrs: rec {
-          version = "2.8.1";
-          src = oldAttrs.src.override {
-            inherit version;
-            sha256 = "14aqmhkc9rw5w0v311jhixdm6ym8vsm29dhyxyrjfqxljwx1yd1m";
-          };
-          doCheck = false;
-        });
+        # Built-in dependency
+        (
+          self: super: {
+            octoprint-filecheck = self.buildPythonPackage rec {
+              pname = "OctoPrint-FileCheck";
+              version = "2020.08.07";
 
-        httpretty = super.httpretty.overridePythonAttrs (oldAttrs: rec {
-          doCheck = false;
-        });
+              src = fetchFromGitHub {
+                owner = "OctoPrint";
+                repo = "OctoPrint-FileCheck";
+                rev = version;
+                sha256 = "05ys05l5x7d2bkg3yqrga6m65v3g5fcnnzbfab7j9w2pzjdapx5b";
+              };
+              doCheck = false;
+            };
+          }
+        )
 
-        celery = super.celery.overridePythonAttrs (oldAttrs: rec {
-          doCheck = false;
-        });
-      })
-      (self: super: {
-        octoprint = self.buildPythonPackage rec {
-          pname = "OctoPrint";
-          version = "1.4.0";
+        # Built-in dependency
+        (
+          self: super: {
+            octoprint-firmwarecheck = self.buildPythonPackage rec {
+              pname = "OctoPrint-FirmwareCheck";
+              version = "2020.06.22";
 
-          src = fetchFromGitHub {
-            owner  = "foosel";
-            repo   = "OctoPrint";
-            rev    = version;
-            sha256 = "0387228544v28d69dcdg2zr5gp6qavkfr6dydpjgj5awxv3w25d5";
-          };
+              src = fetchFromGitHub {
+                owner = "OctoPrint";
+                repo = "OctoPrint-FirmwareCheck";
+                rev = version;
+                sha256 = "19y7hrgg9z8hl7cwqkvg8nc8bk0wwrsfvjd1wawy33wn60psqv1h";
+              };
+              doCheck = false;
+            };
+          }
+        )
 
-          propagatedBuildInputs = with super; [
-            awesome-slugify flask flask_assets rsa requests pkginfo watchdog
-            semantic-version werkzeug flaskbabel tornado
-            psutil pyserial flask_login netaddr markdown
-            pylru pyyaml sarge feedparser netifaces click websocket_client
-            scandir chainmap future wrapt monotonic emoji jinja2
-            frozendict cachelib sentry-sdk filetype markupsafe
-          ] ++ lib.optionals stdenv.isDarwin [ py.pkgs.appdirs ];
+        (
+          self: super: {
+            octoprint = self.buildPythonPackage rec {
+              pname = "OctoPrint";
+              version = "1.4.2";
 
-          checkInputs = with super; [ pytestCheckHook mock ddt ];
+              src = fetchFromGitHub {
+                owner = "OctoPrint";
+                repo = "OctoPrint";
+                rev = version;
+                sha256 = "1bblrjwkccy1ifw7lf55g3k9lq1sqzwd49vj8bfzj2w07a7qda62";
+              };
 
-          postPatch = let
-            ignoreVersionConstraints = [
-              "sentry-sdk"
-            ];
-          in ''
-            sed -r -i \
-              ${lib.concatStringsSep "\n" (map (e:
-                ''-e 's@${e}[<>=]+.*@${e}",@g' \''
-              ) ignoreVersionConstraints)}
-              setup.py
-          '';
+              propagatedBuildInputs = with super; [
+                octoprint-firmwarecheck
+                octoprint-filecheck
+                markupsafe
+                tornado
+                markdown
+                rsa
+                regex
+                flask
+                jinja2
+                flask_login
+                flask-babel
+                flask_assets
+                werkzeug
+                itsdangerous
+                cachelib
+                pyyaml
+                pyserial
+                netaddr
+                watchdog
+                sarge
+                netifaces
+                pylru
+                pkginfo
+                requests
+                semantic-version
+                psutil
+                click
+                feedparser
+                future
+                websocket_client
+                wrapt
+                emoji
+                frozendict
+                sentry-sdk
+                filetype
+                unidecode
+                blinker
+              ] ++ lib.optionals stdenv.isDarwin [ py.pkgs.appdirs ];
 
-          dontUseSetuptoolsCheck = true;
+              checkInputs = with super; [ pytestCheckHook mock ddt ];
 
-          preCheck = ''
-            export HOME=$(mktemp -d)
-            rm pytest.ini
-          '';
+              postPatch = let
+                ignoreVersionConstraints = [
+                  "sentry-sdk"
+                ];
+              in
+                ''
+                  sed -r -i \
+                    ${lib.concatStringsSep "\n" (
+                  map (
+                    e:
+                      ''-e 's@${e}[<>=]+.*@${e}",@g' \''
+                  ) ignoreVersionConstraints
+                )}
+                    setup.py
+                '';
 
-          disabledTests = [
-            "test_check_setup" # Why should it be able to call pip?
-          ] ++ lib.optionals stdenv.isDarwin [
-            "test_set_external_modification"
-          ];
+              dontUseSetuptoolsCheck = true;
 
-          passthru.python = self.python;
+              preCheck = ''
+                export HOME=$(mktemp -d)
+                rm pytest.ini
+              '';
 
-          meta = with stdenv.lib; {
-            homepage = "https://octoprint.org/";
-            description = "The snappy web interface for your 3D printer";
-            license = licenses.agpl3;
-            maintainers = with maintainers; [ abbradar gebner WhittlesJr ];
-          };
-        };
-      })
-      (import ./plugins.nix {inherit pkgs;})
-      packageOverrides
-    ]);
+              disabledTests = [
+                "test_check_setup" # Why should it be able to call pip?
+              ] ++ lib.optionals stdenv.isDarwin [
+                "test_set_external_modification"
+              ];
+
+              passthru.python = self.python;
+
+              meta = with stdenv.lib; {
+                homepage = "https://octoprint.org/";
+                description = "The snappy web interface for your 3D printer";
+                license = licenses.agpl3;
+                maintainers = with maintainers; [ abbradar gebner WhittlesJr ];
+              };
+            };
+          }
+        )
+        (import ./plugins.nix { inherit pkgs; })
+        packageOverrides
+      ]
+    );
   };
-in with py.pkgs; toPythonApplication octoprint
+in
+  with py.pkgs; toPythonApplication octoprint


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Simple Version bump; updated dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
