### PR TITLE
matomo: 3.13.6 -> 3.14.0

### DIFF
--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -3,16 +3,16 @@
 let
   versions = {
     matomo = {
-      version = "3.13.6";
-      sha256 = "1d3s5v96mmhcxdnxi7qh822p55g9a2nxh0zcq2d8bhg0cshi9804";
+      version = "3.14.0";
+      sha256 = "05ycc4k4w01212pklzgxrbwpzp572jmj8i9ija6s7c01071yjjzv";
     };
 
     matomo-beta = {
-      version = "3.13.6";
+      version = "3.14.0";
       # `beta` examples: "b1", "rc1", null
       # TOOD when updating: use null if stable version is >= latest beta or release candidate
       beta = null;
-      sha256 = "1d3s5v96mmhcxdnxi7qh822p55g9a2nxh0zcq2d8bhg0cshi9804";
+      sha256 = "05ycc4k4w01212pklzgxrbwpzp572jmj8i9ija6s7c01071yjjzv";
     };
   };
   common = pname: { version, sha256, beta ? null }:


### PR DESCRIPTION
#### Motivation for this chemail
[Matomo 3.14.0](https://matomo.org/changelog/matomo-3-14-0/) released, should not require backporting to 20.03 in my opinion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
