### PR TITLE
haskellPackages.autoapply: fix build 

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1444,6 +1444,12 @@ self: super: {
   # So let's not go there any just disable the tests altogether.
   hspec-core = dontCheck super.hspec-core;
 
+  # Missing a file required for tests in 0.4, fixed in 0.4.1
+  # Also use correct dependency
+  autoapply = dontCheck (super.autoapply.override {
+    th-desugar = self.th-desugar_1_11;
+  });
+
   # INSERT NEW OVERRIDES ABOVE THIS LINE
 
 } // (let


### PR DESCRIPTION
###### Motivation for this change

haskellPackages.autoapply: fix build

- Don't run broken tests
- Depend on correct version of th-desugar

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).