### PR TITLE
nomad: 0.12.2 -> 0.12.3

### DIFF
--- a/pkgs/applications/networking/cluster/nomad/0.11.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.11.nix
@@ -1,6 +1,7 @@
-{ callPackage }:
+{ callPackage, buildGoPackage }:
 
 callPackage ./generic.nix {
+  inherit buildGoPackage;
   version = "0.11.4";
   sha256 = "1sykp9sji6f564s7bz0cvnr9w5x92n0l1r1djf1bl7jvv2mi1mcb";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.12.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.12.nix
@@ -1,6 +1,7 @@
-{ callPackage }:
+{ callPackage, buildGoPackage }:
 
 callPackage ./generic.nix {
+  inherit buildGoPackage;
   version = "0.12.3";
   sha256 = "100ynhc4nm4mmjxx1jhq2kjbqshxvi5x8y482520j8gsyn40g6zc";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.12.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.12.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
 callPackage ./generic.nix {
-  version = "0.12.2";
-  sha256 = "1gc286ag6plk5kxw7jzr32cp3n5rwydj1z7rds1rfd0fyq7an404";
+  version = "0.12.3";
+  sha256 = "100ynhc4nm4mmjxx1jhq2kjbqshxvi5x8y482520j8gsyn40g6zc";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5687,8 +5687,15 @@ in
   noip = callPackage ../tools/networking/noip { };
 
   nomad = nomad_0_11;
-  nomad_0_11 = callPackage ../applications/networking/cluster/nomad/0.11.nix { };
-  nomad_0_12 = callPackage ../applications/networking/cluster/nomad/0.12.nix { };
+  # Nomad never updates major go versions within a release series and is unsupported
+  # on Go versions that it did not ship with. Due to historic bugs when compiled
+  # with different versions we pin Go for all versions.
+  nomad_0_11 = callPackage ../applications/networking/cluster/nomad/0.11.nix {
+    buildGoPackage = buildGo114Package;
+  };
+  nomad_0_12 = callPackage ../applications/networking/cluster/nomad/0.12.nix {
+    buildGoPackage = buildGo114Package;
+  };
 
   notable = callPackage ../applications/misc/notable { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bumping to 0.12.3

Because of #95885 this should also redefine both versions of nomad to build with go 1.14, as that's the expectation from upstream, but I'm unsure on how to do that.
I understand that usually I'd be able to just specify `buildGoPackage = buildGo114Package`, but because it was requested the individual versions are implemented as files, I'm not entirely sure how to achieve that - any help would be appreciated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
