### PR TITLE
ncgopher: Init at 0.1.5

### DIFF
--- a/pkgs/applications/networking/ncgopher/default.nix
+++ b/pkgs/applications/networking/ncgopher/default.nix
@@ -19,11 +19,10 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "12r4vgrg2bkr3p61yxcsg02kppg84vn956l0v1vb08i94rxzc8zk";
-  verifyCargoDeps = true;
-  
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    (lib.getDev ncurses6)
+    ncurses6
     openssl
     sqlite
   ];

--- a/pkgs/applications/networking/ncgopher/default.nix
+++ b/pkgs/applications/networking/ncgopher/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, ncurses6
+, openssl
+, sqlite
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ncgopher";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "jansc";
+    repo = "ncgopher";
+    rev = "v${version}";
+    sha256 = "1mv89sanmr49b9za95jl5slpq960b246j2054r8xfafzqmbp44af";
+  };
+
+  cargoSha256 = "12r4vgrg2bkr3p61yxcsg02kppg84vn956l0v1vb08i94rxzc8zk";
+  verifyCargoDeps = true;
+  
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    (lib.getDev ncurses6)
+    openssl
+    sqlite
+  ];
+
+  meta = with lib; {
+    description = "A gopher and gemini client for the modern internet";
+    homepage = "https://github.com/jansc/ncgopher";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5600,6 +5600,8 @@ in
 
   ncftp = callPackage ../tools/networking/ncftp { };
 
+  ncgopher = callPackage ../applications/networking/ncgopher { };
+
   ncompress = callPackage ../tools/compression/ncompress { };
 
   ndisc6 = callPackage ../tools/networking/ndisc6 { };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/87784

###### Things done
Packaged ncgopher at release 0.1.5. (Spoiler: takes some time to build)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
