### PR TITLE
Staging-next stabilization

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -7,13 +7,14 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "gdal";
-  version = "3.0.4";
+  # broken with poppler 20.08, however, can't fetch patches cleanly
+  version = "3.1.2.post2020-08-26";
 
   src = fetchFromGitHub {
     owner = "OSGeo";
     repo = "gdal";
-    rev = "v${version}";
-    sha256 = "00a7q9wv8s1bmdhqxvixkq2afr8aibg3pkc76gg50r8lavf6j84c";
+    rev = "9a8df672204a8b3b33c36e09a32f747e21166fe9";
+    sha256 = "1n25jma4x1l7slwxk702q77r84vxr90fyn4c3zpkr07q1b8wqql9";
   };
 
   sourceRoot = "source/gdal";
@@ -57,7 +58,7 @@ stdenv.mkDerivation rec {
     "--with-proj=${proj.dev}" # optional
     "--with-geos=${geos}/bin/geos-config" # optional
     "--with-hdf4=${hdf4.dev}" # optional
-    "--with-xml2=${libxml2.dev}/bin/xml2-config" # optional
+    "--with-xml2=yes" # optional
     (if netcdfSupport then "--with-netcdf=${netcdf}" else "")
   ];
 

--- a/pkgs/development/python-modules/chalice/default.nix
+++ b/pkgs/development/python-modules/chalice/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , attrs
 , botocore
 , click
@@ -21,11 +22,11 @@
 
 buildPythonPackage rec {
   pname = "chalice";
-  version = "1.17.0";
+  version = "1.18.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b1ab4197628f4725ac50479aefe61698ea4a5d83ef88bb88978023cdf840a9a2";
+    sha256 = "0zb4xk9b553pnfzh8s909cixfdplqnc3nda0fjwjrryi2nxjxd6a";
   };
 
   checkInputs = [ watchdog pytest hypothesis mock ];
@@ -41,6 +42,7 @@ buildPythonPackage rec {
     setuptools
     six
     wheel
+  ] ++ lib.optionals (pythonOlder "3.5") [
     typing
   ];
 

--- a/pkgs/development/python-modules/chalice/default.nix
+++ b/pkgs/development/python-modules/chalice/default.nix
@@ -5,16 +5,18 @@
 , botocore
 , click
 , enum-compat
+, hypothesis
 , jmespath
+, mock
+, mypy-extensions
 , pip
+, pytest
+, pyyaml
 , setuptools
 , six
 , typing
-, wheel
 , watchdog
-, pytest
-, hypothesis
-, mock
+, wheel
 }:
 
 buildPythonPackage rec {
@@ -33,7 +35,9 @@ buildPythonPackage rec {
     click
     enum-compat
     jmespath
+    mypy-extensions
     pip
+    pyyaml
     setuptools
     six
     wheel

--- a/pkgs/development/python-modules/hieroglyph/default.nix
+++ b/pkgs/development/python-modules/hieroglyph/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, fetchPypi, buildPythonPackage, sphinx }:
+{ stdenv, fetchPypi, buildPythonPackage, isPy27, sphinx }:
 
 buildPythonPackage rec {
   pname = "hieroglyph";
   version = "2.1.0";
+  disabled = isPy27; # python2 compatible sphinx is too low
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/sphinx_rtd_theme/default.nix
+++ b/pkgs/development/python-modules/sphinx_rtd_theme/default.nix
@@ -8,11 +8,11 @@
 
 buildPythonPackage rec {
   pname = "sphinx_rtd_theme";
-  version = "0.5.0";
+  version = "0.4.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "22c795ba2832a169ca301cd0a083f7a434e09c538c70beb42782c073651b707d";
+    sha256 = "728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a";
   };
 
   propagatedBuildInputs = [ sphinx ];

--- a/pkgs/development/python-modules/vulture/default.nix
+++ b/pkgs/development/python-modules/vulture/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, buildPythonPackage, fetchPypi, coverage, pytest, pytestcov }:
+{ stdenv, buildPythonPackage, fetchPypi, isPy27, coverage, pytest, pytestcov }:
 
 buildPythonPackage rec {
   pname = "vulture";
   version = "2.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/xcffib/default.nix
+++ b/pkgs/development/python-modules/xcffib/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , xorg
 , cffi
+, nose
 , six
 }:
 
@@ -21,6 +22,10 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [ cffi six ];
+
+  checkInputs = [ nose ];
+
+  pythonImportsCheck = [ "xcffib" ];
 
   meta = with stdenv.lib; {
     description = "A drop in replacement for xpyb, an XCB python binding";

--- a/pkgs/development/python-modules/xpybutil/default.nix
+++ b/pkgs/development/python-modules/xpybutil/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, xcffib, pillow }:
+{ lib, buildPythonPackage, fetchFromGitHub, xcffib, pillow, nose }:
 
 buildPythonPackage rec {
   pname = "xpybutil";
@@ -14,6 +14,8 @@ buildPythonPackage rec {
 
   # pillow is a dependency in image.py which is not listed in setup.py
   propagatedBuildInputs = [ xcffib pillow ];
+
+  checkInputs = [ nose ];
 
   meta = with lib; {
     homepage = "https://github.com/BurntSushi/xpybutil";


### PR DESCRIPTION
##### Motivation for this change
just marking a few broken packages as disabled

for the other commits, please look at commit message for details as to why they were done
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
