### PR TITLE
buildRustPackage: add update script

### DIFF
--- a/maintainers/scripts/update-rust-crates
+++ b/maintainers/scripts/update-rust-crates
@@ -1,0 +1,15 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts curl jq
+
+set -euf -o pipefail
+
+echo "args: '$@'"
+
+if [ $# -ne 1 ]; then
+   echo "Usage: $0 CRATE"
+   exit 1
+fi
+
+version="$(curl https://crates.io/api/v1/crates/$1 | jq -r '.crate.newest_version')"
+
+update-source-version $1 "$version"

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -7,6 +7,7 @@
 , git
 , rust
 , rustc
+, update-rust-crates
 , windows
 }:
 
@@ -239,7 +240,11 @@ stdenv.mkDerivation (args // {
     runHook postInstall
   '';
 
-  passthru = { inherit cargoDeps; } // (args.passthru or {});
+  passthru = let
+    updatePassthru = if args ? pname then {
+      updateScript = [ update-rust-crates args.pname ];
+    } else {};
+  in { inherit cargoDeps; } // updatePassthru // (args.passthru or {});
 
   meta = {
     # default to Rust's platforms

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -96,6 +96,8 @@ in
 
   nix-update-script = callPackage ../common-updater/nix-update.nix { };
 
+  update-rust-crates = ../../maintainers/scripts/update-rust-crates;
+
   ### Push NixOS tests inside the fixed point
 
   nixosTests = import ../../nixos/tests/all-tests.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The update script looks up the derivation's pname on crates.io finds
the latest version of that crate.

Tested for me and a few other maintainers. Seems to reliably find
newer versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
