### PR TITLE
tippecanoe: 1.35.0 -> 1.36.0

### DIFF
--- a/pkgs/applications/misc/tippecanoe/default.nix
+++ b/pkgs/applications/misc/tippecanoe/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tippecanoe";
-  version = "1.35.0";
+  version = "1.36.0";
 
   src = fetchFromGitHub {
     owner = "mapbox";
     repo = pname;
     rev = version;
-    sha256 = "0v5ycc3gsqnl9pps3m45yrnb1gvw5pk6jdyr0q6516b4ac6x67m5";
+    sha256 = "0lbmhly4ivnqc6qk1k3sdqvsg6x3nfd8gnjx846bhqj4wag3f88m";
   };
 
   buildInputs = [ sqlite zlib ];
@@ -25,5 +25,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     maintainers = with maintainers; [ sikmir ];
     platforms = with platforms; linux ++ darwin;
+    broken = stdenv.hostPlatform.isAarch64;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/mapbox/tippecanoe/blob/master/CHANGELOG.md)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
