### PR TITLE
grafana: 7.1.3 -> 7.1.5

### DIFF
--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "grafana";
-  version = "7.1.3";
+  version = "7.1.5";
 
   excludedPackages = [ "release_publisher" ];
 
@@ -10,15 +10,15 @@ buildGoModule rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "1acvvqsgwfrkqmbgzdxfa8shwmx7c91agaqv3gsfgpqkqwp3pnmh";
+    sha256 = "089z2x6jhiv5cx70vm7f1pyj5avappnaxrwah8jbnlkaz2kisp79";
   };
 
   srcStatic = fetchurl {
     url = "https://dl.grafana.com/oss/release/grafana-${version}.linux-amd64.tar.gz";
-    sha256 = "0c72xmazr3rgiccrqcy02w30159vsq9d78dkqf5c2yjqn8zzwf98";
+    sha256 = "0l1lw3y5w4s6qfkmclzc6h6hqwxqmxlppnwsq1zpm2hmrndy440j";
   };
 
-  vendorSha256 = "11zi7a4mqi80m5z4zcrc6wnzhgk6xnmzisrk2v4vpmfp33s732lz";
+  vendorSha256 = "0i0qdfh6cjdjg2mrrabm42427aaxs6a90ydb554ds14k6r4jdf8b";
 
   postPatch = ''
     substituteInPlace pkg/cmd/grafana-server/main.go \


### PR DESCRIPTION
###### Motivation for this change
Two patch releases with mostly bug fixes and some enhancements:
https://github.com/grafana/grafana/releases/tag/v7.1.4
https://github.com/grafana/grafana/releases/tag/v7.1.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).