### PR TITLE
Fix: build wkhtmltopdf with patched Qt4

### DIFF
--- a/pkgs/tools/graphics/wkhtmltopdf/default.nix
+++ b/pkgs/tools/graphics/wkhtmltopdf/default.nix
@@ -18,18 +18,18 @@
 #
 # Previously (before this solution here) we thought that individual versions
 # of wkhtmltopdf like 0.12.3, 0.12.4, 0.12.5 had different bugs that users
-# were experiencing, but the "patched QT" fix seems to have shown us that 
+# were experiencing, but the "patched QT" fix seems to have shown us that
 # NixOS (and our own builds) didn't properly include the patched QT version
 # all the time.
 #
 # As a history of this code, here are the bugs we had in our hands:
 #
-# * #128175 triggered a full review of this code and has shown us that 
-#   we maybe do not need pin the versions but need to be careful about 
+# * #128175 triggered a full review of this code and has shown us that
+#   we maybe do not need pin the versions but need to be careful about
 #   including the right version of QT.
 #
 
-let 
+let
   wkQt = qt4.overrideAttrs (oldAttrs: rec {
     name = "qt-mod-4.8.7-7480f44";
     enableParallelBuilding = true;
@@ -130,11 +130,11 @@ let
         -system-libjpeg
         -system-libpng
         -system-zlib
-        -webkit 
+        -webkit
         -xmlpatterns
       '';
   });
-in 
+in
 
 stdenv.mkDerivation rec {
   version = "0.12.6";

--- a/pkgs/tools/graphics/wkhtmltopdf/default.nix
+++ b/pkgs/tools/graphics/wkhtmltopdf/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, qt4, fontconfig, freetype, libpng, zlib, libjpeg
+{ stdenv, fetchFromGitHub, removeReferencesTo
+, qt4, fontconfig, freetype, libpng, zlib, libjpeg
 , openssl, libX11, libXext, libXrender, lib }:
 
 # wkhtmltopdf is a weird beast.
@@ -47,7 +48,7 @@ let
       "qt4-openssl-1.1.patch"
       "libressl.patch"
       "qt4-gcc6.patch" ];
