### PR TITLE
lbry: init at 0.48.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3733,6 +3733,16 @@
       fingerprint = "1412 816B A9FA F62F D051 1975 D3E1 B013 B463 1293";
     }];
   };
+  islandusurper = {
+    email = "ashagua@gmail.com";
+    name = "Lyle Mantooth";
+    github = "IslandUsurper";
+    githubId = 17701;
+    keys = [{
+      longkeyid = "rsa3072/0x6DB52EAE123A5789";
+      fingerprint = "CA84 771F 492B C486 E07D  255C 6DB5 2EAE 123A 5789";
+    }];
+  };
   ivan = {
     email = "ivan@ludios.org";
     github = "ivan";

--- a/pkgs/applications/video/lbry/default.nix
+++ b/pkgs/applications/video/lbry/default.nix
@@ -1,0 +1,85 @@
+{ stdenv
+, dpkg
+, fetchurl
+, at-spi2-core
+, atomEnv
+, ffmpeg
+, gtk3
+, libdrm
+, libpulseaudio
+, libuuid
+, makeWrapper
+, mesa
+, xdg_utils
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lbry-desktop";
+  version = "0.48.2";
+
+  src = fetchurl {
+    url = "https://github.com/lbryio/lbry-desktop/releases/download/v${version}/LBRY_${version}.deb";
+    sha256 = "0kqyiv9lfck9zzhiqpbvmlbyk09hajcaa2bpk1i3w03yk548an6z";
+  };
+
+  rpath = stdenv.lib.makeLibraryPath [
+    at-spi2-core
+    libdrm
+    libpulseaudio
+    libuuid
+    mesa
+    xorg.libXScrnSaver
+    xorg.libxcb
+  ] + ":${atomEnv.libPath}";
+
+  buildInputs = [
+    ffmpeg
+    gtk3
+  ];
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  dontBuild = true;
+  dontPatchELF = true;
+
+  unpackPhase = ''
+      dpkg --fsys-tarfile $src | tar --extract
+      rm -rf usr/share/lintian
+  '';
+
+  installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      mv usr/* $out
+      mv opt/LBRY $out/
+
+      # Otherwise it looks "suspicious"
+      chmod -R g-w $out
+
+      for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+        patchelf --set-rpath ${rpath}:$out/LBRY $file || true
+      done
+
+      makeWrapper $out/LBRY/lbry $out/bin/lbry \
+        --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH \
+        --prefix PATH : ${ffmpeg}/bin:${xdg_utils}/bin
+
+      # Fix the desktop link
+      substituteInPlace $out/share/applications/lbry.desktop \
+        --replace /opt/LBRY/ $out/bin/
+
+      runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    changelog = "https://github.com/lbryio/lbry-desktop/blob/master/CHANGELOG.md";
+    description = "Official LBRY.tv desktop client";
+    downloadPage = "https://lbry.com/get";
+    homepage = "https://lbry.com";
+    license = licenses.mit;
+    maintainers = with maintainers; [ islandusurper ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22140,6 +22140,8 @@ in
 
   lbdb = callPackage ../tools/misc/lbdb { abook = null; gnupg = null; goobook = null; khard = null; mu = null; };
 
+  lbry = callPackage ../applications/video/lbry { };
+
   lbzip2 = callPackage ../tools/compression/lbzip2 { };
 
   lci = callPackage ../applications/science/logic/lci {};


### PR DESCRIPTION
I would have preferred to make it from source, but couldn't get it to work. So this is derived from the `.deb`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add application to watch videos hosted on LBRY. I used this app before I switched to NixOS, so I'm motivated to keep maintaining it, as new versions come out fairly regularly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
