### PR TITLE
tegola: 0.11.2 -> 0.12.0

### DIFF
--- a/pkgs/servers/tegola/default.nix
+++ b/pkgs/servers/tegola/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "tegola";
-  version = "0.11.2";
+  version = "0.12.0";
 
   goPackagePath = "github.com/go-spatial/tegola";
 
@@ -10,8 +10,10 @@ buildGoPackage rec {
     owner = "go-spatial";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0xrjs0py08q9i31rl0cxi6idncrrgqwcspqks3c5vd9i65yqc6fv";
+    sha256 = "1bm791cis6bqgvhkk6n03kdxh0y9fdkhsx4rgmv7pm3zzdd7b17r";
   };
+
+  buildFlagsArray = [ "-ldflags=-s -w -X ${goPackagePath}/cmd/tegola/cmd.Version=${version}" ];
 
   meta = with stdenv.lib; {
     homepage = "https://www.tegola.io/";


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/go-spatial/tegola/releases/tag/v0.12.0)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