-    patches = builtins.filter (
+    patches = [ ./qt4-gcc9.patch ] ++ builtins.filter (
       patch: ! lib.any (exclude: builtins.baseNameOf patch == exclude)
                        excludePatches ) oldAttrs.patches;
     configureFlags =
@@ -146,6 +147,8 @@ stdenv.mkDerivation rec {
     sha256 = "0m2zy986kzcpg0g3bvvm815ap9n5ann5f6bdy7pfj6jv482bm5mg";
   };
 
+  nativeBuildInputs = [ removeReferencesTo ];
+
   buildInputs = [
     wkQt fontconfig freetype libpng zlib libjpeg openssl
     libX11 libXext libXrender
@@ -158,6 +161,10 @@ stdenv.mkDerivation rec {
   '';
 
   configurePhase = "qmake wkhtmltopdf.pro INSTALLBASE=$out";
+
+  postFixup = ''
+    remove-references-to -t ${wkQt} $out/bin/* $out/lib/*
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/graphics/wkhtmltopdf/default.nix
+++ b/pkgs/tools/graphics/wkhtmltopdf/default.nix
@@ -1,10 +1,143 @@
-{ mkDerivation, lib, fetchFromGitHub, qtwebkit, qtsvg, qtxmlpatterns
-, fontconfig, freetype, libpng, zlib, libjpeg
-, openssl, libX11, libXext, libXrender }:
+{ stdenv, fetchFromGitHub, qt4, fontconfig, freetype, libpng, zlib, libjpeg
+, openssl, libX11, libXext, libXrender, lib }:
 
-mkDerivation rec {
+# wkhtmltopdf is a weird beast.
+#
+# Most of the functionality is derived from an older QT version providing
+# webkit applied with a bunch of fixes that never made it upstream.
+#
+# See https://wkhtmltopdf.org/status.html for details and whether things have
+# changed.
+#
+# For the 0.12 release series we came to the conclusion that we simply have to
+# use the patched QT version - otherwise weird output bugs will creep in.
+#
+# NixOS already provides a patched built of QT 4, some of which are already
+# applied in the patched QT version from wkhtmltopdf, so we deselect those.
+#
+# Previously (before this solution here) we thought that individual versions
+# of wkhtmltopdf like 0.12.3, 0.12.4, 0.12.5 had different bugs that users
+# were experiencing, but the "patched QT" fix seems to have shown us that 
+# NixOS (and our own builds) didn't properly include the patched QT version
+# all the time.
+#
+# As a history of this code, here are the bugs we had in our hands:
+#
+# * #128175 triggered a full review of this code and has shown us that 
+#   we maybe do not need pin the versions but need to be careful about 
+#   including the right version of QT.
+#
+
+let 
+  wkQt = qt4.overrideAttrs (oldAttrs: rec {
+    name = "qt-mod-4.8.7-7480f44";
+    enableParallelBuilding = true;
+    src = fetchFromGitHub {
+      owner  = "wkhtmltopdf";
+      repo   = "qt";
+      # This needs to be the exact revision that wkhtmltopdf revers to in its
+      # git submodule matching the release tag of wkhtmltopdf
+      rev    = "7480f44f696fb7db1d473cf447a2c99a656789a9";
+      sha256 = "10v93ffvjzibfda8p890nxxbh9rj23plvqrm1r0fi440phygkbkk";
+    };
+    # The QT version maintained by wkhtmltopdf already includes a number of
+    # the NixOS QT4 patches, so those need to be filtered out.
+    excludePatches = [
+      "clang-5-darwin.patch"
+      "qt4-openssl-1.1.patch"
+      "libressl.patch"
+      "qt4-gcc6.patch" ];
+    patches = builtins.filter (
+      patch: ! lib.any (exclude: builtins.baseNameOf patch == exclude)
+                       excludePatches ) oldAttrs.patches;
+    configureFlags =
+      ''
+        -dbus-linked
+        -glib
+        -no-separate-debug-info
+        -openssl-linked
+        -qdbus
+        -v
+      ''
+      + # This is taken from the wkhtml build script that we don't run
+      ''
+        -confirm-license
+        -exceptions
+        -fast
+        -graphicssystem raster
+        -iconv
+        -largefile
+        -no-3dnow
+        -no-accessibility
+        -no-audio-backend
+        -no-avx
+        -no-cups
+        -no-dbus
+        -no-declarative
+        -no-glib
+        -no-gstreamer
+        -no-gtkstyle
+        -no-icu
+        -no-javascript-jit
+        -no-libmng
+        -no-libtiff
+        -nomake demos
+        -nomake docs
+        -nomake examples
+        -nomake tests
+        -nomake tools
+        -nomake translations
+        -no-mitshm
+        -no-mmx
+        -no-multimedia
+        -no-nas-sound
+        -no-neon
+        -no-nis
+        -no-opengl
+        -no-openvg
+        -no-pch
+        -no-phonon
+        -no-phonon-backend
+        -no-qt3support
+        -no-rpath
+        -no-scripttools
+        -no-sm
+        -no-sql-ibase
+        -no-sql-mysql
+        -no-sql-odbc
+        -no-sql-psql
+        -no-sql-sqlite
+        -no-sql-sqlite2
+        -no-sse
+        -no-sse2
+        -no-sse3
+        -no-sse4.1
+        -no-sse4.2
+        -no-ssse3
+        -no-stl
+        -no-xcursor
+        -no-xfixes
+        -no-xinerama
+        -no-xinput
+        -no-xkb
+        -no-xrandr
+        -no-xshape
+        -no-xsync
+        -opensource
+        -release
+        -static
+        -system-libjpeg
+        -system-libpng
+        -system-zlib
+        -webkit 
+        -xmlpatterns
+      '';
+  });
+in 
+
+stdenv.mkDerivation rec {
   version = "0.12.6";
-  pname = "wkhtmltopdf";
+  name = "wkhtmltopdf-${version}";
 
   src = fetchFromGitHub {
     owner  = "wkhtmltopdf";
@@ -14,9 +147,8 @@ mkDerivation rec {
   };
 
   buildInputs = [
-    fontconfig freetype libpng zlib libjpeg openssl
+    wkQt fontconfig freetype libpng zlib libjpeg openssl
     libX11 libXext libXrender
-    qtwebkit qtsvg qtxmlpatterns
   ];
 
   prePatch = ''
@@ -29,15 +161,14 @@ mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
-    homepage = "https://wkhtmltopdf.org/";
+  meta = with stdenv.lib; {
+    homepage = https://wkhtmltopdf.org/;
     description = "Tools for rendering web pages to PDF or images";
     longDescription = ''
       wkhtmltopdf and wkhtmltoimage are open source (LGPL) command line tools
       to render HTML into PDF and various image formats using the QT Webkit
       rendering engine. These run entirely "headless" and do not require a
       display or display service.
-
       There is also a C library, if you're into that kind of thing.
     '';
     license = licenses.gpl3Plus;

--- a/pkgs/tools/graphics/wkhtmltopdf/qt4-gcc9.patch
+++ b/pkgs/tools/graphics/wkhtmltopdf/qt4-gcc9.patch
@@ -1,0 +1,20 @@
+--- a/configure
++++ b/configure
+@@ -7744,7 +7744,7 @@
+     *-g++*)
+ 	# Check gcc's version
+ 	case "$(${QMAKE_CONF_COMPILER} -dumpversion)" in
+-	    8*|7*|6*|5*|4*|3.4*)
++	    *)
+ 		;;
+             3.3*)
+                 canBuildWebKit="no"
+@@ -8060,7 +8060,7 @@
+     3.*)
+         COMPILER_VERSION="3.*"
+         ;;
+-    8*|7*|6*|5*|4.*)
++    *)
+         COMPILER_VERSION="4"
+         ;;
+     *)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

At some point the build for wkhtmltopdf was switched to upstream Qt5. This is not intended to happen according to the
documentation that wkhtmltopdf itself has published:

When using the version currently available in NixOS we got a lot of complaints that wkhtmltopdf isn't working as expected any longer, specifically with weirdness around X integration, bad renderings, etc. I'm not sure why this was changed to Qt5.

However, I pulled in the original version of the package and updated it to the latest wkhtmltopdf. This works on my 19.03 based system but for some reason I get into a a weird situation on master where this fails to compile: qt4 itself builds fine, but wkhtmltopdf fails with:

```
In file included from ../lib/multipageloader_p.hh:24,
                 from ../lib/multipageloader.cc:21:
../lib/multipageloader.hh:30:10: fatal error: QWebPage: No such file or directory
   30 | #include <QWebPage>
      |          ^~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:434: multipageloader.o] Error 1
make[1]: *** Waiting for unfinished jobs....
In file included from ../lib/converter.cc:22:
../lib/converter_p.hh:27:10: fatal error: QWebSettings: No such file or directory
   27 | #include <QWebSettings>
      |          ^~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:448: converter.o] Error 1
In file included from /nix/store/ycrslxg21nzdiq9whvd0xwpv1whni595-qt-mod-4.8.7-7480f44/include/QtCore/QString:1,
                 from ../lib/logging.hh:25,
                 from ../lib/logging.cc:21:
```

I can see that QtWebkit is not included in the Qt4 output, and the build output seems to configure but not build it. I'm a bit confused by that and would like to:

a) discuss whether we would agree in general whether moving back to the patched qt4 version will be accepted
b) get some help figure out why this works on 19.03 but not master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
