### PR TITLE
nixos/stunnel: Options for client certificates

### DIFF
--- a/nixos/modules/services/networking/stunnel.nix
+++ b/nixos/modules/services/networking/stunnel.nix
@@ -81,7 +81,7 @@ let
       };
 
       key = mkOption {
-        type = with types; nullOr path;
+        type = with types; nullOr (strMatching "/.*");
         default = null;
         description = "Client's key with which it authenticates to the server.";
       };

--- a/nixos/modules/services/networking/stunnel.nix
+++ b/nixos/modules/services/networking/stunnel.nix
@@ -73,6 +73,18 @@ let
         default = null;
         description = "If set, stunnel checks if the provided certificate is valid for the given hostname.";
       };
+
+      cert = mkOption {
+        type = with types; nullOr path;
+        default = null;
+        description = "Client's certificate with which it authenticates to the server.";
+      };
+
+      key = mkOption {
+        type = with types; nullOr path;
+        default = null;
+        description = "Client's key with which it authenticates to the server.";
+      };
     };
   };
 
@@ -204,6 +216,8 @@ in
                ${optionalString (v.CAPath != null) "CApath = ${v.CAPath}"}
                ${optionalString (v.CAFile != null) "CAFile = ${v.CAFile}"}
                ${optionalString (v.verifyHostname != null) "checkHost = ${v.verifyHostname}"}
+               ${optionalString (v.cert != null) (assert v.key != null; "cert = ${v.cert}")}
+               ${optionalString (v.key != null) (assert v.cert != null; "key = ${v.key}")}
                OCSPaia = yes
 
              '')


### PR DESCRIPTION
###### Motivation for this change
Don't stand in the way of folks trying to use this stunnel feature.  (This module has no extraConfig option that would otherwise allow this through.)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
