### PR TITLE
gitAndTools.git-machete: 2.15.3 -> 2.15.4

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonApplication rec {
   pname = "git-machete";
-  version = "2.15.3";
+  version = "2.15.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0kpfi1w1jnn7v7mny71jil3sc9mm08lz47l9v3hzgs5z3ham98jb";
+    sha256 = "0n2lrsjs3flfv7650yfhck1c96wkn41cv49440m7csy5yw16zlim";
   };
 
   nativeBuildInputs = [ installShellFiles pbr ];


### PR DESCRIPTION
###### Motivation for this change
Update to latest upstream version

###### Things done
 * [ ]  Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
 * Built on platform(s)

   * [x]  NixOS
   * [ ]  macOS
   * [ ]  other Linux distributions
 * [ ]  Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
 * [ ]  Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
 * [x]  Tested execution of all binary files (usually in `./result/bin/`)
 * [ ]  Determined the impact on package closure size (by running `nix path-info -S` before and after)
 * [ ]  Ensured that relevant documentation is up to date
 * [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
cc @blitz @Ma27 @tfc @worldofpeace