### PR TITLE
numpy: set runtime_library_dirs too

### DIFF
--- a/pkgs/development/python-modules/numpy/1.16.nix
+++ b/pkgs/development/python-modules/numpy/1.16.nix
@@ -21,15 +21,18 @@ let
       ${blas.implementation} = {
         include_dirs = "${lib.getDev blas}/include:${lib.getDev lapack}/include";
         library_dirs = "${blas}/lib:${lapack}/lib";
+        runtime_library_dirs = "${blas}/lib:${lapack}/lib";
         libraries = "lapack,lapacke,blas,cblas";
       };
       lapack = {
         include_dirs = "${lib.getDev lapack}/include";
         library_dirs = "${lapack}/lib";
+        runtime_library_dirs = "${lapack}/lib";
       };
       blas = {
         include_dirs = "${lib.getDev blas}/include";
         library_dirs = "${blas}/lib";
+        runtime_library_dirs = "${blas}/lib";
       };
     });
   };

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -22,15 +22,18 @@ let
       ${blas.implementation} = {
         include_dirs = "${lib.getDev blas}/include:${lib.getDev lapack}/include";
         library_dirs = "${blas}/lib:${lapack}/lib";
+        runtime_library_dirs = "${blas}/lib:${lapack}/lib";
         libraries = "lapack,lapacke,blas,cblas";
       };
       lapack = {
         include_dirs = "${lib.getDev lapack}/include";
         library_dirs = "${lapack}/lib";
+        runtime_library_dirs = "${lapack}/lib";
       };
       blas = {
         include_dirs = "${lib.getDev blas}/include";
         library_dirs = "${blas}/lib";
+        runtime_library_dirs = "${blas}/lib";
       };
     });
   };


### PR DESCRIPTION
This appears to be needed in some Python distutils for the library to
get on RPATH correctly. I’m not sure why this worked before, but I
needed this value set for Python 3.8 numpy to work correctly.
