### PR TITLE
tty-solitaire: init at 1.3.0

### DIFF
--- a/pkgs/applications/misc/tty-solitaire/default.nix
+++ b/pkgs/applications/misc/tty-solitaire/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "tty-solitaire";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "mpereira";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0kix7wfy2bda8cw5kfm7bm5acd5fqmdl9g52ms9bza4kf2jnb754";
+  };
+
+  buildInputs = [ ncurses ];
+
+  patchPhase = "sed -i -e '/^CFLAGS *?= *-g *$/d' Makefile";
+
+  makeFlags = [ "CC=cc" "PREFIX=${placeholder "out"}" ];
+
+  meta = with stdenv.lib; {
+    description = "Klondike Solitaire in your ncurses terminal";
+    license = licenses.mit;
+    homepage = "https://github.com/mpereira/tty-solitaire";
+    platforms = ncurses.meta.platforms;
+    maintainers = [ maintainers.AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23136,6 +23136,8 @@ in
 
   terminus = callPackage ../applications/misc/terminus { };
 
+  tty-solitaire = callPackage ../applications/misc/tty-solitaire { };
+
   lxterminal = callPackage ../applications/misc/lxterminal { };
 
   aminal = callPackage ../applications/misc/aminal {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
