### PR TITLE
satysfi: 0.0.4 → 0.0.5

### DIFF
--- a/pkgs/tools/typesetting/satysfi/default.nix
+++ b/pkgs/tools/typesetting/satysfi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, fetchFromGitHub, ruby, dune, ocamlPackages
+{ stdenv, fetchzip, fetchFromGitHub, ruby, dune_2, ocamlPackages
 , ipaexfont, junicode, lmodern, lmmath
 }:
 let
@@ -6,8 +6,8 @@ let
     src = fetchFromGitHub {
       owner = "gfngfn";
       repo = "camlpdf";
-      rev = "v2.2.2+satysfi";
-      sha256 = "1dkyibjd8qb9fzljlzdsfdhb798vc9m8xqkd7295fm6bcfpr5r5k";
+      rev = "v2.3.1+satysfi";
+      sha256 = "1s8wcqdkl1alvfcj67lhn3qdz8ikvd1v64f4q6bi4c0qj9lmp30k";
     };
   });
   otfm = ocamlPackages.otfm.overrideAttrs (o: {
@@ -18,23 +18,29 @@ let
       sha256 = "0y8s0ij1vp1s4h5y1hn3ns76fzki2ba5ysqdib33akdav9krbj8p";
     };
   });
-  yojson = ocamlPackages.yojson.overrideAttrs (o: {
+  yojson-with-position = ocamlPackages.buildDunePackage {
+    pname = "yojson-with-position";
+    version = "1.4.2";
     src = fetchFromGitHub {
       owner = "gfngfn";
-      repo = "yojson";
-      rev = "v1.4.1+satysfi";
-      sha256 = "06lajzycwmvc6s26cf40s9xn001cjxrpxijgfha3s4f4rpybb1mp";
+      repo = "yojson-with-position";
+      rev = "v1.4.2+satysfi";
+      sha256 = "17s5xrnpim54d1apy972b5l08bph4c0m5kzbndk600fl0vnlirnl";
     };
-  });
+    useDune2 = true;
+    nativeBuildInputs = [ ocamlPackages.cppo ];
+    propagatedBuildInputs = [ ocamlPackages.biniou ];
+    inherit (ocamlPackages.yojson) meta;
+  };
 in
   stdenv.mkDerivation rec {
     pname = "satysfi";
-    version = "0.0.4";
+    version = "0.0.5";
     src = fetchFromGitHub {
       owner = "gfngfn";
       repo = "SATySFi";
       rev = "v${version}";
-      sha256 = "0ilvgixglklqwavf8p9mcbrjq6cjfm9pk4kqx163c0irh0lh0adv";
+      sha256 = "1y72by6d15bc6qb1lv1ch6cm1i74gyr0w127nnvs2s657snm0y1n";
       fetchSubmodules = true;
     };
 
@@ -44,11 +50,11 @@ in
       $out/share/satysfi
     '';
 
-    nativeBuildInputs = [ ruby dune ];
+    nativeBuildInputs = [ ruby dune_2 ];
 
-    buildInputs = [ camlpdf otfm ] ++ (with ocamlPackages; [
+    buildInputs = [ camlpdf otfm yojson-with-position ] ++ (with ocamlPackages; [
       ocaml findlib menhir
-      batteries camlimages core_kernel ppx_deriving uutf yojson omd cppo re
+      batteries camlimages core_kernel ppx_deriving uutf omd cppo re
     ]);
 
     installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27081,9 +27081,7 @@ in
 
   sanoid = callPackage ../tools/backup/sanoid { };
 
-  satysfi = callPackage ../tools/typesetting/satysfi {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_07;
-  };
+  satysfi = callPackage ../tools/typesetting/satysfi { };
 
   sc-controller = pythonPackages.callPackage ../misc/drivers/sc-controller {
     inherit libusb1; # Shadow python.pkgs.libusb1.


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/gfngfn/SATySFi/blob/v0.0.5/CHANGELOG.md#005---2020-07-11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
