### PR TITLE
firefox-devedition-bin: 80.0b8 -> 81.0b2

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "80.0b8";
+  version = "81.0b2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ach/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ach/firefox-81.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "f9b686c12733f6be1c96fcc71727f55e9c79f417df64a4b703c7fadaaf3a85e6";
+      sha256 = "f536899e2d0a55bad46db99bce4379a85fce46ea66f76361be71a1f54a2271a6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/af/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/af/firefox-81.0b2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "dc73e323741c3612607812878d24450b0b5d5274a8e58d25a9c3957d457b2431";
+      sha256 = "6bf9fc7088b1294068d85df8c5074741c9dbb4b2a4ef6c1613db8cacf8c44e4c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/an/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/an/firefox-81.0b2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "a84e966f8ac0373f63c7fd76148e16c56af645bb9b83cccee91e20065883f92d";
+      sha256 = "d602018d7877fa49bfadfdca20202d868d15fe91355719f04cfc2bfe75886764";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ar/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ar/firefox-81.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "9949f976617961c3853fc6e4596bac9a7c18d66b72df22b9b217dbccaea6b0c7";
+      sha256 = "ba68877e7c37f7ff47fb4ecfb672e72d53a2f63c3f1b809556871bdad3297b4d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ast/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ast/firefox-81.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "89f277e215e11c7efd270c6f0952292db5c85057a50b48a3753fb16c1322587d";
+      sha256 = "d0bdb0688f7650f32db2ac86874f02b3b3d2a6cf3bc1512d5416f34e60387a1e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/az/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/az/firefox-81.0b2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "44c84f6e00f5672c4f4b5d26d727da4aa0e8f5bbdcb4ab484be4015b5ea4bb55";
+      sha256 = "7f83233a3f69a53c5ac73dfafc6b207a7cb8650fb70fdd1e12272930d4844fcf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/be/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/be/firefox-81.0b2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "cbcb4dbf931214f01167705529ce410935a378ddf76f32c04a16a019a04dcec6";
+      sha256 = "e3fc72a47d0c443f66105cc21a4dfd340e539105c5f09b1cfd6388350ee56bbb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/bg/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/bg/firefox-81.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "6af931944901fc143d9958538aecfcfa5c8604aa928dcad7ff4062e4752b2861";
+      sha256 = "12c289adb110163c239abe3e5e28ea082399372d6d89d09a7634819f01e4a8b0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/bn/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/bn/firefox-81.0b2.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "5f44e1a8abf75708aed3c73c217ac6aa31520c32eae8c6a2c28838d4591fd779";
+      sha256 = "6107d1a5f4f2d1f43e8ce91b0d8aece46070a7327546e75395a12950e78b0cff";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/br/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/br/firefox-81.0b2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "7f345832f046770ff20457c902b499a6d2d3650e3cbad696d0a0ce81371b8710";
+      sha256 = "450ba9d63b568144740912717dc6b985bbe06d4de422138b8f84746e77e78849";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/bs/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/bs/firefox-81.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "539e441b74c8897113d8fe36076473f61cd26f9be24d5197dfa8f92a5ce68169";
+      sha256 = "412da2c5e8e64fed7f3793f85ad066db052b77911b6375beb9762782cbc9743d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ca-valencia/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ca-valencia/firefox-81.0b2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "8f8581a6888dbdce1d357e8a289a0befa20e1679a8cc7bff13ef237bb5498ec9";
+      sha256 = "c15aac69c03687ef019e50119ca062e74c7c3e18b2f5cebb4f452a4a38e6bb9d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ca/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ca/firefox-81.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "5f3b7553a62465e18e103ffce48f75cc58489349c3cf966e3ba0138ce14d7b8c";
+      sha256 = "b77629e4dd75e1684594bdc3128a37ffddfb6c2a5ae32519323977eb2bda9224";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/cak/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/cak/firefox-81.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "a1269157c6ec005756c1e0f0bbbf61a524f03b4c69022a2c49661c0375a78839";
+      sha256 = "2ba1bed45755dfaf8afdf2717235bbef2c792bb6c58bfa5e20df94e905ff6f01";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/cs/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/cs/firefox-81.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "15a26b351b40964089c8eed80fd5cadafd66ef39abbf19ce50a8b7ef5bdc661d";
+      sha256 = "1cbf68ddd52ecb58c40f6b25cab8f9340a4522714bca54438ee932cb327e03ab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/cy/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/cy/firefox-81.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "8400fc3e6192f2095d4a57bf354dbeee1b771a8aa61ab0d865956cdddfafcaf6";
+      sha256 = "142884a570ec59372924328665b3bcd74dfa7dc15517a49911c4bfe2e3a439ab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/da/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/da/firefox-81.0b2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "83c7818e65c32723c2bd0a4f65a33f19941fdcc5d84055cf2532cf8c4592020b";
+      sha256 = "494c74efc9b5c296e27dde647d02719403fbed60be703434cdacd5275c89cdf6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/de/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/de/firefox-81.0b2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "589b9249ffcff23c388716c24cd09baa8b309d771b97f4dfcf9c979ad9a3342a";
+      sha256 = "ecf4c3b50413454b0abfc8d9f8c010147f5678c07ebfc46adc8efedde0d22602";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/dsb/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/dsb/firefox-81.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "df57cc439fa74d93921c7c1265b7335e23c0df545e78eccce34e06fa528e75b3";
+      sha256 = "7ab1f13a410da41993e1d843d0d533ac51b1fd8b9678e5800c9fed3f20cb42df";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/el/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/el/firefox-81.0b2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "7a2b0380cc8733e7d6eb5adc228fd543d8459d7b7d9ffbcb39b73dffd395e5de";
+      sha256 = "143ca24223c0ee7f5d2f3097a0d5770c88bda7ad66f0e4aef3d5a9ed77a75746";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/en-CA/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/en-CA/firefox-81.0b2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "6e747524fb05aa987e0c24b21fc9ab27901f1cb205b7cffa100d5bdb7ba130c6";
+      sha256 = "b50929bf668c411039133bc8e66834cd463f3460293407b6d2044ca584f7d25f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/en-GB/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/en-GB/firefox-81.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "4e95f0c08c44e6d4830abaf9c2d25b10e63753f1dd48e192d4464a03b82a68de";
+      sha256 = "9f6d1f50e4f420f10f5165ebd018cdcea66314224eee033460d088e04b609db7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/en-US/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/en-US/firefox-81.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "2b75be9a3961e734ae16e591c367e76828e9a3adc458629db69fe5fb32a8b476";
+      sha256 = "b7207d4fa3f975e574c07b7de0eef3112c12e6cc98286d5d142cffd6191afd99";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/eo/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/eo/firefox-81.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "2fb71c60605c4c56432c262f62d72509d520787a7e86a45b496a68e55d08823b";
+      sha256 = "4320db9422652dff23261f3737a9e6cbe76d72a8d30ddd3e91951e70648f0750";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/es-AR/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/es-AR/firefox-81.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "3aefd418e20dbb7ae0b8aa87d15be140b4ddd7f6572ae0ca691b98f7f919361b";
+      sha256 = "439ab6e9c4161a9eb972ee6f8fdcac9d770a504dcc409d029730eb2491fbb9ea";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/es-CL/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/es-CL/firefox-81.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "7d650204f7f717cb39b218919b3654db5cced3fffa4d06fdcbd4eba5cea1263b";
+      sha256 = "7d63f897213c2334add35db2590bd019779e69c31669ba47af701886dae634bd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/es-ES/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/es-ES/firefox-81.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "5870182df6c69538ac1eaad0e61f580165e2e916cb76bbdee8b659a5a58dc68b";
+      sha256 = "9ae7e619a5cbb898c6873fa1d4aecab5929175e505df39bc1cdd18e93f233834";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/es-MX/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/es-MX/firefox-81.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "166dc0e61759c879737a10c3b709e5bc94493bfbf01a7997c2d38b48254d6af6";
+      sha256 = "b1b867005130e5c1b36a7863345b73ee6d6c5bd1fc9830ab2054ab5cc789cd78";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/et/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/et/firefox-81.0b2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "b8b8ea33ad920876b36abd8d35a61f01548c5a482c7eab0998f83f066bb62e27";
+      sha256 = "904b3738351efa864dcaec43e45ff7175924c676d2edcf01b9a7dfb9c062c0ee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/eu/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/eu/firefox-81.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "255637aa99002ea1f353098b19787077501efc915a74c2bc88a6ed6c05f12079";
+      sha256 = "490cedb239d605772ff3df872fe5992b6550903e41f4c0dabaf49f93e3c33f42";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/fa/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/fa/firefox-81.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "304144942ac8e71f4c29bf4bbc91f17a05bfd712e621cc0029909e0b65e09a95";
+      sha256 = "e2303f7ea353be4283143170b423d322e7525edab24c12b951ec65909199e1c4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ff/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ff/firefox-81.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "7ce1b42078fe98783e2da541cdd69dd2083ada20254ef80fb53454950e77eddd";
+      sha256 = "2bf104342660aeaad83cadd69ff8a31721e379c073c01295413d9f26a2344b12";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/fi/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/fi/firefox-81.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "af9271da2138c9c0d73fec09c5356a87b91aecc36a1211a9ce35e0ee1bcedda2";
+      sha256 = "0d5b75542e24c91ef129772046b4f05d74b91d4b550c6e01cb98271fb07d5b44";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/fr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/fr/firefox-81.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "c7f347082b17060c7af21ef12f9fd8b210ee20f877e7e791379c482a63e04ace";
+      sha256 = "51c41b79f10ccdc0ced6287d694924b33a55c6bcc2317566691d5a03a116a9e1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/fy-NL/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/fy-NL/firefox-81.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "51d42832b2f58e0d8f011762f9884dd49ab243d45b050258ceeae96bb92daad9";
+      sha256 = "8fb4e833628f890f3e8be940191be12d5fe57f5c365327ac85a0c5b9fbcfe278";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ga-IE/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ga-IE/firefox-81.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "33a50b14ff9d965deac611e0dd6a85de9caa9cde9b99a8dd955a28916e026d7e";
+      sha256 = "65e7808239e4a82f5f3c81a0296ee83ac82bf4f64ba5d2afc8fa5408d5a07f7d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/gd/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/gd/firefox-81.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "bd3469f5c101682a723eb5b261c591fa619b64dc99466ae919658cf44ae8fed4";
+      sha256 = "0df9c7c5d11f9b7d91ca609ef6426bca84cdc3c1b0f61c374d3261c34c6c31f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/gl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/gl/firefox-81.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "eedd3b89b26b6634827e07a5b20b57716f54a604b18d9849a4b2fe30ab7c366e";
+      sha256 = "1ce85726818a2aad6b8180e90739164524c90a8d780679af202d0dcc3a7ef979";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/gn/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/gn/firefox-81.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "206a292bdf13d98a502ff89ea57e94b37a528e57b88c1611c5094ed64aae2b0d";
+      sha256 = "f3cee409e0804aec00d084fb52c149981e51aa2985c61eba2dac4fcaa30252d9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/gu-IN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/gu-IN/firefox-81.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "2ec91a2be77abc9b52e4d466cfaef70ef02b7b92e332fe572cdc3f4e53ac5276";
+      sha256 = "8e3a4cb918800ab28fc93da266c70089cafa1a80739edb766d242fbacde1e9cd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/he/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/he/firefox-81.0b2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "5f53772c8a24d4fe1be3cc21673a924a5d65e606168f079b8091f4502d1218b7";
+      sha256 = "604e4db121aec5ba58aec37b73b3685fe4761de525ebb05c8a777e4bae112db1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/hi-IN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/hi-IN/firefox-81.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "15e74fb5124e1547f7eb776bd3b6d4096338731f1d97b6c0944e7f3af1b569c9";
+      sha256 = "742fba4b9d90b861bc2df50ac6d7cfa8e94030ea7d4498a60b5712ed07e93384";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/hr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/hr/firefox-81.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "5c4a0c766ed006e0f43856104aa8bd96e8d63ca618fda401370633b707e80374";
+      sha256 = "52c9b6781eb312ab1bd0a63ca161fd7232bd9875e9b3bb7510b47c1e66432fad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/hsb/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/hsb/firefox-81.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "6945e71a060bcbf8a329c65ddcba786beb4f955cc2105806bf5873c07daae988";
+      sha256 = "ba8847327638a1d6c135d076c37f00e95b64aeb0e8dbc78b44d63fcddc4ec087";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/hu/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/hu/firefox-81.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "5da76038365922aff82c540652132c7763a07f4336ef003a434299240444b036";
+      sha256 = "b1d21afbc31c4102036b9f1010dd9717d9500459d1efedc3e360d875e0024567";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/hy-AM/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/hy-AM/firefox-81.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "4be5260452b39b707d271b5696710038174c397083f626b3fd877aad36c37142";
+      sha256 = "d7c4023ffc66b4acf8320e2368fb5dd30bb5bd4c39972668b248411cb5698c02";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ia/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ia/firefox-81.0b2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "94dac5899d0f2d5afa0dec53472afb329b956347d22581e1b9668a123d200278";
+      sha256 = "e1f6b7bd0bc0b3c2f133b477167b4e4d41b4d9c0512d98f664665d3b34c8b2ac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/id/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/id/firefox-81.0b2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "d4cade715292ed116c2605dd6a8c70854cad373641982283decbc1e2f0417490";
+      sha256 = "6ef77cabecbebabcd56aa11935499f128299c29f5e26de61cec34ff31ef5526d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/is/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/is/firefox-81.0b2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "5f4bf4e8bb2f5e72872e99f8415b864df457c93ddabbcd4377588895c83b1d7a";
+      sha256 = "df279d99cf3a276678204c1653bea20c14e64f0c8e6277768a90b8757c04820a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/it/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/it/firefox-81.0b2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "5fa9251fd8c8e0d4aebc006ea1f8df15afada7276a1bd0517b89c2a6f8e488b6";
+      sha256 = "0309da83ad470d6b824538e0b5d0ad607165448b43c1dba8ad572cbb56e563fa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ja/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ja/firefox-81.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "a1557fd84bb39786566b6c11d1efea9464a96b77a690b1b1c3b165283c031185";
+      sha256 = "266f040b4e8265afffe239c2d99927ab25458ecf869b76a375b339c14f23b889";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ka/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ka/firefox-81.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "f9359c7eb9c6536ced999c18571babd932a1b1bd22565d6489bb43cb17893eb8";
+      sha256 = "8e600a7720cf02a2f70c3734fcfc37ced39fc7681d04f265ab4d9e3c2d77b619";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/kab/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/kab/firefox-81.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "9b34875edfbf6383b5bbddd110d969e32e448e47eaf48b7f41c215e6b3f8da62";
+      sha256 = "be70ae6399e76c9b69eef03b61b2cb9a50b427b47ade54af52c6d3769cc3ee3f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/kk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/kk/firefox-81.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "78bdac1a7f0bd82440e43c6079332624b1e7e60defe45d55493857b1f9e2c7ce";
+      sha256 = "0e24f219cbfaee4871a45d65c96e1fc4caa7257ccd1ad064840971d2c9292b07";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/km/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/km/firefox-81.0b2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "9fc753e4fa4a2a3a911dcfe9d8c7c993416833bedec4e94e85d95ef075209377";
+      sha256 = "17fd66c5573f0f2a5d32bfb298cb27a1425e510c89292f8577ea325be4477fc1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/kn/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/kn/firefox-81.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "1e45e618c6d4db4f870e4d3baf60676d2a76916ce0998ae33d671ab73e8c1bfa";
+      sha256 = "212b9dd7a5bd2c763baa5e668c4300cf168e53f597731ab65272c743cd9a6ef9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ko/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ko/firefox-81.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "afe8410a5be470aa016720f411f33aa0b244fa34dacb138ab145b97a7e195db9";
+      sha256 = "98dac665ac4faf842b1be25f6f56a9d62f7f32ae8cb70e6cce91bafc490379f9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/lij/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/lij/firefox-81.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "094f4ad0a2b988f0d75938dd6439ad5dacb1eee42584e7d1b424289117512d49";
+      sha256 = "108090e39257d2f7410b788102024c6356f99f68b0c84c717f4d5333a97d4c6a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/lt/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/lt/firefox-81.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "69164a34e2cacc8f68e8e87defe713c4dcd1de278d449e1f9eb7b8cf42aae305";
+      sha256 = "37893266ab35693040af5fd6e15bd25fe4459d17b83a31fc999b7e3363fc0a6f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/lv/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/lv/firefox-81.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "10262da2e4d50f2e331b3bd0c4d064002a3a5f10719284b96cced812ca0551bb";
+      sha256 = "9e7f20dc18d9fd9476a3b176e4f1c44408870ca94269a60ba380f9065d1c75bd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/mk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/mk/firefox-81.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "d310667e306b177191965b40b6cc8556e0fa749a3ebfa6120b0255e701d81ac1";
+      sha256 = "5370b2d1835afe1b9c7b6febdd5057b0f28e3d6528ad8b0f596bb6ad4fb7ed50";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/mr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/mr/firefox-81.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "2130fd9a56e2e4f4c09ea57cf0a566ade53c255c52e867c40316e14a04a59e0f";
+      sha256 = "68ccc08943015da8dbe57821c145e52629970dea7212fc257514908abd5d7c6e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ms/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ms/firefox-81.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "ac215f60d098eacfb4d03e857e0229d0368a113e5758f00044790953712cc4bf";
+      sha256 = "aa0f30b404ec5fa6ba68983369396de9bebef7e5acefc9a9d09f35fb00f667f7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/my/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/my/firefox-81.0b2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "0f89f81cde40821463e9ddbd988616d019d73fc0a27cc3a427dad4c9bd6fc931";
+      sha256 = "20ce6c166778df5c3948b1a936efa1dd7ba5bde2d16f036523e3099281e19f1b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/nb-NO/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/nb-NO/firefox-81.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "4d599136e6a8f430f21605895d2ea63aaa3542a2b9dff5fa44d3a618dff1be5b";
+      sha256 = "d96667027b400d60b802259df186198b915d27cea4ec5562b3fa47f92bea97d1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ne-NP/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ne-NP/firefox-81.0b2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "859dc2201e76de7f08b2c29d11382f02bb2eb6f9ec48f65656f578da67cc10d3";
+      sha256 = "6b582fb71295fcd9bf5d80736bc6bc5f3ea96ecd2b551e5fdc6df287bf04a812";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/nl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/nl/firefox-81.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "f9b7784f2c626f6bfe8a39a18a593d9f0d10d0f6407d1015969fd3744a483e88";
+      sha256 = "69b349a6c60ec1e9ed12c6b39f42d8b909b3185301aeffcf14390b995f0f1c0d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/nn-NO/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/nn-NO/firefox-81.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "6c46d8b833423fe0eed0da6c162ae16f6969b569902c41fa21ee7e19ce7515fd";
+      sha256 = "30460ae868c167c424a265324892173d9f1e98cdad9f8441f9164a0dbedc16cf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/oc/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/oc/firefox-81.0b2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "c359b9438f6065adb64baca086b7bed295ffccb825a96b4bcc5721ed4346a061";
+      sha256 = "6a04a173373caa9701f49215d7a00dfcae28da0e18dcbee8ff1164989389608d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/pa-IN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/pa-IN/firefox-81.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "6ae3b82728155e195747176188e30d4ddc3d5e9499ab018902e2e1289b19c171";
+      sha256 = "8c75c39b49e24e3b9b502bf67e7222000c874b2dd61678ae26c192a56bf35cad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/pl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/pl/firefox-81.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "45b97c17dcd1042eb205f6c59f5b679fcd224705cd5009dc2e39c8a22099ecb9";
+      sha256 = "8712e1801a81fcccf7114d91f64bc16906a6d14dded2eb5c7d993e19fcbc9f47";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/pt-BR/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/pt-BR/firefox-81.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "50b2309fc1b083f739b090729096fe82747dc3e889923d271aae500ee5f0c82d";
+      sha256 = "43e88e840356e6e514f2434832ea874529291306a534ef604a2943d904146e89";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/pt-PT/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/pt-PT/firefox-81.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "aac403c497aa1bb9e37038ea7897f57074278d080e592bf1984f1712a80de632";
+      sha256 = "c893a4e7b891afc00ddcb7709abf62b27581d76424eb8e2c417b3eec9161c0bc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/rm/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/rm/firefox-81.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "b8330c7ef733c1d50e320376bdd9c5205fd56f58fc7baf46497f1b0902193dc5";
+      sha256 = "f3646f18fdecb32c79509b753f47d26c81bcd2157fc6b833827228b36f652439";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ro/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ro/firefox-81.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "ae7d39f56d162d7b8bfb4d55c6de9b46a40f45c1bf9a4191e65c7a99a36b22ab";
+      sha256 = "a3a7eb1964b10a70a2c0a9f721e78c54663d44fed496870212c88c50f157f0e2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ru/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ru/firefox-81.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "10e1adf60a23574fd5ccf9ae1be83710c92c902367174f73952d18412228814f";
+      sha256 = "0e3d7414d8cbe4d2408716bf2f42f4021ddbe312696095ff1297782000d9773b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/si/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/si/firefox-81.0b2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "fe02265dfb0bb12ad9a5739e802937540425789c8e36220f59001ef4fc256f16";
+      sha256 = "a6680994d1d42d9adc8fc2138462dcb66820889fb23befbde0c7cc827d5afd56";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/sk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/sk/firefox-81.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "73c58bb35f204f875d2c8d293780810be6083d2934fa8d7d7e02a3bc8d41e5a3";
+      sha256 = "8c882816bc443eb8c562ceca3ed6cc39a4d9a67f93195c9b3eea4711f9988ca5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/sl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/sl/firefox-81.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "90243b7a75889617085715d6cbb65c220f1fc5eba5d4a70612277dcb6a6df6b6";
+      sha256 = "3de3a01df5b471894678afe4093e50f7c390100ddad233266ec91a93f9359e14";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/son/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/son/firefox-81.0b2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "ba8ead8c649116edb7e168b25e6eb3735a85cf5c15a2a78ebe8340cd7071adc1";
+      sha256 = "b32c4ba12f3e280d79c99e0ea4fbf948b0414c8c313d3e52465db37c07ece12d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/sq/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/sq/firefox-81.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "6466c44847b3b0370665e996582a2cbed9a8eb56a8b3f683582011cba77e918c";
+      sha256 = "91d19155a616375872bc986b61d5a2bc936855f6c47bb9a18f12daa1af6887a1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/sr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/sr/firefox-81.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "06869c6fc77aecdf48a991ebd65cc6052c8c3aca976b01cac5e39933c7aa9190";
+      sha256 = "03ed1f553242c6b443b26eeaa34743e971426adf1b1da1163dc6d2345e325f14";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/sv-SE/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/sv-SE/firefox-81.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "e763358e9672fbc8b990bacae8687c7558d9718cc9d1e80798ee9ad220f28b35";
+      sha256 = "7fd555cc837f1f5e3926f3a9e6490f803f41d0d49db2269f05ee4f31ff4ffb63";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ta/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ta/firefox-81.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "1669e95f886a7adeac0489c072fb88f1ca09daf3b42027006305857bdbfced4f";
+      sha256 = "6d121641ecbda4a89b869da263aab1110bf1f1522cee685a5a2500b7fa21743a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/te/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/te/firefox-81.0b2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "3d5c9f1596291eba38fa5b5174674fdcfd335e4cff44ecc50ddc7f08ca254b97";
+      sha256 = "03421f8437eb7d5f9c1123b194fbf22d9571c98dbcab58e6800b7fa4d2f274e0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/th/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/th/firefox-81.0b2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "d583744cc4d1099f23960b0ee7c80992233864c94f877623f0c566a65cd944fe";
+      sha256 = "0f4e2fa58aea23f76782a11040f2a8993777fd9511b6a5370b1473bd5316947f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/tl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/tl/firefox-81.0b2.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "cb6b8cdf1747e211cceeb07bda07573bc193574fa3603bfebaa537857953ce13";
+      sha256 = "20629651f5d7c7468e68a6913efd913b15fb7b053c745b5ef1fc1ee88330b6a1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/tr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/tr/firefox-81.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "e2561f98607ac5dcc67ef825cfe73d1c2af4ef9c5c01ebf48ee4dc0f80b53d07";
+      sha256 = "0b3997cebb9f65b0a81c38787641080489fb112509d7e31c22db65e337b55c97";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/trs/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/trs/firefox-81.0b2.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "de1e1f83c439d17d5489d666f1772ac32e26d70a5b3309176b528de413fae39d";
+      sha256 = "8756f596e33ec587d65a943f98fd3bb3b3fbd72cecba2f10bada6ded92039bf7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/uk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/uk/firefox-81.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "7632b4734ffe3106e78ddfc9e5ed81dbd219045f4b954421be4629397436763c";
+      sha256 = "517c1cf627132a1d0c2c7782877c0d46180e3f400984b6533e994a410ba19ff7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ur/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/ur/firefox-81.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "8e6c6d36546492ae93128c780c80bcae86ebaded38cc753db1f0401d4b5d31e3";
+      sha256 = "15484c6040db5eb105bea38dacc128b06d1f9d2d4ff6e050a9dc9f90c33a472a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/uz/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/uz/firefox-81.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "18c7827cc1337e0a2cb3a1e9603aff8e7c3ac8e5631cb791eb0b7a2de35bb487";
+      sha256 = "ebdebe291249575f88e3d948ecf6867366f28865317ae39a38c7eb4ff8b65f6c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/vi/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/vi/firefox-81.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "e78c922c13e0207c9cfb4d492e855543979e77b49a18fc63796c7e74cc4fcdeb";
+      sha256 = "821529a260cd71f01965faa26a0ba8c175ac2f832c868f89c5e6e2a0d882dd2a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/xh/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/xh/firefox-81.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "bd30e089384bac81aacf68c52ac884712bd0c739f517faa6390090d112d9fcf7";
+      sha256 = "424adcfb9b8da913f03f0f6087f8cc989c3e4ee26478210fde597a22641c64fe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/zh-CN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/zh-CN/firefox-81.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "316ad740bbba808a66b6fa00a9b1391597c949fa217e721563c685ef9fa028f1";
+      sha256 = "18194f71356fdaf71d2e0c87344c9c31766ef46aa01719133832a770cb49239b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/zh-TW/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-x86_64/zh-TW/firefox-81.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "f92189c808903b314ff4cc30fdfa7d5e2085ce22b9763e95144a7d69e6af719d";
+      sha256 = "4496c9723eadfc54520ca8ac3a441fb2e3fb1f3ec639be6c7b2cc2c8a4c39951";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ach/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ach/firefox-81.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "aaf1bc4cda7e1f1182f701485f5cb186d4b731851aca70611cd478c923b2427b";
+      sha256 = "6320c4cfee92de81583719e7e4d689bd802a419f217ead47013a5ce824fb8650";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/af/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/af/firefox-81.0b2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "1be25b19658c15a88031169c57acda5ebd49b63212f584da6f859370b493ad32";
+      sha256 = "27d9ef8b0b0d11eb64a66b6f9f34a9b00b9cc87932f66acb7a2c0b20cda5c207";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/an/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/an/firefox-81.0b2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "d461a566f7efc35ac323b0e8e963b8332a349e1b317401c2975cf4c75f7ce8cd";
+      sha256 = "a1b4fc109900281dc59cb23a4d687fe8e189f0c890ec4b1128041c3bed254e55";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ar/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ar/firefox-81.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "2051bf3ff16a6ebf15ed4fcd97adc2bef65c04500d09ff1f009785f41c0b02a2";
+      sha256 = "324805c8c32a74749ce290e1e2520b956ac45a9d6cce86c32de6809b4b88f57a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ast/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ast/firefox-81.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "97951d00f79bed031680ff9676201c9ff0fe79273e4f2697cd19ca9ccdfe95cc";
+      sha256 = "c8aabde24adf89800c18dc1b73aebaadcfa7c56584aacfe9e86ed0d1769841a0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/az/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/az/firefox-81.0b2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "a461aa41658c34bef1bffba2d34619ea402fdda2e51aa1e0200002b2e9321c8d";
+      sha256 = "67d6a20e11bf4d5c910e62ca31aea1227b87b93d658107ba606f6cb186d37a22";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/be/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/be/firefox-81.0b2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "ff1d2fa9203fce0aac5d91b38034910bbf7b0822b499fe522ed981f3365db8c3";
+      sha256 = "6c0a6c94eaeaa324ef215e0577b77744857825eb9112588e78b01000fa3c06f7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/bg/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/bg/firefox-81.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "17553a8566afe02d916b18d76a8850295512d9514bc37bbac459bd28a3bf46ec";
+      sha256 = "18747b830ce8ce0d1c1b4f47616200eaa5aa1f7599573f58f5c6f2a8d0e2a4e7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/bn/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/bn/firefox-81.0b2.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "9863e968594a556a7bd52a43cd3c965687d4116c9fbfb62bed38b1b7ee343728";
+      sha256 = "3cd6c03667192179ed315974e13f061a6820c803c80ea8f8c23081bad02ace48";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/br/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/br/firefox-81.0b2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "762f1f951560f8c85a44cc2a7c318e4f8e5a0b752011cf06f86235e3aedabebf";
+      sha256 = "45ecb563ad43f236d8c6d6f80c6e766da7248f079a14d4e7a403a5a65a0aac30";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/bs/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/bs/firefox-81.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "24fc8ac01417df1bbcec358c083f7627ed13bc76921bf0efc14e9f7653e9a819";
+      sha256 = "993920d92f0e58543f718a101982749e1a2215931903111656916c70dbcc3d6e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ca-valencia/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ca-valencia/firefox-81.0b2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "b071e20fadfaa2c06baa1579343c18167f6adf88e1c98fc68413287f6a45225f";
+      sha256 = "16248900ef6ad29ae3b64a2de3ba0a8c1465d0a7f11470b8e46f837d75d2b504";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ca/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ca/firefox-81.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "e63fc27b2bd404ae9190035d5537822fe76213545d8dd076566abd12ea213e25";
+      sha256 = "bcf21ab95cc6c3bb861c14589ae41be5304462e42ac47522b916ff4b54836bc6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/cak/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/cak/firefox-81.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "6f4fc3e51819d9d3914ad624593cfc755d9e8f78263700268dab46c38e8fdbcf";
+      sha256 = "8daa7f5682c7875e2f02239e13240930ef7ae50a7d50ff6a2fb761a2fc6d4129";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/cs/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/cs/firefox-81.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "ee61413b6544ec56d13bebd08ee2ee69f8d1f16e886ba31d46c2a786c0984f7c";
+      sha256 = "e310f6c23fb501863230285cd621fe570362369c5eb08e5fee82414b678961ad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/cy/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/cy/firefox-81.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "8f29a8b77732cb1387371538efdf970d0e93d3de866b103c836990a4f0a30933";
+      sha256 = "8a4a21709b128aaa881a741905bbb07beadcf25b87354294349806fe06a3235e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/da/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/da/firefox-81.0b2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "b89854119e139a8e9347b262131ed5da62672f6d728b1017963a11d279861a45";
+      sha256 = "8b0061625ebc39c74108ed25c3d1dc972258167fc984fd6f521e3112f2981cb4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/de/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/de/firefox-81.0b2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "c453a0f5cf528c582a35997a963b944d31666018ffc912ee4e188f795066b925";
+      sha256 = "7b27744aa3f8d2f4d452ec116493164fe4eb979f68e7fd17db596a56268d7c09";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/dsb/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/dsb/firefox-81.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "bf1f7ebef2aa4a5e0ed824a2c89a0b86101b5cc754feec482f0c39ef2ef3dea4";
+      sha256 = "5fc49ded2f2d6c34a58ce0fc9504255e8aae799d79949a8f342f95cd65391db9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/el/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/el/firefox-81.0b2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "b31ea72af96ecfd2b625d813bf32e08dfbffb9c0acb004e1f279b7937d675a90";
+      sha256 = "8c425ee9830664993fdc09cd6ce0f7c1f12bdb712ad2559fbc851e120dbd6eaf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/en-CA/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/en-CA/firefox-81.0b2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "31866007d8bc76202fcec3b9531afe237c9822025a14113051a9389cd9f81ec8";
+      sha256 = "142b1f38e2114fde9f8cfe4f3369bc51161cfb98ab10b8191e42d54709716984";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/en-GB/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/en-GB/firefox-81.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "82b2e6cc268eefb687255fdc5170aa8ab6136d6a07b881d49c044e1700eb9190";
+      sha256 = "e41c4de7c982758c417f3757b02d0e0876fe73857174e8f3feac932bb11ce296";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/en-US/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/en-US/firefox-81.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "dcd29328d9b464c16bd034f635a16d1593f98e08becc6a278d265b07bdc208a2";
+      sha256 = "002956bb8c44f9072c3bc387dc9bae23738e0f0a8e8d04c33fd819bbaca18b78";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/eo/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/eo/firefox-81.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "cfd6996e81513426d0534ba62e4f2d22fafcef51ed48da4a593b9d3ead2cb2fb";
+      sha256 = "b57ac2bdb11926725d090cf1605bfa874b74ac0d97d588ba51759bf22d75a9c5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/es-AR/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/es-AR/firefox-81.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "9d4c24e1153f723a789c1934c15cf8b4d3925fd34e8fee98d7e5ad19c9f7a9d3";
+      sha256 = "997da43509a9421555929465579b27f8d981e112e351e6163b568b86f1bc5bca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/es-CL/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/es-CL/firefox-81.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "91364ba1a2ab6c8bdede117f45a855b5968bee492e054123433c0fc034d66415";
+      sha256 = "8d562741157c438c4094e494d52cc47e3db0078cb386988802b3152fd45dd8dd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/es-ES/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/es-ES/firefox-81.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "1cef40ebfb1b12813d85a975ac0620b3ed339acf5de8e4d0ff0aba6aadedcc7d";
+      sha256 = "22fbb335388678e2ee1274389160b9e8d7254dcf1e813f186eda338bd9e17c9f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/es-MX/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/es-MX/firefox-81.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "e41ae370750f65e59470e05b2ed501a308f8743cde3291bae2fb8d17af553789";
+      sha256 = "340773701d2f5169526c9a1660387fa141bcf77a2ba3a8c4f8ee961f57a9bab4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/et/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/et/firefox-81.0b2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "5a279c246cffd27f6c919f451161e87b30ac8743e1a22ac490496b28af7e75de";
+      sha256 = "de8111d8660415e5f13887725a7f5d91306b2c2efac860bcb0be9c26e9a50809";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/eu/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/eu/firefox-81.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "3530e6f3060fd133dfad72532319c6cdb5be5bdd2dc0395d02e379b203264d20";
+      sha256 = "08a57ca8aa3b799d4b900d1988d981a85ef3db5e1ea4f0a7ab1d60337ce6a80f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/fa/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/fa/firefox-81.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "ae1b1fa06440f1038c97fa9d625a2b58ce5ffe11fb53a71afff632a18675f113";
+      sha256 = "9be033ab9860e8f5958590ccf4ab7fbd8177f5b0739960bf8bf854174b248818";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ff/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ff/firefox-81.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "05b47dda3d1fbce0e3dcd79534aef247516e5ded783d1184975ba97b1abb09f8";
+      sha256 = "9debf50b2d35180c51d6d8c6db49e00b2be616965bcf82b91332a169c457f605";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/fi/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/fi/firefox-81.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "689eeeee1a769ec9bb53014044a615f0a5c05d8a15e6dcd408d18ef452c0b441";
+      sha256 = "9dda6c2a14847828f1f4579777fdc054e8f66a4ecad64e6e67f0f33a9e6f63b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/fr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/fr/firefox-81.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "c64e31adfc24ba1fca84922b33a71bb74150ddc9b4d5e52f3627d2aac3b11516";
+      sha256 = "36d8214df2e592813b522c63090388abb703e1f956099558d0f4196249645bbd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/fy-NL/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/fy-NL/firefox-81.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "36765f1c9e1b15b43fd7d70c9f9dd1b977c4171ff920710346493214e08f9dc0";
+      sha256 = "2df988fd7bf0ea4aa9edadb5668c892a7ba1ae65709e08b0b6f4e921216d22f1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ga-IE/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ga-IE/firefox-81.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "026c461de7bba74facc421a58028e46efe32e7e3f441a8ca030911e2e883f56a";
+      sha256 = "223f28ebda420411d1c1bc6f7690ac0d815c8cf3b6b48c296439456cd477ec59";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/gd/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/gd/firefox-81.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "c2a21914b4f7cc71d6456e9c395fcf2ebbca12408563decc4a400e3d5d43c865";
+      sha256 = "3616c09e81427aa2ee6225df01f8a390fe33892b6d3ed056d4ec634e053f2feb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/gl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/gl/firefox-81.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "888aaad1dba8db4d71785fee01c100aa1919d432e8ccaa044e386224abe9494e";
+      sha256 = "e9db3577048518dcb1e34c144c65a53ba3ed7efa6768e69621d5864c203b1918";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/gn/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/gn/firefox-81.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "d5b1d103104c2e6e7b8198be649b0628acb4cfe6865422fc9e3db3b6ecc07cc6";
+      sha256 = "17d7fa2499650ea86476382d5039e1b60a1d91badb9a1f376dbfd2b5f0f4d4df";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/gu-IN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/gu-IN/firefox-81.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "215b9df33e06685f9b264b06b512d325aa8353b3f3975699b77e9fc8d18531f1";
+      sha256 = "4f4e57b16ed92298313c682b4a8b81f4a6062221c16cf05a970a63408ce19908";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/he/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/he/firefox-81.0b2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "8a19ef1eb702a0083c7751cbd7f2437c5fa46ba3f61a5f5d07f797b8ca696d22";
+      sha256 = "4cee7e7d887541ebd873c4e1b7da451c85aaf09795ada5f16c94af95b33d974f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/hi-IN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/hi-IN/firefox-81.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "17a84efead836ce54c1c0f0f5486595753f97463fbc2031d78b01e33c7a7775d";
+      sha256 = "8f2be0e2d62861494ab817ce1344833a0c55236cf76f812d3115bd29915d8fa1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/hr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/hr/firefox-81.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "41bc47533991b818b26fa149a30825326879cdb3ba92eab0ae5171be595078bd";
+      sha256 = "366f9267c8b474eecf7b6928e08e05bf5423291fdc87cdefc3773ce5e33a9bd2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/hsb/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/hsb/firefox-81.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "9ee8d0255eaaefe37f00960ed59c83a06b8356a8c6ea05d1f9697edb9880593e";
+      sha256 = "8f3864a1245e87d63084e2c81bfba4ad75484000cd3210c350b834c7fc6fa676";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/hu/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/hu/firefox-81.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "a9b6dfa44cc8d90a530aeb98ac96a0ac1e63b4a46b9af8ddfd4d6f268fc7eb5a";
+      sha256 = "a5bca6fe8fe02287a32a8daf5739c23589e59034ff7a2f6105d9f4456130797b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/hy-AM/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/hy-AM/firefox-81.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "e93f74803b536d3b12b6e41d064a7adc5dc16615d045a2e6cf792d25477fbdc6";
+      sha256 = "a8176dac94060b621b15869e15540c69bf3eb054163a2f0c14d8b8992613027e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ia/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ia/firefox-81.0b2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "931dbb0817dd797c5af61bc683f3d95ed99ad9834efe2f66a50f9e444e708061";
+      sha256 = "50ef09e2ad7afe2a5be67cec66840e5a06b59798a82e664a62df065aa3703f5f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/id/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/id/firefox-81.0b2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "1e1afcecc3bcadfbd6989eefc191f8d5cfd0f4d29c1f6814927370aa647af854";
+      sha256 = "3a18c4536437043587834fedafa7fbc79dc963f749714b6de0c87bafa72e1baf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/is/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/is/firefox-81.0b2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "4907987557a6a560557d417dcc31f9c7dd45dc0d2767ed050770f6fc6f308641";
+      sha256 = "9e458408f09e274f51dba78188eca04dce241b7c6fd955aa138e2d12b7d9e788";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/it/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/it/firefox-81.0b2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "d895c87359cfb98e236c4b5bac92391528eef07a45dca2d067a7d55fed4ebe7c";
+      sha256 = "872aa77906e0de0d93f791b3ea74069fff287c5c0dd98d920ee4d2e8d0193129";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ja/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ja/firefox-81.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "30dc7aee461930bea42c9f2985ff766f4aaf3ec0bd7f09562626b155bf80f202";
+      sha256 = "3fb1518b13dd93ea87512c8cafa4cd68c1301160cbf84751c12d6badc8926eab";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ka/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ka/firefox-81.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "d452668daf3b5a9f0602417822f7581183dfd5dbcc5d770afa20e1d61d557003";
+      sha256 = "b6d8bf69c6c1abf0ae351b3e00f1dec9baff55a7469ef220275dec3445fcfefc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/kab/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/kab/firefox-81.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "5e828a4f6abbb80c7b575db2a70ddcff0d734f11eb9bca55c2b8d00f08fa6497";
+      sha256 = "e69e0904ac83339a92e38ec0a3913da82a7c7c837698b14f703daa8a30b122fa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/kk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/kk/firefox-81.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "994e8ccd626f3e640b8a1b687a22ae6e3943b25995278f3333b6814ce61185c2";
+      sha256 = "1f3340f22663f33dd8d3e7a013b002fd907c4f42623de2691e27704157840f1d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/km/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/km/firefox-81.0b2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "a63ad9f77f01523dfb02eb6c2880a4046a556bae6d329a5e5480aa3eea0aec85";
+      sha256 = "240d20dd07becc4d8b88ff5a7a6c3e14defaff90e2cc5547d910a777e133e25e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/kn/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/kn/firefox-81.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "5396452efe004c7cb57105bb7134875e073f822927a98db23e96994e11fc7155";
+      sha256 = "c7ab66321644818e7cecba3fd3d5e62a3cdd26f3a81911db003a64600affe0db";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ko/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ko/firefox-81.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "a0bd2586531902121344b7c70e9ec9ae4e08514d2c467a17664701735f8d74ab";
+      sha256 = "41105497d49449164f4c14fdf186390a12d2b8d1b7f59bc53c4880add1ebc6bb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/lij/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/lij/firefox-81.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ac4f16381c71e3a4f00c6ac615913cc7d5eda77dd9ca337b9a8ec0e63a2e9176";
+      sha256 = "8a911aba3d9108abae1669903da178a383973f18a8f78123b71216feb4a6bade";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/lt/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/lt/firefox-81.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "bbeda439051c1ff43ba08b95de57914237e7b9845fef0d92efa02265cdc81961";
+      sha256 = "b3aaffe2599696c0e68216bd434ab87a17a4fc22e7cede29ddd5564cc082710a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/lv/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/lv/firefox-81.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "bb500de9c32241a7e28828e3f9b89427be1a54475d7b05b9c678d489a457c329";
+      sha256 = "9f45917b163ff1858dd0f4ed3b265e1e5e8e037461900f3dda5105c4f509cde1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/mk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/mk/firefox-81.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "5689b2805b30cece9f9757a1869906529a7094b4a9de5d5180a5bea7582606de";
+      sha256 = "cf11767f3269ed3624a0e1f84efb0f0b8a071fabac495577e0e779bd6d6ea92f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/mr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/mr/firefox-81.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "fc5ec6938f33c548f52cfb90f8a40b342bc9b4a7b97c3fcc1b3cd2aa5a031270";
+      sha256 = "060a6c8cb03c4266a7feaf5359818aeccddb7f17c797f5f1a66decf379ba0064";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ms/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ms/firefox-81.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "374e2a6ea3c59c7f985606f2e631294b57e20d7aff2bd8256ef9c91189e960b3";
+      sha256 = "c9c7c966b60075bba87ec8cb145392537bad9db7f4f6e96adce511e49f701919";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/my/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/my/firefox-81.0b2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "d9058df8893da03a707e549d9f133942fa71bf51e06c1a654f3ac588d79af82b";
+      sha256 = "52eef8a26a6fccca53e3271ed66543a28836ea3daea3266af0a3108add6863d3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/nb-NO/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/nb-NO/firefox-81.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "11019961c5378bb86b45b2c6d4b74ca1e41e86aed500ec0cd73fbe1785ef7742";
+      sha256 = "72283a6cfd98818f07bdd56dacb6a182f4558f1b566600f5069f30786ac725cf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ne-NP/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ne-NP/firefox-81.0b2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "de45c606c961a38c84196cab1827089b1b22e2dd0c23302ce57bf9fcbfcaf82e";
+      sha256 = "f75d91cb0943d4c68af8e26e9f555750caf84160c1ac655ecf4f9547b01deead";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/nl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/nl/firefox-81.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "bc2d98ae8f0fcc608d55b394398c45c1bcfcd02956031ca4762cc98d265916d8";
+      sha256 = "2c831fea388d0fbc236fe7f2e9e94a907836381067ef4da80742b6322eabbf4c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/nn-NO/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/nn-NO/firefox-81.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "b7c1d390a8bdf295ad8951959fcb720f977139592ef0f669005dcca0e6cbb19b";
+      sha256 = "8101a9168c48499ccff0f496b6a9fc25ab17fd5408c7885fe99a06f2f8b36a81";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/oc/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/oc/firefox-81.0b2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "a61a765b698f48c15cf07ea424e8e69be7630261a94c6514fa739974b51243f0";
+      sha256 = "3acff39a69f549a3fd6a04103306321e1426ebdd82d80790d1fbec340f7c3b3f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/pa-IN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/pa-IN/firefox-81.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "6721ca2f49b60f5ff1d86e0b1c9a1d6107c5d701b319a2abec7b6fcb9f845d57";
+      sha256 = "9e64eeac02c722a451d2650cb4d83ec87f01a62652517a050eaf8f9032e2fd16";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/pl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/pl/firefox-81.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "a77c0c05be64f027d25feaa75a788c630dd7af831c0c2fa334db7c36ac340144";
+      sha256 = "fd8431eded8c0f44dd48bb4c6c2ed88fd304def2b7338780c05ff18451a9e48d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/pt-BR/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/pt-BR/firefox-81.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "2baf74be32eec18bb235b57ee3816a3c9df916bbd4458aab1613af864581a072";
+      sha256 = "81906228a7c46238ffa7a744b982eea131c72f9153497a0036dfea62ce555456";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/pt-PT/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/pt-PT/firefox-81.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "0103da6d53b4a9e9512b8e3b90e583d8592a5bd02f09aedb90f49b1ce73516e6";
+      sha256 = "46ff4343c96621e59c449cfac7186a6d2b0179416b0c3ac5bdcc158cbe5b62c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/rm/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/rm/firefox-81.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "5dc1ace0d108460d6a57f7b158a1640d822c4e07a2e4d108db9f17e63150e4a1";
+      sha256 = "44958e55fb3c80f589991b18936699cc14c5f4bb6695746d466602adac78df88";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ro/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ro/firefox-81.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "1e2ee8f338625bf95da2914e54b22e1a052cce955a92102163e67cacc41129b8";
+      sha256 = "810043a5512976bbab96f9fea0e094546e86319b6682ed04fd5b0a81eb131012";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ru/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ru/firefox-81.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "c57cda1ba6e8895044fbc55b37eb5e241b02904f69337a6430b3b9fd47a57fea";
+      sha256 = "416d5f150b84842a963ecb422b1d5d6b5e1fd62cd6bf46327de250863a278290";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/si/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/si/firefox-81.0b2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "e31df32be4babb9b1eeb5f6a5a44d1c94b07fd5c4bf70d8cc78d4061e1e790a0";
+      sha256 = "6310605a58e2c2ae9dd524c8a3bea13a42828c2c9dcfd294fc0d3390550f1383";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/sk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/sk/firefox-81.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "0630c3c617d1a646ab0acdc0c18346ac29066a8a31be9995f96e5daecc74bb24";
+      sha256 = "1b004a97173de0a5f79b8a71350e48bea4028016089919f63a6a11d4d9a3cc75";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/sl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/sl/firefox-81.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "65cc9e3d0e6af8743a768cf23b1dcb281d5ee26cbdf0fb2f0639cfe032f8cc07";
+      sha256 = "134f328e5365ecadf38bf1adff742647ac5728ee56b1a12aa3e4282449a74bbb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/son/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/son/firefox-81.0b2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "7f25deb9d71b23647722745d813e8e115e0d08190811efa4fc0b6456ee5bc634";
+      sha256 = "f4ced7464c23753e597273098b3436dbd49971861b5fb373a2f7bcf9f95d0248";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/sq/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/sq/firefox-81.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "e103461a63337bd7905345091edde08056eb267a522a205d6308e33d477f7d49";
+      sha256 = "4c7905c444c15743a0f913dba690836b4571e07fd3d66f5b33d935ff82f485ac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/sr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/sr/firefox-81.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "cfaead5b0913dd265c18e42793a2a845aeb6e421b6c54a0f979bc80cd7a6cb18";
+      sha256 = "a3a8dae2546ee12dd06506724207e9a02fedd6ec25e760db56f3b5ec30f4637d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/sv-SE/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/sv-SE/firefox-81.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "7343ae52dc3f85d35264fb6cc86daea45deed4cc3b7c3dc3078afdfde9a48919";
+      sha256 = "86c5992464fc2456401b4ee59a60e07bf180592ab63bd3e7bca4c19c47e4b1cd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ta/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ta/firefox-81.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "389ae6d8db8280f74944c2c5d61dc031ba4ae4db792c1f851ff72ebfb123b17c";
+      sha256 = "d807ab6949d9634606fed0e2002119cd69c5f893443d8e61122088ffa578fbe9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/te/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/te/firefox-81.0b2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "e49d8a521ffc7087c8d75f5ecbb9f6c010966c9f92dd4c105278aeeee1eee865";
+      sha256 = "e58b19f87fd613e0da0aa75fa1c565a8e0b19f9d6020cd01c70d5c40f87398a1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/th/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/th/firefox-81.0b2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "a27ff17d3bd090cf5bf798465dbeb3e369ea03a738729b748a0b03bb2d0418f8";
+      sha256 = "d1d64809f789e10e0f7c43f52c51affd8b8b328765bf2ad1db025767a07de39b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/tl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/tl/firefox-81.0b2.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "5826bcb2683e74bc5588c7b12099d9d2ac70ecb0026d375bea92d94a3f381f70";
+      sha256 = "24df911637643a85b19432737717fa000048ec0090c89f35a2c913ae3e086172";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/tr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/tr/firefox-81.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "73d79d2dfc0c7ac86566c1d41a6cbf6367ff57a6c5dcd459e1994d5bb8290fe8";
+      sha256 = "6bc1ae3f8f81c0c75cb9bff8183c32384fd72a83cef898e049f689524d6a753c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/trs/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/trs/firefox-81.0b2.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "a8b7cab92a7b449ce57a2eaf6a447e4cec99fbd8dd43ffe36dd4b87cd04c19a7";
+      sha256 = "965359072a45017fbd1c605b2f5c8fbcafe202efbb6b4e1b9e054a0c0099d7cd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/uk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/uk/firefox-81.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "af59707ac1141ed356a9bacfa116d0a65236352f6bbbddd69e8544a551064782";
+      sha256 = "8f2f52ea90dcf52ea3b244d5c7bf3f594fa9e1c58428511f1f9c584d4149c45d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ur/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/ur/firefox-81.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "4a6068c0384b69592312bde06631584e612fd1f17d0af4b71dbfe38fe19dd413";
+      sha256 = "0d86847e94d991c0abc8ebfab31794f5790f7bcadf5943331b8e5caa763f8be4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/uz/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/uz/firefox-81.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "a6f01fd45fc403dff8a97be0bcdcd2837eff7880ad039eab2cb31a2eca82c6e9";
+      sha256 = "c71885fb2f8973e085bffa408d652b81839f83adf07fc6308ffd5fd15241ea0c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/vi/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/vi/firefox-81.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "b7cc325a09e7e5a6097c81055eec760452ebff160af5e5f9b7a790a2d3fba53d";
+      sha256 = "55629f373a64be99827d4f115d5e53e1c1937afef1d01cc52e8b51991fe61bc8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/xh/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/xh/firefox-81.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "64e6d44ed8b07fefb110463e1003cab01503a52bcb72c76d6030325cd6c796d9";
+      sha256 = "f1d94604739467af2ee0e0bc29f2e3e54088db262ed65012f112684d0244eeb0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/zh-CN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/zh-CN/firefox-81.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "11312a9a212159bb929df04217292481b9aacdebc50ae941729b37f9c7c8312b";
+      sha256 = "9b63ceacc507366bc2dc19f19a9c2d227c0fabdafba3f7d854f276b76b187deb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/zh-TW/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/81.0b2/linux-i686/zh-TW/firefox-81.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0b3f5974dd951fe9ec988c8608b186a2d5ebbc397fb017d587e869cbe4dcc74b";
+      sha256 = "1e4aca40805cb149a45a267c7adc9cd27c84a294f1fa56cfd21b04378d0536c9";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
