### PR TITLE
jinja2: fix dependencies

### DIFF
--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -3,7 +3,9 @@
 , isPy3k
 , fetchPypi
 , pytest
-, markupsafe }:
+, markupsafe
+, setuptools 
+}:
 
 buildPythonPackage rec {
   pname = "Jinja2";
@@ -15,7 +17,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytest ];
-  propagatedBuildInputs = [ markupsafe ];
+  propagatedBuildInputs = [ markupsafe setuptools ];
 
   # Multiple tests run out of stack space on 32bit systems with python2.
   # See https://github.com/pallets/jinja/issues/1158


### PR DESCRIPTION
###### Motivation for this change

Jinja2 had a missing dependency on setuptools, uncovered while trying to use llvm-cov+gcovr with meson: 

```
Traceback (most recent call last):
  File "/nix/store/zg111qhdg44rhahz51ixd6dfrwafsasz-python3.8-gcovr-4.2/bin/.gcovr-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/zg111qhdg44rhahz51ixd6dfrwafsasz-python3.8-gcovr-4.2/lib/python3.8/site-packages/gcovr/__main__.py", line 253, in main
    print_reports(covdata, options, logger)
  File "/nix/store/zg111qhdg44rhahz51ixd6dfrwafsasz-python3.8-gcovr-4.2/lib/python3.8/site-packages/gcovr/__main__.py", line 368, in print_reports
    generator(covdata, output.value, options)
  File "/nix/store/zg111qhdg44rhahz51ixd6dfrwafsasz-python3.8-gcovr-4.2/lib/python3.8/site-packages/gcovr/html_generator.py", line 107, in print_html_report
    data['CSS'] = templates().get_template('style.css').render(
  File "/nix/store/zg111qhdg44rhahz51ixd6dfrwafsasz-python3.8-gcovr-4.2/lib/python3.8/site-packages/gcovr/html_generator.py", line 36, in __call__
    return self.get()
  File "/nix/store/zg111qhdg44rhahz51ixd6dfrwafsasz-python3.8-gcovr-4.2/lib/python3.8/site-packages/gcovr/html_generator.py", line 25, in load
    result = fn()
  File "/nix/store/zg111qhdg44rhahz51ixd6dfrwafsasz-python3.8-gcovr-4.2/lib/python3.8/site-packages/gcovr/html_generator.py", line 46, in templates
    loader=PackageLoader('gcovr'),
  File "/nix/store/2qix64mfl3mw7n76z5ii7plrmms51x2g-python3.8-Jinja2-2.11.2/lib/python3.8/site-packages/jinja2/loaders.py", line 233, in __init__
    from pkg_resources import DefaultProvider
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Originally PR #96381, rebased it on staging in this one.