### PR TITLE
somafm-cli: init at 0.3.1

### DIFF
--- a/pkgs/tools/misc/somafm-cli/default.nix
+++ b/pkgs/tools/misc/somafm-cli/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, fetchFromGitHub
+, makeWrapper
+, curl
+, jq
+, mpv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "somafm-cli";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "rockymadden";
+    repo = "somafm-cli";
+    rev = "v${version}";
+    sha256 = "1h5p9qsczgfr450sklh2vkllcpzb7nicbs8ciyvkavh3d7hds0yy";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -m0755 -D src/somafm $out/bin/somafm
+    wrapProgram $out/bin/somafm --prefix PATH ":" "${stdenv.lib.makeBinPath [ curl jq mpv ]}";
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Listen to SomaFM in your terminal via pure bash";
+    homepage = "https://github.com/rockymadden/somafm-cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25648,6 +25648,8 @@ in
 
   snpeff = callPackage ../applications/science/biology/snpeff { };
 
+  somafm-cli = callPackage ../tools/misc/somafm-cli/default.nix { };
+
   somatic-sniper = callPackage ../applications/science/biology/somatic-sniper { };
 
   sortmerna = callPackage ../applications/science/biology/sortmerna { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

somafm-cli wasn't already in the package repo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
