### PR TITLE
nixos/spice-webdavd: init 

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -499,6 +499,7 @@
   ./services/misc/snapper.nix
   ./services/misc/sonarr.nix
   ./services/misc/spice-vdagentd.nix
+  ./services/misc/spice-webdavd.nix
   ./services/misc/ssm-agent.nix
   ./services/misc/sssd.nix
   ./services/misc/subsonic.nix

--- a/nixos/modules/services/misc/spice-webdavd.nix
+++ b/nixos/modules/services/misc/spice-webdavd.nix
@@ -1,0 +1,27 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+let
+  cfg = config.services.spice-webdavd;
+in
+{
+  options = {
+    services.spice-webdavd = {
+      enable = mkEnableOption "Spice guest WebDAV daemon";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.udev.packages = [ pkgs.phodav.udev ];
+
+    systemd.services.spice-webdavd = {
+      # Config guided by https://gitlab.gnome.org/GNOME/phodav/-/blob/master/data/spice-webdavd.service
+      description = "webdav daemon for Spice guests";
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.phodav}/bin/spice-webdavd -p 9843";
+        Restart = "on-success";
+      };
+    };
+  };
+}

--- a/pkgs/tools/networking/phodav/default.nix
+++ b/pkgs/tools/networking/phodav/default.nix
@@ -21,7 +21,13 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ libsoup pkgconfig meson ninja ];
 
-  outputs = [ "out" "dev" "lib" ];
+  outputs = [ "out" "dev" "lib" "udev" ];
+
+  # We need to do this pre-configure otherwise the data/ folder disappears.
+  preConfigurePhases = ["udevInstallPhase"];
+  udevInstallPhase = ''
+    install -vDt $udev/lib/udev/rules.d/ data/*-spice-webdavd.rules
+  '';
 
   meta = with stdenv.lib; {
     description = "WebDav server implementation and library using libsoup";


### PR DESCRIPTION
###### Motivation for this change

Enable file sharing between a guest NixOS system and a host.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
