### PR TITLE
viewnior: 1.6 -> 1.7 & change upstream

### DIFF
--- a/pkgs/applications/graphics/viewnior/default.nix
+++ b/pkgs/applications/graphics/viewnior/default.nix
@@ -1,24 +1,38 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gtk2, libpng, exiv2, lcms
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, desktop-file-utils, gtk2, libpng, exiv2, lcms
 , intltool, gettext, shared-mime-info, glib, gdk-pixbuf, perl}:
 
 stdenv.mkDerivation rec {
   pname = "viewnior";
-  version = "1.6";
+  version = "1.7";
 
   src = fetchFromGitHub {
-    owner = "xsisqox";
+    owner = "hellosiyan";
     repo = "Viewnior";
     rev = "${pname}-${version}";
-    sha256 = "06ppv3r85l3id4ij6h4y5fgm3nib2587fdrdv9fccyi75zk7fs0p";
+    sha256 = "0y4hk3vq8psba5k615w18qj0kbdfp5w0lm98nv5apy6hmcpwfyig";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs =
-    [ pkgconfig gtk2 libpng exiv2 lcms intltool gettext
-      shared-mime-info glib gdk-pixbuf perl
-    ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    desktop-file-utils
+    intltool
+    gettext
+  ];
 
-  meta = {
+  buildInputs = [
+    gtk2
+    libpng
+    exiv2
+    lcms
+    shared-mime-info
+    glib
+    gdk-pixbuf
+    perl
+  ];
+
+  meta = with stdenv.lib; {
     description = "Fast and simple image viewer";
     longDescription =
       '' Viewnior is insipred by big projects like Eye of Gnome, because of it's
@@ -27,13 +41,9 @@ stdenv.mkDerivation rec {
          with the quality of it's functions. The program is made with better integration
          in mind (follows Gnome HIG2).
       '';
-
-    license = stdenv.lib.licenses.gpl3;
-
+    license = licenses.gpl3;
     homepage = "http://siyanpanayotov.com/project/viewnior/";
-
-    maintainers = [ stdenv.lib.maintainers.smironov ];
-
-    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
+    maintainers = with maintainers; [ smironov artturin ];
+    platforms = platforms.gnu ++ platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Things done
updated the version and changed the upstream to the official repo since the old one is dead
also changed how it builds because it was changed in 1.7 according to this
http://siyanpanayotov.com/project/viewnior/download

[OLD REPO](https://github.com/xsisqox/Viewnior/)
[NEW REPO](https://github.com/hellosiyan/Viewnior/)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
