### PR TITLE
tracy: 0.7 → 0.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9474,6 +9474,12 @@
     github = "fzakaria";
     githubId = 605070;
   };
+  nagisa = {
+    name = "Simonas Kazlauskas";
+    email = "nixpkgs@kazlauskas.me";
+    github = "nagisa";
+    githubId = 679122;
+  };
   yevhenshymotiuk = {
     name = "Yevhen Shymotiuk";
     email = "yevhenshymotiuk@gmail.com";

--- a/pkgs/development/tools/tracy/default.nix
+++ b/pkgs/development/tools/tracy/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, lib, darwin, fetchFromGitHub, tbb, gtk2, glfw, pkgconfig, freetype, Carbon, AppKit, capstone }:
+{ stdenv, lib, darwin, fetchFromGitHub, tbb, gtk3, glfw, pkgconfig, freetype, Carbon, AppKit, capstone }:
 
 stdenv.mkDerivation rec {
   pname = "tracy";
-  version = "0.7";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "wolfpld";
     repo = "tracy";
     rev = "v${version}";
-    sha256 = "07cmz2w7iv10f9i9q3fhg80s6riy9bxnk9xvc3q4lw47mc150skp";
+    sha256 = "13zg3ijzhh7qkhgqff2ca23nd4gj7ac8jr0bp9w1gjf2cpgqkm40";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [ glfw capstone ]
     ++ lib.optionals stdenv.isDarwin [ Carbon AppKit freetype ]
-    ++ lib.optionals stdenv.isLinux [ gtk2 tbb ];
+    ++ lib.optionals stdenv.isLinux [ gtk3 tbb ];
 
   NIX_CFLAGS_COMPILE = [ ]
     ++ lib.optional stdenv.isLinux "-ltbb"
@@ -35,11 +35,15 @@ stdenv.mkDerivation rec {
     install -D ./update/build/unix/update-release $out/bin/update
   '';
 
+  fixupPhase = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -change libcapstone.4.dylib ${capstone}/lib/libcapstone.4.dylib $out/bin/Tracy
+  '';
+
   meta = with stdenv.lib; {
     description = "A real time, nanosecond resolution, remote telemetry frame profiler for games and other applications.";
     homepage = "https://github.com/wolfpld/tracy";
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.bsd3;
-    maintainers = with maintainers; [ mpickering ];
+    maintainers = with maintainers; [ mpickering nagisa ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Tracy 0.7.1 was released a couple of days ago. https://github.com/wolfpld/tracy/releases/tag/v0.7.1

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
