### PR TITLE
update qcad to 3.25.0.0

### DIFF
--- a/pkgs/applications/misc/qcad/application-dir.patch
+++ b/pkgs/applications/misc/qcad/application-dir.patch
@@ -33,3 +33,16 @@ index c6c31cbf5..c51b59ce6 100644
  }
  
  int RSettings::getSnapRange() {
+diff --git a/qcad.desktop b/qcad.desktop
+index 93c5e9720..2d0e6bf32 100644
+--- a/qcad.desktop
++++ b/qcad.desktop
+@@ -48,7 +48,7 @@ Comment[sv]=2D CAD-system
+ Comment[sl]=Sistem 2D CAD
+ Comment[uk]=2D САПР
+ Comment[tr]=2D CAD Sistemi
+-Exec=qcad %F
++Exec=qcad-bin %F
+ X-MultipleArgs=true
+ Icon=qcad_icon
+ Terminal=false

--- a/pkgs/applications/misc/qcad/default.nix
+++ b/pkgs/applications/misc/qcad/default.nix
@@ -11,13 +11,13 @@
 
 mkDerivationWith stdenv.mkDerivation rec {
   pname = "qcad";
-  version = "3.24.3.10";
+  version = "3.25.0.0";
 
   src = fetchFromGitHub {
     owner = "qcad";
     repo = "qcad";
     rev = "v${version}";
-    sha256 = "0izyn4y1ffq1mgxs5dymkrqih6n6v9ifrcpyk1z2vyhbm5xx4qsa";
+    sha256 = "07qph2645m1wi9yi04ixdvx8dli03q1vimj3laqdmnpipi54lljc";
   };
 
   patches = [
@@ -25,11 +25,13 @@ mkDerivationWith stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    mkdir src/3rdparty/qt-labs-qtscriptgenerator-${qt5.qtbase.version}
-    cp \
-      src/3rdparty/qt-labs-qtscriptgenerator-5.12.3/qt-labs-qtscriptgenerator-5.12.3.pro \
-      src/3rdparty/qt-labs-qtscriptgenerator-${qt5.qtbase.version}/qt-labs-qtscriptgenerator-${qt5.qtbase.version}.pro
-  '';
+    if ! [ -d src/3rdparty/qt-labs-qtscriptgenerator-${qt5.qtbase.version} ]; then
+      mkdir src/3rdparty/qt-labs-qtscriptgenerator-${qt5.qtbase.version}
+      cp \
+        src/3rdparty/qt-labs-qtscriptgenerator-5.14.0/qt-labs-qtscriptgenerator-5.14.0.pro \
+        src/3rdparty/qt-labs-qtscriptgenerator-${qt5.qtbase.version}/qt-labs-qtscriptgenerator-${qt5.qtbase.version}.pro
+    fi
+ '';
 
   qmakeFlags = [
     "MUPARSER_DIR=${muparser}"


### PR DESCRIPTION
* update upstream version to 3.25.0.0
* fix the application desktop file to use the right binary name
* make building more robust when qt version changes, automatically try
  to copy qtscriptgenerator directory

- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)