### PR TITLE
noto-fonts-emoji: unstable-2019-10-22 → unstable-2020-08-20; twitter-color-emoji: 12.1.5 → 13.0.1

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -177,7 +177,7 @@ in
 
     meta = with stdenv.lib; {
       description = "Noto Emoji with extended Blob support";
-      homepage = https://github.com/C1710/blobmoji;
+      homepage = "https://github.com/C1710/blobmoji";
       license = with licenses; [ ofl asl20 ];
       platforms = platforms.all;
       maintainers = with maintainers; [ rileyinman ];

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -6,11 +6,12 @@
 , fetchzip
 , optipng
 , cairo
-, python3Packages
+, python3
 , pkgconfig
 , pngquant
 , which
 , imagemagick
+, zopfli
 }:
 
 let
@@ -110,25 +111,36 @@ in
   };
 
   noto-fonts-emoji = let
-    version = "unstable-2019-10-22";
+    version = "unstable-2020-08-20";
+    emojiPythonEnv =
+      python3.withPackages (p: with p; [ fonttools nototools ]);
   in stdenv.mkDerivation {
     pname = "noto-fonts-emoji";
     inherit version;
 
     src = fetchFromGitHub {
-      owner = "googlei18n";
+      owner = "googlefonts";
       repo = "noto-emoji";
-      rev = "018aa149d622a4fea11f01c61a7207079da301bc";
-      sha256 = "0qmnnjpp5lza6g5m3ki6hj46p891h9vl42k3acd0qw8i0jj5yn2c";
+      rev = "1bc491419fa2925d018f27bfe702792031be0e68";
+      sha256 = "1vak4s1p4wlwzpnqfb1c2sg62q82gnjpnmqrfz8xl6bd0z55imzy";
     };
 
-    buildInputs = [ cairo ];
-    nativeBuildInputs = [ pngquant optipng which cairo pkgconfig imagemagick ]
-                     ++ (with python3Packages; [ python fonttools nototools ]);
+    nativeBuildInputs = [
+      cairo
+      imagemagick
+      zopfli
+      pngquant
+      which
+      pkgconfig
+      emojiPythonEnv
+    ];
 
     postPatch = ''
-      sed -i 's,^PNGQUANT :=.*,PNGQUANT := ${pngquant}/bin/pngquant,' Makefile
-      patchShebangs flag_glyph_name.py
+      patchShebangs *.py
+      patchShebangs third_party/color_emoji/*.py
+      # remove check for virtualenv, since we handle
+      # python requirements using python.withPackages
+      sed -i '/ifndef VIRTUAL_ENV/,+2d' Makefile
     '';
 
     enableParallelBuilding = true;
@@ -141,7 +153,7 @@ in
     meta = with lib; {
       inherit version;
       description = "Color and Black-and-White emoji fonts";
-      homepage = "https://github.com/googlei18n/noto-emoji";
+      homepage = "https://github.com/googlefonts/noto-emoji";
       license = with licenses; [ ofl asl20 ];
       platforms = platforms.all;
       maintainers = with maintainers; [ mathnerd314 ];

--- a/pkgs/data/fonts/noto-fonts/tools.nix
+++ b/pkgs/data/fonts/noto-fonts/tools.nix
@@ -1,32 +1,62 @@
-{ fetchFromGitHub, lib, fetchpatch, buildPythonPackage, isPy3k, fonttools, numpy, pillow, six, bash }:
+{ fetchFromGitHub, lib, buildPythonPackage, pythonOlder
+, afdko, appdirs, attrs, black, booleanoperations, brotlipy, click
+, defcon, fontmath, fontparts, fontpens, fonttools, fs, lxml
+, mutatormath, pathspec, psautohint, pyclipper, pytz, regex, scour
+, toml, typed-ast, ufonormalizer, ufoprocessor, unicodedata2, zopfli
+, pillow, six, bash, setuptools_scm }:
 
 buildPythonPackage rec {
   pname = "nototools";
-  version = "unstable-2019-10-21";
+  version = "0.2.12";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "googlefonts";
     repo = "nototools";
-    rev = "cae92ce958bee37748bf0602f5d7d97bb6db98ca";
-    sha256 = "1jqr0dz23rjqiyxw1w69l6ry16dwdcf3c6cysiy793g2v7pir2yi";
+    rev = "v${version}";
+    sha256 = "0drmx1asni3g6616fa4gjn5n43qkcf7icvxq9y2krpjxq78wcmc5";
   };
 
-  propagatedBuildInputs = [ fonttools numpy ];
-
-  patches = lib.optionals isPy3k [
-    # Additional Python 3 compat https://github.com/googlefonts/nototools/pull/497
-    (fetchpatch {
-      url = "https://github.com/googlefonts/nototools/commit/ded1f311b3260f015b5c5b80f05f7185392c4eff.patch";
-      sha256 = "0bn0rlbddxicw0h1dnl0cibgj6xjalja2qcm563y7kk3z5cdwhgq";
-    })
-  ];
-
   postPatch = ''
-    sed -ie "s^join(_DATA_DIR_PATH,^join(\"$out/third_party/ucd\",^" nototools/unicode_data.py
+    sed -i 's/use_scm_version=.*,/version="${version}",/' setup.py
   '';
 
+  nativeBuildInputs = [ setuptools_scm ];
+
+  propagatedBuildInputs = [
+    afdko
+    appdirs
+    attrs
+    black
+    booleanoperations
+    brotlipy
+    click
+    defcon
+    fontmath
+    fontparts
+    fontpens
+    fonttools
+    lxml
+    mutatormath
+    pathspec
+    psautohint
+    pyclipper
+    pytz
+    regex
+    scour
+    toml
+    typed-ast
+    ufonormalizer
+    ufoprocessor
+    unicodedata2
+    zopfli
+  ];
+
   checkInputs = [
-    pillow six bash
+    pillow
+    six
+    bash
   ];
 
   checkPhase = ''

--- a/pkgs/data/fonts/twitter-color-emoji/default.nix
+++ b/pkgs/data/fonts/twitter-color-emoji/default.nix
@@ -3,9 +3,8 @@
 
 { stdenv
 , fetchFromGitHub
-, fetchpatch
 , cairo
-, graphicsmagick
+, imagemagick
 , pkg-config
 , pngquant
 , python3
@@ -15,7 +14,7 @@
 }:
 
 let
-  version = "12.1.5";
+  version = "13.0.1";
 
   twemojiSrc = fetchFromGitHub {
     name = "twemoji";
@@ -24,6 +23,9 @@ let
     rev = "v${version}";
     sha256 = "0acinlv2l3s1jga2i9wh16mvgkxw4ipzgvjx8c80zd104lpdpgd9";
   };
+
+  pythonEnv =
+    python3.withPackages (p: [ p.fonttools p.nototools ]);
 
 in
 stdenv.mkDerivation rec {
@@ -44,21 +46,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cairo
-    graphicsmagick
+    imagemagick
     pkg-config
     pngquant
-    python3
-    python3.pkgs.nototools
+    pythonEnv
     which
     zopfli
-  ];
-
-  patches = [
-    # ImageMagick -> GraphicsMagick
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/twitter-twemoji-fonts/raw/07778605d50696f6aa929020e82611a01d254c90/f/noto-emoji-use-gm.patch";
-      sha256 = "06vg16z79s5adyjy8r3mr8fd391b1hi4xkqvbzkmnjwaai7p08lk";
-    })
   ];
 
   postPatch = let
@@ -74,7 +67,7 @@ stdenv.mkDerivation rec {
       ''s#http://scripts.sil.org/OFL#http://creativecommons.org/licenses/by/4.0/#''
     ];
   in ''
-    patchShebangs ./flag_glyph_name.py
+    ${noto-fonts-emoji.postPatch}
 
     sed '${templateSubstitutions}' NotoColorEmoji.tmpl.ttx.tmpl > TwitterColorEmoji.tmpl.ttx.tmpl
     pushd ${twemojiSrc.name}/assets/72x72/
@@ -88,6 +81,8 @@ stdenv.mkDerivation rec {
     "EMOJI=TwitterColorEmoji"
     "EMOJI_SRC_DIR=${twemojiSrc.name}/assets/72x72"
     "BODY_DIMENSIONS=76x72"
+    # twemoji contains some codepoints noto doesn't like
+    "BYPASS_SEQUENCE_CHECK=True"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/python-modules/afdko/default.nix
+++ b/pkgs/development/python-modules/afdko/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, python
+, fonttools, defcon, lxml, fs, unicodedata2, zopfli, brotlipy, fontpens
+, brotli, fontmath, mutatormath, booleanoperations
+, ufoprocessor, ufonormalizer, psautohint
+, setuptools_scm
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "afdko";
+  version = "3.5.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wid4l70bxm297xgayyrgw5glhp6n92gh4sz1nd4rncgf1ziz8ck";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  propagatedBuildInputs = [
+    booleanoperations
+    fonttools
+    lxml           # fonttools[lxml], defcon[lxml] extra
+    fs             # fonttools[ufo] extra
+    unicodedata2   # fonttools[unicode] extra
+    brotlipy       # fonttools[woff] extra
+    zopfli         # fonttools[woff] extra
+    fontpens
+    brotli
+    defcon
+    fontmath
+    mutatormath
+    ufoprocessor
+    ufonormalizer
+    psautohint
+  ];
+
+  # tests are broken on non x86_64
+  # https://github.com/adobe-type-tools/afdko/issues/1163
+  # https://github.com/adobe-type-tools/afdko/issues/1216
+  doCheck = stdenv.isx86_64;
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    PATH="$PATH:$out/bin" py.test
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Adobe Font Development Kit for OpenType";
+    homepage = "https://adobe-type-tools.github.io/afdko/";
+    license = licenses.asl20;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/python-modules/booleanoperations/default.nix
+++ b/pkgs/development/python-modules/booleanoperations/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchPypi
+, fonttools, fs, pyclipper, defcon, fontpens
+, setuptools_scm, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "booleanOperations";
+  version = "0.9.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1f41lb19m8azchl1aqz6j5ycbspb8jsf1cnn42hlydxd68f85ylc";
+    extension = "zip";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  propagatedBuildInputs = [
+    fonttools
+    fs
+    pyclipper
+    defcon
+    fontpens
+  ];
+
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "Boolean operations on paths";
+    homepage = "https://github.com/typemytype/booleanOperations";
+    license = licenses.mit;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/python-modules/defcon/default.nix
+++ b/pkgs/development/python-modules/defcon/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
+, fonttools
+, pytest, pytestrunner, lxml, fs, unicodedata2, fontpens
+}:
+
+buildPythonPackage rec {
+  pname = "defcon";
+  version = "0.7.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1lfqsvxmq1j0nvp26gidnqkj1dyxv7jalc6i7fz1r3nc7niflrqr";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [
+    fonttools
+  ];
+
+  checkInputs = [
+    pytest
+    pytestrunner
+    lxml
+    fs
+    unicodedata2
+    fontpens
+  ];
+
+  meta = with lib; {
+    description = "A set of UFO based objects for use in font editing applications";
+    homepage = "https://github.com/robotools/defcon";
+    license = licenses.mit;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/python-modules/fontmath/default.nix
+++ b/pkgs/development/python-modules/fontmath/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi
+, fonttools
+, pytest, pytestrunner
+}:
+
+buildPythonPackage rec {
+  pname = "fontMath";
+  version = "0.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09xdqdjyjlx5k9ymi36d7hkgvn55zzjzd65l2yqidkfazlmh14ss";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ fonttools ];
+  checkInputs = [ pytest pytestrunner ];
+
+  meta = with lib; {
+    description = "A collection of objects that implement fast font, glyph, etc. math";
+    homepage = "https://github.com/robotools/fontMath/";
+    license = licenses.mit;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/python-modules/fontparts/default.nix
+++ b/pkgs/development/python-modules/fontparts/default.nix
@@ -1,0 +1,39 @@
+{ lib, buildPythonPackage, fetchPypi, python
+, fonttools, lxml, fs, unicodedata2
+, defcon, fontpens, fontmath, booleanoperations
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "fontParts";
+  version = "0.9.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hwzdppmrrw1xz49x36h6mcsrwya1f3zpqrc206y73j4pbn7fh0k";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [
+    booleanoperations
+    fonttools
+    unicodedata2  # fonttools[unicode] extra
+    lxml          # fonttools[lxml] extra
+    fs            # fonttools[ufo] extra
+    defcon
+    fontpens      # defcon[pens] extra
+    fontmath
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} Lib/fontParts/fontshell/test.py
+  '';
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "An API for interacting with the parts of fonts during the font development process.";
+    homepage = "https://github.com/robotools/fontParts";
+    license = licenses.mit;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/python-modules/fontpens/default.nix
+++ b/pkgs/development/python-modules/fontpens/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildPythonPackage, fetchPypi, fonttools }:
+
+buildPythonPackage rec {
+  pname = "fontPens";
+  version = "0.2.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1za15dzsnymq6d9x7xdfqwgw4a3003wj75fn2crhyidkfd2s3nd6";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ fonttools ];
+
+  # can't run normal tests due to circular dependency with fontParts
+  doCheck = false;
+  pythonImportsCheck = [ "fontPens" ] ++ (builtins.map (s: "fontPens." + s) [
+    "angledMarginPen"
+    "digestPointPen"
+    "flattenPen"
+    "guessSmoothPointPen"
+    "marginPen"
+    "penTools"
+    "printPen"
+    "printPointPen"
+    "recordingPointPen"
+    "thresholdPen"
+    "thresholdPointPen"
+    "transformPointPen"
+  ]);
+
+  meta = with lib; {
+    description = "A collection of classes implementing the pen protocol for manipulating glyphs";
+    homepage = "https://github.com/robotools/fontPens";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/python-modules/fonttools/default.nix
+++ b/pkgs/development/python-modules/fonttools/default.nix
@@ -1,36 +1,68 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, isPy27
-, numpy
+, fetchFromGitHub
+, pythonOlder
+, brotlipy
+, zopfli
+, fs
+, lxml
+, scipy
+, munkres
+, unicodedata2
+, sympy
+, matplotlib
+, reportlab
 , pytest
-, pytestrunner
+, pytest-randomly
 , glibcLocales
 }:
 
 buildPythonPackage rec {
   pname = "fonttools";
-  version = "4.13.0";
-  disabled = isPy27;
+  version = "4.14.0";
+  disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "63987cd374c39a75146748f8be8637634221e53fef15cdf76f17777676d8545a";
-    extension = "zip";
+  src = fetchFromGitHub {
+    owner  = pname;
+    repo   = pname;
+    rev    = version;
+    sha256 = "0aiaxjg2v2391gxnhp4nvmgfb3ygm6x7n080s5mnkfjq2bq319in";
   };
 
-  buildInputs = [
-    numpy
-  ];
-
+  # all dependencies are optional, but
+  # we run the checks with them
   checkInputs = [
     pytest
-    pytestrunner
+    pytest-randomly
     glibcLocales
+    # etree extra
+    lxml
+    # ufo extra
+    fs
+    # woff extra
+    brotlipy
+    zopfli
+    # unicode extra
+    unicodedata2
+    # interpolatable extra
+    scipy
+    munkres
+    # symfont
+    sympy
+    # varLib
+    matplotlib
+    # pens
+    reportlab
   ];
 
   preCheck = ''
     export LC_ALL="en_US.UTF-8"
+  '';
+
+  # avoid timing issues with timestamps in subset_test.py and ttx_test.py
+  checkPhase = ''
+    pytest Tests fontTools \
+      -k 'not ttcompile_timestamp_calcs and not recalc_timestamp'
   '';
 
   meta = {

--- a/pkgs/development/python-modules/mutatormath/default.nix
+++ b/pkgs/development/python-modules/mutatormath/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi
+, defcon, fontmath
+, unicodedata2, fs
+}:
+
+buildPythonPackage rec {
+  pname = "MutatorMath";
+  version = "3.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0r1qq45np49x14zz1zwkaayqrn7m8dn2jlipjldg2ihnmpzw29w1";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ fontmath unicodedata2 defcon ];
+  checkInputs = [ unicodedata2 fs ];
+
+  meta = with lib; {
+    description = "Piecewise linear interpolation in multiple dimensions with multiple, arbitrarily placed, masters";
+    homepage = "https://github.com/LettError/MutatorMath";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/python-modules/psautohint/default.nix
+++ b/pkgs/development/python-modules/psautohint/default.nix
@@ -1,0 +1,40 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+, fonttools, lxml, fs
+, setuptools_scm
+, pytest, pytestcov, pytest_xdist, pytest-randomly
+}:
+
+buildPythonPackage rec {
+  pname = "psautohint";
+  version = "2.1.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner  = "adobe-type-tools";
+    repo   = pname;
+    sha256 = "1k1rx1adqxdxj5v3788lwnvygylp73sps1p0q44hws2vmsag2s8r";
+    rev    = "v${version}";
+    fetchSubmodules = true; # data dir for tests
+  };
+
+  postPatch = ''
+    echo '#define PSAUTOHINT_VERSION "${version}"' > libpsautohint/src/version.h
+    sed -i '/use_scm_version/,+3d' setup.py
+    sed -i '/setup(/a \     version="${version}",' setup.py
+  '';
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  propagatedBuildInputs = [ fonttools lxml fs ];
+
+  checkInputs = [ pytest pytestcov pytest_xdist pytest-randomly ];
+  checkPhase = "pytest tests";
+
+  meta = with lib; {
+    description = "Script to normalize the XML and other data inside of a UFO";
+    homepage = "https://github.com/adobe-type-tools/psautohint";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-randomly/default.nix
+++ b/pkgs/development/python-modules/pytest-randomly/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, factory_boy, faker, numpy
+, pytest, pytest_xdist
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-randomly";
+  version = "3.4.1";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0s9cx692cdchfrjqx7fgf9wnm3fdac211a4hjq1cx9qqnbpdpl2z";
+  };
+
+  propagatedBuildInputs = [ numpy factory_boy faker ];
+
+  checkInputs = [ pytest pytest_xdist ];
+
+  # test warnings are fixed on an unreleased version:
+  # https://github.com/pytest-dev/pytest-randomly/pull/281
+  checkPhase = "pytest -p no:randomly";
+
+  meta = with lib; {
+    description = "Pytest plugin to randomly order tests and control random.seed";
+    homepage = "https://github.com/pytest-dev/pytest-randomly";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/python-modules/ufonormalizer/default.nix
+++ b/pkgs/development/python-modules/ufonormalizer/default.nix
@@ -1,0 +1,19 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "ufonormalizer";
+  version = "0.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0nv80x7l7sya5wzyfk9ss93r6bjzjljpkw4k8gibxp1rqrzkdms4";
+    extension = "zip";
+  };
+
+  meta = with lib; {
+    description = "Script to normalize the XML and other data inside of a UFO";
+    homepage = "https://github.com/unified-font-object/ufoNormalizer";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/python-modules/ufoprocessor/default.nix
+++ b/pkgs/development/python-modules/ufoprocessor/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildPythonPackage, fetchPypi
+, defcon, fonttools, lxml, fs
+, mutatormath, fontmath, fontparts
+, setuptools_scm
+}:
+
+buildPythonPackage rec {
+  pname = "ufoProcessor";
+  version = "1.9.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ns11aamgavgsfj8qf5kq7dvzmgl0mhr1cbych2f075ipfdvva5s";
+    extension = "zip";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  propagatedBuildInputs = [
+    defcon
+    lxml
+    fonttools
+    fs
+    fontmath
+    fontparts
+    mutatormath
+  ];
+
+  meta = with lib; {
+    description = "Read, write and generate UFOs with designspace data";
+    homepage = "https://github.com/LettError/ufoProcessor";
+    license = licenses.mit;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/python-modules/unicodedata2/default.nix
+++ b/pkgs/development/python-modules/unicodedata2/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pytest }:
+
+buildPythonPackage rec {
+  pname = "unicodedata2";
+  version = "13.0.0-2";
+
+  src = fetchFromGitHub {
+    owner  = "mikekap";
+    repo   = pname;
+    rev    = version;
+    sha256 = "0p9brbiwyg98q52y0gfyps52xv57fwqfpq0mn18p1xc1imip3h2b";
+  };
+
+  checkInputs = [ pytest ];
+  checkPhase = "pytest tests";
+
+  meta = with lib; {
+    description = "";
+    homepage = "http://github.com/mikekap/unicodedata2";
+    license = licenses.asl20;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/python-modules/zopfli/default.nix
+++ b/pkgs/development/python-modules/zopfli/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi, pytest }:
+
+buildPythonPackage rec {
+  pname = "zopfli";
+  version = "0.1.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0smaxh7iihjr9mwxw1ifc9vnlh3ra8l060dd1gbvp1963k0r68pd";
+    extension = "zip";
+  };
+
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "cPython bindings for zopfli";
+    homepage = "https://github.com/obp/py-zopfli";
+    license = licenses.asl20;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2087,6 +2087,8 @@ in {
 
   boltztrap2 = callPackage ../development/python-modules/boltztrap2 { };
 
+  booleanoperations = callPackage ../development/python-modules/booleanoperations { };
+
   boolean-py = callPackage ../development/python-modules/boolean-py { };
 
   bumps = callPackage ../development/python-modules/bumps {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4946,6 +4946,8 @@ in {
     else
       callPackage ../development/python-modules/mutagen { };
 
+  mutatormath = callPackage ../development/python-modules/mutatormath { };
+
   muttils = callPackage ../development/python-modules/muttils { };
 
   mygpoclient = callPackage ../development/python-modules/mygpoclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1721,6 +1721,8 @@ in {
 
   ufonormalizer = callPackage ../development/python-modules/ufonormalizer { };
 
+  ufoprocessor = callPackage ../development/python-modules/ufoprocessor { };
+
   unifi = callPackage ../development/python-modules/unifi { };
 
   uvcclient = callPackage ../development/python-modules/uvcclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6928,6 +6928,8 @@ in {
 
   zope_interface = callPackage ../development/python-modules/zope_interface { };
 
+  zopfli = callPackage ../development/python-modules/zopfli { };
+
   hgsvn = callPackage ../development/python-modules/hgsvn { };
 
   cliapp = callPackage ../development/python-modules/cliapp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2206,6 +2206,8 @@ in {
 
   debian = callPackage ../development/python-modules/debian {};
 
+  defcon = callPackage ../development/python-modules/defcon { };
+
   defusedxml = callPackage ../development/python-modules/defusedxml {};
 
   dodgy = callPackage ../development/python-modules/dodgy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2746,6 +2746,8 @@ in {
 
   pytest-raisesregexp = callPackage ../development/python-modules/pytest-raisesregexp { };
 
+  pytest-randomly = callPackage ../development/python-modules/pytest-randomly { };
+
   pytest-random-order = callPackage ../development/python-modules/pytest-random-order { };
 
   pytest-repeat = callPackage ../development/python-modules/pytest-repeat { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4146,6 +4146,8 @@ in {
 
   fontmath = callPackage ../development/python-modules/fontmath { };
 
+  fontparts = callPackage ../development/python-modules/fontparts { };
+
   fonttools = callPackage ../development/python-modules/fonttools { };
 
   foolscap = callPackage ../development/python-modules/foolscap { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4140,6 +4140,8 @@ in {
 
   fontpens = callPackage ../development/python-modules/fontpens { };
 
+  fontmath = callPackage ../development/python-modules/fontmath { };
+
   fonttools = callPackage ../development/python-modules/fonttools { };
 
   foolscap = callPackage ../development/python-modules/foolscap { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1719,6 +1719,8 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) CFNetwork Security;
   };
 
+  ufonormalizer = callPackage ../development/python-modules/ufonormalizer { };
+
   unifi = callPackage ../development/python-modules/unifi { };
 
   uvcclient = callPackage ../development/python-modules/uvcclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4138,6 +4138,8 @@ in {
     inherit python;
   }));
 
+  fontpens = callPackage ../development/python-modules/fontpens { };
+
   fonttools = callPackage ../development/python-modules/fonttools { };
 
   foolscap = callPackage ../development/python-modules/foolscap { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6811,6 +6811,8 @@ in {
 
   unicodecsv = callPackage ../development/python-modules/unicodecsv { };
 
+  unicodedata2 = callPackage ../development/python-modules/unicodedata2 { };
+
   unicode-slugify = callPackage ../development/python-modules/unicode-slugify { };
 
   unidiff = callPackage ../development/python-modules/unidiff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5494,6 +5494,8 @@ in {
     protobuf = pkgs.protobuf;
   };
 
+  psautohint = callPackage ../development/python-modules/psautohint { };
+
   psd-tools = callPackage ../development/python-modules/psd-tools { };
 
   psutil = callPackage ../development/python-modules/psutil { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -158,6 +158,8 @@ in {
 
   aenum = callPackage ../development/python-modules/aenum { };
 
+  afdko = callPackage ../development/python-modules/afdko { };
+
   affinity = callPackage ../development/python-modules/affinity { };
 
   agate = callPackage ../development/python-modules/agate { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update Noto Color Emoji and Twitter Color Emoji to support Unicode 13.0 for new emojis like 🏳️‍⚧️.

Following renderings are with the updated fonts from this PR:

* [Twitter Color Emoji](https://sterni.lv/tmp/twemoji.png) (the hole stems from the fact as far as I can see that twemoji is missing man with veil, person with veil and their variations)
* [Noto Color Emoji](https://sterni.lv/tmp/noto.png)

###### TODO

- [x] update `noto-fonts-emoji`
- [x] update / fix `twitter-emoji-color`
- [ ] test packages depending on these changes (aka `nixpkgs-review`)?

Also feedback especially on the new python packages would be appreciated. I'm not sure if there's a better way to handle the `extras` than I'm doing right now.

Also sorry for the huge PR, but all these changes are more or less related to each other, so opening thousands of PRs would be more of a hassle, I guess.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
