### PR TITLE
thunderbird, thunderbird-bin: 78.1.1 -> 78.2.1, 68.11.0 -> 68.12.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/68_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/68_sources.nix
@@ -1,615 +1,615 @@
 {
-  version = "68.11.0";
+  version = "68.12.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ar/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/ar/thunderbird-68.12.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "878336931005573f76fb15c25fcf2593bfabde16356ec6b1f9b8913663b5fcaa";
+      sha256 = "70cfb9e6a7a1f285f37a8f13c9a010237e6aabf815b77a12f54ee0deedd36400";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ast/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/ast/thunderbird-68.12.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "5e3f29fb47ccb059d983946d6efec14b8ab00695fdd84a5cc7baa0cc40657cc5";
+      sha256 = "5645657f20d37ffdb11f383f164f03c66ed2024244849b09bfa60075d5d07490";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/be/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/be/thunderbird-68.12.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "5cd4c3a3d6ac865b727b58cbb51def60779c0d731a9f6b8f01d4b8cdc90d42b5";
+      sha256 = "d38cdcc2ba4534c23a1bb42b93f271623c497f48e1d255a23bf12a368ff339bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/bg/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/bg/thunderbird-68.12.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "f359cf1bd12f14bd6636fdb0bd885ed829235559c20c86bd361668f057039f34";
+      sha256 = "c8883242683dec57f9db502d96d2036ec46753f474a33c0f1ae31f97f2c3113c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/br/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/br/thunderbird-68.12.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "6cfc9608b392b1e604eaefda5a5dcdc346bd88a1bc411532e8864a04631cf6f8";
+      sha256 = "cfb669e2378f97689a14f23e2c55ef4987e2508695eb195be3af75ed1d648345";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ca/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/ca/thunderbird-68.12.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "9068b49e2d8a6f5e82b70ddda1b0a048d094328c96cf21848eefa431d358e6ca";
+      sha256 = "9ae4b43e0d5d9edd83291f0be7d53d07e5c84f1d0ad4348654136543b7b53a54";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/cak/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/cak/thunderbird-68.12.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "b3aef7c88302e2b9d0fcff8daa0d8ad4e2893d41e54ec29b746e79d5b03128b2";
+      sha256 = "d6d635a15b913679ed943c3501dd03140d099ff36b48c8731a47eacda1b5232b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/cs/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/cs/thunderbird-68.12.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "a2338c8ac38a4cef41d8fab1e7857c290afa30af0b131a31e675368944d69ba9";
+      sha256 = "616fbf24e36d63ce3cbc957d69b8972d517524c613a22bedcf5b57534f9a9a41";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/cy/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/cy/thunderbird-68.12.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "b02118f945ee76653df0364da6b2b8c597fff2bf52f4e20b64f2b8ac69aaf60a";
+      sha256 = "548c51228d2f3003bb94e1bee91cea0d2edb95bd0f86ee4259c8daef90a2dca8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/da/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/da/thunderbird-68.12.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "a565beeaf67c01edf83a2478732fa9e245645d6e6b4fb566affe552762b8bc86";
+      sha256 = "ad0e4b7a693d881b8875a5b8cc3e607a3883df759278129f0933522b9a6acd24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/de/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/de/thunderbird-68.12.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "00a8f51254b2152ba37d964bfaca77cc06b9d778ef750eb6500e01510e298fb4";
+      sha256 = "bf9b70b345ffe5df03365d819c5abc3339ed3af4d8a716cdfe7099134864a9b4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/dsb/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/dsb/thunderbird-68.12.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "7cfcafbf7f46a4be23003a59390b0404d04ee344c883c29a18f42accb5fddc4c";
+      sha256 = "a2cd7ffb0e8b4c3d1715c18e636d0dcd5efa245200d6d0f14048fc4b399b8121";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/el/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/el/thunderbird-68.12.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "b0d0865f8b64de26af8eeff6eb84f159f585e3f9f7590dab413e04167215dcf3";
+      sha256 = "07836ce122936848e26cd5a1522967760bee67654582076c53e4ec183cc4c40e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/en-GB/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/en-GB/thunderbird-68.12.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "eb6731a9baaa1cd99584aec7c6dcce8f819d41106ac6ed4f42f02f747cb2afe4";
+      sha256 = "c89fa35af79eca3cc26b492c602a3f8af0dbaf6ce4ee3af93d93f10daf4e9d6e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/en-US/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/en-US/thunderbird-68.12.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "6ddd72732957282280a7209f2d5137229ca8af4ad7f02e112187fe333cc79a7f";
+      sha256 = "6eeea0de838909f91da7270e42ae1513d2b801f412fc758f2f8c682d260a7c24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/es-AR/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/es-AR/thunderbird-68.12.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "0d620d929ed41ffd16cfd8297ec70e8cb9105e726af99d2cd207de50920a1f93";
+      sha256 = "e9d84032a91f7feb2db3d22a500c564f273c2b637f97aaab2edf3209b93dda1d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/es-ES/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/es-ES/thunderbird-68.12.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "28bac94492c7444caab029f3cc3995275000496aab854f20368f941514cd7b11";
+      sha256 = "a986e8a48b59354421193f2dd01e3c291fb6c98031af43531e723dc217a43d4a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/et/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/et/thunderbird-68.12.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "49fe0adb4fc5c5135083ba53369030faa95d3a530e8eb49180f81e359229bf81";
+      sha256 = "2f7508e83aba4fd64a817c7eb4b44d4ea9371956339a009ba541bf3a349693cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/eu/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/eu/thunderbird-68.12.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "a422935f96d5a3033c6c2a7bd39f19e3f84211d99b57d3996b31e404414703e4";
+      sha256 = "edbc5ff4ba45106233cdbf5255405c4ee52ba7e6811736958323a616881b943f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/fi/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/fi/thunderbird-68.12.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "649c3908ecccc8466e555aa76aac47bf7153da8b6f45ddf83f36f6ac676cb4c3";
+      sha256 = "f4ad740a724efdbfec54445304ca75e9a16e0881bc18789b8ea35632d8857d4b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/fr/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/fr/thunderbird-68.12.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "8270cf0e0acfb7280b8616462cd87a1d8d929c7c5fd4839f9607cb588a97c025";
+      sha256 = "ebf60a227c9fe5237eff22fb81f3c8bc02a593de823d6f0ad9b67f07af129dea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/fy-NL/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/fy-NL/thunderbird-68.12.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "177a9f337719b2902ae964525803cd437b2cbcc8c7b85c7881e14f7e0d207875";
+      sha256 = "b12983077a62c5bf7353f50dd951348a457ce07f5beb2a579f199c4d77ed0906";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ga-IE/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/ga-IE/thunderbird-68.12.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "80d3625a04d027382ec3fdfdabd45d501fa4b451c82ec5cfdf5c3352a395a6ba";
+      sha256 = "aa7c3a4b54fd6fef0f120a6748c45a3f379268f31e087cb3df07d270bf060bad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/gd/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/gd/thunderbird-68.12.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "0b2fc2582ef518529f204b5096601047b5b3406201b1fc9f7ea88736d1ce1e0a";
+      sha256 = "39fadb2bd4c01da0eb188cb9f52ccd726ec9f7eb5ced44e2a30ee0cfac2527bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/gl/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/gl/thunderbird-68.12.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "d1cfc4e646fa6ce03765a56ea4cc2ad3936ec8224f1a7f5e74a34c189be11721";
+      sha256 = "b4ee1f89b0326b22fc7a5b980b857c2652d6881d096060a8bc083015b47762d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/he/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/he/thunderbird-68.12.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "588f22ff9dd4dea7c808c4786f2c897842dedbf2a04c0b4d28b3aa162f88773c";
+      sha256 = "cefbc742672942e310dc9f4dbcefc8b66cf01d58ac64448ac8c0dc33fdace5ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/hr/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/hr/thunderbird-68.12.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "126ae387a1c97d253c4ca60441a192d6a00f63f0483b2888371624337e4fd2a9";
+      sha256 = "9e132811cb6bd98faee86e298b78e845727bfded84c0cdab41608ed1565f1aee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/hsb/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/hsb/thunderbird-68.12.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "456c323f61f77c07ae73a260a3ad2641190f165d14c75da1dba33ed1f8d2a3d5";
+      sha256 = "2a41d1e188fd5fed93a37a1bedc67cb745367447504a76836f79928194730d3b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/hu/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/hu/thunderbird-68.12.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "4790f014d95fe3ae00433e27fa291f7e4657b8062538ca52c46dd46ea41a05cb";
+      sha256 = "9196df7850b9cff69f52b5db69ec3b64cfa312bba5669380c137b95a8140cf39";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/hy-AM/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/hy-AM/thunderbird-68.12.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "7d81493a67e27eb485c1cb702cb8305788733e133bcb22659026737cc2afe1e9";
+      sha256 = "4a08137a9a714677ecf86a24f165047b809e22eff50d196b92c153e59f943c30";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/id/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/id/thunderbird-68.12.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "9f558c85ba88c6350da0445ca2d2b63205c8c1e6700388e1d4f7de0978321667";
+      sha256 = "39784aab0bc3253af47cdcd95824eccdecae4dac819bacf6a04daa7b5c86d6e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/is/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/is/thunderbird-68.12.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "1f1f65bb573fb4fb563e890c043ff8c3283687575892853dd3e076473072b63f";
+      sha256 = "a041d1af23e9c64967e4d014b6a84ddc80ad24e852146e448f6b380cdd672e67";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/it/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/it/thunderbird-68.12.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "de6c3adf83745370241c8935edccc412a60642ec758bd891d03c098b40b8792f";
+      sha256 = "b0e3161c801fbaee2f589b1bc61a4fba9968f5f363a62cf0f8af855d23e4782c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ja/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/ja/thunderbird-68.12.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "8b2ce4598af7323f59a31269c24bd05e369d9898266dc6e8cfa360dae7609273";
+      sha256 = "ad416d47930d81be9ac2f20b3699f4c74471c36e08b14f9d5c6ee1af97c7c9d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ka/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/ka/thunderbird-68.12.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "be74a3edf9a1d931124c4351b51147be2e7a74f453d07482bce4f7721de701ce";
+      sha256 = "3b30bc5f0971310d71e1909b4ed891481457ac8baf11c1e505c3400b2a7cfb63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/kab/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/kab/thunderbird-68.12.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "1be81ab7bb429b44e0c63c81ebf249b66a79d43a3dba39ba0af6242db165d6d3";
+      sha256 = "abdc58d5d5ef251e63c0c40a48460f90e299a4420cbe4e290d519fbed4c335b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/kk/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/kk/thunderbird-68.12.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "ee308381b1e0643b7e0683c365c763beb4afcaf21c9b0a1e8c8c2ec3c218c965";
+      sha256 = "08018b951de59b1a92717fc82bd98a0c324a019ee0ae14888f09c5351a586284";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ko/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/ko/thunderbird-68.12.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "af2d7ee49a6295e41dbfcc7b8e19b8f146890f12baa36ffddbc7dfbfa39a8eb3";
+      sha256 = "1178adc42b3a2ddac46dd50ad8436d1be50db409963e8fac3beb22a431f885fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/lt/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/lt/thunderbird-68.12.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "8d384844274d048772fbc35da75f91ab6398ca64e26f089c4da116065584acf1";
+      sha256 = "18d88a8cbb24d2a78af0de282187a743e707136fdb61912e5f64bf75730e3a76";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ms/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/ms/thunderbird-68.12.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "6e447b3ed1903a20001963021598d957270c88980ff04d3da6c819ab106a2210";
+      sha256 = "e1754cfbf20e286fd6304b8d75337e3794893c5ebd9b242cf624090e6fc6e9ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/nb-NO/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/nb-NO/thunderbird-68.12.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "710a982216120cbec822d7a9f74d8ae789b4a234fb3a192797604c9a47a23a62";
+      sha256 = "6379f6dca3d8bacb466044f0a7d11b32eb61166d3f14c37431f77843eb884c90";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/nl/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/nl/thunderbird-68.12.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "2b02b7e3b5e310e5b7935cb72e59d6a385567100d22e87d196c4b4700851d439";
+      sha256 = "66a56e218365bb260980848427609d390674e2ba3c70b9adc4121f73c861d9b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/nn-NO/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/nn-NO/thunderbird-68.12.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "128807f651cc0b09618bad42703970c391c17f5ff883c3ab11d115d0878fe1aa";
+      sha256 = "ccdb135d43f5542151fe2c99a8e13cebfbc032367abb0308213433b753dc8125";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/pl/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/pl/thunderbird-68.12.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "181721ac04e9911f57ec7b4f36a5db82e261da71a310dc502efab75a101bec03";
+      sha256 = "5dc2151d1bb956c4b6fbd1b6185d9328f7091e60fdcd51bad5a9ebaa8fcbb7d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/pt-BR/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/pt-BR/thunderbird-68.12.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "e82f40343e28ecd0abafb71f421c6d7df40b7cfca4898503b32fb0500686d7c4";
+      sha256 = "5ebf77d47bf45b058aaeca857060c908dbf7036bae2c2c5812ff145aed840203";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/pt-PT/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/pt-PT/thunderbird-68.12.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "96bea893919ff89441dd47e027a7d83aa691cc99abf4eaa342c941777ecf319a";
+      sha256 = "73baa68f79b4a15795fc426dfc9a8d573a05e4ab8a663d122cfd802f93941825";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/rm/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/rm/thunderbird-68.12.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "544f666af94043737503a30551ad5832f22ae529bc32495bef9d7443c8869072";
+      sha256 = "29f8ba57d9000803bae795c2ff977347af9a1f0df123337eaab3bdcc20786734";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ro/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/ro/thunderbird-68.12.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "4c6e7793c206999e0a9510b390e4b47d82e19dc2da1cae8b4341b8afee440191";
+      sha256 = "b8233ad81c6620c26a02457b9235ce0be0c5d93b81f88d9ddc84bc12f869dbad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/ru/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/ru/thunderbird-68.12.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "66e951339323a3a44326cada8c572d7040d33057a3a487d8078eb27efa791eb8";
+      sha256 = "f959f786dbbb7d06cb33eca24efd9e2763c5ca73fc4ba47e9b933b6298d7f026";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/si/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/si/thunderbird-68.12.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "3ef89e462359d09d95216a132c462f0529948073a4f0aef6358362d0457e747e";
+      sha256 = "dcf59c0c1ea0acdcc894463b04c54339a72dcceb25fe5478608265eb3ead226a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/sk/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/sk/thunderbird-68.12.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "476641e4d45cd114dca94f59ddee15fda5fbd432c50e4f29af09eb3298782854";
+      sha256 = "2a06329fd4a9dd6333e2d73a44fca7eaf593032e8ace33736a03dbfffb2920a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/sl/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/sl/thunderbird-68.12.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "5e85ff37554f47f585a155db65ae9e782c8604fa44db8d0dc9c3e2741704909d";
+      sha256 = "f7bd3e3a407dbab07836342ff29fc143fe3904e7f878ea719522ade3fc4f6b84";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/sq/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/sq/thunderbird-68.12.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "fc4f839973d6986979089c1dcc1e9b219007c34ecd2d587538db706e4b01eccd";
+      sha256 = "0edc58751a6794494efab8b0a2ce852374a747ccb73b38455475f0099ea0f238";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/sr/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/sr/thunderbird-68.12.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "85a32f352d2b535366dd10a49116e65de4c8ec87886b37e34ac55082c4c310fd";
+      sha256 = "91ac5cc0646c062b00b3b064af53ba03c7e034b75afa13dca7586eb80578d377";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/sv-SE/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/sv-SE/thunderbird-68.12.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "19af3a847c9e28baed2db8f6b025dcfb0e688932b0483bae461c86861bfa67ea";
+      sha256 = "5aa21e4b78f4294835197f784a651f17453d83fce98e7140e49c6da117464fd9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/tr/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/tr/thunderbird-68.12.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "deea2513814df3e7a9004316dc50f6fa2bac46e0d9456cf124e33e6e03a9b4c8";
+      sha256 = "3ab2639dd126e3ed9b031fc10f4396c7d98ffa7b7ffca6a9b3f2f47590e3b83c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/uk/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/uk/thunderbird-68.12.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "22b34b43ccc74eb2dc565a0c63bde89ff0d22f710bd26868341be91f51489f94";
+      sha256 = "59be2ddc7c65405e0b3854c2a551dab73df9736842ee362b2a20dc9088242a96";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/uz/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/uz/thunderbird-68.12.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "26bb8336c617dc6fe485339b3c8da814f7aa0b46eb0a821db36309305ea87e58";
+      sha256 = "ae196683b283525511fbd2e3ad428339672f2f1339566a323e01f6f649d333c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/vi/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/vi/thunderbird-68.12.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "88705691ae084991c198865f1e93d1ed127496245313cb8f28dafac0a64793a5";
+      sha256 = "9d66b8e4eefbb6b8c0d9893b056fc684310ae583921d626cb676cd8a7b4b39de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/zh-CN/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/zh-CN/thunderbird-68.12.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "5ebf1ad54acb6d6d17985d80bff9a0b39726d1f62eea30ad9ca0f04577f640a1";
+      sha256 = "2839f2f076a8a6e283a3ffdd6100986a11d19b9108fce074f8e7f127cb0f375e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-x86_64/zh-TW/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-x86_64/zh-TW/thunderbird-68.12.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "b795b0127cf922f65a2ad2d8f17ebe64089c6d06fe7a701c289b7af5afe7c371";
+      sha256 = "02ef645a7de8abc1c5dd92eb685d64570cf1db971cfe7e248111d6a17b3ddcd9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ar/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/ar/thunderbird-68.12.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "d19d082b55d76862977b9357e9cf245697c24d207a6d6b3aacd81abf1443747b";
+      sha256 = "5c4d899245a38626fa18d849bcf01d50125dee60d715d76224ca0bb4623f73be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ast/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/ast/thunderbird-68.12.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "6cd6c484888fe96fb08eab2b6b2a4dc8495823efee6a373536c26e9679fc664e";
+      sha256 = "f657bdc5b43b75e43578251abccf5c7b9e6d0848fd55c6105060daba33c36721";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/be/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/be/thunderbird-68.12.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "bdd2ac4571d6444ff9a3ffd72c1b55cf5f564c740b5ceafce7a2e2268f482dda";
+      sha256 = "669a2cbfe600727b9d9a8ed5046272a1f19b80b6af9a6a6977ce1b89f60fa36e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/bg/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/bg/thunderbird-68.12.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "3354c7e4b505e99a53a10cdbeac5b6425b13182def27a82c839eaee6ba6e2f86";
+      sha256 = "e1b33857544c10c0191316f6e3d16b34957196b35a922c884315714fe851389b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/br/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/br/thunderbird-68.12.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "27339c12c5cdabea7a9a057cad70fa02cf4f69860e71b604f81a60f891345268";
+      sha256 = "b9e4a530529449446fe5a302277878c4d2192ef7bb48206f8528024087f520ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ca/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/ca/thunderbird-68.12.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "b65b6d20d7251795e0a9f0ce88f8133d7742c6361375e4897a0bb2e043dd8c97";
+      sha256 = "aa5e4ae20fa9e5dbb8c0ba275ba18d1ba94900094ba3186aac40ffb27396a96f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/cak/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/cak/thunderbird-68.12.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "173a85565dfb7b9d44b5757245f8b5f8a62fd15a8a15bfee0680a96ef8f84625";
+      sha256 = "a812c9150feec48e2ebfb1786f5e30ade33203160fa4102382435641caeaf3b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/cs/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/cs/thunderbird-68.12.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "9cb5def4eca0bb103516a66f90baf91f7b4e962d5ed59b4f09ae9f19e7f95b47";
+      sha256 = "75813ad7dd0ae5c073964296dd687e5c1289178491adc98d40e853ed812bdca9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/cy/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/cy/thunderbird-68.12.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "8b51e01daf38091d3b1b32a249f3c6fb220ad8075bbfd16914cb72b24435d8bb";
+      sha256 = "b3894f05cf905aa96612860dcef0bdb4bb9564901ef84172e11856a9fa9e0ca4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/da/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/da/thunderbird-68.12.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "1269600ab71c691563482c6d5787a7670fdceeda3a07c61d7cf2477aa16fe075";
+      sha256 = "a4f21bd2017043872a962167f98db358b824ae1821fcf03e2df1bef7783e07c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/de/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/de/thunderbird-68.12.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "46c5fcae1b11b7e31fff2e70397a560c502bb3360ed646dd09945fcee81efad7";
+      sha256 = "3a079685f75d2ec0320ec9e366b4e037954d67fa3f9e3bda055b8cd7de8fbdd0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/dsb/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/dsb/thunderbird-68.12.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "4dc661243d99edb84d0bafd45300bf18d86d5289ede3db066ff89cc4094afed1";
+      sha256 = "295a0f56429b3638dd0dcbf8d97a6376636b67e22d493ce8dfaceeb579466d18";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/el/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/el/thunderbird-68.12.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "efd5f7f46d53bf34146a6f39149abb2aed9c47b735339cf767e32e6387ba50bb";
+      sha256 = "86e4b98ede80cc07cc1aec043af82068a73b7c76820f70df8314e3b91c108d18";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/en-GB/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/en-GB/thunderbird-68.12.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "ce97a84ba103a7e5bedba43ee47a5c603c1b5d9bf3bc1a8cab4c26ec9ace21c7";
+      sha256 = "2cb03a17f88e3826181911ec6a7455528d1e4c051b065252c964c6c0794175e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/en-US/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/en-US/thunderbird-68.12.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "632f078407322995eef93db134f1da753a1b35696a668a5b8be29f908a34c223";
+      sha256 = "11fe953ede0d99656534ac676f118e939024744c5301d378acbeac6792e668e5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/es-AR/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/es-AR/thunderbird-68.12.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "88b67f07b6069adcb82c04f818493e25bd145b5d874a7503453e88ea14200499";
+      sha256 = "596264396a25adb873320222697e7f1a58aaab484de9c0d2e85f99962b6d893d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/es-ES/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/es-ES/thunderbird-68.12.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "a52a6917d77364e5f7ed06f4484abf7e607c53445ff338e65af6b9bad4626e0d";
+      sha256 = "a9512af30e2b1613a6bd1ae6f4ce785f676b2cf70b80a37d85a5e1566bb2b35f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/et/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/et/thunderbird-68.12.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "a0c15f0000a00984760419e6f737840b4637bf5aa014ee88093aa2a7a3258807";
+      sha256 = "b7dcb196881a23e979edb5ae247a7c07b1cf1250cb4c159ce523d1a26be188c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/eu/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/eu/thunderbird-68.12.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "d69e9af1a381743acc9ee1f800999b015129cba4fc112f312a04884c121535b0";
+      sha256 = "4066164b4c9242a9885bc2de802c4f5b6b594c928db36ac72c94faabaad86679";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/fi/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/fi/thunderbird-68.12.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "876673de48a047d75e0ac766dca338629069af1872308a7bc6a7e068da026d3a";
+      sha256 = "a7c635cbbbc10725b28052ccc61603fb60b91e06bbf1f240561bdb8f941af55a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/fr/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/fr/thunderbird-68.12.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "d83d87dca716d4cd3850df1c5923e88f15e35354abc874202c8c12bf8d1a006f";
+      sha256 = "7dba28adb1287e1aa9ae85840fc3aca42aaedd4b2c2aa6cc68d5f793549d19b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/fy-NL/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/fy-NL/thunderbird-68.12.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "0cce3392aaace190f9ea0247d89699f73d534762278f4776146a1f75bbc09996";
+      sha256 = "bd763e264eb684ec3b0b1f2c68ce295d1df86994d15f5c66c487e4742bfef86e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ga-IE/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/ga-IE/thunderbird-68.12.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "83b7e660e8098718bd4b205ad2de53522bd94e7a602afb960b6381fe4c11a395";
+      sha256 = "52f9b5694efbdd8ecc76aef58695423c6a4b547b5b0cfedca313386b7500685e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/gd/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/gd/thunderbird-68.12.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "447a887ef76e57b9c12a0991d7eaf903ce29d7621d4f9143edd18b56bdab81d3";
+      sha256 = "6c9c1b0f11ad13e0780371d54fedb52d2463713db3bc52adb72c8ea9ff80eb8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/gl/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/gl/thunderbird-68.12.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "288b865596e2b8b1087cbca98bd9c55f9aff1f1cb8d432953d20854b0b1e9ab8";
+      sha256 = "608bf5c0d6148cc3014758829ba06135222b462242456ca0984e7dc12654c2cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/he/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/he/thunderbird-68.12.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "9d801a18324849e4a6faf3266c09eb5898c8122e89b020e35ea25a6b3899a4d2";
+      sha256 = "f92d569a53f34bfdda4dac185834e5692526f13f20853d1943f165af33b54a37";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/hr/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/hr/thunderbird-68.12.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "f20210372b36b43cdae8f7f1294927dfb364d1ca4db21ee8af1c059a06f3e45e";
+      sha256 = "60d2f184219f8d17c2739ee3cc8463bed474142bd2caad74157b97db2306b27f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/hsb/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/hsb/thunderbird-68.12.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "54daf67c97f2e7496fabe6bef2d1d9a60baccfee35d7331444d48fc6fe675c26";
+      sha256 = "40ffece26101b2f6a7789511b026d99234bd34ec78e566e7e25065ae3201d693";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/hu/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/hu/thunderbird-68.12.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "0791aa7bec49ff1bfe862f9114ed4b0013361f2f1fa0e4745ad49c8c0e0a9f84";
+      sha256 = "e74da0bdb27fe3375dfbd1ab042892de3ded84f33a6f6d46e209fdcaa28183d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/hy-AM/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/hy-AM/thunderbird-68.12.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "e64bacff30d0b2b2a5038aa11d719c9ef3124d64b9923d52a9c5856f6584f9c2";
+      sha256 = "fd93972c11842b56453449e72617deb3177d020c8f25cf4d5fb687f4a3ddb5c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/id/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/id/thunderbird-68.12.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "ba6108ba9b4f31f49e7c925a6051738276c67545f7f8d2b3cb378e8834dbd0ce";
+      sha256 = "546825968ad86e4c5c6effefd0f924cc1d10489fff7968f17401e3f84c4d1ab0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/is/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/is/thunderbird-68.12.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "a3eac36b640a61f2fc6bd62350bd8aaf020636035547c2b9d687df2bd2d7174b";
+      sha256 = "1f2e2228c685be2d65d6e0b92eef8ff3e58d7b772f846d0707a9b02e6d0ad306";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/it/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/it/thunderbird-68.12.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "bf3cc19a7d1c1415cad867b72c5765dfced27511616a8cbd230516adf8d3f20a";
+      sha256 = "41b27c8195432e1412e3c4645b823b8dd1f673eabf07ddc72f3d792d3f7488da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ja/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/ja/thunderbird-68.12.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "d4788294f5e91c033c3c3251cfb614e50843631252a2b1fcc6389d099b1fee1e";
+      sha256 = "68940d44d933bb7228d6f9a03406ca01903c54fdf57eb5a1e1033b12ef507df6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ka/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/ka/thunderbird-68.12.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "8735be035cf0ab5d4b2102aab8b207c1cc686da8843b45f15c1be91931850968";
+      sha256 = "ce0aff0fd47b00803ea66278b3514dcf65ecb5547878f8081f7ec6c1f411ce10";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/kab/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/kab/thunderbird-68.12.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "a570fd29e5eacdc08ed484bce7336f90ae74744e80d8f2ac0f05395cb3363e51";
+      sha256 = "3936b56eaa1e05a96626f7d10c8fcc3ba9014b1385b21243c049b133b923ddef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/kk/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/kk/thunderbird-68.12.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "186b7457a96a64da0564c1b411bb04598de1067362a6238f7327abe780cc6aa3";
+      sha256 = "7fa0aa64d0f0dcc6f71d6a21647cc4fccef935b783deb5d19b88f5b96b4b4ec4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ko/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/ko/thunderbird-68.12.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "3c9513362c6b7a64bf6e74bbfad6ef586b0085baeb9a8ad8eb2fbc73461e9f67";
+      sha256 = "4bddd0ccb747bb12cdc6d88c2c9544354293000c586454bb5932f4d81afbf400";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/lt/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/lt/thunderbird-68.12.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "e90df1606ec0e875fa02f7bf5a52b14d84f758bdc18ab0f395703c0129a18e57";
+      sha256 = "f1a3514188c1b887afd2c662a1b6abf6fe37b558864be0cc79e87ed147188461";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ms/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/ms/thunderbird-68.12.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "ea686adcfb5cf4b1642e7dcb21053090ffb57d344b27269d807cebcf8469934c";
+      sha256 = "7ea045d6db78ec7d6ebf164c8e3d28c2540a573238de518e934646573aec71dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/nb-NO/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/nb-NO/thunderbird-68.12.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "6f827fee307917b590b99b5c85b16337865f027059f52bc9ab12da33f80448b9";
+      sha256 = "d2c0e2099ea60b9da95ebd9bd79a5d0a6a1ebc84b8b490511a68c81355f97761";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/nl/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/nl/thunderbird-68.12.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "b88843831b982d1317e8bf64df99a8c7a1fa9f67461aa966b2737f12715c9cf3";
+      sha256 = "48741be79422d80140ec862d004fa75a407f67490f67a3e440c01e0defe1f85f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/nn-NO/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/nn-NO/thunderbird-68.12.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "ab8383a432f55944d417108b59d891953f2d322ec81d09e971ec63d1883d4b46";
+      sha256 = "b40f0d7112cadab322c8b71cacce5d6df87fb80f40cc55ca22c279016c3ea805";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/pl/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/pl/thunderbird-68.12.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "0f8c0feb68b090598a3db9295d4b4e09d9ffdedb69a73914228d7ef76b768414";
+      sha256 = "e64b10526cb460f437427cc4a7ea90959cc693a75fd6a61b43e9d3fd76ded618";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/pt-BR/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/pt-BR/thunderbird-68.12.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "ca78fad9dce15534754571b14d82ede798b123210599ade352016420faf0db5a";
+      sha256 = "bdb558f9430c06871954ec6c7d54267625184a0cba914a87ad199e8f32b03de2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/pt-PT/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/pt-PT/thunderbird-68.12.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "cf79430e02259d9117feeaebb5fe02139c3e3d95013e48fe290550814200cf6e";
+      sha256 = "4631e8247446653e91f239fdb5ad3c8531f3d007dbdc83818178a4cdc525edf4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/rm/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/rm/thunderbird-68.12.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "cc7d9614130f24969356b3496f4d322a9f73cafa5c7b60302ca8f2e2efe1f6ec";
+      sha256 = "13e6aca7139fd89e83e7ae9b71253731f0954b0a83cc3560ecc00500b9bc1df7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ro/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/ro/thunderbird-68.12.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "a8fcc2c6e0755fe701a56c2fa3bbf2d288d6351179ee74b8aa3da3180f14cdd1";
+      sha256 = "023a567c42dad9bdbd465c8b99f12cf5f667ef4691e16971e09496c4a7db0f12";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/ru/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/ru/thunderbird-68.12.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "b9f68985e70f8aa47c36cd4a4fc0fb41918d43f089cc760ace8ec879e2561770";
+      sha256 = "9ec35bbce5f026a4262a5d708b53a767f47ac8e90314513d36a587d1a49dbb6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/si/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/si/thunderbird-68.12.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "a2563b3c9d0ecb567c366aa41cb6a10bde8d09b8c1065cd3934c8c221afee056";
+      sha256 = "c540b94a45deeddf1f7f5a8cca8de7e944ee8ad9f8595a308836c159901ec0b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/sk/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/sk/thunderbird-68.12.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "566906f011283fd27abf55e1e9a1bf7504e4028f7c4a631716ba590c07fe9d91";
+      sha256 = "5296241664023773d2c0c4fa55e74eb6470482389c834d1934c252f79e79ebff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/sl/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/sl/thunderbird-68.12.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "8b74b751b3ee706be9aeb06726ffd3a989a57a1dc9794112262fa2aac45498ad";
+      sha256 = "cd0376137d8018875873332fdfae3bc3c0d6b2a2b881dfa970d7d7999e8b312b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/sq/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/sq/thunderbird-68.12.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "9f7bcc51d4bb3f7c8d6ae49c61b88c17a7a59f6de8d2f62e0ee3fb3a68d30791";
+      sha256 = "6fbf47759ca8c4d7cf30ca3af8a3fd35a01b7738422d29448cfd9eed81eba49b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/sr/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/sr/thunderbird-68.12.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "809c22c379c0c9943acb23de8b7023843ad6ecfedb9cf89006d6889ac1214203";
+      sha256 = "636708320247c7c45622fd9179d5689da97472a9308f11810623129cf5a0e8d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/sv-SE/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/sv-SE/thunderbird-68.12.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "9381345ab9229f4b8465c183c936c17ab73680fa6aca27535daff9a2f9a133a3";
+      sha256 = "9550c173b047e3ff774f4c3faf2c1f125b3abc34e6feb5801c108fda94e54e4e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/tr/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/tr/thunderbird-68.12.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "0f08bc1e65a8bccf8765cf26af5c09ebf6b77ff463af2f8f133dd2499c1d935c";
+      sha256 = "ffe82a300c7fa7a0e826d11613f5187c003b009efa29f4755f17af0f88d9e73b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/uk/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/uk/thunderbird-68.12.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "37a1fee3bcf2fca901c542295d01a32545e814217985414419a270ad9576c14c";
+      sha256 = "b018769149c0a4ff323b90b5d51465733629e7c527b39381ba9696cb077ad767";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/uz/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/uz/thunderbird-68.12.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "50668670b10f3171b9033306d43c51ce24f1a48286c4156eff369530ae6d93d1";
+      sha256 = "b0b59ac4d08c9f385f4ed7980065ce99ef24874734390a83af6e8fbd18173d99";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/vi/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/vi/thunderbird-68.12.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "3588d2ed7c67459f5c091a1881821eaba72c9f3307624f7890549fcd1da120f6";
+      sha256 = "901b40a99d84e7c7360fd5be6a14aa04ef6cc04fe1275cac26824b310bbd26e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/zh-CN/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/zh-CN/thunderbird-68.12.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "d8f2976535ef60e62c94338fd049365234a7b2a8658b32df231d1faa22529c0e";
+      sha256 = "509478710f7c4fb404eec9fed0b6d22f4c5d76fee09ed833dffcefdacc53d55c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.11.0/linux-i686/zh-TW/thunderbird-68.11.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.12.0/linux-i686/zh-TW/thunderbird-68.12.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "aca4a8410429bde9926f6ce6a183439750f490fd68dda229531b2e16bb7068ef";
+      sha256 = "a12dd777cc3eaf629cc7a6f4b8d4744cf63c3e778e559d9b3ce332414e509515";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.2.0";
+  version = "78.2.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/af/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/af/thunderbird-78.2.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "d64e507c291a93c5f3977e34d991bea4d39d7b2a6e438d2780c4f71dd18b6714";
+      sha256 = "de73b113e488e76caca47b90abb4fa3f1c4d6ce04885d036f2e6aed81fe34038";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ar/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ar/thunderbird-78.2.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "ef340fc26d314511325f830c935b3564bab4367b4f17b734a04d257d8927b86d";
+      sha256 = "d6eeb95b1bd8e53663bd48570a0c2a03f570f906ca715ddf1d9f2cb8de37f3b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ast/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ast/thunderbird-78.2.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "39d4d8a671ebdf6584b7cfcc1e0979c1396d30d7952293db8b481b90e4fa4571";
+      sha256 = "f244c41515a2382d15697a47b88781120c649e319d86a1c6350fd20cade25809";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/be/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/be/thunderbird-78.2.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "804bbba47279445ae4c5ba82a540b6d0ef2e6a641de47e8dd37cf4e2e13bd86e";
+      sha256 = "188c8850324bbc04535d4a1dfe1ef1f2e52de8cc2e1df7432623f6afcf8dbf1f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/bg/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/bg/thunderbird-78.2.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "d1f5e199a0b448ff6b7709dfabdf6f63c42a125e51109b21c0778f77cfbc6f9f";
+      sha256 = "3e7ab29fc795b577aa3bd2ac3df872c31a7ed22960e987d9bca6f348becb69a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/br/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/br/thunderbird-78.2.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "f3532117e7e646a74a6b169066e2685b1c372c5bcf3007238762496e1dceccde";
+      sha256 = "c1138c59275149aaa6071cf128e7b480b7f74fa0d8f237552a5c54ce1ae573e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ca/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ca/thunderbird-78.2.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "3403cfab8094a227869bff8f0ef9116ba6fc7d94a0e3312cdc8bb99bcbf185a4";
+      sha256 = "4d18b0b11710ab3427bf917ebe17cdf5e98508f517cf5cc4c97822d42a019dd1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/cak/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/cak/thunderbird-78.2.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "aada755ce418968578884a5b836f6e152d4581c8d010fc8bdaa9ba78c2226e0e";
+      sha256 = "5231c3b6c9b57ab528905184b740dd23de470f8bc4814a13000c8fc1fe4877cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/cs/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/cs/thunderbird-78.2.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "c0c9f22000d3dad94eee99832cd086630a0660fbbb1a4caa7a7e4307803d40dd";
+      sha256 = "04d1614000f1854b5d82e0d1740beb43ed9bef440b43f7bedce32cccec48fd59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/cy/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/cy/thunderbird-78.2.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "d25d743973288fcb492c8431658142f4762da2a1c894be7cb867aa190ea8e3a7";
+      sha256 = "0ef895fdc1878b77650846d2ea4624a50d06838a3c51a91523019bb4d00a1322";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/da/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/da/thunderbird-78.2.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "bb8ce50143d484fcf2eb7c15e7b0ca5474232a93a2a07ca04f7ef28b98c192bf";
+      sha256 = "e909f7ba1890cebcac435c2cfaab7db1791785e6b5b1e8b205ee3b9962624c8d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/de/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/de/thunderbird-78.2.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "97536ef763374e3fdaa2da1289931f876a721be3c95a495ef920b756a9d34706";
+      sha256 = "cce1e0acc3c61a66e5eaa065e81e01edb298b6dbf07a2376bf5a96ad2c1e784d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/dsb/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/dsb/thunderbird-78.2.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "9c88d5d07b39e0294fc5c90b4adc70b3919068d6ff157e3a35110afee9a4027a";
+      sha256 = "a5acad173a15e77e21057e7450d997387f88a608dd602df7509fa13743758445";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/el/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/el/thunderbird-78.2.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "075332016a50493ecb925402a5d09086b4bb39dd83aae449a48189bb35134757";
+      sha256 = "7cb4dd233037415d9de96e0c292bd0a288ea62bc875b79a138aaf9639a8f8896";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/en-CA/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/en-CA/thunderbird-78.2.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "2290544e6075721c62c2e0f6f39c77af8fd3f31862330d852e60a4c81c59ca8c";
+      sha256 = "158547432a7f38ab87ac5334b891921ef54f199896fe459cf65c81344d900edc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/en-GB/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/en-GB/thunderbird-78.2.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "e9d9337b4dd961c578ca29ef7774732872c32d1d13a75be1abaae810bd0fe8bd";
+      sha256 = "1f434d2aa74143eb8695fe54f031fdc7270b1dfe7365896b08f9a55c9dcc8197";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/en-US/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/en-US/thunderbird-78.2.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "77b24d9d4185491752d2ddb609aa2a80acbc71829f14e0a8e703f06d77805ee1";
+      sha256 = "f5004ba1ac64911aec7dec3ec60a415500adfb0bfd566197f0f4fb139c71ff2a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/es-AR/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/es-AR/thunderbird-78.2.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "176e9b9912ac423546d52ffef7c26eb2631da27efabacc8291ab1e0704a26793";
+      sha256 = "49063e6e19b9c4ee1cd63826fda1c969d9739759a57ffabba5e2f93fc11de06a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/es-ES/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/es-ES/thunderbird-78.2.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "040f8e3f21cad483406a826768bb3ab2ba7e9be332b9291510eeea5642ff518c";
+      sha256 = "216fe2514dc21190532b19af814b825d8a39c7dfe91a120848491f98c49f8ec4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/et/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/et/thunderbird-78.2.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "a495f15bd7bfde1594b0becc952e7c086d87ee8d8ceaff38ea5945d8cacc972d";
+      sha256 = "5a89262ffbdc536abf9d780d5d30ce7d0c626a4cf75bfe957689640f94323a34";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/eu/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/eu/thunderbird-78.2.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "5b53597ec6bdbf184d0feb182d6459719c159edd1143c68b95863444162b3484";
+      sha256 = "f59c050361c617e4b2ca92f8e7081a135e976bb99ea4b650b80064aedef2c698";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/fa/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/fa/thunderbird-78.2.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "cce6970ea1373b8dfa6f4b16a803c55aef6ad6a1752be62dfe73b1ec252d0017";
+      sha256 = "b9764595b4cb08584ccce801c08fa19dbbced21c3f89045800d83d531b0c825a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/fi/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/fi/thunderbird-78.2.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "6e7ce171900883e798bf66a6b48d37f359e45120fa36771b37137ef90a644d63";
+      sha256 = "98169b3018a61ae6c2303300c1942c7d1d14a5318147a08a883b5a7b7042eba6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/fr/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/fr/thunderbird-78.2.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "07b853c6758e991b1d0f021b6bc48b0e82741edbb107e2e517115675d9bba602";
+      sha256 = "49563e87d9543c52d33b7168c78adaab0483f14ceef22759541e927c13620657";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/fy-NL/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/fy-NL/thunderbird-78.2.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "d27a72ab1812e7d9d9bd9ac6dbc6982fb22b89982a58ec5b2b07a163bd72bc5e";
+      sha256 = "1f3444faf91c24f8608ec59a4f705b42c7520079e4ad6756e693e92cdc8b142d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ga-IE/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ga-IE/thunderbird-78.2.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "bf5ae7fce3c74421923baabb4a3391c0e5eff4f470029286e1868df631451396";
+      sha256 = "28b27f73016f0a4d53a6c47248c26458ca2bdceb46ae231f16086b8cabed5210";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/gd/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/gd/thunderbird-78.2.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "a433875241721d54f3c48c84a48cf786df5b757bfe4afd2053f2bca6f4a36e9d";
+      sha256 = "b81b247ebecd1727d27b64f96ba08b08cf59921e9b2e8ae732407b27e233c971";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/gl/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/gl/thunderbird-78.2.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "22a19264f09c2e184e4d0ced2a88b1feb83cf5f47ed71b7fdd88b0b42e17557c";
+      sha256 = "ea019d11fed7d87173b218d86fcee0dea7d4e20200bc73171fa8c1bc8f7288fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/he/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/he/thunderbird-78.2.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "0e8be83ba353088d3de57e7e075067ab11523678eedb61e5c9b8dbd4a93bae9c";
+      sha256 = "6308a7e4e2cc35e48bbd67a1a7b8ab37112f47ab228c703a6db681ac7af79cb6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/hr/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/hr/thunderbird-78.2.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "e9af05d2c0716c63f187022ffccfa413fc4c3ba938be62559f3243b3e3387239";
+      sha256 = "3fb27f1e001817260981567fdb9949ad2f34818e9c919bd16fa0e939cf993cb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/hsb/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/hsb/thunderbird-78.2.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "04aece2ac7ccabf025798016731ba610d5401361b403a6822b6770543670da51";
+      sha256 = "2240e34fd713b39b410b584a8a6d06525f6abe0db2ee7b76b740a7252ec85e36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/hu/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/hu/thunderbird-78.2.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "83163c8a1cc002d14e8198b6bb6a7fddd66fe8edaaa5abde0447d4c4ad55047a";
+      sha256 = "f303a1f1219c7b23d71471a00174e6084cee3773af72e855faa63a5384b08aee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/hy-AM/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/hy-AM/thunderbird-78.2.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "77f4d439957161cb13e8564ce2951a2102b7c1663c675068ed73e3809c04ddf0";
+      sha256 = "3e74775e459ebdca2661e2e2f55307429dcc4d4a6623bbb8447946a75c94dd20";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/id/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/id/thunderbird-78.2.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "d1530e24d70ca54121270468d699471d92d2cfba538c6a9083980d09c066aa32";
+      sha256 = "0c9baf8cff28193f774e13c3a49cfd0ebcf27d8ef73ade151d2371ea69cbafac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/is/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/is/thunderbird-78.2.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "e1b25920b7ec9353f1cbb511a635d57aa45e65707f1ba493d9c7af6c50e3a601";
+      sha256 = "5c505948333d9259d87aa5f2b53f33ade1bbbfd29b9d5438c2688d34891e29bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/it/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/it/thunderbird-78.2.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "38315dfe412c8b4460805210fcc6aabb859b20ffa41773c7a87634875016079c";
+      sha256 = "a99896e8ccf8d01099834ee502601cb9de993fd7101e426cb87c240a744f2f88";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ja/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ja/thunderbird-78.2.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "ffc20370c6252f80d8f191460d97249cce99667049a0a7610b01b16ad48f3af8";
+      sha256 = "83be10be5e946b785ac61e9a51c7054357c69af0a8e7bca524e27961dea4eef8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ka/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ka/thunderbird-78.2.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "4dc0ae26e215fccf6a0c3dc3d49544f960564ff9ae5b0f7054d0d7ba60c90d85";
+      sha256 = "585a1d805663225b1c154e27b54aa1aa5d8a1b96576c0f8ea36bde7844921474";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/kab/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/kab/thunderbird-78.2.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "e9666986e06d89e202dba5abff6722d11c0fbff3ebbe7a5664ae816c9e305304";
+      sha256 = "85128be7e4c28a526d0a395e38e86e5e85dc6c154be6b16fb2df6675effe3d0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/kk/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/kk/thunderbird-78.2.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "742be512385a5d9984ac8ccb96abb856cf7a25c0d8517996774726bb24f6c702";
+      sha256 = "09538c022bbcfcb2a77a7ab11b5569eb56b483817d199cfd0ede68ad556601d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ko/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ko/thunderbird-78.2.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "94f8833e2dfb8f905fe7b37da7f3f197620763f6944c565f547554a7d8756cb0";
+      sha256 = "3e6f472e69d40d46f388096e1d13bc6735860021fc655e3efd4e5b93b1a83240";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/lt/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/lt/thunderbird-78.2.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "9a9b49068639803973fe30f1a44bc2a17fe7b8583a549cf996b2deb0cd145a10";
+      sha256 = "8b85c0874306afd3a39d8cf851d378f5f1bfce74129b16b02230c516001adc92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ms/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ms/thunderbird-78.2.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "0fc01d5be421b36ecfc31ff818692edf44f29757c6e80789c64bdd5459f6b500";
+      sha256 = "b14e7baa06a2d4f98313a7f363b0d998f902164abad13a992878812cc5a0b6c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/nb-NO/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/nb-NO/thunderbird-78.2.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "88f3b13462488aba548f553d6d9e8025233e13f48c054c51f989de0d0ea3d02e";
+      sha256 = "c3718581db153ad8b171b3c454e9d156e3d55ff0969217ac36435d13ac0c7c3a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/nl/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/nl/thunderbird-78.2.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "8b7cb8152c995add11be80152031f5b50e0bc571cca0503536db630b8cbc8127";
+      sha256 = "802417acdc722e34c21936f840cd347ae86cf5ac8ad2ae05bd1e1ae078c4518c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/nn-NO/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/nn-NO/thunderbird-78.2.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "41c8ccaee5ead407b7ebbd73d12ae04188f5dbc8a97d20c20c21b4d688edc43f";
+      sha256 = "5034f1fe526cab8de8091d5f20851a678e742ed37fa80e8491f3891ed89c43a8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/pa-IN/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/pa-IN/thunderbird-78.2.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "77b6a9265c07834ed79ad68e44927eeaf52a64724b58c3067dd99aac36abdfcf";
+      sha256 = "01ae1e84d990433b7cbb12dc637deec37b32998803cb60f5834d386e080505f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/pl/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/pl/thunderbird-78.2.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "2f01c4b5c058fd56c52a32671e486d1ebc462a96aea5a27a2a0393bd3a34ed5b";
+      sha256 = "84b877dba77c8be4400f4fc76128a85878781c4d8ff7845d265225211092674e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/pt-BR/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/pt-BR/thunderbird-78.2.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "598dbdfdea842d607d65dde5d674634a03f152d5fcfed1891352356d1d61a80b";
+      sha256 = "4daabc0cad02b878d8e17af4402b6b52fdd7783f89192909a43bed09f8aae196";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/pt-PT/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/pt-PT/thunderbird-78.2.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "73a3dd9b640d23099561452d5fb5c639bc04b1d8a3b3b1091f922622ebeb559b";
+      sha256 = "6ce92a7a1ea62398d22ee4e4fbdc383daa5d35d38c83cf1852953757563d17ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/rm/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/rm/thunderbird-78.2.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "3a762d2f6b049778bf8372435210d27d98c1255fb14300bc297cb691e8524c49";
+      sha256 = "d876eb51534d8a5796b486f22f9602bcb9c4cd9c99042583f95c4464f7ee99f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ro/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ro/thunderbird-78.2.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "61cbf80023d54aa030ae309ba4a952afacfaae12baea7494802ec18d3950bed7";
+      sha256 = "ab4bfaea0914401188d486554963c9ab3014237e7116afdf274dce6e55725cae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ru/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ru/thunderbird-78.2.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "195cf37d9999c696976617a1281aa73f28e421513941639c5bed70e42a177a9d";
+      sha256 = "e722a13113896bde97dd72d0c7182c26734d7d546d8fe210bbce900854ac925c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/si/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/si/thunderbird-78.2.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "d6f4637d875be6aa2c2b3ba4a3948f61e39738b5a2d9a0ec1cd6158e0c4aae9b";
+      sha256 = "595588d25de16c3781c85a9ed5e3c767d4df85f0820d4503770468b1669e9411";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/sk/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/sk/thunderbird-78.2.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "499bdb9c2504a29e3990c0738090410afbaf016722b12169734564abae745aff";
+      sha256 = "f30929cad216539754842c0d938b4d5b8ec5f4e813b3ff0d5108d9c4a0fc6df2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/sl/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/sl/thunderbird-78.2.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "f8fa3dd94d63566e6e14cbb66b7f92e7e2591796f7c9900117b0a06880b8d0f4";
+      sha256 = "65d716b3fb5cad93d17704b62fd035a86ef6838cfff6ad95e571cedbb9e0974d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/sq/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/sq/thunderbird-78.2.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "1249f85fb8e30e7ff5ea9baf30c56b91d78d965038a7121f25f9e327ca4489c1";
+      sha256 = "38c652f6aae768ab7a8b0c1e975c676a3724ae22f5f7e3ffc6224ee032a9dc47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/sr/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/sr/thunderbird-78.2.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "6e5b30eb1b2df7dce4e366e246f28dbabb542af3b50e581b71a8cd7fb59656be";
+      sha256 = "7f73bcc8efb4452fedb0f9707c5e2b1d0db936fda4c6b9582207043aeddf8747";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/sv-SE/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/sv-SE/thunderbird-78.2.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "431da982c97b39e60605bc2a0b1d0cdc117c336451c9fae26f17e397e2088da0";
+      sha256 = "221974d62563b49f6c030b7a1f6307a71e60ce2a0e107b551363621320bba485";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/th/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/th/thunderbird-78.2.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "3d1f813e9363887a465e11a7729fb5f2d6204bc1d5fa3690c1301a83bb32b06c";
+      sha256 = "a8641ee0dc5bcd40ec84a4d4640e74e44710b5ac10d629ea0dd42ad2370e8d3b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/tr/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/tr/thunderbird-78.2.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "3e4edac805121565ae3e0c77e446028759d60402832f259b694df80e7f060172";
+      sha256 = "1d80d967b5ef98f0e642390c55618d454f2d82acec36bfd56db21e872490ff66";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/uk/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/uk/thunderbird-78.2.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "632dbf35842b208d65c0d4196ea21d18bad848a43c12d1f29b321bc9095ca3e2";
+      sha256 = "fcc24a9885db5511c0b2859e6472d436769da2670573177f7bf332fb363a3ee3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/uz/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/uz/thunderbird-78.2.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "93cee199f136c829276eb203312b658414726628a9501a916740e555549e4fd3";
+      sha256 = "b0f62e8fc5c6da398ad2e1a3488ddb37f0075c90ad54e6028293be7cfcd2f6f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/vi/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/vi/thunderbird-78.2.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "27c73e1ee3fdb19c4be32a5e00da43b627a1d2cf33e8efdf74e1c43b715a400e";
+      sha256 = "0e38a1b645894ff81a481250ed434157fa2b70792b423c31dab61288612a82f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/zh-CN/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/zh-CN/thunderbird-78.2.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "46a3d7e6f370638612c17da492dc5edfb8fc693906efedfa6f19bc754f9879ce";
+      sha256 = "04f37793bd17df88573d9d3f8c8412c26cfb3332395689a06f5fca6efb02b2ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/zh-TW/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/zh-TW/thunderbird-78.2.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "501e76ed3fa9f180358f290191c26c65db10fcf7339359058eabc854bb9a88c6";
+      sha256 = "6c1e5b71bb2a9e005971050c9643c52090828e1ecb3910d66d2d0dbaa107011c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/af/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/af/thunderbird-78.2.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "3c986afcc681713ef2f958e060054ca5e0a91502b3d3b9ce9cb168c84f1d8dc8";
+      sha256 = "2601d98ad27a2ed7277f673876c2a7d206fe1cfd8c7c8febdead85884031a416";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ar/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ar/thunderbird-78.2.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "29970a358b02740709e370e29d22747235b10e74ea0ce9a937487cd486492e44";
+      sha256 = "5d126b1152b42b6bd6c29ac602b59ab88f3491b0b6f2a69aa1e6ae3d9ded04d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ast/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ast/thunderbird-78.2.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "1c8a013d36f74264d3a72cd28a54ef55be1ae5a964cfa0136bfafcd22bf400e6";
+      sha256 = "7b22fbd980df00d6b1a2c0f14d68a3a7daf06dcb6a13033ca2619371b098445c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/be/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/be/thunderbird-78.2.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "1ff4b2213ebe1402acc737baf11dc4b88e0b5f8ab0849f1293ce94c9ffa408cd";
+      sha256 = "bd59d2a9e70944a736e8e5db100b2cbe937fb8021577fdd912087e2cbe38723f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/bg/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/bg/thunderbird-78.2.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "0874616da3474cb4fde8cf74a088bce88872a714f872ae32afcf6375fde2afac";
+      sha256 = "ce3906cafce8ce00c4b69f2b1b584f7e4148d2d40ac12916f1108f78d7d3cdae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/br/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/br/thunderbird-78.2.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "f56758fc1622295fb83041f3c36599251bf31f5dc28a5b7eaf9928b801af418a";
+      sha256 = "2f41237e0dd3dff4e0e4b196f8d02b988d7e5db3ac1984ea5577ce5052d43514";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ca/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ca/thunderbird-78.2.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "ac7eb3b393c1755fe1614cb5376bece50a64031a5c1383307d0a74deb0814660";
+      sha256 = "0ec94acd77cca38d37dd23fb240c3c9e3840defccb491704d01072c1cab1f543";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/cak/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/cak/thunderbird-78.2.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "772627d1142b0f142eccf4ca135898dfb198c21dfd823b737d80ac6d5e5086a3";
+      sha256 = "1c77ebb51a83c57c7d81ef278f9fceae07f98330a8ccf8f863c2f0b613141e23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/cs/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/cs/thunderbird-78.2.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "c833322e5984a3a161a77c3e7cc893a6dd098681e5533c48b020a6258f69308b";
+      sha256 = "adf8c11ff60e697fc5087698088c42c95a15766ccebf24d77141a53dc255c366";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/cy/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/cy/thunderbird-78.2.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "04d7089f68d0685aab9a41eda247b48a8024c8deeeb3979a76a5197d8fdb745e";
+      sha256 = "9b7c51652714c116c9bb22fab4f0fc6dcbce6ad2133cc860067898841d01b5b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/da/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/da/thunderbird-78.2.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "1b5347af18a019a29bc8f9e21161cae8f3b955670325e28f117884fa540b71f9";
+      sha256 = "e7245ea0909efccaa9b94701061410437f16273c935484dd3638f5f4fa65aad9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/de/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/de/thunderbird-78.2.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "225f1f703b30f784271f62e5ef25568913e3007448c317969b18b2ef7af5ddc9";
+      sha256 = "302394d24f919b0a24dc574001458b265bfc90024bf21b3d98a43b31ae50adf7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/dsb/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/dsb/thunderbird-78.2.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "90ea05cef5fdd187fe281081d854273529993928d8fd7773a923b1a5feb6b9d7";
+      sha256 = "18ea8d27387581d49dd156957a089f1dbbe05f2772811aeddb1ebe81d26961e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/el/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/el/thunderbird-78.2.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "3d6402bec493ee5663d8ee0b8480cc35769938d22cb81a02f819ce4b4e59839d";
+      sha256 = "bcec06d4b01268ca90d99a98a45c2ef5927ae4152b6b2d356332f3690de08f62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/en-CA/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/en-CA/thunderbird-78.2.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "9a6e7f840ee9f1951d901f2cf3b37717ed5a70fa4e005c16654f48e43fb84060";
+      sha256 = "475a1393917665c17bc5e787ef29dd886f1480d544f55d1caacb2a89503da685";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/en-GB/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/en-GB/thunderbird-78.2.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "324c086e7c293b500de45f4e684f37fdad9a7ccd2720439e5feff15a5ac26c9d";
+      sha256 = "dda5664fd8d843f3f29b85b855d54e00d15188c57e80c01d79a8be0a2eaa0be1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/en-US/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/en-US/thunderbird-78.2.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "bdb2228970ec715690ac94feaa487d11ae1b5fbd8f0f6a0db6feca1440ba7f92";
+      sha256 = "b299267b8a113dcd325bc6a928c561fe872535e1e876518e3075b85043aa7b23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/es-AR/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/es-AR/thunderbird-78.2.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "ddf513766398f8affbeda8c16e09521a5f5e141cff332a6e9482798286b8dc19";
+      sha256 = "e3e7cb829b07b7db95cad09c8887b9c91123665cd4601b685e3c7a7b0036992d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/es-ES/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/es-ES/thunderbird-78.2.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "34e34962f1a20752eefcbe6befd7a44e1c0dcfd2da387d61296af975dfc8af7b";
+      sha256 = "be8428e1cce22aff5000bdc11f632adfc4c1096060a7456d36230ebd6040d12d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/et/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/et/thunderbird-78.2.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "bd74e5d6d9da18211c90e36de506df6acbe4bf61c0e0a199ae048fc5373bf68b";
+      sha256 = "deb81a63704b12ad2a945f5f0dcec878c3b7ec46f551f2d0122c03c52c031f73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/eu/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/eu/thunderbird-78.2.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "036c95223452537d7a39dea188f82ebacf1ccb70f4919bf575970eb50ca5b487";
+      sha256 = "8a2935dd5f83854b4d98bdab67e7b376a7e1d19a2ff790234516ba8211ed7345";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/fa/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/fa/thunderbird-78.2.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "9e9b402de1799afa3d680ced4622072322a516982c86e3a8dfd1df3b3de9fb24";
+      sha256 = "c39189bc1f740a1e5a372eaf3c6e99090f04ed8b1e86016c54ed25612d16f341";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/fi/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/fi/thunderbird-78.2.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "c693786d8cd597e1ccd627201418d6e98e8f09c526167dc04e0b54143f99c8e7";
+      sha256 = "4f23c9941975e67e6e40d7a504a24e4058a27786c5989dd3e25cfc4fab4c4c0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/fr/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/fr/thunderbird-78.2.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "b1fbfa0deb18015e2fb6594aa1eec58e2a897d7eacc4faf2e4887c434ce47d77";
+      sha256 = "4de9885664bf4828355d09ceae11fc7cfb603d4514255b4de464c0653ddd45b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/fy-NL/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/fy-NL/thunderbird-78.2.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "826b558412a5e9f83c2d5a822a2d3ef2f0bdafc882a2283c5ec4bb14f8c9bf82";
+      sha256 = "82ae68d970a02ad57aa9c3dfb6c1ef7783c25211e9228c0bad515c3fef385f88";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ga-IE/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ga-IE/thunderbird-78.2.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "ad7508e4b44b7188b64427b71cb1e23de5cadd7e438c95ea97f31cb57e96c391";
+      sha256 = "e6035d81bfa5c58ab79e71b9895638f23e47e8ab2990794786c5e9f590bb70e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/gd/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/gd/thunderbird-78.2.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "3c93322cb883011533bf1187a683e1e5c93977b79165bdb60e248604390335c2";
+      sha256 = "2c628c5ed8ad0c00c42b384f8b925887e624f6a6dee69c86800a9b5137f04886";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/gl/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/gl/thunderbird-78.2.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "1e649d0dd20dafc736cab7ced71d93dc0c68b852bc4ac28a1d9572a0bb2d2672";
+      sha256 = "49b8e22610f8e602a3870f541209251b61da8cb81df7f0a762d01002fef568e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/he/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/he/thunderbird-78.2.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "b1bc9b85d23bb0150edc29461e9b2999a25ec78001bfdc1fee6f08c98468f138";
+      sha256 = "5bb7193eb498d1edd713e18bbac630ba881b0a9b7fca9b05c9b8e4dd1ea1edbf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/hr/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/hr/thunderbird-78.2.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "6de165437b37733a21b4b7eda7abcf7f08fc7ce81962fed25c8758bc33daad3b";
+      sha256 = "c31022ae9a1665cc0b22ab0e911730ccf5cd0dd24614fbd8d3bd51624760baa3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/hsb/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/hsb/thunderbird-78.2.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "bfef9fd1d13362b9007150fa822d59e61a1ccfc035eb85add98562aa6f198400";
+      sha256 = "3e286b3ccf66300ead4d6b98a88a370fa1bac96244b143005c4974f075ceca92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/hu/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/hu/thunderbird-78.2.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "3973249fe4a0fdedd82ae4a08faa4f1045a29d1ca6a01036eb6f9ae736f985a7";
+      sha256 = "6d0c88c46d0f4ffb296638e4e8217041d8fdaec3abaa6bda7b7cf97c4bcabc2a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/hy-AM/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/hy-AM/thunderbird-78.2.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "1c3fedc2c62c089cc375cb6057cd7faabe15a452e5b034ba3a3a695dceb75a59";
+      sha256 = "aac23dfa8c299623bca2e3b0501a636c630fbf3f5b08689911569a568b3ad060";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/id/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/id/thunderbird-78.2.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "8570e4441e908ec0033535f1f5e2c7ca7c69dd412fd1545b54917ebfa718bc69";
+      sha256 = "5bd5597cb6e91613a39c288d694f3af4f5686dcab1573e3b58c04dce3d1de865";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/is/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/is/thunderbird-78.2.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "1a5c74a43095599623b16ca38fbbde6226b3f9771b02d789617075056a14e213";
+      sha256 = "bcd926c704177945aa7b917fe12940e058d12e6cf8a3eedbf1ab205fb9c41b80";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/it/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/it/thunderbird-78.2.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "22d7d45079d68d2d8e890a075ea4319d4e24ddced860b24eb3bfac546a067e36";
+      sha256 = "04ca02a4fed6e8d904173d9ce52c16e47d7e9b3d16f5483d986f8188ec79d65c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ja/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ja/thunderbird-78.2.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "753beca4177c59c763f99d97e5f8d0f31ba4ea478dd4e4149b09ebf2804aaffe";
+      sha256 = "1dbdc30ec3a06f2e7e7d38d9036fb90a2fdaad42356e9386ecc710d9a51f94b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ka/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ka/thunderbird-78.2.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "2d0461e64bfcd96c563e10124592aae33f0520adc8a99dcc8ce661c0625cbe48";
+      sha256 = "2db1fa86ac87e0b8001b99c0eea30589db515c58e10548565533014481b1be9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/kab/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/kab/thunderbird-78.2.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "0ae95c76f24d8771ab80e4365da350a20ef1900580b48cc65bbeeccb702a4765";
+      sha256 = "8499d0d8a0372617800b039c9198cc372783b8ff4ce385fc692e39b1dca22576";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/kk/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/kk/thunderbird-78.2.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "f7c0da9664a486e917abb52cc4a43ca4d54dc5e35a19f77188ff089bf545ff23";
+      sha256 = "29b228042a7f06c22300b123cc0fcdf7a86005d0d4c3c282c97635ebc25ce826";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ko/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ko/thunderbird-78.2.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "349fb6acfff9fc93af3b1e64cf6a7bb1473ac44591a49bca3c4462d91ad69318";
+      sha256 = "a7af79975107cb32b408c7dd26827793c3c11f998705bc711c60f3dd6b7a1173";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/lt/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/lt/thunderbird-78.2.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "791c878b611325e6d7a8cc6e17e164664580d3d7d6d978d6d3c724ef2649cd92";
+      sha256 = "7a5010761d0af24a6852f32b1ebd6b543b1e1011888ded3f4a4297fc35f455b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ms/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ms/thunderbird-78.2.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "650ffe45f1076abbadeae915c0ed3fc22f016af32997b477350502c5b10a0467";
+      sha256 = "8573dc35bd69ff20d05aa06484a2243f5a35ec78c1c31dbccc067f0cb9e6617a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/nb-NO/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/nb-NO/thunderbird-78.2.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "71f0d3b2608967ba7eacee0295fd11a9451d256af9e8a7f9c3d267198a516077";
+      sha256 = "722c0a4ce2a0d774f8971707ff553d9f2e62af10267ef491e670b020a2d8a49c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/nl/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/nl/thunderbird-78.2.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "1ef722c0694a8fa314406a0747864f06200cbc99ba3c134ac4a72cbb522345f3";
+      sha256 = "63a08123e795ab8e51a2c98f33b0b6424c1f5f2c09a5d1683585f9762813afaf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/nn-NO/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/nn-NO/thunderbird-78.2.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "a994f07a7034440b650748dc1910e291c1fbe3e03ce1df94fc1c0ccbde66ea2f";
+      sha256 = "8968de35faf9fe304631ece4e08a9944342a08dc518ac1eec0ba2d5c1ff268ed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/pa-IN/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/pa-IN/thunderbird-78.2.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "c31349f21b65039983f22ff25b8b0071d463dab4b7a32422a78c873c8ad7cc2e";
+      sha256 = "57685a05321195019ef4d3c489dbb14ac0f1bd5ce51fda1f7573392de215e4e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/pl/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/pl/thunderbird-78.2.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "d82f721f67ea6961d5a184f5414663835a5adb533a504e3973847562e3c058e8";
+      sha256 = "d98967c9d54f9314faae53472b9d1506576761cd3de09747d3b407e1f26931e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/pt-BR/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/pt-BR/thunderbird-78.2.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "32f83437183201739acd8a16d9d0409bb50738b73f642738c1dc3a89d3d66ac9";
+      sha256 = "14fa89b2d8f659a90e19068130ce1a2da83137b7fb9a5a009d2363ccc2415009";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/pt-PT/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/pt-PT/thunderbird-78.2.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "731abc38adc2b9a498bc1e3d6111a769fb82aef13831c1e8b85aaf89e8d4b3bf";
+      sha256 = "279f325e75157e0cedffe6a455e731373b077078f70b89bba76e12e2439350d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/rm/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/rm/thunderbird-78.2.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "65be4d569df37a8207b614316cbcb868fdfdd3bfcefce668d9ec716039ed38b0";
+      sha256 = "7432093e7516625957c3dcb90e8668fab1e22c0edba0411e3e2106d49e052fdf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ro/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ro/thunderbird-78.2.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "fb4d2d36ea227558e320ec860c3f0dd4982f2cb548ed579ecc84e05843a2d15b";
+      sha256 = "f5d5f564cf56c66d1f2f9717df7c7f021532dc1912384c9921ca286030f7d82c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ru/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ru/thunderbird-78.2.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "d68c44ef363d443e6ba7861c1a0a3b77563470a87765295147236119e34d2c0e";
+      sha256 = "4c4e31e74c4d10d88044fc49c24b3ae3ffb0b18e4a23295b60ac2d38d723753a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/si/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/si/thunderbird-78.2.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "e2f1ccc57793fb2c2fdfc829d790a0bed0e96c1d156cac505f99e1fe948a2a7c";
+      sha256 = "689be324633f6a872a09d6498d8772562dceca9bca96f7029830c965ad2e4138";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/sk/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/sk/thunderbird-78.2.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "fe17bc1f3c729478029981b247e03efc62707380b3b4efb11736865d4f86c5d4";
+      sha256 = "194ff5a23a3a40ba98fb1968965c79f99246c6d93b81254d11df5d22530f1d86";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/sl/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/sl/thunderbird-78.2.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "7003d144e6646f7a9c22aeaed497296f7a6fc512cb1219e145388dfb80d67d7c";
+      sha256 = "9746db435fe3dbf5ab51603780d52862a6afda0e40c1ebc915b309ac93e75e25";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/sq/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/sq/thunderbird-78.2.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "e83efa34c14046ada92cfaf9684680aeb8398182d39c81ef822fb6c90c6d22d6";
+      sha256 = "86f675921cdf0de41855d5e2c3d2d56c163d915ac8a0f8cc9678d1a55f87e069";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/sr/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/sr/thunderbird-78.2.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "9f78de776cdbbce197f0e263bb95be815326cc0f6a5b3475f8cb14fd08702742";
+      sha256 = "587e4c867dd43621c8e5e04461c4a2dcf2b0f256476b5b72d8fc6722e573e347";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/sv-SE/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/sv-SE/thunderbird-78.2.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "d92235360937d81da4577521324415227e23588d6447166f4550f2c0788c100e";
+      sha256 = "a46294d3dafc8bfaaa7f5376c2db2402f31f24664e73045c653ea8660079b879";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/th/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/th/thunderbird-78.2.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "aa6c43197aa08f92889f85537c221c62dec1b7da856db0cdae4bcd21cb9d799d";
+      sha256 = "6105278c11c3e586240d50c9612730e75caecd08765b5b5cfe010f37d71c971d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/tr/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/tr/thunderbird-78.2.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "0b8efd5789e9bd397c98ce6246b22da908b86e4c364a23a9b9c63d9c58d99eac";
+      sha256 = "4bdd2c91e8f361d1b2ade88cec06accb244adf3d7f1d714feea3e4004ed31968";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/uk/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/uk/thunderbird-78.2.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "98f6e512224bf597126d443b77a6db319ec2f075ae041afb0de3f27e7b9f2b32";
+      sha256 = "40e2012a5b5dc05cb887a6c4cbb0c8f7bbc25cebd2de1247e5e8dc355cad78fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/uz/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/uz/thunderbird-78.2.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "1a8fb208962ff365f5362b1c95b97144456f8231ba0da8b7bbd4a406746ed681";
+      sha256 = "15f4aafba6b2bcb102683d9a665d208ab21c5767cf6d59c45d996fa26ef1e12a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/vi/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/vi/thunderbird-78.2.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "e955597d9d2e3bf721bfee549f61e46b492d62ee678399eef11b33440fe42175";
+      sha256 = "32640a1c8e42cc79774a3b75539010dfb65e32c703992001eb03916d4fb46e91";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/zh-CN/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/zh-CN/thunderbird-78.2.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "58bef7ac37b2976b43f0a451dbf144497aa7149cb38fdc276135f97f4a2b709b";
+      sha256 = "09b52b6ebf0033738444bacfb53b84b1c98f7d3e10b32c001356083afbe4e89e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/zh-TW/thunderbird-78.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/zh-TW/thunderbird-78.2.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "7e27e58297a781872ac6ac113b361e43abeeb5ef2eae24506a920c9214351454";
+      sha256 = "606e416a158023f674eda141bf67f9b3956e3e231ba85605173d73cad0d22a59";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.1.1";
+  version = "78.2.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/af/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/af/thunderbird-78.2.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "540aa91a70379c4d6975820649abbe3063515bae031229f01ed7e794cf87395d";
+      sha256 = "d64e507c291a93c5f3977e34d991bea4d39d7b2a6e438d2780c4f71dd18b6714";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ar/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ar/thunderbird-78.2.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "18d1b4f33895b5c4b17199ca8412f8060f40660c7e45e024d0dda486ad290044";
+      sha256 = "ef340fc26d314511325f830c935b3564bab4367b4f17b734a04d257d8927b86d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ast/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ast/thunderbird-78.2.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "dd87c494ef5f142517aeec3d8890bc553664b323f2cadb46bca597101b275c91";
+      sha256 = "39d4d8a671ebdf6584b7cfcc1e0979c1396d30d7952293db8b481b90e4fa4571";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/be/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/be/thunderbird-78.2.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "90e0d5354f41244e2ebaeeeb65959d64fcef52f914a15af7b9808125e6e25639";
+      sha256 = "804bbba47279445ae4c5ba82a540b6d0ef2e6a641de47e8dd37cf4e2e13bd86e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/bg/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/bg/thunderbird-78.2.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "4e8f53fc2e1c3b8dddec3d62bfa104a458943c1b0794fcca3a1658b812359b97";
+      sha256 = "d1f5e199a0b448ff6b7709dfabdf6f63c42a125e51109b21c0778f77cfbc6f9f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/br/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/br/thunderbird-78.2.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "068c48e37b4d921cb33e2df27b32a8e9abfc29698c30779b1771f2ab61697f27";
+      sha256 = "f3532117e7e646a74a6b169066e2685b1c372c5bcf3007238762496e1dceccde";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ca/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ca/thunderbird-78.2.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "1f09e12e53d7bc76551c47995b0fa5ff649db94013a66e4ee445e6901352ead6";
+      sha256 = "3403cfab8094a227869bff8f0ef9116ba6fc7d94a0e3312cdc8bb99bcbf185a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/cak/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/cak/thunderbird-78.2.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "e917249cbc16e1ccaf630a5335577e76d971f422fb7c7d9b7c7f05805de18d78";
+      sha256 = "aada755ce418968578884a5b836f6e152d4581c8d010fc8bdaa9ba78c2226e0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/cs/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/cs/thunderbird-78.2.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "89926439c396b64a701d688b2520eb1364e5f2a348a645651396e7f91a4b774a";
+      sha256 = "c0c9f22000d3dad94eee99832cd086630a0660fbbb1a4caa7a7e4307803d40dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/cy/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/cy/thunderbird-78.2.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "65a124a1840efdc33b0426a0a8ab8426423425326f7905844c74f7503c6e60f4";
+      sha256 = "d25d743973288fcb492c8431658142f4762da2a1c894be7cb867aa190ea8e3a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/da/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/da/thunderbird-78.2.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "a572014192e6ba98994f8693b062400b7909bdcede065dd363a3ab182cf40293";
+      sha256 = "bb8ce50143d484fcf2eb7c15e7b0ca5474232a93a2a07ca04f7ef28b98c192bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/de/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/de/thunderbird-78.2.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "a0eeef52d89bee326402354eb1de3f531c9c255d31840ed91e93110c9f170aaa";
+      sha256 = "97536ef763374e3fdaa2da1289931f876a721be3c95a495ef920b756a9d34706";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/dsb/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/dsb/thunderbird-78.2.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "35d0295ebd60415457a7defa40c5bdee2dbf40b08dad387aef0557dc511ce489";
+      sha256 = "9c88d5d07b39e0294fc5c90b4adc70b3919068d6ff157e3a35110afee9a4027a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/el/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/el/thunderbird-78.2.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "135fe2424a1731e24c9602c40e0ae4f8fc551ed058fcd17516ce8f39a7d88bbe";
+      sha256 = "075332016a50493ecb925402a5d09086b4bb39dd83aae449a48189bb35134757";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/en-CA/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/en-CA/thunderbird-78.2.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "b5741a82e8d59300c1f2046b4a4deaa2804d90ad8e8cda7cda9a39b7d6293b87";
+      sha256 = "2290544e6075721c62c2e0f6f39c77af8fd3f31862330d852e60a4c81c59ca8c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/en-GB/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/en-GB/thunderbird-78.2.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "61b0e85a24f56b1b7ad03e9d8206313d50cfc6480627cd377a4a4b1bfdd9f13a";
+      sha256 = "e9d9337b4dd961c578ca29ef7774732872c32d1d13a75be1abaae810bd0fe8bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/en-US/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/en-US/thunderbird-78.2.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "9f0cc0edd2b23bc67824d3e8ed19b8c0a331e69a307b6d48c20e0e29e756e7e7";
+      sha256 = "77b24d9d4185491752d2ddb609aa2a80acbc71829f14e0a8e703f06d77805ee1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/es-AR/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/es-AR/thunderbird-78.2.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "b0390addfb6133074aab52d1b6b73eccb9fae9031967fc94d57f95be30cce54d";
+      sha256 = "176e9b9912ac423546d52ffef7c26eb2631da27efabacc8291ab1e0704a26793";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/es-ES/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/es-ES/thunderbird-78.2.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "4d9f115bba5f9f32247465398e8ccd2f279776fadc3961f79b9fcc923c9cc363";
+      sha256 = "040f8e3f21cad483406a826768bb3ab2ba7e9be332b9291510eeea5642ff518c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/et/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/et/thunderbird-78.2.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "6db8f8c69d8452e402724bf3fc6fb42242d2839307f6ad387f813a97286f4773";
+      sha256 = "a495f15bd7bfde1594b0becc952e7c086d87ee8d8ceaff38ea5945d8cacc972d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/eu/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/eu/thunderbird-78.2.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "7c8165bc0a0feffd71431f3dd30ce99092a0816581363c2d317c6f40149234e1";
+      sha256 = "5b53597ec6bdbf184d0feb182d6459719c159edd1143c68b95863444162b3484";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/fa/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/fa/thunderbird-78.2.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "9537892fa5e9ba5b3f79b96fafef1e8e37c4813f0515f965ce05b410bc7c9448";
+      sha256 = "cce6970ea1373b8dfa6f4b16a803c55aef6ad6a1752be62dfe73b1ec252d0017";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/fi/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/fi/thunderbird-78.2.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "31ca37c4d0f13d1a30b2d7541fa9fbe80add66c6d787bbec069cb904d1157e18";
+      sha256 = "6e7ce171900883e798bf66a6b48d37f359e45120fa36771b37137ef90a644d63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/fr/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/fr/thunderbird-78.2.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "c7507fd9096e9c47632be197054be68631c9d1812b7242b4de06774dbc9c3b1b";
+      sha256 = "07b853c6758e991b1d0f021b6bc48b0e82741edbb107e2e517115675d9bba602";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/fy-NL/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/fy-NL/thunderbird-78.2.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "0a3d9d62861eb11bf409ac20905e787fdb273dd1d74b754f10790ff7deb7160d";
+      sha256 = "d27a72ab1812e7d9d9bd9ac6dbc6982fb22b89982a58ec5b2b07a163bd72bc5e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ga-IE/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ga-IE/thunderbird-78.2.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "4bd0b50313e9a85a83d5b5a032710478feb2df52936bcdfd2621cf30a4d02efb";
+      sha256 = "bf5ae7fce3c74421923baabb4a3391c0e5eff4f470029286e1868df631451396";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/gd/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/gd/thunderbird-78.2.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "a72ed3ea99e863f4a6150cfeeaa0052adf84f8f5ad52388b8bc30bf15d58a310";
+      sha256 = "a433875241721d54f3c48c84a48cf786df5b757bfe4afd2053f2bca6f4a36e9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/gl/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/gl/thunderbird-78.2.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "5d9bae1205ac9490821b1b6d5b700a540bccbb21a3d41943d7f3ccb8576e2087";
+      sha256 = "22a19264f09c2e184e4d0ced2a88b1feb83cf5f47ed71b7fdd88b0b42e17557c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/he/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/he/thunderbird-78.2.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "7cd6417391db27934b6945edcdd9d14b46a69052af7bccd5a62fed588c77894a";
+      sha256 = "0e8be83ba353088d3de57e7e075067ab11523678eedb61e5c9b8dbd4a93bae9c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/hr/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/hr/thunderbird-78.2.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "b641cb7393e1e655adff946c82c43edf580e9fe3852b5c0cffe8f6d12759d190";
+      sha256 = "e9af05d2c0716c63f187022ffccfa413fc4c3ba938be62559f3243b3e3387239";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/hsb/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/hsb/thunderbird-78.2.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "39a27b797117eaed4e939e1c38ade2da13486f9050b5c4d87219cdd46abb67c4";
+      sha256 = "04aece2ac7ccabf025798016731ba610d5401361b403a6822b6770543670da51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/hu/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/hu/thunderbird-78.2.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "5c9795de2316add4e482f9e074c861ef2e05411ea3792d6256d3c43359dc692f";
+      sha256 = "83163c8a1cc002d14e8198b6bb6a7fddd66fe8edaaa5abde0447d4c4ad55047a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/hy-AM/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/hy-AM/thunderbird-78.2.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "be1ba0a8fecf9a577cd63de519f92f48ddaf7c4b68fd629f94bb2ebff3cf16fb";
+      sha256 = "77f4d439957161cb13e8564ce2951a2102b7c1663c675068ed73e3809c04ddf0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/id/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/id/thunderbird-78.2.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "15eb3d6acda87645da2874cc92366fb50e821d7ec7885f87951366ddc66db2a0";
+      sha256 = "d1530e24d70ca54121270468d699471d92d2cfba538c6a9083980d09c066aa32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/is/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/is/thunderbird-78.2.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "06549f464526e931f23c0925b402eb3da6fbd9bd16595387604fe7edc62c4672";
+      sha256 = "e1b25920b7ec9353f1cbb511a635d57aa45e65707f1ba493d9c7af6c50e3a601";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/it/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/it/thunderbird-78.2.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "d81344b5dc0e131d1796f63de559a18b59dc70403a957eab737354ab05fd31c4";
+      sha256 = "38315dfe412c8b4460805210fcc6aabb859b20ffa41773c7a87634875016079c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ja/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ja/thunderbird-78.2.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "48bd5534bfebd6c6f976ea4230ac7d364544c1467b2912f0db46fd23944d0908";
+      sha256 = "ffc20370c6252f80d8f191460d97249cce99667049a0a7610b01b16ad48f3af8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ka/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ka/thunderbird-78.2.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "8f581c4d9f6c2e8f79bf7be92bf06a69d0dfed017346e1c380a31f541c5155fa";
+      sha256 = "4dc0ae26e215fccf6a0c3dc3d49544f960564ff9ae5b0f7054d0d7ba60c90d85";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/kab/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/kab/thunderbird-78.2.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "2cbcf1e64dcb914af8dfa0f8dab462d59d37992b3f4e22159e2edd340cb6e73a";
+      sha256 = "e9666986e06d89e202dba5abff6722d11c0fbff3ebbe7a5664ae816c9e305304";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/kk/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/kk/thunderbird-78.2.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "1fd067e9751c60dc6c6dcf1e5cfee3650758ae6593cb20fa5e6103cd01e6e6b7";
+      sha256 = "742be512385a5d9984ac8ccb96abb856cf7a25c0d8517996774726bb24f6c702";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ko/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ko/thunderbird-78.2.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "efdd154ad42d1b8f257d0cf619afc4bdea44d7014882c82847cb5f21d7037469";
+      sha256 = "94f8833e2dfb8f905fe7b37da7f3f197620763f6944c565f547554a7d8756cb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/lt/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/lt/thunderbird-78.2.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "4256ec374ea5a22553469393e7fde51b46cd2ade5a620e9b0fc442e9d524494f";
+      sha256 = "9a9b49068639803973fe30f1a44bc2a17fe7b8583a549cf996b2deb0cd145a10";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ms/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ms/thunderbird-78.2.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "40f6fc9fb01a83288a6952b7a6e625bd00659594f7fa21ee883c16501407b8be";
+      sha256 = "0fc01d5be421b36ecfc31ff818692edf44f29757c6e80789c64bdd5459f6b500";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/nb-NO/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/nb-NO/thunderbird-78.2.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "b3f363ccbc5946c6e0e87ca4b75e12e4e4372688ae7a034c9cf37fd401794840";
+      sha256 = "88f3b13462488aba548f553d6d9e8025233e13f48c054c51f989de0d0ea3d02e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/nl/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/nl/thunderbird-78.2.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "6963f3f09cf8a3370b06c894aa744c4ddbaa7c11df4e41f540a21427ec391135";
+      sha256 = "8b7cb8152c995add11be80152031f5b50e0bc571cca0503536db630b8cbc8127";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/nn-NO/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/nn-NO/thunderbird-78.2.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "da647b3c85db5ebbfbc530dd8d8fb1005928430775cd5c8a2999709614f4e35c";
+      sha256 = "41c8ccaee5ead407b7ebbd73d12ae04188f5dbc8a97d20c20c21b4d688edc43f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/pa-IN/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/pa-IN/thunderbird-78.2.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "9df18348eedd3b43a13ac991b875fe12678929faa58712b09ee7364a8dedbd2e";
+      sha256 = "77b6a9265c07834ed79ad68e44927eeaf52a64724b58c3067dd99aac36abdfcf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/pl/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/pl/thunderbird-78.2.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "7f60d5a0a819f6b69cd3f8444c12758f7cee17a681859c03cbea29ec27e1221e";
+      sha256 = "2f01c4b5c058fd56c52a32671e486d1ebc462a96aea5a27a2a0393bd3a34ed5b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/pt-BR/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/pt-BR/thunderbird-78.2.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "229073650b742b4566350ce82ea65f93f639a2b502bf706de4038c3c13ead354";
+      sha256 = "598dbdfdea842d607d65dde5d674634a03f152d5fcfed1891352356d1d61a80b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/pt-PT/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/pt-PT/thunderbird-78.2.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "f8596511964a688747ce51cf0ca6bb6da65ea78b9b3ef70ced4f69fae8edbeb0";
+      sha256 = "73a3dd9b640d23099561452d5fb5c639bc04b1d8a3b3b1091f922622ebeb559b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/rm/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/rm/thunderbird-78.2.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "fb101dae4058f2cf804aacaf60c1354415cb0287432bb367a83e2ef8109375ce";
+      sha256 = "3a762d2f6b049778bf8372435210d27d98c1255fb14300bc297cb691e8524c49";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ro/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ro/thunderbird-78.2.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "1cb1fc985122dea685fc1998764c60979a7c357d5e1e0646b8c4f45e856b4f00";
+      sha256 = "61cbf80023d54aa030ae309ba4a952afacfaae12baea7494802ec18d3950bed7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/ru/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/ru/thunderbird-78.2.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "d89b9a418c78422e2a715e7e1c5d2bf57e90c2293ad63dc5e9f2645fdc910103";
+      sha256 = "195cf37d9999c696976617a1281aa73f28e421513941639c5bed70e42a177a9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/si/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/si/thunderbird-78.2.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "584cd0dca877163073824e9dfbee4d6146e0ef8bd0b23cd2325462a1a72a41a4";
+      sha256 = "d6f4637d875be6aa2c2b3ba4a3948f61e39738b5a2d9a0ec1cd6158e0c4aae9b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/sk/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/sk/thunderbird-78.2.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "cbb2b5678d11eef244a175d88207e00fc59584afd0b788a82319987368ff19c2";
+      sha256 = "499bdb9c2504a29e3990c0738090410afbaf016722b12169734564abae745aff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/sl/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/sl/thunderbird-78.2.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "e8727e9942c4555d6413a3ebe1d4b2ab2ea39da4f5b3b2ad7baaeb8abf49fd47";
+      sha256 = "f8fa3dd94d63566e6e14cbb66b7f92e7e2591796f7c9900117b0a06880b8d0f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/sq/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/sq/thunderbird-78.2.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "31141f45121dab9c5ce3f3d6195264df91e61e434ee993c409c3cac164215737";
+      sha256 = "1249f85fb8e30e7ff5ea9baf30c56b91d78d965038a7121f25f9e327ca4489c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/sr/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/sr/thunderbird-78.2.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "dc9a868b1345da0633d090877ae6cddaa3a1b2bb1fc3113bc9de2aac1c30366c";
+      sha256 = "6e5b30eb1b2df7dce4e366e246f28dbabb542af3b50e581b71a8cd7fb59656be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/sv-SE/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/sv-SE/thunderbird-78.2.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "fab7e11f8de1fcd2e8719d20e818d8bd2c39f7539328fb79f2cce56d4f312a78";
+      sha256 = "431da982c97b39e60605bc2a0b1d0cdc117c336451c9fae26f17e397e2088da0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/th/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/th/thunderbird-78.2.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "fa3173940d4e7109385d65b479297110545cc7e2e76e8a657f376553e370563a";
+      sha256 = "3d1f813e9363887a465e11a7729fb5f2d6204bc1d5fa3690c1301a83bb32b06c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/tr/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/tr/thunderbird-78.2.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "a8cf6b95a6b890892d034c0b014a62f710bbafa34f3282a80e17828ad9365513";
+      sha256 = "3e4edac805121565ae3e0c77e446028759d60402832f259b694df80e7f060172";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/uk/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/uk/thunderbird-78.2.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "a5086a87a87ccb605154aad5bc2986d6fe995391189b3e452640210e2016b08f";
+      sha256 = "632dbf35842b208d65c0d4196ea21d18bad848a43c12d1f29b321bc9095ca3e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/uz/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/uz/thunderbird-78.2.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "b5bea650b678808b7fbcca432c1de0121dc19886b2f32e764e4fe1a797d1e8ab";
+      sha256 = "93cee199f136c829276eb203312b658414726628a9501a916740e555549e4fd3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/vi/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/vi/thunderbird-78.2.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "8b8b57417b1d6faeb283b1b6037eac92841029bd73769d5cb8bc6c227e87efbf";
+      sha256 = "27c73e1ee3fdb19c4be32a5e00da43b627a1d2cf33e8efdf74e1c43b715a400e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/zh-CN/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/zh-CN/thunderbird-78.2.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "4a0c8629e2a5e5f95799169dba4ee9c10b728bf503e090ed829cdd11fbeb57d1";
+      sha256 = "46a3d7e6f370638612c17da492dc5edfb8fc693906efedfa6f19bc754f9879ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-x86_64/zh-TW/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-x86_64/zh-TW/thunderbird-78.2.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "11a892d8ec3ec6e2dccbad4b97ce2fe7cb0a0b1dc309bef9819432f0be9d510c";
+      sha256 = "501e76ed3fa9f180358f290191c26c65db10fcf7339359058eabc854bb9a88c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/af/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/af/thunderbird-78.2.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "a254eecebf45c16f55b7d72cc38da2c4d22f49704cdb5db72d2adfc199a7a78c";
+      sha256 = "3c986afcc681713ef2f958e060054ca5e0a91502b3d3b9ce9cb168c84f1d8dc8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ar/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ar/thunderbird-78.2.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "3e735d996bb3bf2674f1c04f035489893169ab632208af1427756bc3c15b1600";
+      sha256 = "29970a358b02740709e370e29d22747235b10e74ea0ce9a937487cd486492e44";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ast/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ast/thunderbird-78.2.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "a8fe0f85c250b0f71b0bac30cd51e10e5d1ded4265775afe93f986ccde4fbc49";
+      sha256 = "1c8a013d36f74264d3a72cd28a54ef55be1ae5a964cfa0136bfafcd22bf400e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/be/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/be/thunderbird-78.2.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "279a98d38f6c33945ddd1e86c9263e72f9a52555e7f26c56a2f3062696436bbb";
+      sha256 = "1ff4b2213ebe1402acc737baf11dc4b88e0b5f8ab0849f1293ce94c9ffa408cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/bg/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/bg/thunderbird-78.2.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "cb23b56841818af2e3e8dc922cace29c8538d22977ee951dee744bbc490c24a6";
+      sha256 = "0874616da3474cb4fde8cf74a088bce88872a714f872ae32afcf6375fde2afac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/br/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/br/thunderbird-78.2.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "f729274b064205cb9baf57be3732268a2c56893ac6b17ae6ddc0aed3269fda15";
+      sha256 = "f56758fc1622295fb83041f3c36599251bf31f5dc28a5b7eaf9928b801af418a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ca/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ca/thunderbird-78.2.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "eb434c12d8d841eb8426b95663591f742a9e62b630cadb7afebfa79ab1142a38";
+      sha256 = "ac7eb3b393c1755fe1614cb5376bece50a64031a5c1383307d0a74deb0814660";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/cak/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/cak/thunderbird-78.2.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "daa19634d796f849ab9b3a575bc53e451453902f82ce7384a7ae5ae4f99a2165";
+      sha256 = "772627d1142b0f142eccf4ca135898dfb198c21dfd823b737d80ac6d5e5086a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/cs/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/cs/thunderbird-78.2.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "181cc3c70985d41a806395b353ccd98475c37ae8151fd5f59adbe25bf2059457";
+      sha256 = "c833322e5984a3a161a77c3e7cc893a6dd098681e5533c48b020a6258f69308b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/cy/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/cy/thunderbird-78.2.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "4cb93a1b38582e6fd4e4fc514c36e469b88bedf0bd36bee4d7a66d9c33c3c8ca";
+      sha256 = "04d7089f68d0685aab9a41eda247b48a8024c8deeeb3979a76a5197d8fdb745e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/da/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/da/thunderbird-78.2.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "6eb46018b763d22e62739ec9dd98d5f3804f85b5b65ca3092c42d5d9a1a258ee";
+      sha256 = "1b5347af18a019a29bc8f9e21161cae8f3b955670325e28f117884fa540b71f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/de/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/de/thunderbird-78.2.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "dff12cffa89c1ad5666b92b66361e17c604f0ca34305fb0e3b06be5fa8fb0f96";
+      sha256 = "225f1f703b30f784271f62e5ef25568913e3007448c317969b18b2ef7af5ddc9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/dsb/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/dsb/thunderbird-78.2.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "efa2f9449703fc0941620650f1ca1332682b2866339413aa03f2438580d18f78";
+      sha256 = "90ea05cef5fdd187fe281081d854273529993928d8fd7773a923b1a5feb6b9d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/el/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/el/thunderbird-78.2.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "675cfc628dd02fe874a701e0e16986c797adac263605b304c1c69bb01552037f";
+      sha256 = "3d6402bec493ee5663d8ee0b8480cc35769938d22cb81a02f819ce4b4e59839d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/en-CA/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/en-CA/thunderbird-78.2.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "a710c91df20b4b25d9e363b585344e1595ab96b9cc1df35e973e485834942957";
+      sha256 = "9a6e7f840ee9f1951d901f2cf3b37717ed5a70fa4e005c16654f48e43fb84060";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/en-GB/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/en-GB/thunderbird-78.2.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "3acd3020cb6116588a0f061aa9ba5d620477e3265eefac3dc22f4705757fe025";
+      sha256 = "324c086e7c293b500de45f4e684f37fdad9a7ccd2720439e5feff15a5ac26c9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/en-US/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/en-US/thunderbird-78.2.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "bf9ebc54aff457654b5ea1fc81437281f70d78de96d5a4d3586ae83fb8135d39";
+      sha256 = "bdb2228970ec715690ac94feaa487d11ae1b5fbd8f0f6a0db6feca1440ba7f92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/es-AR/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/es-AR/thunderbird-78.2.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "cf1c278a36c9303956ac8dc29a51226a42ea17cf64559c34bef318c79ba6ed74";
+      sha256 = "ddf513766398f8affbeda8c16e09521a5f5e141cff332a6e9482798286b8dc19";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/es-ES/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/es-ES/thunderbird-78.2.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "4a9356476a18f292f763f1647611189ebe89ee368a3f01a7c75ef8dce48d91af";
+      sha256 = "34e34962f1a20752eefcbe6befd7a44e1c0dcfd2da387d61296af975dfc8af7b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/et/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/et/thunderbird-78.2.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "03d3a43153b714f334a8f5d7d23e9080624488ec54400451b508c6aa50bcd594";
+      sha256 = "bd74e5d6d9da18211c90e36de506df6acbe4bf61c0e0a199ae048fc5373bf68b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/eu/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/eu/thunderbird-78.2.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "a7cca16186f0e2627dc6e06164b3cb2bb691cf798f7c41378ae90349521d9199";
+      sha256 = "036c95223452537d7a39dea188f82ebacf1ccb70f4919bf575970eb50ca5b487";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/fa/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/fa/thunderbird-78.2.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "6a19a79d409acdc25c69b5c8d75a18f2de665a7d18244d578e4ef0f65597daea";
+      sha256 = "9e9b402de1799afa3d680ced4622072322a516982c86e3a8dfd1df3b3de9fb24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/fi/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/fi/thunderbird-78.2.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "4b82f0fadfb5f388948e33fd3408e9f6ece6737c8e5e4b53c164a124f017e553";
+      sha256 = "c693786d8cd597e1ccd627201418d6e98e8f09c526167dc04e0b54143f99c8e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/fr/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/fr/thunderbird-78.2.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "bc4fb423664576d4d94eb24383e3f4f23c199e52f1c985fd3bfccc947212f82a";
+      sha256 = "b1fbfa0deb18015e2fb6594aa1eec58e2a897d7eacc4faf2e4887c434ce47d77";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/fy-NL/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/fy-NL/thunderbird-78.2.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "6eb76c3a4d3b31160dc0d0b807596095354c7c0740f5593f86042af1e1b03d48";
+      sha256 = "826b558412a5e9f83c2d5a822a2d3ef2f0bdafc882a2283c5ec4bb14f8c9bf82";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ga-IE/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ga-IE/thunderbird-78.2.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "5321fff3eb4d341307233976de74624f6002abb8662f40ecbf77e3bdb5757add";
+      sha256 = "ad7508e4b44b7188b64427b71cb1e23de5cadd7e438c95ea97f31cb57e96c391";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/gd/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/gd/thunderbird-78.2.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "515207242fffd0513a550017f8bfb53061f0a0e3d795a111adf0154b55363d38";
+      sha256 = "3c93322cb883011533bf1187a683e1e5c93977b79165bdb60e248604390335c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/gl/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/gl/thunderbird-78.2.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "84c32bd92a783c680343aa5b01dbf58e37eda9ee466b16f817a79a135e37fbe5";
+      sha256 = "1e649d0dd20dafc736cab7ced71d93dc0c68b852bc4ac28a1d9572a0bb2d2672";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/he/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/he/thunderbird-78.2.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "96d07263578fb16068e0f48309552ea9237d3dd5a46fc63e3293326778cb7af1";
+      sha256 = "b1bc9b85d23bb0150edc29461e9b2999a25ec78001bfdc1fee6f08c98468f138";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/hr/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/hr/thunderbird-78.2.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "9c612aad3a12530052dd609c2f20a3739c458b3c7f3d761e7c00754f9b43db95";
+      sha256 = "6de165437b37733a21b4b7eda7abcf7f08fc7ce81962fed25c8758bc33daad3b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/hsb/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/hsb/thunderbird-78.2.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "376e4d8eadb9bb8f301053d30260ab0cbeb3dc9f590564583f07547585105fe0";
+      sha256 = "bfef9fd1d13362b9007150fa822d59e61a1ccfc035eb85add98562aa6f198400";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/hu/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/hu/thunderbird-78.2.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "4e7e51dbbe359ec542e553f5b0691f1d191343261094828b2572dd5a03ec2c8a";
+      sha256 = "3973249fe4a0fdedd82ae4a08faa4f1045a29d1ca6a01036eb6f9ae736f985a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/hy-AM/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/hy-AM/thunderbird-78.2.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "735624e30d1986d6c822fcbee4694389cf8a0061eba40926265bd4ac998e2186";
+      sha256 = "1c3fedc2c62c089cc375cb6057cd7faabe15a452e5b034ba3a3a695dceb75a59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/id/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/id/thunderbird-78.2.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "ce6d668f38d1e74e7c8bbfc7408edc749eed9449908044bdd57b2dcd868cb89f";
+      sha256 = "8570e4441e908ec0033535f1f5e2c7ca7c69dd412fd1545b54917ebfa718bc69";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/is/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/is/thunderbird-78.2.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "589369ce68b6c78ad7753ddd14412eb68f438dbd7cae449f828288d25ee3f795";
+      sha256 = "1a5c74a43095599623b16ca38fbbde6226b3f9771b02d789617075056a14e213";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/it/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/it/thunderbird-78.2.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "fd909d5aaa68a208050a0812f15024ef115b99fbde0edb0afe995c3b766c0d76";
+      sha256 = "22d7d45079d68d2d8e890a075ea4319d4e24ddced860b24eb3bfac546a067e36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ja/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ja/thunderbird-78.2.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "160c2a1c36ef34339270abd59fed13b37414f8c37edd60463e0945e6751a0c74";
+      sha256 = "753beca4177c59c763f99d97e5f8d0f31ba4ea478dd4e4149b09ebf2804aaffe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ka/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ka/thunderbird-78.2.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "e822a28e62aae6d6e84e6788d5311af45396248f48cc60152b4273d75359dd8f";
+      sha256 = "2d0461e64bfcd96c563e10124592aae33f0520adc8a99dcc8ce661c0625cbe48";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/kab/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/kab/thunderbird-78.2.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "2ea58cc79b80966b5bbc310fa32bd27621f95d4ffbd3646bf9e04f922c36ca6e";
+      sha256 = "0ae95c76f24d8771ab80e4365da350a20ef1900580b48cc65bbeeccb702a4765";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/kk/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/kk/thunderbird-78.2.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "a874bc02f065be73a54b70567b7a04be5fc6a9f766f3b054b12555763361ea2a";
+      sha256 = "f7c0da9664a486e917abb52cc4a43ca4d54dc5e35a19f77188ff089bf545ff23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ko/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ko/thunderbird-78.2.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "d9678f72569dfde84544fcb9afa7cb8d5a4a35baa52d4e560aa2b082a418ab00";
+      sha256 = "349fb6acfff9fc93af3b1e64cf6a7bb1473ac44591a49bca3c4462d91ad69318";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/lt/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/lt/thunderbird-78.2.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "1d7ec489dc52fae0f7597e40f8505bdd6a57a717389c75b66481749e85e2fab6";
+      sha256 = "791c878b611325e6d7a8cc6e17e164664580d3d7d6d978d6d3c724ef2649cd92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ms/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ms/thunderbird-78.2.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "5d0c7cc00139c39a69dfc9ba1dc5c83b56973f26679860d048952bcf09baa737";
+      sha256 = "650ffe45f1076abbadeae915c0ed3fc22f016af32997b477350502c5b10a0467";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/nb-NO/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/nb-NO/thunderbird-78.2.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "e72a25e7d53e6e0d470632c487d31e08afdb6c27543d50c93ff72ecac3f70bc6";
+      sha256 = "71f0d3b2608967ba7eacee0295fd11a9451d256af9e8a7f9c3d267198a516077";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/nl/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/nl/thunderbird-78.2.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "19efd7323e671fe25b64ee44c85f698f608e6c2b18fdbfc9f0cc95b9cd8cd149";
+      sha256 = "1ef722c0694a8fa314406a0747864f06200cbc99ba3c134ac4a72cbb522345f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/nn-NO/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/nn-NO/thunderbird-78.2.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "b4be21281c6a13de05e5d0b96e43454bab662140a00d3837f609e23f14360c90";
+      sha256 = "a994f07a7034440b650748dc1910e291c1fbe3e03ce1df94fc1c0ccbde66ea2f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/pa-IN/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/pa-IN/thunderbird-78.2.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "f2795a504616404616f7d22022e105e9e4ea54025d60e262c405b867cb9c7936";
+      sha256 = "c31349f21b65039983f22ff25b8b0071d463dab4b7a32422a78c873c8ad7cc2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/pl/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/pl/thunderbird-78.2.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "52f80b074dc168ec00d0fd78f6376c1dfd357c2b7e7ed78bb1b9cf17536508a6";
+      sha256 = "d82f721f67ea6961d5a184f5414663835a5adb533a504e3973847562e3c058e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/pt-BR/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/pt-BR/thunderbird-78.2.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "d02867899a54eebffb2b6e600f7e6260b960d686a8bcd61ce705e9d0bbebe377";
+      sha256 = "32f83437183201739acd8a16d9d0409bb50738b73f642738c1dc3a89d3d66ac9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/pt-PT/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/pt-PT/thunderbird-78.2.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "659a7ff3a0dcbb4f3fec32eda6b5a2087191c8d49ea310662ad540433d869180";
+      sha256 = "731abc38adc2b9a498bc1e3d6111a769fb82aef13831c1e8b85aaf89e8d4b3bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/rm/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/rm/thunderbird-78.2.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "d9ee3c5e3cf2d7eedced9d12bf4d499ae931c262be166af6a14bbd4a2538788a";
+      sha256 = "65be4d569df37a8207b614316cbcb868fdfdd3bfcefce668d9ec716039ed38b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ro/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ro/thunderbird-78.2.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "c3db9965a25d52d25cde0b52bffcc274ae32862fb29be368f27b102774d0971b";
+      sha256 = "fb4d2d36ea227558e320ec860c3f0dd4982f2cb548ed579ecc84e05843a2d15b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/ru/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/ru/thunderbird-78.2.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "f0356ef5eadccfcdfc694d0bed9b1e4027e4883095f9c117403a68f1cb2810c8";
+      sha256 = "d68c44ef363d443e6ba7861c1a0a3b77563470a87765295147236119e34d2c0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/si/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/si/thunderbird-78.2.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "5b5d17a2b098fbe1c2d8686ab0e1adb7c72efedc38365ca9b39b1e122302c85c";
+      sha256 = "e2f1ccc57793fb2c2fdfc829d790a0bed0e96c1d156cac505f99e1fe948a2a7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/sk/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/sk/thunderbird-78.2.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "b39bd41a38947ea467e1a89c5a173fd07cbce09562c10e6a60adb2150b04c9cf";
+      sha256 = "fe17bc1f3c729478029981b247e03efc62707380b3b4efb11736865d4f86c5d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/sl/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/sl/thunderbird-78.2.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "602e0feffc5b786930005c376ca3e8819b834a0cfc9a649bc46d86c27999144d";
+      sha256 = "7003d144e6646f7a9c22aeaed497296f7a6fc512cb1219e145388dfb80d67d7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/sq/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/sq/thunderbird-78.2.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "fb265490d00c3a844f73e8f531b7c73f3787cb4e4ddc7cdcde72017fd7f3d612";
+      sha256 = "e83efa34c14046ada92cfaf9684680aeb8398182d39c81ef822fb6c90c6d22d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/sr/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/sr/thunderbird-78.2.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "1574eaee6effc4df2c88fc94597e295f352455a9f68501080385c08cb4ab7e35";
+      sha256 = "9f78de776cdbbce197f0e263bb95be815326cc0f6a5b3475f8cb14fd08702742";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/sv-SE/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/sv-SE/thunderbird-78.2.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "8d55df4937fe28f7b9d0fcaebcde3fb9650de9f0b74f677111f339ae2365b822";
+      sha256 = "d92235360937d81da4577521324415227e23588d6447166f4550f2c0788c100e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/th/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/th/thunderbird-78.2.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "6a872a6c332c7b3bfc24721bf1114c85475a73ae5c7b16d8637b0eb0045e112d";
+      sha256 = "aa6c43197aa08f92889f85537c221c62dec1b7da856db0cdae4bcd21cb9d799d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/tr/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/tr/thunderbird-78.2.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "26d2b8493a1508591b45f9ecc43598e244856c0d9bc3c185721a7239679c4e63";
+      sha256 = "0b8efd5789e9bd397c98ce6246b22da908b86e4c364a23a9b9c63d9c58d99eac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/uk/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/uk/thunderbird-78.2.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "ddb4b5fab55ded8f7bc2ae914f41af42b3b69c738727b055efd5e05b253ac872";
+      sha256 = "98f6e512224bf597126d443b77a6db319ec2f075ae041afb0de3f27e7b9f2b32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/uz/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/uz/thunderbird-78.2.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "dce93fab320f90ece938ae2b2343c1d27a1143b0183318a9d9e0cbbcfb607982";
+      sha256 = "1a8fb208962ff365f5362b1c95b97144456f8231ba0da8b7bbd4a406746ed681";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/vi/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/vi/thunderbird-78.2.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "cf1b4f96ef1a510d21b232e748ace6e567d27e382393a7d7f51ab392f026d55c";
+      sha256 = "e955597d9d2e3bf721bfee549f61e46b492d62ee678399eef11b33440fe42175";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/zh-CN/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/zh-CN/thunderbird-78.2.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "574acd0743a1202b6629883618278eb3ce113c518bc9c39f3d90e2dc12d4f644";
+      sha256 = "58bef7ac37b2976b43f0a451dbf144497aa7149cb38fdc276135f97f4a2b709b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.1.1/linux-i686/zh-TW/thunderbird-78.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.0/linux-i686/zh-TW/thunderbird-78.2.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "51ccc5a4696841b3391a5dd9fb9ff1f55a9f6ccd6fbd86587ffb86c5f664f10f";
+      sha256 = "7e27e58297a781872ac6ac113b361e43abeeb5ef2eae24506a920c9214351454";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/68.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/68.nix
@@ -71,13 +71,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "68.11.0";
+  version = "68.12.0";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "1rdxizg1mpagh17fhnrbkilyv1i2zfcr6z62jf3ng31ns94za9kdg9f580srkp63png67jaj3b1kc33v5vb8wavl09n5d38g113x2m9";
+      "33350vjgzvsg6sdhdld92z75k1xcf1wmngdcvzsj4f3y3aal73pyw03mlvgg6y36bm0j8fhaxvgbbg5zm7hxhn779z78970m4v9amg7";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -69,13 +69,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.1.1";
+  version = "78.2.0";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "1lf15zl3p8y1vxv4s04y088flkspf0r0c6j8gfrlfzla5ckfcsbad3zbygh6y73m35j882g7fbacby5a4hiw891zq2kji5dn3nbahyi";
+      "2mcd2ywa8kgz3gcah5acpw7wwc194plwca9f09l18ibml64mxbdk6ilmp8cbq2mgkap99brdz923apslf9y4fdlcw64g2s4m8xdy3mj";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -69,13 +69,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.2.0";
+  version = "78.2.1";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "2mcd2ywa8kgz3gcah5acpw7wwc194plwca9f09l18ibml64mxbdk6ilmp8cbq2mgkap99brdz923apslf9y4fdlcw64g2s4m8xdy3mj";
+      "2iya9a5qaini524wrdrnxx6wsrgb8fa2b1m42mlypskxjjgb7n66vpxlbpi9x9mqzc63ca2ag36fjpbpsvbv5ppxvpfwk2j1zbfvb5w";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Various security fixes (68 only)
- Updates and fixes.
- OpenPGP enabled by default (78 only). 

https://www.thunderbird.net/en-US/thunderbird/78.2.0/releasenotes/
https://www.thunderbird.net/en-US/thunderbird/78.2.1/releasenotes/
https://www.thunderbird.net/en-US/thunderbird/68.12.0/releasenotes/
https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.12

At this time, users of the Enigmail Add-on should not update to Thunderbird 78.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
