### PR TITLE
[20.03] Add cuda 11

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -95,12 +95,33 @@ stdenv.mkDerivation rec {
       cd ..
     done
     ''}
-    ${lib.optionalString (lib.versionAtLeast version "10.1") ''
+    ${lib.optionalString (lib.versionAtLeast version "10.1" && lib.versionOlder version "11") ''
       cd pkg/builds/cuda-toolkit
       mv * $out/
     ''}
+    ${lib.optionalString (lib.versionAtLeast version "11") ''
+      mkdir -p $out/bin $out/lib64 $out/include $out/doc
+      for dir in pkg/builds/* pkg/builds/cuda_nvcc/nvvm pkg/builds/cuda_cupti/extras/CUPTI; do
+        if [ -d $dir/bin ]; then
+          mv $dir/bin/* $out/bin
+        fi
+        if [ -d $dir/doc ]; then
+          (cd $dir/doc && find . -type d -exec mkdir -p $out/doc/\{} \;)
+          (cd $dir/doc && find . \( -type f -o -type l \) -exec mv \{} $out/doc/\{} \;)
+        fi
+        if [ -L $dir/include ] || [ -d $dir/include ]; then
+          (cd $dir/include && find . -type d -exec mkdir -p $out/include/\{} \;)
+          (cd $dir/include && find . \( -type f -o -type l \) -exec mv \{} $out/include/\{} \;)
+        fi
+        if [ -L $dir/lib64 ] || [ -d $dir/lib64 ]; then
+          (cd $dir/lib64 && find . -type d -exec mkdir -p $out/lib64/\{} \;)
+          (cd $dir/lib64 && find . \( -type f -o -type l \) -exec mv \{} $out/lib64/\{} \;)
+        fi
+      done
+      mv pkg/builds/cuda_nvcc/nvvm $out/nvvm
+    ''}
 
-    rm $out/tools/CUDA_Occupancy_Calculator.xls # FIXME: why?
+    rm -f $out/tools/CUDA_Occupancy_Calculator.xls # FIXME: why?
 
     ${lib.optionalString (lib.versionOlder version "10.1") ''
     # let's remove the 32-bit libraries, they confuse the lib64->lib mover
@@ -152,7 +173,7 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    for b in nvvp nsight; do
+    for b in nvvp ${lib.optionalString (lib.versionOlder version "11") "nsight"}; do
       wrapProgram "$out/bin/$b" \
         --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
     done

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -4,6 +4,7 @@
 , gcc48
 , gcc6
 , gcc7
+, gcc9
 }:
 
 let
@@ -136,4 +137,14 @@ in rec {
   };
 
   cudatoolkit_10 = cudatoolkit_10_2;
+
+  cudatoolkit_11_0 = common {
+    version = "11.0.3";
+    url = "https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run";
+    sha256 = "1h4c69nfrgm09jzv8xjnjcvpq8n4gnlii17v3wzqry5d13jc8ydh";
+
+    gcc = gcc9;
+  };
+
+  cudatoolkit_11 = cudatoolkit_11_0;
 }

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, cudatoolkit_7, cudatoolkit_7_5, cudatoolkit_8, cudatoolkit_9_0, cudatoolkit_9_1, cudatoolkit_9_2, cudatoolkit_10_0, cudatoolkit_10_1 }:
+{ callPackage, cudatoolkit_7, cudatoolkit_7_5, cudatoolkit_8, cudatoolkit_9_0, cudatoolkit_9_1, cudatoolkit_9_2, cudatoolkit_10_0, cudatoolkit_10_1, cudatoolkit_10_2 }:
 
 let
   generic = args: callPackage (import ./generic.nix (removeAttrs args ["cudatoolkit"])) {
@@ -70,6 +70,13 @@ in rec {
     cudatoolkit = cudatoolkit_10_1;
     srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.6.3.30.tgz";
     sha256 = "0qc9f1xpyfibwqrpqxxq2v9h6w90j0dbx564akwy44c1dls5f99m";
+  };
+
+  cudnn_cudatoolkit_10_2 = generic rec {
+    version = "7.6.5";
+    cudatoolkit = cudatoolkit_10_2;
+    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.6.5.32.tgz";
+    sha256 = "084c13vzjdkb5s1996yilybg6dgav1lscjr1xdcgvlmfrbr6f0k0";
   };
 
   cudnn_cudatoolkit_10 = cudnn_cudatoolkit_10_1;

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, cudatoolkit_7, cudatoolkit_7_5, cudatoolkit_8, cudatoolkit_9_0, cudatoolkit_9_1, cudatoolkit_9_2, cudatoolkit_10_0, cudatoolkit_10_1, cudatoolkit_10_2 }:
+{ callPackage, cudatoolkit_7, cudatoolkit_7_5, cudatoolkit_8, cudatoolkit_9_0, cudatoolkit_9_1, cudatoolkit_9_2, cudatoolkit_10_0, cudatoolkit_10_1, cudatoolkit_10_2, cudatoolkit_11_0 }:
 
 let
   generic = args: callPackage (import ./generic.nix (removeAttrs args ["cudatoolkit"])) {
@@ -80,4 +80,13 @@ in rec {
   };
 
   cudnn_cudatoolkit_10 = cudnn_cudatoolkit_10_1;
+
+  cudnn_cudatoolkit_11_0 = generic rec {
+    version = "8.0.2";
+    cudatoolkit = cudatoolkit_11_0;
+    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v8.0.2.39.tgz";
+    sha256 = "0ib3v3bgcdxarqapkxngw1nwl0c2a7zz392ns7w9ipcficl4cbv7";
+  };
+
+  cudnn_cudatoolkit_11 = cudnn_cudatoolkit_11_0;
 }

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -32,6 +32,13 @@ stdenv.mkDerivation {
     mkdir -p $out
     cp -a include $out/include
     cp -a lib64 $out/lib64
+
+    ${lib.optionalString (lib.versionAtLeast version "8") ''
+      # patchelf fails on libcudnn_cnn_infer due to it being too big.
+      # I'm hoping it's not needed for most programs.
+      # (https://github.com/NixOS/patchelf/issues/222)
+      rm -f $out/lib64/libcudnn_cnn_infer*
+    ''}
   '';
 
   # Set RUNPATH so that libcuda in /run/opengl-driver(-32)/lib can be found.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2670,7 +2670,9 @@ in
     cudatoolkit_10
     cudatoolkit_10_0
     cudatoolkit_10_1
-    cudatoolkit_10_2;
+    cudatoolkit_10_2
+    cudatoolkit_11
+    cudatoolkit_11_0;
 
   cudatoolkit = cudatoolkit_10;
 
@@ -2687,7 +2689,9 @@ in
     cudnn_cudatoolkit_10
     cudnn_cudatoolkit_10_0
     cudnn_cudatoolkit_10_1
-    cudnn_cudatoolkit_10_2;
+    cudnn_cudatoolkit_10_2
+    cudnn_cudatoolkit_11
+    cudnn_cudatoolkit_11_0;
 
   cudnn = cudnn_cudatoolkit_10;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2669,7 +2669,8 @@ in
     cudatoolkit_9_2
     cudatoolkit_10
     cudatoolkit_10_0
-    cudatoolkit_10_1;
+    cudatoolkit_10_1
+    cudatoolkit_10_2;
 
   cudatoolkit = cudatoolkit_10;
 
@@ -2685,7 +2686,8 @@ in
     cudnn_cudatoolkit_9_2
     cudnn_cudatoolkit_10
     cudnn_cudatoolkit_10_0
-    cudnn_cudatoolkit_10_1;
+    cudnn_cudatoolkit_10_1
+    cudnn_cudatoolkit_10_2;
 
   cudnn = cudnn_cudatoolkit_10;
 


### PR DESCRIPTION
This includes part of https://github.com/NixOS/nixpkgs/pull/95727 for 20.03. Leaving out the nccl update because that would drop support for cuda 9. So this just adds the base cudatoolkit11 library.

/cc @bhipple 