### PR TITLE
vokosscreenNG: Init at 3.0.5

### DIFF
--- a/pkgs/applications/video/vokoscreen-ng/default.nix
+++ b/pkgs/applications/video/vokoscreen-ng/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, fetchpatch
+, pkg-config
+, qmake
+, qttools
+, gstreamer
+, libX11
+, qtbase
+, qtmultimedia
+, qtx11extras
+
+, gst-plugins-base
+, gst-plugins-good
+, gst-plugins-bad
+, gst-plugins-ugly
+}:
+mkDerivation rec {
+
+  pname = "vokoscreen-ng";
+  version = "3.0.5";
+
+  src = fetchFromGitHub {
+    owner = "vkohaupt";
+    repo = "vokoscreenNG";
+    rev = version;
+    sha256 = "1spyqw8h8bkc1prdb9aixiw5h3hk3gp2p0nj934bnwq04kmfp660";
+  };
+
+  patches = [
+    # Better linux integration
+    (fetchpatch {
+      url = "https://github.com/vkohaupt/vokoscreenNG/commit/0a3784095ecca582f7eb09551ceb34c309d83637.patch";
+      sha256 = "1iibimv8xfxxfk44kkbrkay37ibdndjvs9g53mxr8x8vrsp917bz";
+    })
+  ];
+
+  qmakeFlags = [ "src/vokoscreenNG.pro" ];
+
+  nativeBuildInputs = [ qttools pkg-config qmake ];
+  buildInputs = [
+    gstreamer
+    libX11
+    qtbase
+    qtmultimedia
+    qtx11extras
+
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+    gst-plugins-ugly
+  ];
+
+  postPatch = ''
+    substituteInPlace src/vokoscreenNG.pro \
+      --replace lrelease-qt5 lrelease
+  '';
+
+  postInstall = ''
+    qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
+  '';
+
+  meta = with lib; {
+    description = "User friendly Open Source screencaster for Linux and Windows";
+    license = licenses.gpl2Plus;
+    homepage = "https://github.com/vkohaupt/vokoscreenNG";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27215,6 +27215,10 @@ in
 
   vokoscreen = libsForQt5.callPackage ../applications/video/vokoscreen { };
 
+  vokoscreen-ng = libsForQt5.callPackage ../applications/video/vokoscreen-ng {
+    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly;
+  };
+
   vttest = callPackage ../tools/misc/vttest { };
 
   wacomtablet = libsForQt5.callPackage ../tools/misc/wacomtablet { };


### PR DESCRIPTION
###### Motivation for this change
Closes: #96286

###### Things done
Packaged version 3.0.5, not sure if it's gpl2Only, https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/video/vokoscreen/default.nix#L49 says gpl2Plus  ?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
