### PR TITLE
nixos/redis Add connection wait script to ensure connections can be made to redis

### DIFF
--- a/pkgs/applications/editors/emacs-modes/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/elpa-generated.nix
@@ -294,7 +294,7 @@
           license = lib.licenses.free;
         };
       }) {};
-    bbdb = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+    bbdb = callPackage ({ cl-lib ? null, elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "bbdb";
         ename = "bbdb";
@@ -303,7 +303,7 @@
           url = "https://elpa.gnu.org/packages/bbdb-3.2.tar";
           sha256 = "1p56dg0mja2b2figy7yhdx714zd5j6njzn0k07zjka3jc06izvjx";
         };
-        packageRequires = [ emacs ];
+        packageRequires = [ cl-lib emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/bbdb.html";
           license = lib.licenses.free;
@@ -328,10 +328,10 @@
       elpaBuild {
         pname = "bluetooth";
         ename = "bluetooth";
-        version = "0.1.2";
+        version = "0.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/bluetooth-0.1.2.el";
-          sha256 = "1vp2vpyq0ybjni35ics1mg1kiwgvc7x12dlmvygy78sqp52sfkcv";
+          url = "https://elpa.gnu.org/packages/bluetooth-0.2.el";
+          sha256 = "1dq04p6ms0zx4awlypp4crkz7dzal4xg8ac7p8fqacz196rczssp";
         };
         packageRequires = [ dash emacs ];
         meta = {
@@ -760,10 +760,10 @@
       elpaBuild {
         pname = "debbugs";
         ename = "debbugs";
-        version = "0.25";
+        version = "0.26";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/debbugs-0.25.tar";
-          sha256 = "0h0pxav170yzfpjf4vb8simiw67x9dkcjx9m4ghdk6wia25y8jni";
+          url = "https://elpa.gnu.org/packages/debbugs-0.26.tar";
+          sha256 = "14n2rrs3ccvlp8fhxs08awlqdfawxwbj8nq1xpa0wwlbfvxnf24c";
         };
         packageRequires = [ emacs soap-client ];
         meta = {
@@ -955,10 +955,10 @@
       elpaBuild {
         pname = "ebdb";
         ename = "ebdb";
-        version = "0.6.18";
+        version = "0.6.19";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ebdb-0.6.18.tar";
-          sha256 = "0znbv3c7wdgak1f1zb051vg4r29fksqh53k1j77jfmqcvwkpz2mw";
+          url = "https://elpa.gnu.org/packages/ebdb-0.6.19.tar";
+          sha256 = "0ch5vzhxa8h5v75lg3blsmrln497lr3ylivx6w28aiyb6cv5016l";
         };
         packageRequires = [ cl-lib emacs seq ];
         meta = {
@@ -985,10 +985,10 @@
       elpaBuild {
         pname = "ebdb-i18n-chn";
         ename = "ebdb-i18n-chn";
-        version = "1.3";
+        version = "1.3.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ebdb-i18n-chn-1.3.el";
-          sha256 = "1w7xgagscyjxrw4xl8bz6wf7skvdvk5qdcp5p7kxl4r9nhjffj20";
+          url = "https://elpa.gnu.org/packages/ebdb-i18n-chn-1.3.1.el";
+          sha256 = "02drr89i4kzjm1rs22sj0nv9sj95dmqk40xvxd75qzfn8y33k9vl";
         };
         packageRequires = [ ebdb pyim ];
         meta = {
@@ -1070,10 +1070,10 @@
       elpaBuild {
         pname = "eldoc";
         ename = "eldoc";
-        version = "1.8.0";
+        version = "1.10.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/eldoc-1.8.0.el";
-          sha256 = "1zxy9x9a0yqwdi572jj04x9lyj3d87mpyfbn3092a5nqwc864k9w";
+          url = "https://elpa.gnu.org/packages/eldoc-1.10.0.el";
+          sha256 = "19jpvlwa7hagkwdzgrgdfd1l8w0vy4l3wibpv62sr8ybll2fpap3";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1115,10 +1115,10 @@
       elpaBuild {
         pname = "elisp-benchmarks";
         ename = "elisp-benchmarks";
-        version = "1.7";
+        version = "1.8";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/elisp-benchmarks-1.7.tar";
-          sha256 = "1ps28bvh87d98k84ygx374a1kbwvnqm4w8jpkgzic01as78hgkiz";
+          url = "https://elpa.gnu.org/packages/elisp-benchmarks-1.8.tar";
+          sha256 = "0kybddzmyccc22q1knlz05b45bymdkxaf6lngxvyixvid81iydjg";
         };
         packageRequires = [];
         meta = {
@@ -1197,6 +1197,7 @@
                                , fsm
                                , lib
                                , nadvice
+                               , org
                                , soap-client
                                , url-http-ntlm }:
       elpaBuild {
@@ -1207,7 +1208,7 @@
           url = "https://elpa.gnu.org/packages/excorporate-0.8.3.tar";
           sha256 = "04bsbiwgfbfd501qvwh0iwyk0xh442kjfj73b3876idwj3p8alr5";
         };
-        packageRequires = [ emacs fsm nadvice soap-client url-http-ntlm ];
+        packageRequires = [ emacs fsm nadvice org soap-client url-http-ntlm ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/excorporate.html";
           license = lib.licenses.free;
@@ -1427,10 +1428,10 @@
       elpaBuild {
         pname = "gnorb";
         ename = "gnorb";
-        version = "1.6.7";
+        version = "1.6.8";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/gnorb-1.6.7.tar";
-          sha256 = "17pz6i51z298rk7j3rraw1gxlssn88yi4bbpzyxv9cs7y1lfy8ld";
+          url = "https://elpa.gnu.org/packages/gnorb-1.6.8.tar";
+          sha256 = "14b612s2220b6gc1gzgn7z7smsci80k4fclwqkxpbl7yl426x3qd";
         };
         packageRequires = [ cl-lib ];
         meta = {
@@ -1636,10 +1637,10 @@
       elpaBuild {
         pname = "hyperbole";
         ename = "hyperbole";
-        version = "7.1.2";
+        version = "7.1.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/hyperbole-7.1.2.tar";
-          sha256 = "1bspmqnbniwr9385wh823dsr5fgch5qnlkf45s4vi0nvg8jdccp1";
+          url = "https://elpa.gnu.org/packages/hyperbole-7.1.3.tar";
+          sha256 = "0bizibn4qgxqp89fyik6p47s9hss1g932mg8k7pznn3kkhj5c8rh";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2071,10 +2072,10 @@
       elpaBuild {
         pname = "minimap";
         ename = "minimap";
-        version = "1.3";
+        version = "1.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/minimap-1.3.el";
-          sha256 = "15azlmi6kk9pg1c4zrw952qsh9wq6ggqb4qqc84a7l67nhqb9bqp";
+          url = "https://elpa.gnu.org/packages/minimap-1.4.el";
+          sha256 = "09fm0ziy8cdzzw08l7l6p63dxz2a27p3laia2v51mvbva8177ls1";
         };
         packageRequires = [];
         meta = {
@@ -2101,10 +2102,10 @@
       elpaBuild {
         pname = "modus-operandi-theme";
         ename = "modus-operandi-theme";
-        version = "0.11.0";
+        version = "0.12.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/modus-operandi-theme-0.11.0.el";
-          sha256 = "11sq105vpp8rmyayfb7h8gz099kfdr7nb8n4pg81iby4fllj1kgd";
+          url = "https://elpa.gnu.org/packages/modus-operandi-theme-0.12.0.el";
+          sha256 = "1mllyysn701qfnglxs7n2f6mrzrz55v9hcwspvafc6fl2blr393y";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2116,10 +2117,10 @@
       elpaBuild {
         pname = "modus-vivendi-theme";
         ename = "modus-vivendi-theme";
-        version = "0.11.0";
+        version = "0.12.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/modus-vivendi-theme-0.11.0.el";
-          sha256 = "14ky9cxg9cpvhgg24ra0xla2dapqjlf948470q7v0m402x1r2iif";
+          url = "https://elpa.gnu.org/packages/modus-vivendi-theme-0.12.0.el";
+          sha256 = "01f6z5xjnmki1k9m83jwva42lxidb31pdpwm4wpxjzxqmb96picn";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2301,16 +2302,16 @@
           license = lib.licenses.free;
         };
       }) {};
-    oauth2 = callPackage ({ elpaBuild, fetchurl, lib }:
+    oauth2 = callPackage ({ cl-lib ? null, elpaBuild, fetchurl, lib, nadvice }:
       elpaBuild {
         pname = "oauth2";
         ename = "oauth2";
-        version = "0.13";
+        version = "0.15";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/oauth2-0.13.el";
-          sha256 = "0y5nbdwxz2hfr09xgsqgyv60vgx0rsaisibcpkz00klvgg26w33r";
+          url = "https://elpa.gnu.org/packages/oauth2-0.15.el";
+          sha256 = "0ij17g6i8d4cyzc8v6sy2qglwhzd767331gavll6d507krdh3ca3";
         };
-        packageRequires = [];
+        packageRequires = [ cl-lib nadvice ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/oauth2.html";
           license = lib.licenses.free;
@@ -2380,10 +2381,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "9.3.6";
+        version = "9.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/org-9.3.6.tar";
-          sha256 = "0jwpgfzjvf1hd3mx582pw86hysdryaqzp69hk6azi9kmq4bzk87d";
+          url = "https://elpa.gnu.org/packages/org-9.4.tar";
+          sha256 = "1awkrh3y90q7c0as3327rqj0zylf5cpjzr1pyvbzymli16irhwb6";
         };
         packageRequires = [];
         meta = {
@@ -2395,14 +2396,29 @@
       elpaBuild {
         pname = "org-edna";
         ename = "org-edna";
-        version = "1.1.1";
+        version = "1.1.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/org-edna-1.1.1.tar";
-          sha256 = "1hfkdjbjnhbwb27vgs43ywl4kn2lqc037f4xppp2v0s97850za8r";
+          url = "https://elpa.gnu.org/packages/org-edna-1.1.2.tar";
+          sha256 = "1a022ssqpxbkp03n2bij78srwjx7kacpsgj9a6wbm0yn946hgjpz";
         };
         packageRequires = [ emacs org seq ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/org-edna.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    org-translate = callPackage ({ elpaBuild, emacs, fetchurl, lib, org }:
+      elpaBuild {
+        pname = "org-translate";
+        ename = "org-translate";
+        version = "0.1.1";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/org-translate-0.1.1.el";
+          sha256 = "004ajbbk20ywsckb4wd5dj9l8wm6chql95zfzbzbmj4903svfhfk";
+        };
+        packageRequires = [ emacs org ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/org-translate.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -2545,10 +2561,10 @@
       elpaBuild {
         pname = "phps-mode";
         ename = "phps-mode";
-        version = "0.3.52";
+        version = "0.3.62";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/phps-mode-0.3.52.tar";
-          sha256 = "11783i4raw6z326bqin9g37ig2szbqsma1r0fsdckyn2q6w7nn92";
+          url = "https://elpa.gnu.org/packages/phps-mode-0.3.62.tar";
+          sha256 = "07kfyal5lfmf64kbqml4aqa81n2lmnpxgsi8d0zcg183qpbs9hpb";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2605,10 +2621,10 @@
       elpaBuild {
         pname = "project";
         ename = "project";
-        version = "0.5.1";
+        version = "0.5.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/project-0.5.1.el";
-          sha256 = "1i15hlrfipsfrdmgh6xzkr6aszgvik3y8j9363qkj654dl04pmz4";
+          url = "https://elpa.gnu.org/packages/project-0.5.2.el";
+          sha256 = "181hls4phhj8kgpfcky6h0mgzpl9xj616abvcvx8mrn4nmpyh655";
         };
         packageRequires = [ emacs xref ];
         meta = {
@@ -3041,10 +3057,10 @@
       elpaBuild {
         pname = "seq";
         ename = "seq";
-        version = "2.20";
+        version = "2.22";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/seq-2.20.tar";
-          sha256 = "0vrpx6nnyjb0gsypknzagimlhvcvi5y1rcdkpxyqr42415zr8d0n";
+          url = "https://elpa.gnu.org/packages/seq-2.22.tar";
+          sha256 = "0zlqcbabzj8crg36ird2l74dbg5k7w1zf5iwva0h2dyvwyf9grma";
         };
         packageRequires = [];
         meta = {
@@ -3232,6 +3248,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    sql-beeline = callPackage ({ elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "sql-beeline";
+        ename = "sql-beeline";
+        version = "0.1";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/sql-beeline-0.1.el";
+          sha256 = "0z2wdvvq1zdw90253s5i57lx8b59rjf7g7isns4yz29lwav04j3r";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/sql-beeline.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     sql-indent = callPackage ({ cl-lib ? null, elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "sql-indent";
@@ -3281,10 +3312,10 @@
       elpaBuild {
         pname = "svg";
         ename = "svg";
-        version = "1.0";
+        version = "1.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/svg-1.0.el";
-          sha256 = "1hh0x7sz2rqb7zdhcm2q9knr8nnwqrsbz1zfp29k8l1318li9f62";
+          url = "https://elpa.gnu.org/packages/svg-1.1.el";
+          sha256 = "0j69xsaj0d1pnxjfb5m0yf2vxbrcmr8i3g75km4dzbha46v4xxvg";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3420,10 +3451,10 @@
       elpaBuild {
         pname = "tramp";
         ename = "tramp";
-        version = "2.4.4.1";
+        version = "2.4.4.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/tramp-2.4.4.1.tar";
-          sha256 = "0jayd75yscaqvg6y0m6g2mgbjswyj5gqdij2az9g0j18vm5vbqy3";
+          url = "https://elpa.gnu.org/packages/tramp-2.4.4.2.tar";
+          sha256 = "16c8x5d803hjql0z88lidyx3zrhxlpjphdpzn3ppzz3wrsxsv8rf";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3480,10 +3511,10 @@
       elpaBuild {
         pname = "undo-tree";
         ename = "undo-tree";
-        version = "0.7.4";
+        version = "0.7.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/undo-tree-0.7.4.el";
-          sha256 = "018ixl802f076sfyf4gkacpgrdpybin88jd8vq9zgyvc6x2dalfa";
+          url = "https://elpa.gnu.org/packages/undo-tree-0.7.5.el";
+          sha256 = "00admi87gqm0akhfqm4dcp9fw8ihpygy030955jswkha4zs7lw2p";
         };
         packageRequires = [];
         meta = {
@@ -3674,10 +3705,10 @@
       elpaBuild {
         pname = "vlf";
         ename = "vlf";
-        version = "1.7.1";
+        version = "1.7.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/vlf-1.7.1.tar";
-          sha256 = "0cnwxk20573iqkwk0c0h7pyjk0rkr8l2qd0xmyqj8mvdxjb8nnkz";
+          url = "https://elpa.gnu.org/packages/vlf-1.7.2.tar";
+          sha256 = "0hpri19z6b7dqmrj5ckp8sf0m0l72lkgahqzvfmwhgpgv2p81bny";
         };
         packageRequires = [];
         meta = {
@@ -3779,10 +3810,10 @@
       elpaBuild {
         pname = "which-key";
         ename = "which-key";
-        version = "3.3.0";
+        version = "3.3.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/which-key-3.3.0.tar";
-          sha256 = "0436hvqdn2jafgfwdr0m9mwz8k2swl661xnrkypyrwg66j9wi1qz";
+          url = "https://elpa.gnu.org/packages/which-key-3.3.2.tar";
+          sha256 = "01g5jcikhgxnri1rpbjq191220b4r3bimz2jzs1asc766w42q2gb";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3934,10 +3965,10 @@
       elpaBuild {
         pname = "xref";
         ename = "xref";
-        version = "1.0.2";
+        version = "1.0.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/xref-1.0.2.el";
-          sha256 = "156rfwdihb3vz31iszbmby16spqswyf69nhl3r2cp6jzkgwzc1d8";
+          url = "https://elpa.gnu.org/packages/xref-1.0.3.el";
+          sha256 = "1r531gl73y1br8g4n77gxbyj26yiaw7snjad21fgs5m80cka8fi3";
         };
         packageRequires = [ emacs ];
         meta = {

--- a/pkgs/applications/editors/emacs-modes/org-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/org-generated.nix
@@ -4,10 +4,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "20200817";
+        version = "20200921";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-20200817.tar";
-          sha256 = "159hch9zls3apxq11c5rjpmci1avyl7q3cgsrqxwgnzy8c61104d";
+          url = "https://orgmode.org/elpa/org-20200921.tar";
+          sha256 = "0qwa375j11d2rx6z18sr6s4qja96k78rv9r2y04ksn103gr9dd4l";
         };
         packageRequires = [];
         meta = {
@@ -19,10 +19,10 @@
       elpaBuild {
         pname = "org-plus-contrib";
         ename = "org-plus-contrib";
-        version = "20200817";
+        version = "20200921";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-plus-contrib-20200817.tar";
-          sha256 = "0n3fhcxjsk2w78p7djna4nlppa7ypjxzpq3r5dmzc8jpl71mipba";
+          url = "https://orgmode.org/elpa/org-plus-contrib-20200921.tar";
+          sha256 = "1chxm7w8ls2qmrzvv80m3pmi5x5gybppfzpvgxlankz5rj34vgd3";
         };
         packageRequires = [];
         meta = {

--- a/pkgs/applications/editors/emacs-modes/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs-modes/recipes-archive-melpa.json
@@ -81,6 +81,29 @@
   }
  },
  {
+  "ename": "2bit",
+  "commit": "ef96a414470d59c68659f5a66b6244f35804e2d7",
+  "sha256": "0npkjj21hcngzp2cl9g42l259wrf66x5h4hnd96a4wv2v4a74w23",
+  "fetcher": "github",
+  "repo": "davep/2bit.el",
+  "unstable": {
+   "version": [
+    20200926,
+    1418
+   ],
+   "commit": "69b4ec1d6d2ad95c9e59dacb43224abbec7a8989",
+   "sha256": "086hxacbm2jjqak3b1dpnjhif2r3w3jvrrsg114224a26rwz49sm"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "commit": "1ce390483cf55a039a8bdad28d294ce068f31e75",
+   "sha256": "01w4mr663jzjfznm301br96ggnlw9pz35cx2zxdpn8h1qnb1b0l6"
+  }
+ },
+ {
   "ename": "4clojure",
   "commit": "3fea8d290fe4d71b954ad6b68a8d182e40ee1e13",
   "sha256": "1cqab8kh4varf5hasvhkia39fa8qmmqycica7mbcvp33n8w3941j",
@@ -223,6 +246,29 @@
    ],
    "commit": "44b7d946bc3a693f5a931c4a62c0a67d42e8d4dc",
    "sha256": "070c408bq5pliq0xbd1861l6db4sbfpnj3r6aknbqh2vb7l4yimb"
+  }
+ },
+ {
+  "ename": "abridge-diff",
+  "commit": "9e289182de96d10f020724ec81f2a32d8de0d915",
+  "sha256": "0sxcrg74xlkl84idz9acdvfqamsggdg4dhbdngsvq6cnj8m3j0rb",
+  "fetcher": "github",
+  "repo": "jdtsmith/abridge-diff",
+  "unstable": {
+   "version": [
+    20200917,
+    1754
+   ],
+   "commit": "3015630a2fcb2d0f8dc532da4549fad060579b8d",
+   "sha256": "1kwwnba9kvmknrkyznhi7ykkcacggi9q7haplbxf02l6a46652lv"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "commit": "449f0d688f3ee44e53f3c9b62595022c5aad8cc7",
+   "sha256": "05x8xn4ibdbfkj7908fn9jl4ga32asnzhyzz7ddfbm899vzzdqpx"
   }
  },
  {
@@ -952,16 +998,16 @@
   "repo": "xcwen/ac-php",
   "unstable": {
    "version": [
-    20190424,
-    222
+    20200916,
+    751
    ],
    "deps": [
     "ac-php-core",
     "auto-complete",
     "yasnippet"
    ],
-   "commit": "8db6d911f2e19bbef5fe915e42c4e12f283bfd41",
-   "sha256": "0yzad3bc48xdmkgcsffdj9zx9j853w1k2p2v586bcfl2vmvvq3zj"
+   "commit": "7c023b9ced156cee03171e16c3dac6d26923042f",
+   "sha256": "0vaxha2f37bs634bl0122c09mkp1yyy2444pkikdavhjx9gzc55j"
   },
   "stable": {
    "version": [
@@ -986,8 +1032,8 @@
   "repo": "xcwen/ac-php",
   "unstable": {
    "version": [
-    20200516,
-    52
+    20200916,
+    751
    ],
    "deps": [
     "dash",
@@ -997,8 +1043,8 @@
     "s",
     "xcscope"
    ],
-   "commit": "8db6d911f2e19bbef5fe915e42c4e12f283bfd41",
-   "sha256": "0yzad3bc48xdmkgcsffdj9zx9j853w1k2p2v586bcfl2vmvvq3zj"
+   "commit": "7c023b9ced156cee03171e16c3dac6d26923042f",
+   "sha256": "0vaxha2f37bs634bl0122c09mkp1yyy2444pkikdavhjx9gzc55j"
   },
   "stable": {
    "version": [
@@ -1064,8 +1110,8 @@
     "auto-complete",
     "rtags"
    ],
-   "commit": "b57b36039f6411f23009c4ec0315ca5a7adb6824",
-   "sha256": "1816yxyqkxd895wka9xkxpca59iwjpcv73d25sq03z2gf1ayd56b"
+   "commit": "9ad2ff1c2c09c9d2eb945bc9f174f27fa36f0ae1",
+   "sha256": "19l0iiwkz6q9gs0wmi792016d18fp1m1i9g60yfk4wg5w9rbvzk2"
   },
   "stable": {
    "version": [
@@ -1212,25 +1258,20 @@
   "repo": "tam17aki/ace-isearch",
   "unstable": {
    "version": [
-    20200420,
-    518
+    20200912,
+    754
    ],
-   "commit": "58e4f1ad5cbbd2f86d161881d3f3ded3a3db984c",
-   "sha256": "0mlswnyd89ir060kiinzlrh70mdy8nfm2zpwr9jj2p19hrslmc4r"
+   "commit": "422aaa50b6452c2399682782cbf23168ed4357c6",
+   "sha256": "1gx106znzb6wq72yixq3z8arj1hhh215yy3324shvjwgqkyc3xi8"
   },
   "stable": {
    "version": [
-    0,
     1,
-    4
+    0,
+    1
    ],
-   "deps": [
-    "ace-jump-mode",
-    "avy",
-    "helm-swoop"
-   ],
-   "commit": "7e041d058492c5c35ec70de0e7c5586043e7e5ec",
-   "sha256": "0233ai62zhsy5yhv72016clygwp2pcg80y6kr4cjm2k1k2wwy7m9"
+   "commit": "7defe3517f2be444a1479c0a18859d78da4919a5",
+   "sha256": "0l14hd4yqyrwf5iz4g9zdy8bd9rx64yp27hywjs32wm9dssdymvm"
   }
  },
  {
@@ -1816,6 +1857,35 @@
   }
  },
  {
+  "ename": "agda2-mode",
+  "commit": "714e0fe062981d27e3f1d48b2fd759d60bbb4d8c",
+  "sha256": "0vbi64fri02ziy68dvpq1y946w4n4mla8gh1cmldqq8x24l8ssdg",
+  "fetcher": "github",
+  "repo": "agda/agda",
+  "unstable": {
+   "version": [
+    20200922,
+    1231
+   ],
+   "deps": [
+    "annotation",
+    "eri"
+   ],
+   "commit": "caeadacf80e0290c02d5fa35af71f319e57ae34e",
+   "sha256": "1441gk8ipz1yk2xz5z8s02cfmmldxkg5x44aa6xbj8fmq37qscgd"
+  },
+  "stable": {
+   "version": [
+    2,
+    6,
+    1,
+    1
+   ],
+   "commit": "fce01db8f9d2ceb9c3a4aa179330ea4aa7587a71",
+   "sha256": "0fzq9pfkvsdin04vzcz2vyjq3gx0lfhbpwpz0zyfa3b84dgffxq7"
+  }
+ },
+ {
   "ename": "aggressive-fill-paragraph",
   "commit": "982f5936f2d83222263df2886ca0b629076366bb",
   "sha256": "1df4bk3ks09805y67af6z1gpfln0lz773jzbbckfl0fy3yli0dja",
@@ -1841,14 +1911,11 @@
   "repo": "Malabarba/aggressive-indent-mode",
   "unstable": {
    "version": [
-    20200512,
-    1207
+    20200824,
+    2352
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "12a64b4e5c1a1e124baa74336738b6ae1972607f",
-   "sha256": "1pkqjg30l9sjh5m8w4p8qrlw92sxr28c3d7mq6h8sfc8dkgivd33"
+   "commit": "b0ec0047aaae071ad1647159613166a253410a63",
+   "sha256": "0rz010ypy1rg8v6na05zs942ikzqg1l32inzpzqg2q2rnfa3wkx1"
   },
   "stable": {
    "version": [
@@ -2264,14 +2331,14 @@
   "repo": "domtronn/all-the-icons.el",
   "unstable": {
    "version": [
-    20200730,
-    1545
+    20200923,
+    1339
    ],
    "deps": [
     "memoize"
    ],
-   "commit": "8c0228053dd6693d926970d89270094be52b0f75",
-   "sha256": "08p2x6da4dp6imw6dg501kw68m4rhjfdbc6yn5ld29mazvv923zl"
+   "commit": "6917b08f64dd8487e23769433d6cb9ba11f4152f",
+   "sha256": "0jzpil1k5brg4dvy0fxibbwwb2hkni5fkxng4n0wfv6099b2zc68"
   },
   "stable": {
    "version": [
@@ -2337,8 +2404,8 @@
    "deps": [
     "all-the-icons"
    ],
-   "commit": "8bb1a893e826e39ad4d7abc0add5dd6c33b18f29",
-   "sha256": "02sbddvjys6bf8pcbg3pv5fc1f8b48vmx0bnfyqw1x04dyb8cdm7"
+   "commit": "f584d08d5155794f80a0e3edd4b48a614b87c6f8",
+   "sha256": "1g44i98p9ibl8iq4ry21nv59j7bcnsy8n9qyxznvjk4426px32km"
   },
   "stable": {
    "version": [
@@ -2400,8 +2467,8 @@
     "all-the-icons",
     "ivy-rich"
    ],
-   "commit": "e918b23d55313a7464d8cb5d45eb917249638e32",
-   "sha256": "1wz3dgn8cggdkijzm7qf13g3s9gmz6v895bjck7sdhmr5mbr28a4"
+   "commit": "6428cb39729b7290368c5b95f563a320c98f972d",
+   "sha256": "0b9d1cs39j8x238s14b1smrhanapwai123dvpplmgb07wmrwwwwg"
   },
   "stable": {
    "version": [
@@ -2664,8 +2731,8 @@
   "repo": "pythonic-emacs/anaconda-mode",
   "unstable": {
    "version": [
-    20200806,
-    436
+    20200912,
+    239
    ],
    "deps": [
     "dash",
@@ -2673,8 +2740,8 @@
     "pythonic",
     "s"
    ],
-   "commit": "73266a48fa964d44268c3f3478597e553b9843f1",
-   "sha256": "0b4zzkr73hmjg92vr348294xymrynw4j0x89jzklh2plizp0alcr"
+   "commit": "39b1cf88c8c459901630d248d6135d8644075648",
+   "sha256": "0nwrs6cw2dpl522rrdhzrka4fkcw4f2grxlz0mjwwlaxafd2zc3y"
   },
   "stable": {
    "version": [
@@ -2808,10 +2875,10 @@
   "repo": "emacsattic/angular-mode",
   "unstable": {
    "version": [
-    20200510,
-    1729
+    20151201,
+    2127
    ],
-   "commit": "b24020768217f16b1b86aa236e9729b3d40e17b3",
+   "commit": "8720cde86af0f1859ccc8580571e8d0ad1c52cff",
    "sha256": "04kg2x0lif91knmkkh05mj42xw3dkzsnysjda6ian95v57wfg377"
   },
   "stable": {
@@ -2982,20 +3049,20 @@
   "repo": "bastibe/annotate.el",
   "unstable": {
    "version": [
-    20200812,
-    1439
+    20200829,
+    1336
    ],
-   "commit": "2bf7a7c1acb6768a590954c9bfef5f72ae8cc452",
-   "sha256": "05zwfflsx69904jxlayalh3n3n9msl92zw2rk5kk17p9psjpv9yw"
+   "commit": "4cc32fc2fb403dd0c501ffe7c23ba13fd23fd6ec",
+   "sha256": "0wjrmy2qsndfg7lwql6xw5b88j468cz365jx1sgpsplkgm25xsk2"
   },
   "stable": {
    "version": [
     0,
-    7,
-    0
+    8,
+    3
    ],
-   "commit": "99c45f553e7caef693506498d11e4b664b6f2946",
-   "sha256": "154655p54xxsbr06lbbdpzzx4hif6542a4cf767qnichsz9cj75j"
+   "commit": "4cc32fc2fb403dd0c501ffe7c23ba13fd23fd6ec",
+   "sha256": "0wjrmy2qsndfg7lwql6xw5b88j468cz365jx1sgpsplkgm25xsk2"
   }
  },
  {
@@ -3011,6 +3078,31 @@
    ],
    "commit": "fcb24fa36287250e40d195590c4ca4a8a696277b",
    "sha256": "18cav5wl3d0yq15273rqmdwvrgw96lmqiq9x5fxhf3wjb543mifl"
+  }
+ },
+ {
+  "ename": "annotation",
+  "commit": "714e0fe062981d27e3f1d48b2fd759d60bbb4d8c",
+  "sha256": "0f73v077c1niwcjf5rngmbnlw5k9w1z19im24vhwbgq5k3fg5sx2",
+  "fetcher": "github",
+  "repo": "agda/agda",
+  "unstable": {
+   "version": [
+    20200914,
+    644
+   ],
+   "commit": "caeadacf80e0290c02d5fa35af71f319e57ae34e",
+   "sha256": "1441gk8ipz1yk2xz5z8s02cfmmldxkg5x44aa6xbj8fmq37qscgd"
+  },
+  "stable": {
+   "version": [
+    2,
+    6,
+    1,
+    1
+   ],
+   "commit": "fce01db8f9d2ceb9c3a4aa179330ea4aa7587a71",
+   "sha256": "0fzq9pfkvsdin04vzcz2vyjq3gx0lfhbpwpz0zyfa3b84dgffxq7"
   }
  },
  {
@@ -3345,11 +3437,11 @@
   "repo": "wanderlust/apel",
   "unstable": {
    "version": [
-    20190407,
-    1056
+    20200823,
+    2222
    ],
-   "commit": "d146ddbf8818e81d3577d5eee7825d377bec0c73",
-   "sha256": "04ic76gzn3m4rnmm2xjc72vrxazxjvsjabd3lbxvwj6c1fb11fnw"
+   "commit": "28bca5f7027da26c90bf25ab835a1d615ce316e4",
+   "sha256": "08mcni8ljva5ap3mmjj5p3nvr9ci3gjl8yn0pd3c962c5maq0jrn"
   }
  },
  {
@@ -3865,8 +3957,8 @@
     20200809,
     501
    ],
-   "commit": "36a10151e70e956e2f766ed9e65f4a9cfc8479b2",
-   "sha256": "08glbksm13kgxvy17x0kg01x9cgnkz01yqqnlwzfaan0zbf6brdl"
+   "commit": "14f48de586b0977e3470f053b810d77b07ea427a",
+   "sha256": "16m67s2mpr2ak7vyc3dxzln3v5136b85dsirjkd2fm2n934q9h0r"
   },
   "stable": {
    "version": [
@@ -3988,11 +4080,11 @@
   "repo": "jonathanchu/atom-one-dark-theme",
   "unstable": {
    "version": [
-    20190705,
-    554
+    20200831,
+    342
    ],
-   "commit": "623fc08252e30174401750a09168279571288c7f",
-   "sha256": "09y4zh0i07vq8njvi4y1vmjqip057y3w2rhd7qzz6326bjz75cxk"
+   "commit": "321739d50b8a3b9152972134e83e69a67e12ee81",
+   "sha256": "0a6lx2pav0a0k6lfq8ar03z33dis29diq1gvxfdqwa3sayn6fbab"
   },
   "stable": {
    "version": [
@@ -4044,8 +4136,8 @@
   "repo": "jyp/attrap",
   "unstable": {
    "version": [
-    20200114,
-    1928
+    20200908,
+    1252
    ],
    "deps": [
     "dash",
@@ -4053,8 +4145,8 @@
     "flycheck",
     "s"
    ],
-   "commit": "4cf3e4a16255997e7c3c39682a72866a0a37dd4b",
-   "sha256": "0wqc7bqx9rvk8r7fd3x84h8p01v97s6w2jf29nnjb59xakwp22i7"
+   "commit": "9c881548debcf59b8aadda0ef4abca3c9a68dd80",
+   "sha256": "01x2nwqzrnngvmw6zynh6xhfg3jx7l22mv3gndi5xzxqngqh137s"
   },
   "stable": {
    "version": [
@@ -4085,8 +4177,8 @@
    "deps": [
     "auctex"
    ],
-   "commit": "7e36dcb88c0021e48e7a095257e63e2913f75789",
-   "sha256": "1wfsd7kcjm8inbhacsilngjqcwfn5alr02m4bcpv5w8gjyc0qwgx"
+   "commit": "f330f0983dd3c147a2f3f18f39109cdffe6d8ff2",
+   "sha256": "1sszk2197mm2hqacp2b63way522dq8r5nia6dgk6pi21kkqnk6nj"
   },
   "stable": {
    "version": [
@@ -4252,11 +4344,11 @@
   "repo": "ccrusius/auth-source-xoauth2",
   "unstable": {
    "version": [
-    20200817,
-    1604
+    20200911,
+    1554
    ],
-   "commit": "b0386d4a12a88c5635b26eaa4c9e355fc84fb3f6",
-   "sha256": "11i184s36ddxs06d8gq15nd0q59im8vfqnww3mvy35q12y6r8gpq"
+   "commit": "d3890eaa3a46dc89758ec6b789949e70ae782896",
+   "sha256": "1diflmg6sswz0xc1s9cygyg7y1ims8nqcyhs9yx5vn687gf82zlx"
   },
   "stable": {
    "version": [
@@ -4339,15 +4431,15 @@
   "repo": "auto-complete/auto-complete",
   "unstable": {
    "version": [
-    20170125,
-    245
+    20200823,
+    1758
    ],
    "deps": [
     "cl-lib",
     "popup"
    ],
-   "commit": "c0836fa0662095071e3c40237db611063e3c3ceb",
-   "sha256": "1269k2q1hv1yixn7w32ani7g0zspiiwfmbywxi8lvh9hj0asbrsc"
+   "commit": "80725ae176f88e461044cb0a307cb0b0e94b67ad",
+   "sha256": "1wij3qkqmhblmhrsqrigvm6531z9fff9aq55rpdh0m9n94vdrp5b"
   },
   "stable": {
    "version": [
@@ -4662,17 +4754,25 @@
  },
  {
   "ename": "auto-highlight-symbol",
-  "commit": "fdf73ee62f0a4e762e3a1aa94284abea8da8ce7c",
-  "sha256": "02mkji4sxym07jf5ww5kgv1c18x0xdfn8cmvgns5h4gij64lnr66",
+  "commit": "96293eb591e5f436efe8e9dc131d29ede292d2c3",
+  "sha256": "0n8acv58jkbqj00pi7d4g3nryvgvy52z0xg874jfh73d2f17dcdl",
   "fetcher": "github",
-  "repo": "gennad/auto-highlight-symbol",
+  "repo": "jcs-elpa/auto-highlight-symbol",
   "unstable": {
    "version": [
-    20130313,
-    943
+    20200923,
+    448
    ],
-   "commit": "26573de912d760e04321b350897aea70958cee8b",
-   "sha256": "0jfiax1qqnyznhlnqkjsr9nnv7fpjywvfhj9jq59460j0nbrgs5c"
+   "commit": "2a0ce27ee3fad4eecd7eadc64db7296e0f1cc89b",
+   "sha256": "1dyxaff0ps3l5l9sxw2bhjzd0n8nn03h99ycdbm0j389mv597lg2"
+  },
+  "stable": {
+   "version": [
+    1,
+    58
+   ],
+   "commit": "2a0ce27ee3fad4eecd7eadc64db7296e0f1cc89b",
+   "sha256": "1dyxaff0ps3l5l9sxw2bhjzd0n8nn03h99ycdbm0j389mv597lg2"
   }
  },
  {
@@ -4744,14 +4844,14 @@
   "repo": "rranelli/auto-package-update.el",
   "unstable": {
    "version": [
-    20200421,
-    309
+    20200826,
+    2227
    ],
    "deps": [
     "dash"
    ],
-   "commit": "cf7f7486ed699f2ed7cc8af950740aece0de6124",
-   "sha256": "14sq8p3qbhlfmpisanjxpginiibngmb84mjga97aq5sgpxy38wix"
+   "commit": "c0df65ac9845ba2c7c9f53bbdbe013f1024f96f9",
+   "sha256": "0fy45psfsfsfrailiqv86bxsb3vxb36wyf7farb0zaxlrqay8qvd"
   },
   "stable": {
    "version": [
@@ -4789,14 +4889,14 @@
   "repo": "zonuexe/auto-read-only.el",
   "unstable": {
    "version": [
-    20200726,
-    1356
+    20200827,
+    1754
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "a6c493c5279d484c00ce7fe75dfd2e60101b97db",
-   "sha256": "0wg6pl69k1hy69hgsqry5zahycr1n13avjfrw7g3sva71rqzkzrn"
+   "commit": "db209bf5b7f76f4c3dc4d0892fc6a24430779f29",
+   "sha256": "0zb8n97x5ji9clyls7k5pj7pq3yms82b6wgkww6djcabb26b5xb4"
   }
  },
  {
@@ -4807,20 +4907,20 @@
   "repo": "jcs-elpa/auto-rename-tag",
   "unstable": {
    "version": [
-    20200717,
-    814
+    20200830,
+    800
    ],
-   "commit": "7227c93e58a2c1837aa35ca35b6325c6f734d0f9",
-   "sha256": "1q029xy4ssb6lvd199yl1p63ir142q9waw31v2zagxlyn9rs9qx9"
+   "commit": "416a146d4386943c751a44c1484b0f5dedb23307",
+   "sha256": "11a53xppvx0izq724iqwb7l0bh0v4s4k2cdm42j3kivkgrxm09hd"
   },
   "stable": {
    "version": [
     0,
-    2,
-    9
+    3,
+    3
    ],
-   "commit": "7227c93e58a2c1837aa35ca35b6325c6f734d0f9",
-   "sha256": "1q029xy4ssb6lvd199yl1p63ir142q9waw31v2zagxlyn9rs9qx9"
+   "commit": "416a146d4386943c751a44c1484b0f5dedb23307",
+   "sha256": "11a53xppvx0izq724iqwb7l0bh0v4s4k2cdm42j3kivkgrxm09hd"
   }
  },
  {
@@ -5201,11 +5301,11 @@
   "repo": "avkoval/avk-emacs-themes",
   "unstable": {
    "version": [
-    20191220,
-    625
+    20200905,
+    617
    ],
-   "commit": "e97ec20d07cc9093661f51853375063bcdc91993",
-   "sha256": "14011k7rafibjpfd7g903a81pml176m7hxvvgd8a65vgqx52q4d3"
+   "commit": "d0d93459a19a1b789d2cd8fa2fb51753681fd897",
+   "sha256": "014c1mgv0xv38qcwvmdcpyxk55i97x4ddagws26b403j85qbmy1m"
   }
  },
  {
@@ -5398,8 +5498,8 @@
     20190930,
     1517
    ],
-   "commit": "1a75f88f53a2969fe821c31e6857861d0a0c0a5e",
-   "sha256": "13ry0lhh8ss93h9c60gc02i28bwc70jb4fzqmvw778fk0shj8jxn"
+   "commit": "eadfb26b35802ae8164565581e4a9c4d0280a7b5",
+   "sha256": "1kh01yfzz565z0qdidvrl94cpfgsvf27n4k709j63xccbip0hp4a"
   }
  },
  {
@@ -5638,6 +5738,24 @@
   }
  },
  {
+  "ename": "baff",
+  "commit": "a366fdfb3594b5cf910aebc58a249699f1f956a4",
+  "sha256": "1s8s5yvr8c7a6yzlwa38a1slkqad5szq92k5wxygvfyw1ikwvkxg",
+  "fetcher": "github",
+  "repo": "dave-f/baff",
+  "unstable": {
+   "version": [
+    20200824,
+    1807
+   ],
+   "deps": [
+    "f"
+   ],
+   "commit": "7af72db9c6e542ed2b60952933113d0aa86728cf",
+   "sha256": "099jhbn65kw45yb8ahvrpmpqba1ffxbmxkkxs6iswfjcx2vdf23j"
+  }
+ },
+ {
   "ename": "baidu-translate",
   "commit": "c9cdf13f64a1de8c57dcb90229da0f62a8e14e7a",
   "sha256": "0m8pqnp57bmk41wij5a0dcilg09p992q5413llfac41b6biqf2yd",
@@ -5675,11 +5793,11 @@
   "url": "https://git.sr.ht/~zge/bang",
   "unstable": {
    "version": [
-    20200811,
-    1008
+    20200924,
+    1601
    ],
-   "commit": "e02338331463461a85144c0ce6b9b877bd3a7567",
-   "sha256": "1rvgmkl950zrakczk9libws29c9l2hklw49m3xb4swa14kz1r639"
+   "commit": "0e0c7258f8ff2ca218211626ba8771fa3dd81ca9",
+   "sha256": "1kbi7aazc488kp16936kqs1kpb91101bc6ikpxl9vlwvzwl89253"
   },
   "stable": {
    "version": [
@@ -5790,11 +5908,11 @@
   "repo": "szermatt/emacs-bash-completion",
   "unstable": {
    "version": [
-    20200806,
-    1743
+    20200823,
+    851
    ],
-   "commit": "d47edb9d4142a22746009c1f680df93a4fefd107",
-   "sha256": "11j2k3irixp47r2iglxdmjphahqhgnxg98n2xwagwzyq99lsamj4"
+   "commit": "d6c28d31327629ae19109b75f7fb738452d15861",
+   "sha256": "0x6nysrrv679a6z5lzxzy4z1x6n3f0w3iy0igfnc5qhnp6d9m3cb"
   },
   "stable": {
    "version": [
@@ -5998,11 +6116,11 @@
   "url": "https://git.savannah.nongnu.org/git/bbdb.git",
   "unstable": {
    "version": [
-    20200102,
-    403
+    20200829,
+    2050
    ],
-   "commit": "45529e315ba861f9df2914f9b88d2f7b991d5595",
-   "sha256": "0iim6394q02yw5rcyjs7ym16v9jbq5pwqsbpwc98ckg26063p3fi"
+   "commit": "fb45ec3aa2dd22fa59107e5481e7f10e52989748",
+   "sha256": "02shvfkqxmfllxr21824lp66sy8jmn482689hrnbwwwynxmk1x4c"
   },
   "stable": {
    "version": [
@@ -6237,11 +6355,11 @@
   "stable": {
    "version": [
     2,
-    1,
+    2,
     0
    ],
-   "commit": "0710e25138c1cec40ccf78d704741143c5bac735",
-   "sha256": "1ic5z3qb5sc3mjrjdlg0rqm2l59a43gwnakagns4cilln2a3xdg8"
+   "commit": "9c7a92779d75f6fd985cf707ff5241bc98ccea6c",
+   "sha256": "1r9033zlx2q2dk3bjz004flxdiw79qiswq0zqdjnlzwassvk0f35"
   }
  },
  {
@@ -6420,6 +6538,30 @@
    ],
    "commit": "6d240032ca213ccb3347e25f26c29b6822bf03a7",
    "sha256": "0vdrdd0q4rlpyxgwbc31zz8f6sr7sy0gdw84sb1dy9bpq6qvdbdw"
+  }
+ },
+ {
+  "ename": "better-scroll",
+  "commit": "0cdedd3a03cb05d6a474a84626aacda7c90c9d6d",
+  "sha256": "1fqbcn867svyxmp8w7b5v9k81fm1mi5n8723sjvcf62q6q0qvyq5",
+  "fetcher": "github",
+  "repo": "jcs-elpa/better-scroll",
+  "unstable": {
+   "version": [
+    20200821,
+    535
+   ],
+   "commit": "9dcfd7481aa0c37a1aa2b2f4b9098d3da0958d33",
+   "sha256": "13vhryskblx5k22j30wgjjmql7dx200zvm44vwv9bmgb4kzpd2jz"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    3
+   ],
+   "commit": "5c281293e90399e38d52a24e0a22edab88a833d1",
+   "sha256": "0hjf9aw2lflnmwj8sc6marc175zk32sm5xmanhpxgi8f7wxb0b44"
   }
  },
  {
@@ -6604,8 +6746,8 @@
     "a",
     "pdf-tools"
    ],
-   "commit": "61a14d1a8c17930caca5c5daf893cedc9c23c5f3",
-   "sha256": "0acq8d8vlx3hd405wmi5w36gg88bz1c1crmlxbd2whgi8kyf506z"
+   "commit": "e086c59a14701cd041641b51c952fa704ee963df",
+   "sha256": "0w1crw5lsk22jfw2w5qq6ab7zxdzp38akasvyvxakvpp1782xq9p"
   }
  },
  {
@@ -6653,8 +6795,8 @@
   "repo": "tmalsburg/helm-bibtex",
   "unstable": {
    "version": [
-    20200513,
-    852
+    20200908,
+    1017
    ],
    "deps": [
     "biblio",
@@ -6664,8 +6806,8 @@
     "parsebib",
     "s"
    ],
-   "commit": "8a0dd9841316793aacddea744d6b8ca4a7857a35",
-   "sha256": "1av058d7888kr3q15y1122r8jkarfw1s83gvkillj7kyzj3i53m5"
+   "commit": "12f8809aac3a13dd11a1c664a13f789005f7a199",
+   "sha256": "1h5sm479i9rs09h2xxj8qc4jjdqy7fbx7c5df143lrf69mq0sxgf"
   },
   "stable": {
    "version": [
@@ -6852,6 +6994,36 @@
    ],
    "commit": "bf4181e3a41463684adfffc6c5c305b30480e30f",
    "sha256": "0vrk17yg3jbww92p433p64ijmjf7cjg2wmzi9w418235w1xdfzz8"
+  }
+ },
+ {
+  "ename": "binder",
+  "commit": "b11447ece6105f59abec185b6ca809f488f2b864",
+  "sha256": "0hfg1rq4qhfqzxi5y51sjsqw069w15x1fkknqq8dwv8a7sjj6yaz",
+  "fetcher": "github",
+  "repo": "rnkn/binder",
+  "unstable": {
+   "version": [
+    20200927,
+    850
+   ],
+   "deps": [
+    "seq"
+   ],
+   "commit": "75b448a7c8e1f44c82f30a995ad8831ae42937ac",
+   "sha256": "0nmr1qryhs7fs2q25nhfqy3zhd14vyccqz6622sxpkmlmif1093c"
+  },
+  "stable": {
+   "version": [
+    0,
+    4,
+    2
+   ],
+   "deps": [
+    "seq"
+   ],
+   "commit": "418f9f8afe8bfc82cecec05ee17e6825c608ffe9",
+   "sha256": "0c8q5h4s94pjki1abp33ijd9422k8f7qf5ilmdvvnx99i4wnm903"
   }
  },
  {
@@ -7471,15 +7643,15 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20200805,
-    1131
+    20200908,
+    1134
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "1fe1d2b7a574dd560740a55d87d9a5fb3a989dbc",
-   "sha256": "19rxqh6qagznsm5hqal65cv03k9gg1cfvb0j5saaqfc4nxkhkv7v"
+   "commit": "b547feb27d892dd36ec1897a7a0049be0cd87588",
+   "sha256": "0mxavxi0vfvl3ghdkciwpfic0dkm2lgnyfpn1jqypddf1rzjfp5a"
   },
   "stable": {
    "version": [
@@ -7733,16 +7905,16 @@
   "repo": "rmuslimov/browse-at-remote",
   "unstable": {
    "version": [
-    20200308,
-    639
+    20200820,
+    654
    ],
    "deps": [
     "cl-lib",
     "f",
     "s"
    ],
-   "commit": "6aecae4b5d202e582425fc8aa2c9c2b6a4779f25",
-   "sha256": "0c93ilvxmfv28a05fs2lbdyc2q308anjw0xvbkg7dc0blg0fgb05"
+   "commit": "fadf99d6d8e891f3b112e36c772e0eea0b9bc7f2",
+   "sha256": "15x32g8g90jjxlxj8h6yzyi1k9dgnk8an2c66ibj93dzcfci28m9"
   },
   "stable": {
    "version": [
@@ -8136,20 +8308,20 @@
   "repo": "jcs-elpa/buffer-wrap",
   "unstable": {
    "version": [
-    20200724,
-    906
+    20200924,
+    345
    ],
-   "commit": "ef0fcb38b23246cfea1721570acc266764cef0a4",
-   "sha256": "029vq5hfknp5l8b9lmxw4hskq9bmv56kqysdfka0636hp7bvc63p"
+   "commit": "2b12ed29cbcd733ad21d91475d1fcbd4092c604e",
+   "sha256": "1x9vayhq5cpqglkz4bzd9iaa1p0j0qsvh5pr6vkqi2z1nrjcwi8g"
   },
   "stable": {
    "version": [
     0,
     1,
-    3
+    5
    ],
-   "commit": "c24eb1f251baecfb0bbfa750904e6b15cc977a6c",
-   "sha256": "1bzr5bf4rm1wm0xdhhdprlv7z60ijwrp1lq9h572iw6giyl0hgc3"
+   "commit": "2b12ed29cbcd733ad21d91475d1fcbd4092c604e",
+   "sha256": "1x9vayhq5cpqglkz4bzd9iaa1p0j0qsvh5pr6vkqi2z1nrjcwi8g"
   }
  },
  {
@@ -8170,8 +8342,8 @@
     "magit-section",
     "pretty-hydra"
    ],
-   "commit": "b2b260e4f9e8ba76bb8b4d71344c7b75e05ac44f",
-   "sha256": "0ww7z2xz185i97wa1rnmqwlx2mvwx69hhlyi5m3sm0nkyckb2hjs"
+   "commit": "02bb6c55de71b1fb4a3246d150ff9c63eb694df0",
+   "sha256": "08w8gzx3c4c8v1cncwa1zchcpxksxgvgd8s9mc2dilgj2h4p7pbi"
   },
   "stable": {
    "version": [
@@ -8490,11 +8662,11 @@
   "repo": "jorgenschaefer/emacs-buttercup",
   "unstable": {
    "version": [
-    20200817,
-    2001
+    20200921,
+    1916
    ],
-   "commit": "0e5eae0766a33b5c8997e1477e3914d5c8ba3d29",
-   "sha256": "0qn3i26g119h14jv9q0vha55s4g154djp3f68d2g7i0f46wm54hz"
+   "commit": "cccdedff38208ad4aa989ccdab8e0b059adf3728",
+   "sha256": "0n0zg7aivxknvhmn5549yiqppig4rknwis3c52wr1qk5hjl78d54"
   },
   "stable": {
    "version": [
@@ -8764,14 +8936,14 @@
   "repo": "xwl/cal-china-x",
   "unstable": {
    "version": [
-    20190518,
-    1057
+    20200924,
+    1837
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "177f60e011606126f23c8ffed69458439f1c12e0",
-   "sha256": "1a0qdiihyc5qwz5j68hnpfp0fx3qbzgvzflrbfv072r7ldxzfi57"
+   "commit": "94005e678a1d2522b7a00299779f40c5c77286b8",
+   "sha256": "0dy9awy5y990wz925rdn95gn23ywarwbvkqq0l0xms1br1v8kxc6"
   }
  },
  {
@@ -8955,32 +9127,30 @@
   "repo": "chenyanming/calibredb.el",
   "unstable": {
    "version": [
-    20200809,
-    1128
+    20200831,
+    855
    ],
    "deps": [
     "dash",
-    "org",
     "s",
     "transient"
    ],
-   "commit": "a53d3c3d87fb7cd756f73fcd813aca0480ada5f7",
-   "sha256": "11m9d015fnjf89qg6wpy0vs1vhvak5q753m4dzqrdw3jgm9zsnmv"
+   "commit": "7c650cd30af3d36c2201887b073b401a21ae65ed",
+   "sha256": "04kvi9qvk3bdiphp53dwh23wq978l537sklgl31rijqm59jcylgp"
   },
   "stable": {
    "version": [
     2,
-    5,
+    6,
     0
    ],
    "deps": [
     "dash",
-    "org",
     "s",
     "transient"
    ],
-   "commit": "a53d3c3d87fb7cd756f73fcd813aca0480ada5f7",
-   "sha256": "11m9d015fnjf89qg6wpy0vs1vhvak5q753m4dzqrdw3jgm9zsnmv"
+   "commit": "9673bf6e0fd54872ca0357b9315ee448a2a976cf",
+   "sha256": "132afbbh4km2cbll46i6bpksvin0ncgfy782g4nkfjmwjaqh3d5l"
   }
  },
  {
@@ -9165,15 +9335,15 @@
   "repo": "kwrooijen/cargo.el",
   "unstable": {
    "version": [
-    20191224,
-    47
+    20200826,
+    1537
    ],
    "deps": [
     "markdown-mode",
     "rust-mode"
    ],
-   "commit": "dc9ff35c2861d524ac4d65020c5320eec71acacf",
-   "sha256": "0nng284i5jygsnbda6ycrm2wv8rw47z8ilcs6r1z0w1gv3p012fd"
+   "commit": "91ccfef6e36ff9e96352a03c4a057b5ee181438d",
+   "sha256": "1hyz834hwashcxpv5kxlzn3n0h7a50lniwdwrb62390d0x8pm6vy"
   },
   "stable": {
    "version": [
@@ -9245,8 +9415,8 @@
   "repo": "cask/cask",
   "unstable": {
    "version": [
-    20200814,
-    913
+    20200822,
+    1015
    ],
    "deps": [
     "ansi",
@@ -9258,8 +9428,8 @@
     "s",
     "shut-up"
    ],
-   "commit": "c69822a1a3168d43caebb7afaa13249429419ae0",
-   "sha256": "0w7q16y2r54rann07lk4gwi7jkqnb5xc8cbjnx2avgpsk7kawi8w"
+   "commit": "13944cef1c4fbe2e1bae2aaacacd0b338f3ead88",
+   "sha256": "1jnw8nv3k14cmm0x77sh2yrn3hkp5j8hwd2pah7x1l4ldbv42qc4"
   },
   "stable": {
    "version": [
@@ -9453,11 +9623,11 @@
   "repo": "skk-dev/ddskk",
   "unstable": {
    "version": [
-    20200314,
-    1557
+    20200904,
+    1431
    ],
-   "commit": "275a831be77573470309a78967734d2b6d10f218",
-   "sha256": "1a25aybavi6p7ijc4rbd8zyzgiim1m2xwm7yqfmsvrfzwgb29xal"
+   "commit": "a66a7b16f13533afdd03e21eebcdd6309e469a13",
+   "sha256": "1x5qrzzsn977hyi8xnc37jrsq7adwg2jd1ln3vapfxr05pgiijk7"
   }
  },
  {
@@ -9468,15 +9638,15 @@
   "repo": "MaskRay/emacs-ccls",
   "unstable": {
    "version": [
-    20200819,
-    106
+    20200820,
+    308
    ],
    "deps": [
     "dash",
     "lsp-mode"
    ],
-   "commit": "44f1fb38786cb6159e03e930876239a215d3feee",
-   "sha256": "0adw1gfp8a6cfyh7s1bchdpak7z32jlnliq35ynhakwwx3ixzmfv"
+   "commit": "675a5704c14a27931e835a431beea3631d92e8e6",
+   "sha256": "0l4bhyr9d8ljz1f0cfg1s2cjcmh6fiwbk5mdlvc7rrwz5hxc21is"
   }
  },
  {
@@ -9502,11 +9672,11 @@
   "repo": "skk-dev/ddskk",
   "unstable": {
    "version": [
-    20200803,
-    2138
+    20200904,
+    1431
    ],
-   "commit": "275a831be77573470309a78967734d2b6d10f218",
-   "sha256": "1a25aybavi6p7ijc4rbd8zyzgiim1m2xwm7yqfmsvrfzwgb29xal"
+   "commit": "a66a7b16f13533afdd03e21eebcdd6309e469a13",
+   "sha256": "1x5qrzzsn977hyi8xnc37jrsq7adwg2jd1ln3vapfxr05pgiijk7"
   }
  },
  {
@@ -9640,15 +9810,15 @@
   "repo": "ema2159/centaur-tabs",
   "unstable": {
    "version": [
-    20200722,
-    27
+    20200821,
+    335
    ],
    "deps": [
     "cl-lib",
     "powerline"
    ],
-   "commit": "7e0332b138f836b9d0b6d2134310f53369598cfd",
-   "sha256": "1fjs1l79wsyiyi4nrdkxg2hhfkngm7g0zpdq5ca3c1zi4fsv084i"
+   "commit": "5453317b6b9f68bfbd934eee3b883207bfa331e0",
+   "sha256": "0npkjmpkhl23w9abdx2brk1a6bdnnif2b59rdkag5g29qnaszkqw"
   },
   "stable": {
    "version": [
@@ -9775,8 +9945,8 @@
     20171115,
     2108
    ],
-   "commit": "ec47889f4bef53c6c5a15add60d34c44c6ef1634",
-   "sha256": "16lndmhm0ad23g0pa4rl7dyrwmdv22xmscnpqnd49sg88356fyd2"
+   "commit": "da4135060b88b568481e9b445c39022464d3f707",
+   "sha256": "1hinpngf2gay8qv3hw3y12x8amqirg8a7ln19xxb9s52c6h5qvp6"
   },
   "stable": {
    "version": [
@@ -9941,14 +10111,14 @@
   "repo": "damon-kwok/chapel-mode",
   "unstable": {
    "version": [
-    20200814,
-    759
+    20200920,
+    501
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "0855d6ea5e74da7b02e7307066da912c242084c8",
-   "sha256": "08bgjwkm6bhm5s73pdx62bjm58z18q21fhj02zdp0q8dds5babf9"
+   "commit": "a99319a43b0a2bf9621a1f61a519ea102ec65783",
+   "sha256": "0p91lwm2bymx5yw2ni0b0iaxmy26mnwvg6g6xp9yaxnr477q5wkn"
   },
   "stable": {
    "version": [
@@ -10369,8 +10539,8 @@
   "repo": "contrapunctus-1/chronometrist",
   "unstable": {
    "version": [
-    20200816,
-    1947
+    20200905,
+    1617
    ],
    "deps": [
     "anaphora",
@@ -10379,23 +10549,24 @@
     "seq",
     "ts"
    ],
-   "commit": "c886dbb1ec8d1e22f7e9891ce9794d373b3b4e9b",
-   "sha256": "0f94w039ibqyysldgs0rdzjczhpgd1dq6ll85gdb4av7vw6mp3hy"
+   "commit": "ad2a7fffed94c093e6d83a6938115f66e4e888f3",
+   "sha256": "0raa34888cyjqhr4562gbjdi4j4k5lpp0f4zwlxxrvfwn6yxwhm1"
   },
   "stable": {
    "version": [
     0,
     5,
-    3
+    5
    ],
    "deps": [
+    "anaphora",
     "dash",
     "s",
     "seq",
     "ts"
    ],
-   "commit": "0445b5187293a927f505633e851ca871bb89d8df",
-   "sha256": "0jz35972m372kx9x8mgf42zhzdw2w9wv2ri52chfb2fin4bh1biy"
+   "commit": "2331edbf00cf56f28905d5a91334af4b902cdb68",
+   "sha256": "1zccyfpgq68ixrcl8jq2r38165ngkqrb42y2hkyab6gxhvh4wkpl"
   }
  },
  {
@@ -10406,15 +10577,15 @@
   "repo": "contrapunctus-1/chronometrist-goal",
   "unstable": {
    "version": [
-    20200706,
-    1306
+    20200906,
+    1522
    ],
    "deps": [
     "alert",
     "chronometrist"
    ],
-   "commit": "a9c4410f25f875c55b9237ef6544e82f4a805af6",
-   "sha256": "0wydrc4x19rp6nn1hyhaa5zxr4br51aamrv0ky5yppr17rnyygsy"
+   "commit": "c8bb401155a8a2c5718ffd3667c516f8e178a1b5",
+   "sha256": "0lqllxhq8r38gm12ia5s2mjsv75l1d99dbning5lmwwbcyc9cn17"
   },
   "stable": {
    "version": [
@@ -10486,8 +10657,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20200814,
-    1540
+    20200916,
+    1152
    ],
    "deps": [
     "clojure-mode",
@@ -10498,8 +10669,8 @@
     "sesman",
     "spinner"
    ],
-   "commit": "a89b694cc3cec0294d84bf9dbe1163ad2373e8db",
-   "sha256": "0m77jbxl380dp1wyj12m82bb06r80js8yxl530ryp1mwvy74f00d"
+   "commit": "1618ad3f6cff66ecc9781d0a079c2659fa88d404",
+   "sha256": "0fcj8pxlfrj2s7fqvxjnx9li8nqhkqmi6w59xhjs262vlj9q8d9m"
   },
   "stable": {
    "version": [
@@ -10690,14 +10861,14 @@
   "repo": "jorgenschaefer/circe",
   "unstable": {
    "version": [
-    20200815,
-    1410
+    20200914,
+    1916
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "89aac22259e5d09ae1183e0df163338fe491e9e7",
-   "sha256": "16hfahyhl1vv3r0amyvc514sw6x9x56b319lkp7bwcy8mxicc3cy"
+   "commit": "5c54374f6c13104deded2e3b348cc188af64785a",
+   "sha256": "1hjid38bsi4f4vmvcbm7br8x2r94mri89rswc32glny7d2fysghk"
   },
   "stable": {
    "version": [
@@ -10790,8 +10961,8 @@
   "repo": "andras-simonyi/citeproc-org",
   "unstable": {
    "version": [
-    20200615,
-    947
+    20200915,
+    2009
    ],
    "deps": [
     "citeproc",
@@ -10800,8 +10971,8 @@
     "org",
     "org-ref"
    ],
-   "commit": "342f6531b08f5d789a1ae222f9707f636b1f5e2f",
-   "sha256": "1dc5qkwmfi2jm12297yy14fqbc335qjsdfi2mfgiz8wvs84hyci8"
+   "commit": "22a759c4f0ec80075014dcc594baa4d1b470d995",
+   "sha256": "1j7jdc2as87zycbfhz2nav97dqnx3xnq321dbjswmidg5fbhsr7q"
   },
   "stable": {
    "version": [
@@ -10928,13 +11099,13 @@
   "repo": "emacsmirror/clang-format",
   "unstable": {
    "version": [
-    20191121,
-    1708
+    20191106,
+    950
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "2d6a4526a2518b7c0059a8a0dfee156e90a49369",
+   "commit": "e48ff8ae18dc7ab6118c1f6752deb48cb1fc83ac",
    "sha256": "1l64r9rr59g26mlph6r8pkn8vzadmh3mh8gvv398kz8skayfa55f"
   }
  },
@@ -11160,8 +11331,8 @@
   "repo": "clojure-emacs/clj-refactor.el",
   "unstable": {
    "version": [
-    20200405,
-    1419
+    20200831,
+    1244
    ],
    "deps": [
     "cider",
@@ -11174,8 +11345,8 @@
     "seq",
     "yasnippet"
    ],
-   "commit": "97095682580bbc5bfebcbc5349f03f5bd7121c96",
-   "sha256": "1dgksqzdln8cv0hyq273ikfk2bmk16rwvkiyscqsxzi8jdv8cdck"
+   "commit": "6db85b37b57497b56d97d5e5512160e5db85f798",
+   "sha256": "1aig67ps65adsnpdkjvl0wdglzjzhw1jc2v1rdhyfszqk0w30sz9"
   },
   "stable": {
    "version": [
@@ -11422,11 +11593,11 @@
   "repo": "clojure-emacs/clojure-mode",
   "unstable": {
    "version": [
-    20200813,
-    639
+    20200922,
+    549
    ],
-   "commit": "84ed16c5ddb6561620886485e20669d0c81f88a1",
-   "sha256": "1kdm9dfj3qifwylj9j2x12xwxzrkmyp4pvph7bvwfrv65jp4r58j"
+   "commit": "f21e544c157040a0e5ea6fa8eb41641596028b8d",
+   "sha256": "1gznl6zkgrx5bgd0hkgwid396fnbwjb4dwl503fffi7y7gk81m1c"
   },
   "stable": {
    "version": [
@@ -11446,14 +11617,14 @@
   "repo": "clojure-emacs/clojure-mode",
   "unstable": {
    "version": [
-    20200320,
-    823
+    20200922,
+    656
    ],
    "deps": [
     "clojure-mode"
    ],
-   "commit": "84ed16c5ddb6561620886485e20669d0c81f88a1",
-   "sha256": "1kdm9dfj3qifwylj9j2x12xwxzrkmyp4pvph7bvwfrv65jp4r58j"
+   "commit": "f21e544c157040a0e5ea6fa8eb41641596028b8d",
+   "sha256": "1gznl6zkgrx5bgd0hkgwid396fnbwjb4dwl503fffi7y7gk81m1c"
   },
   "stable": {
    "version": [
@@ -11700,14 +11871,14 @@
   "repo": "Lindydancer/cmake-font-lock",
   "unstable": {
    "version": [
-    20200103,
-    1702
+    20200914,
+    1715
    ],
    "deps": [
     "cmake-mode"
    ],
-   "commit": "9e0fcd1ee2cf316f661f2d652368b12f83a4ec9c",
-   "sha256": "0m1i5ijiwsxral544xd4nygcr1qbackaghjfgr8pfb5yfwgdxifh"
+   "commit": "47687b6ccd0e244691fb5907aaba609e5a42d787",
+   "sha256": "03am60wr5jzx1vqyvfc885z8vy959zypjbmar37ln2pffiz9510l"
   }
  },
  {
@@ -11755,17 +11926,17 @@
     20190710,
     1319
    ],
-   "commit": "92d724903192b98e42cc1048ca587207aa20043f",
-   "sha256": "1ig5wjiq31rgf57gkf37d2rzx4qkkif997w1dfllwc4w3svwykp0"
+   "commit": "558ce94016f898aee596acc570e97a149f1b3dbf",
+   "sha256": "0c6ciiaixd2vn1yfir327d9dxc3hkxlvdvmwfk2gd94ard5bkc60"
   },
   "stable": {
    "version": [
     3,
     18,
-    1
+    3
    ],
-   "commit": "63a65baf4c343c73b2142078ef0045d3711dea1d",
-   "sha256": "1a3r119qca4sg83zchnsnmmq9k7ad8pljl5s24k00xbyyfs1wm7k"
+   "commit": "177fc020731bcee747295573c92cd0f7ca200e53",
+   "sha256": "0p62xvdvp165lg7a1qyaz5si2id80d8vadc3njhdr01fdj3xskxs"
   }
  },
  {
@@ -11833,11 +12004,11 @@
   "repo": "tumashu/cnfonts",
   "unstable": {
    "version": [
-    20200819,
-    543
+    20200824,
+    240
    ],
-   "commit": "d4d303b0045b682b9e699e63fa3af4dd00daf878",
-   "sha256": "06gcm7wc1ayz0z2fqz3bqyfxqlgbx31z95gwbwjd9x2mqgkp02mh"
+   "commit": "b967605d571d827c1cb041c174fb363985758729",
+   "sha256": "1h4c6czj7zr1p8b0233rxmczkaf7hh72869lijsvkvx9xmq9pk8w"
   },
   "stable": {
    "version": [
@@ -12265,11 +12436,11 @@
   "repo": "purcell/color-theme-sanityinc-tomorrow",
   "unstable": {
    "version": [
-    20200813,
-    333
+    20200923,
+    345
    ],
-   "commit": "b7e33d1ccb10a93d6a0393c43400435b70a48689",
-   "sha256": "1qg5wz04d7kq63zsjbhdcxn96j6x84hsbj7vbx6d051yql6l3m8s"
+   "commit": "631bf53de0a213f85906301af55032253cde8104",
+   "sha256": "00vl1xzkm63017qhfjs4wdfkyxrhzkyqmfvxfl3600gl5pxnd9r5"
   },
   "stable": {
    "version": [
@@ -12661,14 +12832,14 @@
   "repo": "ddoherty03/commify",
   "unstable": {
    "version": [
-    20200812,
-    1241
+    20200921,
+    2002
    ],
    "deps": [
     "s"
    ],
-   "commit": "92514f071c667653f146629c0aec0ab4d3b78226",
-   "sha256": "1n6jpkhq0kncsszkkpfi923zq75h3d032vwmlz7pp8szs93w2308"
+   "commit": "b1c1a06e488208ef653e0d86c97b746fd6d2bbc2",
+   "sha256": "1q843ay7zkci2xdavia6wkj06acn83a198ykpxl0xbl5wihdd6w2"
   }
  },
  {
@@ -12709,11 +12880,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20200818,
-    1753
+    20200920,
+    2215
    ],
-   "commit": "54f60ef523878c4d332f29df380f36cf2f165935",
-   "sha256": "08lbjvm97fh1bm5201ncbnr5b1456y9mwf6yhrrhg1rjqvcca74q"
+   "commit": "d5912821e7798a51e15586cc75818c7c18c21b7d",
+   "sha256": "14awwp4x1jll8z3b73db5db93b57a89z8yyaqdnfa0i2p2ds04bc"
   },
   "stable": {
    "version": [
@@ -12883,16 +13054,17 @@
   "repo": "sebastiencs/company-box",
   "unstable": {
    "version": [
-    20200818,
-    738
+    20200927,
+    1039
    ],
    "deps": [
     "company",
     "dash",
-    "dash-functional"
+    "dash-functional",
+    "frame-local"
    ],
-   "commit": "20384f0e382c063173b9d863344b1b23bc1e4954",
-   "sha256": "0l66ajzh1x0gazmv9nzgcsy72kyja3yq4gmzgzpkgin5dxms33k0"
+   "commit": "7696cebf6b87a80fbd45216fa2e7735e879af2c4",
+   "sha256": "1ivy9rpwc8dgz7jzz15732dr7ggailax24h8rpsvpg0a9zk8fzsc"
   }
  },
  {
@@ -13229,28 +13401,28 @@
   "repo": "jcs-elpa/company-fuzzy",
   "unstable": {
    "version": [
-    20200712,
-    49
+    20200925,
+    300
    ],
    "deps": [
     "company",
     "s"
    ],
-   "commit": "af017d00f4576fddee1d386f41c9ccebd7038d9a",
-   "sha256": "1a3317wzilp7z01j34rqg5khr77hqz9nxm930d16225gki98g9q3"
+   "commit": "bc0112e3cbce932c35be490ebb8eba56d7f1a7bb",
+   "sha256": "12a2ks5z2n6s8a7rbx5bm2m3jgggpzil9jd7csr9kppw8qb1bfzn"
   },
   "stable": {
    "version": [
     0,
-    6,
-    0
+    7,
+    2
    ],
    "deps": [
     "company",
     "s"
    ],
-   "commit": "af017d00f4576fddee1d386f41c9ccebd7038d9a",
-   "sha256": "1a3317wzilp7z01j34rqg5khr77hqz9nxm930d16225gki98g9q3"
+   "commit": "bc0112e3cbce932c35be490ebb8eba56d7f1a7bb",
+   "sha256": "12a2ks5z2n6s8a7rbx5bm2m3jgggpzil9jd7csr9kppw8qb1bfzn"
   }
  },
  {
@@ -13587,6 +13759,19 @@
     "company",
     "ivy"
    ],
+   "commit": "44c7a655e5f2a462835a96d1f0ed2ce434848416",
+   "sha256": "007zyvr5mw16j7gxxx8bm0jpy8hyph9xrmxsi1dy2pshb2fnpq95"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "company",
+    "ivy"
+   ],
    "commit": "b922318da821fc3cf1d3155f21d543ea8470c881",
    "sha256": "1s2bv040gg22qzjca39r32cz3qhairnvppk9wdp1hl52i6by57v9"
   }
@@ -13782,16 +13967,16 @@
   "repo": "xcwen/ac-php",
   "unstable": {
    "version": [
-    20190424,
-    222
+    20200916,
+    751
    ],
    "deps": [
     "ac-php-core",
     "cl-lib",
     "company"
    ],
-   "commit": "8db6d911f2e19bbef5fe915e42c4e12f283bfd41",
-   "sha256": "0yzad3bc48xdmkgcsffdj9zx9j853w1k2p2v586bcfl2vmvvq3zj"
+   "commit": "7c023b9ced156cee03171e16c3dac6d26923042f",
+   "sha256": "0vaxha2f37bs634bl0122c09mkp1yyy2444pkikdavhjx9gzc55j"
   },
   "stable": {
    "version": [
@@ -13963,8 +14148,8 @@
     "company",
     "prescient"
    ],
-   "commit": "cc289ba3b0d89f251267ca2b669d01b3afecc530",
-   "sha256": "0xwy2xh55dm4y7wlz2g6fkwf1xyqqjyp0sjb522qgasivknzwa5p"
+   "commit": "0c5d611d9fc6431dd049a71a6eda163c37617a33",
+   "sha256": "1wl445iric3jnhkf2wq4f23zi4yb0k731p0hrydvb2c5vyhsbb6n"
   },
   "stable": {
    "version": [
@@ -14038,28 +14223,28 @@
   "repo": "jcs-elpa/company-quickhelp-terminal",
   "unstable": {
    "version": [
-    20200627,
-    908
+    20200904,
+    305
    ],
    "deps": [
     "company-quickhelp",
     "popup"
    ],
-   "commit": "e18b4cf309e2bbc63995ebc3c1230c8c865dd00e",
-   "sha256": "1ixl54wgynq0zzqr7cxphblwmxx5a9gs28rfyq5c2l499ja4r1k7"
+   "commit": "c2e077e8d32610f80a506c410ab51a4ba747a47f",
+   "sha256": "014gk5ara9xh218wm2ygh2nilyp3s1rbg6y5y2z2ki460biwi166"
   },
   "stable": {
    "version": [
     0,
     1,
-    0
+    1
    ],
    "deps": [
     "company-quickhelp",
     "popup"
    ],
-   "commit": "e18b4cf309e2bbc63995ebc3c1230c8c865dd00e",
-   "sha256": "1ixl54wgynq0zzqr7cxphblwmxx5a9gs28rfyq5c2l499ja4r1k7"
+   "commit": "c2e077e8d32610f80a506c410ab51a4ba747a47f",
+   "sha256": "014gk5ara9xh218wm2ygh2nilyp3s1rbg6y5y2z2ki460biwi166"
   }
  },
  {
@@ -14152,8 +14337,8 @@
     "company",
     "rtags"
    ],
-   "commit": "b57b36039f6411f23009c4ec0315ca5a7adb6824",
-   "sha256": "1816yxyqkxd895wka9xkxpca59iwjpcv73d25sq03z2gf1ayd56b"
+   "commit": "9ad2ff1c2c09c9d2eb945bc9f174f27fa36f0ae1",
+   "sha256": "19l0iiwkz6q9gs0wmi792016d18fp1m1i9g60yfk4wg5w9rbvzk2"
   },
   "stable": {
    "version": [
@@ -14287,21 +14472,21 @@
     "company",
     "stan-mode"
    ],
-   "commit": "e891a0fcb3a7ab7d9cedbe3deda560134636897e",
-   "sha256": "158afanfaww2jkrz9szap6ys8xhbpz35kd5apkxr1j9j7s8h0iw0"
+   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
+   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
   },
   "stable": {
    "version": [
     10,
-    1,
+    2,
     0
    ],
    "deps": [
     "company",
     "stan-mode"
    ],
-   "commit": "599a0440086c660e6823622b35058f6d2d6d9637",
-   "sha256": "0mm0kpyihpd55hx14smlm0ayz05zw750fihhqhxqc258y8y73m5y"
+   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
+   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
   }
  },
  {
@@ -14342,14 +14527,14 @@
   "repo": "juergenhoetzel/company-suggest",
   "unstable": {
    "version": [
-    20200804,
-    1127
+    20200911,
+    1845
    ],
    "deps": [
     "company"
    ],
-   "commit": "7f4efb0e2577b7b34928db3dc71758ab6852f66b",
-   "sha256": "0hlvg11p4xkafqys322ablbld2v7fks924cpc3bs3wcipjjxl3cf"
+   "commit": "1c89c9de3852f07ce28b0bedf1fbf56fe6eedcdc",
+   "sha256": "0xy2al4b888f32qmxcai2wshx4ajgkk9wnv3rdmdmianx0xmzpzh"
   }
  },
  {
@@ -14520,10 +14705,10 @@
  },
  {
   "ename": "compdef",
-  "commit": "462b3d92c8c5f72ae1b70fa4d48b803c2f3d07e2",
-  "sha256": "04cav3f1ggyjfgnbx1wsyfaj8d63sxwfqkjar869p6kz9gajy4qr",
-  "fetcher": "gitlab",
-  "repo": "jjzmajic/compdef",
+  "commit": "b95fa8694bd49595da9fb56454e6539e76feff97",
+  "sha256": "1ndwkmmd4ajpg3g78b761dhhkjzwp9qan10r568rp2knbf6xnaw4",
+  "fetcher": "github",
+  "repo": "wurosh/compdef",
   "unstable": {
    "version": [
     20200304,
@@ -14841,8 +15026,8 @@
     20191111,
     446
    ],
-   "commit": "c9cad101100975e88873636bfd426b7a19304ebd",
-   "sha256": "0zsjbpq0s0xdxd9r541f04bj1khhgzhdlzr0m4p17zjh1zardbpi"
+   "commit": "46ee5d9ba15cac7282ed73c8b4c272a969c6159e",
+   "sha256": "06mqf19k96mgpa7iv3li2qmfra6qgh4g0s43ark24bk63hdxqvyc"
   },
   "stable": {
    "version": [
@@ -15135,15 +15320,15 @@
   "repo": "conao3/cort.el",
   "unstable": {
    "version": [
-    20200812,
-    910
+    20200904,
+    609
    ],
    "deps": [
     "ansi",
     "cl-lib"
    ],
-   "commit": "28c8422e84fd545f7a166f1904277b6b3f98398c",
-   "sha256": "06fcwadrn32i19qp30xw65976wplsw3xh2jm0zzsp9g0pir1snxb"
+   "commit": "98532580e0425ac96f45f73ef7cebf80cb4101e2",
+   "sha256": "0pwdh0c0ilrp8bx594qw2684q009ls1ras8ha2xavnwxph84jpd2"
   },
   "stable": {
    "version": [
@@ -15181,14 +15366,14 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20200818,
-    1428
+    20200922,
+    1006
    ],
    "deps": [
     "swiper"
    ],
-   "commit": "dd43ab1217f72948dc5cd669467e33b8b568db44",
-   "sha256": "0h4273gr4h9xkdf5g08ci95jq0n9l1w3vgd1y9452cry1r07ya9l"
+   "commit": "b65e401c22ec56a008b00f651cd9536caf593d43",
+   "sha256": "0i1q520anbhglfgv35ivvgqwaxf6mzaw45lxmikcijcvc3z1aq4s"
   },
   "stable": {
    "version": [
@@ -15328,26 +15513,26 @@
   "repo": "redguardtoo/counsel-etags",
   "unstable": {
    "version": [
-    20200814,
-    716
+    20200911,
+    1007
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "5ec1e422b47163e17d0d5c1cf732068f93ffc39c",
-   "sha256": "0zwyff7lamlpqd52ifspf6bb78cpanlsy5gccp7ms7mnj82zhfxm"
+   "commit": "c40a7337a2a6cc083078b7a156aad98cddb7b3b3",
+   "sha256": "15h0q42l7xnxry9x2pwrjrsbi64sxffsy5wifk32f5gwshhqp0w1"
   },
   "stable": {
    "version": [
     1,
     9,
-    12
+    14
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "9436bdbddc0deba88d97b5f31d62a2c95a52c400",
-   "sha256": "08glszh5y8y078vjrnmasxdfmxiics88hkva4nqq6spl0a0hrn9f"
+   "commit": "c3a554c74f9a46f162fbd643fa881fc137a731f0",
+   "sha256": "1hd7xb8k8509kcdz5p8lh5yjvf2bfk273zi7b0284k6wik22igiw"
   }
  },
  {
@@ -15358,14 +15543,14 @@
   "repo": "CsBigDataHub/counsel-fd",
   "unstable": {
    "version": [
-    20200505,
-    1344
+    20200902,
+    2147
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "afba62f73d348cd7dfd10db039769788f5ae7ad4",
-   "sha256": "1v5iy8axlrapaav0vwhns32xbsnsay62dc9g50bv7n84cn1pvmmy"
+   "commit": "533d70f229abc73b013668bd03f7486effa1e369",
+   "sha256": "0iz0blxbi0zcilyg4a5aqzggy1b0rdygw5q45szp9hbzzqdb5wfg"
   }
  },
  {
@@ -15395,15 +15580,15 @@
   "repo": "FelipeLema/emacs-counsel-gtags",
   "unstable": {
    "version": [
-    20200101,
-    1701
+    20200901,
+    1535
    ],
    "deps": [
     "counsel",
     "seq"
    ],
-   "commit": "5d2a8c2c2d358e374a576cf8a3a67f7997a8839b",
-   "sha256": "0qx7gdxgd28grz8pn57kb9qrsvdiysci6hya1fif3iqb1hbyg2mn"
+   "commit": "95ccefe4aec578efa28e9cac0f0841637c361a65",
+   "sha256": "1km3acc3wnznsiiphvvfpf7rqvqq8gsr41mdafhm35ilg3xg4mhx"
   },
   "stable": {
    "version": [
@@ -15432,8 +15617,8 @@
     "ivy",
     "swiper"
    ],
-   "commit": "b14dfc5c18d991c3b3051c3cbb244d5923b3a327",
-   "sha256": "0f5h7nnqrkzbyxi4mgzahqzylszrqb25l3i24ml8yra2a23nl2w8"
+   "commit": "104c77b9f0037322da8231f98b94aca298e002be",
+   "sha256": "1365zxsx0lmii86v7mg4y4mvwhhrc4gcxsl0znh8g6wcvx13dagj"
   },
   "stable": {
    "version": [
@@ -16220,11 +16405,11 @@
   "repo": "josteink/csharp-mode",
   "unstable": {
    "version": [
-    20200728,
-    1113
+    20200904,
+    922
    ],
-   "commit": "48851778e0f01a2b0395e054e418a1d8a1687a06",
-   "sha256": "0nikm2sn59ichbd3ikyhdn696fqj5ikzh79iniylza8gzmhxgddi"
+   "commit": "5a9c8eb2e851f0ba1f5d94548afab9381e6da7bc",
+   "sha256": "1q6agan328bgj6gafagkfj3yy077sgvczqnbbvlvfxcjsmhsj07v"
   },
   "stable": {
    "version": [
@@ -16439,11 +16624,11 @@
   "repo": "raxod502/ctrlf",
   "unstable": {
    "version": [
-    20200802,
-    1422
+    20200920,
+    242
    ],
-   "commit": "5a13161bb2ef2908dd5a00b3b6aa7b8dacfecd8a",
-   "sha256": "09gd2zi3wvg9vhaxz6y1zii0n8nxhffp9qyjsgswyzaa1j7dzv2i"
+   "commit": "2279f684f8d75a75f6b98ddaa908182f08c0d877",
+   "sha256": "0bqzkdsp2fjywy96xhxka9v3608h7id7sq0g45x01178fria8vji"
   },
   "stable": {
    "version": [
@@ -16452,6 +16637,21 @@
    ],
    "commit": "b91f88a24c05408757ae9c9b5ce74d46d6ce20d8",
    "sha256": "1ffcjf0ff0748gqipkklz6jmcj4f3blgzdcax93ql9ws8bmvlsdc"
+  }
+ },
+ {
+  "ename": "ctrlxo",
+  "commit": "94b9c456d9896c345158cf43dfd9695cbb393af2",
+  "sha256": "158l994l3z6bwi6g3igcksv0b3yr5i358cs262391w9awaghl5rh",
+  "fetcher": "github",
+  "repo": "muffinmad/emacs-ctrlxo",
+  "unstable": {
+   "version": [
+    20200923,
+    1839
+   ],
+   "commit": "037c5edfe12cba4eefa020c420dca7c300fbb225",
+   "sha256": "19nar6wzg6xny3dxi5qp729wb69gb67y3qsw006gp1n82jr7k3hb"
   }
  },
  {
@@ -16817,8 +17017,8 @@
     20190111,
     2150
    ],
-   "commit": "fcfd16c7467c31f255287a73f36cf66b32bc096c",
-   "sha256": "1yscd5q1qqw8xx4ds2pifpiyzhdnx0la5n50mxqjb3hlky7p48wh"
+   "commit": "af1300f7655b2ccdf6308d9c9fb839d7083782e9",
+   "sha256": "0bjx4044kdmvxl07idpy9zvfv53bfjbia9h3iyxrgfpwz9ac6z09"
   },
   "stable": {
    "version": [
@@ -16853,20 +17053,20 @@
   "repo": "Emacs-D-Mode-Maintainers/Emacs-D-Mode",
   "unstable": {
    "version": [
-    20191009,
-    903
+    20200830,
+    833
    ],
-   "commit": "cfd1d0869d51b7548b3fb738b2f2593c76533d44",
-   "sha256": "0vkl470vvmxap8ca773a0jvjvalmvdbbax3qvgjdclp54ml75al4"
+   "commit": "b40a7abd33d56ce20fbb51697d54f9cc68dcbb8d",
+   "sha256": "15i765k10zvg50h1qkgpi775pbzgl2p5liwd8qzgdb3agpnpm04f"
   },
   "stable": {
    "version": [
     2,
     0,
-    10
+    11
    ],
-   "commit": "b5d936dfd4c1d0b68a0d911aadd4ba25df7af0e4",
-   "sha256": "0915kb9jcaixgindhj85fmykkhvj31ckp1yg6746fznwdgfrlifv"
+   "commit": "cfd1d0869d51b7548b3fb738b2f2593c76533d44",
+   "sha256": "0vkl470vvmxap8ca773a0jvjvalmvdbbax3qvgjdclp54ml75al4"
   }
  },
  {
@@ -16984,8 +17184,8 @@
   "repo": "jyp/dante",
   "unstable": {
    "version": [
-    20200416,
-    1217
+    20200921,
+    723
    ],
    "deps": [
     "company",
@@ -16996,8 +17196,8 @@
     "lcr",
     "s"
    ],
-   "commit": "c516bc9e8f09e0f928de9a93e82acfb382636f5c",
-   "sha256": "16msp36vflq10w0h1hh6fy7z9gmqzhr61w0xali2jkb203v1pi6d"
+   "commit": "e2acbf6dd37818cbf479c9c3503d8a59192e34af",
+   "sha256": "18w9ifykrcxxjn9pwp3xfyxvx54c0icwsv0n12xfjghfdkph21qq"
   },
   "stable": {
    "version": [
@@ -17025,8 +17225,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20200814,
-    1819
+    20200921,
+    1845
    ],
    "deps": [
     "bui",
@@ -17038,8 +17238,8 @@
     "posframe",
     "s"
    ],
-   "commit": "0c11dd205152f3b8712362e4bc8919def7f312a4",
-   "sha256": "1j7vxf42icl4nsnza91lp8l3lgrhn6y11xi9ql5lji5vfgj94mk6"
+   "commit": "1126a50e244044eb0b6640f923c3f01dcc05aca4",
+   "sha256": "1kkw2555kqx9hby5sbj1s8jxg53i7mnkz2kknqxp6mx43a31flyw"
   },
   "stable": {
    "version": [
@@ -17401,8 +17601,8 @@
    "deps": [
     "page-break-lines"
    ],
-   "commit": "bf38867ae80902d58207974b4a2bba4249324599",
-   "sha256": "1ksa1rq6xmyxc4srj1n3l0rd66zcz9br8k2bp3pzriljqvk8l753"
+   "commit": "23dec339dd8d04bb8c0af6465b212ed833c2528e",
+   "sha256": "1r0im7sbpq0s6g61ilfll5bqrrcsyiffjm3k7wd94h6bvdc2x5c0"
   },
   "stable": {
    "version": [
@@ -17735,15 +17935,15 @@
   "repo": "skk-dev/ddskk",
   "unstable": {
    "version": [
-    20200816,
-    1809
+    20200906,
+    233
    ],
    "deps": [
     "ccc",
     "cdb"
    ],
-   "commit": "275a831be77573470309a78967734d2b6d10f218",
-   "sha256": "1a25aybavi6p7ijc4rbd8zyzgiim1m2xwm7yqfmsvrfzwgb29xal"
+   "commit": "a66a7b16f13533afdd03e21eebcdd6309e469a13",
+   "sha256": "1x5qrzzsn977hyi8xnc37jrsq7adwg2jd1ln3vapfxr05pgiijk7"
   }
  },
  {
@@ -18054,11 +18254,11 @@
   "repo": "abo-abo/define-word",
   "unstable": {
    "version": [
-    20200417,
-    844
+    20200824,
+    1120
    ],
-   "commit": "08c71b1ff4fd07bf0c78d1fcf77efeaafc8f7443",
-   "sha256": "053kyg2jqayphdkm7s8fz8yl97yspib6qszcajyr77m6n7j4i764"
+   "commit": "3af6825c5f3bf4f6176a3f5b2e499616c65e2fe0",
+   "sha256": "1l418w5lhlyh62557ffrsisv7ips0ql7bpcxc32msc51dlh7ilhh"
   },
   "stable": {
    "version": [
@@ -18149,26 +18349,25 @@
   "repo": "liblit/demangle-mode",
   "unstable": {
    "version": [
-    20200621,
-    2344
+    20200926,
+    2014
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "697c1dbde93f164eac7ea0dc530d7e8b799272d6",
-   "sha256": "1ycbggyljbm5iawhk6i1cm21a3gzz1javab99c3abprkgmldmd5l"
+   "commit": "aaef0bd77a3ea9ce9132e9a53ac021b0f5d33e12",
+   "sha256": "0pz49zn81bwszcaq24x9p3kkybrl47xl3ndj5xalg4ifw7nw0ygb"
   },
   "stable": {
    "version": [
-    1,
-    3,
-    2
+    2,
+    0
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "697c1dbde93f164eac7ea0dc530d7e8b799272d6",
-   "sha256": "1ycbggyljbm5iawhk6i1cm21a3gzz1javab99c3abprkgmldmd5l"
+   "commit": "901242db26d00432ba075a2325b389cc847825e2",
+   "sha256": "0qkkrjb4yai5qd6hdabkwsgh696dazahswsk674jqwn39c3b2d4c"
   }
  },
  {
@@ -18396,14 +18595,14 @@
   "repo": "psibi/dhall-mode",
   "unstable": {
    "version": [
-    20200716,
-    2147
+    20200822,
+    258
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "484bcf8f78f1183ef45c3b04a362bb73690c6b9b",
-   "sha256": "1wggg8jlzg9rph4jhxp6yiri178rnasbv38838i973kjgqjxrl76"
+   "commit": "97524f934556d561c6c9268ed719f027ed9f55e9",
+   "sha256": "1c8dzk19f3n5v1r43iaynd1cs2valypz0ldh8l22cdbg82smva1b"
   }
  },
  {
@@ -18441,8 +18640,8 @@
     20200404,
     1549
    ],
-   "commit": "2850e8f27662eb1e8a34425b3032a361a5c989cc",
-   "sha256": "0p4l6gsfazq6aigvyy8mjkr9jpqs8cbmpzsfwdr7yvr5llxg77ds"
+   "commit": "4f9d3104f0d89fe3e39c878d2035e6b6d9510659",
+   "sha256": "094x2n9nlqwxdppkw7wsyxwp34gf0b1dfyxp97nn712mfy98g1fc"
   },
   "stable": {
    "version": [
@@ -18520,8 +18719,8 @@
     "connection",
     "link"
    ],
-   "commit": "c9cad101100975e88873636bfd426b7a19304ebd",
-   "sha256": "0zsjbpq0s0xdxd9r541f04bj1khhgzhdlzr0m4p17zjh1zardbpi"
+   "commit": "46ee5d9ba15cac7282ed73c8b4c272a969c6159e",
+   "sha256": "06mqf19k96mgpa7iv3li2qmfra6qgh4g0s43ark24bk63hdxqvyc"
   },
   "stable": {
    "version": [
@@ -18544,11 +18743,11 @@
   "repo": "kisaragi-hiu/didyoumean.el",
   "unstable": {
    "version": [
-    20191020,
-    531
+    20200905,
+    1843
    ],
-   "commit": "4a6049f2de36801e0a50e93b17a375501f16cf28",
-   "sha256": "0plwn23h96m71vx0jxilnl6nj7lsq4mpjv8mjaiankrxhvjcv6f0"
+   "commit": "ce5edcce160b86e7f6480f0381be785d43f97e19",
+   "sha256": "0a89bp9vz8lzg5klhmzpfmc0mhqmx667ivr86ckkjhiwr2mmzq0s"
   },
   "stable": {
    "version": [
@@ -18685,20 +18884,20 @@
   "repo": "retroj/digistar-mode",
   "unstable": {
    "version": [
-    20200819,
-    1316
+    20200827,
+    9
    ],
-   "commit": "7f89372f27eff9e4db55bcf39f9cce3693d95bb2",
-   "sha256": "0s9q9f9bqr4w9ll0im65h95hxki3svanlikwxgq6m7p493s1q5j0"
+   "commit": "f46d58ea690c7c9ff9aca19441dff23284bab7cf",
+   "sha256": "0x29502mn9cpbsfiqsdaa90j2566zfai5lbv2c49w5wxxm904b7j"
   },
   "stable": {
    "version": [
     0,
     9,
-    0
+    1
    ],
-   "commit": "343de0e0fe408f422a32e1bda22cafc2cc9900bb",
-   "sha256": "1cg38x7zd1n9zqsyg47famss91nqs7giqpgsi5qy10zp8y3i3l2c"
+   "commit": "f46d58ea690c7c9ff9aca19441dff23284bab7cf",
+   "sha256": "0x29502mn9cpbsfiqsdaa90j2566zfai5lbv2c49w5wxxm904b7j"
   }
  },
  {
@@ -19366,14 +19565,14 @@
   "repo": "xuhdev/dired-quick-sort",
   "unstable": {
    "version": [
-    20161208,
-    2112
+    20200910,
+    524
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "1845f978d313f750a5b70b832457ed803c4ffbdb",
-   "sha256": "014frvpszixn8cx7rdx704glmjbslv3py3kw0pb0xqf50k4scynf"
+   "commit": "66646e7bc9f841e2a5636027d53b57556c0c9f63",
+   "sha256": "0lq3qh6pmhzz5kapl2pqz8svqzy0c5n2pb9npa73jzrdqlssz2gc"
   },
   "stable": {
    "version": [
@@ -19547,11 +19746,11 @@
   "repo": "crocket/dired-single",
   "unstable": {
    "version": [
-    20200303,
-    1144
+    20200824,
+    708
    ],
-   "commit": "90ade369ba478fdebf61957f837c0b10cef128b1",
-   "sha256": "08qm8s77kfx9yfhm10vivhq15jrndvd29azkv4y1wd9qsrh5ylk0"
+   "commit": "98c2102429fcac6fbfdba9198c126eb1b3dcc4e5",
+   "sha256": "1adh8sr7g2xc6b7is1cz48v109iavr2krkp5nd23bkgnjsjjkxlm"
   },
   "stable": {
    "version": [
@@ -20542,15 +20741,15 @@
   "repo": "meqif/docker-compose-mode",
   "unstable": {
    "version": [
-    20200730,
-    1258
+    20200830,
+    1336
    ],
    "deps": [
     "dash",
     "yaml-mode"
    ],
-   "commit": "4c0c897fb0572e6b026b2a5ab9f2c76174be7a14",
-   "sha256": "01fj856511qjn5zw370axyz4imdnq3j5sqvbm8nkd71z1mz3dyv1"
+   "commit": "abaa4f3aeb5c62d7d16e186dd7d77f4e846e126a",
+   "sha256": "123msjiw5jsgmb5r1vmp3h2m4qia2pjg9wrb9cjhi3fjlspk9x2d"
   },
   "stable": {
    "version": [
@@ -20629,11 +20828,11 @@
   "repo": "progfolio/doct",
   "unstable": {
    "version": [
-    20200815,
-    2139
+    20200917,
+    1712
    ],
-   "commit": "89eb2e6f1c2630c980bdf4c0430ba54722c9ee00",
-   "sha256": "0210jwk19b59hx7gi2ddy5ja9jndvmwmip8bh16g35qiscn2jwml"
+   "commit": "dabb30ebea866ef225b81561c8265d740b1e81c3",
+   "sha256": "0pbalf1a9jrfwb6h1zw3bxz16qn1md10w030hbcbm0dblafchz0y"
   }
  },
  {
@@ -20748,16 +20947,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20200819,
-    117
+    20200909,
+    1236
    ],
    "deps": [
     "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "ffbaaee832f1c97ff608bc4959b408997d959b7d",
-   "sha256": "0gvdlwa4w7s1igy8hqapng2s1k9ca6f76g68m5wzrfnx1z0zf7xl"
+   "commit": "aa056cfca639c9c41306fad9f5eb502cffc7fc1a",
+   "sha256": "1qy4mjkbsqxrncqdmn5harr2c631glrca1fx5ipnsjkfiksjgs13"
   },
   "stable": {
    "version": [
@@ -20782,14 +20981,14 @@
   "repo": "hlissner/emacs-doom-themes",
   "unstable": {
    "version": [
-    20200816,
-    2044
+    20200902,
+    308
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "24023de3c80c9f3afc3d012762d1ef0f8dbd326e",
-   "sha256": "0dwwpdwi0722xyap3xnm7034syb2fssfm4c6k5868k0344rvdkr8"
+   "commit": "d6ee47dc8ed2cf9e585f62243214af03ba5b1687",
+   "sha256": "074i7zwpi8ah72aa7j0f8bzaphmb8sh0pm9kvna9ip7ir2bgix5f"
   },
   "stable": {
    "version": [
@@ -21245,8 +21444,8 @@
   "repo": "dtk01/dtk",
   "unstable": {
    "version": [
-    20200816,
-    2055
+    20200912,
+    1918
    ],
    "deps": [
     "cl-lib",
@@ -21254,8 +21453,8 @@
     "s",
     "seq"
    ],
-   "commit": "a0e789919f71ff4ab752432fe9e295f9f44c7b12",
-   "sha256": "029xsdasbrvkg8w2ykgy6iq618cdjkr4gkp4l094na35jpv96yca"
+   "commit": "351297153129c383d3230d3a67bf57f1414ee221",
+   "sha256": "1r9fpggpial7r02pnq02g4pl1c24m0ww0dncjp6w69mlg0x4bd69"
   }
  },
  {
@@ -21363,16 +21562,16 @@
   "repo": "jacktasia/dumb-jump",
   "unstable": {
    "version": [
-    20200815,
-    1537
+    20200914,
+    2016
    ],
    "deps": [
     "dash",
     "popup",
     "s"
    ],
-   "commit": "0d74b2f2aa834b602e91d99e9cb23197a389f042",
-   "sha256": "01jwyridywbihspan8zrrfpxl4gl275z8l23swhczg0bcjq1x8g8"
+   "commit": "fbbe6b0c3010bea8a6eaac2297080137319160e2",
+   "sha256": "02rh9xmhmphnf4xiyidyz4s50mcrm5p3zdwaypnh8p5syj836s2x"
   },
   "stable": {
    "version": [
@@ -21416,17 +21615,17 @@
     20191016,
     1241
    ],
-   "commit": "26078df94ea16e2fc9221a84c5d42f2fe024074b",
-   "sha256": "1pvqrijx5bmnbvwk4pz6j1ldir5zi95ixbfrqki284qcgq28krd1"
+   "commit": "01bcdbdc631fa6b635d89b0ade53f9723bfb6023",
+   "sha256": "1l1879klykb8bzd3m05xgqvc2a71cm8jxhmf19wy8grba88g85c8"
   },
   "stable": {
    "version": [
     2,
     7,
-    0
+    1
    ],
-   "commit": "85b4e16bd6c310811fcc206d3d0cbb391eb8b81c",
-   "sha256": "19fn7ywx13j1hc600pccyghz2izjy26bzwaqjynn7swlbkc96ymz"
+   "commit": "5472766b2448308a7160dfd0fca1ec711e124a5c",
+   "sha256": "10qgx83fq8b522y9mpllrp0l5cgmr2bs5s7aix5img21hlbm34in"
   }
  },
  {
@@ -21460,6 +21659,30 @@
   }
  },
  {
+  "ename": "dw",
+  "commit": "8ffaf9cbc25e7f24ef605df422a3f7217b67b135",
+  "sha256": "06ckyydsn9l2pb7wi2ydw2hxsya1jcxvs072rpszxfq9vjpcawrh",
+  "fetcher": "github",
+  "repo": "integral-dw/dw-passphase-generator",
+  "unstable": {
+   "version": [
+    20200921,
+    1937
+   ],
+   "commit": "d72c8183b5deee3b1e6eb15344eb816c33326f88",
+   "sha256": "1rq3abgxyffdrmdc1xhi54nf4mmf6dkrkqr89pyqpkq82d1r1z0s"
+  },
+  "stable": {
+   "version": [
+    0,
+    6,
+    0
+   ],
+   "commit": "2df0332f5d4b8a81e4aa6c20c6d4ccb7b442e2ec",
+   "sha256": "1x3xas6gp4ijn6h9hqx62xw14k9h94dzw07251hsvliww8f6gd0b"
+  }
+ },
+ {
   "ename": "dyalog-mode",
   "commit": "1a8f86df54f1243fea71e1e73ed0b9fb049032bd",
   "sha256": "00mbkl275g8x3w341nsi90ffm5cfalnrfzx8ww1hnxc86q5ldivw",
@@ -21467,14 +21690,14 @@
   "repo": "harsman/dyalog-mode",
   "unstable": {
    "version": [
-    20200817,
-    737
+    20200822,
+    1536
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "5d703d91f90ddebdfb4cae1b45c476aec5976313",
-   "sha256": "1vf88vywb4cjfndc4jd185fdqjydd7ckbf1n2qsi9w3k8940q2pq"
+   "commit": "f42e49b9dd7ab41f08361185cc25509f19b949a8",
+   "sha256": "1cqaa12pycwiv4cj100n8326f3yg59xgww3lk2l6x7841n7g7szm"
   }
  },
  {
@@ -21534,11 +21757,11 @@
   "repo": "zellerin/dynamic-graphs",
   "unstable": {
    "version": [
-    20200818,
-    442
+    20200902,
+    1238
    ],
-   "commit": "10dffcbc4011647c16e8d65d05856e043de1865d",
-   "sha256": "08f3f4bwryyhvj8yp2y2v3fppl6drd4rq3wyx48mxwkiw6z1db4r"
+   "commit": "ba3fdf2cf0e5e1e952a1961a03dfb7f61a4ab0e7",
+   "sha256": "0cyngkba93swhgklh88r5czlvimc0pa9blg02cwz3mjwj5r558bl"
   }
  },
  {
@@ -22070,26 +22293,26 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20200628,
-    2157
+    20200926,
+    2251
    ],
    "deps": [
     "parsebib"
    ],
-   "commit": "805c2e30e30f9f211f4aa443263d1c3971935295",
-   "sha256": "0kgw049wph40kk0kin7zxj44ghd1s1pr8zpl1gli4zic02vzcaga"
+   "commit": "f41c579af69441e563c885141007e1f53bae36dc",
+   "sha256": "0zlns49vr7fxcgzdk40dpiiaw57xyc1ig0y6b369651cvmvybbra"
   },
   "stable": {
    "version": [
     2,
     25,
-    1
+    5
    ],
    "deps": [
     "parsebib"
    ],
-   "commit": "bd258c1f364a8c96b0026fdc3de75117ca4e324a",
-   "sha256": "1mvsa2a761va74ybxprdvmhkzhjl6axn1ngjfhrrljqgsvqgyjwk"
+   "commit": "f41c579af69441e563c885141007e1f53bae36dc",
+   "sha256": "0zlns49vr7fxcgzdk40dpiiaw57xyc1ig0y6b369651cvmvybbra"
   }
  },
  {
@@ -22866,8 +23089,8 @@
     20200107,
     2333
    ],
-   "commit": "54b0f51a103e4c12515cd814e3bc6be67c3da966",
-   "sha256": "1yvf4qns69smcg6vbb6l25g8dnai5da827qpd8f6pg3qp8w1q5wc"
+   "commit": "f7f7af97830c7b09d3871cbb557986258fbca0b1",
+   "sha256": "1f7kn6pwciycmyfzwjj6c0y1rqk38zms03wrg3h8imwiwqszjk25"
   },
   "stable": {
    "version": [
@@ -22887,8 +23110,8 @@
   "repo": "joaotavora/eglot",
   "unstable": {
    "version": [
-    20200816,
-    1810
+    20200830,
+    1254
    ],
    "deps": [
     "eldoc",
@@ -22897,8 +23120,8 @@
     "project",
     "xref"
    ],
-   "commit": "5f873d288e1c5434c1640bef03555ed056cb0d35",
-   "sha256": "1rdfrw6qcbkl7bnjsfrzz6ndbr6lk0s4ldyqwv48k1nvlk9jc796"
+   "commit": "61b71ea769fa14887465517f70832861f7052816",
+   "sha256": "07d86f55j9mxh6p2ba62yg4dnajp75lamm4z6qdaigl9a1zq77pn"
   },
   "stable": {
    "version": [
@@ -23014,8 +23237,8 @@
   "repo": "millejoh/emacs-ipython-notebook",
   "unstable": {
    "version": [
-    20200812,
-    230
+    20200926,
+    403
    ],
    "deps": [
     "anaphora",
@@ -23027,8 +23250,8 @@
     "websocket",
     "with-editor"
    ],
-   "commit": "99a4718f50538a439a2a3f2011d1aa97246e259b",
-   "sha256": "0qi012pbyj1zdj7h0y3r26ijf80046827ln079v1q9hgkz9ipaam"
+   "commit": "1bfb80c8bbe4ace10c4b430c493149efa4aabbbd",
+   "sha256": "1n5x1k4yv0mfckvfgjw802p87h80kkqkcb3yllg3xvy31jxvr9pm"
   },
   "stable": {
    "version": [
@@ -23179,8 +23402,8 @@
     20180422,
     243
    ],
-   "commit": "4917f486a7be7482dedfea0a7ac3d01cab4ce21c",
-   "sha256": "19ap5l2i0ydkl2whzy44rxc8cgjgrrwi4w7i429ga3pjkac9170g"
+   "commit": "39738c88c01a3a035edffe63400d434edb1e3003",
+   "sha256": "1p29h1ab9iciray6yzg120vw8zi9zx3lsms120szhqdn1chaldcg"
   }
  },
  {
@@ -23191,11 +23414,11 @@
   "repo": "dimitri/el-get",
   "unstable": {
    "version": [
-    20181006,
-    225
+    20200912,
+    1653
    ],
-   "commit": "3b5e48ba4a4dca5c91610e2eb607a8bbb725a6ab",
-   "sha256": "1kx0c3wgij66hhryb9ggf8c975406vb9a9m6z4yrsrrisyc2ljgk"
+   "commit": "6138ce5b0a9df779e33ef42eadc4c15a5cf65f39",
+   "sha256": "19qfpv0f0xhj04f572a20a0yd7qqhrivxjx9mfp15g43pgdp9ajz"
   },
   "stable": {
    "version": [
@@ -23311,8 +23534,8 @@
     20200716,
     1428
    ],
-   "commit": "ff1951d776f80d2fd4a0cd9a0c930182fbb57b3c",
-   "sha256": "1f783xapqa6zigg0gqayxsf8lfkldng8r4ns9x04rqg9vmhkxmk0"
+   "commit": "a47067b4d63f3674d284a772bfe773021540c043",
+   "sha256": "17gpysk41qf40xa4vab79d3dmi7l3xay5gb27wn7fmj9nrzbm4sm"
   },
   "stable": {
    "version": [
@@ -23534,29 +23757,30 @@
   "repo": "DamienCassou/elcouch",
   "unstable": {
    "version": [
-    20190820,
-    1641
+    20200921,
+    1932
    ],
    "deps": [
     "json-mode",
     "libelcouch",
     "navigel"
    ],
-   "commit": "8e1b7ddec91ae863c3951776a0fcbfead8ca7a80",
-   "sha256": "07psfjynphzpm5jgajf31cigs5jyj8qnq491xrk88jvxm63sq55c"
+   "commit": "5a870f85f792eb2bf85a02b633e655f213fc4030",
+   "sha256": "0cmgnwg1dbxxv3ci6szmprs8kf8s39fp8d3ixmx92mjdcypm3519"
   },
   "stable": {
    "version": [
     0,
-    3,
+    10,
     0
    ],
    "deps": [
     "json-mode",
-    "libelcouch"
+    "libelcouch",
+    "navigel"
    ],
-   "commit": "d22e8cab9328966b2e2d5bc4fc17a4abbb222736",
-   "sha256": "0l9ah3ijlidjshwkazfcdasm3hmigw8dcyqgi9pmpv0kw9096y64"
+   "commit": "5a870f85f792eb2bf85a02b633e655f213fc4030",
+   "sha256": "0cmgnwg1dbxxv3ci6szmprs8kf8s39fp8d3ixmx92mjdcypm3519"
   }
  },
  {
@@ -23567,20 +23791,20 @@
   "repo": "doublep/eldev",
   "unstable": {
    "version": [
-    20200815,
-    2332
+    20200926,
+    1649
    ],
-   "commit": "ae353301c15b15930b0a83807275ed58a3be82e6",
-   "sha256": "0l1ac2ll2127wn6nlrpvxzk38xb74rb8bmp6c5sjh79hnjr04zh5"
+   "commit": "5f5ef70aa9b9e7d0cb84955200684bb071bf76ae",
+   "sha256": "1g5fyngp8rrmmsc4zqkr4fpxp0n2x6ymhwffqnzjaw30xypks1qz"
   },
   "stable": {
    "version": [
     0,
-    6,
-    1
+    7,
+    2
    ],
-   "commit": "8440e797f0dcaf7bf6da2a7573a7b07c4ea9da82",
-   "sha256": "16g68lgd5lp3rdskym4xnkvsm6953xgx48yah8zs5fpk4qny212r"
+   "commit": "a25ea7a9f6c15c18457e737ef61a0ff81970c5cc",
+   "sha256": "1xxcxgycn0a03irjcdq2pcb4p1bddhfjspni7lliwpv6zjqgkyhb"
   }
  },
  {
@@ -23630,11 +23854,11 @@
   "repo": "thierryvolpiatto/eldoc-eval",
   "unstable": {
    "version": [
-    20190423,
-    1858
+    20200902,
+    1339
    ],
-   "commit": "a67fe3637378dcb6c5f9e140acc8131f0d2346b3",
-   "sha256": "0504yyzxp1rk0br6f25395n4aa4w8ixf59vqxxb55a7agxplfpjc"
+   "commit": "f6e639047d9b3695877e63dd3de8f24e704d6d23",
+   "sha256": "0avl9yfprf4q1xpnvhdx0dbcgrf25sln7w7d76jqjmp93cn4idrc"
   },
   "stable": {
    "version": [
@@ -23672,26 +23896,26 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20200221,
-    2025
+    20200830,
+    1032
    ],
    "deps": [
     "stan-mode"
    ],
-   "commit": "e891a0fcb3a7ab7d9cedbe3deda560134636897e",
-   "sha256": "158afanfaww2jkrz9szap6ys8xhbpz35kd5apkxr1j9j7s8h0iw0"
+   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
+   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
   },
   "stable": {
    "version": [
     10,
-    1,
+    2,
     0
    ],
    "deps": [
     "stan-mode"
    ],
-   "commit": "599a0440086c660e6823622b35058f6d2d6d9637",
-   "sha256": "0mm0kpyihpd55hx14smlm0ayz05zw750fihhqhxqc258y8y73m5y"
+   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
+   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
   }
  },
  {
@@ -23802,11 +24026,11 @@
   "repo": "skeeto/elfeed",
   "unstable": {
    "version": [
-    20200716,
-    1921
+    20200910,
+    239
    ],
-   "commit": "8fb09ad75f2ff7d6f7d8b8d1ac65b9be873cc31d",
-   "sha256": "0rs32xvpwky37y18wr6maqbkncijia7yvmbrsngbhgdpzdvijp7v"
+   "commit": "7b2b6fadaa498fef2ba212a50da4a8afa2a5d305",
+   "sha256": "003hkmhns8bmbfy7a1rf9jnpqfsbpwhhrv81bjvwcdvrbddsys6x"
   },
   "stable": {
    "version": [
@@ -23871,28 +24095,28 @@
   "repo": "fasheng/elfeed-protocol",
   "unstable": {
    "version": [
-    20200526,
-    341
+    20200820,
+    505
    ],
    "deps": [
     "cl-lib",
     "elfeed"
    ],
-   "commit": "c5a928d4217060a49444d80d2fd54282d32a12a5",
-   "sha256": "0zky2iqkpckaq8c1fyhw9drdnmnyapix8jw46p6jvspljb9vwzkb"
+   "commit": "180bea08406861b43ba44564480da060d37e6fda",
+   "sha256": "1sc7dn62bi6ncqzs9n6wkrl4nsxkpssmix9hrh1xj45yxij7rlzp"
   },
   "stable": {
    "version": [
     0,
     7,
-    8
+    9
    ],
    "deps": [
     "cl-lib",
     "elfeed"
    ],
-   "commit": "c5a928d4217060a49444d80d2fd54282d32a12a5",
-   "sha256": "0zky2iqkpckaq8c1fyhw9drdnmnyapix8jw46p6jvspljb9vwzkb"
+   "commit": "180bea08406861b43ba44564480da060d37e6fda",
+   "sha256": "1sc7dn62bi6ncqzs9n6wkrl4nsxkpssmix9hrh1xj45yxij7rlzp"
   }
  },
  {
@@ -23942,8 +24166,8 @@
     "elfeed",
     "simple-httpd"
    ],
-   "commit": "8fb09ad75f2ff7d6f7d8b8d1ac65b9be873cc31d",
-   "sha256": "0rs32xvpwky37y18wr6maqbkncijia7yvmbrsngbhgdpzdvijp7v"
+   "commit": "7b2b6fadaa498fef2ba212a50da4a8afa2a5d305",
+   "sha256": "003hkmhns8bmbfy7a1rf9jnpqfsbpwhhrv81bjvwcdvrbddsys6x"
   },
   "stable": {
    "version": [
@@ -24045,11 +24269,11 @@
   "repo": "xuchunyang/elisp-demos",
   "unstable": {
    "version": [
-    20200606,
-    949
+    20200917,
+    735
    ],
-   "commit": "8c9748134f7c017ae1536dbd0b76434afb52e64d",
-   "sha256": "15gyhqnlppsswmmcknc3yfm6p7s2y06r2py656vh5vwhah7pcqxj"
+   "commit": "617fee7e9517a738ed747f6d55fcbf49c141bf37",
+   "sha256": "0g8j7zz09jv0rgbjm8a5sswrvxpxi0r2dy5vvpwgbjmqsyhxi4i2"
   },
   "stable": {
    "version": [
@@ -24388,15 +24612,15 @@
   "repo": "Silex/elmacro",
   "unstable": {
    "version": [
-    20191208,
-    1057
+    20200905,
+    2130
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "ba4086ef241dadfc2b1ce1bcfa56e12dbb89ef58",
-   "sha256": "0q29h3y6q1xkz2jx9bvrk8nvmisv1di2l79yc3zrw5k4hirq8j2a"
+   "commit": "4888d1baa8b943adf0bab94419357c55b7e6e697",
+   "sha256": "0g1iavy7f0n14c34b808kv5sf3imvc9aqv5814r231i6qjck5vj4"
   },
   "stable": {
    "version": [
@@ -24436,6 +24660,30 @@
    ],
    "commit": "091f61c70c9e7630a74b7b127488051d143a35e7",
    "sha256": "080nnw6ddsczbm7gk50x4dkahi77fsybfiki5iyp39fjpa7lfzq3"
+  }
+ },
+ {
+  "ename": "elmpd",
+  "commit": "32b6fcf73b083eec2332c547ab4df4994bfdafff",
+  "sha256": "1ph0c1xq93pk53wq2vbh588nwifpji1ixn5wpgm9wp421ad3z5br",
+  "fetcher": "github",
+  "repo": "sp1ff/elmpd",
+  "unstable": {
+   "version": [
+    20200927,
+    152
+   ],
+   "commit": "9bf5784396bba30c12e5cbc4c5051ae4e807bb4f",
+   "sha256": "0dir897nkzliphjxvjvs0g87nskzs482563af084jibgm1cx9np5"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    2
+   ],
+   "commit": "9bf5784396bba30c12e5cbc4c5051ae4e807bb4f",
+   "sha256": "0dir897nkzliphjxvjvs0g87nskzs482563af084jibgm1cx9np5"
   }
  },
  {
@@ -24618,20 +24866,20 @@
   "url": "git://thelambdalab.xyz/elpher.git",
   "unstable": {
    "version": [
-    20200628,
-    2255
+    20200919,
+    1025
    ],
-   "commit": "b4450244a5e23605f80b2179ce7d4dbaff56d927",
-   "sha256": "0fjqdp4xh9q50rdxg20il1y6wwn5l1af7139f4613z4j5ha3zxxg"
+   "commit": "3561c2815bc6bc896fc7a6da8f094edca48c55b8",
+   "sha256": "0vy1ak5gphnih90c1n7js91p0fdyccdqqbagdjqdfbpbir41gba5"
   },
   "stable": {
    "version": [
     2,
     10,
-    0
+    2
    ],
-   "commit": "b4450244a5e23605f80b2179ce7d4dbaff56d927",
-   "sha256": "0fjqdp4xh9q50rdxg20il1y6wwn5l1af7139f4613z4j5ha3zxxg"
+   "commit": "1edbaec565d413a9c7d4c55e9356c38b2037e0f5",
+   "sha256": "0xqiisirpvw4ka9417pq4r73x937wl3qbf8cpn2i03akm8d58smd"
   }
  },
  {
@@ -24642,11 +24890,11 @@
   "repo": "twlz0ne/elpl",
   "unstable": {
    "version": [
-    20191229,
-    1929
+    20200821,
+    1052
    ],
-   "commit": "48ecee2aa7b3d085a3deff809fb3ae31ae4ef9dd",
-   "sha256": "06xqww1r3i2hlr4hyg4n2l9zbpiki3g90b51jylaiabj4gqfswzv"
+   "commit": "ca6a6237681c641d5137d58e52f884dec0da6349",
+   "sha256": "0nh300bn5wc753dpyi5p8ihgm173h07mg04fryz5w173xxqqhj8c"
   }
  },
  {
@@ -24657,8 +24905,8 @@
   "repo": "jorgenschaefer/elpy",
   "unstable": {
    "version": [
-    20200805,
-    1736
+    20200926,
+    1724
    ],
    "deps": [
     "company",
@@ -24667,8 +24915,8 @@
     "s",
     "yasnippet"
    ],
-   "commit": "c766feb5c34dd17b7afba480ae9e90a08d75012c",
-   "sha256": "13z21jfvinjxyyi37xvx12gbr28fbr0g43x0nsip270dz797ls0v"
+   "commit": "3c5b09b5c04840324fcf52f62ad04311917e1b03",
+   "sha256": "0qg1zvb2m9lka2d590s2dkj54riaya37c2pbpmd0lysh1kqw7vgj"
   },
   "stable": {
    "version": [
@@ -25147,26 +25395,26 @@
   "repo": "cireu/emacsql-sqlite3",
   "unstable": {
    "version": [
-    20200718,
-    614
+    20200914,
+    508
    ],
    "deps": [
     "emacsql"
    ],
-   "commit": "e920671872cd8e0ef9c3646e6f0fae331bf8a7df",
-   "sha256": "1yy9y27rckm776jnl2rh1fz3bh09690xwzq7102vlw7xkb9s7jhj"
+   "commit": "50aa9bdd76b0d18bf80526cff13a69fe306ee29c",
+   "sha256": "1jzvvsvi8jm2ws3y49nmpmwd3zlvf8j83rl2vwizd1aplwwdnmd6"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
    "deps": [
     "emacsql"
    ],
-   "commit": "e920671872cd8e0ef9c3646e6f0fae331bf8a7df",
-   "sha256": "1yy9y27rckm776jnl2rh1fz3bh09690xwzq7102vlw7xkb9s7jhj"
+   "commit": "50aa9bdd76b0d18bf80526cff13a69fe306ee29c",
+   "sha256": "1jzvvsvi8jm2ws3y49nmpmwd3zlvf8j83rl2vwizd1aplwwdnmd6"
   }
  },
  {
@@ -25417,14 +25665,14 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20200716,
-    1815
+    20200925,
+    1453
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "36d760e2bd7e5376aff3f03456fa6445833242ad",
-   "sha256": "0xgshxdd5zmy1c7sxvrmw0wkqwhwaccqf93zwz98gb9gsfabyxd8"
+   "commit": "52dc0bd21de846db17e20a02d072603338ae33d7",
+   "sha256": "0hyirg64a8k3z7pjcrszyhq1d7scsnzl9f0kwvqdyblx5hbrx048"
   },
   "stable": {
    "version": [
@@ -25699,28 +25947,28 @@
   "repo": "jcs-elpa/emoji-github",
   "unstable": {
    "version": [
-    20200323,
-    233
+    20200825,
+    425
    ],
    "deps": [
     "emojify",
     "request"
    ],
-   "commit": "43f63c0dd64aae6c8054c2dad617bf810abdfadd",
-   "sha256": "0wcxsy3q8912kf87bn3mi2si010i5dd99yinf23nhb2nqvqgiw94"
+   "commit": "d512c2babb412820945444c6daf309b470e2eb12",
+   "sha256": "1llqn6ik0dnrpmvdxcgiyadbffjlbxqv6i7bxh2rnqiy4fhk9s1n"
   },
   "stable": {
    "version": [
     0,
     2,
-    2
+    3
    ],
    "deps": [
     "emojify",
     "request"
    ],
-   "commit": "5d1512fb30c65018a507ef549d92c668d8221da3",
-   "sha256": "00dj0kfllyhiklylj4cjcv64zjaxs6a4cc79f8pppmzvf1spivvz"
+   "commit": "d512c2babb412820945444c6daf309b470e2eb12",
+   "sha256": "1llqn6ik0dnrpmvdxcgiyadbffjlbxqv6i7bxh2rnqiy4fhk9s1n"
   }
  },
  {
@@ -26004,14 +26252,14 @@
   "repo": "purcell/envrc",
   "unstable": {
    "version": [
-    20200714,
-    201
+    20200914,
+    2203
    ],
    "deps": [
     "seq"
    ],
-   "commit": "1dc5aad14d2c27211c7c288d2d9dffeb2e27cb2d",
-   "sha256": "11ad4i1cyz6cfsckm4jf10w0570sd2fcrji87sf5052csl4ril2h"
+   "commit": "da8e306b0a562af05c5e990aced968d7fda06296",
+   "sha256": "0h6zaxwf1wx831qfp3mahw7ir7l236a6f04dz54qzvqsx9593pfb"
   },
   "stable": {
    "version": [
@@ -26260,15 +26508,14 @@
   "repo": "emacsomancer/equake",
   "unstable": {
    "version": [
-    20200805,
-    2110
+    20200824,
+    1549
    ],
    "deps": [
-    "dash",
-    "tco"
+    "dash"
    ],
-   "commit": "85fe1033e3aa64986d297bf1fde2d172827309cc",
-   "sha256": "0w3yp9ixdwcm3fl8104yb3rxp1h8z6i6msd95b48jia52dbajzcj"
+   "commit": "b0a5e334a7ccf69b837656c8a91c2e9e254e4c76",
+   "sha256": "1m6p148pcgcfywqzgc0v5wyf1k4knz7kwidf76qhvcff8z9fd5j5"
   }
  },
  {
@@ -26279,11 +26526,11 @@
   "repo": "olav35/eradio",
   "unstable": {
    "version": [
-    20200729,
-    1817
+    20200919,
+    1617
    ],
-   "commit": "5e257849113b70b2b42a999994d89ec8abadf253",
-   "sha256": "1nni4yyvhqg4dscgn1xlbgh073lwjff5mqw8zxwyiahfsdi0z9ca"
+   "commit": "e3878c5bb51ac26cc0576d2c657ad8c852ebb542",
+   "sha256": "0sf02zmjcfbgiphi96qj1kgn0gxvyi1mfamynj9c3f209hvhimns"
   }
  },
  {
@@ -26385,6 +26632,21 @@
   }
  },
  {
+  "ename": "erc-matterircd",
+  "commit": "c74850115b5b3da103407971f40a44f22791928e",
+  "sha256": "19qrh5k26gdpg1pb2fwa8abnllpmm4r95nf5ign32qyq83d0dyh4",
+  "fetcher": "github",
+  "repo": "alexmurray/erc-matterircd",
+  "unstable": {
+   "version": [
+    20200831,
+    31
+   ],
+   "commit": "1ca2ca2e513a8918793e4a9f05eedeb848bb3029",
+   "sha256": "0vv29j86cqgsgx51hvmwl0ykjj7cg28g863ssxz384dczpyv0pg8"
+  }
+ },
+ {
   "ename": "erc-scrolltoplace",
   "commit": "848cb17d871287c401496e4483e400b44696e89d",
   "sha256": "0632i1p26z3f633iinkqka0x2dd55x02xidk9qr66jh0dzfs6q3i",
@@ -26437,14 +26699,14 @@
   "repo": "drewbarbs/erc-status-sidebar",
   "unstable": {
    "version": [
-    20200811,
-    136
+    20200907,
+    1307
    ],
    "deps": [
     "seq"
    ],
-   "commit": "b589b74245591257c9e666bd5cd25812e04b7a34",
-   "sha256": "08fvr5ba6gb3y52sypbdj236nxr5rl95zgz1b120scz6xal7mysy"
+   "commit": "87210a3ccc16a86e6b5992744b68daabed3b2d11",
+   "sha256": "1gb8lzsi3clbass40sllfwf8akzlgb2k93wqlw1lf4gfb9shx08v"
   }
  },
  {
@@ -26736,6 +26998,31 @@
   }
  },
  {
+  "ename": "eri",
+  "commit": "714e0fe062981d27e3f1d48b2fd759d60bbb4d8c",
+  "sha256": "0rnrx6fc9zwh9pl2n90nzhp702ww9hlbqk16wqcbbm88awbznc6p",
+  "fetcher": "github",
+  "repo": "agda/agda",
+  "unstable": {
+   "version": [
+    20200914,
+    644
+   ],
+   "commit": "caeadacf80e0290c02d5fa35af71f319e57ae34e",
+   "sha256": "1441gk8ipz1yk2xz5z8s02cfmmldxkg5x44aa6xbj8fmq37qscgd"
+  },
+  "stable": {
+   "version": [
+    2,
+    6,
+    1,
+    1
+   ],
+   "commit": "fce01db8f9d2ceb9c3a4aa179330ea4aa7587a71",
+   "sha256": "0fzq9pfkvsdin04vzcz2vyjq3gx0lfhbpwpz0zyfa3b84dgffxq7"
+  }
+ },
+ {
   "ename": "erlang",
   "commit": "d9cd526f43981e0826af59cdc4bb702f644781d9",
   "sha256": "1cs768xxbyrr78ln50k4yknmpbcc1iplws3k07r0gx5f3ca73iaq",
@@ -26743,20 +27030,19 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20200519,
-    530
+    20200902,
+    641
    ],
-   "commit": "d9bc7858e985143a433953ba286422511b466a0c",
-   "sha256": "0ik1hhmw4xsmny9j5gbz7lr73jsvdd79xb3ygcsi8jkwz7lxi3v1"
+   "commit": "8ef1bc22b940c085be26024af090f1eeec71eaed",
+   "sha256": "0vfazad1m65n1lyirssqy067hbgvzdv6v8r66iyhqjb8dqgk2iw9"
   },
   "stable": {
    "version": [
     23,
-    0,
-    3
+    1
    ],
-   "commit": "44b6531bc575bac4eccab7eea2b27167f0d324aa",
-   "sha256": "133aw1ffkxdf38na3smmvn5qwwlalh4r4a51793h1wkhdzkyl6mv"
+   "commit": "1b5dce9313e29c320593b3bba5ca020a23019706",
+   "sha256": "1k74g6m2lidhp04vrcwrg0jszj3zwxyrm4fsma09sfn9rfsra36g"
   }
  },
  {
@@ -26977,8 +27263,8 @@
     "s",
     "spark"
    ],
-   "commit": "3aacf72daf6a2b4104914dd40e5f33e78fb084ac",
-   "sha256": "1ki839cfsn2xr2d8a2j89llbl452d45x3y5jiaiwkcmfhf7xadcb"
+   "commit": "49f22443da3ed5fa7bc684385c5549409d47f458",
+   "sha256": "1jplravq9in4yn211z6573vi3yank4wh0fxk73jngh8fi06v56di"
   },
   "stable": {
    "version": [
@@ -27271,6 +27557,30 @@
   }
  },
  {
+  "ename": "eshell-outline",
+  "commit": "94fa37bf308dd377ffab3ae56ae727bd38b5c0a6",
+  "sha256": "0k31kf76rc6mbm1ncqif3mg92avk9imjd6679szw5sn16vx959k8",
+  "fetcher": "git",
+  "url": "git://jamzattack.xyz/eshell-outline.git",
+  "unstable": {
+   "version": [
+    20200912,
+    142
+   ],
+   "commit": "d497b1b321d47ce68195dd7d04620d7d9acb41de",
+   "sha256": "0zlszgacy9pjcapd91qlxrmfrslqv7zxq4vgf8gdkknfh52a8fhn"
+  },
+  "stable": {
+   "version": [
+    2020,
+    8,
+    31
+   ],
+   "commit": "45311744f38dea4f750b382068c0b720568449b1",
+   "sha256": "1qwlrv7nkxkq9w1vxp5d2sznssbpswkj3pxrygv0bjp46vc5rf7z"
+  }
+ },
+ {
   "ename": "eshell-prompt-extras",
   "commit": "cdd1f8002636bf02c7a3d3d0a075758972eaf228",
   "sha256": "1k0cig7chdm349bp6rz9z105njs9bxicnpkcm4v0nrnk59ynj2h6",
@@ -27291,6 +27601,29 @@
    ],
    "commit": "356a540f9365b2f37f8a8cfb9c0e0e1994d12f4a",
    "sha256": "0gb07mns23dgqqr6qfy7d6ndizy15sqgbgfaig6k5xbjnwi02v9g"
+  }
+ },
+ {
+  "ename": "eshell-syntax-highlighting",
+  "commit": "0e79e165f80e1ed4c727508839f74a866ca99e61",
+  "sha256": "1cbfdwrsr6jwrlpfrvxn4gy3a3xsclp5hxgdhlycx7v17bkip3iy",
+  "fetcher": "github",
+  "repo": "akreisher/eshell-syntax-highlighting",
+  "unstable": {
+   "version": [
+    20200925,
+    823
+   ],
+   "commit": "da73a1e6d3e2dae43d2a40754f51afe849f37755",
+   "sha256": "1f2dazly90l66jgs6849glmbjyzk3l99ir01lqp043fi3i9frxic"
+  },
+  "stable": {
+   "version": [
+    0,
+    3
+   ],
+   "commit": "6dc15347a88e019e283fd98ec9e3ddd34d210b5c",
+   "sha256": "1fb9aa85a3hx1rcmv71j6sc3y278452p1y4dabpwy07avb6apd0p"
   }
  },
  {
@@ -27546,11 +27879,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20200819,
-    1030
+    20200905,
+    822
    ],
-   "commit": "1baf8bf1403fe5956a25475b03be0d8f02b3f3ca",
-   "sha256": "0asyd67krsq3xx7kk770x1f70j33bga8w0i7l4089a1jqzmpn3kx"
+   "commit": "82cd308ae54a6b918bbceb235e6bf02f53e48e19",
+   "sha256": "0zw6j8jzrdmy41g6313js7c0xlmc2wmiazx4d4wm6hdvykn8q39k"
   },
   "stable": {
    "version": [
@@ -27596,6 +27929,35 @@
    ],
    "commit": "d6e98d3ae1e2a2ea39a56eebcdb73e99d29562e9",
    "sha256": "1ya2ay52gkrd31pmw45ban8kkxgnzhhwkzkypwdhjfccq3ys835x"
+  }
+ },
+ {
+  "ename": "ess-r-insert-obj",
+  "commit": "ed21286f280f7b4021a6e789ab638bee09a046ca",
+  "sha256": "0jm074h55qsby4bvq1hqpzcbbl99a734mcgw39grnidqb2912nsk",
+  "fetcher": "github",
+  "repo": "ShuguangSun/ess-r-insert-obj",
+  "unstable": {
+   "version": [
+    20200916,
+    843
+   ],
+   "deps": [
+    "ess"
+   ],
+   "commit": "554bdc7d6c7fafc5b8a886690970b5145276a3f5",
+   "sha256": "0v4cj8d44a52h3r8k4yhr84xalfwrkwpdn3c5m44x7xp36s6zgbn"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "deps": [
+    "ess"
+   ],
+   "commit": "a3b9339a066ecf0b4e13b123c2034c2ad0235a6a",
+   "sha256": "0lrh8gcvx6jzngk0n5yh0f4nxaqipfi319i0iidjrdarnnbjvin0"
   }
  },
  {
@@ -27675,6 +28037,35 @@
    ],
    "commit": "d4e5a340b7bcc58c434867b97923094bd0680283",
    "sha256": "1yzki5f2k7gmj4m0871h4h46zalv2x71rbpa6glkfx7bm9kyc193"
+  }
+ },
+ {
+  "ename": "ess-view-data",
+  "commit": "5467365756ac525321e2f0e28d3afebd7ad9fa7d",
+  "sha256": "0pz5ypcsr6pfnxlp1vabwilsq8zyjq2fqnj8kn0989g1wr7vdf2h",
+  "fetcher": "github",
+  "repo": "ShuguangSun/ess-view-data",
+  "unstable": {
+   "version": [
+    20200902,
+    44
+   ],
+   "deps": [
+    "ess"
+   ],
+   "commit": "99ddbceaa54941a5e8438eadb0210fd16470e581",
+   "sha256": "1crbrzphs49ghkx3rv952wbdv483rwfblryv8bx8lgpxv5gkar9w"
+  },
+  "stable": {
+   "version": [
+    1,
+    2
+   ],
+   "deps": [
+    "ess"
+   ],
+   "commit": "99ddbceaa54941a5e8438eadb0210fd16470e581",
+   "sha256": "1crbrzphs49ghkx3rv952wbdv483rwfblryv8bx8lgpxv5gkar9w"
   }
  },
  {
@@ -28024,16 +28415,16 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20200816,
-    737
+    20200917,
+    2003
    ],
    "deps": [
     "cl-lib",
     "goto-chg",
     "undo-tree"
    ],
-   "commit": "1e7aa5bfbd86feff0ed5982e487070352d326b90",
-   "sha256": "1vb7np6yzv8iqblxg0yi1ac080k2bn7n8wz6wj8vkm080zmfwfb0"
+   "commit": "3277bf66fff1fac7ff58a046de3d42c31375fdb2",
+   "sha256": "06m0a9a064yk5gjl5xqmxcyibnkjmic2nz5mjnxn9grns0mi1a75"
   },
   "stable": {
    "version": [
@@ -28184,8 +28575,8 @@
     "evil",
     "evil-snipe"
    ],
-   "commit": "dcdf5c3e844f6eef2bf9d6a502cf8c81b3edaff2",
-   "sha256": "1g9li89kg3wgpm39prz9xra12vw7mhrnjl9wqqkvj98fx6dxsdr7"
+   "commit": "2354c9fa3d396fa5b1de8608e6920420b89ee323",
+   "sha256": "1cb7dv8wgixrfyx0mnc82i0ydg5bz7snn2643xi261kbrwhg51yj"
   },
   "stable": {
    "version": [
@@ -28227,15 +28618,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20200808,
-    850
+    20200922,
+    1520
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "c136589d9584e5d01a4b3f2e4cf8ac5f5a23be63",
-   "sha256": "0kbv4p4v5mgjk2hbrg0c5p29yd74s4xaa8z6c8f2h6l5p28dsk4j"
+   "commit": "bddb53cdfc55cea121727409778912753dbe0321",
+   "sha256": "1hbkjnvvk1nxacp869yqixlz4c55x5xd5kj4dmsjjl7nramdsi92"
   },
   "stable": {
    "version": [
@@ -28572,27 +28963,27 @@
   "repo": "syl20bnr/evil-iedit-state",
   "unstable": {
    "version": [
-    20180607,
-    558
+    20200830,
+    617
    ],
    "deps": [
     "evil",
     "iedit"
    ],
-   "commit": "f75cff4ecbd5beaa9ca64a6c157c4105f078daec",
-   "sha256": "0f6m5wi1q6ac9mkvalm62rlnlkjz1c315a4sa93p6iw9x12llkgw"
+   "commit": "30fcfa96ceebed0191337c493f5c2efc8ae090ad",
+   "sha256": "0aqwjd7pmzxf7l768vyqqgjzmqdwlpznh30w5bdr7yh79r6xm6n1"
   },
   "stable": {
    "version": [
     1,
-    1
+    2
    ],
    "deps": [
     "evil",
     "iedit"
    ],
-   "commit": "eab7d5e3e7d25c4a852fedb6c0c7f50dd9e9bd7c",
-   "sha256": "0r9gif2sgf84z8qniz6chr32av9g2i38rlyms81m8ssghf0j86ss"
+   "commit": "f5573ddefc03309037bd98c4c649d517f4f8d659",
+   "sha256": "1i4kq34kghabkx0mp0asw2d0ybrrlv2ps50h8mgkm20sm5ha9lbh"
   }
  },
  {
@@ -28822,26 +29213,26 @@
   "repo": "redguardtoo/evil-matchit",
   "unstable": {
    "version": [
-    20200812,
-    1050
+    20200906,
+    255
    ],
    "deps": [
     "evil"
    ],
-   "commit": "574d3c4e4517d3bb10bf652cacf459376ae401fe",
-   "sha256": "12c7y8dmkpqlak733cak6274fxzrk1hpywj7ky6nkfspqdvc2xz8"
+   "commit": "539192328ec521796c3f2bd8c1ac1a1b0e4f08f9",
+   "sha256": "1a5x2rp2lsz9svlhkvrqn4nzsz1cm3zqjdqns9bpwgbxi84mbwka"
   },
   "stable": {
    "version": [
     2,
     3,
-    8
+    9
    ],
    "deps": [
     "evil"
    ],
-   "commit": "8fba4f12e1bbfdbf25a8ed2a5308840f104bc7c0",
-   "sha256": "04s650hz6aa4ld3xqa272a2jsw9j1scnn5qkhpgis0w2d3gpwvpa"
+   "commit": "23a0576255dbf79af269847b6834ac2341e441fa",
+   "sha256": "1jk5qkqz3c4fnh6d2y889k5ycz8ipbkmzk4i8bl86xv9rhis1pv9"
   }
  },
  {
@@ -28859,8 +29250,8 @@
     "cl-lib",
     "evil"
    ],
-   "commit": "4d4c0172e4c7f80acc1d0e73d5fb3e536929b262",
-   "sha256": "1a5glj1n5dyhdaas5b8m3v2p36s1w9qcpmj7gnfxyp75iy0rqlbs"
+   "commit": "7dfb2ca5ac00c249cb2f55cd6fa91fb2bfb1117e",
+   "sha256": "18a4xcxadchyh9vrg9pqjmby40d5d0j78y1298kpflx78m5c9rgx"
   },
   "stable": {
    "version": [
@@ -28957,11 +29348,11 @@
   "repo": "redguardtoo/evil-nerd-commenter",
   "unstable": {
    "version": [
-    20200630,
-    911
+    20200904,
+    813
    ],
-   "commit": "87734b9c7fcd047f73a072b9d03ec05f786eeb03",
-   "sha256": "15dahrvary0ahyzg83jxdhf00pd2231rr628nq9fl0dl54laixsd"
+   "commit": "b670f69b646693b50645760ee3b12bd1b9eba46b",
+   "sha256": "00x4yzs2mg6k9fbnghsg03isppyd3srgb3sdmiqfn53mckn7ysdm"
   },
   "stable": {
    "version": [
@@ -29051,14 +29442,14 @@
   "repo": "Somelauw/evil-org-mode",
   "unstable": {
    "version": [
-    20200601,
-    1855
+    20200922,
+    1933
    ],
    "deps": [
     "evil"
    ],
-   "commit": "4b23116a6ecfa687819050e5a9a419cf08d5ba90",
-   "sha256": "0r3b6j0ywkz8wggzyfnvqwwrd7ir317njdwldcdncirfwy603337"
+   "commit": "35e1fe26208ae40608e4f0beb726c37cbe809167",
+   "sha256": "0ci5i9lvmirhb2vlllfvwmczysfh2d9bcjyji1n5xyq1hwnq02js"
   },
   "stable": {
    "version": [
@@ -29130,15 +29521,15 @@
   "repo": "laishulu/evil-pinyin",
   "unstable": {
    "version": [
-    20200726,
-    546
+    20200927,
+    849
    ],
    "deps": [
     "evil",
     "names"
    ],
-   "commit": "ee4ea5a297fb8a445e0c886f9d20bbd4e94c00df",
-   "sha256": "1g1v0513ypq4kax56rmq5dvf8yf9absvfls6zadhniwjzmdh68ii"
+   "commit": "3e9e501ded86f88e01a4edec5d526ab0fab879d7",
+   "sha256": "14by4ilj5bw9jx6kglbm63v2cpy1flijikpymqqvs1z4flmj7cgr"
   }
  },
  {
@@ -29579,8 +29970,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "1e7aa5bfbd86feff0ed5982e487070352d326b90",
-   "sha256": "1vb7np6yzv8iqblxg0yi1ac080k2bn7n8wz6wj8vkm080zmfwfb0"
+   "commit": "3277bf66fff1fac7ff58a046de3d42c31375fdb2",
+   "sha256": "06m0a9a064yk5gjl5xqmxcyibnkjmic2nz5mjnxn9grns0mi1a75"
   },
   "stable": {
    "version": [
@@ -29603,15 +29994,15 @@
   "repo": "iyefrat/evil-tex",
   "unstable": {
    "version": [
-    20200818,
-    1628
+    20200910,
+    1801
    ],
    "deps": [
     "auctex",
     "evil"
    ],
-   "commit": "03c014d63373c21c511506f36763a355e566eb01",
-   "sha256": "096im6yld0bqkdrb3ywxiabv55l8qdvg10887iwq86zprj89igmf"
+   "commit": "f5480696de11c8c87f282251efa53c8646623b86",
+   "sha256": "0qsx34jn76387g7imrv2jnmnwqxq98ffllfdycsmshr0nh0rcpk5"
   },
   "stable": {
    "version": [
@@ -29974,17 +30365,17 @@
  },
  {
   "ename": "ewal",
-  "commit": "33592edc97154b396b469e2352779721d5df670b",
-  "sha256": "1i6j8dgbgj64wa08wl4kzf26q2x73zy2n4zfa4dzvdspm2bn0ddr",
-  "fetcher": "gitlab",
-  "repo": "jjzmajic/ewal",
+  "commit": "b95fa8694bd49595da9fb56454e6539e76feff97",
+  "sha256": "1gwq8n64v173g2jp2i23qm9lzbhjikr6y0j6nry720sa7j0y4pm2",
+  "fetcher": "github",
+  "repo": "wurosh/ewal",
   "unstable": {
    "version": [
     20200305,
     230
    ],
-   "commit": "4ecc355dae9c7d648cd2874e01a15dfa02b9350d",
-   "sha256": "1v444nfrzz0lkybrgfics5kc8gncbvvs23qlq1pkz7ann6q84ip0"
+   "commit": "e2a04f5c97b7d5e087af26e646c0b45a24522e56",
+   "sha256": "05wrz53jxhzkncsbhgg25lyi6b1vbw2kprhq0n5n87i6g9hlvl56"
   },
   "stable": {
    "version": [
@@ -29998,21 +30389,21 @@
  },
  {
   "ename": "ewal-doom-themes",
-  "commit": "5f59228fa54a9733f549c1ba531cd90d4350fb62",
-  "sha256": "14blxk8dkr0hkhf1hd75xk0zzx6qxavynymhbwbvbf3m0mp64x6l",
-  "fetcher": "gitlab",
-  "repo": "jjzmajic/ewal",
+  "commit": "b95fa8694bd49595da9fb56454e6539e76feff97",
+  "sha256": "0fn1ds2w7zcfqrcn9p74sz4hkccwg4xf8dbcgxg9sxzl89waya4b",
+  "fetcher": "github",
+  "repo": "wurosh/ewal",
   "unstable": {
    "version": [
-    20200301,
-    839
+    20200922,
+    325
    ],
    "deps": [
     "doom-themes",
     "ewal"
    ],
-   "commit": "4ecc355dae9c7d648cd2874e01a15dfa02b9350d",
-   "sha256": "1v444nfrzz0lkybrgfics5kc8gncbvvs23qlq1pkz7ann6q84ip0"
+   "commit": "e2a04f5c97b7d5e087af26e646c0b45a24522e56",
+   "sha256": "05wrz53jxhzkncsbhgg25lyi6b1vbw2kprhq0n5n87i6g9hlvl56"
   },
   "stable": {
    "version": [
@@ -30030,10 +30421,10 @@
  },
  {
   "ename": "ewal-evil-cursors",
-  "commit": "ee7f9833a1dda00e12bcf45c7194ebc38e26168b",
-  "sha256": "177f5m1a3cvgjkgqz61w8gz3q272sk2cafq2z29rk88gcfbm2iqc",
-  "fetcher": "gitlab",
-  "repo": "jjzmajic/ewal",
+  "commit": "b95fa8694bd49595da9fb56454e6539e76feff97",
+  "sha256": "1xkjf31ba3ixv7nmxngba9pswpfr1nj4jni5y08rxfjxirwm0vbl",
+  "fetcher": "github",
+  "repo": "wurosh/ewal",
   "unstable": {
    "version": [
     20190911,
@@ -30042,8 +30433,8 @@
    "deps": [
     "ewal"
    ],
-   "commit": "4ecc355dae9c7d648cd2874e01a15dfa02b9350d",
-   "sha256": "1v444nfrzz0lkybrgfics5kc8gncbvvs23qlq1pkz7ann6q84ip0"
+   "commit": "e2a04f5c97b7d5e087af26e646c0b45a24522e56",
+   "sha256": "05wrz53jxhzkncsbhgg25lyi6b1vbw2kprhq0n5n87i6g9hlvl56"
   },
   "stable": {
    "version": [
@@ -30060,10 +30451,10 @@
  },
  {
   "ename": "ewal-spacemacs-themes",
-  "commit": "5aebe80668479c02a694fef153cea0e9f9ca7eb0",
-  "sha256": "0a0xpjlw3yfqfn2wcyqzpdisyr5pm1x35k8rpcjhwn5lhh7njlfc",
-  "fetcher": "gitlab",
-  "repo": "jjzmajic/ewal",
+  "commit": "b95fa8694bd49595da9fb56454e6539e76feff97",
+  "sha256": "1dliqwmlnl9bdw166xyadlgf3is22qn5bzrm0mv2gqi8p8ib5dl8",
+  "fetcher": "github",
+  "repo": "wurosh/ewal",
   "unstable": {
    "version": [
     20190911,
@@ -30073,8 +30464,8 @@
     "ewal",
     "spacemacs-theme"
    ],
-   "commit": "4ecc355dae9c7d648cd2874e01a15dfa02b9350d",
-   "sha256": "1v444nfrzz0lkybrgfics5kc8gncbvvs23qlq1pkz7ann6q84ip0"
+   "commit": "e2a04f5c97b7d5e087af26e646c0b45a24522e56",
+   "sha256": "05wrz53jxhzkncsbhgg25lyi6b1vbw2kprhq0n5n87i6g9hlvl56"
   },
   "stable": {
    "version": [
@@ -30178,8 +30569,8 @@
     20200526,
     324
    ],
-   "commit": "e5647b910900972bc59acea7b74e932ba0a94ce2",
-   "sha256": "18awpmyrvcw6yckms8wfgyh5kfyva1w7vpvclqa655l22brbvpph"
+   "commit": "18cad603c45c5544e8a9666be64d0c51bbc1af90",
+   "sha256": "0k4jm24b6lmmh7mgz7a24d3149lqrm62mwxh2z1q2s1d70c2zijf"
   },
   "stable": {
    "version": [
@@ -30499,14 +30890,11 @@
   "repo": "ieure/exwm-mff",
   "unstable": {
    "version": [
-    20200516,
-    2335
+    20200913,
+    2056
    ],
-   "deps": [
-    "exwm"
-   ],
-   "commit": "81fbbea495e32aef2e2d86c097cb586422d8822c",
-   "sha256": "0c3k2cs57iahm5dc1i3h05kiz4fjh7l2675im8kh91jx7lk27vb5"
+   "commit": "c3a132164ea5fdcaa9df49d8a115eab0481ee342",
+   "sha256": "0r0j3xja70i4k7rxw0fgbnl1wzy2ragq7cway57293a25534bmlm"
   },
   "stable": {
    "version": [
@@ -31014,11 +31402,11 @@
   "url": "https://framagit.org/steckerhalter/emacs-fasd.git",
   "unstable": {
    "version": [
-    20180606,
-    505
+    20200925,
+    1549
    ],
-   "commit": "020c6a4b5fd1498a84ae142d2e32c7ff678fb029",
-   "sha256": "142zq0zz38j3akgc1gipqhgs05krlkig1i97pgzmi4jcqdgm3lx9"
+   "commit": "38555b501430bb684feb58901ede5347dca287c7",
+   "sha256": "0wncbk910c7nw3wi602psx5hc6cwzigim5ahyqmkm8gry3vhwbyd"
   }
  },
  {
@@ -31603,14 +31991,14 @@
   "repo": "technomancy/find-file-in-project",
   "unstable": {
    "version": [
-    20200227,
-    1204
+    20200924,
+    305
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "506f35e91e06463cca7390da6ebffc411b8c220f",
-   "sha256": "1iwfhymbmlmakbga1jlp7w6jlnj0jbb0zs1yxxg8mmj7k9ss2xjr"
+   "commit": "c52a11e0736abcf047b1572c0f40917546c09d48",
+   "sha256": "0klwz8jk697m1684r3c7qh5xjb8bwbwqyn7b65pn2vl6dqj6vrrz"
   },
   "stable": {
    "version": [
@@ -31646,6 +32034,21 @@
    ],
    "commit": "8b888f85029a2ff9159a724b42aeacdb051c3420",
    "sha256": "0wbmmrd7brf4498pdyilz17rzv7221cj8sd4h11gac2r72f1q2md"
+  }
+ },
+ {
+  "ename": "find-file-rg",
+  "commit": "682c5a4d6c772906d88702c3c0a4f45cbcecd636",
+  "sha256": "0md2b37z6y96kid442cyiakxmbgh4rnym7lm3p1pbgzrvkx8dyll",
+  "fetcher": "github",
+  "repo": "muffinmad/emacs-find-file-rg",
+  "unstable": {
+   "version": [
+    20200827,
+    704
+   ],
+   "commit": "ed556e092a92e325f335554ab193cef2d8fec009",
+   "sha256": "1db2vv4fgxq26kr9d7n3dc302wv20wwviyaq0lg9i5swy2ng4wj6"
   }
  },
  {
@@ -32114,6 +32517,29 @@
   }
  },
  {
+  "ename": "flatbuffers-mode",
+  "commit": "abb03905163b2e277a396b0cf13886c59d3ddbd7",
+  "sha256": "1v4443p69zfsnb2a9x2g97kss21z7yzdx4c13jlyr73066gk67nc",
+  "fetcher": "github",
+  "repo": "Asalle/flatbuffers-mode",
+  "unstable": {
+   "version": [
+    20200822,
+    957
+   ],
+   "commit": "c0e9dc220db5f08410f40becf03531938484cb6c",
+   "sha256": "0dahs0q004pgalxrll1f8995q1ws358fk87a1jkm3fazl97p7gx4"
+  },
+  "stable": {
+   "version": [
+    0,
+    2
+   ],
+   "commit": "1b563b450e5353797083bcb03ab02f456e9a7361",
+   "sha256": "17g7y2nzhdwzck63miks4kn2w1nlari0qkc5v6lc4ksiaacispfb"
+  }
+ },
+ {
   "ename": "flatfluc-theme",
   "commit": "de15ce71674965c5e0a8564ae2e640bc05dbd589",
   "sha256": "0rpmiw71scdl3dgrvf2j9d909wmafyvlgraxfg5hsxngcyj5gjk0",
@@ -32220,27 +32646,27 @@
   "repo": "plandes/flex-compile",
   "unstable": {
    "version": [
-    20200506,
-    1309
+    20200813,
+    1356
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "dc6d920b477fe96a71bc37d593beef5ae8b2ae7e",
-   "sha256": "1vcpb0bnklq89vgynnpfs4dmjacaajrzkasgwzix7q4qfzcbid9n"
+   "commit": "9b09f830897e323b155ef857961ef838fdcf98b9",
+   "sha256": "17dv0zjma0h62p7nhshb63sigg8nyxhj98dknxjdrq0kgzziqfwi"
   },
   "stable": {
    "version": [
     0,
-    5
+    6
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "29caf6573eb9bb730a851dec2a234a7cfe912a13",
-   "sha256": "17s1v4xwgq98jfa3i57dbmy9ls29xsdhp5ng7bz46dhgmkrksbj5"
+   "commit": "9b09f830897e323b155ef857961ef838fdcf98b9",
+   "sha256": "17dv0zjma0h62p7nhshb63sigg8nyxhj98dknxjdrq0kgzziqfwi"
   }
  },
  {
@@ -32266,14 +32692,14 @@
   "repo": "wanderlust/flim",
   "unstable": {
    "version": [
-    20200303,
-    319
+    20200908,
+    1428
    ],
    "deps": [
     "apel"
    ],
-   "commit": "f303f2f6c124bc8635add96d3326a2209749437b",
-   "sha256": "08gxrpzxxfgbxznvpj00bjvh8l7afg2h2vaj6iasis9724f3mgl6"
+   "commit": "edb5982bdc24960798f6038db2c863d7c264cffb",
+   "sha256": "1cxnhwa6310c8gymwhgw3bbxj9116dhz515p61g401zinwyxhf4r"
   }
  },
  {
@@ -32365,11 +32791,11 @@
   "repo": "an-sh/flow-minor-mode",
   "unstable": {
    "version": [
-    20191214,
-    1309
+    20200905,
+    1730
    ],
-   "commit": "5db3936d9eba8ccb2beca476afc84675b7b161ca",
-   "sha256": "1rnihrhkr1xpwsl6c4cgg75slsqs31bckrlkgw1252ihpl9laa6p"
+   "commit": "804217a15a28f6918fba93c91d495ed7d50b0495",
+   "sha256": "0a4pbk5bx4l2hsqafpqqaz96bw1ffig2yjz16mkgd6zf41rw70la"
   },
   "stable": {
    "version": [
@@ -32566,8 +32992,8 @@
   "repo": "flycheck/flycheck",
   "unstable": {
    "version": [
-    20200610,
-    1809
+    20200926,
+    1529
    ],
    "deps": [
     "dash",
@@ -32575,8 +33001,8 @@
     "pkg-info",
     "seq"
    ],
-   "commit": "c02cd773dded0215f9417ec04dfe8dabda63ef43",
-   "sha256": "15w2b98zylppbfvy653i3a5jrxqvbrz8lqs4pzb39w2mbf8nxibx"
+   "commit": "4f5c93446b37ca4f405fad73616101dc6ae10c27",
+   "sha256": "1ad8nhj62q73s60rypvqjg5p05m1mbw3awiif22bfsvks09ph9fy"
   },
   "stable": {
    "version": [
@@ -32653,6 +33079,24 @@
   }
  },
  {
+  "ename": "flycheck-aspell",
+  "commit": "bdb8a8a66ea40c3d75ea4ab92410b742a289234a",
+  "sha256": "1wmk8an076f5cqxppsdd743p3033pvjbw7kkj5s6wq599my2a5hy",
+  "fetcher": "github",
+  "repo": "leotaku/flycheck-aspell",
+  "unstable": {
+   "version": [
+    20200830,
+    2357
+   ],
+   "deps": [
+    "flycheck"
+   ],
+   "commit": "da8c3748228b9c08b518686117163f5da5ea7eb6",
+   "sha256": "163xax4lfn8jsf4wji6k8m17wqzpp01xb81mzinrnhhgw98wwd08"
+  }
+ },
+ {
   "ename": "flycheck-ats2",
   "commit": "2d3605bdc402e6b13f53910eafb7f1428a5f749f",
   "sha256": "0xm7zzz6hs5qnqkmv7hwxpvp3jjca57agx71sj0m12v0h53gbzhr",
@@ -32696,15 +33140,15 @@
   "repo": "flycheck/flycheck-cask",
   "unstable": {
    "version": [
-    20191030,
-    2253
+    20200926,
+    1502
    ],
    "deps": [
     "dash",
     "flycheck"
    ],
-   "commit": "3457ae553c4feaf8168008f063d78fdde8fb5f94",
-   "sha256": "0fw5ikifp0n8jjkcg328hg1sklsgd7b8bsd538dvymk6qhx223zc"
+   "commit": "4b2ede6362ded4a45678dfbef1876faa42edbd58",
+   "sha256": "0fzcknz2gicpx5rqf8qdxiy1g2kppy2qzsgszxm28mbahf0913bb"
   },
   "stable": {
    "version": [
@@ -32853,14 +33297,14 @@
   "repo": "borkdude/flycheck-clj-kondo",
   "unstable": {
    "version": [
-    20200414,
-    1444
+    20200913,
+    1819
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "5472c26ffdf754a0661357564874ffd4f8598805",
-   "sha256": "0nb88mil1nlhv0nalswl3xwndzz91yah52zpri2jfbyvivshpfm4"
+   "commit": "152df7ffa1ba3ea6dfcb238fabbf50e1e1a4dc97",
+   "sha256": "0qf5rcrzwscy96ddxzih5hpw5sg8nn7rz7dm4wanrv8aygqijznk"
   },
   "stable": {
    "version": [
@@ -33161,15 +33605,15 @@
   "repo": "atilaneves/flycheck-dmd-dub",
   "unstable": {
    "version": [
-    20180625,
-    1635
+    20200824,
+    852
    ],
    "deps": [
     "f",
     "flycheck"
    ],
-   "commit": "d7df2895d7d27cc39916816e3c32a60ce0e1d2d9",
-   "sha256": "11p1r8gfii7mbh65nrm5hzrz50bmfgx5c4a0zmy6wr219syiggnl"
+   "commit": "39f7fc3f80ea7567a49012d235d22cf640fb0dfa",
+   "sha256": "12vcf4lrpj852lygpz8533m2h8zf54xs05gna2izigj7jqhmqy2y"
   },
   "stable": {
    "version": [
@@ -33485,15 +33929,15 @@
   "repo": "jcs-elpa/flycheck-grammarly",
   "unstable": {
    "version": [
-    20200720,
-    951
+    20200823,
+    926
    ],
    "deps": [
     "flycheck",
     "grammarly"
    ],
-   "commit": "698b82936f6b592591f7ed9cc3e3cdf0099e8d96",
-   "sha256": "14lp2js3vlwj2wd8l38bkg4q3dgp4n51smfi70isg3rpi8i0csxy"
+   "commit": "4ee6480871df74b05ada5f0afab5190930a70be9",
+   "sha256": "1xczp6v3463xk333bqr4w7gpicwam1s2ckpw0m3r14i22jd8qwaf"
   },
   "stable": {
    "version": [
@@ -34404,6 +34848,25 @@
   }
  },
  {
+  "ename": "flycheck-projectile",
+  "commit": "2760b15caa9b23c344ad9a6685fd6994110cba36",
+  "sha256": "1xpl0p07m95gh187jikiz850396h388d24mg97zr6sa6krq8vv55",
+  "fetcher": "github",
+  "repo": "nbfalcon/flycheck-projectile",
+  "unstable": {
+   "version": [
+    20200926,
+    1648
+   ],
+   "deps": [
+    "flycheck",
+    "projectile"
+   ],
+   "commit": "397abbecc7366cae9784702687fdd01c9c0526d1",
+   "sha256": "12rq10ln648pnk6zfm977dal73mb7b7xrj5lf27ll6zs354jy5id"
+  }
+ },
+ {
   "ename": "flycheck-prospector",
   "commit": "45475a408ff287f4f9d2a8bc729b995635579c84",
   "sha256": "1z028qi40pk7jh0m8w332kr5qi6k6sw1kbymqdxxfakh1976fww9",
@@ -34461,14 +34924,14 @@
   "repo": "msherry/flycheck-pycheckers",
   "unstable": {
    "version": [
-    20200807,
-    610
+    20200828,
+    1814
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "055830b67cd0f0d7196a5b71bd5cce3197a557a7",
-   "sha256": "1zw6993a8l7yf3j8dbagmj051m1z8cdax2pzm0l2p2dxvkm0h4s2"
+   "commit": "e8ce874eea4bba13aead8eb8e0262e94fb51f25e",
+   "sha256": "0i98viqm5plifaw3qdf2sxnk70l32qnkr82gl6j561vqhycxjq40"
   },
   "stable": {
    "version": [
@@ -34565,8 +35028,8 @@
     "flycheck",
     "rtags"
    ],
-   "commit": "b57b36039f6411f23009c4ec0315ca5a7adb6824",
-   "sha256": "1816yxyqkxd895wka9xkxpca59iwjpcv73d25sq03z2gf1ayd56b"
+   "commit": "9ad2ff1c2c09c9d2eb945bc9f174f27fa36f0ae1",
+   "sha256": "19l0iiwkz6q9gs0wmi792016d18fp1m1i9g60yfk4wg5w9rbvzk2"
   },
   "stable": {
    "version": [
@@ -34624,28 +35087,28 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20200221,
-    2025
+    20200830,
+    1032
    ],
    "deps": [
     "flycheck",
     "stan-mode"
    ],
-   "commit": "e891a0fcb3a7ab7d9cedbe3deda560134636897e",
-   "sha256": "158afanfaww2jkrz9szap6ys8xhbpz35kd5apkxr1j9j7s8h0iw0"
+   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
+   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
   },
   "stable": {
    "version": [
     10,
-    1,
+    2,
     0
    ],
    "deps": [
     "flycheck",
     "stan-mode"
    ],
-   "commit": "599a0440086c660e6823622b35058f6d2d6d9637",
-   "sha256": "0mm0kpyihpd55hx14smlm0ayz05zw750fihhqhxqc258y8y73m5y"
+   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
+   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
   }
  },
  {
@@ -35007,6 +35470,21 @@
    ],
    "commit": "d042a673b4d717c3ca9d641f120bfe16c994c740",
    "sha256": "0rxw86xi9xgr0fp6wmd6hgqgqr9flk7p4lcr0052jhlwknj1nrx0"
+  }
+ },
+ {
+  "ename": "flymake-aspell",
+  "commit": "bdb8a8a66ea40c3d75ea4ab92410b742a289234a",
+  "sha256": "1q1yhnmybh9w6amwc6gn3ipp7r7mxcxvg1k04hwj7qxryv2f9ws7",
+  "fetcher": "github",
+  "repo": "leotaku/flycheck-aspell",
+  "unstable": {
+   "version": [
+    20200902,
+    2226
+   ],
+   "commit": "da8c3748228b9c08b518686117163f5da5ea7eb6",
+   "sha256": "163xax4lfn8jsf4wji6k8m17wqzpp01xb81mzinrnhhgw98wwd08"
   }
  },
  {
@@ -35498,14 +35976,26 @@
   "repo": "turbo-cafe/flymake-kondor",
   "unstable": {
    "version": [
-    20200714,
-    646
+    20200925,
+    1539
    ],
    "deps": [
     "flymake-quickdef"
    ],
-   "commit": "530bf3e6c401d17f6b4f784a1f2524d5ba2d3414",
-   "sha256": "06adysd3q1gh92y0cdsnlmb588gdax85ad7pkmi324bixck5ggqx"
+   "commit": "72052b5ba827faf357608cf720a70221192a8282",
+   "sha256": "0h8dqk35r10pxx2w4swb3kij4y2vi17j9wfk978x8lf0wd3h3hsy"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    3
+   ],
+   "deps": [
+    "flymake-quickdef"
+   ],
+   "commit": "72052b5ba827faf357608cf720a70221192a8282",
+   "sha256": "0h8dqk35r10pxx2w4swb3kij4y2vi17j9wfk978x8lf0wd3h3hsy"
   }
  },
  {
@@ -35703,6 +36193,24 @@
    ],
    "commit": "bf9e82a63f2ccb12af02c9e79a83e7989eeb7cb1",
    "sha256": "15kv5xv6lcfgf048wr2zsnpvrplbxypy3wq56zvrzbq18hwprqg1"
+  }
+ },
+ {
+  "ename": "flymake-proselint",
+  "commit": "481c3e415dd731b06747f8b2ee86ccc2536cfca2",
+  "sha256": "115x8syar7f3crw2pfdcmv60q92i9d270dxw0m251w3906rqhdj2",
+  "fetcher": "github",
+  "repo": "manuel-uberti/flymake-proselint",
+  "unstable": {
+   "version": [
+    20200927,
+    640
+   ],
+   "deps": [
+    "flymake-quickdef"
+   ],
+   "commit": "4375cbafd369c6ad6f09dd6c9822ed6f82af9414",
+   "sha256": "05biqz0fnj7dwr91q0657w2za7kvmd8rbn2q0qbpp6a6icixjnrl"
   }
  },
  {
@@ -35904,11 +36412,11 @@
   "repo": "federicotdn/flymake-shellcheck",
   "unstable": {
    "version": [
-    20200329,
-    2005
+    20200921,
+    2341
    ],
-   "commit": "78956f0e5bb9c4d35989657a55929e8e3f5691e6",
-   "sha256": "068mx5p4drwgppy4ry1rfq6qi79w6d82b4rnpl2jm37grsg94lix"
+   "commit": "060da4097c1caadc1eb1d6feac4deaedaadb6dc0",
+   "sha256": "021qmkysx8gmwxnxcx6izs1q1h66ncvrwlvpk1wsxw9lf9symm7c"
   }
  },
  {
@@ -36021,11 +36529,11 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20200601,
-    944
+    20200904,
+    526
    ],
-   "commit": "dea1290a371c540dde7b8d0eef7a12d92f7a0b83",
-   "sha256": "0b15w96hihdblw71xvaysf8p1bmwvjp0qzrqwcij9qz72kd1w72x"
+   "commit": "6d603a1dc51918f7f8aaf99dd5443f74a0afc794",
+   "sha256": "0w23y1x5nh3rjvd35dv3ylk8iamih5qyjr2y9hqva6ydbnqrg3yx"
   },
   "stable": {
    "version": [
@@ -36052,8 +36560,8 @@
     "avy-menu",
     "flyspell-correct"
    ],
-   "commit": "dea1290a371c540dde7b8d0eef7a12d92f7a0b83",
-   "sha256": "0b15w96hihdblw71xvaysf8p1bmwvjp0qzrqwcij9qz72kd1w72x"
+   "commit": "6d603a1dc51918f7f8aaf99dd5443f74a0afc794",
+   "sha256": "0w23y1x5nh3rjvd35dv3ylk8iamih5qyjr2y9hqva6ydbnqrg3yx"
   },
   "stable": {
    "version": [
@@ -36084,8 +36592,8 @@
     "flyspell-correct",
     "helm"
    ],
-   "commit": "dea1290a371c540dde7b8d0eef7a12d92f7a0b83",
-   "sha256": "0b15w96hihdblw71xvaysf8p1bmwvjp0qzrqwcij9qz72kd1w72x"
+   "commit": "6d603a1dc51918f7f8aaf99dd5443f74a0afc794",
+   "sha256": "0w23y1x5nh3rjvd35dv3ylk8iamih5qyjr2y9hqva6ydbnqrg3yx"
   },
   "stable": {
    "version": [
@@ -36116,8 +36624,8 @@
     "flyspell-correct",
     "ivy"
    ],
-   "commit": "dea1290a371c540dde7b8d0eef7a12d92f7a0b83",
-   "sha256": "0b15w96hihdblw71xvaysf8p1bmwvjp0qzrqwcij9qz72kd1w72x"
+   "commit": "6d603a1dc51918f7f8aaf99dd5443f74a0afc794",
+   "sha256": "0w23y1x5nh3rjvd35dv3ylk8iamih5qyjr2y9hqva6ydbnqrg3yx"
   },
   "stable": {
    "version": [
@@ -36141,15 +36649,15 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20200204,
-    521
+    20200828,
+    629
    ],
    "deps": [
     "flyspell-correct",
     "popup"
    ],
-   "commit": "dea1290a371c540dde7b8d0eef7a12d92f7a0b83",
-   "sha256": "0b15w96hihdblw71xvaysf8p1bmwvjp0qzrqwcij9qz72kd1w72x"
+   "commit": "6d603a1dc51918f7f8aaf99dd5443f74a0afc794",
+   "sha256": "0w23y1x5nh3rjvd35dv3ylk8iamih5qyjr2y9hqva6ydbnqrg3yx"
   },
   "stable": {
    "version": [
@@ -36414,11 +36922,11 @@
   "repo": "jaalto/project-emacs--folding-mode",
   "unstable": {
    "version": [
-    20190524,
-    1632
+    20200901,
+    953
    ],
-   "commit": "a1361aa154b27bd4db2e1cfe6c3b81b4fc1fdc9a",
-   "sha256": "0ghj0nw2zlrppsgl6x2nda9fj4w04rz6647v9823wxhfirrgnd5z"
+   "commit": "8110b4137198aee816a6323d873b547864893da6",
+   "sha256": "00d5qyqz2hbyjbxh293g0k4k4wc5f4gzhy39j8dn7lfc98z4zajy"
   }
  },
  {
@@ -36544,8 +37052,8 @@
     20191004,
     1850
    ],
-   "commit": "61a14d1a8c17930caca5c5daf893cedc9c23c5f3",
-   "sha256": "0acq8d8vlx3hd405wmi5w36gg88bz1c1crmlxbd2whgi8kyf506z"
+   "commit": "e086c59a14701cd041641b51c952fa704ee963df",
+   "sha256": "0w1crw5lsk22jfw2w5qq6ab7zxdzp38akasvyvxakvpp1782xq9p"
   }
  },
  {
@@ -36622,8 +37130,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20200725,
-    1419
+    20200830,
+    1816
    ],
    "deps": [
     "closql",
@@ -36635,8 +37143,8 @@
     "markdown-mode",
     "transient"
    ],
-   "commit": "feee7e2fce3f87f7aa113c5edcb1896127ee9d12",
-   "sha256": "1nn73hxhp7rziwdnnvz6avn1gkax531f4l72sk0v4ywdwjhnnlgs"
+   "commit": "7a0cc3e019b8f8edc4af1ff2c40c17ee9f7b4dd4",
+   "sha256": "1lgjgzji4ac4h0iy0ndk1fza72069v68z9n181wfalb6phl5i7rq"
   },
   "stable": {
    "version": [
@@ -36836,26 +37344,26 @@
   "repo": "rnkn/fountain-mode",
   "unstable": {
    "version": [
-    20200811,
-    652
+    20200926,
+    1132
    ],
    "deps": [
     "seq"
    ],
-   "commit": "55be196ef20cdc276b3bde1a39444df1cc599f9b",
-   "sha256": "14baj9ldssdb5vrc3fl7c7nhc2iff6gxa7v2flcjjnazfg87r3b2"
+   "commit": "338ca9649489c21604b7bf707f00043825aefc09",
+   "sha256": "0zh00lnpw6np8s3p1nqrka24zl8sch9dz9wqlpxpiyzx172777fr"
   },
   "stable": {
    "version": [
     3,
-    2,
-    2
+    3,
+    1
    ],
    "deps": [
     "seq"
    ],
-   "commit": "1405217e69d055b869e804d33feca23cb602f759",
-   "sha256": "0rwdwbw9cq8ljvbmgmz9izank8dqjki79l1bw127lli69fs72gyi"
+   "commit": "d2f4d4d439605c280f0d00252e581069731bee71",
+   "sha256": "03k05vdp1z66jwcx5rhfipcvxvqaw56za112qbix3gck6xfcv578"
   }
  },
  {
@@ -37125,8 +37633,8 @@
     20200416,
     1605
    ],
-   "commit": "b93af18633bc783c2cb8443808aeeaaca33e1146",
-   "sha256": "0gljal6hmchx5zyd268kwlqn8pqq206y8a89ff7kq6qaql88mngn"
+   "commit": "968cb4580bbd7d23ee78e53152e30e0cdf0f5e41",
+   "sha256": "0v9yriw45rg12mz72gmhwi2mz19h6svh3dsw1fpbww4qcx4mnjvd"
   },
   "stable": {
    "version": [
@@ -37155,14 +37663,14 @@
     "friendly-tramp-path",
     "with-shell-interpreter"
    ],
-   "commit": "5c0eda312d8da6de0848d56abca1b0f5840e81e6",
-   "sha256": "0zmrqxbclq0630sw96shf8alql21w70879flbbk26b837j8vyw16"
+   "commit": "1b1ba2033e59e5968380640280bd853701fbbb21",
+   "sha256": "0hh6y21vcpxazqsk9qdr3d120ai9qb5rkdjdh99ck2s26zvm1hjs"
   },
   "stable": {
    "version": [
     0,
     2,
-    3
+    4
    ],
    "deps": [
     "cl-lib",
@@ -37170,8 +37678,8 @@
     "friendly-tramp-path",
     "with-shell-interpreter"
    ],
-   "commit": "5c0eda312d8da6de0848d56abca1b0f5840e81e6",
-   "sha256": "0zmrqxbclq0630sw96shf8alql21w70879flbbk26b837j8vyw16"
+   "commit": "1b1ba2033e59e5968380640280bd853701fbbb21",
+   "sha256": "0hh6y21vcpxazqsk9qdr3d120ai9qb5rkdjdh99ck2s26zvm1hjs"
   }
  },
  {
@@ -37182,28 +37690,28 @@
   "repo": "p3r7/friendly-shell",
   "unstable": {
    "version": [
-    20200527,
-    830
+    20200828,
+    1218
    ],
    "deps": [
     "cl-lib",
     "with-shell-interpreter"
    ],
-   "commit": "5c0eda312d8da6de0848d56abca1b0f5840e81e6",
-   "sha256": "0zmrqxbclq0630sw96shf8alql21w70879flbbk26b837j8vyw16"
+   "commit": "1b1ba2033e59e5968380640280bd853701fbbb21",
+   "sha256": "0hh6y21vcpxazqsk9qdr3d120ai9qb5rkdjdh99ck2s26zvm1hjs"
   },
   "stable": {
    "version": [
     0,
     2,
-    3
+    4
    ],
    "deps": [
     "cl-lib",
     "with-shell-interpreter"
    ],
-   "commit": "5c0eda312d8da6de0848d56abca1b0f5840e81e6",
-   "sha256": "0zmrqxbclq0630sw96shf8alql21w70879flbbk26b837j8vyw16"
+   "commit": "1b1ba2033e59e5968380640280bd853701fbbb21",
+   "sha256": "0hh6y21vcpxazqsk9qdr3d120ai9qb5rkdjdh99ck2s26zvm1hjs"
   }
  },
  {
@@ -37222,22 +37730,22 @@
     "dash",
     "with-shell-interpreter"
    ],
-   "commit": "5c0eda312d8da6de0848d56abca1b0f5840e81e6",
-   "sha256": "0zmrqxbclq0630sw96shf8alql21w70879flbbk26b837j8vyw16"
+   "commit": "1b1ba2033e59e5968380640280bd853701fbbb21",
+   "sha256": "0hh6y21vcpxazqsk9qdr3d120ai9qb5rkdjdh99ck2s26zvm1hjs"
   },
   "stable": {
    "version": [
     0,
     2,
-    3
+    4
    ],
    "deps": [
     "cl-lib",
     "dash",
     "with-shell-interpreter"
    ],
-   "commit": "5c0eda312d8da6de0848d56abca1b0f5840e81e6",
-   "sha256": "0zmrqxbclq0630sw96shf8alql21w70879flbbk26b837j8vyw16"
+   "commit": "1b1ba2033e59e5968380640280bd853701fbbb21",
+   "sha256": "0hh6y21vcpxazqsk9qdr3d120ai9qb5rkdjdh99ck2s26zvm1hjs"
   }
  },
  {
@@ -37317,16 +37825,16 @@
   "repo": "waymondo/frog-jump-buffer",
   "unstable": {
    "version": [
-    20200114,
-    1826
+    20200908,
+    225
    ],
    "deps": [
     "avy",
     "dash",
     "frog-menu"
    ],
-   "commit": "1eb289c9b2a4bbebb3065076750f54216ac9c718",
-   "sha256": "0qlwjk3a13gb3glib9irgpyx94j933kflky7pbnrl17a53pnryrw"
+   "commit": "7f97ccb543d6ef272a927bf19af228ee3ae39aca",
+   "sha256": "0i7vh8fjl9vwrfkrj67jywv8vl70sarg20ankmzr2pyl6qkfjdxh"
   }
  },
  {
@@ -37360,16 +37868,16 @@
   "repo": "fsharp/emacs-fsharp-mode",
   "unstable": {
    "version": [
-    20200520,
-    1842
+    20200830,
+    1605
    ],
    "deps": [
     "dash",
     "eglot",
     "s"
    ],
-   "commit": "3e41fe1391b64eefa66a8a02fce27a12a04e1e01",
-   "sha256": "03ln0dmjkg4bnpabnw27vby3jqf40wzvs3znynqqqx7cn53vy5fp"
+   "commit": "a3a239d8b50f507fb398985559c35831d02cdc56",
+   "sha256": "0mabvfgd1k4zn0wqc8nzfn6zwbaldrw1lrv01mfhsaxxilndplf3"
   },
   "stable": {
    "version": [
@@ -37404,8 +37912,8 @@
     "quick-peek",
     "yasnippet"
    ],
-   "commit": "bd28cb8f25538e26287c76efbbc5ef7378d1fbc6",
-   "sha256": "1jvvasin29bwxq7cmviv0431jb7p2gq3yh12pyf6f5zinsax97cp"
+   "commit": "3d79115e41befefda2090e9d3b3079cced4818f3",
+   "sha256": "09y6xbxsar5cg9crv51cl6gzf8akqagch1bsa178k8dii36lx9kr"
   },
   "stable": {
    "version": [
@@ -37435,8 +37943,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "3fdb0325ca2a6d80e4111af43b1b166808022020",
-   "sha256": "0kid3a0qq2qvzndbs1c69z30f2in7q7fzpv6yas84f8y5kkmk220"
+   "commit": "fed5fd7c507d45c5ce3ad8192e848c5e29f8ec66",
+   "sha256": "08gn0ynxl3lm7zdmxssby6f18wawf9g6aac6dr872x9cl9yvr1pk"
   },
   "stable": {
    "version": [
@@ -37589,14 +38097,14 @@
   "repo": "diku-dk/futhark-mode",
   "unstable": {
    "version": [
-    20200627,
-    732
+    20200823,
+    1521
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "9db9fb81e08b6ded43a4eede5220644ce354060d",
-   "sha256": "0hcwqsq65hlznsq2k5bviwzyh82sddfb28v5xna0016yphbdng2h"
+   "commit": "88e7bb1eefbe01f781cc4958bc0431fea90b7d93",
+   "sha256": "1srb3a7p0zgsjgbrdsyx7ql68ygg9h8y93781v4zjmzq4z9qfl8x"
   }
  },
  {
@@ -37644,6 +38152,30 @@
    ],
    "commit": "939f4e9a3f08d83925b41dd3d23b2321f3f6b09c",
    "sha256": "1g7my9ha5cnwg3pjwa86wncg5gphv18xpnpmj3xc3vg7z5m45rss"
+  }
+ },
+ {
+  "ename": "fuzzy-finder",
+  "commit": "e217226f37d9184b175d7e36902b4977fce8a5bf",
+  "sha256": "0irwkc59c66wqhr6vmmdczj678224lng4qjhw9yv4lz3dn06n5i3",
+  "fetcher": "github",
+  "repo": "10sr/fuzzy-finder-el",
+  "unstable": {
+   "version": [
+    20200909,
+    907
+   ],
+   "commit": "c19235a35db076eebb5ad31fb42daf6520620f6d",
+   "sha256": "0nwbvgj2z15g88d9mgbc408xhsf3wx8r1ky70cgn7kqfv4wvd25n"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    1
+   ],
+   "commit": "f459ee206cbb324c13fe939656b0b9d3a4c3c0b7",
+   "sha256": "0ziziylcaahq491v5m1a8pbrwrifksaj1374rnfvp9d5d9w02lf7"
   }
  },
  {
@@ -37883,8 +38415,26 @@
     20200409,
     1456
    ],
-   "commit": "b1bde5089169a74f62033d027e06e98cbeedd43f",
-   "sha256": "0k0gh1dr3hipg73mpgkw6hlg27c7c5r8aa61p4vj2rpmf6k90pc5"
+   "commit": "84c43a4c0b41a595ac6e299fa317d2831813e580",
+   "sha256": "1r3wiqhrzh7wvqy484nl031fd4bn4cpvkv9646s4cjgvnnnv7jz3"
+  }
+ },
+ {
+  "ename": "gcode-mode",
+  "commit": "b7e68005a164c01004ba19c3a8c2aafe81d5f6f4",
+  "sha256": "0r4say2vj2m1dwal00qjha5d0lyshv69cy05frzv6n37wva45k38",
+  "fetcher": "gitlab",
+  "repo": "wavexx/gcode-mode.el",
+  "unstable": {
+   "version": [
+    20200916,
+    1741
+   ],
+   "deps": [
+    "cl-lib"
+   ],
+   "commit": "7a18195eedc13856b9645a5c9f20af64d684cf41",
+   "sha256": "02ax5fyh418z2dkh9472264gs8vkbp6gj87wxbrsasfjkz6j2ig4"
   }
  },
  {
@@ -37895,20 +38445,20 @@
   "repo": "GDQuest/emacs-gdscript-mode",
   "unstable": {
    "version": [
-    20200726,
-    1721
+    20200909,
+    1514
    ],
-   "commit": "7aea87bd7b3cd14b1a767e7d835cee896722cd29",
-   "sha256": "1cq2k054ngqwanayy7fgkqdb5fq6xcqdglpyxngqmh765lyb7nrb"
+   "commit": "dde7ffa7353c2605087a2b8df705c46d81fe0079",
+   "sha256": "1zywvj7k9pvjnx67xrpfsl87ndfh4vkjsbxh5xbiag4x1ijaa5nr"
   },
   "stable": {
    "version": [
     1,
-    2,
+    3,
     0
    ],
-   "commit": "36c92dff1587d7c3c7ff2cd02d8e158cbed55215",
-   "sha256": "02by4bvdayldbjlz6jkp36m5rgcy2h5bwhqx2cj7wma6xf6cw3lf"
+   "commit": "099ca4471fe5e44da57f1d34e3d3b5604e619977",
+   "sha256": "0p0271lfq602hwb07l9n7lsdm7b8wkl3wpbbilgksac7n16q12cn"
   }
  },
  {
@@ -37996,11 +38546,11 @@
   "repo": "jaor/geiser",
   "unstable": {
    "version": [
-    20200714,
-    1210
+    20200826,
+    2018
    ],
-   "commit": "adc5c4ab5ff33cf94cb3fcd892bb9503b5fa2aa2",
-   "sha256": "0n718xpys7v94zaf9lpmsx97qgn6qxif1acr718wyvpmfr4hiv08"
+   "commit": "2accab72e289ed82707237d2013ba034c88ff6c2",
+   "sha256": "1hkfml2m85lfskv62aviih8ga0d9bl1214flf667m45g7s466skr"
   },
   "stable": {
    "version": [
@@ -38505,15 +39055,15 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20200801,
-    815
+    20200829,
+    916
    ],
    "deps": [
     "let-alist",
     "treepy"
    ],
-   "commit": "942e7bdabc4b938a0535530c26eb6548504fca24",
-   "sha256": "07iy4203ppvzkh67sb0v968hnypnvy4dpfy0qpqrp8zmc455dxq5"
+   "commit": "6cc1b76d9df05ceb2904fb61f5463ed3ac57420e",
+   "sha256": "13d6djsfi7g2kxvw4rfknsxsqxps8iyal149n5frbz9k3hxia64p"
   },
   "stable": {
    "version": [
@@ -38735,20 +39285,20 @@
   "repo": "ryuslash/git-auto-commit-mode",
   "unstable": {
    "version": [
-    20200801,
-    748
+    20200828,
+    653
    ],
-   "commit": "d4fd94320610100f23de083493d12de3324304b5",
-   "sha256": "180rzh53hrd374nf96cz8n6brxvi68fgss21ic5r623hkczhi73b"
+   "commit": "df07899acdb3f9c114b72fdab77107c924b3172c",
+   "sha256": "0gpib57f7xza04g3iyihw5v15hb7pncqsmvyggib902yvcxlkvqf"
   },
   "stable": {
    "version": [
     4,
-    6,
+    7,
     0
    ],
-   "commit": "ae69e61233417a7f14efba35e42bd842b707aeb0",
-   "sha256": "0nrx3wnn2jii4yiv9c1cbbll4bgll5j73ypp1fi82kk99n0d8372"
+   "commit": "df07899acdb3f9c114b72fdab77107c924b3172c",
+   "sha256": "0gpib57f7xza04g3iyihw5v15hb7pncqsmvyggib902yvcxlkvqf"
   }
  },
  {
@@ -38856,16 +39406,16 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20200701,
-    2112
+    20200828,
+    1753
    ],
    "deps": [
     "dash",
     "transient",
     "with-editor"
    ],
-   "commit": "321214c3a2dd10fdf672ba96bd00703a51094bbe",
-   "sha256": "152i5kvkx8hsy9qlhalhjc4sf6ly3rlfymb8daygj428363xx25n"
+   "commit": "cd9ab2c63c71cee01a7fef35f11a84f3ef5cdec2",
+   "sha256": "0gw6bx5vk07lh5jdwxxccchw6w3wj7r33i323sykqgn66hgqnx5m"
   },
   "stable": {
    "version": [
@@ -38933,6 +39483,24 @@
    ],
    "commit": "485c732130686c2f28a026e385366006435394b9",
    "sha256": "0rcrsjx4ifa9y3rd5l4498kvqkh58zx21gl7mqp053jdsqqq1yrx"
+  }
+ },
+ {
+  "ename": "git-grep",
+  "commit": "0878cf8cccf1a8808be3b99cda443972d9f57c60",
+  "sha256": "0jfvs2bmsmjy19vg2ilillj1wkng6psaxr1dvy7nxy929gzp4vcl",
+  "fetcher": "github",
+  "repo": "tychoish/git-grep.el",
+  "unstable": {
+   "version": [
+    20200920,
+    1751
+   ],
+   "deps": [
+    "projectile"
+   ],
+   "commit": "12ff6045e9b6aa42f98abd4ddc44d670268a0849",
+   "sha256": "0c1hfh62vdi9ly530crsz2aghapf0s2z9i3xdvfyyynr1gqs3mis"
   }
  },
  {
@@ -39136,11 +39704,11 @@
   "repo": "sshaw/git-link",
   "unstable": {
    "version": [
-    20200721,
-    2250
+    20200827,
+    2326
    ],
-   "commit": "cbaf7033edad8d4712b6e7dc11cad979c6a002de",
-   "sha256": "074xqp1apcrmnh2cb9m60gaq78hzybyg5sr09n37ka0sw447rp15"
+   "commit": "7109c36c82496d6954dcf2b0b9c622b26e6ac75d",
+   "sha256": "1prcsyakslpmsr19hjgn2lvf0r6k8h5frijlkfzsm4pxslzp9z9w"
   },
   "stable": {
    "version": [
@@ -39601,8 +40169,8 @@
   "repo": "charignon/github-review",
   "unstable": {
    "version": [
-    20200314,
-    438
+    20200904,
+    2303
    ],
    "deps": [
     "dash",
@@ -39610,8 +40178,8 @@
     "ghub",
     "s"
    ],
-   "commit": "fab440aeae4fbf6a8192fd11795052e9eb5d27d1",
-   "sha256": "19kk55r0qixmvw1q80x3rnvcssrq64k5b5ixp8wjzpg6h65s9vk9"
+   "commit": "24cf8b32d9bddbd98ed2dbfdcbbbb7926410e651",
+   "sha256": "1bravpkp4hfzarnpfin9rxfjwiacvy7ma8z8j9rr8v4gw017825r"
   }
  },
  {
@@ -39824,6 +40392,36 @@
   }
  },
  {
+  "ename": "gitlab-pipeline",
+  "commit": "9cc5450e4dd1ea31f719ba6b48d68130cc7ea0ef",
+  "sha256": "1i1dp3qn6yasqs4ay7h3f43spwk9rrqjr411zdvpn6c0hmcs5vfs",
+  "fetcher": "github",
+  "repo": "TxGVNN/gitlab-pipeline",
+  "unstable": {
+   "version": [
+    20200903,
+    201
+   ],
+   "deps": [
+    "ghub"
+   ],
+   "commit": "ecb3a2277f6a1c7fed73f9381834724c143c85da",
+   "sha256": "1nqrim3fpgf5npzl14sd0h6dlhi925hns2f75l4arrhbcjgcn984"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "ghub"
+   ],
+   "commit": "ecb3a2277f6a1c7fed73f9381834724c143c85da",
+   "sha256": "1nqrim3fpgf5npzl14sd0h6dlhi925hns2f75l4arrhbcjgcn984"
+  }
+ },
+ {
   "ename": "gitlab-snip-helm",
   "commit": "d73cc8f3490f5e56bc0fda1b7e680d21839f4c98",
   "sha256": "0hv0m9lh105f18d4jhc5i68nhv5hxlv4264mkza4cwq07amxlhw2",
@@ -39925,6 +40523,40 @@
    ],
    "commit": "bd2ba457109dd5d3e4b419e3ef5cbd3b5c9498d6",
    "sha256": "1fzl40bwdfbcq55p3kvbzjqr5w0703imzgrmqcf4f6jhav127zk6"
+  }
+ },
+ {
+  "ename": "gkroam",
+  "commit": "3ac02c053619ab01b13e1c48ab64c7a963df97a1",
+  "sha256": "1bxsdj2xx1x7i1gr81yvs20qrv8czqhwk70y4vxp5vhcym8480hv",
+  "fetcher": "github",
+  "repo": "Kinneyzhang/gkroam.el",
+  "unstable": {
+   "version": [
+    20200926,
+    552
+   ],
+   "deps": [
+    "company",
+    "simple-httpd",
+    "undo-tree"
+   ],
+   "commit": "1d446f757848120cc6b443441b1de1c272ba9162",
+   "sha256": "1wg87xaka8hvzwmgafy915x88g24kldzi2903cllvy9gb4nx0pdw"
+  },
+  "stable": {
+   "version": [
+    2,
+    2,
+    2
+   ],
+   "deps": [
+    "company",
+    "simple-httpd",
+    "undo-tree"
+   ],
+   "commit": "383c47dbb44532f8dd0c7f78008b7fac6f2e40f3",
+   "sha256": "1wy2pm84xhwhb1f68lxb2ld2dka2axx1ybd1fpgdpw2sxnzhbzhk"
   }
  },
  {
@@ -40373,8 +41005,8 @@
     20190617,
     1419
    ],
-   "commit": "3968667bfded60fbbf33f2fba3170e2b6501ec43",
-   "sha256": "0rxaxc7b0dkhsd5547hngq24bdvnxig5a7xp9jir59fp2k8xd4aw"
+   "commit": "d0cb218fea13563c1b2bfba3e72716fb860f767c",
+   "sha256": "1ljbgksdnqkgh5m41l95lir5l53r1q1j1rz5nlvhhdv1jlxp19q7"
   },
   "stable": {
    "version": [
@@ -40736,8 +41368,8 @@
     "cl-lib",
     "go-mode"
    ],
-   "commit": "734d5232455ffde088021ea5908849ac570e890f",
-   "sha256": "0228l3s3afmvm4cy3vwcpz3g2gkmyhqdq2kwwn1n5dsha8fzbdps"
+   "commit": "d17d21060b16a77f9ee28ff453e674225acbf1b1",
+   "sha256": "12za0s3mx4da2wdxiv032ifbx8vbx4as923rkbm90gdxrxlifvj5"
   },
   "stable": {
    "version": [
@@ -40829,11 +41461,11 @@
   "repo": "dominikh/go-mode.el",
   "unstable": {
    "version": [
-    20200425,
-    1740
+    20200822,
+    1936
    ],
-   "commit": "734d5232455ffde088021ea5908849ac570e890f",
-   "sha256": "0228l3s3afmvm4cy3vwcpz3g2gkmyhqdq2kwwn1n5dsha8fzbdps"
+   "commit": "d17d21060b16a77f9ee28ff453e674225acbf1b1",
+   "sha256": "12za0s3mx4da2wdxiv032ifbx8vbx4as923rkbm90gdxrxlifvj5"
   },
   "stable": {
    "version": [
@@ -40952,8 +41584,8 @@
    "deps": [
     "go-mode"
    ],
-   "commit": "734d5232455ffde088021ea5908849ac570e890f",
-   "sha256": "0228l3s3afmvm4cy3vwcpz3g2gkmyhqdq2kwwn1n5dsha8fzbdps"
+   "commit": "d17d21060b16a77f9ee28ff453e674225acbf1b1",
+   "sha256": "12za0s3mx4da2wdxiv032ifbx8vbx4as923rkbm90gdxrxlifvj5"
   },
   "stable": {
    "version": [
@@ -41062,6 +41694,29 @@
   }
  },
  {
+  "ename": "go-translate",
+  "commit": "26092d1830f6a0f46916b0d07afe467ce76e257c",
+  "sha256": "0ls7fy89936jn8kqwyii9214h258ds64fjmfc61mdcqsbg9r07s4",
+  "fetcher": "github",
+  "repo": "lorniu/go-translate",
+  "unstable": {
+   "version": [
+    20200912,
+    212
+   ],
+   "commit": "27d9218aa10dc361aa89f666f91aea7fdfb43d1f",
+   "sha256": "0jgicsv8102pk340fn122w0hbhvac2nqcpr16lj7ccjg44qmnrdw"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "commit": "9fce7399ada7fec29e5bcd0948c9a6efd96238b1",
+   "sha256": "0hwm9gpk4pidabifl0i1i7ivjdy0r22jf5y5vnb7xpilzwv05wmk"
+  }
+ },
+ {
   "ename": "gobgen",
   "commit": "8c9fed22bb8dbfb359e4fdb0d802ed4b5781f50d",
   "sha256": "0fb0q9x7wj8gs1iyr87q1vpxmfa2d43zy6cgxpzmv2wc26x96vi7",
@@ -41087,8 +41742,8 @@
     20200708,
     2200
    ],
-   "commit": "ad2e6745294843462f78768b5a1cd3b0d3563951",
-   "sha256": "00v69c76737yfmy3injhf6l1khj67rr0xvpq0yyjxg4hh9dv4j90"
+   "commit": "f51c8f60e55393cced8cb0bd4a5bf0ab1612caa4",
+   "sha256": "03n6zhxbgqzlrwl7jkmw3d5b78z2yw3qk8xk20x3wk3j58g9kk0j"
   },
   "stable": {
    "version": [
@@ -41272,8 +41927,8 @@
     20180130,
     1736
    ],
-   "commit": "25e977d641fc204a38263a2272f92307c545121b",
-   "sha256": "1dgna85s3gwb0a2504min4ch0xih4ygnv8ia2jvx3wyxgn436z1x"
+   "commit": "96f6a64d30a47b09f4be98d83a3e30d624febf86",
+   "sha256": "0af4z73fmgbgnlb7l470g8wbvbf9l9chb3ycp68n4bnx9grf3ppn"
   }
  },
  {
@@ -41353,8 +42008,8 @@
     20200809,
     1430
    ],
-   "commit": "0ab218f9e1a620af7b4b22d9c82b8d83ff5f4606",
-   "sha256": "1z0jbjgjnb36cj14l6khnxmrcfvbmlw89sc9dbkw6j7a3k51nlc0"
+   "commit": "0270073331de9358f29d049a27aa9145697d6dc7",
+   "sha256": "12nhl3h0f1kmv7ak9lh0p96k0f2284k20ilwn3ail7p2kpp8affk"
   },
   "stable": {
    "version": [
@@ -41512,20 +42167,20 @@
   "repo": "jcs-elpa/goto-char-preview",
   "unstable": {
    "version": [
-    20200717,
-    730
+    20200927,
+    509
    ],
-   "commit": "11fb6b8c77c6191f839f86afc8c8ca3341919058",
-   "sha256": "14wcz9azp1c66jz1wz75v0ijbsk5hjmchcm36k7phbn3hjag99ji"
+   "commit": "6209973933bec4081145dbcb8e3e442cb29a8c52",
+   "sha256": "1ckpdgfr7da37fwx9pw0vc8bdcmbpdpygfn8gkwwmz3yjk3021h7"
   },
   "stable": {
    "version": [
     0,
-    0,
-    2
+    1,
+    0
    ],
-   "commit": "446e5236227d6b3f180be2eb5ef2209aef947553",
-   "sha256": "0dd5iq9xkvqavabipg1iz9zk1rnz830grhzw0z1l89b1vvgzpd62"
+   "commit": "6209973933bec4081145dbcb8e3e442cb29a8c52",
+   "sha256": "1ckpdgfr7da37fwx9pw0vc8bdcmbpdpygfn8gkwwmz3yjk3021h7"
   }
  },
  {
@@ -41602,20 +42257,20 @@
   "repo": "jcs-elpa/goto-line-preview",
   "unstable": {
    "version": [
-    20200717,
-    733
+    20200927,
+    252
    ],
-   "commit": "b1df7fe72b0281704d277a69dfd9e2b8214a328b",
-   "sha256": "00862y6r5xbq5crb581xh1b18dqigc8k42di9mjc6zvslxq8n6qd"
+   "commit": "66817b66ce124b2961df3521faa3adc87943d0d9",
+   "sha256": "0w9cqp5xcqnncwpb90xvirvm05bknsaxhd51y2wkhqr7j5xi489i"
   },
   "stable": {
    "version": [
     0,
-    0,
-    6
+    1,
+    1
    ],
-   "commit": "a4173abfffda03ad27e695a316adfe560a97f00e",
-   "sha256": "0bh70d2isl3kdzxyidjrxhs7sh8rqr8cmdwil7ksp9a28mz3l55p"
+   "commit": "66817b66ce124b2961df3521faa3adc87943d0d9",
+   "sha256": "0w9cqp5xcqnncwpb90xvirvm05bknsaxhd51y2wkhqr7j5xi489i"
   }
  },
  {
@@ -41635,8 +42290,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "609218c5232673cec215d088eb01d043120de385",
-   "sha256": "0wg2sn5zfcsdnv6ymy0a13px7j6pkgmdd9dpss98l70xf3b6g590"
+   "commit": "62b3008059127c8e634a5511a81c7ac078960b6d",
+   "sha256": "0is4ky3ks5wm2yca28ddraw2awrsxkpw85r02hwfjqnyf1pnm90r"
   },
   "stable": {
    "version": [
@@ -42017,11 +42672,11 @@
   "repo": "davazp/graphql-mode",
   "unstable": {
    "version": [
-    20191024,
-    1221
+    20200825,
+    918
    ],
-   "commit": "7c37aee28bf8c8ffb3da73df5571c4e1e352562b",
-   "sha256": "0hjzqmrc024b98nisvn2ld8gn3bslg8ip19d1fnid3m8q9zk8w8b"
+   "commit": "9bed568ec86242dbe30bdbab324aa0eb2cd9bf08",
+   "sha256": "0x9y7qq6y0zg8ncamzvk68ccmdyzh7xsj0xs0ykyl20d5wdpplj4"
   }
  },
  {
@@ -42251,8 +42906,8 @@
     20200725,
     725
    ],
-   "commit": "281ada2c93bac7043c6f665fac065a17d4247bdc",
-   "sha256": "14gsmxpp8znk2w2yszdpwb8dx0hxbpy2rjr7rshs3bvqjib8rzyp"
+   "commit": "91da46f29c455c3cd24b2a6b20ff2db2c4ce8cd6",
+   "sha256": "08bw5mllx3hsgz8b43dlqdqh2y8asw735623r174prhv84rnq1cq"
   },
   "stable": {
    "version": [
@@ -42383,20 +43038,20 @@
   "repo": "ROCKTAKEY/grugru",
   "unstable": {
    "version": [
-    20200810,
-    1411
+    20200905,
+    938
    ],
-   "commit": "2f304daa39df10ebe9e4cb982af5343bca252c6d",
-   "sha256": "1bry2iqab6shyhlmka7334yqc5k4c9hl1qrigz2p9km9hv45r7hw"
+   "commit": "f07ca219f4328d2e61b02acf994aa16e53928fff",
+   "sha256": "0a172hkmm154asf19pcpl1437lzqqs24gb0xpd83mjsdafrcbcpf"
   },
   "stable": {
    "version": [
     1,
-    10,
+    12,
     0
    ],
-   "commit": "d71007802389028a70d0ccbf5c57330241add7cc",
-   "sha256": "1gr8jdm8g7cxysf1f83mkfwp3la6bcd08r8gw5v9ms4k217nx2is"
+   "commit": "6d2276c5daa353947b402096d51808bb1a1c4ebc",
+   "sha256": "0imjryq6g5brr773xi6c8673jappah030n85s1b2vgqlp1zjy17j"
   }
  },
  {
@@ -42663,8 +43318,8 @@
   "repo": "alezost/guix.el",
   "unstable": {
    "version": [
-    20200730,
-    930
+    20200918,
+    1116
    ],
    "deps": [
     "bui",
@@ -42673,8 +43328,8 @@
     "geiser",
     "magit-popup"
    ],
-   "commit": "58a840d0671091e3064e36244790ef8839da87d6",
-   "sha256": "1qnr5sixmvrhr9rinrhfy7sy20mikjvvwbdixwkbx30qpcdwgwj1"
+   "commit": "d246b2c443bbb9d49575b63bb78c14699c4448cf",
+   "sha256": "1j6bjdg8f0fgb6dqcl1634al7lxbna4i8bkikqqy8nipxk22h5w3"
   },
   "stable": {
    "version": [
@@ -42719,8 +43374,8 @@
     20200708,
     728
    ],
-   "commit": "9d0aff6cda6d3d78d5102f07f813b9fca6f0ab7b",
-   "sha256": "1ja98di2iwjp0l4ndh22pwm7s56753kmz255xlv6vni2ai4rf8sm"
+   "commit": "0aadb72b4a3ec503d48de59d071e8dbafa1ad2ac",
+   "sha256": "1w5xf3fjyi1ljjfv0h3snxvvn7is6smq6dhq5g6h06y1m4rc4kki"
   },
   "stable": {
    "version": [
@@ -43047,10 +43702,10 @@
  },
  {
   "ename": "handle",
-  "commit": "da5debb55f7b34dcbcea81675bddd872bdb7fd69",
-  "sha256": "032rfk3hiv0ps0p332gkf67vqs5nif8hhraiv3zlybxblzhcxaw1",
-  "fetcher": "gitlab",
-  "repo": "jjzmajic/handle",
+  "commit": "b95fa8694bd49595da9fb56454e6539e76feff97",
+  "sha256": "0r0675hhficyhpz41sxpi2ah06918aa3df1sxsx7vqh4pbv2ixl8",
+  "fetcher": "github",
+  "repo": "wurosh/handle",
   "unstable": {
    "version": [
     20191029,
@@ -43288,11 +43943,11 @@
   "repo": "haskell/haskell-mode",
   "unstable": {
    "version": [
-    20200531,
-    2255
+    20200925,
+    2324
    ],
-   "commit": "41683c0e634bb3f54eac8747919a82132e1714fe",
-   "sha256": "1fxj11in90xvpbqhxx5c3qynkd8yfainpbf8cvdh3gdgpifrc0gg"
+   "commit": "bf29f209e42cf8157bc3ca2127d8e9b576f39704",
+   "sha256": "0zi0q50rpc3sn950j7ar8qazhcmasfhxifr3n387y4n6j4shy277"
   },
   "stable": {
    "version": [
@@ -43622,30 +44277,30 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20200818,
-    742
+    20200910,
+    1036
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "e9a1e53c57478389343ee23ebb962c8b9b4b4bba",
-   "sha256": "1vw6qcpz71sb6xhjzlikr4l1q23sfbphlza4x4ma0gc7mfzyqfh0"
+   "commit": "19d2ba9d36615f1dea6be6cd6dcf5792dfefc45b",
+   "sha256": "07cl4cndz8mylylpj83ismir47q8vph5vfi9a7n0ll1i3ffpc0b5"
   },
   "stable": {
    "version": [
     3,
     6,
-    4
+    5
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "a3343a370975d9c01df4f1ff42875cc32ae89592",
-   "sha256": "0cl5awhq5py872qx9s30sfgfpfwjivwbsi18mgar8lj6lvs4s8zz"
+   "commit": "1f32ad2793222985cb8a3bf9a346f4448618224d",
+   "sha256": "0yzpb84346v42ig4h0rsnvzmln58ilhc0gsq0ggc7038ypqkdw4d"
   }
  },
  {
@@ -43745,25 +44400,25 @@
   "repo": "emacsorphanage/helm-ag",
   "unstable": {
    "version": [
-    20200811,
-    1304
+    20200915,
+    1650
    ],
    "deps": [
     "helm"
    ],
-   "commit": "4ee2174c4e27e02c75a487a235de4d80c663aa08",
-   "sha256": "1sc9ksfb3s5p5kqriz5402r785fklw3ykz8fb107xykl9kdjnzy3"
+   "commit": "db52f860b50aa4d5edfa1c6c97802d36aef7f78b",
+   "sha256": "1l95vskrvk88a2glpn2pdylcpy7qxqg5qgmjnh9w24xfyc77g513"
   },
   "stable": {
    "version": [
     0,
-    62
+    64
    ],
    "deps": [
     "helm"
    ],
-   "commit": "08aaab53b8876caba619f956945a8152ece47182",
-   "sha256": "0xgbpp8xqdiyvfs64x0q909g77ml28z3irw2lnasvpsg0dfdm2zy"
+   "commit": "6a3e738c1bb5e80c7ea80f7166fda34a714284d8",
+   "sha256": "0ml9yp3qaiwn7iixyxvsj3fxn7gw913qxisr47df57q4ka912law"
   }
  },
  {
@@ -43792,14 +44447,43 @@
   "repo": "emacs-helm/helm-apt",
   "unstable": {
    "version": [
-    20200719,
-    1131
+    20200823,
+    1546
    ],
    "deps": [
     "helm"
    ],
-   "commit": "f6204e2333881291b007e4859d9446994e988653",
-   "sha256": "08gxfby2i80nmzlbj39p0nnicg95swzjxc222wksvggfxvvln5f7"
+   "commit": "42923e367f6ccc1c94b1a5c070993e0ad96c9ea3",
+   "sha256": "1q5pxd0vjxqrvk0gf0nxbc9b77xidaijkddh6zz3j7fbjmzyrp4x"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "deps": [
+    "helm"
+   ],
+   "commit": "42923e367f6ccc1c94b1a5c070993e0ad96c9ea3",
+   "sha256": "1q5pxd0vjxqrvk0gf0nxbc9b77xidaijkddh6zz3j7fbjmzyrp4x"
+  }
+ },
+ {
+  "ename": "helm-atoms",
+  "commit": "6463d30672315419f3092864f321670c7b663507",
+  "sha256": "0bjinkajlzl8xqb0pia8bmb0d24a1xxvikamqy92x1f2p4brwr7s",
+  "fetcher": "github",
+  "repo": "dantecatalfamo/helm-atoms",
+  "unstable": {
+   "version": [
+    20200925,
+    1641
+   ],
+   "deps": [
+    "helm"
+   ],
+   "commit": "ef786afcd8030498bc0316053c95a0abc1421a99",
+   "sha256": "1msahcb32f8278kj76q5nygdi5ws7pgzp85ccwdzvd2id67g6dqk"
   }
  },
  {
@@ -43915,8 +44599,8 @@
     "cl-lib",
     "helm"
    ],
-   "commit": "8a0dd9841316793aacddea744d6b8ca4a7857a35",
-   "sha256": "1av058d7888kr3q15y1122r8jkarfw1s83gvkillj7kyzj3i53m5"
+   "commit": "12f8809aac3a13dd11a1c664a13f789005f7a199",
+   "sha256": "1h5sm479i9rs09h2xxj8qc4jjdqy7fbx7c5df143lrf69mq0sxgf"
   },
   "stable": {
    "version": [
@@ -44084,8 +44768,8 @@
     "bufler",
     "helm"
    ],
-   "commit": "b2b260e4f9e8ba76bb8b4d71344c7b75e05ac44f",
-   "sha256": "0ww7z2xz185i97wa1rnmqwlx2mvwx69hhlyi5m3sm0nkyckb2hjs"
+   "commit": "02bb6c55de71b1fb4a3246d150ff9c63eb694df0",
+   "sha256": "08w8gzx3c4c8v1cncwa1zchcpxksxgvgd8s9mc2dilgj2h4p7pbi"
   },
   "stable": {
    "version": [
@@ -44521,26 +45205,26 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20200803,
-    1032
+    20200905,
+    1311
    ],
    "deps": [
     "async"
    ],
-   "commit": "e9a1e53c57478389343ee23ebb962c8b9b4b4bba",
-   "sha256": "1vw6qcpz71sb6xhjzlikr4l1q23sfbphlza4x4ma0gc7mfzyqfh0"
+   "commit": "19d2ba9d36615f1dea6be6cd6dcf5792dfefc45b",
+   "sha256": "07cl4cndz8mylylpj83ismir47q8vph5vfi9a7n0ll1i3ffpc0b5"
   },
   "stable": {
    "version": [
     3,
     6,
-    4
+    5
    ],
    "deps": [
     "async"
    ],
-   "commit": "a3343a370975d9c01df4f1ff42875cc32ae89592",
-   "sha256": "0cl5awhq5py872qx9s30sfgfpfwjivwbsi18mgar8lj6lvs4s8zz"
+   "commit": "1f32ad2793222985cb8a3bf9a346f4448618224d",
+   "sha256": "0yzpb84346v42ig4h0rsnvzmln58ilhc0gsq0ggc7038ypqkdw4d"
   }
  },
  {
@@ -45110,26 +45794,26 @@
   "repo": "jcs-elpa/helm-file-preview",
   "unstable": {
    "version": [
-    20190903,
-    331
+    20200927,
+    528
    ],
    "deps": [
     "helm"
    ],
-   "commit": "d7e0c1814299fc0e345e159f02733cee5277716e",
-   "sha256": "07767jm0wqnn4qavnvnsf6wzfsvsk5bfba2sm16l5036sj4dyjxn"
+   "commit": "59adbf2d3c67b174a354f0dd64f647b4391ab8d0",
+   "sha256": "1x2ds29k4wwv406j49nzjkh43scahmrshx4lssqrkc9cay7210nx"
   },
   "stable": {
    "version": [
     0,
     1,
-    4
+    5
    ],
    "deps": [
     "helm"
    ],
-   "commit": "52dbc68cf7484d66c40593733770c0c61b383ef0",
-   "sha256": "1xrq5481mri9nfdwkn14zjq1zgl31w6aywca6sr1by5cqggqrqr1"
+   "commit": "59adbf2d3c67b174a354f0dd64f647b4391ab8d0",
+   "sha256": "1x2ds29k4wwv406j49nzjkh43scahmrshx4lssqrkc9cay7210nx"
   }
  },
  {
@@ -45190,27 +45874,27 @@
   "repo": "emacs-helm/helm-fish-completion",
   "unstable": {
    "version": [
-    20200622,
-    1255
+    20200908,
+    1504
    ],
    "deps": [
     "fish-completion",
     "helm"
    ],
-   "commit": "f055dab2f14462ff130841d4ab421f34baab39d5",
-   "sha256": "0hpsm39kx8vpz2zmarjrkvy1capkk5lwpsmdg2xnklsck6xsn922"
+   "commit": "2a2001b3a876da3c468ffec8935572509c485aac",
+   "sha256": "1j2vfngq3512naaayv9kx0d1q2zg1xgs69l8afc7swg72h0l0imw"
   },
   "stable": {
    "version": [
     0,
-    5
+    6
    ],
    "deps": [
     "fish-completion",
     "helm"
    ],
-   "commit": "f055dab2f14462ff130841d4ab421f34baab39d5",
-   "sha256": "0hpsm39kx8vpz2zmarjrkvy1capkk5lwpsmdg2xnklsck6xsn922"
+   "commit": "2a2001b3a876da3c468ffec8935572509c485aac",
+   "sha256": "1j2vfngq3512naaayv9kx0d1q2zg1xgs69l8afc7swg72h0l0imw"
   }
  },
  {
@@ -45374,28 +46058,28 @@
   "repo": "jcs-elpa/helm-fuzzy",
   "unstable": {
    "version": [
-    20190905,
-    526
+    20200927,
+    532
    ],
    "deps": [
     "flx",
     "helm"
    ],
-   "commit": "152d54bcd7137e4f5df54cf213e578c9d71864bd",
-   "sha256": "1msnagb1mxxi9c64j54j9r95l98jha2n6qdgs236b953lz8d9wwf"
+   "commit": "72d618f95d6531854a60322d88b242825016f8e6",
+   "sha256": "0bpnspq7c3akny8blsp75br11g6fh425v9hxfpwyk8iqs5zwvlb7"
   },
   "stable": {
    "version": [
     0,
     1,
-    5
+    6
    ],
    "deps": [
     "flx",
     "helm"
    ],
-   "commit": "fc080a0b4be8a68944a64bc4fb5b38cd11a70bc7",
-   "sha256": "01632zrpl69b034srgsfidf62r1kwc8f4z8i48kz95g5n2ax1xk9"
+   "commit": "72d618f95d6531854a60322d88b242825016f8e6",
+   "sha256": "0bpnspq7c3akny8blsp75br11g6fh425v9hxfpwyk8iqs5zwvlb7"
   }
  },
  {
@@ -46295,16 +46979,16 @@
   "repo": "emacs-lsp/helm-lsp",
   "unstable": {
    "version": [
-    20200808,
-    713
+    20200910,
+    518
    ],
    "deps": [
     "dash",
     "helm",
     "lsp-mode"
    ],
-   "commit": "4263c967267b0579956b3b12ef32878a9ea80d97",
-   "sha256": "1j0w6391ivw7gyx03vmmhccj25d5p94dnbblhd6vxl8d22azdfq3"
+   "commit": "fc09aa0903ee6abe4955e9a6062dcea667ebff5a",
+   "sha256": "1gcs6aky8h6g9wkrqjl8j50zm4lnvnjv4xcfxxg2z0j7vln81pbx"
   },
   "stable": {
    "version": [
@@ -46486,14 +47170,14 @@
   "repo": "emacs-helm/helm-mu",
   "unstable": {
    "version": [
-    20190819,
-    1311
+    20200823,
+    1534
    ],
    "deps": [
     "helm"
    ],
-   "commit": "481964fb26c59ea280a1ec7bce192d724ddf7d12",
-   "sha256": "08cszx5iqr65sz66ank722c1kdvjff2k7kvhxdilhf3gb6f8ph9p"
+   "commit": "c02bba3c6e52e623951781c98a1cf2ce923439e6",
+   "sha256": "0i9k03x6gnwfsf3r7m3yhmgf3y9hnc895mv5x4zdv1jazr4gc8gf"
   }
  },
  {
@@ -47394,8 +48078,8 @@
     "helm",
     "rtags"
    ],
-   "commit": "b57b36039f6411f23009c4ec0315ca5a7adb6824",
-   "sha256": "1816yxyqkxd895wka9xkxpca59iwjpcv73d25sq03z2gf1ayd56b"
+   "commit": "9ad2ff1c2c09c9d2eb945bc9f174f27fa36f0ae1",
+   "sha256": "19l0iiwkz6q9gs0wmi792016d18fp1m1i9g60yfk4wg5w9rbvzk2"
   },
   "stable": {
    "version": [
@@ -47510,6 +48194,42 @@
    ],
    "commit": "b42b4ba5fd1b17c4b54c30376a053281686beeb8",
    "sha256": "1s6aw1viyzhhrfiazzi82n7bkvshp7clwi6539660m72lfwc5zdl"
+  }
+ },
+ {
+  "ename": "helm-searcher",
+  "commit": "aafea99e6091ada48708db7a42ffe13effa17a41",
+  "sha256": "063453h22811inn55z09kfz5a42lzjw3mv41ghwypnqgy0lnjs0r",
+  "fetcher": "github",
+  "repo": "jcs-elpa/helm-searcher",
+  "unstable": {
+   "version": [
+    20200921,
+    1309
+   ],
+   "deps": [
+    "f",
+    "helm",
+    "s",
+    "searcher"
+   ],
+   "commit": "1c6016b6d97b9b631b2d35e036b69687097c2ec5",
+   "sha256": "0m6c672c52bzkjp6h4d7c115x2imbqciip9nsw59fd7ka1da4fvm"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    3
+   ],
+   "deps": [
+    "f",
+    "helm",
+    "s",
+    "searcher"
+   ],
+   "commit": "1c6016b6d97b9b631b2d35e036b69687097c2ec5",
+   "sha256": "0m6c672c52bzkjp6h4d7c115x2imbqciip9nsw59fd7ka1da4fvm"
   }
  },
  {
@@ -47772,15 +48492,15 @@
   "repo": "jamesnvc/helm-switch-shell",
   "unstable": {
    "version": [
-    20200817,
-    1725
+    20200831,
+    1329
    ],
    "deps": [
     "dash",
     "helm"
    ],
-   "commit": "9cab3dfd2f006148e969555bc3bfb6456d1b3f84",
-   "sha256": "0z1785cw5sbcyqs2zbi35b5y6ac9lws1wxp89la7hwdlzwzk1c2a"
+   "commit": "e9927561cfc62c8427e9d10526518d643f4bc26d",
+   "sha256": "1l4irigdirvbn1xh0py135q5463z8axdh0y0icvzinn7z1z0141j"
   }
  },
  {
@@ -48240,8 +48960,8 @@
   "repo": "Wilfred/helpful",
   "unstable": {
    "version": [
-    20200506,
-    816
+    20200923,
+    620
    ],
    "deps": [
     "dash",
@@ -48250,8 +48970,8 @@
     "f",
     "s"
    ],
-   "commit": "c0662aa07266fe204f4e6d72ccaa6af089400556",
-   "sha256": "1k61k7hhrfi8rzsniy15almvnvdsv85l7bmlaqs695pvanr5zlgh"
+   "commit": "27373703625fdf86fe0f71500767802a28350b9f",
+   "sha256": "1pakxal4zgfv558vxplbbnrk3ibby3vpfxqcicf56d4zgrlj0mjm"
   },
   "stable": {
    "version": [
@@ -48301,10 +49021,10 @@
  },
  {
   "ename": "hercules",
-  "commit": "c0a3b713c6c8465dc461d9776ccd27f06659993e",
-  "sha256": "1ggb8ax18nvcrcf1rqf8lkjjxb90kl05ivk0110h6pb9270x03hy",
-  "fetcher": "gitlab",
-  "repo": "jjzmajic/hercules.el",
+  "commit": "b95fa8694bd49595da9fb56454e6539e76feff97",
+  "sha256": "13c70hncl53xvnx54mz9hd9763zx7kwwcr5p2fsqyfrcj0qcganl",
+  "fetcher": "github",
+  "repo": "wurosh/hercules",
   "unstable": {
    "version": [
     20200420,
@@ -48694,11 +49414,11 @@
   "repo": "DarthFennec/highlight-indent-guides",
   "unstable": {
    "version": [
-    20200528,
-    2128
+    20200820,
+    2328
    ],
-   "commit": "a4f771418e4eed1f3f7879a43af28cf97747d41c",
-   "sha256": "0zwp7kh10b0gxwp6128am94fwc5lmn73qar13qzyh3r1jsc8f95y"
+   "commit": "cf352c85cd15dd18aa096ba9d9ab9b7ab493e8f6",
+   "sha256": "0wh1sfbbbz52ppr0fkl0csc4n46ipx36dli9pp9nsvpz9r28pc1g"
   }
  },
  {
@@ -48793,11 +49513,14 @@
   "repo": "tsdh/highlight-parentheses.el",
   "unstable": {
    "version": [
-    20180704,
-    1102
+    20200920,
+    832
    ],
-   "commit": "f0bd58c8dadd2db703b7bfd09e911b5fda05b3df",
-   "sha256": "14jzh0vr2sig2ql1iq2x7svvk8ayvy9ahz04y407f53h70ifbmdl"
+   "deps": [
+    "cl-lib"
+   ],
+   "commit": "e18f2c2b240d7586ff7ffdc2881079e2dd8944ca",
+   "sha256": "1agdsqn3g18s9nicp23mlwvshxqskkbfzs9lgjmzxsa5628rxixc"
   },
   "stable": {
    "version": [
@@ -48944,14 +49667,14 @@
   "repo": "chrisdone/hindent",
   "unstable": {
    "version": [
-    20180518,
-    902
+    20200904,
+    2236
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "50242bb64e946555defc9fff11ab32bcb05300b6",
-   "sha256": "0k062mswihnpl1h7r0w37siv57fi5k90956ji2vix9r9qc33zsxc"
+   "commit": "a75d4033969ecf7d4d0a5eb985d3d1abb3b9301f",
+   "sha256": "0g9dm3mr7wi7bk55fvswv0zcw1khgyr2bmchrg6ks82jc9znxkr6"
   },
   "stable": {
    "version": [
@@ -49566,20 +50289,26 @@
   "repo": "ericdallo/hover.el",
   "unstable": {
    "version": [
-    20200321,
-    1819
+    20200911,
+    2356
    ],
-   "commit": "6f9ed1a6517e3a43ef2deafc2f86c70b2abce008",
-   "sha256": "06vhxmvd57hf8kc21ncv6is9h70syjbzqwfcl3xf5zwcpc8vn13s"
+   "deps": [
+    "dash"
+   ],
+   "commit": "e213f2b29b7728edd42e834260c13fffd0c48edc",
+   "sha256": "01cb28n2p35lf16r1xwgiqgdv7xgmi23fayck09zwi2fyszx17n1"
   },
   "stable": {
    "version": [
     1,
-    1,
-    3
+    2,
+    1
    ],
-   "commit": "6f9ed1a6517e3a43ef2deafc2f86c70b2abce008",
-   "sha256": "06vhxmvd57hf8kc21ncv6is9h70syjbzqwfcl3xf5zwcpc8vn13s"
+   "deps": [
+    "dash"
+   ],
+   "commit": "e213f2b29b7728edd42e834260c13fffd0c48edc",
+   "sha256": "01cb28n2p35lf16r1xwgiqgdv7xgmi23fayck09zwi2fyszx17n1"
   }
  },
  {
@@ -49605,16 +50334,16 @@
   "repo": "thanhvg/emacs-howdoyou",
   "unstable": {
    "version": [
-    20200805,
-    1739
+    20200828,
+    1909
    ],
    "deps": [
     "org",
     "promise",
     "request"
    ],
-   "commit": "6bf4d5964299c5b51a2299869c0402079869343b",
-   "sha256": "0rzyh71w5ccimzy1wm489sj96119bnn86mdfshhyk753h9ldjjgp"
+   "commit": "7cb47ea7339cd7830ebacc8a4900bb930de3f59f",
+   "sha256": "0m4n267dznx5h4z3sm3ihvjklfa08m3gn56kdmjrv4vr7nzw9mnv"
   }
  },
  {
@@ -50083,11 +50812,11 @@
   "repo": "Riyyi/emacs-hybrid-reverse",
   "unstable": {
    "version": [
-    20200819,
-    240
+    20200830,
+    331
    ],
-   "commit": "18b1b786fb4346ad31ec76df75cb672ef5cc7cbf",
-   "sha256": "03wgxhly8n3j05l9k3pzixczj4xzqd499k0l3d4nngsxps2v67w3"
+   "commit": "a28044a1dc42920b5107986dadef8322877c3d81",
+   "sha256": "0fxybcmnrgfa0xyj562nng6ff6jm9dk78bwdc8vs6ffyccd6dmij"
   }
  },
  {
@@ -50170,6 +50899,36 @@
   }
  },
  {
+  "ename": "hyperkitty",
+  "commit": "d9cec9706c0f06b631777c30ae38198d60b61c7f",
+  "sha256": "1axxjpmmhwc0b4f8hvq3cz4crmd9xajlhzj2lm4r942pdf3n7bp3",
+  "fetcher": "github",
+  "repo": "maxking/hyperkitty.el",
+  "unstable": {
+   "version": [
+    20200927,
+    106
+   ],
+   "deps": [
+    "request"
+   ],
+   "commit": "ad65766fee2675bf123491544707b056b89b52ce",
+   "sha256": "1h819sxbzpcnr6mkl6aw9qxhyhkydppwwwqsgyw9qfil9sk8hyff"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    2
+   ],
+   "deps": [
+    "request"
+   ],
+   "commit": "fcb923616e69d8f72c2f4a666d381a6a66bc12bc",
+   "sha256": "0s9vabpzcziqab0f2zclyvw6ly1h8d065mijafg7jhxgsiicnx4v"
+  }
+ },
+ {
   "ename": "hyperlist-mode",
   "commit": "a3c6e6adb1a63534275f9d3d3d0fe0f5e85c549b",
   "sha256": "0c3jdwbarxvnczfx2g3g1m53kiyjls7l48s6l4bzxl2w4x8axvsw",
@@ -50198,8 +50957,8 @@
    "deps": [
     "s"
    ],
-   "commit": "825ac47887bf2f63e7dc2ecce264a52d9f0fae70",
-   "sha256": "00bjwgg67y6igm2k2rwrw4n35jiw5akhl01mhbggwy999gb01cg2"
+   "commit": "a7ea085baf4a51cac0513cb57216677722938781",
+   "sha256": "004bdas6339af8zzb2agc27vb86wwbxxinp1n4fhswnlb2llr18c"
   },
   "stable": {
    "version": [
@@ -51082,11 +51841,11 @@
   "repo": "victorhge/iedit",
   "unstable": {
    "version": [
-    20200807,
-    853
+    20200828,
+    1129
    ],
-   "commit": "59430e8c11c1fa9a294a070a3b1d571bd3887806",
-   "sha256": "1phm9n25hdg7v7gjjb5l173hrsgb64rc5frmdpchkd7li4ka4g91"
+   "commit": "def0c19ff77aef32ccf11eb118771a11cff59584",
+   "sha256": "1wzhqwd6x5dcmmnc2ajwmy5n5cislj77lg6n2k78g7i9yvi1vs6n"
   },
   "stable": {
    "version": [
@@ -51327,6 +52086,21 @@
    ],
    "commit": "79bbbe918319bc1e8f42a0bef53dc7c77fe868ea",
    "sha256": "0lqhwh8kav7f526a40rjdy2hzarzph1i3ig2dmbf02gp32sl7rg9"
+  }
+ },
+ {
+  "ename": "imbot",
+  "commit": "93148f04643d7b7325232e9badbca166aba26759",
+  "sha256": "1mn1qb65q87r36jl7r8ygvcy1xg004wfm4ali4xcb87ahid0y0mk",
+  "fetcher": "github",
+  "repo": "QiangF/imbot",
+  "unstable": {
+   "version": [
+    20200923,
+    314
+   ],
+   "commit": "070d3b5938ebdbb3cdb993df98786ba7ec494a8d",
+   "sha256": "12ay52p67znqm8w63174qxc3jhlixqfimpwj44hgddzygjwlr1mh"
   }
  },
  {
@@ -51819,8 +52593,8 @@
    "deps": [
     "clojure-mode"
    ],
-   "commit": "2c8e46b584be71fe1a585c9072da86382710dc59",
-   "sha256": "13rk3g58vaizp67c1plhfc80vsshdvvsz81wsf3076xp35p05w9b"
+   "commit": "e291da3cd0c11271ad7372594139974057612172",
+   "sha256": "1cnr72s3d224l7wk742hlj5mlgr65pchfc2w6dz9gx3ww6by9b8l"
   },
   "stable": {
    "version": [
@@ -51888,11 +52662,11 @@
   "repo": "nonsequitur/inf-ruby",
   "unstable": {
    "version": [
-    20200730,
-    1456
+    20200826,
+    1458
    ],
-   "commit": "9f0f79ff459c7c417e8931ca020db121e24b45b5",
-   "sha256": "0h0kxgihjrabklnwfphaf86b67q0wmfjywffrydhdmlidi56rbis"
+   "commit": "b0124578db09b64902c8ca981b02e74bec92ef36",
+   "sha256": "0ivk80x6sfns4c5s21sr4qrg1zysqq3s8rz2hx8s55f7jbq4k51w"
   },
   "stable": {
    "version": [
@@ -52850,26 +53624,26 @@
   "repo": "jcs-elpa/isearch-project",
   "unstable": {
    "version": [
-    20200717,
-    807
+    20200907,
+    1453
    ],
    "deps": [
     "f"
    ],
-   "commit": "9113d9452a9a879dc0e503f35e8c1fb4d44d9b64",
-   "sha256": "0gvr758kbfxcvrcwkvf8msibwbfqfp44zl99s7ls0gi81pgzwryj"
+   "commit": "1077b395e1c34a734120faf1f3a7feae6dc4d9c5",
+   "sha256": "1zdlk6s0j0825wy2blpxhsg5pxaybk5adxxpjvm6jj9r612xyn73"
   },
   "stable": {
    "version": [
     0,
     2,
-    4
+    6
    ],
    "deps": [
     "f"
    ],
-   "commit": "9113d9452a9a879dc0e503f35e8c1fb4d44d9b64",
-   "sha256": "0gvr758kbfxcvrcwkvf8msibwbfqfp44zl99s7ls0gi81pgzwryj"
+   "commit": "1077b395e1c34a734120faf1f3a7feae6dc4d9c5",
+   "sha256": "1zdlk6s0j0825wy2blpxhsg5pxaybk5adxxpjvm6jj9r612xyn73"
   }
  },
  {
@@ -53097,11 +53871,11 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20200818,
-    1250
+    20200826,
+    955
    ],
-   "commit": "dd43ab1217f72948dc5cd669467e33b8b568db44",
-   "sha256": "0h4273gr4h9xkdf5g08ci95jq0n9l1w3vgd1y9452cry1r07ya9l"
+   "commit": "b65e401c22ec56a008b00f651cd9536caf593d43",
+   "sha256": "0i1q520anbhglfgv35ivvgqwaxf6mzaw45lxmikcijcvc3z1aq4s"
   },
   "stable": {
    "version": [
@@ -53128,8 +53902,8 @@
     "avy",
     "ivy"
    ],
-   "commit": "dd43ab1217f72948dc5cd669467e33b8b568db44",
-   "sha256": "0h4273gr4h9xkdf5g08ci95jq0n9l1w3vgd1y9452cry1r07ya9l"
+   "commit": "b65e401c22ec56a008b00f651cd9536caf593d43",
+   "sha256": "0i1q520anbhglfgv35ivvgqwaxf6mzaw45lxmikcijcvc3z1aq4s"
   }
  },
  {
@@ -53148,8 +53922,8 @@
     "cl-lib",
     "swiper"
    ],
-   "commit": "8a0dd9841316793aacddea744d6b8ca4a7857a35",
-   "sha256": "1av058d7888kr3q15y1122r8jkarfw1s83gvkillj7kyzj3i53m5"
+   "commit": "12f8809aac3a13dd11a1c664a13f789005f7a199",
+   "sha256": "1h5sm479i9rs09h2xxj8qc4jjdqy7fbx7c5df143lrf69mq0sxgf"
   },
   "stable": {
    "version": [
@@ -53449,8 +54223,8 @@
     "hydra",
     "ivy"
    ],
-   "commit": "dd43ab1217f72948dc5cd669467e33b8b568db44",
-   "sha256": "0h4273gr4h9xkdf5g08ci95jq0n9l1w3vgd1y9452cry1r07ya9l"
+   "commit": "b65e401c22ec56a008b00f651cd9536caf593d43",
+   "sha256": "0i1q520anbhglfgv35ivvgqwaxf6mzaw45lxmikcijcvc3z1aq4s"
   },
   "stable": {
    "version": [
@@ -53610,8 +54384,8 @@
     "ivy",
     "prescient"
    ],
-   "commit": "cc289ba3b0d89f251267ca2b669d01b3afecc530",
-   "sha256": "0xwy2xh55dm4y7wlz2g6fkwf1xyqqjyp0sjb522qgasivknzwa5p"
+   "commit": "0c5d611d9fc6431dd049a71a6eda163c37617a33",
+   "sha256": "1wl445iric3jnhkf2wq4f23zi4yb0k731p0hrydvb2c5vyhsbb6n"
   },
   "stable": {
    "version": [
@@ -53702,8 +54476,8 @@
     "ivy",
     "rtags"
    ],
-   "commit": "b57b36039f6411f23009c4ec0315ca5a7adb6824",
-   "sha256": "1816yxyqkxd895wka9xkxpca59iwjpcv73d25sq03z2gf1ayd56b"
+   "commit": "9ad2ff1c2c09c9d2eb945bc9f174f27fa36f0ae1",
+   "sha256": "19l0iiwkz6q9gs0wmi792016d18fp1m1i9g60yfk4wg5w9rbvzk2"
   },
   "stable": {
    "version": [
@@ -53716,6 +54490,42 @@
    ],
    "commit": "9687ccdb9e539981e7934e768ea5c84464a61139",
    "sha256": "1r6l7dgr2ch586zrdi5l8fhdj4qdva8ldz7cjvi2byc2pd2xs8rx"
+  }
+ },
+ {
+  "ename": "ivy-searcher",
+  "commit": "6263a1c7140f349fe3eef8542e57f6a817b9e868",
+  "sha256": "0alvk5n5m8lpf6bllqbdprlc49pdf2z3mdfp7zkjmw7w9n3gzsla",
+  "fetcher": "github",
+  "repo": "jcs-elpa/ivy-searcher",
+  "unstable": {
+   "version": [
+    20200921,
+    1254
+   ],
+   "deps": [
+    "f",
+    "ivy",
+    "s",
+    "searcher"
+   ],
+   "commit": "6c2bbde452650bb34eeae83d31f6a60c22b28ad8",
+   "sha256": "092r5cmazrlgayw8f21k4cmdf0kwx7bwqzcxinqsffpam64wgfl5"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    6
+   ],
+   "deps": [
+    "f",
+    "ivy",
+    "s",
+    "searcher"
+   ],
+   "commit": "6c2bbde452650bb34eeae83d31f6a60c22b28ad8",
+   "sha256": "092r5cmazrlgayw8f21k4cmdf0kwx7bwqzcxinqsffpam64wgfl5"
   }
  },
  {
@@ -54047,14 +54857,14 @@
   "repo": "emacs-jp/japanese-holidays",
   "unstable": {
    "version": [
-    20190317,
-    1220
+    20200912,
+    1106
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "45e70a6eaf4a555fadc58ab731d522a037a81997",
-   "sha256": "041rww8ngvjmgkiviqwq6wci8wgh4bs0wjjc8v8lqpwqhbzf65jy"
+   "commit": "cd96468ab66bba6b68c8cb3737f8a64468280373",
+   "sha256": "1saavqzkwla38lb0qqsjz421m6anr4pbfcrq2bnryqlsigkgviyh"
   }
  },
  {
@@ -54110,11 +54920,11 @@
   "repo": "rudi/jastadd-ast-mode",
   "unstable": {
    "version": [
-    20161219,
-    926
+    20200926,
+    1820
    ],
-   "commit": "a29fdb470cbf0a398164950a3b0d2217de48e0c0",
-   "sha256": "01fv0ixkshy7i6wzcgq6xvijvh3n402vyhmh3qzjwi9p0vxvdyxv"
+   "commit": "b7a0e32b669e726c8ccc348dd6b18ad4a7c70e1b",
+   "sha256": "1669lchqh07pd5c0b2xv8230dz0189hdn86vm37x8hnv8l742jg6"
   }
  },
  {
@@ -54253,11 +55063,11 @@
   "repo": "synic/jbeans-emacs",
   "unstable": {
    "version": [
-    20180309,
-    1625
+    20200924,
+    1946
    ],
-   "commit": "3caa95998d8492a2ca6c17971de499ca15609871",
-   "sha256": "0k8bd5j09753czl55dcwijs4j1vxir4zwcwlgsxli4b4f8sl2z8r"
+   "commit": "a63916a928324c42bfbe3016972c2ecff598b1ae",
+   "sha256": "1kw5czn7ddzhjhdhb8jpqbd2ha8s68fkk4m4iir09wnqdg6icvl8"
   }
  },
  {
@@ -54495,14 +55305,14 @@
   "repo": "john2x/jenkinsfile-mode",
   "unstable": {
    "version": [
-    20200725,
-    2325
+    20200919,
+    505
    ],
    "deps": [
     "groovy-mode"
    ],
-   "commit": "00d259ff9b870d234540e00e1d7c83cccdb063b8",
-   "sha256": "0srf6xdjnrd4v4ks9pal7i48wmkcl4q5ry7d0yzfx1c9pz2qg9zx"
+   "commit": "9520388d249230596753790cfcd0ccfb2d41d44a",
+   "sha256": "17qfqi6xzz37pbsx4q8pkghpzjdiqzzg9hj9b5nr3irgckh7m2xy"
   }
  },
  {
@@ -54513,8 +55323,8 @@
   "repo": "Emiller88/emacs-jest",
   "unstable": {
    "version": [
-    20200625,
-    1611
+    20200819,
+    2319
    ],
    "deps": [
     "cl-lib",
@@ -54525,8 +55335,8 @@
     "projectile",
     "s"
    ],
-   "commit": "4c6ddd3304e199211f0fbdc8a5b83ccbfe1f7fcc",
-   "sha256": "1v940c6p77dhs3rf016qqzhaniifkfsspbkpknf7vdssxgk9g1a5"
+   "commit": "b719a200f9980db5318d40e2ed02b61aa05441f9",
+   "sha256": "0a8zxjyfrrcpyqhp5rjlr7xjlxlb8aidlzgn2y43i5kbf2gbqnz9"
   }
  },
  {
@@ -55058,8 +55868,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "40aab27581279d0fdbfeb9afeb85f39d401a927f",
-   "sha256": "0ysd0ji3vvk2zpjcg1wl7b2hva8471vq0ypib4h6spnpjdr43vzk"
+   "commit": "ffb70990c1a4d4616034cb810b4ce36953aecb47",
+   "sha256": "1c9nchiq8n80qq2dqmcwmg2cpc6p5gwri26l885qxbc9vw201m4r"
   },
   "stable": {
    "version": [
@@ -55366,11 +56176,11 @@
   "repo": "Sterlingg/json-snatcher",
   "unstable": {
    "version": [
-    20150512,
-    347
+    20200916,
+    1717
    ],
-   "commit": "c4cecc0a5051bd364373aa499c47a1bb7a5ac51c",
-   "sha256": "05zsgnk7grgw9jzwl80h5sxfpifxlr37b4mkbvx7mjq4z14xc2jw"
+   "commit": "b28d1c0670636da6db508d03872d96ffddbc10f2",
+   "sha256": "1nxvi2iqcfp802rn3d2q4b91904nnxfp8w2d4zgak26ry7pjl90h"
   },
   "stable": {
    "version": [
@@ -55484,11 +56294,11 @@
   "repo": "JuliaEditorSupport/julia-emacs",
   "unstable": {
    "version": [
-    20200717,
-    1915
+    20200917,
+    713
    ],
-   "commit": "b5f5983d2b232c8bba4c5eff75cccdb787c19d98",
-   "sha256": "0pxaga920bab6n5byag6h0wql2akiybhsh9nlinfx708i9dzmvv6"
+   "commit": "8ea90c7927f6d87a291cfb0216f34dacf43c722e",
+   "sha256": "1ymanbalx41xri5kiqs83a80a72yr9831if6cz2m24pg3g7rwr9c"
   },
   "stable": {
    "version": [
@@ -55792,8 +56602,8 @@
    "deps": [
     "yaml-mode"
    ],
-   "commit": "9364cdbbae00055c4efa1eeb80503e0b0a215743",
-   "sha256": "1ap8nwlv9ha5a03gc10sva12sc6qzq1vig8hibg1igbsc1qmfkad"
+   "commit": "bbceb256bf2b6a56c86aed5963102fb4898aadc9",
+   "sha256": "16ani1d8c9g3v1zpwxcczm5bjbkymd86i1adcvc9xcaz46v7sb3w"
   },
   "stable": {
    "version": [
@@ -56059,28 +56869,28 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20200817,
-    1844
+    20200917,
+    748
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "380bcb745c9bbf7328b7f190680a0e51231e3c3e",
-   "sha256": "1yw1c97ynjjr3md2shrhviiqycaggcmzhkb0i5y49b2w2mdvp1fa"
+   "commit": "1172cf02dd998e46247052c75030441998281dab",
+   "sha256": "1xfvbrrr0lp12r2g2rw5p05zmpbpn8p098w55slh8byam0j6awr9"
   },
   "stable": {
    "version": [
     1,
     6,
-    0
+    1
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "3e2c700aa1cf9f0ee17486ef9a7a68f77fb9946a",
-   "sha256": "07lydl1b8fz4g4q22ffrl6li9kc3zp9zq5rpqghzr9b8f56ddfqj"
+   "commit": "1114a8d84b60eaf8cadb628a29e0eaf6b5906f69",
+   "sha256": "0hfwxbsq9hdascs2vp56yw86m0ha9148596gm27yiqm6di51l571"
   }
  },
  {
@@ -56813,8 +57623,8 @@
     20180702,
     2029
    ],
-   "commit": "f34c43f235f35767ed04765a90d68b23807436ba",
-   "sha256": "06pgjd79kvkpznniw90hrsb7fvc0y3hhnxs6pyay869d50vbyw53"
+   "commit": "0b7d32702714c4792e5373171423357ffd22d054",
+   "sha256": "1l5p5mcvn7k2pxk33cvhilpw8yaar6475rbs2fybh2kpx7c84acw"
   },
   "stable": {
    "version": [
@@ -57003,11 +57813,11 @@
   "repo": "Emacs-Kotlin-Mode-Maintainers/kotlin-mode",
   "unstable": {
    "version": [
-    20191102,
-    1510
+    20200925,
+    1541
    ],
-   "commit": "8e6dd578f2b3d77ac33b6384d2bfe1b1f6799a1a",
-   "sha256": "12gwy76kz4qjw1qxma4q9pk9s2arzr5p95ni5vzizm2p4x4c5a8x"
+   "commit": "0e4bafb31d1fc2a0a420a521c2723d5526646c0b",
+   "sha256": "09inpgwmnnqaakyn4r4xs8kax8b89dw94kvl521x6d43h9zl5i70"
   }
  },
  {
@@ -57101,16 +57911,17 @@
   "repo": "abrochard/kubel",
   "unstable": {
    "version": [
-    20200812,
-    2143
+    20200925,
+    1530
    ],
    "deps": [
     "dash",
     "s",
-    "transient"
+    "transient",
+    "yaml-mode"
    ],
-   "commit": "55099f130803b56eb1f7595ba34a313df4ec138a",
-   "sha256": "1sly3fgdrynazaab0nb7hbxs0vb42g0r00m7zr162kqw7n57gxaw"
+   "commit": "d3a07c8bb2ada6a3f091029263acee33cf4575a0",
+   "sha256": "12rm53rqi0qrzbw0jx77qg1hhm5b34079lgzbasfxxq6gfp43v96"
   },
   "stable": {
    "version": [
@@ -57136,8 +57947,8 @@
     "evil",
     "kubel"
    ],
-   "commit": "55099f130803b56eb1f7595ba34a313df4ec138a",
-   "sha256": "1sly3fgdrynazaab0nb7hbxs0vb42g0r00m7zr162kqw7n57gxaw"
+   "commit": "d3a07c8bb2ada6a3f091029263acee33cf4575a0",
+   "sha256": "12rm53rqi0qrzbw0jx77qg1hhm5b34079lgzbasfxxq6gfp43v96"
   },
   "stable": {
    "version": [
@@ -57160,16 +57971,16 @@
   "repo": "chrisbarrett/kubernetes-el",
   "unstable": {
    "version": [
-    20200114,
-    436
+    20200911,
+    756
    ],
    "deps": [
     "dash",
     "magit",
     "magit-popup"
    ],
-   "commit": "cc33d8c7bb114c34809ee86020b9e635eff0017b",
-   "sha256": "11bi1z28rf2ldx20mqgq6yfkpc1af9kgvjzrz3w3dcf074jp89lb"
+   "commit": "f4c763016620a4ddb41698bb8aa02b18e07ac509",
+   "sha256": "129qfb8c18lj6ln8brf9jqzp16vq930hf31rav7xqzsfp0h8ixwg"
   },
   "stable": {
    "version": [
@@ -57201,8 +58012,8 @@
     "evil",
     "kubernetes"
    ],
-   "commit": "cc33d8c7bb114c34809ee86020b9e635eff0017b",
-   "sha256": "11bi1z28rf2ldx20mqgq6yfkpc1af9kgvjzrz3w3dcf074jp89lb"
+   "commit": "f4c763016620a4ddb41698bb8aa02b18e07ac509",
+   "sha256": "129qfb8c18lj6ln8brf9jqzp16vq930hf31rav7xqzsfp0h8ixwg"
   },
   "stable": {
    "version": [
@@ -57337,11 +58148,11 @@
   "repo": "ksjogo/labburn-theme",
   "unstable": {
    "version": [
-    20200309,
-    1556
+    20200822,
+    2153
    ],
-   "commit": "d11537a2060df7e992217ede8f65d6c11de49458",
-   "sha256": "0aqdl3hq76r315h2h75lxgbyb7hw3hdg49n72frm1wx7hj372d0g"
+   "commit": "4ef2892f56c973907361bc91495d14204744f678",
+   "sha256": "1kpin7r1a1la9s4khrn6rwhgkbib9j7lgyqk9b48fzjhp1h25mgq"
   },
   "stable": {
    "version": [
@@ -57364,8 +58175,23 @@
     20191229,
     19
    ],
-   "commit": "0da19f68ba22a39c02d83063f5b4936401ce4d97",
-   "sha256": "1r8di1cmhcx2vfk3fsydx24spib1fi4wihnxa41favnkjzklz9jv"
+   "commit": "2aea296b236966cdb8dbdc238678f2752b505aba",
+   "sha256": "0yspvfbczyqicr10p01dzdz4azvniwli65dx7iqhkw95iw85nhks"
+  }
+ },
+ {
+  "ename": "lakota-input",
+  "commit": "65110d2232914d55ac87c64276be9a9ccf748b9e",
+  "sha256": "1cjaxp04bm2ncp2b1qkarbrkf4srn075kvf6m5lcpmvj7mfdaz6r",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~shoshin/lakota-input.git",
+  "unstable": {
+   "version": [
+    20200823,
+    2146
+   ],
+   "commit": "b74b9de284a0404a120bb15340def4dd2f9a4779",
+   "sha256": "1zn5n34jhjk1shjinjh3nv0x9y61gp7n5ywvmxwijffhva58h3w6"
   }
  },
  {
@@ -57376,15 +58202,16 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20200706,
-    1546
+    20200825,
+    1003
    ],
    "deps": [
     "eglot",
+    "highlight",
     "math-symbol-lists"
    ],
-   "commit": "665cb18e484b8e41b0314fc442422b671cda2962",
-   "sha256": "0qsd30xnhzcvfdk0p2adzrbzl6hw4z5is0wwirzr79qx025zm4gf"
+   "commit": "25de57be7e7ac034c66cb864cb65bfaa830f77ca",
+   "sha256": "0b0gn01zzsf8ba5zip1f6z9vz2dcgma14ndpw8jk1qhs851az2jq"
   }
  },
  {
@@ -57891,16 +58718,16 @@
   "repo": "conao3/leaf-convert.el",
   "unstable": {
    "version": [
-    20200812,
-    1306
+    20200821,
+    651
    ],
    "deps": [
     "leaf",
     "leaf-keywords",
     "ppp"
    ],
-   "commit": "d716e0bc3be91a79c791e7a4cb8335132a69d195",
-   "sha256": "0a2rqylqzvvfs62rrqkigga9jaxs89b2l8sdzkfb30vwp0y3d0sb"
+   "commit": "eae0f4f6df5c3a35361f1a010368f0fa9ec8a9e5",
+   "sha256": "08lvq7c994r9c9hb7z4hgfil38mrpw4a9qbdfhkshig4hac5sjw9"
   }
  },
  {
@@ -57911,14 +58738,14 @@
   "repo": "conao3/leaf-keywords.el",
   "unstable": {
    "version": [
-    20200812,
-    1025
+    20200920,
+    1542
    ],
    "deps": [
     "leaf"
    ],
-   "commit": "c38d9d0d8cdb5a95df788af784e4eb989b674622",
-   "sha256": "19a1wrzikbzn2lswf5xwy8145a60mrj9ndj7cx29qrbr8fjcz431"
+   "commit": "e1c166985da017d01852fdf2453da47a0dd78110",
+   "sha256": "1gr27szk84yd5vvvwnxdh730f7gnjq2mchqh7cqba68fhzdbqvwa"
   },
   "stable": {
    "version": [
@@ -57938,16 +58765,16 @@
   "repo": "conao3/leaf-manager.el",
   "unstable": {
    "version": [
-    20200812,
-    1004
+    20200920,
+    1643
    ],
    "deps": [
     "leaf",
     "leaf-convert",
     "ppp"
    ],
-   "commit": "baea372b3cfc7e1ad6d341d2f06e2932dcebf801",
-   "sha256": "031qgwc3pdxxqzkbdkaxd9lq4chngjba1s6q01wm98i5bdj4n4r0"
+   "commit": "b9aaa539677d1492cb16ee595c2e81bf29967475",
+   "sha256": "0klp0yjpf8njdavwh71i7wkl5yrjh42wgakigizgb1l1sksp9iy9"
   },
   "stable": {
    "version": [
@@ -58209,24 +59036,6 @@
   }
  },
  {
-  "ename": "lenlen-theme",
-  "commit": "47d5b3c931cdbc2351e01d15e2b98c78081c9506",
-  "sha256": "1bddkcl9kzj3v071qpzmxzjwywqfj5j6cldz240qgp5mx685r0a9",
-  "fetcher": "github",
-  "repo": "zk-phi/lenlen-theme",
-  "unstable": {
-   "version": [
-    20170329,
-    245
-   ],
-   "deps": [
-    "color-theme-solarized"
-   ],
-   "commit": "b8a6412c81633b10fb98ba0930f55b25071c084a",
-   "sha256": "177fqqhd498v2h6wki6pgg982rp4jxhn4wrzajcqppjz4nidb1b7"
-  }
- },
- {
   "ename": "lentic",
   "commit": "cbb6f9cc3c1040b80fbf3f2df2ac2c3c8d18b6b1",
   "sha256": "0y94y1qwj23kqp491b1fzqsrjak96k1dmmzmakbl7q8vc9bncl5m",
@@ -58349,11 +59158,11 @@
   "repo": "fniessen/emacs-leuven-theme",
   "unstable": {
    "version": [
-    20200707,
-    1143
+    20200926,
+    1028
    ],
-   "commit": "a116202c82613c087440d2e8a6a504b08f1862ce",
-   "sha256": "1pqv4idkbqbxxvdfqxwf5rq2isl1jikba5nd0z8d7fr09wv48pv7"
+   "commit": "0d5d75173436d7fef4660557a9ac52737aaaf2d7",
+   "sha256": "0b941y45r1l9wwl9fgranx7pv0xhs5d6wkzpah3di7kbprp4lx9w"
   }
  },
  {
@@ -58394,18 +59203,18 @@
   "repo": "rvirding/lfe",
   "unstable": {
    "version": [
-    20170121,
-    1254
+    20200905,
+    1252
    ],
-   "commit": "9d15bc75a34052f7f2749bd38b3d0297ed60b29a",
-   "sha256": "07ysaihl24fiqz8n6hvdvaj53nyalk68dsn073zb8q88sdmzf33w"
+   "commit": "0b9d068b3bf82a110127f77ca666acf40c4a5ce6",
+   "sha256": "16h2m5922c7nyywkr46lrm7h5fxv2f81rrb75i0y6x63djy0v5jh"
   },
   "stable": {
    "version": [
     1,
     3
    ],
-   "commit": "af14b1439097850ffa39935419ed83f5bcaa6d09",
+   "commit": "d8337516ab09edd4b281a27ac85684b81cdeb8bd",
    "sha256": "0pgwi0h0d34353m39jin8dxw4yykgfcg90k6pc4qkjyrg40hh4l6"
   }
  },
@@ -58447,26 +59256,26 @@
   "repo": "DamienCassou/libelcouch",
   "unstable": {
    "version": [
-    20190820,
-    1632
+    20200923,
+    1836
    ],
    "deps": [
     "request"
    ],
-   "commit": "29e369df4f96c7ad95bb33292de7a44122e0b4e7",
-   "sha256": "1xaa90dy1jq1yzcn9px931sgqsrsbwrc89lv0lss975jr827kfg2"
+   "commit": "5ae35266c9a2eb33f0c708bc8c0687339cee9133",
+   "sha256": "0vk7m8napg3ss4d9cgsrhkycb5k07q440lspxihy047556l6q3cm"
   },
   "stable": {
    "version": [
     0,
-    9,
+    11,
     0
    ],
    "deps": [
     "request"
    ],
-   "commit": "fd90ff7989632452434fc19a609805f7276821f3",
-   "sha256": "0rpipbcfvi8ysx8aykj9sd23gkzq3knn656g84lb9h1zdjvc4zf1"
+   "commit": "5ae35266c9a2eb33f0c708bc8c0687339cee9133",
+   "sha256": "0vk7m8napg3ss4d9cgsrhkycb5k07q440lspxihy047556l6q3cm"
   }
  },
  {
@@ -58477,11 +59286,11 @@
   "repo": "merrickluo/liberime",
   "unstable": {
    "version": [
-    20200804,
-    147
+    20200915,
+    547
    ],
-   "commit": "2a6f1bca1aff64a9136368c4afa15c0ea1042893",
-   "sha256": "1nvpy2mclcyi75clcnic7ap5rihccvgf7yn10an4y50sas8g2jiv"
+   "commit": "ea504da75c9edddfd7259f1ef4caa0520fb9630e",
+   "sha256": "0wf2jzrwaglg3pc7h0pglw7nwlnckm3qcp245g41rmx19558jai9"
   },
   "stable": {
    "version": [
@@ -58531,11 +59340,11 @@
   "repo": "mpdel/libmpdel",
   "unstable": {
    "version": [
-    20200105,
-    1537
+    20200907,
+    1454
    ],
-   "commit": "95cb45ecea933e7befb2a5a6a6e7d15651c8746a",
-   "sha256": "0g0gsah4y12d2hrk2rsraxqjnd52fkikr0pgcrbrv2mcnqhs8c5m"
+   "commit": "99cb4c83d051cf771f5574713bde8e19787de7d9",
+   "sha256": "1mh2bngixlp9hp5yrzg2ja9vv3ji4p30mxq0hq2wi872nzycqp57"
   },
   "stable": {
    "version": [
@@ -58571,6 +59380,36 @@
   }
  },
  {
+  "ename": "license-templates",
+  "commit": "39a65e959db4f618f7fa36b1c61bf44f48fef8ad",
+  "sha256": "0sp73i9lcgmdci4d8q2fa8sjrc0a0syswn6wd151sgxzk00jmsl2",
+  "fetcher": "github",
+  "repo": "jcs-elpa/license-templates",
+  "unstable": {
+   "version": [
+    20200906,
+    2047
+   ],
+   "deps": [
+    "request"
+   ],
+   "commit": "ef80eff8b7be117f9c48bdc6d9a62e56b0a93554",
+   "sha256": "1z6qd4bcpwdpvi6w9yrkrnk2ypllhm6k4zjl8v1p8k0j93dbn3ny"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    3
+   ],
+   "deps": [
+    "request"
+   ],
+   "commit": "ef80eff8b7be117f9c48bdc6d9a62e56b0a93554",
+   "sha256": "1z6qd4bcpwdpvi6w9yrkrnk2ypllhm6k4zjl8v1p8k0j93dbn3ny"
+  }
+ },
+ {
   "ename": "light-soap-theme",
   "commit": "053be1123bb934d80b4d6db0e7e39b59771be035",
   "sha256": "09p4w51d5szhi81a6a3l0r4zd4ixkrkzxldr938bcmj0qmj62iyk",
@@ -58593,26 +59432,26 @@
   "repo": "jcs-elpa/line-reminder",
   "unstable": {
    "version": [
-    20200816,
-    1151
+    20200914,
+    611
    ],
    "deps": [
     "indicators"
    ],
-   "commit": "4eafedb1f4f9b0fb9c6268ac6c72fea4b786233e",
-   "sha256": "1vygzd7gw9a4cwg554hdvpy4h6ywjk4gg6iffcgwxhvdwg2vmrvs"
+   "commit": "65332e11735e2b3321bcab8e1456c13b6b6c1aa5",
+   "sha256": "1wcfzpl0vnpw8bfqbxb4jqkiziwcivwh7rdg0kjai1c3xhzfpwds"
   },
   "stable": {
    "version": [
     0,
     4,
-    3
+    4
    ],
    "deps": [
     "indicators"
    ],
-   "commit": "4eafedb1f4f9b0fb9c6268ac6c72fea4b786233e",
-   "sha256": "1vygzd7gw9a4cwg554hdvpy4h6ywjk4gg6iffcgwxhvdwg2vmrvs"
+   "commit": "65332e11735e2b3321bcab8e1456c13b6b6c1aa5",
+   "sha256": "1wcfzpl0vnpw8bfqbxb4jqkiziwcivwh7rdg0kjai1c3xhzfpwds"
   }
  },
  {
@@ -58650,8 +59489,8 @@
     20180422,
     247
    ],
-   "commit": "a018ba90549384d52ec58c2685fd14a0f65252be",
-   "sha256": "0bwc4d2gnfhaqzn455nzrvd9lys7z7ay2v1hxgwp99ndqq93ws6i"
+   "commit": "31bce4b79fe16251b7cf118f0d343b0b46f72360",
+   "sha256": "0r3jqkwwsrcj37m0kvk587aanl2wi50z44q2srhk85aiad4in598"
   }
  },
  {
@@ -58711,8 +59550,8 @@
     20191111,
     446
    ],
-   "commit": "c9cad101100975e88873636bfd426b7a19304ebd",
-   "sha256": "0zsjbpq0s0xdxd9r541f04bj1khhgzhdlzr0m4p17zjh1zardbpi"
+   "commit": "46ee5d9ba15cac7282ed73c8b4c272a969c6159e",
+   "sha256": "06mqf19k96mgpa7iv3li2qmfra6qgh4g0s43ark24bk63hdxqvyc"
   },
   "stable": {
    "version": [
@@ -58731,15 +59570,14 @@
   "repo": "noctuid/link-hint.el",
   "unstable": {
    "version": [
-    20200718,
-    1737
+    20200902,
+    1841
    ],
    "deps": [
-    "avy",
-    "cl-lib"
+    "avy"
    ],
-   "commit": "be735e5b57dfad891a7394c116b584bf005fe3b4",
-   "sha256": "0vg0pmvyya3gncih6rj83zx6qjm5gh9qs4svxb8f3wd053ppnvk9"
+   "commit": "81cce65ae0ee41d316ee9748ce5ee6218ed91c2a",
+   "sha256": "0zcsmiizaq18zclm2rnigfbdbiawjfbm4l7g482qhsmzsfw0x7fz"
   }
  },
  {
@@ -59390,8 +60228,8 @@
     20200709,
     422
    ],
-   "commit": "fdc85e5f2ddc72934be704ac90d5436d379c3381",
-   "sha256": "1g74m9v5818v8wg2zsm4zb74lzw28zfvlpv98b2dkqzikpxgz362"
+   "commit": "185da3530e3145b7fea7d15e33a8b581bbe3a111",
+   "sha256": "1w32nzp0ym16wsagj933595wic7x8iswgr0fwpv4hkagvcgbqzn2"
   },
   "stable": {
    "version": [
@@ -59791,28 +60629,28 @@
   "repo": "doublep/logview",
   "unstable": {
    "version": [
-    20200331,
-    2111
+    20200829,
+    1516
    ],
    "deps": [
     "datetime",
     "extmap"
    ],
-   "commit": "c67298a215136617de60c9041904ee6a455dcd4f",
-   "sha256": "0bjgzh4z4bz4nr97cn9wd92brg7wik37c0vd3kfisdalxq2wrgn5"
+   "commit": "dec120cf8d43673c31f7cd7bc0e1800006067cf4",
+   "sha256": "088qx0zq0ldw928a1d70v75m7j1biag32v3zvf51nhj2cds4i5n8"
   },
   "stable": {
    "version": [
     0,
     13,
-    1
+    2
    ],
    "deps": [
     "datetime",
     "extmap"
    ],
-   "commit": "c67298a215136617de60c9041904ee6a455dcd4f",
-   "sha256": "0bjgzh4z4bz4nr97cn9wd92brg7wik37c0vd3kfisdalxq2wrgn5"
+   "commit": "b1be477c5824d5e06f8e40bb1c7ff64ae109bec7",
+   "sha256": "1j2rdgsdnd1xpjwqaisnlz5hkbj29gil1y6q7m0839rmvswl3vyn"
   }
  },
  {
@@ -60009,8 +60847,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20200814,
-    1405
+    20200922,
+    1550
    ],
    "deps": [
     "dap-mode",
@@ -60021,13 +60859,13 @@
     "lsp-treemacs",
     "pkg-info"
    ],
-   "commit": "437c548d411c9e166b7c658fd45294775235fd5f",
-   "sha256": "1pl7payda8i9cyca2j808inb8pmnyhh1sjc9f4qvxpbwd7b94vlr"
+   "commit": "c1ff5cec6adfdf41d1a0e18c89869304ebb2bcb6",
+   "sha256": "1z8r0ycab5cx4281h965jds7c57d200k9yf2z32f7207647y2br3"
   },
   "stable": {
    "version": [
     1,
-    14,
+    17,
     6
    ],
    "deps": [
@@ -60039,8 +60877,8 @@
     "lsp-treemacs",
     "pkg-info"
    ],
-   "commit": "437c548d411c9e166b7c658fd45294775235fd5f",
-   "sha256": "1pl7payda8i9cyca2j808inb8pmnyhh1sjc9f4qvxpbwd7b94vlr"
+   "commit": "c1ff5cec6adfdf41d1a0e18c89869304ebb2bcb6",
+   "sha256": "1z8r0ycab5cx4281h965jds7c57d200k9yf2z32f7207647y2br3"
   }
  },
  {
@@ -60063,24 +60901,6 @@
   }
  },
  {
-  "ename": "lsp-elixir",
-  "commit": "c875a05e68d09ecf37f7e13149f2624c70164ea3",
-  "sha256": "0mimb67swcq2yis0s6w2bkk7sgqv7lyvz1hrh48h2q6qr3ywmq0n",
-  "fetcher": "github",
-  "repo": "elixir-lsp/lsp-elixir.el",
-  "unstable": {
-   "version": [
-    20190105,
-    2059
-   ],
-   "deps": [
-    "lsp-mode"
-   ],
-   "commit": "9fd091c092144a09c0df2d477257c1f4c37bb985",
-   "sha256": "0m5hxlx0cnx4rdcz5chxqp074z9h1wj1nvg8dzmilsnmg3kmsshx"
-  }
- },
- {
   "ename": "lsp-focus",
   "commit": "a71079ecb60d84bded984d856f52590f64adbd9b",
   "sha256": "0w0kywrs3pcs4kgdwhh4r9c1hdjblbdfcn66iz0xhrv1qxpv0zqv",
@@ -60088,15 +60908,15 @@
   "repo": "emacs-lsp/lsp-focus",
   "unstable": {
    "version": [
-    20200809,
-    1413
+    20200906,
+    1917
    ],
    "deps": [
     "focus",
     "lsp-mode"
    ],
-   "commit": "c8270663c1fa8650cf0e248caa6a8e3d8f25d80d",
-   "sha256": "13d7s2pm7nqz06bj6qkibi50f69slqwz6dc0fik97glxnlqqqva5"
+   "commit": "d01f0af156e4e78dcb9fa8e080a652cf8f221d30",
+   "sha256": "1pi6vmykp6x5c1yz9cgcf4nc5cbkbxhxqmp6g9aipwd8kwii1xx6"
   },
   "stable": {
    "version": [
@@ -60120,15 +60940,15 @@
   "repo": "emacs-lsp/lsp-haskell",
   "unstable": {
    "version": [
-    20200527,
-    2014
+    20200924,
+    1508
    ],
    "deps": [
     "haskell-mode",
     "lsp-mode"
    ],
-   "commit": "17d7d4c6615b5e6c7442828720730bfeda644af8",
-   "sha256": "1kkp63ppmi3p0p6qkfpkr8p5cx8qggmsj73dwphv90mdq0nrfsx8"
+   "commit": "a56667b496e5370f1a50310589a2d2a4d3b9d11e",
+   "sha256": "0dd0ir7driz9imm4lypwkz0b76gb6yr9g1qpac3wh6wfv07rbw15"
   }
  },
  {
@@ -60165,8 +60985,8 @@
     "ivy",
     "lsp-mode"
    ],
-   "commit": "4cdb739fc2bc47f7d4dcad824f9240c70c4cb37d",
-   "sha256": "08dpn0vcfdwwysijwdpnnj91m69yw0q464i0wmp51zpj3dyd4kb1"
+   "commit": "20cac6296e5038b7131ee6f34a96635f1d30fe3c",
+   "sha256": "09k7mmpp08vskallhf06q1ldrk32sblfz6dq9ir1vd2ysf2m2k03"
   },
   "stable": {
    "version": [
@@ -60190,8 +61010,27 @@
   "repo": "emacs-lsp/lsp-java",
   "unstable": {
    "version": [
-    20200804,
-    1609
+    20200911,
+    522
+   ],
+   "deps": [
+    "dap-mode",
+    "dash",
+    "dash-functional",
+    "f",
+    "ht",
+    "lsp-mode",
+    "markdown-mode",
+    "request",
+    "treemacs"
+   ],
+   "commit": "380b7380ca4468b70b768cc814b8147f719e7088",
+   "sha256": "0av9xdnw1nn3yzvj1kvrfiz7s6k5azhic7hwn7s89r30p6l9wn6y"
+  },
+  "stable": {
+   "version": [
+    3,
+    1
    ],
    "deps": [
     "dap-mode",
@@ -60206,24 +61045,6 @@
    ],
    "commit": "260016236fa0520b5b6ec7f51ca2086288524cba",
    "sha256": "1h0hqgjpk5mbylma1fkva0vx45achf0k7ab2c5y8a2449niww90h"
-  },
-  "stable": {
-   "version": [
-    3,
-    0
-   ],
-   "deps": [
-    "dash",
-    "dash-functional",
-    "f",
-    "ht",
-    "lsp-mode",
-    "markdown-mode",
-    "request",
-    "treemacs"
-   ],
-   "commit": "811760ad89a29939c28f47d0925f58d9eeea9fa3",
-   "sha256": "1grcapmd9k0a128vhgpy2a5dh6iqmf8bdvz0hykl4v7d55vcm423"
   }
  },
  {
@@ -60283,28 +61104,28 @@
   "repo": "non-Jedi/lsp-julia",
   "unstable": {
    "version": [
-    20200511,
-    1444
+    20200912,
+    1106
    ],
    "deps": [
     "julia-mode",
     "lsp-mode"
    ],
-   "commit": "b342e5f74f9b815d2a7db9fffee7b9c46850d293",
-   "sha256": "13haa9jvcq6wvj8g1bnqrrczg1j50lwk41pr4n7q0i7313r8f89v"
+   "commit": "11c701ac347da69b173b01d073efe0fb09f3298f",
+   "sha256": "0avx42lnc8w2mbhzv137y0p8cg6dmkwp6i0pprw8n8g9qfvxcgnx"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
    "deps": [
     "julia-mode",
     "lsp-mode"
    ],
-   "commit": "9f158a290168149fd301a1c1c2016600106ad5be",
-   "sha256": "077mrvxf8df4dppl3xqa7p3ksm3wcms64l306y7i5x878vyjgibv"
+   "commit": "72e26d0c1d34e3dd16ff6427af883bd0136015d3",
+   "sha256": "0f4zmvn13x468p6vpfixx3ghlrygdgdyx8xpb7nx232pv38156dn"
   }
  },
  {
@@ -60345,8 +61166,8 @@
   "repo": "emacs-lsp/lsp-metals",
   "unstable": {
    "version": [
-    20200727,
-    1925
+    20200922,
+    915
    ],
    "deps": [
     "dap-mode",
@@ -60358,8 +61179,8 @@
     "lsp-treemacs",
     "treemacs"
    ],
-   "commit": "039aa72439e3c52cfef4bcde416ba49d88ac0991",
-   "sha256": "12b2f1d07rqnbj27whdkk74c3fkqp7qrsqmwnyv0ysc870w29sb0"
+   "commit": "8f8471ca1b2a3d54bafce8949e6b13c9567d0405",
+   "sha256": "0q3swqkr4kkfzp1fd7g97r2gzp11vcrx51xbywk336mb6ghlshyc"
   },
   "stable": {
    "version": [
@@ -60382,14 +61203,14 @@
  },
  {
   "ename": "lsp-mode",
-  "commit": "1a7b69312e688211089a23b75910c05efb507e35",
-  "sha256": "0cklwllqxzsvs4wvvvsc1pqpmp9w99m8wimpby6v6wlijfg6y1m9",
+  "commit": "525ea5927f1c66dc56b49aab40667be15a7ea063",
+  "sha256": "0vjk60avwydap3zacygmrxsapbkfxb26k89km38633sg3788xqx9",
   "fetcher": "github",
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20200819,
-    1349
+    20200926,
+    953
    ],
    "deps": [
     "dash",
@@ -60400,8 +61221,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "4145a70ce1d4bfb2463606ba34c5965080b080d9",
-   "sha256": "01nji47mh79ip67vagi8yb5dd9kscnvg4070zklnfyp9v0rfl73r"
+   "commit": "442d7b51d9a84b0cf13fae3fe9629fd106948b45",
+   "sha256": "1138bifwinzk885nmsddhl8w276i111c95jhc5kvph2gpnlwryb1"
   },
   "stable": {
    "version": [
@@ -60440,8 +61261,8 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "b462cfa9b8071c624b905baf37a255d808ac6376",
-   "sha256": "1wig6hr5g0q0lg7zkqw1bfgagpx1ndpga75lnxaqpm0f0rgwdc33"
+   "commit": "88319a61a06e27fc1d3ea2e7b853ec1692b4c166",
+   "sha256": "0007lv95cqh8makipas2m4rkllig5zvi51hv3zadlhw57xnvlhjw"
   }
  },
  {
@@ -60452,8 +61273,21 @@
   "repo": "emacs-lsp/lsp-origami",
   "unstable": {
    "version": [
-    20200809,
-    1537
+    20200914,
+    1846
+   ],
+   "deps": [
+    "lsp-mode",
+    "origami"
+   ],
+   "commit": "aa309589668d32a8b4bb23c8f41163f6ae208f7b",
+   "sha256": "1l5n01icyp00ljcs5sfk3wbp74gn53p0mj1l4fqdpi70c1wahwmv"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
    ],
    "deps": [
     "lsp-mode",
@@ -60536,16 +61370,16 @@
   "repo": "emacs-lsp/lsp-pyright",
   "unstable": {
    "version": [
-    20200810,
-    354
+    20200826,
+    1656
    ],
    "deps": [
     "dash",
     "ht",
     "lsp-mode"
    ],
-   "commit": "9603dda12afaae9c82608c7d3762f98b24b8563f",
-   "sha256": "1xh0q356q7sy68m9syfbclabamdnw5y772inspn5y8640ig4rg21"
+   "commit": "ccd00074622520acb7a65357a59d8c8426c12a00",
+   "sha256": "1hda92pcc8700iqac5m901srxdz91nbrprhg0sj853dlwkhwnff4"
   }
  },
  {
@@ -60556,14 +61390,14 @@
   "repo": "emacs-lsp/lsp-python-ms",
   "unstable": {
    "version": [
-    20200811,
-    1204
+    20200917,
+    1326
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "a884a9a4eb1a3acd3d70c776aec5e968bbdc1731",
-   "sha256": "02fws6ph1ikpx86709dswlag180m6b34nchqcsfcvx4zp7qg2wj2"
+   "commit": "a0c56f429e14cc9086fd06aa764e9aab697970d7",
+   "sha256": "0bmaqlmmpgjxv8ia58b1jdznvynny2nzrf571qq4xcc0xgh77w6r"
   },
   "stable": {
    "version": [
@@ -60605,30 +61439,30 @@
   "repo": "emacs-lsp/lsp-sonarlint",
   "unstable": {
    "version": [
-    20200702,
-    2351
+    20200821,
+    1703
    ],
    "deps": [
     "dash",
     "ht",
     "lsp-mode"
    ],
-   "commit": "e0a27c07e886a147e2b8750471660af02e142086",
-   "sha256": "1kfgqdxynzpy98j1hc07zsygi0npw4xfm80jx3h30wyvxmgy7flp"
+   "commit": "ef32b6f734323698fc8ba28646a07515aaafea44",
+   "sha256": "0mgz6y4x6wy4afh15ara8iv0irk8hkbf8gq2aj9gdandh86iq048"
   },
   "stable": {
    "version": [
     0,
     0,
-    1
+    2
    ],
    "deps": [
     "dash",
     "ht",
     "lsp-mode"
    ],
-   "commit": "5f519612c6a10b189292083b04dcd652b64bc7d1",
-   "sha256": "04xs8n0lxx54hyj1y002ps52cxwb7s79k38q3dqzzbfax1nxwfw3"
+   "commit": "d2c0ffe736d6cda4cc524f62ac8b5c5c98490c04",
+   "sha256": "1x6m5j119qa45rqydq9svsrf16s0lw8zivfppzfiikyi405g75yz"
   }
  },
  {
@@ -60645,8 +61479,8 @@
    "deps": [
     "lsp-mode"
    ],
-   "commit": "130f7a8f7a37869515953aa7715b3b969c3d7a0b",
-   "sha256": "0mz1wdxn31qngk98k924mwf4f5pb8v1y9jjl2sf4mrjw1wz2xsnb"
+   "commit": "948c3a35fd05496a77af2d8935e754db112cb4c3",
+   "sha256": "1n9jfaq1w2vxhv2gpvmj3qyc8bwacyj6kdyw62hlgbl7xnhhhc6d"
   }
  },
  {
@@ -60657,8 +61491,8 @@
   "repo": "emacs-lsp/lsp-treemacs",
   "unstable": {
    "version": [
-    20200815,
-    1841
+    20200919,
+    632
    ],
    "deps": [
     "dash",
@@ -60668,8 +61502,8 @@
     "lsp-mode",
     "treemacs"
    ],
-   "commit": "3f8ca910c8e8724f93d8268a91771a51427684ff",
-   "sha256": "0xnbw3j7n10wp6jbzrgrr0xfzilrlhrmmzs4d00y56g1fmqn3jja"
+   "commit": "c54503bec3d7a17eb7b4d30e3ab2f7916a26124c",
+   "sha256": "042jr7gh0rjvwzihzdl545vwrm5j9gbprn2g882xiz7fvihjkywa"
   },
   "stable": {
    "version": [
@@ -60690,14 +61524,14 @@
  },
  {
   "ename": "lsp-ui",
-  "commit": "b7c78c9b07ede9949d14df74b188d4c1a3365196",
-  "sha256": "0fylav8b54g020z039zm1mx26d257715bfn9nnpw9i0b97539lqi",
+  "commit": "883d739e46c32c95adcf41835078ba3604188eda",
+  "sha256": "0n4z7gmpkbz9azbk8pi4f368396y4s9bpqvkdykzq6ykqyswk4bm",
   "fetcher": "github",
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20200816,
-    841
+    20200923,
+    1558
    ],
    "deps": [
     "dash",
@@ -60705,8 +61539,8 @@
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "c39ae3713f95a2d86e11fd1f77e89a671d08d18a",
-   "sha256": "033ah4mz3pa6da3xdn6yk3lmkv6lanpj07b0icf30c6bp7rmk3il"
+   "commit": "edb229fb774f0c2ebf00fe49c53baac5c0800e0a",
+   "sha256": "0jp0fxrd96k7fbk96bgli2nv8yfcg8g8vj7g1f7k6xfdj1warhcx"
   },
   "stable": {
    "version": [
@@ -60732,11 +61566,11 @@
   "repo": "immerrr/lua-mode",
   "unstable": {
    "version": [
-    20200508,
-    1316
+    20200921,
+    1745
    ],
-   "commit": "35b6e4c20b8b4eaf783ccc8e613d0dd06dbd165c",
-   "sha256": "1bwyyp9fbvy0p4f3mmbqc0plxrcm0ag2r3zb74gb5k2vcxi2vdw4"
+   "commit": "345ebfc1e236d9676e7e9f7364493785e7756348",
+   "sha256": "0yx0h5kir8r3mi9vqpwsz8nsh1b1w7zk0hahn9003j3dxzi755lv"
   },
   "stable": {
    "version": [
@@ -61150,8 +61984,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20200816,
-    955
+    20200923,
+    1515
    ],
    "deps": [
     "async",
@@ -61160,8 +61994,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "321214c3a2dd10fdf672ba96bd00703a51094bbe",
-   "sha256": "152i5kvkx8hsy9qlhalhjc4sf6ly3rlfymb8daygj428363xx25n"
+   "commit": "cd9ab2c63c71cee01a7fef35f11a84f3ef5cdec2",
+   "sha256": "0gw6bx5vk07lh5jdwxxccchw6w3wj7r33i323sykqgn66hgqnx5m"
   },
   "stable": {
    "version": [
@@ -61248,8 +62082,8 @@
     "magit",
     "xterm-color"
    ],
-   "commit": "d988abd99882c6b89f21f2746f721a4d7ece6ad4",
-   "sha256": "1dj2kw2wzxnms4z54pk7qngylvy903jwd84x3k5ys3wsydmk4bbf"
+   "commit": "46a3d36842a9c9ba74dae44f6b0fe4e728dd55a3",
+   "sha256": "1kaa8hkr9qaz7nxp8vjwgnmycqpbjdw7v2wvarl2wxs0k61277ff"
   }
  },
  {
@@ -61507,8 +62341,8 @@
     "libgit",
     "magit"
    ],
-   "commit": "321214c3a2dd10fdf672ba96bd00703a51094bbe",
-   "sha256": "152i5kvkx8hsy9qlhalhjc4sf6ly3rlfymb8daygj428363xx25n"
+   "commit": "cd9ab2c63c71cee01a7fef35f11a84f3ef5cdec2",
+   "sha256": "0gw6bx5vk07lh5jdwxxccchw6w3wj7r33i323sykqgn66hgqnx5m"
   }
  },
  {
@@ -61656,14 +62490,14 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20200816,
-    955
+    20200908,
+    1021
    ],
    "deps": [
     "dash"
    ],
-   "commit": "321214c3a2dd10fdf672ba96bd00703a51094bbe",
-   "sha256": "152i5kvkx8hsy9qlhalhjc4sf6ly3rlfymb8daygj428363xx25n"
+   "commit": "cd9ab2c63c71cee01a7fef35f11a84f3ef5cdec2",
+   "sha256": "0gw6bx5vk07lh5jdwxxccchw6w3wj7r33i323sykqgn66hgqnx5m"
   },
   "stable": {
    "version": [
@@ -61938,6 +62772,28 @@
    ],
    "commit": "605b01505ba30589c77ebb4c96834b5072ccbdd4",
    "sha256": "1hqz26zm4bdz5wavna4j9yia3ns4z19dnszl7k0lcpgbgmb0wh8y"
+  }
+ },
+ {
+  "ename": "magrant",
+  "commit": "0be4da82e342dd015fc0ba85e29829fad34a0a82",
+  "sha256": "1xzi86lg8ha8lwyf4qc6fqh8a581z9bakmvw5ridhslgnq1m03hf",
+  "fetcher": "github",
+  "repo": "p3r7/magrant",
+  "unstable": {
+   "version": [
+    20200917,
+    857
+   ],
+   "deps": [
+    "dash",
+    "friendly-shell-command",
+    "s",
+    "tablist",
+    "transient"
+   ],
+   "commit": "9e1ba1fb13af6e62a2f40ebbe049e81267292a0d",
+   "sha256": "1x354bmpdj1mhjk2rapczqv57x0vn12csc8x38yyb6w1rxqbdycz"
   }
  },
  {
@@ -62530,11 +63386,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20200815,
-    203
+    20200909,
+    2355
    ],
-   "commit": "ef2cb4d94af68908a4963afa492afba876725128",
-   "sha256": "0pi971jgil2wpfnrg7j7i9hh3a418nxf82jkammzry2ijv2q5kj5"
+   "commit": "8c6775a000bf40d7c7b35a529011a99231a4a4f7",
+   "sha256": "11w28nh3yfwrzdp8ml9da59m6cc81x4ivvr0id24pqwwdg7ws8dh"
   },
   "stable": {
    "version": [
@@ -63400,8 +64256,8 @@
   "repo": "skangas/mentor",
   "unstable": {
    "version": [
-    20190511,
-    1638
+    20200925,
+    1055
    ],
    "deps": [
     "async",
@@ -63409,8 +64265,8 @@
     "seq",
     "xml-rpc"
    ],
-   "commit": "b5e441b7dc077d5532a3818b5441e52baefad839",
-   "sha256": "1xrhg1jwmzlcqdk2w92s7ghbma1pfzjc48akl3d2cixxz3ha2ca2"
+   "commit": "0fddd3821de02cfe80ae6dc0e5eb0a52058b88df",
+   "sha256": "0w9p5n5skc4mykrcsn0psfsgac62l7rzqs5f9igxkxpg63xmr1fz"
   },
   "stable": {
    "version": [
@@ -63458,17 +64314,17 @@
     20191025,
     851
    ],
-   "commit": "3751cbfff75022c396c4ff4dc1729048f80daa4f",
-   "sha256": "0vbzbjajm0ww864cl7aaj70s3fkgg79cq8srdf5dmw1vwdrqq6ld"
+   "commit": "f578e387b4a025ccd5ac30e1f3a40de4767475a8",
+   "sha256": "0ffy2h1b1fik6mjb5xp1cjdhki9nrs3gkq3fxcpz15vnd9cx52pn"
   },
   "stable": {
    "version": [
     3,
-    3,
-    6
+    4,
+    0
    ],
-   "commit": "464df1a60775fd2bb70f4efff4f8603eaf834b74",
-   "sha256": "0yw3a8mhjsjh9359cvk7kr5ch6dhwvhv9zilk12fgyii9iw08mlz"
+   "commit": "f24ffbd7732b8b58f15092b0b5c11acd90a80ddb",
+   "sha256": "030v0v8vblgzimknq679jqyfidm0ggslz7hylfxxz9s1vzgr0y5s"
   }
  },
  {
@@ -63508,14 +64364,14 @@
   "repo": "abrochard/mermaid-mode",
   "unstable": {
    "version": [
-    20200804,
-    2107
+    20200819,
+    1759
    ],
    "deps": [
     "f"
    ],
-   "commit": "795bcf830d9345474fad864602180408891b292d",
-   "sha256": "0qdpbayxar0vkan0m83k4jir8saqy47nq2240608l8h9bjv48hz2"
+   "commit": "6ec97ab934023a8aa094705bb1c9803fd85d24c1",
+   "sha256": "1hhpihmacbam3fgk7pjlzn7hnakz38ksds052nzirvw6a68ynzgk"
   }
  },
  {
@@ -63526,19 +64382,19 @@
   "repo": "wentasah/meson-mode",
   "unstable": {
    "version": [
-    20200806,
-    1325
+    20200907,
+    743
    ],
-   "commit": "b471b9282724d6f324dbd6fa25d083635fc4293a",
-   "sha256": "0y5a1sfk4h4szv4v6693i3ylrf3xiwf8khrahdaz0bx210h2qmpg"
+   "commit": "d995dafa388ec03c0113cd1ac46403c20ad18ab0",
+   "sha256": "1swipsr9j0r2rpngz0dwykqnbs84j3pspx70dxmqyjm7qqabypnq"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
-   "commit": "d80ef159242402609a52c29949bd550c8442db53",
-   "sha256": "1720b3hpfqd989zrgcns51jbjrv4vzl9di9mccl55vkmkbqzfin0"
+   "commit": "70c35d7a303a66cada554c89d02ebd97d45c2a06",
+   "sha256": "0hlqvq3j4f6g16nj3bm2wbkncn8hv8c8iqd0sch3w80wwqnr622y"
   }
  },
  {
@@ -63753,8 +64609,8 @@
     "projectile",
     "s"
    ],
-   "commit": "5eb0423d4b7083cb330a73ef1cfd3e0dd8538567",
-   "sha256": "0vk2d59jvzhdm47w4kcn58njps444i0350lp5z7dnzhaag10dwc0"
+   "commit": "36166b9bffeb1b5f967be2ab6f3a504632c33a65",
+   "sha256": "1w16sx15fk2m04gl6ahkw2scw6bvpl6bf4g0gf7532rxg339xgjg"
   },
   "stable": {
    "version": [
@@ -63803,8 +64659,8 @@
    "deps": [
     "calfw"
    ],
-   "commit": "f9f048de9fe85a90d376d828ce3dad2a96c62c40",
-   "sha256": "1m6w12y9dcz85xm7lc7dhc7vjhw0bhdm0b4rcp1fr2sn9wv7c4wz"
+   "commit": "21c56d58f16d83c311fc2d603f2411e7f7fa8657",
+   "sha256": "0p6dghzms6v3vhy44qjb4y8mpx4y67sqzcdjk7ijdx3106n1wfj7"
   },
   "stable": {
    "version": [
@@ -63879,14 +64735,14 @@
   "repo": "emacs-jp/migemo",
   "unstable": {
    "version": [
-    20190112,
-    516
+    20200913,
+    12
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f42832c8ac462ecbec9a16eb781194f876fba64a",
-   "sha256": "0yasamfvad4azyby8mqyr2laap3ppknwb7i9w84zw14qq7g7pq5w"
+   "commit": "f756cba3d5268968da361463c2e29b3a659a3de7",
+   "sha256": "0q2mljzkpci6p8svz17xz48kv4yhh86irg2dpypk0k2dlyr8gykx"
   },
   "stable": {
    "version": [
@@ -63965,11 +64821,11 @@
   "repo": "muffinmad/emacs-mini-frame",
   "unstable": {
    "version": [
-    20200430,
-    721
+    20200926,
+    1323
    ],
-   "commit": "78d9bbb272acc5f2927648cc706321f95e2955c9",
-   "sha256": "1d4zgrpy21j35dzcspbv4szbprxxv9mygwqfx0x2bs53z4abk1kg"
+   "commit": "1fd7fcac0a5c6ba5bfdb9be00f9594fd8ffa90fd",
+   "sha256": "0j2w6rbhsfh135z189d7h8j880qxfby3ngv6y2189xpnha5cb8yw"
   }
  },
  {
@@ -64001,8 +64857,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "754a28efdf043e193922a897fc724ad9b9f2e8de",
-   "sha256": "1jx1baw6zskpnfdi02as59736jx4iy0q1n4x5n5ypvr7csrs1nz3"
+   "commit": "a4455fb70c6b4062c63ce61af09d2af99683b492",
+   "sha256": "0bwlx937hx11d4mj5cqp5rg7dh02499z85irgaylwvnsnx5sbni4"
   },
   "stable": {
    "version": [
@@ -64293,11 +65149,11 @@
   "repo": "ayrat555/mix.el",
   "unstable": {
    "version": [
-    20200419,
-    820
+    20200920,
+    1500
    ],
-   "commit": "37916fa5f7dfe448585fb83ea6253eb0f84df15f",
-   "sha256": "09pk4bakqz01ci06c79ywwb8ijdfgw3rxrz0wlaz4zmlbirkzma6"
+   "commit": "8a2f8c2df0e1817190c4dc0d2d7c7b5e5407744a",
+   "sha256": "0r8b3v4vp46afw8q5v03aifd1kpap79qc4af84placrhy80kya2v"
   }
  },
  {
@@ -64308,11 +65164,11 @@
   "repo": "jabranham/mixed-pitch",
   "unstable": {
    "version": [
-    20200511,
-    2052
+    20200916,
+    2311
    ],
-   "commit": "1cad46fddf741ed7ec5fc477d70e079e908e9ce6",
-   "sha256": "062np4d7blbwjc1kciqcp6hngmwr8i540zsv5f8p2qki4804b8ng"
+   "commit": "d305108f9520e196b533f05d1dcc284cf535faaf",
+   "sha256": "0yx89is3g2m8af8vfsz5rgjmfmx7mfrxlffb1x6y4b8lh9l0k6dj"
   },
   "stable": {
    "version": [
@@ -64350,11 +65206,11 @@
   "repo": "Mulling/mlso-theme",
   "unstable": {
    "version": [
-    20200513,
-    1751
+    20200828,
+    1221
    ],
-   "commit": "059c5773403b73a14a1b04d62d1d5b077a3f6e06",
-   "sha256": "1a00mybf269hlfzfhpcvlkkqgwck73hz5w1qsspg5w9w78qlymkn"
+   "commit": "b47243006470798caa4d3f8fe1af9bd5ef06bbee",
+   "sha256": "0gwa2izmi2ljh4avfpfq778ym1p91gsssbqz2q95m9py1vvb3xr7"
   }
  },
  {
@@ -64394,14 +65250,14 @@
   "repo": "purcell/mmm-mode",
   "unstable": {
    "version": [
-    20200714,
-    1714
+    20200908,
+    2236
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "9ffe364f3a31c7a771fe3401b8924642609953e8",
-   "sha256": "1yr7nd6kmvy3mc5k6vvwaikzy9cvly4617l4s9zrfrbnldpsyjk7"
+   "commit": "0d00cdf4d02cc166304f6967a20fa22e2eaf208b",
+   "sha256": "1drm89pi67khc04816nynslcqdr9xaf6mb85y6aqrrl4sy0zzwxl"
   },
   "stable": {
    "version": [
@@ -64538,8 +65394,8 @@
    "deps": [
     "yasnippet"
    ],
-   "commit": "361a3809f755577406e109b9e44d473dfa7c08e0",
-   "sha256": "0xcybq0cwd0c33bi1jf7h098a4anc4gkj3m1c97gc8mz9x4fjksy"
+   "commit": "44998ea42136a6912ce80061909db1c4c77c8ed8",
+   "sha256": "0w1d7j3ay0nkq4lp63lf7597rxfchikvw58w2h8g49cxx8vyl4l8"
   },
   "stable": {
    "version": [
@@ -64618,14 +65474,14 @@
   "repo": "ryuslash/mode-icons",
   "unstable": {
    "version": [
-    20190627,
-    2121
+    20200920,
+    2031
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f16969f053f43bf706257673d0800de438d4e33b",
-   "sha256": "0lvpvmc1fhhjg9rgh8gy6c0nqfn89v9cxy5pjpy0c8bdnwys2x7q"
+   "commit": "82cfba411c544c862a0854f682494a437642c957",
+   "sha256": "02rg73rnz9kp73f6c9vm7wihg3hp4x3x7bw6khx206qjwpy8pcfk"
   },
   "stable": {
    "version": [
@@ -64735,6 +65591,25 @@
   }
  },
  {
+  "ename": "modern-sh",
+  "commit": "b0db199b134810cd2912aaaaa9793d9a59bdedef",
+  "sha256": "1lz14cwv61kn765ahs91dzgpp18kzyhj0a10p6y39pk481fp7wbl",
+  "fetcher": "github",
+  "repo": "damon-kwok/modern-sh",
+  "unstable": {
+   "version": [
+    20200904,
+    1838
+   ],
+   "deps": [
+    "eval-in-repl",
+    "hydra"
+   ],
+   "commit": "05430398a5070245c4358e6a1b7e49a154da174e",
+   "sha256": "05k5ak09rw8zrn5k7zjc54ckv4jrp9fs3s3r3ja5cil45irgcmhv"
+  }
+ },
+ {
   "ename": "modtime-skip-mode",
   "commit": "486a675ca4898f99133bc18202e123fb58af54c0",
   "sha256": "1drafwf4kqp83jp47j2ddl2n4a92zf1589fnp6c72hmjqcxv3l28",
@@ -64750,51 +65625,66 @@
   }
  },
  {
+  "ename": "modular-config",
+  "commit": "48d97bd2c3940a1950b37ded3fba90beebab7725",
+  "sha256": "0par1pj52n67my8f8r1hjgjx0waqq6hjzfgzhwphl7skfsa38r0f",
+  "fetcher": "github",
+  "repo": "SidharthArya/modular-config.el",
+  "unstable": {
+   "version": [
+    20200824,
+    442
+   ],
+   "commit": "c0a6d3dac1aa176deb8417c77dfeac06e9f18e1f",
+   "sha256": "1pky409m3mip42k6qw4sf28ja50lsw17318kwgcrkl0nrvnbs31j"
+  }
+ },
+ {
   "ename": "modus-operandi-theme",
-  "commit": "6f3291ebede304fe14240870372c0d396f43c0d9",
-  "sha256": "15rq4l14a7y6p8vhgbs017crfwyp7fq61n03xbfycq92mlx89kgx",
+  "commit": "e5d94c5aa3f058c3919c44a931c86bb2086a3171",
+  "sha256": "1i1pqg73pf6pfbgfvb126yvf5cfipsljnv0ll4zv5ma4cmq2m0z9",
   "fetcher": "gitlab",
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20200819,
-    628
+    20200927,
+    1047
    ],
-   "commit": "26a211835b6e62e4ad29b2feee75472e02046fa8",
-   "sha256": "12rqgyrnk6x2a7b635wg4c5ihyh9s8ig7s1431xqj91pdx7756kx"
+   "commit": "f8460e53e6c24bf792f15fd86be4fa1de8021f61",
+   "sha256": "0syjlrb7336103cqi8bg3a9rbwrcfm42v2dy4w0mycswqr470ipb"
   },
   "stable": {
    "version": [
     0,
-    11,
+    12,
     0
    ],
-   "commit": "c376b08059028737390f41fb82f64d748c42970c",
-   "sha256": "08alhr6d7shmm1fcvca0a0ipi9mvnaqp5klvqdb1d171h457fcv3"
+   "commit": "67554a6291aa4ad39b9351e8ee3025d4a2aaba6e",
+   "sha256": "1k89942qgbzf5n96f2f1nn2z3i859iy5dxjz55ldq4d1dsd8g9db"
   }
  },
  {
   "ename": "modus-vivendi-theme",
-  "commit": "74909ab53df89c5b720c89527b3b4c9aec8351b9",
-  "sha256": "16bs48amvwikp4ikv8fs9zrsyz942jdzlz9ddf3qv8c9vpc5x58q",
+  "commit": "e5d94c5aa3f058c3919c44a931c86bb2086a3171",
+  "sha256": "1wzvswpvwd89vf1475zk5rnyjggkvydhimx30p7bvf9ld0ivipcf",
   "fetcher": "gitlab",
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20200819,
-    628
+    20200927,
+    1047
    ],
-   "commit": "26a211835b6e62e4ad29b2feee75472e02046fa8",
-   "sha256": "12rqgyrnk6x2a7b635wg4c5ihyh9s8ig7s1431xqj91pdx7756kx"
+   "commit": "f8460e53e6c24bf792f15fd86be4fa1de8021f61",
+   "sha256": "0syjlrb7336103cqi8bg3a9rbwrcfm42v2dy4w0mycswqr470ipb"
   },
   "stable": {
    "version": [
     0,
-    11,
+    12,
     0
    ],
-   "commit": "c376b08059028737390f41fb82f64d748c42970c",
-   "sha256": "08alhr6d7shmm1fcvca0a0ipi9mvnaqp5klvqdb1d171h457fcv3"
+   "commit": "67554a6291aa4ad39b9351e8ee3025d4a2aaba6e",
+   "sha256": "1k89942qgbzf5n96f2f1nn2z3i859iy5dxjz55ldq4d1dsd8g9db"
   }
  },
  {
@@ -64805,20 +65695,20 @@
   "repo": "kuanyui/moe-theme.el",
   "unstable": {
    "version": [
-    20200216,
-    1927
+    20200917,
+    356
    ],
-   "commit": "01d00a8d75b19f641b639ba23793cdd507c61f05",
-   "sha256": "14higsv6h0pka90gr25a3yxh95xn65l6qxb39mmdzkfdlnzsg664"
+   "commit": "b135f24d5ad4af171f27954b8d4cd6112e0300e0",
+   "sha256": "0mdf2amfbg10gdp3vlwly792hz210gj4ay6mc2sf201qlgryscsb"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
-   "commit": "b8f0206614ab40ffb75e50ce6c38675fb9c7cf2e",
-   "sha256": "0pn3a1rrj7ycxh91x3q008b6rmq7rbl8ir6diqzqfp6y465pn2w2"
+   "commit": "01d00a8d75b19f641b639ba23793cdd507c61f05",
+   "sha256": "14higsv6h0pka90gr25a3yxh95xn65l6qxb39mmdzkfdlnzsg664"
   }
  },
  {
@@ -64972,11 +65862,11 @@
   "repo": "oneKelvinSmith/monokai-emacs",
   "unstable": {
    "version": [
-    20200416,
-    2001
+    20200918,
+    1348
    ],
-   "commit": "4281fc13dadef98942c8d43024de024f2392fec5",
-   "sha256": "0049ny3m1mgn0b97m0clcmmh2xzn66flbsd8k45dn0qxm5wlaj3n"
+   "commit": "791baae69b02ee007cde779a80abc1a6b5962cf7",
+   "sha256": "00r5i98lplsra7fwrvir9pr7mbc1kia0xlmrlgs0vmn4bhxa2fpc"
   },
   "stable": {
    "version": [
@@ -65059,20 +65949,20 @@
   "repo": "jessieh/mood-one-theme",
   "unstable": {
    "version": [
-    20200730,
-    18
+    20200904,
+    1639
    ],
-   "commit": "00e2d3797a271c0b3ecb0bab56dc705558015311",
-   "sha256": "0cq5y5fcx581vv8fzbxn5k71r95ss92yvddw4nk85h3710scclds"
+   "commit": "47f043c1a883e3b0fd550eafffe71b915eb892c1",
+   "sha256": "0zh0l2zpnms4s1c33ksj6rr8cc6bd9pxnc73cwvmaysak1650jfq"
   },
   "stable": {
    "version": [
     1,
-    0,
-    6
+    1,
+    0
    ],
-   "commit": "00e2d3797a271c0b3ecb0bab56dc705558015311",
-   "sha256": "0cq5y5fcx581vv8fzbxn5k71r95ss92yvddw4nk85h3710scclds"
+   "commit": "82b471852a23bc4de972cac32da322c2b168ad9c",
+   "sha256": "09ykh1c21kphfzli1qzrlx13bn6p22873y6rwkx9fnj2232gv9vi"
   }
  },
  {
@@ -65107,11 +65997,11 @@
   "repo": "takaxp/moom",
   "unstable": {
    "version": [
-    20200725,
-    126
+    20200908,
+    1438
    ],
-   "commit": "d6dc1f42ccf0d53c8f5d5a327442ae52b2de7aed",
-   "sha256": "0s0liwc9sriv2ar6905n2vsdf9x8l85mwfyw05kr6vmxh9w08wbx"
+   "commit": "806f9fe170c010138caa6970802ac7ed6f31a5f6",
+   "sha256": "0p3jk5dbcih4zf4si3l8kjqsyzd0vz7ghaf7kgmhwy8nwvg1x26c"
   },
   "stable": {
    "version": [
@@ -65439,8 +66329,19 @@
   "repo": "google/mozc",
   "unstable": {
    "version": [
-    20180101,
-    800
+    20200822,
+    1229
+   ],
+   "commit": "667db549e000778e9b08749326086b6bec58cad0",
+   "sha256": "0nbxcai97h5gdiy7aryx3dxs6whl66900mvwxbygmh1nlzvc439h"
+  },
+  "stable": {
+   "version": [
+    2018,
+    -4,
+    2,
+    -4,
+    26
    ],
    "commit": "afb03ddfe72dde4cf2409863a3bfea160f7a66d8",
    "sha256": "0w2dy2j9x5nc7x3g95j17r3m60vbfyn5j617h7js9xryv33yzpgx"
@@ -65852,14 +66753,14 @@
   "repo": "wavexx/mu4e-jump-to-list.el",
   "unstable": {
    "version": [
-    20190419,
-    1442
+    20200913,
+    1558
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "358bba003543b49ffa266e503e54aebd0ebe614b",
-   "sha256": "00y9nap61q1z2cdql4k9g7fgi2gdgd9iy5s5lzrd9a4agbx6r7sv"
+   "commit": "a9a3a1d371451d12e0ec24e456c7d90ccacd9cdd",
+   "sha256": "0yq7ky2yk2j6i2p5bzh06ipbj2ab70bi6hvq7hf4jqvr2i94mlwb"
   }
  },
  {
@@ -65896,11 +66797,11 @@
   "repo": "mkcms/mu4e-overview",
   "unstable": {
    "version": [
-    20200817,
-    2046
+    20200824,
+    1549
    ],
-   "commit": "467a7dfda4e534783469a137545193ded8a66723",
-   "sha256": "08lwvgwfsxmvm5bnw0sl96dry57h4wcjsi2fr2mmfq190kdjrizy"
+   "commit": "7daaa35a6d78feb83167e780a9c23da719c9051b",
+   "sha256": "1fv31h6f7vhnkdrjf2jij6nirnqfxmxq464cmqzp3lfyzxi8pxg0"
   },
   "stable": {
    "version": [
@@ -65920,11 +66821,42 @@
   "repo": "wavexx/mu4e-query-fragments.el",
   "unstable": {
    "version": [
-    20170923,
-    1322
+    20200913,
+    1558
    ],
-   "commit": "34ddad4e6785f575333efcc66153d892daa1c884",
-   "sha256": "0l5i3a88j9il2y0jq2sfzwi9q3czc1wi8n9nvgdysj5db5m4xsw6"
+   "commit": "6a81d43fcbdc51c2fc47d88f4fd8f25d8f906b79",
+   "sha256": "0sdjkxb7f31bsi1vj6vn2aw1lwq026sz782ys92zprncjp2mkizp"
+  }
+ },
+ {
+  "ename": "mu4e-views",
+  "commit": "f4030dadc74622b7c004775905a1b5307943d72e",
+  "sha256": "0y0ya7scianpi8zmqzbxv5f6a3q7rhxlsg0dcrdrdjnpn8k88b9c",
+  "fetcher": "github",
+  "repo": "lordpretzel/mu4e-views",
+  "unstable": {
+   "version": [
+    20200830,
+    1608
+   ],
+   "deps": [
+    "ht",
+    "xwidgets-reuse"
+   ],
+   "commit": "af3916b2639a5a94676d4f11471e25b63ba76d0a",
+   "sha256": "1h0anxs5xammkjky1syy9ja8xgskbf3j7a8hf12ggmihk9qa1dvk"
+  },
+  "stable": {
+   "version": [
+    0,
+    4
+   ],
+   "deps": [
+    "ht",
+    "xwidgets-reuse"
+   ],
+   "commit": "4977f6517cf12ac994859c4ba992d5e2999ae016",
+   "sha256": "07y96ii3ysqlikq7cixcwf1mr7ysazmmnp42wzah02zdchj9irzh"
   }
  },
  {
@@ -65938,8 +66870,8 @@
     20180415,
     1219
    ],
-   "commit": "7078e439ee0433a8fbd1cb174464496f9a9d00fa",
-   "sha256": "1wpcv4wdk735w701d9bm9qqji98mmzg7l7qkq1jmjw1hbpqhnwl2"
+   "commit": "fd052645bcaa3cca8cede1c587a0b05ab5bd66b2",
+   "sha256": "13jz41iwzczrx9psp5dzh3l1m08idl5walr5lk6yljvx4840r9ij"
   }
  },
  {
@@ -65950,15 +66882,15 @@
   "repo": "mihaiolteanu/mugur",
   "unstable": {
    "version": [
-    20200602,
-    642
+    20200831,
+    702
    ],
    "deps": [
     "anaphora",
     "s"
    ],
-   "commit": "5333d0ff56cb4d1448e4cdf48278abcbc32e96eb",
-   "sha256": "07xglyc05d42inlh4j3nvdyi55pa0cy013c5yk8rv94xs31pjd8k"
+   "commit": "34dfba027bf11e4cca2c547ce80b73d7324c7ba6",
+   "sha256": "011qr9jc90arg3y8y49hjmv94968ym81a36db0dvxyf08hspz006"
   }
  },
  {
@@ -65993,14 +66925,14 @@
   "repo": "ReanGD/emacs-multi-compile",
   "unstable": {
    "version": [
-    20200517,
-    1747
+    20200913,
+    8
    ],
    "deps": [
     "dash"
    ],
-   "commit": "e3772f7e68968f7fa2c97615115cd3fc0f701229",
-   "sha256": "0r1ahchfhyqjyc0q0xp5x0p34d6hg4ga3cga1l6dlaw1xjflrsq2"
+   "commit": "508b524aa880e0ca6695f0d5543ee7659f2dea7c",
+   "sha256": "0g5ja8ra6kyfpvkavy9diiwjasc4v2z80yi98kahi5nckfp90kvc"
   }
  },
  {
@@ -67362,8 +68294,8 @@
   "repo": "felko/neuron-mode",
   "unstable": {
    "version": [
-    20200806,
-    833
+    20200922,
+    1522
    ],
    "deps": [
     "company",
@@ -67371,8 +68303,8 @@
     "markdown-mode",
     "s"
    ],
-   "commit": "18d230ce6b126fe7193db9c20ac93811ccfe779d",
-   "sha256": "18s7phs285jc4whd54x3dvbajqil7yff18xirbvf9pjlzivqwfk5"
+   "commit": "6042cb8960f0018d19db7be84e76622bdfaed5ec",
+   "sha256": "1wvi1apnsxmlc93lnhgkrvxcb9b3d13sr722lzwjr0sv1vjp8gnq"
   }
  },
  {
@@ -67621,8 +68553,8 @@
     20181024,
     1439
    ],
-   "commit": "9ddd3c917793bb97eb19d571429cdedf07501c03",
-   "sha256": "0lrj3k5ng748faarz63rspnd4sh38qvkxxcgbmk81h4cqvv529fy"
+   "commit": "54959b0f2c4950d97d94c03810b3b5185be0d69e",
+   "sha256": "1nxlj9nx9j923dy6iy6i2is4v15k8c74jksgzld8iq6fjzlmi1aw"
   },
   "stable": {
    "version": [
@@ -67720,20 +68652,20 @@
   "repo": "NixOS/nix-mode",
   "unstable": {
    "version": [
-    20200811,
-    1947
+    20200915,
+    1537
    ],
-   "commit": "0cf1ea1e0ed330b59f47056d927797e625ba8f53",
-   "sha256": "0wsiyvv23jcazh7jrbkg3d0qs1y5i88ahsdi3pp2s8q9h3lyhwnb"
+   "commit": "bb0b49e3ac1579d3d811529ed274272c54a9fe3c",
+   "sha256": "1qcr1b0nappk1cw8xc3wj7jq1f10x1ywkdjwc371vwimrcy68phd"
   },
   "stable": {
    "version": [
     1,
     4,
-    4
+    5
    ],
-   "commit": "e4e604ae3ac91748c4e7d51a591cb9ee60961b7c",
-   "sha256": "19f36kl00pxm2a18hn4cdsdvxlfsdx1pnnm6s6zxd8nw6y8ynvn0"
+   "commit": "471a90ac96f4c94a717e5138fb0b03a167cfbf26",
+   "sha256": "1bqlhkxg0faddhvxx909dq46dxdxk4mdyhdpww92dmzgxdpq38sx"
   }
  },
  {
@@ -67904,8 +68836,8 @@
   "repo": "dickmao/nndiscourse",
   "unstable": {
    "version": [
-    20200524,
-    1649
+    20200829,
+    1751
    ],
    "deps": [
     "anaphora",
@@ -67914,8 +68846,8 @@
     "json-rpc",
     "rbenv"
    ],
-   "commit": "e8d99d132d649e179f7cc81b80d873436b4e8ce1",
-   "sha256": "03iqbb3svidczzci0l8b19zk8yx9xdslf9y0hpn2y8fzhf4gszrp"
+   "commit": "899e2c05026bf32c414190b9e57ae60fe33de2a0",
+   "sha256": "0kvrag88nkdw20ql2mbz3lwixz1r73s60gn5xad6x5msqn6q4bpl"
   }
  },
  {
@@ -67999,14 +68931,14 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20200817,
-    1831
+    20200923,
+    1939
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "85629e5979f2159ab8cc77814dd4cb219e6ba69c",
-   "sha256": "0ii19sbmsl35y1glj2mz309aila8954rmpah7y7mr2b34ami6hdw"
+   "commit": "438472ca63d8368a3d9d1691618df873758739c8",
+   "sha256": "0b5sgy2ksykcy9ha1nij8qkwnjx8n06gqp05fldw7ad1z1ljsjhp"
   },
   "stable": {
    "version": [
@@ -68305,21 +69237,19 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20200816,
-    1342
+    20200919,
+    949
    ],
-   "commit": "8776faf6d5118e8152ecfacf94accf35ccebf1d2",
-   "sha256": "0r4f12m2xbwzl0fhqcz2vv7dcr0psnhy8ahhv6b5gsdfdfd2w4w3"
+   "commit": "45193bab16c728ba892a5d45fc62ef59e2a6ef85",
+   "sha256": "18z9gicy3m91axv8grxn1d68r66bnxa2nlw4y7nq6wsjd683v5qd"
   },
   "stable": {
    "version": [
     0,
-    31,
-    -1,
-    1
+    31
    ],
-   "commit": "75ec89dfb4c254ba0b88ddb479e6ede6bfb7d0c7",
-   "sha256": "1pc4nkbhxmx1qlamnjzd1arzr3sgp0m95vn1jmmfivgddy3xh8b0"
+   "commit": "4175d5cb914416dc0e159a00457b1c2a82f3905f",
+   "sha256": "0f9d9k9avb46yh2r8fvijvw7bryqwckvyzc68f9phax2g4c99x4x"
   }
  },
  {
@@ -68382,6 +69312,36 @@
   }
  },
  {
+  "ename": "notmuch-maildir",
+  "commit": "4d3569dd0faa536bce74636f010c836606367a69",
+  "sha256": "1m45nq256s0k86p0rkfq0rvdifbcvx40x7sybdzg9pgn8q2kvbff",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~tarsius/notmuch-maildir",
+  "unstable": {
+   "version": [
+    20200829,
+    1749
+   ],
+   "deps": [
+    "notmuch"
+   ],
+   "commit": "6d9f4abd2c97cec60a6e565d2a74fd4e0b1cae5d",
+   "sha256": "1fm46bq137dxagsyr8irbn907zzlzdzyjqa2mbhdrphf6sdi0s6j"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "notmuch"
+   ],
+   "commit": "8c641d9688f20262c9dac59901aaecd2a21525d7",
+   "sha256": "1nh7vkxhwb2cmm8g7gxh3rc6lcfqlhsbf82vi3lsbdq008p1b3kh"
+  }
+ },
+ {
   "ename": "nov",
   "commit": "20b2cc78b41a26e434b984943681fea774fd3c50",
   "sha256": "1w4il2jbn0x6v11y3rnz5w5vs0d0hhlqqzzxdpkpmrq9ycbq58hw",
@@ -68389,15 +69349,15 @@
   "url": "https://depp.brause.cc/nov.el.git",
   "unstable": {
    "version": [
-    20200813,
-    821
+    20200911,
+    1352
    ],
    "deps": [
     "dash",
     "esxml"
    ],
-   "commit": "6cfd80124038504038bcb5d4cf2e8b037c36841a",
-   "sha256": "1zr8q9kl3i1900vp08c52ywx2lpwp4iyqs8vm3kb8a7dsc4hpggf"
+   "commit": "23e5d9c4c63e3a7dc08110a8dfcbb97a1186a37f",
+   "sha256": "11b8s1hncm5d443jypz18x5v13kb6bxsfw6qc8j2sglkdhfvj43y"
   },
   "stable": {
    "version": [
@@ -68421,11 +69381,11 @@
   "repo": "muirmanders/emacs-nova-theme",
   "unstable": {
    "version": [
-    20200213,
-    102
+    20200826,
+    1803
    ],
-   "commit": "4553fabbcd340f3f2fa59dbfb6f3f32ecb016e6f",
-   "sha256": "0y0f7f03hikd5j20fc40g0hrp7aiwzna9rfwpxzlj10n8ijmygq9"
+   "commit": "279e165171558930f56d8d5cfc83e1bb6560e452",
+   "sha256": "0rwqnqkbasgp80cgsz0pp1gbg2w7803lh7z02565p193mrvfwr3b"
   }
  },
  {
@@ -68926,16 +69886,16 @@
   "repo": "astahlman/ob-async",
   "unstable": {
    "version": [
-    20190916,
-    1537
+    20200921,
+    205
    ],
    "deps": [
     "async",
     "dash",
     "org"
    ],
-   "commit": "80a30b96a007d419ece12c976a81804ede340311",
-   "sha256": "0jhgzmqds73yc49hc4yarp1a25pci9qmsvnpcxd7kv5saha40hnn"
+   "commit": "de1cd6c93242a4cb8773bbe115b7be3d4dd6b97e",
+   "sha256": "12n6fvjiwkf02aypvj5zrbjrxhz2p0rcq2k3mfz5ravyarpvrybp"
   },
   "stable": {
    "version": [
@@ -69401,8 +70361,8 @@
    "deps": [
     "org"
    ],
-   "commit": "d21d436814e9605cf2a942b709f957695298dc70",
-   "sha256": "0zmckisi9q9kv25jh0jn0ab9xbh2b7d4mzyyi1sdgnkg0ayzvvhb"
+   "commit": "a20e3fedbac4034de4ab01436673a0f8845de1df",
+   "sha256": "0dgygnh12izr92k28ygjhhpz0jx6vkrskbiplk87fkg1w8hyiy2a"
   }
  },
  {
@@ -69869,14 +70829,14 @@
   "repo": "clemera/objed",
   "unstable": {
    "version": [
-    20200815,
-    1504
+    20200911,
+    1435
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "dea5a64a4da32e8947fe5b45de569e293aaa8a96",
-   "sha256": "1jmr14bfs489g0czpmn987gpmmdqx72blkzcnd8sn1sfyk5n18ng"
+   "commit": "e93dda73bd932563d35e76f1c2f1b50895b640cf",
+   "sha256": "13d4lsx8jglw5cz5r3mdv15vppvqxvqw4a9g1p2y9mn09kgx9bvk"
   },
   "stable": {
    "version": [
@@ -70087,26 +71047,26 @@
   "repo": "oer/oer-reveal",
   "unstable": {
    "version": [
-    20200813,
-    1540
+    20200921,
+    1652
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "165eaf9d151c589226f7a4e0edc3a3100c0a9efb",
-   "sha256": "06740c4qdpdrim5wj88gw973lbh59h6sx4kzrpl37cqjvdsawbzv"
+   "commit": "81f4b92c1cd78b6bd2b65379ab5da1371448f34b",
+   "sha256": "1iys8v29crsq9sbjmk0gi792bf9dag93n086k0g8bw5py1v46wsr"
   },
   "stable": {
    "version": [
     3,
-    2,
-    1
+    5,
+    0
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "7a99fa342eae234069344893b5bc851280ff2dc9",
-   "sha256": "1fsp6li73dk2272lgj4kxapd1sqw2pqj42rlcbl5hhh35hva714h"
+   "commit": "81f4b92c1cd78b6bd2b65379ab5da1371448f34b",
+   "sha256": "1iys8v29crsq9sbjmk0gi792bf9dag93n086k0g8bw5py1v46wsr"
   }
  },
  {
@@ -70211,11 +71171,11 @@
   "repo": "rnkn/olivetti",
   "unstable": {
    "version": [
-    20200702,
-    601
+    20200924,
+    813
    ],
-   "commit": "0bc5e98b8456493084d1bd3df35e92a12c5da3b2",
-   "sha256": "121dzm051jivskssfvxs5kxkviqivf1j0fr3q8rkfqii7rxdw84r"
+   "commit": "075c30c187609b907e2482b66029866900c7b7ca",
+   "sha256": "15f2kll4350lnjm3nldy9229zjh3fj5wxfksv4gkgbs481jml4gf"
   },
   "stable": {
    "version": [
@@ -70776,11 +71736,11 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20200614,
-    1920
+    20200905,
+    2113
    ],
-   "commit": "1f1e0380e2a8cd4fc29b8cc2e00cb01b56d86fbc",
-   "sha256": "15an4y0xdaih86p33zmb6r7qx5n0cs54flcnnq50jakkxlg9s8xh"
+   "commit": "e56eeef6e11909ccd62aa7250867dce803706d2c",
+   "sha256": "1g4963snkp1gxlf5h1h5kjn4pj55f844ajzx4n5nhkws44sr6isg"
   },
   "stable": {
    "version": [
@@ -71089,34 +72049,36 @@
   "repo": "lepisma/org-books",
   "unstable": {
    "version": [
-    20200522,
-    1800
+    20200905,
+    740
    ],
    "deps": [
     "dash",
     "enlive",
     "helm",
     "helm-org",
+    "org",
     "s"
    ],
-   "commit": "49617901d087f532d7cae1aa23637671fd153d20",
-   "sha256": "09nq7na9r39pl6aljrf5vpkfih92ms7s081nxdrhxcscaysk08kb"
+   "commit": "a88d39e364757594c6b3830cc36f342ee0d1b8ab",
+   "sha256": "1axzhb9k1i8l9rksk14bb04v4q4mx498f5psnalxwvn0563ngs5r"
   },
   "stable": {
    "version": [
     0,
     2,
-    19
+    21
    ],
    "deps": [
     "dash",
     "enlive",
     "helm",
     "helm-org",
+    "org",
     "s"
    ],
-   "commit": "4b93bb1e20e2e66b9e64819b21ca75f36c389370",
-   "sha256": "1ksvdl8liqv74am1r7brn8slkwgbc83jv7l92qk9md7s1krcb6y0"
+   "commit": "a88d39e364757594c6b3830cc36f342ee0d1b8ab",
+   "sha256": "1axzhb9k1i8l9rksk14bb04v4q4mx498f5psnalxwvn0563ngs5r"
   }
  },
  {
@@ -71133,8 +72095,8 @@
    "deps": [
     "org"
    ],
-   "commit": "671db0e08b91c7d2637d765a7afca8b2561275c8",
-   "sha256": "17i0lnp9xyzbky0xh1qi6q7jpnpz950j2zxwv2hg007zziqd21ks"
+   "commit": "1662ebd680f041eb7deae68d3a24465a37ffadde",
+   "sha256": "03m28kq3yvq2qa0g64w99i9ax8vqsc2xg7mc7vva4a9vdbyl1zdn"
   }
  },
  {
@@ -71458,11 +72420,11 @@
   "repo": "emacsattic/org-doing",
   "unstable": {
    "version": [
-    20200510,
-    1732
+    20161017,
+    1620
    ],
-   "commit": "df916bb13577f4de9d58332453cb8bf51eac37ba",
-   "sha256": "014xz7yjw97i1dzyg487r2v9rf3jk9jwc5acgg1fj5kc2n1m299m"
+   "commit": "07ddbfc238cba31e4990c9b52e9a2757b39111da",
+   "sha256": "1d9gf6wf3jp07bn2h6bbc75iy0wwdvzdlj9n4nwbc46nf3k154pa"
   },
   "stable": {
    "version": [
@@ -71500,14 +72462,14 @@
   "repo": "abo-abo/org-download",
   "unstable": {
    "version": [
-    20200818,
-    1117
+    20200914,
+    1558
    ],
    "deps": [
     "async"
    ],
-   "commit": "67b3c744f94cf0bf50f7052ce428e95af5a6ff3f",
-   "sha256": "0f94drnfkyd1vpdhkr463zv952lk1v895dwrzk1251j8fb9vdf9m"
+   "commit": "42ac361ef5502017e6fc1bceb00333eba90402f4",
+   "sha256": "0cg4y7hy7xbq4vrbdicfzgvyaf3cjbx2zkqd4yl0y2garz71j99l"
   },
   "stable": {
    "version": [
@@ -71941,8 +72903,8 @@
   "repo": "trevoke/org-gtd.el",
   "unstable": {
    "version": [
-    20200809,
-    2319
+    20200820,
+    1444
    ],
    "deps": [
     "f",
@@ -71950,14 +72912,14 @@
     "org-agenda-property",
     "org-edna"
    ],
-   "commit": "6837b4b192c850ae45b042a78b79f4e7cca2d56e",
-   "sha256": "1m3na0xswmndhjmgpqh1m5pj9cy5jp3vjmga74x2igrhk40ba8ly"
+   "commit": "e9be1ff6c1d5d2d2381b8e7bb45150f6734af1fa",
+   "sha256": "11lfjs4mpcsw565s45s4f50awfigdf5dq4plcid0x0zz361jgs3f"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
    "deps": [
     "f",
@@ -71965,8 +72927,8 @@
     "org-agenda-property",
     "org-edna"
    ],
-   "commit": "ee10b8cb70d27d01280de8f282d9602f3497b8ab",
-   "sha256": "0j555cfi312j0kkpba91np3vwly26y7hyyyaxr2lcg84jd17frjg"
+   "commit": "4ca0c8c50e559f2c15bdaf076d3e08a6cb524b5b",
+   "sha256": "17gz0w3bab2agqbyx4kpinn68xk026wa1rmscr3b73sf94gaxmfi"
   }
  },
  {
@@ -71977,15 +72939,15 @@
   "repo": "marcIhm/org-id-cleanup",
   "unstable": {
    "version": [
-    20200523,
-    735
+    20200914,
+    505
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "e79540b64e0ee5ef11adfeb932a9b04beb905680",
-   "sha256": "0qn85515lzhqhn49byf0vpyhbgfwyibf21f7xl2j7cj306x1f79c"
+   "commit": "c2018252fb22aa13005fcf5869af0c3317f0b46d",
+   "sha256": "10kxayj93kns9y4zhayshgp69j1ji664762qibb1kzx18yax0fkj"
   },
   "stable": {
    "version": [
@@ -72033,15 +72995,15 @@
   "repo": "marcIhm/org-index",
   "unstable": {
    "version": [
-    20200516,
-    1343
+    20200917,
+    1932
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "f868df4aa4f49484cf818627251b7c7282d8d20e",
-   "sha256": "14mr03sjjkxix0sphnp7flr6f9z20g5x7ifv3hl2nvmh4794cf6n"
+   "commit": "cd80c9085a6cf797385bc75ca48eafb6b5fc354d",
+   "sha256": "0wwp5hyh0a3r0sqhd7if03zbgk4zds2fg2w6dj8zbbh8prm02ggg"
   },
   "stable": {
    "version": [
@@ -72085,16 +73047,16 @@
   "repo": "ahungry/org-jira",
   "unstable": {
    "version": [
-    20200714,
-    41
+    20200926,
+    446
    ],
    "deps": [
     "cl-lib",
     "dash",
     "request"
    ],
-   "commit": "5c90dce918fcb873754bff375e988b17dcc69701",
-   "sha256": "1d38szx1vq4k1pfdisr3czwaasfw7jkwa2vswfcrnk3d65akkgzk"
+   "commit": "0b7bd4d85bb7e64d88ced0f850db3a3fbf6433df",
+   "sha256": "0vc3r25a1aqxzss15qpgnym7rgkwb9d5mxwigxdsrqmcb6zi6hmv"
   },
   "stable": {
    "version": [
@@ -72120,26 +73082,26 @@
   "repo": "bastibe/org-journal",
   "unstable": {
    "version": [
-    20200815,
-    1335
+    20200912,
+    1339
    ],
    "deps": [
     "org"
    ],
-   "commit": "a2728e25b854af21cea8e8d313714c993eb1c848",
-   "sha256": "1rvlrn0jlw6a3p48zg50vw4nll2cffk9nkng0qvh8ws0a161w2j1"
+   "commit": "e7c51c40f1d6c1f24a9924efa78256044d72c653",
+   "sha256": "0hc5d0ad638qp5n44x048bvi2hvj3bpwlj8wfvc6as1ihiw10slz"
   },
   "stable": {
    "version": [
     2,
     1,
-    0
+    1
    ],
    "deps": [
     "org"
    ],
-   "commit": "f7bfc592ec11e9e5d0b0bfa377961167b68bba72",
-   "sha256": "1imrfvzc52l976598df2243s4jdwicznnxs3q91m5vrjsk23zfp2"
+   "commit": "25ebb8f1c8cd8993fb75a15e2bb8144fb6f9e006",
+   "sha256": "1p9i6v3bwi1ab576vc9qg1ki91197d6nkkg857s52zsan1zlkzzw"
   }
  },
  {
@@ -72199,15 +73161,33 @@
   "repo": "stardiviner/org-kindle",
   "unstable": {
    "version": [
-    20190315,
-    439
+    20200906,
+    944
    ],
    "deps": [
     "cl-lib",
     "seq"
    ],
-   "commit": "612a2894bbbff8a6cf54709d591fee86005755de",
-   "sha256": "1h3pbjiy5v8lp3p6dry4jk3pvdp7hpkc517d3w9ldhz6nmaiccgg"
+   "commit": "5fde4a53f062612b2a118c53ff0196a128b80d6d",
+   "sha256": "0rkj936cdlk9n9k8pi957p3y43xs85zfc9pnn4qhn943sk111b6c"
+  }
+ },
+ {
+  "ename": "org-link-beautify",
+  "commit": "ee5e68e4aeea824af0abef8b6552852a8436b178",
+  "sha256": "0s0hrq3pr3c7mdmnl69spn7k8905y3j75wkzncnq8dsia9s5q7xi",
+  "fetcher": "github",
+  "repo": "stardiviner/org-link-beautify",
+  "unstable": {
+   "version": [
+    20200828,
+    922
+   ],
+   "deps": [
+    "all-the-icons"
+   ],
+   "commit": "be208d2aceb0cc71fcd54a8127af25800461b94e",
+   "sha256": "1zhjhdjywqh49ks0vmqs6h747y3kpl8vpyv953ypg43310a8fvyz"
   }
  },
  {
@@ -72287,24 +73267,6 @@
    ],
    "commit": "65c09c5deba065752eb88875c54dc26abcdfaffb",
    "sha256": "11chlfvil0wbvzaplzdymn4ajz85956hcs8bh3zds6ij806mqa4y"
-  }
- },
- {
-  "ename": "org-lookup-dnd",
-  "commit": "77a8cd0ff954ab87fa57cc6544146b5937779a3b",
-  "sha256": "06g2w75nyk354fpg8b8w1v4xzsiwx3sglwxk3azrn2g4sdlammmz",
-  "fetcher": "gitlab",
-  "repo": "maltelau/org-lookup-dnd",
-  "unstable": {
-   "version": [
-    20190622,
-    2224
-   ],
-   "deps": [
-    "org-pdfview"
-   ],
-   "commit": "bba86a9b9979bd79e9bfaf4a7b472682b9435490",
-   "sha256": "1ndd1iw207jnv0mib2r6mxldba4c4nna69wdvj8mzynn6ldxg5bk"
   }
  },
  {
@@ -72397,28 +73359,30 @@
   "repo": "ndwarshuis/org-ml",
   "unstable": {
    "version": [
-    20200806,
-    2244
+    20200921,
+    36
    ],
    "deps": [
     "dash",
+    "org",
     "s"
    ],
-   "commit": "e3df332fac6dea0810db0286ef154e917c971c49",
-   "sha256": "1pdl13hmvyznvk1k1096pid628rmhfif09bhryla7xjqkczpv25g"
+   "commit": "35972043d512d83ddc26bf51fa20bf2b340b38ee",
+   "sha256": "1fdcmr93jrckd7x2whyc35c72jis199kyq3a8l4f6a3h4q537rfa"
   },
   "stable": {
    "version": [
-    2,
+    4,
     0,
-    1
+    0
    ],
    "deps": [
     "dash",
+    "org",
     "s"
    ],
-   "commit": "c36f8a7f6b15dddcfa9e270a86d48a5e5f2beea3",
-   "sha256": "0vv8rk1mn7vhwz5riadg1fdjx5nmvm8h578yb9b85a100nq7av2w"
+   "commit": "dd2605734d1bec4ca6efd8cd664dbe33a83c8058",
+   "sha256": "1fdcmr93jrckd7x2whyc35c72jis199kyq3a8l4f6a3h4q537rfa"
   }
  },
  {
@@ -73173,34 +74137,34 @@
  },
  {
   "ename": "org-re-reveal",
-  "commit": "c3e6c90a6b9004fbf0fbc08556f8effbcde8b468",
-  "sha256": "05p8iml0fapi4yf7ky45kf7m0ksz917lxg7c4pdd9hjkjmz29xn9",
+  "commit": "26e79e7efb378a0c7f816cbd2a517ff9cb7e3fa8",
+  "sha256": "1svgmga905fw8sayxnly5wvk110m6dbg0cv9ggi1ngb0xpm7acgj",
   "fetcher": "gitlab",
   "repo": "oer/org-re-reveal",
   "unstable": {
    "version": [
-    20200813,
-    1104
+    20200922,
+    559
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "7fe39d5d03ccc75d2811445d25cbbb473b53de76",
-   "sha256": "1cmvqr97vx22lw510z0k2nsy5xfgnz2lvchmx5sdxrqz54pz1wfq"
+   "commit": "1373dc1e28ceb5f87577aea178203e31e0c3cef9",
+   "sha256": "08a52g9drz2d263j57q1gzhzpvcmjwwbdvzlglz590g66jw53my7"
   },
   "stable": {
    "version": [
     3,
-    1,
-    0
+    2,
+    2
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "7fe39d5d03ccc75d2811445d25cbbb473b53de76",
-   "sha256": "1cmvqr97vx22lw510z0k2nsy5xfgnz2lvchmx5sdxrqz54pz1wfq"
+   "commit": "1373dc1e28ceb5f87577aea178203e31e0c3cef9",
+   "sha256": "08a52g9drz2d263j57q1gzhzpvcmjwwbdvzlglz590g66jw53my7"
   }
  },
  {
@@ -73311,8 +74275,8 @@
   "repo": "jkitchin/org-ref",
   "unstable": {
    "version": [
-    20200814,
-    1307
+    20200922,
+    1821
    ],
    "deps": [
     "dash",
@@ -73326,8 +74290,8 @@
     "pdf-tools",
     "s"
    ],
-   "commit": "831fe96c242bf178f0c55b93fd076dfb549f7791",
-   "sha256": "18r9n6vln65czjvk46r5lbr7d2rd2dpcqrzhs37jffz9qj93cpcc"
+   "commit": "71f4eb75785dd2a6735b4416d14fe4becff3988d",
+   "sha256": "12icjpndgqx2rzpb2zpsksbqyih62j4fc9awn0rrm180hv2rvphi"
   },
   "stable": {
    "version": [
@@ -73382,14 +74346,15 @@
   "repo": "akirak/org-reverse-datetree",
   "unstable": {
    "version": [
-    20200812,
-    1340
+    20200923,
+    856
    ],
    "deps": [
-    "dash"
+    "dash",
+    "org"
    ],
-   "commit": "e0b04fe953de43bec51dd867d5fe12498099f2b4",
-   "sha256": "0r5vkx5la5dvw8vbrmmbxfffxjmhjmzdfbwy6c31lr60p55m5m7d"
+   "commit": "29ed12a75f4adcfb4689c5b68eee581f3adf3624",
+   "sha256": "14cr2cssryza3s8j19a5937ndyrm9isdb4zd9hfkn3qwyfjanqgg"
   },
   "stable": {
    "version": [
@@ -73451,8 +74416,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20200818,
-    816
+    20200927,
+    751
    ],
    "deps": [
     "dash",
@@ -73462,8 +74427,8 @@
     "org",
     "s"
    ],
-   "commit": "c33867e6bc282ff0a69d4ef4a020db82604039bb",
-   "sha256": "0nklci9ixnkawa0ryffcnxvj7hm4vhklsv7whdynhr9w6aw6f7kq"
+   "commit": "64d8ba1900205e1be403940db370c0208d9cb597",
+   "sha256": "0k0xn3yk450v60nnbpsg5c154rhynlip5ywj90i994jhz8cfxcwn"
   },
   "stable": {
    "version": [
@@ -73491,15 +74456,15 @@
   "repo": "org-roam/org-roam-bibtex",
   "unstable": {
    "version": [
-    20200803,
-    1209
+    20200918,
+    738
    ],
    "deps": [
     "bibtex-completion",
     "org-roam"
    ],
-   "commit": "a92d9e6f523f449314e72911ba300192a42fc4dc",
-   "sha256": "1np029bspw14lcv8qzzgfyqimjz697wx2isasad06qbnhqbyc84m"
+   "commit": "3f601130f452a0cec95533a591bc6b07ff29f674",
+   "sha256": "17c4cd2dcnn4z5zda7awb8b2hdw2psdzaszc7vnzs5m3j80q6gbc"
   },
   "stable": {
    "version": [
@@ -73523,18 +74488,19 @@
   "repo": "org-roam/org-roam-server",
   "unstable": {
    "version": [
-    20200816,
-    819
+    20200927,
+    1053
    ],
    "deps": [
     "dash",
+    "f",
     "org",
     "org-roam",
     "s",
     "simple-httpd"
    ],
-   "commit": "5ea3d1403bd68af49ac0593a8cdff7514595d025",
-   "sha256": "0ajsid9p5znxqz7bq39jbf779s46ymmxwpfki4yxpa9308pwjwgc"
+   "commit": "88d6bc36e0a9e83b5657e2618ec1f7138b222445",
+   "sha256": "0ddm2zyapjqk93jp543ysky6di73iswymcbm3w8ah44gazwql9ki"
   },
   "stable": {
    "version": [
@@ -73745,8 +74711,8 @@
     "org",
     "s"
    ],
-   "commit": "38c3a0a2c2f9b99e0426334c7c6a9320cc6e39a5",
-   "sha256": "1rp9hyn9bshp4wjqgr8rpgjabyp86f3905ghpf5nnc4w4dfgq9vk"
+   "commit": "f7d90e4f92df74140ad160a5fa0dc38be7199036",
+   "sha256": "186jfa1g4qxwv7qvyn6cwg19z5j7nnvz6w2xlhilkrb14hqqzjxa"
   },
   "stable": {
    "version": [
@@ -73770,14 +74736,30 @@
   "repo": "ndwarshuis/org-sql",
   "unstable": {
    "version": [
-    20200217,
-    2130
+    20200925,
+    1928
    ],
    "deps": [
-    "dash"
+    "dash",
+    "org-ml",
+    "s"
    ],
-   "commit": "9543ad58bc471abf09705d2615c50c1ead90c660",
-   "sha256": "18i4zhk955q13qvascvr8ag6pv2i9s14xfwl2061zjqarx89sxa1"
+   "commit": "8182dc045d9a21e9f26ac4b67c3a95d8cc134005",
+   "sha256": "1jnvc0wbgpa8baxswrfr7y8ih2ybbgddmmv3p9iz0p99yh58yzy2"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    2
+   ],
+   "deps": [
+    "dash",
+    "org-ml",
+    "s"
+   ],
+   "commit": "11c06480821dbd07bbdbff2325d5ed5633dc121d",
+   "sha256": "1jnvc0wbgpa8baxswrfr7y8ih2ybbgddmmv3p9iz0p99yh58yzy2"
   }
  },
  {
@@ -73916,8 +74898,8 @@
     "s",
     "ts"
    ],
-   "commit": "dd0d104c269fab9ebe5af7009bc1dd2a3a8f3c12",
-   "sha256": "0kx9sikk7c3j0zp3a31kj8zv2kjxqjhhl25n7c7nslf2fp5w2d8b"
+   "commit": "3264255989021b8563ea42b5d26acbc2a024f14d",
+   "sha256": "0mgf027qhl2iqzqjjb0b7svzpq1kzalnn06zg9sbl93bd07alamc"
   },
   "stable": {
    "version": [
@@ -74083,43 +75065,6 @@
    ],
    "commit": "af83a73ae542d5cb3c9d433cbf2ce1d4f4259117",
    "sha256": "11rfn0byy0k0321w7fjgpa785ik1nrk1j6d0y4j0j4a8gys5hjr5"
-  }
- },
- {
-  "ename": "org-taskforecast",
-  "commit": "757def05a6104d8aab2dde9977762bdaef63241a",
-  "sha256": "1xbck5kdbfzjw55amjfxsjscmdj7yl3fyrfzgqpdicdih0fas7kz",
-  "fetcher": "github",
-  "repo": "HKey/org-taskforecast",
-  "unstable": {
-   "version": [
-    20200817,
-    748
-   ],
-   "deps": [
-    "dash",
-    "dash-functional",
-    "org-ql",
-    "s",
-    "transient"
-   ],
-   "commit": "fc160ce255a98da36c59da4d49a628dd7f742087",
-   "sha256": "063myyg4p2qwbvhb8kcgnz15xp48rv8zhcb86kxh51bm92ifwgb0"
-  },
-  "stable": {
-   "version": [
-    0,
-    3,
-    0
-   ],
-   "deps": [
-    "dash",
-    "dash-functional",
-    "org-ql",
-    "s"
-   ],
-   "commit": "036da7c14e0defb85917293f00a5fa9ac0977da4",
-   "sha256": "0lz6c1hq35qw44fllzsrzv9p4r4sjikciyzvi6nyf0fw189b0c4h"
   }
  },
  {
@@ -74445,11 +75390,11 @@
   "repo": "cadadr/elisp",
   "unstable": {
    "version": [
-    20191207,
-    2022
+    20200919,
+    1348
    ],
-   "commit": "61a14d1a8c17930caca5c5daf893cedc9c23c5f3",
-   "sha256": "0acq8d8vlx3hd405wmi5w36gg88bz1c1crmlxbd2whgi8kyf506z"
+   "commit": "e086c59a14701cd041641b51c952fa704ee963df",
+   "sha256": "0w1crw5lsk22jfw2w5qq6ab7zxdzp38akasvyvxakvpp1782xq9p"
   }
  },
  {
@@ -74537,8 +75482,8 @@
   "repo": "akhramov/org-wild-notifier.el",
   "unstable": {
    "version": [
-    20200328,
-    1153
+    20200926,
+    1502
    ],
    "deps": [
     "alert",
@@ -74546,14 +75491,14 @@
     "dash",
     "dash-functional"
    ],
-   "commit": "4011d7f557da3ae5eee73c56ae514b963fb4d1c1",
-   "sha256": "0mr5qmrnz0mr6w7ib8bcdlqwhzwnxfbnd47zyg9i6lmh20p8qrns"
+   "commit": "b83d31422abcf9527d5ec0344f2fa2df5b76a357",
+   "sha256": "0cdd93sqx0ijajqa2z91bg6h6m1njsaqzwygr8q28dd2pazxq5xc"
   },
   "stable": {
    "version": [
     0,
     4,
-    0
+    1
    ],
    "deps": [
     "alert",
@@ -74561,8 +75506,8 @@
     "dash",
     "dash-functional"
    ],
-   "commit": "4011d7f557da3ae5eee73c56ae514b963fb4d1c1",
-   "sha256": "0mr5qmrnz0mr6w7ib8bcdlqwhzwnxfbnd47zyg9i6lmh20p8qrns"
+   "commit": "b83d31422abcf9527d5ec0344f2fa2df5b76a357",
+   "sha256": "0cdd93sqx0ijajqa2z91bg6h6m1njsaqzwygr8q28dd2pazxq5xc"
   }
  },
  {
@@ -74573,16 +75518,16 @@
   "repo": "marcIhm/org-working-set",
   "unstable": {
    "version": [
-    20200819,
-    708
+    20200914,
+    456
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "d6f2d1ebcfe0b6ccb3a799f04ba6842ca86c9115",
-   "sha256": "1lkf497qpydvw5f7vi0v7yr43j9v03hys16qz6nsqkbizr54b5jh"
+   "commit": "742669e6cb3763494f5baea797175860f9b0b787",
+   "sha256": "07lzmrqmlxq2srpadf36w3ms6ckz6bfc0ci3zk4gzhlm27fm4g9y"
   },
   "stable": {
    "version": [
@@ -74795,43 +75740,45 @@
   "repo": "kostafey/organic-green-theme",
   "unstable": {
    "version": [
-    20200717,
-    1937
+    20200906,
+    20
    ],
-   "commit": "01fe614086e31e166d2a2f1d6b34e301f060458e",
-   "sha256": "1hsidgcyqsbm96gh0nfrdpnm4vq1sw8777d0zslsczr1fp51il6d"
+   "commit": "df8641b20538690230efa17c9c0cad0fbac183fa",
+   "sha256": "0in3vpyawswk22r1q26k6xb9ymg6mwp7ssbmlcph6ny9wmr14l6g"
   }
  },
  {
   "ename": "organize-imports-java",
-  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
-  "sha256": "0j4fpbzmi0mq2f493hwl94b3xmkhdcjscvbgv4dz31rw10bl4q7h",
+  "commit": "e38a261ab64a1ce897d997fcfba6f01e9ad969f0",
+  "sha256": "1m7nqw0mgyjzh0wyqkk6542ibg7d6fx6mgj21gv32js8rcnmkrmv",
   "fetcher": "github",
   "repo": "jcs-elpa/organize-imports-java",
   "unstable": {
    "version": [
-    20200717,
-    757
+    20200921,
+    1156
    ],
    "deps": [
+    "dash",
     "f",
     "s"
    ],
-   "commit": "c431b338d34c94345217b2b904d9c6f331d4015c",
-   "sha256": "1dqvx49lcfi5472aq17nd7y7v7d2ljxcmy5zhks2mfbhhzgdp8n6"
+   "commit": "0ad16e70e31da2a2536202856fd19ac4334cd5a2",
+   "sha256": "0wk80l6pn3g84q65j67r9lmznb3lysw3m94azhdsm947m49yxyh0"
   },
   "stable": {
    "version": [
     0,
-    1,
-    4
+    2,
+    1
    ],
    "deps": [
+    "dash",
     "f",
     "s"
    ],
-   "commit": "c431b338d34c94345217b2b904d9c6f331d4015c",
-   "sha256": "1dqvx49lcfi5472aq17nd7y7v7d2ljxcmy5zhks2mfbhhzgdp8n6"
+   "commit": "a66713fd19f5054908bb1ee39a364dac538500bf",
+   "sha256": "11ip6qzjv7z8n7h596qvsxlcv3h89pkb27s6flpxb9cs5hn8kr8l"
   }
  },
  {
@@ -75006,6 +75953,29 @@
   }
  },
  {
+  "ename": "orgstrap",
+  "commit": "35f53a7b64b1a5c14a6d8b951c809a8696cfcd99",
+  "sha256": "1cjgmibybw24acz5r4zb9jddmng7c0f819h0wl5ih2af2skvpi7k",
+  "fetcher": "github",
+  "repo": "tgbugs/orgstrap",
+  "unstable": {
+   "version": [
+    20200925,
+    451
+   ],
+   "commit": "01c7c761098af663897ad419afc3b858ffac181b",
+   "sha256": "19l2rbfrqmvy3nlylf3668zxrb8ivfd3yx9h68pcvlal3hapygbf"
+  },
+  "stable": {
+   "version": [
+    1,
+    1
+   ],
+   "commit": "01c7c761098af663897ad419afc3b858ffac181b",
+   "sha256": "19l2rbfrqmvy3nlylf3668zxrb8ivfd3yx9h68pcvlal3hapygbf"
+  }
+ },
+ {
   "ename": "orgtbl-aggregate",
   "commit": "bf64b53c9d49718a8ffc39b14c90539b36840280",
   "sha256": "0gnyjwn6jshs8bzdssm2xppg2s9p2x3rrhp523q39aydskc6ggc9",
@@ -75013,11 +75983,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20200708,
-    2131
+    20200829,
+    708
    ],
-   "commit": "99c6bc8c9b72dc9ce886a09540ed24ec83bcc056",
-   "sha256": "03q02cxz76wnx20rhwqiysxnskzs7caw428ij3jj4nsmjkhxdfv0"
+   "commit": "bab95388b182c07bc9f0679426514fe7e8c997d9",
+   "sha256": "18qasx17hgfrmzkljjpni4m2lgic3imyksjg6wa7xrjf0y3kwmgw"
   }
  },
  {
@@ -75043,14 +76013,14 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20200708,
-    2127
+    20200825,
+    640
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "1aa352a09a2c543352fceb32a505c44e080efcb3",
-   "sha256": "0aczwlssnhn1xpgk3s7l2smrxmhb8af6gg9xjdsfysss4ybbcgy6"
+   "commit": "e93e8eaeab2137bc391cf6d0643619ce6b066d19",
+   "sha256": "0rbcdgsb7vzsjiwk5zskv15sf8npxdsbvpzd9r6s7aib83mb5kqa"
   }
  },
  {
@@ -75111,8 +76081,8 @@
    "deps": [
     "origami"
    ],
-   "commit": "edcba971ba52a14f69a436ad47888827d7927982",
-   "sha256": "1r3dbnjwmg7y1zsimvqw3bi4168ikwdd5fqkjqd6gm905w32hwc0"
+   "commit": "cc363f4b2fd20021ab330fc989369e2658457f93",
+   "sha256": "0lsr356yq0414fn6wy54fryx9k3zl43x9blnvlif5vbghf0r1axg"
   },
   "stable": {
    "version": [
@@ -75886,14 +76856,14 @@
   "repo": "kaushalmodi/ox-hugo",
   "unstable": {
    "version": [
-    20200722,
-    1939
+    20200911,
+    453
    ],
    "deps": [
     "org"
    ],
-   "commit": "75b849e9561c4a6022babf6eaf0e037310ded7c1",
-   "sha256": "1xsxljf99h2pyvpp9gvma6g42q1n2xmhnwvpmciwj5rajw5xqc5v"
+   "commit": "95723cd4ff977fed11b5a952aacec9604eb45761",
+   "sha256": "1jz57dnn53abqxy8l0118ya1snk1sx29dlg1ck30w2nnflxjwy2d"
   },
   "stable": {
    "version": [
@@ -75982,14 +76952,14 @@
   "repo": "stig/ox-jira.el",
   "unstable": {
    "version": [
-    20200616,
-    2310
+    20200920,
+    1119
    ],
    "deps": [
     "org"
    ],
-   "commit": "e9a47ef51862f11a5c006cf9e8c5f4ec5517aced",
-   "sha256": "1ws3myl2z6vv3idq28m8q97zlrmsfg5z3i8y3adsbm56ga9jqvdj"
+   "commit": "64d364cf08109e6877b74c0aa2c4ef690fe9501b",
+   "sha256": "0ymwgq44zsbdsac8z1x748mcfgzagv72n0i119sihydjy1q1v12x"
   }
  },
  {
@@ -76066,8 +77036,8 @@
     "org",
     "ox-gfm"
    ],
-   "commit": "8c8d026aa3a31cb6dcd2530ac5902e551b161343",
-   "sha256": "0i88bzcczvhsylcbk7nwx19gn6ydiw8vrgwl2p5njm10vngrjlny"
+   "commit": "eaf30f455cb306e8d6f1224ce5f7c020340af1a7",
+   "sha256": "13dwjmnixzyid5r8j0qzlkcy2kbwx7c9l2qxl72wcn525px9nsp5"
   }
  },
  {
@@ -76201,14 +77171,37 @@
   "repo": "0x60df/ox-qmd",
   "unstable": {
    "version": [
-    20200813,
-    408
+    20200824,
+    49
    ],
    "deps": [
     "org"
    ],
-   "commit": "8c3d8ce2a21044fc85e5e4e06be0220900d7ba4f",
-   "sha256": "1j6zmjy3s2l2wj500q9i75xd3hf8wlh04ycmmad45swrkgp70f2s"
+   "commit": "de5c8b45249b4e21c0cdd291b982273c53a6df38",
+   "sha256": "0vkddaq4hkivb1qbp6r3mb8q6kcivm8yc1bbagzjwphzrzs7w5ci"
+  }
+ },
+ {
+  "ename": "ox-report",
+  "commit": "17e401f8ebb478e0a77fa64f65a700185e0f3648",
+  "sha256": "049dbyf07xy3vzmrs9ihwxsyxj21763xlilh72zr457z0c57rbid",
+  "fetcher": "github",
+  "repo": "DarkBuffalo/ox-report",
+  "unstable": {
+   "version": [
+    20200912,
+    1316
+   ],
+   "commit": "dbfd8903ec6c4d53b436605cc55d4aaf23c0a6b9",
+   "sha256": "05dha9kzzapzhpd6b8fpvrwv2a2girhilqya95f5p24mxaq4zjph"
+  },
+  "stable": {
+   "version": [
+    0,
+    2
+   ],
+   "commit": "ebd57eda69466735d7fc8f52831490176e1f144b",
+   "sha256": "1xhyvc1v5hdgki2sbdpajhhq8ydgym5q1cywcaxwbbmpjxi5sd64"
   }
  },
  {
@@ -76219,14 +77212,14 @@
   "repo": "yjwen/org-reveal",
   "unstable": {
    "version": [
-    20200802,
-    710
+    20200926,
+    429
    ],
    "deps": [
     "org"
    ],
-   "commit": "553e1a9d678e74c2646e4c19bd9f6c08d8a00486",
-   "sha256": "18khlffdmg88pd50vwg00vz143ysqhkdkvva9h4bkw618inz70wq"
+   "commit": "79b01ae85bccf3622dc79d17d3eceebfa9a81636",
+   "sha256": "1q12v1qm1hq96g3z6z91ym6arnysp6kszhjj3jrw9zwz8qzkacg7"
   }
  },
  {
@@ -76358,15 +77351,14 @@
   "repo": "dfeich/org8-wikiexporters",
   "unstable": {
    "version": [
-    20180626,
-    2052
+    20200927,
+    857
    ],
    "deps": [
-    "cl-lib",
     "org"
    ],
-   "commit": "99d0c25d56dbf75ce894a84e776ba4459208dbc2",
-   "sha256": "1812sp7z4241da1mfg4wxm1wcax59cqyy2n0xfd67a1mphihsniz"
+   "commit": "3377d8732aa916e736ce5822c7a9a4fbdc894e37",
+   "sha256": "05133n998sp3qymhrz6sarjc7ypzjiwpvpcgilq6z8i4sl2ip98q"
   }
  },
  {
@@ -76437,15 +77429,14 @@
   "repo": "dfeich/org8-wikiexporters",
   "unstable": {
    "version": [
-    20170803,
-    2039
+    20200927,
+    857
    ],
    "deps": [
-    "cl-lib",
     "org"
    ],
-   "commit": "99d0c25d56dbf75ce894a84e776ba4459208dbc2",
-   "sha256": "1812sp7z4241da1mfg4wxm1wcax59cqyy2n0xfd67a1mphihsniz"
+   "commit": "3377d8732aa916e736ce5822c7a9a4fbdc894e37",
+   "sha256": "05133n998sp3qymhrz6sarjc7ypzjiwpvpcgilq6z8i4sl2ip98q"
   }
  },
  {
@@ -76476,6 +77467,24 @@
    ],
    "commit": "d34d1b72e4e940745a377bfa745dfb618900a09e",
    "sha256": "05813w4adafm596x1rikvc7xqk10xwfihdpdq1zr2zyqcpdabqza"
+  }
+ },
+ {
+  "ename": "ox-zenn",
+  "commit": "30a54915cf91b47230ddf66ad2e5e17c36fb5e7d",
+  "sha256": "1lsvq5av234dbm88bw4jlj1vxmm3jd8hnzf8vv7q675qcxgpnz5j",
+  "fetcher": "github",
+  "repo": "conao3/ox-zenn.el",
+  "unstable": {
+   "version": [
+    20200924,
+    1607
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "b53bd82116c9f7dbb5b476d2cfcc8ed0f3bc9c78",
+   "sha256": "1n57bzsp73g5iqdnhc4jhsylif93h4kkl7zgqi1i9b8bi90sqrl1"
   }
  },
  {
@@ -76524,14 +77533,14 @@
   "repo": "UndeadKernel/pacfiles-mode",
   "unstable": {
    "version": [
-    20200418,
-    1806
+    20200915,
+    1815
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "222ae3f540cddee306067c83451cfece1112c09e",
-   "sha256": "1ps6blv2jhm4i2gr1fbsr1lii9cpr99prhwnxvhxxxy08c9b6mrx"
+   "commit": "8d06f64abc98c3f3338560c8d6eb47719e034069",
+   "sha256": "177v9mb2clwymnq9v6b9qza9d7rsd78mvx13hyc9cpbjnlalpjzc"
   },
   "stable": {
    "version": [
@@ -76607,14 +77616,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20200601,
-    1939
+    20200909,
+    150
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4cb0f98a21729f9ef0189f095384555c9d2b6fe4",
-   "sha256": "0ij6p7i5x0fs0yn8zxcx7gf9ldanflh7mj7mblr8snpgbzx3jwnz"
+   "commit": "c0858f8f5895f48421ed4f57e9f3d5f4ab7a139f",
+   "sha256": "0rg9q4p3gaamby0q0skm1x5gr12xgn03jnxj8xldsjmdmr9phykv"
   },
   "stable": {
    "version": [
@@ -76651,15 +77660,15 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20200816,
-    24
+    20200906,
+    512
    ],
    "deps": [
     "cl-lib",
     "let-alist"
    ],
-   "commit": "c4b16a90196d6d83d6ba668923c1ce725e13a5d6",
-   "sha256": "0kz8snjl0802ypxzag2n7552f6ssmj0hxx4lkal4v421pr2cqka6"
+   "commit": "05596996286089acc7693b700c7c31780439e39f",
+   "sha256": "09ngfyh3l6shqmxzaaidr73r2j7am9il6wimvc4w1lbfvfxdjq7x"
   },
   "stable": {
    "version": [
@@ -76688,8 +77697,8 @@
    "deps": [
     "package-lint"
    ],
-   "commit": "c4b16a90196d6d83d6ba668923c1ce725e13a5d6",
-   "sha256": "0kz8snjl0802ypxzag2n7552f6ssmj0hxx4lkal4v421pr2cqka6"
+   "commit": "05596996286089acc7693b700c7c31780439e39f",
+   "sha256": "09ngfyh3l6shqmxzaaidr73r2j7am9il6wimvc4w1lbfvfxdjq7x"
   },
   "stable": {
    "version": [
@@ -76985,8 +77994,8 @@
     20200715,
     338
    ],
-   "commit": "6508ac3228975c39d10a1caa70b9ce34ff3ed21d",
-   "sha256": "019nigy5yh1qrzw0agp2kgjfpfm503fgkj07c9m2xqs9hww781x1"
+   "commit": "44beb80ac991e58231c05dc4afa1646fa768d573",
+   "sha256": "17x0ayf894gnm7kkm5bp64h9bfigr6shjm8y7pi91vk0xij3l7jx"
   }
  },
  {
@@ -77102,8 +78111,8 @@
     20200510,
     5
    ],
-   "commit": "61a14d1a8c17930caca5c5daf893cedc9c23c5f3",
-   "sha256": "0acq8d8vlx3hd405wmi5w36gg88bz1c1crmlxbd2whgi8kyf506z"
+   "commit": "e086c59a14701cd041641b51c952fa704ee963df",
+   "sha256": "0w1crw5lsk22jfw2w5qq6ab7zxdzp38akasvyvxakvpp1782xq9p"
   }
  },
  {
@@ -77170,23 +78179,26 @@
   "repo": "ajgrf/parchment",
   "unstable": {
    "version": [
-    20200812,
-    1259
+    20200910,
+    2217
    ],
    "deps": [
     "autothemer"
    ],
-   "commit": "271ab4b7d023d730e3d684a1505cc77e2d0cc14a",
-   "sha256": "138n4fs33cv2ly89cvs7lkh372kghldhw8pw18zsi39qfvggw6wm"
+   "commit": "c90665145573f5e314ede1b7df3bb732e30f4bcd",
+   "sha256": "0n6biizy3hs5xcj678ajdndjvm2kpfcg0pd73g21src6f2i45636"
   },
   "stable": {
    "version": [
     0,
-    3,
+    4,
     0
    ],
-   "commit": "b4dabed7939f8cf052c858ba29e295eee3f0ca13",
-   "sha256": "0361621f0xg786dvcw6xrfm9qkjr19cs8dkxgj8b5nq9isxyknh5"
+   "deps": [
+    "autothemer"
+   ],
+   "commit": "c90665145573f5e314ede1b7df3bb732e30f4bcd",
+   "sha256": "0n6biizy3hs5xcj678ajdndjvm2kpfcg0pd73g21src6f2i45636"
   }
  },
  {
@@ -77544,21 +78556,21 @@
     "a",
     "parseclj"
    ],
-   "commit": "92bf875962e62f8c6370b56991d546f122536c6b",
-   "sha256": "0xli6cf0fzydnd683v3hk5kfsbxwh83s916fd64j8ak0wzjnlsfr"
+   "commit": "90cfe3df51b96f85e346f336c0a0ee6bf7fee508",
+   "sha256": "0fhmxj8qjhpqzmj07phf1njkjryc6d2qqqcl4f515b6hly1l41kz"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
     "a",
     "parseclj"
    ],
-   "commit": "ddf824bc1df1585867cb7f27f2dd8ca8df760569",
-   "sha256": "11wi3hwcgmy54p6ivpijqm7v0hj6j75a19qk5z779bqfrp79b4pc"
+   "commit": "d25ebc5554c467b1501f1655204ed419e00ca720",
+   "sha256": "0271amhw63650rrzikcyqxa8sb42npnk7q3yrsay2v79wbqkdaw9"
   }
  },
  {
@@ -78069,11 +79081,11 @@
   "repo": "zwild/pcmpl-homebrew",
   "unstable": {
    "version": [
-    20190213,
-    318
+    20200911,
+    742
    ],
-   "commit": "39f2e8faf4d866410a625bbcf88f2504940c8982",
-   "sha256": "0p5iynpg9c7zw7717m2mj1lmzcawc8sz4r2di3f8jc8qkng3avns"
+   "commit": "a2044042dd498abad1dc06162a8ee0d70314ca40",
+   "sha256": "1x0hc6n710199aygqch9nh55dsic2sdl7nnncs4h2s0dd91bnz6g"
   }
  },
  {
@@ -78356,8 +79368,8 @@
    "deps": [
     "csv"
    ],
-   "commit": "263d6d940d7e4203bbecda46dbaa89b7af1db54f",
-   "sha256": "1jw27asnfd48mx3mi9qiihvj2hgzpmk53xdq87ajq9nsx8m6x110"
+   "commit": "c72c4a6f1e47ed5fe5103e0eaadad5a76deeec30",
+   "sha256": "0jahf914qmvlk0xjka9dy7n19smndjnybjl26pbgf7lvd8lxzyb0"
   }
  },
  {
@@ -78431,20 +79443,20 @@
   "repo": "Fanael/persistent-scratch",
   "unstable": {
    "version": [
-    20190922,
-    1046
+    20200921,
+    2309
    ],
-   "commit": "fd690e138459e0b490f1fda469811a9cbcb34df7",
-   "sha256": "1nig9ja42sm3nkbi9wrsm86akrq0m85jfc65k9rmym13vrdpflvq"
+   "commit": "57221e5fdff22985c0ea2f3e7c282ce823ea5932",
+   "sha256": "0fp9kqpbphzafd28xd30n7j4mibki56fg4xmfv13pbs459awrzdh"
   },
   "stable": {
    "version": [
     0,
     3,
-    4
+    5
    ],
-   "commit": "fd690e138459e0b490f1fda469811a9cbcb34df7",
-   "sha256": "1nig9ja42sm3nkbi9wrsm86akrq0m85jfc65k9rmym13vrdpflvq"
+   "commit": "57221e5fdff22985c0ea2f3e7c282ce823ea5932",
+   "sha256": "0fp9kqpbphzafd28xd30n7j4mibki56fg4xmfv13pbs459awrzdh"
   }
  },
  {
@@ -78519,11 +79531,11 @@
   "repo": "Bad-ptr/persp-mode.el",
   "unstable": {
    "version": [
-    20200617,
-    2154
+    20200920,
+    1506
    ],
-   "commit": "14325c11f7a347717d7c3780f29b24a38c68fbfc",
-   "sha256": "1kb5v7pl2vhx6zdwf9kip38qjk8nkd9xpgdy74q8p3c56ap9lg6g"
+   "commit": "c132efe3094ce1368f54195028b29b82c65a64dc",
+   "sha256": "0758wsklv3mvaa9m3cdgdyrcbpz34wwn44b5mf3ipf43ggcvp0ij"
   },
   "stable": {
    "version": [
@@ -78597,25 +79609,25 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20200814,
-    554
+    20200827,
+    1945
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "74e811ccbada09dd9a3d90b983e78d146542121b",
-   "sha256": "1xfcm69nd6f9chwlqfz5vd8nnyl5mwharxjrn1m515568dqrk62x"
+   "commit": "17cfb7f3a50c5ebc8edafd6418531c17c2cbf47e",
+   "sha256": "0nka5z6226r174ligja023qx2bb1pfyjbanafxprbyxkr17b2794"
   },
   "stable": {
    "version": [
     2,
-    10
+    11
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "74e811ccbada09dd9a3d90b983e78d146542121b",
-   "sha256": "1xfcm69nd6f9chwlqfz5vd8nnyl5mwharxjrn1m515568dqrk62x"
+   "commit": "17cfb7f3a50c5ebc8edafd6418531c17c2cbf47e",
+   "sha256": "0nka5z6226r174ligja023qx2bb1pfyjbanafxprbyxkr17b2794"
   }
  },
  {
@@ -78806,14 +79818,14 @@
   "repo": "zk-phi/phi-autopair",
   "unstable": {
    "version": [
-    20200816,
-    535
+    20200914,
+    355
    ],
    "deps": [
     "paredit"
    ],
-   "commit": "3e78793f9c480adf79b12d441fae5571e97b9e5f",
-   "sha256": "003dnixrnn7qcm25dbibc4rc8yrqsj9jci9rxp9l7ci6ya1bi0i2"
+   "commit": "8bebd5d3018746812847b6c47ab7c79a36382e7c",
+   "sha256": "1mf5blmws9kc3h4d9iy7r38w6kvi5w2gvmlbrxlwmh95a3y1n3nz"
   }
  },
  {
@@ -78842,11 +79854,11 @@
   "repo": "zk-phi/phi-rectangle",
   "unstable": {
    "version": [
-    20200816,
-    650
+    20200911,
+    204
    ],
-   "commit": "4ea8b40a614c1cc9087b9c0bd924a2d9d6cc0a83",
-   "sha256": "1ajjdpx4xbgig11380lyy10gqfmp23k5zwb77pwdl1rhapsdpjp8"
+   "commit": "43ee8aea9998b34a9fdb28d7da2e4f75e4154030",
+   "sha256": "1kjvhpbwakcxhkmninasr0waziyclr13iwfyl2cg8yihk5xnakji"
   }
  },
  {
@@ -78858,10 +79870,10 @@
   "unstable": {
    "version": [
     20200510,
-    905
+    906
    ],
-   "commit": "f567f048b3892062c5528b42d4f6af4b313721a3",
-   "sha256": "15yc5nlfx2z48n8p7pb6qzgbzfpnapb83w5xx6z8lq0mywf3k5jj"
+   "commit": "c34f5800968922d1f9e7b10092b8705d6640ad18",
+   "sha256": "1ss2ywx93wm372fvgc9vp4h8xkjbpl5i4268r7556n4zwk5nngf5"
   },
   "stable": {
    "version": [
@@ -79112,20 +80124,20 @@
   "repo": "vpxyz/php-quickhelp",
   "unstable": {
    "version": [
-    20200818,
-    1944
+    20200830,
+    2113
    ],
-   "commit": "f1d79fbed01b667495f64438687f1fbd6bf486c6",
-   "sha256": "0lnjd0ris288ia6i2wvw30yg57fmh5xgq1dln243s57yvm1wccfd"
+   "commit": "9a852daa409808efee200e8929a19a785b3609d3",
+   "sha256": "1qx45935dxbv04hrifxhardaa17sh0wy9infayd3pg35866d3kz1"
   },
   "stable": {
    "version": [
     0,
-    3,
-    4
+    4,
+    1
    ],
-   "commit": "325668a47127bee77f094ed2b09171b8656c7429",
-   "sha256": "16cm754r1cg1rb6blfqcja41klr4hy90gkhg6p9p79qgxjrnbbbd"
+   "commit": "9a852daa409808efee200e8929a19a785b3609d3",
+   "sha256": "1qx45935dxbv04hrifxhardaa17sh0wy9infayd3pg35866d3kz1"
   }
  },
  {
@@ -79647,11 +80659,11 @@
   "repo": "cute-jumper/pinyinlib.el",
   "unstable": {
    "version": [
-    20170827,
-    2142
+    20200911,
+    1723
    ],
-   "commit": "45f05d3dbb4fe957f7ab332ca6f94675848b6aa3",
-   "sha256": "0pmgb4y06dbffs4442aa92vn8ydwl45zqwzxzwhk6md1318fppvd"
+   "commit": "1772c79b6f319b26b6a394a8dda065be3ea4498d",
+   "sha256": "1lmw0hf6cjbvpsyjx686za74kwgz5bap7z1b49jgsimgrn5c20s4"
   },
   "stable": {
    "version": [
@@ -80259,11 +81271,11 @@
   "repo": "emacsmirror/po-mode",
   "unstable": {
    "version": [
-    20200610,
-    1743
+    20200606,
+    1404
    ],
-   "commit": "3114e245c2ee6208e9b506f3e65e631e1b236019",
-   "sha256": "1f84fziibcc1bjhcmmzvbsvsw2lwabsb70vl4x2jpqsraygzhw0b"
+   "commit": "25eb1bdca30ed25d2e5d51b9feeb28a3faff51ec",
+   "sha256": "00ff5njs4aghkhipw5pmha4mj1a5s35g1cxihhbqpn9gr7kmbg02"
   },
   "stable": {
    "version": [
@@ -80353,8 +81365,8 @@
   "repo": "alphapapa/pocket-reader.el",
   "unstable": {
    "version": [
-    20181219,
-    930
+    20200828,
+    9
    ],
    "deps": [
     "dash",
@@ -80366,13 +81378,14 @@
     "rainbow-identifiers",
     "s"
    ],
-   "commit": "86c51c65d97819e11b3df403beea424f30125d30",
-   "sha256": "16dj1853qgd4farqb7wdpyyp1a4mxkasyb0j489h7saz9xn9q8xc"
+   "commit": "dbb7b043edb42341b7f48ce0d81ba08c3c676076",
+   "sha256": "1xkhk8zb84c8jdgc5yjizzfyf265gk110fv8adww270sqg71la9v"
   },
   "stable": {
    "version": [
     0,
-    2
+    2,
+    1
    ],
    "deps": [
     "dash",
@@ -80384,8 +81397,8 @@
     "rainbow-identifiers",
     "s"
    ],
-   "commit": "a7f080ec3e9522f942166de61b24a375b8f1c2bb",
-   "sha256": "0l7dln7qcrgzm73vk7jp8wr2kibg18973xmdzyyc162hdnlbrpb0"
+   "commit": "dbb7b043edb42341b7f48ce0d81ba08c3c676076",
+   "sha256": "1xkhk8zb84c8jdgc5yjizzfyf265gk110fv8adww270sqg71la9v"
   }
  },
  {
@@ -80557,11 +81570,11 @@
   "repo": "RyanMillerC/poke-line",
   "unstable": {
    "version": [
-    20200818,
-    1403
+    20200901,
+    131
    ],
-   "commit": "fe876cd6e8fdf3a68037285eda4ac2eaf977eae4",
-   "sha256": "04dpfg22nqmqrw3rzpyh62kb17iqdadmimrnrvy9cnyd8mla0k5z"
+   "commit": "b002693c6cb3ac681de4b6049f90fdd1c685aaad",
+   "sha256": "1xg8kz4hffmj1m3gkj2qn3gmfr879mcyhhc277m0s01rhff162h4"
   }
  },
  {
@@ -80624,8 +81637,8 @@
   "repo": "mavit/poly-ansible",
   "unstable": {
    "version": [
-    20181222,
-    1517
+    20200826,
+    1542
    ],
    "deps": [
     "ansible",
@@ -80634,23 +81647,24 @@
     "polymode",
     "yaml-mode"
    ],
-   "commit": "2cb970a0e27b41ae85bc51d24ef36fa2c7b34bbc",
-   "sha256": "04vf6zgcra47j3phxbb43q5sa5ldavnbiwwdlw1xipg44991j6md"
+   "commit": "d76f6ec2374ec46ad78f2d0c3e1d1d91ee44c2bf",
+   "sha256": "0f0yq6gmkp194nxk90ipprglf1xkmxrgz1rkgrhfslvxq4q2l81h"
   },
   "stable": {
    "version": [
     0,
-    2,
-    1
+    3,
+    0
    ],
    "deps": [
+    "ansible",
     "ansible-doc",
     "jinja2-mode",
     "polymode",
     "yaml-mode"
    ],
-   "commit": "01c9ec1d8a933fa0b2711940d29331d58c27d2a7",
-   "sha256": "02ff0df8bn5cwvnpc2862wsii2xvjh0waymgiybm8j829x1awjp9"
+   "commit": "d76f6ec2374ec46ad78f2d0c3e1d1d91ee44c2bf",
+   "sha256": "0f0yq6gmkp194nxk90ipprglf1xkmxrgz1rkgrhfslvxq4q2l81h"
   }
  },
  {
@@ -81002,8 +82016,8 @@
   "repo": "ponylang/ponylang-mode",
   "unstable": {
    "version": [
-    20200724,
-    137
+    20200825,
+    1857
    ],
    "deps": [
     "company-ctags",
@@ -81015,14 +82029,14 @@
     "yafolding",
     "yasnippet"
    ],
-   "commit": "136cc4f7ab4f2ab549633392a72d55051c8b31ac",
-   "sha256": "0pjjccd145bla2gshs648kwhlw9r4n449g318nw81v2nn10z6qwl"
+   "commit": "7c1c8c3e507dcd4eeb47c804c8d2eb648d4cadfc",
+   "sha256": "0xgg5sc5r3ybns6szfqn6h515fdjiml9vayc93akh11mxgcfy8ap"
   },
   "stable": {
    "version": [
     0,
-    5,
-    3
+    6,
+    0
    ],
    "deps": [
     "company-ctags",
@@ -81034,8 +82048,8 @@
     "yafolding",
     "yasnippet"
    ],
-   "commit": "0b876e6a2d602f94cc118e6b76f5f79d18244325",
-   "sha256": "00xn2mhnf5qvn4v6yncmfa9ijrb33zl49mlc7pqn8pzr8nhbxzvc"
+   "commit": "ebf9c096b26ec1708acc7c84e96998d2b83cb548",
+   "sha256": "066hargy2nfgkkrr0yhlsf2bdjmkmybx513lf91bn1mgwhrmq84v"
   }
  },
  {
@@ -81238,20 +82252,20 @@
   "repo": "emacsorphanage/popwin",
   "unstable": {
    "version": [
-    20200122,
-    1440
+    20200908,
+    816
    ],
-   "commit": "d69dca5c9ec4b08f5268ff2d6b5097618d4082d7",
-   "sha256": "1w2dmzmy8k4drdhjzkryk6nbkl56aizvyawwn3dyc2gr0vg8lbb4"
+   "commit": "215d6cb509b11c63394a20666565cd9e9b2c2eab",
+   "sha256": "1x1iimzbwb5izbia6aj6xv49jybzln2qxm5ybcrcq7xync5swiv1"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
-   "commit": "4052b6e51bc6cc80cfc86007d2cadbbc4bbd55b5",
-   "sha256": "0kdlpjrf1xqyqyzfdymbin34jgs06l465p2ggpj4bb4zaypw2hr5"
+   "commit": "215d6cb509b11c63394a20666565cd9e9b2c2eab",
+   "sha256": "1x1iimzbwb5izbia6aj6xv49jybzln2qxm5ybcrcq7xync5swiv1"
   }
  },
  {
@@ -81339,11 +82353,11 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20200818,
-    606
+    20200915,
+    921
    ],
-   "commit": "7b92a54e588889a74d36d51167e067676db7be8a",
-   "sha256": "1638qw6m588a1dh8gfic1n2mzacm7rzs99ds8qwdfqs3ids857nj"
+   "commit": "5696463afe2b0bc7b9c2705663daf9afc7ef18ad",
+   "sha256": "19ivn1zi020b6rdn30wjyrfwr3wnrdzpvffwwb7wfvfzn6k2b6a5"
   },
   "stable": {
    "version": [
@@ -81625,8 +82639,8 @@
     20200818,
     1400
    ],
-   "commit": "cc289ba3b0d89f251267ca2b669d01b3afecc530",
-   "sha256": "0xwy2xh55dm4y7wlz2g6fkwf1xyqqjyp0sjb522qgasivknzwa5p"
+   "commit": "0c5d611d9fc6431dd049a71a6eda163c37617a33",
+   "sha256": "1wl445iric3jnhkf2wq4f23zi4yb0k731p0hrydvb2c5vyhsbb6n"
   },
   "stable": {
    "version": [
@@ -82256,14 +83270,14 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20200819,
-    531
+    20200916,
+    814
    ],
    "deps": [
     "pkg-info"
    ],
-   "commit": "46d2010c6a6cccfc4be72317f10ea99fd041ab54",
-   "sha256": "1xd4ag6sypqhfn85vnr8609cl9nip0l5j77226p6apv6yhdippqx"
+   "commit": "7b6ac286120421216faae43f9e234d801a30ee3d",
+   "sha256": "16rlz3dz3lw6kjajylq7js1ggpvdc38fxans06chbk5x6l4rh9h6"
   },
   "stable": {
    "version": [
@@ -82325,15 +83339,14 @@
   "repo": "andrmuel/projectile-git-autofetch",
   "unstable": {
    "version": [
-    20191013,
-    1806
+    20200820,
+    2028
    ],
    "deps": [
-    "alert",
     "projectile"
    ],
-   "commit": "4a3eba7658a52c6e955d5f7085cd3fd62b53b9c6",
-   "sha256": "01jsj0pv9qqbkdmbykvk4ic40hc1nhaiaqvx17hi7p89hq3nzffr"
+   "commit": "423ed5fa6508c4edc0a837bb585c7e77e99876be",
+   "sha256": "18z8ik1wgrs57j52pjc7pq1z09c5xz0mxwjz0w37fk0iyhirchd4"
   },
   "stable": {
    "version": [
@@ -82357,8 +83370,8 @@
   "repo": "asok/projectile-rails",
   "unstable": {
    "version": [
-    20200417,
-    1711
+    20200916,
+    1458
    ],
    "deps": [
     "f",
@@ -82367,8 +83380,8 @@
     "projectile",
     "rake"
    ],
-   "commit": "11980b2bcb99208888856a9b8666ff329b6f0142",
-   "sha256": "0crb08byq1i9wcjmcl645wc03p1jadm4f9nd138rii69nzancwfl"
+   "commit": "c48c91424fde0f91e37ed9b2535daeab38c66822",
+   "sha256": "1qqmps41c9a67yyp5j9xg36pp3p8w0ix9wdljaz1z48g9744cbg7"
   },
   "stable": {
    "version": [
@@ -82688,11 +83701,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20200623,
-    1748
+    20200911,
+    3
    ],
-   "commit": "03e427a8f19485e12b2f95387ed3e0bff7cc944c",
-   "sha256": "0ykxb4xdsxv2mja620kf61k2l18scs0jdsfsg1kzs2qf4ddjscyn"
+   "commit": "4f6b6027632f55d7a8248ae509cc6526a372ce9f",
+   "sha256": "127zgy1bm14z74c2crifjpm2q7hbs58q8pkm7bxpfl65c58xgzb3"
   },
   "stable": {
    "version": [
@@ -82795,8 +83808,8 @@
     20200619,
     1742
    ],
-   "commit": "214c77e1b76e63e512bd675d1c300c80438642b6",
-   "sha256": "1fxf5gydjcfc9gdwv6yfcwv85ww5glqbzlfv9hcnkddwlz6schxa"
+   "commit": "300dfcc5bf46d0fae35146db2195891df4959e4b",
+   "sha256": "1xq04ljf6q6l20mnrqg4y88sc3mplqws1cgfhh9p6ddppsi8kivc"
   },
   "stable": {
    "version": [
@@ -82847,11 +83860,11 @@
   "repo": "stardiviner/proxy-mode",
   "unstable": {
    "version": [
-    20200131,
-    816
+    20200913,
+    38
    ],
-   "commit": "e9b2a4bb032aaf13b006b74eec309a9bf2249cf0",
-   "sha256": "1wmj3ahjj1g7sx36fda6fhicvmxkm8qm64zqdk3qqj808jik1pry"
+   "commit": "efe2ad19a20898c145fd63b5f85f25b662f6ea43",
+   "sha256": "11l8v3igwwx0n0l3a069zzwzzj9q0p99l9x91sxzgw8v0g438vjx"
   }
  },
  {
@@ -83029,6 +84042,24 @@
    ],
    "commit": "a539dc11ecb2d69760ff50f76c96f49895ce1e1e",
    "sha256": "1p0k770h96iw8bxm8ssi0a91m050s615q036870lrlsz35mzc5kw"
+  }
+ },
+ {
+  "ename": "ptemplate",
+  "commit": "59f4fde6fa549e45a520e42a331266c687b40e31",
+  "sha256": "08pyr3kbsilfgcsss8hk1w01xrbgavipgl8ih1rhfnz76q1ay2dp",
+  "fetcher": "github",
+  "repo": "nbfalcon/ptemplate",
+  "unstable": {
+   "version": [
+    20200927,
+    1003
+   ],
+   "deps": [
+    "yasnippet"
+   ],
+   "commit": "b953b9decd12a049b53a68d3857de147925d388b",
+   "sha256": "06x7jhvc98caz5bz85lbpbdlmzfbkpwc6qpr5dxmqdwg2xj980ih"
   }
  },
  {
@@ -83555,8 +84586,8 @@
    "deps": [
     "pythonic"
    ],
-   "commit": "d191037fe62ed8d4fee5888845da3e2c386d8e89",
-   "sha256": "0dipwjdkx4887g61gn22wga4pvvkwv6rx7izq73l8b6x1mc17c0h"
+   "commit": "b818901b8eac0e260ced66a6a5acabdbf6f5ba99",
+   "sha256": "16hclgvqbz98py70aic7cz070snyikyb4wflml4qr40pqf91iw48"
   },
   "stable": {
    "version": [
@@ -83619,8 +84650,8 @@
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20200510,
-    704
+    20200927,
+    323
    ],
    "deps": [
     "async",
@@ -83628,8 +84659,8 @@
     "pyim-basedict",
     "xr"
    ],
-   "commit": "e54153f462dd8cd8e9bb379e0483a2849ec94f42",
-   "sha256": "0zsw25q1nqkqc3vgi95064v9wph1ynhiqi8gvc3fqq3k8i2jgy4v"
+   "commit": "73cf3fa35a5ead31de373eb4c8d59498ee3d64e6",
+   "sha256": "08w86k30lr16h7cda9a2s1wvh6a18q17i8l4a2jcclqnizzq90zk"
   },
   "stable": {
    "version": [
@@ -83696,14 +84727,14 @@
   "repo": "tumashu/pyim-wbdict",
   "unstable": {
    "version": [
-    20200331,
-    542
+    20200910,
+    1445
    ],
    "deps": [
     "pyim"
    ],
-   "commit": "daa223e2603a5ef3e6c8e33575d8f4e4604a8d3c",
-   "sha256": "0inl29fa2l5grn6z2wszj43bv17yf7n9x8l77zk2xp8q3gkswd86"
+   "commit": "8b1f0dfa1c5f5f8e5fb110a0963603ee08d60932",
+   "sha256": "11y4xa27w8n16181bddxs8w5p7r2mk38l19id69w2xvvaqa36prf"
   },
   "stable": {
    "version": [
@@ -83775,8 +84806,8 @@
     20200503,
     1624
    ],
-   "commit": "52fd8e17c6aedbc68f58f1169363d6cc216f405b",
-   "sha256": "0nvgv67gq80hriaasck4zrr3v7qqrw6apxhnyixyavabdvvrawqz"
+   "commit": "c433df74231c8e38d64f3a4e6f0d77b8753eb257",
+   "sha256": "1jyp3vif5sczzlxmpbwc58sdjvgksv3aicqk5hjxy4fch79jr9cn"
   }
  },
  {
@@ -84041,8 +85072,8 @@
   "repo": "wbolster/emacs-python-pytest",
   "unstable": {
    "version": [
-    20200812,
-    737
+    20200906,
+    914
    ],
    "deps": [
     "dash",
@@ -84051,8 +85082,8 @@
     "s",
     "transient"
    ],
-   "commit": "fc056faf2757c42641ed94d36a090e56eb13572f",
-   "sha256": "00dwbh549ygnrp98s883v45f5pbb34f2j5qwvw92camhp6daw38y"
+   "commit": "a2f88b197cc1c38c6d5a20c46d801f3377c54822",
+   "sha256": "0njnh1vph07zdx1hjj4518vc0gqy1xy3pas3k40wa2gfzqbyyvnr"
   },
   "stable": {
    "version": [
@@ -84336,8 +85367,16 @@
   "repo": "quelpa/quelpa",
   "unstable": {
    "version": [
-    20200617,
-    2205
+    20200906,
+    1153
+   ],
+   "commit": "1bbd327d6b62ae682e07e4949c6f62b43bc35e14",
+   "sha256": "0dzjn2sp8ypr9dpyhnqsqwap4ryzl8ajsr6mfgdh0djf81dh55n6"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
    ],
    "commit": "f1fc228f217be692eaae2d53f51966ce922d6a32",
    "sha256": "03h30qcixq54q212381cf7mahi2k9q4590vm44pqy9widpigmxz7"
@@ -84449,20 +85488,20 @@
   "repo": "emacsorphanage/quickrun",
   "unstable": {
    "version": [
-    20200603,
-    1902
+    20200924,
+    301
    ],
-   "commit": "ce7383c53215077f7e1d258d389cf8731309fbe9",
-   "sha256": "0dscg35hrywn8qr02q46y0cdclyscz6qxa0dqphkx3bv9xvzmqjl"
+   "commit": "772ca9be69483c49427d51877907e60c35aaa48d",
+   "sha256": "010wasrj3r793947c7hx589znddhz0xc88y5xfda234bvg4xz39b"
   },
   "stable": {
    "version": [
     2,
     3,
-    0
+    1
    ],
-   "commit": "072ec7be93f31e9dd265fb834cd709d0c0d4a8bb",
-   "sha256": "1zx8hpm5wa9ad675py8676071pip6831d4jy2dqyrlxpfvi6q47l"
+   "commit": "0133cac651918071a824e85b55e10d44f32a1979",
+   "sha256": "0a1n2v09h0n7d9p2izflqqang4ny0b46dlqvmxvkkik4bb6f4wcz"
   }
  },
  {
@@ -84611,15 +85650,15 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20200810,
-    1513
+    20200924,
+    1506
    ],
    "deps": [
     "faceup",
     "pos-tip"
    ],
-   "commit": "c55fd70c5e9a371f262486f7d5d8837481388b95",
-   "sha256": "13ngnm22h5rzmm9pvgbw9nidv8jkkcsckbypi2mn1k8j8wfjypx0"
+   "commit": "a712101ab183a764e6958b4dc74002db8434ffd9",
+   "sha256": "0021a578k80d2djx90apq1gc5b65kwg3hv9xgqpaymnyx30npg79"
   }
  },
  {
@@ -84708,11 +85747,11 @@
   "repo": "Fanael/rainbow-delimiters",
   "unstable": {
    "version": [
-    20191018,
-    1233
+    20200827,
+    321
    ],
-   "commit": "5125f4e47604ad36c3eb4706310fcafac729ca8c",
-   "sha256": "1jh1gv69cjlrjkmjrkhgc7jffyxlkq9nci5ag4z1alskfp6favir"
+   "commit": "f43d48a24602be3ec899345a3326ed0247b960c6",
+   "sha256": "1lm1nwm3hg7nss9i8ar1265ziiyn4ckmc4fvn5zwnqq96hxmdk7x"
   },
   "stable": {
    "version": [
@@ -84808,14 +85847,14 @@
   "repo": "Raku/raku-mode",
   "unstable": {
    "version": [
-    20200524,
-    1625
+    20200902,
+    2139
    ],
    "deps": [
     "pkg-info"
    ],
-   "commit": "e0639c89a3a29e9196e298951da6c3a79fb944e8",
-   "sha256": "02zn1sm86srwdzdkhw53ll0h41a9hwh6c8lan72530zysjrm4x1i"
+   "commit": "8a6e17f1749c084251d19c3d58b9c1495891db6d",
+   "sha256": "1nxv5x9ywm9zzzl69ssvvxf0lphjqjfazf5qcd3qpv4w5rqa1s3b"
   },
   "stable": {
    "version": [
@@ -84892,7 +85931,7 @@
     20200607,
     2002
    ],
-   "commit": "d7c18370981c9e585bc0fb78f7e55033457ca643",
+   "commit": "caf75f0060e503af078c7e5bb50d9aaa508e6f3e",
    "sha256": "0xfg38ginrd0sdn194gpapi67q6i81csddgsf0rqmwihazpgs060"
   },
   "stable": {
@@ -85014,20 +86053,20 @@
   "repo": "thiagoa/rbtagger",
   "unstable": {
    "version": [
-    20200714,
-    1658
+    20200911,
+    2209
    ],
-   "commit": "b3333b9dc9ffdaf5dfb2ea6ef2dd0f74e2f0f03f",
-   "sha256": "04zccf9bis259c13nzljfjajjgkrhhbb3b2v6q6q12c30ikj5b09"
+   "commit": "32d1df138a9b70530ec7a71dc85aa6e133a6cd95",
+   "sha256": "0bcd54pfy6sw95nc344ahpd2m7a7w6x2qf7badda2sil3bk6fcd1"
   },
   "stable": {
    "version": [
     0,
     3,
-    2
+    4
    ],
-   "commit": "b3333b9dc9ffdaf5dfb2ea6ef2dd0f74e2f0f03f",
-   "sha256": "04zccf9bis259c13nzljfjajjgkrhhbb3b2v6q6q12c30ikj5b09"
+   "commit": "32d1df138a9b70530ec7a71dc85aa6e133a6cd95",
+   "sha256": "0bcd54pfy6sw95nc344ahpd2m7a7w6x2qf7badda2sil3bk6fcd1"
   }
  },
  {
@@ -85290,16 +86329,16 @@
   "repo": "realgud/realgud",
   "unstable": {
    "version": [
-    20200809,
-    2221
+    20200923,
+    610
    ],
    "deps": [
     "load-relative",
     "loc-changes",
     "test-simple"
    ],
-   "commit": "332d13673074bee252ae7819b0898ee7c7895d2e",
-   "sha256": "0cnnhxgyrjvr75pin7kis5qzd54hh0qscbnvvm8jflmljzca77lz"
+   "commit": "ff660011c82c6af504915833e2d981a547b7ad58",
+   "sha256": "1cqzrp1fk4hk28fh0q9d448cjv47qgvxy2z786x2hpmb42izrc76"
   },
   "stable": {
    "version": [
@@ -86000,10 +87039,10 @@
   "stable": {
    "version": [
     0,
-    5
+    6
    ],
-   "commit": "e8f70b20caf6672353a2b0ee3161d4791c412696",
-   "sha256": "19mji7frfvj925nx2m2cdvsx0lf69dzdl5wbdppyra9717rsspbq"
+   "commit": "45c0add95025f53ca644a6c8b9afa05b2da3c474",
+   "sha256": "1dfn7c3gpavpiwd73v2pasd8wd8b62dczhg9iv1cgh8vaqlsf92x"
   }
  },
  {
@@ -86166,8 +87205,8 @@
    "deps": [
     "reformatter"
    ],
-   "commit": "439a4d5e130e67e9e8c34e813fa1dc6631e7a8d5",
-   "sha256": "0lzlhmz0c4jv65phksh6aya93rlh8rqcffbvz1llcyj8i2gr7hqj"
+   "commit": "0c6a49a06e8686eefd0c8029f76fe59b7349b8ed",
+   "sha256": "018zf03yzxp8maa49lnz0bdqcyfbc7xz55xq025ccgvmpsm1cxy8"
   }
  },
  {
@@ -86229,16 +87268,16 @@
   "repo": "mtekman/remind-bindings.el",
   "unstable": {
    "version": [
-    20200301,
-    2213
+    20200820,
+    1723
    ],
    "deps": [
     "map",
     "omni-quotes",
     "popwin"
    ],
-   "commit": "730b6d7b30e397f8f11a6d3d5c269df21a33c450",
-   "sha256": "16fk0xnp5awsq45i0wpdkzy6hwccayvwwiag9kar8kmb6nqs2y17"
+   "commit": "c9a327bfd3c68a0c41b5b64df491bdee4c73ca39",
+   "sha256": "1rwlzf9mg66hgdqjgh2garp8qckajs4a1kiqg3xygaf7009kr4nk"
   }
  },
  {
@@ -86638,11 +87677,11 @@
   "repo": "pashky/restclient.el",
   "unstable": {
    "version": [
-    20200502,
-    831
+    20200901,
+    1442
    ],
-   "commit": "ac8aad6c6b9e9d918062fa3c89c22c2f4ec48bc3",
-   "sha256": "1a2c7xzy7rsan1zcdskia6m7n6j29xacfkqjlfdhzk6rr1bpzkwk"
+   "commit": "abc307b965bf6720bc466281f2e204cd5ce37dc3",
+   "sha256": "0dv9was6ycwwyfabr8z71wcc3hbqnxgwbdqkdkx0iaccq2xyj07b"
   }
  },
  {
@@ -86660,8 +87699,8 @@
     "helm",
     "restclient"
    ],
-   "commit": "ac8aad6c6b9e9d918062fa3c89c22c2f4ec48bc3",
-   "sha256": "1a2c7xzy7rsan1zcdskia6m7n6j29xacfkqjlfdhzk6rr1bpzkwk"
+   "commit": "abc307b965bf6720bc466281f2e204cd5ce37dc3",
+   "sha256": "0dv9was6ycwwyfabr8z71wcc3hbqnxgwbdqkdkx0iaccq2xyj07b"
   }
  },
  {
@@ -86706,6 +87745,29 @@
    ],
    "commit": "976d6f01a3e214917f16b82e750d825cb9bfcc59",
    "sha256": "08rwhkx2chphrfqd6l2bjr1w4rn394q8w5iy93cdprl5y56axvp6"
+  }
+ },
+ {
+  "ename": "revbufs",
+  "commit": "959511aaaee405b1e56a9966a8746a24bc477f5e",
+  "sha256": "15l2arcm9khmq4gngli9k06x0pcbbkb68hhdhf6bc5dxssfps2gw",
+  "fetcher": "github",
+  "repo": "tychoish/revbufs",
+  "unstable": {
+   "version": [
+    20200907,
+    2223
+   ],
+   "commit": "df3c02d3063951582c693ae12547993cec8256e2",
+   "sha256": "087drifqzap5nh6ias109wsk0ndc2yp7xp62k7n2imp3m4wlq77z"
+  },
+  "stable": {
+   "version": [
+    1,
+    2
+   ],
+   "commit": "74dc21949fe0f910e92b8e4e85318c8fb0b7c86a",
+   "sha256": "1mwplm93src8js33dlpdmjrbc6hr5yf92x4d7jzh14wpiahzpxaz"
   }
  },
  {
@@ -86813,8 +87875,8 @@
     20200710,
     155
    ],
-   "commit": "343e7155f8238a7a53ef1f753319b8e2f9e8e8b9",
-   "sha256": "13wgrj5qbg2pv6d9yxkbsrrllvd40m4p7911g23wcwnnx211p943"
+   "commit": "9d39012068c60d1c525354132e1ee48a871d076d",
+   "sha256": "1ry7mipfrrgv4k5iw9l7m2q31mlxbjzxp1lrsr474avwkqnlqb3m"
   }
  },
  {
@@ -86840,14 +87902,14 @@
   "repo": "galdor/rfc-mode",
   "unstable": {
    "version": [
-    20200719,
-    1241
+    20200823,
+    1217
    ],
    "deps": [
     "helm"
    ],
-   "commit": "02546beecf4c495940885e7b7b911d84b12646ef",
-   "sha256": "1v52vbs2zbqv62wcgcrqgjcwcdq0w6hdb14nma4yhqldnqi57875"
+   "commit": "8587416c2123dd4dd1a7c2bc9207205e47e9b54a",
+   "sha256": "0d17i0sk69v8008j2isv792wgzgbg6zdxn6nhj6bapha78p21syx"
   },
   "stable": {
    "version": [
@@ -86870,30 +87932,28 @@
   "repo": "dajva/rg.el",
   "unstable": {
    "version": [
-    20200703,
-    1250
+    20200926,
+    1048
    ],
    "deps": [
-    "s",
     "transient",
     "wgrep"
    ],
-   "commit": "853c1acaf999500d867180b9e71938366c8e1a7c",
-   "sha256": "0lp32mjmbzjbsvzia2zd29yv0i75mqvp1w7c0jcwvyyl6gqbg3k1"
+   "commit": "382fdfc8f35b7a054fce478bbc3ca788786c7f2c",
+   "sha256": "0119i8bfkb47dxfwngd1dxj6glb022vlijz71fjzxbbwwddyawhc"
   },
   "stable": {
    "version": [
-    1,
-    8,
+    2,
+    0,
     1
    ],
    "deps": [
-    "cl-lib",
-    "s",
+    "transient",
     "wgrep"
    ],
-   "commit": "3f07304b8a7ee70ac91f3b66e76dc1d621a96bff",
-   "sha256": "0k7x5z7mh9flwih35cqy8chs54rack3nswdcpw5wcpgv6xim227y"
+   "commit": "7326691e9c761a80f64d00c0848925c6e25c53c0",
+   "sha256": "0anmgh336lgnzg4pwyg7irax7xlz63hjf47kw9j4v7gikyc1wna2"
   }
  },
  {
@@ -87029,8 +88089,8 @@
   "repo": "DogLooksGood/emacs-rime",
   "unstable": {
    "version": [
-    20200816,
-    827
+    20200925,
+    1225
    ],
    "deps": [
     "cl-lib",
@@ -87038,14 +88098,14 @@
     "popup",
     "posframe"
    ],
-   "commit": "aab21695f1dee0db3ddf0f0c834b94aecec7057c",
-   "sha256": "0rzghfnrdyrqijw76f4vvsn3hsninwp3qyvr1p7r0ddz21xz04np"
+   "commit": "56f2c358000472eafef6015688dce2aab19349fb",
+   "sha256": "1jf1wl8jbifbakx1a6862dvrcwrg8qa4vw981pj29xlda90ll8p7"
   },
   "stable": {
    "version": [
     1,
     0,
-    3
+    4
    ],
    "deps": [
     "cl-lib",
@@ -87053,8 +88113,8 @@
     "popup",
     "posframe"
    ],
-   "commit": "2a0b116d56bf54456eb5d6e8e80a7a6cf6944863",
-   "sha256": "08rzkiqwcl8j3i2yyibll5lcsj8720plzm9zfdgmxgkw7vhcyix5"
+   "commit": "ee7f951f0bc3b55034634019dd385706bc413dbb",
+   "sha256": "1a50cziwg7lpgh26yvwxs46jfyfq1m0l6igbg5g5m288mz4d3an9"
   }
  },
  {
@@ -87321,6 +88381,21 @@
   }
  },
  {
+  "ename": "ron-mode",
+  "commit": "67c658fe2ee340f3902c7ff5c0138995e69fe5dc",
+  "sha256": "1w0zicbva3xvqi1qz87fbr4ciq28hg70f0n2q70drh4nqb4ahwm2",
+  "fetcher": "git",
+  "url": "https://codeberg.org/Hutzdog/ron-mode",
+  "unstable": {
+   "version": [
+    20200830,
+    1554
+   ],
+   "commit": "c5e0454b9916d6b73adc15dab8abbb0b0a68ea22",
+   "sha256": "132r5346m3li5n7v7fyzyg8sg3679apl7q4y57n5aq395s0q9wyn"
+  }
+ },
+ {
   "ename": "rope-read-mode",
   "commit": "7bf40e9d550fba9ded11b99032d78c69af21a6f3",
   "sha256": "1xbbf3slgil19p34k5wsnvq60y64wkz40153sh8y1gxlssmy55fy",
@@ -87484,11 +88559,11 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20200810,
-    2326
+    20200826,
+    1731
    ],
-   "commit": "b57b36039f6411f23009c4ec0315ca5a7adb6824",
-   "sha256": "1816yxyqkxd895wka9xkxpca59iwjpcv73d25sq03z2gf1ayd56b"
+   "commit": "9ad2ff1c2c09c9d2eb945bc9f174f27fa36f0ae1",
+   "sha256": "19l0iiwkz6q9gs0wmi792016d18fp1m1i9g60yfk4wg5w9rbvzk2"
   },
   "stable": {
    "version": [
@@ -87513,8 +88588,8 @@
    "deps": [
     "rtags"
    ],
-   "commit": "b57b36039f6411f23009c4ec0315ca5a7adb6824",
-   "sha256": "1816yxyqkxd895wka9xkxpca59iwjpcv73d25sq03z2gf1ayd56b"
+   "commit": "9ad2ff1c2c09c9d2eb945bc9f174f27fa36f0ae1",
+   "sha256": "19l0iiwkz6q9gs0wmi792016d18fp1m1i9g60yfk4wg5w9rbvzk2"
   },
   "stable": {
    "version": [
@@ -88032,8 +89107,8 @@
   "repo": "brotzeit/rustic",
   "unstable": {
    "version": [
-    20200724,
-    1517
+    20200925,
+    2127
    ],
    "deps": [
     "dash",
@@ -88047,8 +89122,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "75b99201bb4e7a0bd990c006896ad7897f284ca2",
-   "sha256": "1ddma5fi2yaxg2c2hvigfz4hbp218l71ixcnnkzp8ilqr8m2jvjj"
+   "commit": "781a2914db5e29823a878533b20f302cdea0e5e4",
+   "sha256": "0fs0yr72l1r70md25qplai9a87b3ixvaxzw7mng3m0kkgh79amas"
   }
  },
  {
@@ -88059,11 +89134,11 @@
   "repo": "senny/rvm.el",
   "unstable": {
    "version": [
-    20150402,
-    1442
+    20200913,
+    144
    ],
-   "commit": "081d5173158054c6d0780b9462c74c5697eac1fc",
-   "sha256": "1s950jmhrwjmzrr3qv3636sn2rhxfvaqlrl36h8700pq3791l1fs"
+   "commit": "6897576bb068b967347fabd7fb15f4ae7ec13462",
+   "sha256": "06wgkb33s5xff43rzs4xf4zxdzywb950j9mw6ssvj0kv9r9l9lcl"
   },
   "stable": {
    "version": [
@@ -88083,11 +89158,11 @@
   "repo": "Kungsgeten/ryo-modal",
   "unstable": {
    "version": [
-    20200515,
-    1703
+    20200907,
+    647
    ],
-   "commit": "5d988e8b3a5d3d6f2f58d97031d2f500ef55473b",
-   "sha256": "0p7f02h5vsf4500gf4nl95myvh7pha47rdllscgs3b9jcx1kgyz2"
+   "commit": "5f8ce6b7c5aab5efabf1f7af1e3a1d2155b0407c",
+   "sha256": "150b5wqz43vwgb3kmff7bqk3v15janx3w4h6x4j6d6w7p40wnlvx"
   }
  },
  {
@@ -88418,8 +89493,8 @@
    "deps": [
     "pdf-tools"
    ],
-   "commit": "bbbc466fff060b372a9d2b30e48ec6bbb7d03095",
-   "sha256": "13dxd06dicv50rl1kk6c5971iaj7x3imkqs5q2ndm0daqzrp0lva"
+   "commit": "9bdb911989a0d84d5cac62dc533e9a8a6141effb",
+   "sha256": "05j7ijp8wnz4vhbk8yk3l56v2dqyhwnxr9v3d2bsng7rrf3g2y4i"
   }
  },
  {
@@ -88453,26 +89528,26 @@
   "repo": "clojure-emacs/sayid",
   "unstable": {
    "version": [
-    20190919,
-    654
+    20200902,
+    703
    ],
    "deps": [
     "cider"
    ],
-   "commit": "cbc3546fb6b1374080f1646ac3a6532a5723b7eb",
-   "sha256": "06aysbwr4lr9cd8mbfdpkiz8458hwl5qg41nq1wnl5dx0gvw3fgn"
+   "commit": "27f35778de9509067716a7bed14306787334a589",
+   "sha256": "01a6cvk3ycg0z1qg30rqsnx49drmdfpgd78mhf2m6avvagzf8l9s"
   },
   "stable": {
    "version": [
     0,
-    0,
-    18
+    1,
+    0
    ],
    "deps": [
     "cider"
    ],
-   "commit": "5412d0e129337f0f97a5501521f86dd7deee5804",
-   "sha256": "1immns40clz78frsd4dc5ck5n90ac5pfid40bw3phxwr4prhmgf6"
+   "commit": "985837897ca6f9bc5f1d1b1414ad15554a60d3b3",
+   "sha256": "0vdz3dxwi02an5k956apq3ah0dpzly9zd44fhmrqlcjimxc69m7p"
   }
  },
  {
@@ -88507,11 +89582,11 @@
   "repo": "openscad/openscad",
   "unstable": {
    "version": [
-    20200628,
-    2256
+    20200830,
+    301
    ],
-   "commit": "0c9a36b82c7129a0fdce20ce99e15ecdffd3b437",
-   "sha256": "0qsvi7d3bcsai99dvbdfm8n6qafvwj51r4g4ph5jch2f1yb8m995"
+   "commit": "2c56f80a3aed70e1f58a711489091803d00ab7d5",
+   "sha256": "04401b94rknk9ssgqxdygshsnvxbn9acwf150g7srrjpizhi444i"
   }
  },
  {
@@ -88845,14 +89920,11 @@
   "repo": "zk-phi/scratch-pop",
   "unstable": {
    "version": [
-    20200818,
-    1820
+    20200910,
+    226
    ],
-   "deps": [
-    "popwin"
-   ],
-   "commit": "b1bdd0f8a345737069194ab8727f164f5d8560b4",
-   "sha256": "03x0kb0cf4yzjxl9nqwl3sg9nl75l9n8k4ain0yw0h2vpi2g0wf3"
+   "commit": "cbe842fd78e4b742ece9fc493ebf43e69d872866",
+   "sha256": "1rqmh5nv9qlc17bvqm7q000r0h0y1ymgy7gvxyhjwk6yhaynh0jw"
   }
  },
  {
@@ -89029,6 +90101,38 @@
    ],
    "commit": "c4ae86ac1acfc572b81f3d78764bd9a54034c331",
    "sha256": "08yc67a4ji7z8s0zh500wiscziqsxi92i1d33fjla2mcr8sxxn0i"
+  }
+ },
+ {
+  "ename": "searcher",
+  "commit": "88a19196a3bdbc00245c8721bc518cd760482355",
+  "sha256": "0n8hwqdb5kasbai7mixdvr1yq7h7xg639ykqz2lfc22k43fgjfy6",
+  "fetcher": "github",
+  "repo": "jcs-elpa/searcher",
+  "unstable": {
+   "version": [
+    20200921,
+    1253
+   ],
+   "deps": [
+    "dash",
+    "f"
+   ],
+   "commit": "c891883bc12dc025d9c389ef406120c1f2b396a2",
+   "sha256": "0i2g0amfwvjrbpcflpm0hfalp6sw8i6pds3z6ips9lscjifib61f"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    2
+   ],
+   "deps": [
+    "dash",
+    "f"
+   ],
+   "commit": "c891883bc12dc025d9c389ef406120c1f2b396a2",
+   "sha256": "0i2g0amfwvjrbpcflpm0hfalp6sw8i6pds3z6ips9lscjifib61f"
   }
  },
  {
@@ -89237,11 +90341,11 @@
   "repo": "raxod502/selectrum",
   "unstable": {
    "version": [
-    20200817,
-    1459
+    20200920,
+    1416
    ],
-   "commit": "5448e7cbaeb8d58c5dfd474cd0e03d6db60ac532",
-   "sha256": "09xfi0gfk9jmjmz941cfzwrv15jlzqxzwlq4m0qb29g1r4kv62ng"
+   "commit": "1c8a9c32306f8a6519a312013bb07740c7414f17",
+   "sha256": "1ph5p25ac3ppgcbiws2n53mkrphidgw7x5yyf2x7lz08bvwmm7gv"
   },
   "stable": {
    "version": [
@@ -89267,8 +90371,8 @@
     "prescient",
     "selectrum"
    ],
-   "commit": "cc289ba3b0d89f251267ca2b669d01b3afecc530",
-   "sha256": "0xwy2xh55dm4y7wlz2g6fkwf1xyqqjyp0sjb522qgasivknzwa5p"
+   "commit": "0c5d611d9fc6431dd049a71a6eda163c37617a33",
+   "sha256": "1wl445iric3jnhkf2wq4f23zi4yb0k731p0hrydvb2c5vyhsbb6n"
   },
   "stable": {
    "version": [
@@ -89325,14 +90429,14 @@
   "repo": "wanderlust/semi",
   "unstable": {
    "version": [
-    20200818,
-    1252
+    20200831,
+    1137
    ],
    "deps": [
     "flim"
    ],
-   "commit": "10897f024fd9282c73385d24514cc4b57fe193db",
-   "sha256": "14d4j17l0ngg6fp00mf2zgyz6989cx9n5n3za7ifcfr8gjbbn7gp"
+   "commit": "939c80580101126c81a72f1643762fbc964f8b64",
+   "sha256": "1fdbyk264xdmkdyg7a1pr46w240h14y8d2iz14lpy56bnrw3syfd"
   }
  },
  {
@@ -89444,15 +90548,16 @@
   "repo": "twlz0ne/separedit.el",
   "unstable": {
    "version": [
-    20200702,
-    634
+    20200827,
+    725
    ],
    "deps": [
     "dash",
+    "dash-functional",
     "edit-indirect"
    ],
-   "commit": "fa752df206f8f6e64f27e2a6d998ddd58e3c444b",
-   "sha256": "1c0k5cg2si4i0hwdi7lbh058rq6vmry8ncddgq5dxbih14wpbys4"
+   "commit": "dc0b3448f3d9738f5233c34c5c8fc172eda26323",
+   "sha256": "0qjfhal2pjw1lk7qyb89lwibabpycibf5vsadinvqnn77m25sx04"
   }
  },
  {
@@ -90192,8 +91297,8 @@
     20200813,
     37
    ],
-   "commit": "7dcbab77334c5adf8309c7a93512c9f95a2c64e4",
-   "sha256": "0in8ir99b33d83nfxsnpj2dgyv4f558yrid77bp7f9k0qpgpj4zk"
+   "commit": "6ed57faedf7b0459c41438bf2077a7ff4946e742",
+   "sha256": "0hkx5yxydw789zks6570z7fidfczgnwa7hkpyk4rrq7vzhjfbb9b"
   }
  },
  {
@@ -90265,20 +91370,20 @@
   "repo": "jcs-elpa/show-eol",
   "unstable": {
    "version": [
-    20200723,
-    706
+    20200921,
+    1201
    ],
-   "commit": "9fe95a4b1cda218082eb1d977190cc66c7a6b4ea",
-   "sha256": "1nzid34cwgyqih46glw3r5hkav1px5wf8w2skbac1f3vvjfm6qk7"
+   "commit": "02fdb5b2832889afd6cad5c517da9b1e4611c766",
+   "sha256": "0yy97yzc8v1h0vjpm6zbrdwy8sd931mscrbrq1svvv2y227s4ffl"
   },
   "stable": {
    "version": [
     0,
     0,
-    4
+    5
    ],
-   "commit": "9fe95a4b1cda218082eb1d977190cc66c7a6b4ea",
-   "sha256": "1nzid34cwgyqih46glw3r5hkav1px5wf8w2skbac1f3vvjfm6qk7"
+   "commit": "02fdb5b2832889afd6cad5c517da9b1e4611c766",
+   "sha256": "0yy97yzc8v1h0vjpm6zbrdwy8sd931mscrbrq1svvv2y227s4ffl"
   }
  },
  {
@@ -90364,14 +91469,14 @@
   "repo": "chenyanming/shrface",
   "unstable": {
    "version": [
-    20200816,
-    1032
+    20200919,
+    1215
    ],
    "deps": [
     "org"
    ],
-   "commit": "9470de04daf0d917d0501432cea78cd6f5cefec4",
-   "sha256": "00qi4dg0684all2aw9dljzd3hp01vk3hsfqpf2pvri8l31a9dls5"
+   "commit": "64f9f0aac5242992473b868cf5627ebebec39215",
+   "sha256": "0bl3rrsl2mrkhpccsb99k4fwx6znmpkfciikli3am2dz82w7cxy3"
   },
   "stable": {
    "version": [
@@ -90518,20 +91623,20 @@
   "repo": "riscy/shx-for-emacs",
   "unstable": {
    "version": [
-    20200410,
-    639
+    20200905,
+    1918
    ],
-   "commit": "5308d6891276b0aa2b0fd865f6c6f8c1a80ecb54",
-   "sha256": "01sz7iqny2r1zfipkria6r5w48rlbrp3ranqqyywvsxhwwr3apmp"
+   "commit": "63e0feb8eca13691d4ebd5cf3a3ddef4d7675ece",
+   "sha256": "1cb5w6p9gnfxgh8qp7yj2f5ibpk1b4b5af3ynldaaj6yfpa8hqzn"
   },
   "stable": {
    "version": [
     1,
-    4,
+    5,
     0
    ],
-   "commit": "e5b4bae0a1a9bb8a762da40397a04efdd0b2b397",
-   "sha256": "0p9b621rgy34r1hl9xfzxh4xpx9gpsr3n330ypfxhlr0s5754j73"
+   "commit": "63e0feb8eca13691d4ebd5cf3a3ddef4d7675ece",
+   "sha256": "1cb5w6p9gnfxgh8qp7yj2f5ibpk1b4b5af3ynldaaj6yfpa8hqzn"
   }
  },
  {
@@ -90572,11 +91677,11 @@
   "repo": "rnkn/side-notes",
   "unstable": {
    "version": [
-    20200617,
-    1445
+    20200926,
+    1404
    ],
-   "commit": "27c964334b8e30fa88e4278ae58dc3d00df34f1f",
-   "sha256": "1xl2ykdscrwpxm02ypnf68mkxf9dkp64cj465b69s874x10bxfc3"
+   "commit": "f5135f652d2b21f55b4809151143845c6807de01",
+   "sha256": "1jnh4djxp4k0c1r6yq0n0zi9vadsj9daqnajs33g2npvhmyav0sr"
   },
   "stable": {
    "version": [
@@ -90831,11 +91936,11 @@
   "repo": "wachikun/simple-screen",
   "unstable": {
    "version": [
-    20161009,
-    920
+    20200926,
+    109
    ],
-   "commit": "596e3a451d9af24730ab31a8fe15c91a4264d09d",
-   "sha256": "0mqlwrkipgf977s0gx57fv5xrqli67hixprvra6q64isapr86yh1"
+   "commit": "3ce535755986f7c25890d11e42fa621a3a069a4f",
+   "sha256": "1cfgmpffqdxg536whik4ph2knxnmbgr4njq744glx82sfy9qp6wx"
   }
  },
  {
@@ -90951,8 +92056,8 @@
    "deps": [
     "terminal-focus-reporting"
    ],
-   "commit": "2568d04908af2d529f5ce0e71f0da541ff53e2a8",
-   "sha256": "0kmfhq6rypcc00ylmhf0m9nd51r6kzqfp6hcd22riynq51fb2cyh"
+   "commit": "ea022fcf821983e1be8b53a3157bf450edf8b565",
+   "sha256": "0bff7swm0vq8s496lgnadax85lhqjzha6vnzaxdjjqf4i639wgl4"
   }
  },
  {
@@ -91124,8 +92229,8 @@
   "repo": "yuya373/emacs-slack",
   "unstable": {
    "version": [
-    20200725,
-    1052
+    20200830,
+    1021
    ],
    "deps": [
     "alert",
@@ -91135,8 +92240,8 @@
     "request",
     "websocket"
    ],
-   "commit": "7570e82604b59b65e9ef31c5325bef45769ae027",
-   "sha256": "1i7fb4icj9h4lkcsfqqqhsi59msmslckcgxaa5aag4v3cdy93prg"
+   "commit": "1f6a40faec0d8d9c9de51c444508d05a3e995ccd",
+   "sha256": "19lan9nd8qfw2ws7mx814vrin04c892yn5c8g3nad7lpnzszgr1r"
   }
  },
  {
@@ -91363,11 +92468,11 @@
   "repo": "Fuco1/slovak-holidays",
   "unstable": {
    "version": [
-    20150418,
-    855
+    20200919,
+    1345
    ],
-   "commit": "effb16dfcd14797bf7448f5113085479db339c02",
-   "sha256": "1y1gay1h91c0690gly4qibx1my0l1zpb6s3x58lks8m21jdwfw28"
+   "commit": "4c6f635a2153ecb8f76d566d40ccb9d7b1d5fdc7",
+   "sha256": "05gjpmqxbbppxl2yag1c7shdld22grxqax4kinjs6ydkbd5mv5ai"
   }
  },
  {
@@ -91422,11 +92527,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20200816,
-    928
+    20200925,
+    1020
    ],
-   "commit": "155cb0655e037477b592f8bde9c80022427293e5",
-   "sha256": "0g0ncqb7x3g3gafxm5j0v893cvnskq4idb5442f0v8d3y9pr0lyi"
+   "commit": "2a117b802cda50686e58f0eb50f501fbbf774797",
+   "sha256": "1m4jbwcc745qhfs2iwaqvfcnjd47lc8i0259dc22d4npfy2lwv6r"
   },
   "stable": {
    "version": [
@@ -91837,11 +92942,11 @@
   "repo": "iquiw/smart-semicolon",
   "unstable": {
    "version": [
-    20171008,
-    133
+    20200909,
+    1412
    ],
-   "commit": "bcea2aa37befa40abf8b24a2d2314904e6df43b3",
-   "sha256": "0c58ncxwf8wakql2pfiawkl3rlfxsf2zy937nvahf9ygiic8bl3y"
+   "commit": "dd52a3e1a7b043fb88f799827c7b3e39f60a14f1",
+   "sha256": "109iygijidw2wljc9i151zh4r0n6ivrakb2p4zdy9cml7dwk3lzk"
   },
   "stable": {
    "version": [
@@ -91891,19 +92996,19 @@
   "repo": "jcsalomon/smarttabs",
   "unstable": {
    "version": [
-    20160629,
-    1452
+    20200907,
+    2025
    ],
-   "commit": "9cc2594b82b03e7d68645a4878f9359f8b8c34c5",
-   "sha256": "0bjl3j047jh674vyfmh9izwak2yic8f7aqv832hn1inhnavsl3xx"
+   "commit": "1044c17e42479de943e69cdeb85e4d05ad9cca8c",
+   "sha256": "0hkgw9i4yynazx5vbkb8a1lfp0yndyi8c1w3cf7ajxpnig3hs9j6"
   },
   "stable": {
    "version": [
     1,
-    0
+    1
    ],
-   "commit": "8b196d596b331f03fba0efdb4e31d2fd0752c4a7",
-   "sha256": "1kfihh4s8578cwqyzn5kp3iib7f9vvg6rfc3klqzgads187ryd4z"
+   "commit": "1044c17e42479de943e69cdeb85e4d05ad9cca8c",
+   "sha256": "0hkgw9i4yynazx5vbkb8a1lfp0yndyi8c1w3cf7ajxpnig3hs9j6"
   }
  },
  {
@@ -91932,15 +93037,15 @@
   "repo": "Fuco1/smartparens",
   "unstable": {
    "version": [
-    20200324,
-    2147
+    20200911,
+    1124
    ],
    "deps": [
     "cl-lib",
     "dash"
    ],
-   "commit": "555626a43f9bb1985aa9a0eb675f2b88b29702c8",
-   "sha256": "0hfywwhzv2dphi7gacp1sdyk47cmajzx5sqrcwxkn7mlwx876nsx"
+   "commit": "9489d4be73dfdd07734a4a85180b5c531fe0d0bd",
+   "sha256": "0p8iy70rmd2xb0fys3pqlfaf0r37qhmiflpsqch2m00z6n1kw92f"
   },
   "stable": {
    "version": [
@@ -92553,14 +93658,14 @@
   "repo": "bbatsov/solarized-emacs",
   "unstable": {
    "version": [
-    20200717,
-    1054
+    20200913,
+    2046
    ],
    "deps": [
     "dash"
    ],
-   "commit": "63eb59a7ef32abc6780883e27df69a6e42a8a6e4",
-   "sha256": "1hqqmji6vh468w73xi3fvkyzznr27f83czz0pcxzb00q62cbdqf4"
+   "commit": "2171202d12af19967e7a90f11c93c4f80e13f352",
+   "sha256": "173x5qiq1w0lqsbifws14p2ir7ncrh9jz53prbmwv6m2lsv8xl24"
   },
   "stable": {
    "version": [
@@ -92753,14 +93858,14 @@
   "repo": "emacsattic/sos",
   "unstable": {
    "version": [
-    20200510,
-    1734
+    20141215,
+    403
    ],
    "deps": [
     "org"
    ],
-   "commit": "6c25beae9f6db8fc7a037112ad5d4be9f5f36986",
-   "sha256": "1ia90sanqbigpag63w953kvfd1gyaakcvh65fsd79pcx4k38p4ly"
+   "commit": "1573adca912b88b5010d99a25c83a5b2313bd39c",
+   "sha256": "19jwnny0v6ppakpaaxv9qhr6353mksh9kxiz61kp4h12n6sfrb7p"
   },
   "stable": {
    "version": [
@@ -93122,11 +94227,11 @@
   "repo": "nashamri/spacemacs-theme",
   "unstable": {
    "version": [
-    20200808,
-    1859
+    20200825,
+    1818
    ],
-   "commit": "462ef2ac16ab8c51de21d5f3d2b1b6122b314391",
-   "sha256": "1qhvf0xf58cm4x8wij1l6301q1y6jp8j7i61g8lizlb24f7fla9l"
+   "commit": "1f5b03254de6bfa9645711f2b79781f5cca8d203",
+   "sha256": "04x8x557va2nsl1wginvaq9ha9wfk8l45dgs88sxm60jyrci802x"
   }
  },
  {
@@ -93298,14 +94403,26 @@
   "repo": "ukari/speedbar-git-respect",
   "unstable": {
    "version": [
-    20191121,
-    2120
+    20200901,
+    246
    ],
    "deps": [
     "f"
    ],
-   "commit": "4703650c20cb77f08833747529b55be13d450bae",
-   "sha256": "0qb2azx3blm8iz0y5f8p5zxkbmx6pjzxwpfzg64qi3741xijv8lw"
+   "commit": "dd8f0849fc1dd21b42380e1a8c28a9a29acd9511",
+   "sha256": "0pzml057q2sswjfzd95i2acy50gpczfjbydivl4h5zkbpxgzhrw8"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "deps": [
+    "f"
+   ],
+   "commit": "9663b7d71385041fdd7488d74d54cb6c4e05b74a",
+   "sha256": "03cgy2yczmy186kzjj3qipr181zw83aarhk5w0gisvl7h7w0blj0"
   }
  },
  {
@@ -93799,11 +94916,11 @@
   "repo": "pekingduck/emacs-sqlite3-api",
   "unstable": {
    "version": [
-    20200710,
-    1432
+    20200916,
+    132
    ],
-   "commit": "e5b14b03183cde855059084eba425428ec4618c1",
-   "sha256": "1r7hs23xa2yhr0rbgdhxid8gg4fwhrk2wjrk1scrp37aj2szwpjm"
+   "commit": "95abc25cc67d652ce2ba79907224e581aef62e93",
+   "sha256": "1kx2ik7k0ads71r2xq4c8jkk460m44prggiiskj1g88yxx0rnqkj"
   }
  },
  {
@@ -93908,11 +95025,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20200817,
-    549
+    20200922,
+    1852
    ],
-   "commit": "1588f720ecd7f69a7972d5c9e113975af045c813",
-   "sha256": "136zx2sr0n4lb396vpz5nq60zjc3cav4kpx8r5h3nzgnmamqz61b"
+   "commit": "a0177f178b224f2f25ef78d2210dd4b5fc13f2cb",
+   "sha256": "0f5cs20dbywza8xp4nk422ncy4zfy0q4v29548ih6vcf0m7kxmm6"
   },
   "stable": {
    "version": [
@@ -94025,11 +95142,11 @@
   "repo": "jhgorrell/ssh-config-mode-el",
   "unstable": {
    "version": [
-    20200503,
-    2042
+    20200927,
+    344
    ],
-   "commit": "8fda737131fef2e55c4965a938cf907acbf03372",
-   "sha256": "1cjcav28a6bw8h8axx5ms2cacdqcjv6imb4pj4r4zx08jd4nljdk"
+   "commit": "64ed50791b82dd77c239bdc4c7070847d1c6cab6",
+   "sha256": "09wa881406c692nn4fg0l31wycp4fxhd0agpxjcxixkdzyw135b1"
   }
  },
  {
@@ -94101,20 +95218,20 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20200221,
-    2025
+    20200830,
+    1032
    ],
-   "commit": "e891a0fcb3a7ab7d9cedbe3deda560134636897e",
-   "sha256": "158afanfaww2jkrz9szap6ys8xhbpz35kd5apkxr1j9j7s8h0iw0"
+   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
+   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
   },
   "stable": {
    "version": [
     10,
-    1,
+    2,
     0
    ],
-   "commit": "599a0440086c660e6823622b35058f6d2d6d9637",
-   "sha256": "0mm0kpyihpd55hx14smlm0ayz05zw750fihhqhxqc258y8y73m5y"
+   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
+   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
   }
  },
  {
@@ -94125,28 +95242,28 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20200221,
-    2025
+    20200830,
+    1032
    ],
    "deps": [
     "stan-mode",
     "yasnippet"
    ],
-   "commit": "e891a0fcb3a7ab7d9cedbe3deda560134636897e",
-   "sha256": "158afanfaww2jkrz9szap6ys8xhbpz35kd5apkxr1j9j7s8h0iw0"
+   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
+   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
   },
   "stable": {
    "version": [
     10,
-    1,
+    2,
     0
    ],
    "deps": [
     "stan-mode",
     "yasnippet"
    ],
-   "commit": "599a0440086c660e6823622b35058f6d2d6d9637",
-   "sha256": "0mm0kpyihpd55hx14smlm0ayz05zw750fihhqhxqc258y8y73m5y"
+   "commit": "2dd330604563d143031fc8ffd516266217aa1f9b",
+   "sha256": "1l49fqd4wh9bkdpb4mk5a1cbl5i3iwc3q690viakhpb4840jmlry"
   }
  },
  {
@@ -94164,8 +95281,8 @@
     "f",
     "s"
    ],
-   "commit": "e37b7e1c714c7798cd8e3a6569e4d71b96718a60",
-   "sha256": "0r814qcrhvx4qlx4sdzwdmrhiryslqclx0bnpp0qcrbx6g8qfl25"
+   "commit": "92460e21f964cb7495d974c42acd0b726af3fbcb",
+   "sha256": "1vxgg1gs2ma2c121dgqg9vnzcacb7dxdkxlwdxg0dkivnqicxiyg"
   },
   "stable": {
    "version": [
@@ -94192,8 +95309,8 @@
     20171115,
     1731
    ],
-   "commit": "cf84b14066d63694d931395c6026fd0245d8a62b",
-   "sha256": "0dbcaz3faw8knx91yjsrb988sn2d9k0i5byhs1bi1ww36y6hmgs6"
+   "commit": "76cc8122a39a3ef5947d706377b007ef53a354fe",
+   "sha256": "034h6mrz8nh42k3dsw7lcaackg95xqa9khkdwl6pj0i3z4rhgph8"
   }
  },
  {
@@ -94336,8 +95453,8 @@
     20200606,
     1308
    ],
-   "commit": "333e9e434cec9aa2f887083cdf2cefcaa316f438",
-   "sha256": "1q058qav0al8mb6f3f3jc4mnzlvhlis9dllchw3flw3gx57qcrx5"
+   "commit": "a622f17d79214c0a1dc64c8e8b2750adc18c3451",
+   "sha256": "03ap41zhybmw15q5ribvax7hrfg0s4ibr6dsxibj60z01pd24lj2"
   },
   "stable": {
    "version": [
@@ -94672,6 +95789,21 @@
   }
  },
  {
+  "ename": "su",
+  "commit": "f48d82af18e7e3caa1e7c51670e7009c2168fd4e",
+  "sha256": "05261i2hfzjalhbz9sbg7r44brbmvk08wg9b3924hi5bwran0bc3",
+  "fetcher": "github",
+  "repo": "PythonNut/su.el",
+  "unstable": {
+   "version": [
+    20200820,
+    57
+   ],
+   "commit": "eadfacdbcb8d54d83f6f6cfe7990b492f7217453",
+   "sha256": "0xwkkzs4pl3wgjq7n43klkh814h3kzh0mwnka07dbb0gv1xmaigl"
+  }
+ },
+ {
   "ename": "subatomic-theme",
   "commit": "a3c6e6adb1a63534275f9d3d3d0fe0f5e85c549b",
   "sha256": "0qh311h8vc3c7f2dv6gqq3kw1pxv6a7h4xbyqlas5ybkk2vzq12r",
@@ -94756,14 +95888,11 @@
   "repo": "zk-phi/sublimity",
   "unstable": {
    "version": [
-    20200816,
-    854
+    20200905,
+    1730
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "133ac118eaa51cce81978ed78abba6aa8d427577",
-   "sha256": "0sqjdrzsp7pf1wj14vcr322n8fydjzzii4msdvlhj0xr3xhl0469"
+   "commit": "8e2ffc4d62194106130014531e7b54fc9b4b9e6c",
+   "sha256": "0lx0kyzsjn9dhahyi3smcg6hykralrn09mnnn8x74mbpdv4alwrv"
   },
   "stable": {
    "version": [
@@ -94968,20 +96097,20 @@
   "repo": "tlikonen/suomalainen-kalenteri",
   "unstable": {
    "version": [
-    20190310,
-    910
+    20200830,
+    1107
    ],
-   "commit": "c8c03fe9bae57d4e15c287aef4f98911a3529240",
-   "sha256": "1n4nz309rr1cpx1c5aighakpcmrbzzg2xprh5hi4kln0rngggycp"
+   "commit": "99fd77d25fc12c0a9f1fc75f0b83b31774d493bd",
+   "sha256": "12b2534cz9qqc923cf4nj76gmx3l19wrqmha077rlgl5pqlgqh6b"
   },
   "stable": {
    "version": [
-    2017,
+    2020,
     8,
-    1
+    30
    ],
-   "commit": "c702e33cb6e13cb28bd761844e95be112a3c04f3",
-   "sha256": "13avc3ba6vhysmhrcxfpkamggfpal479gn7k9n7509dpwp06dv8h"
+   "commit": "99fd77d25fc12c0a9f1fc75f0b83b31774d493bd",
+   "sha256": "12b2534cz9qqc923cf4nj76gmx3l19wrqmha077rlgl5pqlgqh6b"
   }
  },
  {
@@ -95269,26 +96398,26 @@
   "repo": "swift-emacs/swift-mode",
   "unstable": {
    "version": [
-    20200606,
-    730
+    20200920,
+    643
    ],
    "deps": [
     "seq"
    ],
-   "commit": "d266fbd300a1bf1592e1462ead4be093b8b68f98",
-   "sha256": "0l3i74acv1msmbfkn99mz9g73kd7j1a7j0b082vcxw6kr69476yc"
+   "commit": "7d93c75d876d600bcb2d5b694b473bca583bc008",
+   "sha256": "0xzacd6fjq2d9k4r9k98qx5my0crjsrwmhqf4kkrwp2m1klvdgz2"
   },
   "stable": {
    "version": [
     8,
-    0,
-    2
+    1,
+    0
    ],
    "deps": [
     "seq"
    ],
-   "commit": "2ab9ea1784a12a482ed9e3fb284b7a7658f40fff",
-   "sha256": "0wml7f8k3gqlxm0yg744271mqh087prlsfmbiv7fvkrcs55q0592"
+   "commit": "7d93c75d876d600bcb2d5b694b473bca583bc008",
+   "sha256": "0xzacd6fjq2d9k4r9k98qx5my0crjsrwmhqf4kkrwp2m1klvdgz2"
   }
  },
  {
@@ -95359,8 +96488,8 @@
    "deps": [
     "ivy"
    ],
-   "commit": "dd43ab1217f72948dc5cd669467e33b8b568db44",
-   "sha256": "0h4273gr4h9xkdf5g08ci95jq0n9l1w3vgd1y9452cry1r07ya9l"
+   "commit": "b65e401c22ec56a008b00f651cd9536caf593d43",
+   "sha256": "0i1q520anbhglfgv35ivvgqwaxf6mzaw45lxmikcijcvc3z1aq4s"
   },
   "stable": {
    "version": [
@@ -95620,14 +96749,14 @@
   "repo": "wolray/symbol-overlay",
   "unstable": {
    "version": [
-    20200809,
-    2023
+    20200828,
+    425
    ],
    "deps": [
     "seq"
    ],
-   "commit": "f2734ce633c2b498d3ea70042a3ae9f93f9f046a",
-   "sha256": "1n1a2jldshfyyyxc3msr16fzczjlpglzdy7ab4qpyyz6ghklaqys"
+   "commit": "39f772b531117edba596e7a1210b3dbb87d56adb",
+   "sha256": "10n0871xzycifyqp73xnbqmrgy60imlb26yhm3p6vfj3d84mg1b2"
   },
   "stable": {
    "version": [
@@ -95849,14 +96978,14 @@
   "repo": "emacs-berlin/syntactic-close",
   "unstable": {
    "version": [
-    20200408,
-    1148
+    20200909,
+    1320
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "c21ffdf6a2f8c2a83d3efc729852cd2b09fe03a6",
-   "sha256": "1m6y7njkn5vibgnr3pnh6nci75j2ksr93ajp01jwpxxxc0wmipa8"
+   "commit": "fbeb5c03b3ba94d7302c541ae7281a84de02b499",
+   "sha256": "1cwfnj0n64q632ldarhf2pg6nvkmw3hldb6kf60b96karp1qsrrc"
   }
  },
  {
@@ -95891,11 +97020,11 @@
   "repo": "jpkotta/syntax-subword",
   "unstable": {
    "version": [
-    20160519,
-    1905
+    20160205,
+    2154
    ],
-   "commit": "ad0db0fcb464652a1d3408f525dee9293ce2b70c",
-   "sha256": "1wcgr6scvwwfmhhjbpq3riq0gmp4g08ffbl91fpgp72j8zrc1c6x"
+   "commit": "9aa9b3f846bfe2474370642458a693ac4760d9fe",
+   "sha256": "15zvh6dk02rm16zs6c9zvw1w76ycn61g3cpx6jb3456ff9zn6m9m"
   },
   "stable": {
    "version": [
@@ -96280,11 +97409,11 @@
   "repo": "juba/color-theme-tangotango",
   "unstable": {
    "version": [
-    20170924,
-    1509
+    20200907,
+    729
    ],
-   "commit": "e2f2ea9c35f06dfc43a29c91c14cf0cdb19f2144",
-   "sha256": "01gvsvha8z7pyr8c33gh3xmz47lh6b8g0nwf1gzdiw1gd0sfhs4z"
+   "commit": "2293311166308a76bda691898b6952921bb95da9",
+   "sha256": "1964h3sgd5pzh58i1gjawhlpqfli2n183n9c55y8klb5i3kbf32h"
   }
  },
  {
@@ -96319,11 +97448,11 @@
   "repo": "saf-dmitry/taskpaper-mode",
   "unstable": {
    "version": [
-    20200701,
-    1436
+    20200827,
+    1214
    ],
-   "commit": "5ded73ae13d58ab0bbd52ac7556ff29e114a96d6",
-   "sha256": "00bvjrbcqalwlw1lc883p8l7szb9qniqp120pwd6hgyvgpr7h3s1"
+   "commit": "c31e6df4a767cbe1a7e02a27c13b90baaf966af6",
+   "sha256": "1vpnd6yc63fn0v4nj80fzq25l1pzp8x19n7l09vwvvxrw9pvkpjn"
   },
   "stable": {
    "version": [
@@ -96510,15 +97639,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20200814,
-    1652
+    20200903,
+    1506
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "9594ebcb0f605e5b01bc4ec6d1bd1b6470002bc0",
-   "sha256": "0hm6yvr4ygkcycw850sd4lcwmrr49s88nhan08hal0xylzazlq24"
+   "commit": "3416f42e35d1ac1d0e1cfbbfe706aef8657fa83d",
+   "sha256": "1njnc6sxx97w327qgn0m0nw6pvm93lirpp08rvcv2j44lx2ldmch"
   },
   "stable": {
    "version": [
@@ -96616,20 +97745,20 @@
   "repo": "clarete/templatel",
   "unstable": {
    "version": [
-    20200818,
-    241
+    20200905,
+    121
    ],
-   "commit": "796021c2964a5bfbba7abf7f339f970bbedc3aab",
-   "sha256": "1yv85ik2slaibnajsfns1icliw0qyqw871jxdklav918lic9fia0"
+   "commit": "77cbb852c3737f4738e106a51607bfdcd7727fd8",
+   "sha256": "0wbzl540ik9x5qac6gvxcipc29hvklhd7vl6zadp5rlrs5wh0lq2"
   },
   "stable": {
    "version": [
     0,
     1,
-    1
+    2
    ],
-   "commit": "6785b487aaa6bbab3cffcf74e9f596c0058c1b18",
-   "sha256": "1qdjbbr6mq2ib8aan5hb47vdj2s50yxfidmjyfyyms28qpi3524g"
+   "commit": "d80881dcddc965af896208dbd628dd9279d87e93",
+   "sha256": "1aadg92yqbh0r75ifdv6xkny9r4vrgcjkr0dv9iaa6rx8dmpbwzm"
   }
  },
  {
@@ -97376,8 +98505,8 @@
    "deps": [
     "tablist"
    ],
-   "commit": "3c20cb76ccd7951eda0b5f076cd79e42f71e7220",
-   "sha256": "0pwx1cxc1d2hx823520b5a942nhl5w8alnhlq4kwi869wwzkmxfw"
+   "commit": "6865d7bf772a6ecabacc868e45a0f5a5e197e1a5",
+   "sha256": "1xrw81n3llyr3191mpnr85grhayhkq5cq6g56p52mc4sahmqbqlg"
   }
  },
  {
@@ -97388,11 +98517,11 @@
   "repo": "hadronzoo/theme-changer",
   "unstable": {
    "version": [
-    20171221,
-    1927
+    20200919,
+    2307
    ],
-   "commit": "61945695a30d678e6a5d47cbe7c8aff59a8c30ea",
-   "sha256": "14xc36jfgj8896pklrkpg394fgikir051rh9vm70v132n6i9j0cn"
+   "commit": "13adb7d0cf0e8dfbb79b0f649d33474ddf4301a2",
+   "sha256": "0f8b81ck229z3gf34ic9v27w776fal16wg17mbiqxzj0pqfl6y9n"
   },
   "stable": {
    "version": [
@@ -97555,18 +98684,18 @@
     20200212,
     1903
    ],
-   "commit": "32b109977cbde37bf719c2955ff7dd1e657a6c70",
-   "sha256": "0ww3k4yd5bk40r3v1a96mgzhaayqgb0v2kjvxzn10wcybqxf1zqb"
+   "commit": "c4a7b56e63f471f72d483bcbc3cbb78a63b950f1",
+   "sha256": "0w5fb282z3ckz5pvmxf73sla0ckm12k6d6xz9pbcb61amvdki92h"
   },
   "stable": {
    "version": [
     2020,
-    8,
-    17,
+    9,
+    21,
     0
    ],
-   "commit": "b733bf19c3c68c0aa6d5e0bb7db4321fe13b47a2",
-   "sha256": "11kpja52drs4xsja6gyg37rq1681pfgv71cc3lksh2dn6jrn8nbq"
+   "commit": "53216cb40521530217db158af6c068c635af61e8",
+   "sha256": "10r4wpmphf29svz7gwiv2p6sr4f0296xipa4rnfggvn8v6xy8p8c"
   }
  },
  {
@@ -97622,8 +98751,8 @@
    "deps": [
     "haskell-mode"
    ],
-   "commit": "137192a2ef6c4f457ddba38a0397570266333854",
-   "sha256": "1wwmgzlqih3j8slggmi79xiy811qzlrwjqpd7y37lj508w96qppi"
+   "commit": "f3f06ba9ace1e745dee6e6097af19abddc64b51b",
+   "sha256": "0i4s96699x8rm7s3xkkh44z044mqkvsnc37ahzfbdaz44300j96m"
   },
   "stable": {
    "version": [
@@ -97646,8 +98775,8 @@
   "repo": "ananthakumaran/tide",
   "unstable": {
    "version": [
-    20200811,
-    2114
+    20200823,
+    524
    ],
    "deps": [
     "cl-lib",
@@ -97656,14 +98785,14 @@
     "s",
     "typescript-mode"
    ],
-   "commit": "f0b6dac4829c3daecf02bf445a5b41b4c68f2911",
-   "sha256": "0533kxxl68vsx99b5nwdhy885nl2ad8wc6my38kardmklshjpvj1"
+   "commit": "fa617f54629dc53a3182251dd8076c9e7ac9effa",
+   "sha256": "1zib1wa01xpbam2jm6lz4r1d3jwyv7slf43541fb5s08ph54inqn"
   },
   "stable": {
    "version": [
-    3,
-    7,
-    4
+    4,
+    0,
+    2
    ],
    "deps": [
     "cl-lib",
@@ -97672,8 +98801,8 @@
     "s",
     "typescript-mode"
    ],
-   "commit": "1878a097fc41ee81c40c155022c8feaaf8bfaa6d",
-   "sha256": "0ipri5jxx73vrra6dikbv0y2ws96wfi7bjh2v6pshiw3b1x2isav"
+   "commit": "dafb6befd83e5eea2e2c7f79ab89bc4877001b6d",
+   "sha256": "1n2dihpl53a48jis3l4rry581wpr5lxjd433drlkaa4lqgx8cw67"
   }
  },
  {
@@ -97871,14 +99000,14 @@
   "repo": "yyr/tinkerer.el",
   "unstable": {
    "version": [
-    20170906,
-    1224
+    20200914,
+    1756
    ],
    "deps": [
     "s"
    ],
-   "commit": "e34135555f3748b578c7f8706dfd0c888fb87581",
-   "sha256": "0lzrarqh965ysd7w0z5rbisl45j11fbibyxmgivgy9parvhg59hk"
+   "commit": "7cedeb264a44cd62bcd9c778dca52316d09e07e5",
+   "sha256": "0ym6cxglacclk0sgwbnbswwslf8bs6d0drj89nrabnhad15prxgz"
   }
  },
  {
@@ -98007,8 +99136,23 @@
     "names",
     "s"
    ],
-   "commit": "923524efe8e6e5e0d269de6bb253b45e02d9a663",
-   "sha256": "0bhck6vrb48zxfh5id637mq57k7jv4f2ax0lrhyvr0nw8m0ndqmx"
+   "commit": "92f67c6d270c7c923edcde81a235ed0b49a61a70",
+   "sha256": "0b94ma5ycq5hvmkrwf3yp265dh140bx5dk7dp0r4n9xilpwk7nla"
+  }
+ },
+ {
+  "ename": "toc-mode",
+  "commit": "a6a89db329bf990e95c1a89d1cbea73396308ed5",
+  "sha256": "1c0q0d4rzvkh62p7bg6msmxp2njqvjz73ds4g9kpmc081qvkz2ig",
+  "fetcher": "github",
+  "repo": "dalanicolai/toc-mode",
+  "unstable": {
+   "version": [
+    20200926,
+    2117
+   ],
+   "commit": "06de33f5113c8ce136e08f1ff9852abad7677bac",
+   "sha256": "1hhax9k19zndv30dbl0nbq9x2y7bxgljdchvgq54r1807bmfkmyx"
   }
  },
  {
@@ -98191,6 +99335,15 @@
    "version": [
     20130903,
     1255
+   ],
+   "commit": "994644f9e68c383071eeee23389a7989b228c2d2",
+   "sha256": "01k03dbvng5rzdvr51wk5xfg3za723qaqwnpd3yh211hknb83k3q"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
    ],
    "commit": "9633a6872928e737a2335aae1065768b23d8c3b3",
    "sha256": "1b3bkla6i5nvanifxchph6ab6ldrskdf240hy4d27dkmmnr3pban"
@@ -98447,8 +99600,8 @@
     20171210,
     2102
    ],
-   "commit": "89aac22259e5d09ae1183e0df163338fe491e9e7",
-   "sha256": "16hfahyhl1vv3r0amyvc514sw6x9x56b319lkp7bwcy8mxicc3cy"
+   "commit": "5c54374f6c13104deded2e3b348cc188af64785a",
+   "sha256": "1hjid38bsi4f4vmvcbm7br8x2r94mri89rswc32glny7d2fysghk"
   },
   "stable": {
    "version": [
@@ -98554,8 +99707,8 @@
     20200819,
     1133
    ],
-   "commit": "f5d81ef0ed24be935f3c0192b746a1738d903d37",
-   "sha256": "0kyrf0nh9l9x1jwfca1921qc0w2ii1xp4ya4mv2jmanm3apbihb9"
+   "commit": "96cec8e16e081491bd7e04880e0037bc190fae16",
+   "sha256": "0rmq2ydwg88lwvz5cjx06ggmw5yblyh5q6jn9qqxvcxfn4k72rjr"
   },
   "stable": {
    "version": [
@@ -98662,20 +99815,20 @@
   "repo": "jcs-elpa/transwin",
   "unstable": {
    "version": [
-    20200704,
-    356
+    20200910,
+    1636
    ],
-   "commit": "df814cb578b0a4c01ed68f1da262df17d2a0a694",
-   "sha256": "0kfq7br70cn9jpjnc7lxgimqcw9cpp4yf95dkjalbk5l8w8gzlm2"
+   "commit": "20694aae145edd6ad496a395ef1a53ab37a59521",
+   "sha256": "01afsgkzn5y4ld5m1gmvai8pgdy73kmllivmz18a2q9fdrgaa6xb"
   },
   "stable": {
    "version": [
     0,
     1,
-    2
+    3
    ],
-   "commit": "df814cb578b0a4c01ed68f1da262df17d2a0a694",
-   "sha256": "0kfq7br70cn9jpjnc7lxgimqcw9cpp4yf95dkjalbk5l8w8gzlm2"
+   "commit": "20694aae145edd6ad496a395ef1a53ab37a59521",
+   "sha256": "01afsgkzn5y4ld5m1gmvai8pgdy73kmllivmz18a2q9fdrgaa6xb"
   }
  },
  {
@@ -98797,8 +99950,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20200816,
-    939
+    20200922,
+    2006
    ],
    "deps": [
     "ace-window",
@@ -98810,8 +99963,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "400b3916b61e61a299916f053cc52b48638479b7",
-   "sha256": "1z9kvq0p3fhb48n85bav12pj9xgblhh7v1xsi3bymimxhdmkziq8"
+   "commit": "18baf5d412645ea780aec718f8960904d6bf91c1",
+   "sha256": "1lhl4fxyyjlxikhqgc6yby0nip57bcjp216zxl6c4v8pai8vwix9"
   },
   "stable": {
    "version": [
@@ -98840,15 +99993,15 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20200801,
-    920
+    20200819,
+    1950
    ],
    "deps": [
     "all-the-icons",
     "treemacs"
    ],
-   "commit": "400b3916b61e61a299916f053cc52b48638479b7",
-   "sha256": "1z9kvq0p3fhb48n85bav12pj9xgblhh7v1xsi3bymimxhdmkziq8"
+   "commit": "18baf5d412645ea780aec718f8960904d6bf91c1",
+   "sha256": "1lhl4fxyyjlxikhqgc6yby0nip57bcjp216zxl6c4v8pai8vwix9"
   }
  },
  {
@@ -98866,8 +100019,8 @@
     "evil",
     "treemacs"
    ],
-   "commit": "400b3916b61e61a299916f053cc52b48638479b7",
-   "sha256": "1z9kvq0p3fhb48n85bav12pj9xgblhh7v1xsi3bymimxhdmkziq8"
+   "commit": "18baf5d412645ea780aec718f8960904d6bf91c1",
+   "sha256": "1lhl4fxyyjlxikhqgc6yby0nip57bcjp216zxl6c4v8pai8vwix9"
   },
   "stable": {
    "version": [
@@ -98890,14 +100043,14 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20200530,
-    2129
+    20200901,
+    1550
    ],
    "deps": [
     "treemacs"
    ],
-   "commit": "400b3916b61e61a299916f053cc52b48638479b7",
-   "sha256": "1z9kvq0p3fhb48n85bav12pj9xgblhh7v1xsi3bymimxhdmkziq8"
+   "commit": "18baf5d412645ea780aec718f8960904d6bf91c1",
+   "sha256": "1lhl4fxyyjlxikhqgc6yby0nip57bcjp216zxl6c4v8pai8vwix9"
   },
   "stable": {
    "version": [
@@ -98920,16 +100073,16 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20200421,
-    1426
+    20200901,
+    1550
    ],
    "deps": [
     "magit",
     "pfuture",
     "treemacs"
    ],
-   "commit": "400b3916b61e61a299916f053cc52b48638479b7",
-   "sha256": "1z9kvq0p3fhb48n85bav12pj9xgblhh7v1xsi3bymimxhdmkziq8"
+   "commit": "18baf5d412645ea780aec718f8960904d6bf91c1",
+   "sha256": "1lhl4fxyyjlxikhqgc6yby0nip57bcjp216zxl6c4v8pai8vwix9"
   },
   "stable": {
    "version": [
@@ -98953,16 +100106,16 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20200530,
-    2129
+    20200901,
+    1550
    ],
    "deps": [
     "dash",
     "persp-mode",
     "treemacs"
    ],
-   "commit": "400b3916b61e61a299916f053cc52b48638479b7",
-   "sha256": "1z9kvq0p3fhb48n85bav12pj9xgblhh7v1xsi3bymimxhdmkziq8"
+   "commit": "18baf5d412645ea780aec718f8960904d6bf91c1",
+   "sha256": "1lhl4fxyyjlxikhqgc6yby0nip57bcjp216zxl6c4v8pai8vwix9"
   },
   "stable": {
    "version": [
@@ -98993,8 +100146,8 @@
     "projectile",
     "treemacs"
    ],
-   "commit": "400b3916b61e61a299916f053cc52b48638479b7",
-   "sha256": "1z9kvq0p3fhb48n85bav12pj9xgblhh7v1xsi3bymimxhdmkziq8"
+   "commit": "18baf5d412645ea780aec718f8960904d6bf91c1",
+   "sha256": "1lhl4fxyyjlxikhqgc6yby0nip57bcjp216zxl6c4v8pai8vwix9"
   },
   "stable": {
    "version": [
@@ -99031,6 +100184,21 @@
    ],
    "commit": "3ac940e97f3d03e48ca9d7fcd74916a9b01c72f3",
    "sha256": "0pmrpij80m5kgcr8bw36r8wllgppasw08vn3ghwvis9srpaq75cn"
+  }
+ },
+ {
+  "ename": "treeview",
+  "commit": "76e3235134af34a522b5bee69f0a16a54cbd9b52",
+  "sha256": "18df7xpz42z408784w0s39hwp5pxrramzrbk7zfbr4qrnxnk0bva",
+  "fetcher": "github",
+  "repo": "tilmanrassy/emacs-treeview",
+  "unstable": {
+   "version": [
+    20200921,
+    6
+   ],
+   "commit": "e6012303670d112596e00eb3cb505eb0e0d61d84",
+   "sha256": "0drjzjwrk7fkcc6q8qbvzf60dgcbnysm482cdvzikc0phzgjpl9n"
   }
  },
  {
@@ -99513,6 +100681,24 @@
   }
  },
  {
+  "ename": "twtxt",
+  "commit": "4627ee00b9439d9dac9971ad1060af4bcf31446c",
+  "sha256": "0fpq3nz30v0g355xq0pcwf8iqykvn9af1wdx76v5fgzimlrpwy7l",
+  "fetcher": "github",
+  "repo": "deadblackclover/twtxt-el",
+  "unstable": {
+   "version": [
+    20200824,
+    1323
+   ],
+   "deps": [
+    "request"
+   ],
+   "commit": "e7bafaf92124bb4f2a0be5c1a635b80f9b3a8c87",
+   "sha256": "1qqc6ykrpq311fwn5mvzc3yl6z48v1c3yq3vi8g9zv63ywj33bbk"
+  }
+ },
+ {
   "ename": "typescript-mode",
   "commit": "94455323364d5a6b00e2786d577134eb350826b4",
   "sha256": "1abnik2dq0zfnp8pk8x6zy962qww78xadm87xyiwz17559g88d82",
@@ -99523,8 +100709,8 @@
     20200817,
     817
    ],
-   "commit": "42a60e5c881082db2ec2c541a5c154308c4863e6",
-   "sha256": "14hn0v5gcbzj6y2xs30qyh8wba4l073x5281xd7xs05f9yv7dv5j"
+   "commit": "bbbe50aadecb4d3b71dbda8cb163f5272cc94e00",
+   "sha256": "06qbg9ff28b261ah7v3jr821s4lrbj0gzxripi37czgnldk2ym7l"
   },
   "stable": {
    "version": [
@@ -99628,28 +100814,32 @@
   "repo": "kadircancetin/typo-suggest",
   "unstable": {
    "version": [
-    20200801,
-    1000
+    20200830,
+    1143
    ],
    "deps": [
     "company",
-    "helm"
+    "dash",
+    "helm",
+    "s"
    ],
-   "commit": "ac48f2e59daee15983a5fd13009f751e0d928ab1",
-   "sha256": "0kjyjav2bwrr2kwvdm3dx7mi966ji49n9hcw9dxx458bl72giwqf"
+   "commit": "3014d18ae2f0b6b857bb613f373e034c743f4d2e",
+   "sha256": "0pbmmwk5qh1ld9yzy4vxxp9ix4kzw9m71qjwqz0fqw3md9xlr6z6"
   },
   "stable": {
    "version": [
     0,
     0,
-    3
+    4
    ],
    "deps": [
     "company",
-    "helm"
+    "dash",
+    "helm",
+    "s"
    ],
-   "commit": "ac48f2e59daee15983a5fd13009f751e0d928ab1",
-   "sha256": "0kjyjav2bwrr2kwvdm3dx7mi966ji49n9hcw9dxx458bl72giwqf"
+   "commit": "938fdad51d1177627ed9a34da6b937481861bda2",
+   "sha256": "0q8kgjnbcmqr1my7qgfcwjbk9misgkq4ymvrslhwlfwnnkg18x9a"
   }
  },
  {
@@ -99828,28 +101018,28 @@
   "repo": "undercover-el/undercover.el",
   "unstable": {
    "version": [
-    20191122,
-    2126
+    20200830,
+    1638
    ],
    "deps": [
     "dash",
     "shut-up"
    ],
-   "commit": "9f4fbd04cd25c61397a7058bf2bad33c7b669aa4",
-   "sha256": "13cn2cxspaqa9filclk66963by7khaci4lyrxgmjpdz04rijkh1q"
+   "commit": "9515b247649d05219bf96b1843eed7c4d02a332e",
+   "sha256": "1dh4cpn1l1shchr0gg6jyld1qbjn3fy12s43pksfww4sm4rjn9rn"
   },
   "stable": {
    "version": [
     0,
-    6,
-    1
+    7,
+    0
    ],
    "deps": [
     "dash",
     "shut-up"
    ],
-   "commit": "86f856c799aacfd48d2eb42d1a6afda0e6e49845",
-   "sha256": "080bmfwyfi8663y8x594770hqz7mff7zvj2v03qdfwbhdr9w9y29"
+   "commit": "9515b247649d05219bf96b1843eed7c4d02a332e",
+   "sha256": "1dh4cpn1l1shchr0gg6jyld1qbjn3fy12s43pksfww4sm4rjn9rn"
   }
  },
  {
@@ -99946,11 +101136,11 @@
   "repo": "ideasman42/emacs-undo-fu-session",
   "unstable": {
    "version": [
-    20200517,
-    949
+    20200918,
+    330
    ],
-   "commit": "e2043f8350970e1a9ef06a94956a733826cdf32b",
-   "sha256": "14qlrdal1z64cqqssa34cw1yzsppslgwwy23060sxgjz2vvwwwfb"
+   "commit": "5135b5cb610203cdb3e64227b8f437bb87292b18",
+   "sha256": "11vzw5wsh7ap4xlf2j5vj14ha30706nhvs7zf1dpj2j56bbljsrh"
   }
  },
  {
@@ -99964,8 +101154,8 @@
     20200204,
     1612
    ],
-   "commit": "20409358ad321fb937152cf93a50a4a775e405d6",
-   "sha256": "0mc6qldsjh8671kayl6wxmmcb8q0wjcg09qr7ppmsmwzsd9ydn0n"
+   "commit": "5a9eb34ed945a4d62362528cc7557b9c4e81a12b",
+   "sha256": "10ybvgdrw9hzqwbzvsr3hmzci4yp9rxi5nbcm6iafrsn7p1vv1wj"
   }
  },
  {
@@ -100715,6 +101905,36 @@
   }
  },
  {
+  "ename": "use-proxy",
+  "commit": "e9fb7f05b76517aa918fbd08a52719d1692d6dfc",
+  "sha256": "05j06mbbyb4imlg480y29cfwkmpn93qdjd7jx687lrikg2z0ypbc",
+  "fetcher": "github",
+  "repo": "rayw000/use-proxy",
+  "unstable": {
+   "version": [
+    20200907,
+    1131
+   ],
+   "deps": [
+    "exec-path-from-shell"
+   ],
+   "commit": "a2916f512a0260ae9050a64b8f83328323d88eb0",
+   "sha256": "072h2z2pj31w81ry7lrxrx1iirylscyfnqjlh81mqsvh45zkbsi9"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    1
+   ],
+   "deps": [
+    "exec-path-from-shell"
+   ],
+   "commit": "3179aea22d0839e55c42a605682bfef0184d18a7",
+   "sha256": "1r656z5vg7f37qm8azl2gms8kw907w27p368ahibpg6wgpl65h66"
+  }
+ },
+ {
   "ename": "use-ttf",
   "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
   "sha256": "18ry06d6llq86k5awd23jj0qb68k459dc2i5hqrmpjykqzq6bvya",
@@ -100814,15 +102034,15 @@
   "repo": "damon-kwok/v-mode",
   "unstable": {
    "version": [
-    20200812,
-    956
+    20200823,
+    535
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "15a73b304e624d9b07fd8f23670569678d6cd9c3",
-   "sha256": "1arbd9wwaqlhc1hl4hgpfjn4ncyrirjmpq8sgnhffgw7vkzl99pv"
+   "commit": "d97fb8de5ab19359029dec1195f3d5b87aeb27b1",
+   "sha256": "1rhk9bcrn43gv0cz92cbvhhjvbifyq7lkdg3hcrla87b2dm4rp3l"
   }
  },
  {
@@ -100908,11 +102128,11 @@
   "repo": "emacsorphanage/vala-mode",
   "unstable": {
    "version": [
-    20150324,
-    2225
+    20200909,
+    2058
    ],
-   "commit": "fb2871a4492d75d03d72e60474919ab89adb267b",
-   "sha256": "10vs4d8csww781j1ps3f6dczy5zzza36z7a8zqk40fg4x57ikw44"
+   "commit": "6eeae8a631697ff087123ee43e313ff01015bdef",
+   "sha256": "0ql30hsyzinmdjgrmkh6y071jdry1hx5qpc5dr0cf9ynjhsc2v8k"
   }
  },
  {
@@ -100946,6 +102166,21 @@
    ],
    "commit": "48bbc4b4ee5bf0b1b73e52705c0fbc112b255cd0",
    "sha256": "1p0b7jh572wfz7cmzfbd70pr7i59xbbi15jw6rvzgnr558v3fmlg"
+  }
+ },
+ {
+  "ename": "validate-html",
+  "commit": "9642a3c32d773bd935fd8f0d11c753a9b139f98e",
+  "sha256": "113amcpmjljnbyzmwpf6gsl7vdrs48b4hmax6lk5pb61ylv9fyhp",
+  "fetcher": "github",
+  "repo": "arthurgleckler/validate-html",
+  "unstable": {
+   "version": [
+    20200913,
+    2002
+   ],
+   "commit": "04321596380c7a87ed85762b6764e98b2ef31bf8",
+   "sha256": "09c24i4b5yg21qzlyss4si607d1n63sj5dr2pysikkzzd81b9hki"
   }
  },
  {
@@ -101413,11 +102648,11 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20200801,
+    20200903,
     2217
    ],
-   "commit": "f8755213c8fadea92b7a2313fb38c0ee37b8a2cc",
-   "sha256": "0f59rw78hfc7hkgd9ja2hzyb6gaf400aa6375zcl3zxh2ljnvbvb"
+   "commit": "cd8f0d0004d10da018d8e95c42b8c5f1b8271088",
+   "sha256": "11cmm8iph7x58gpw0lsk0383j1yw8g9xdqcg33b4pvfg1bzan5bl"
   },
   "stable": {
    "version": [
@@ -101474,15 +102709,15 @@
   "repo": "damon-kwok/verona-mode",
   "unstable": {
    "version": [
-    20200812,
-    807
+    20200823,
+    536
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "3519f83e68af163a6b01753ad7bb4cecf26c24b2",
-   "sha256": "1ck3x1w0nyn31s3fdks6wms5ic5n56jcxg49r56j3dwnifpk87mm"
+   "commit": "72dd31ef847344d79409503f3c42169041eb3da4",
+   "sha256": "04am1kzrimnkl2g1inik5l50i6gr5mafs0jdinvalhrdnbdr45iq"
   }
  },
  {
@@ -101791,15 +103026,15 @@
   "repo": "luisgerhorst/virtual-auto-fill",
   "unstable": {
    "version": [
-    20200217,
-    2333
+    20200906,
+    2038
    ],
    "deps": [
     "adaptive-wrap",
     "visual-fill-column"
    ],
-   "commit": "291f6178a5423f01f2f69d6bc48603d4f605b61a",
-   "sha256": "15kg23xkcc060y8a5f9657gk3bvkax23myhajaa0b2i1qcd6p43i"
+   "commit": "ac8bf947a1f87efe8967cb18166178f5fd93a8e1",
+   "sha256": "1mhw6ysi29s57dccq8a1jh810hz0a90ssw66ih5byvrysgs0hmqw"
   }
  },
  {
@@ -102158,11 +103393,11 @@
   "repo": "ianpan870102/vscode-dark-plus-emacs-theme",
   "unstable": {
    "version": [
-    20200818,
-    341
+    20200926,
+    900
    ],
-   "commit": "a33ef7fd5d9249bbb59fcb822c032e28bb3bf792",
-   "sha256": "0wm54jy09hsg3vbw4qc5k4nzznsn3mqcn0al8mwh2522q6kb6l8j"
+   "commit": "2b358b98405541c1982ea0c63fab65bc643037ab",
+   "sha256": "0mf4g0phjjxnv8c414gzmh2wi6m5plgnhbsvnm3llpxla6rp0p4b"
   },
   "stable": {
    "version": [
@@ -102197,11 +103432,11 @@
   "repo": "akermu/emacs-libvterm",
   "unstable": {
    "version": [
-    20200813,
-    1748
+    20200926,
+    1215
    ],
-   "commit": "797357bf65952337627f2d0c594c2fef600aafae",
-   "sha256": "0lqlx97kb1mpw17lmrx2xa407ixn3wl2cv9rdwrvlrlvg8kcpjmn"
+   "commit": "4f01d260d83bcced0644bee724fcc0c4e1748245",
+   "sha256": "000cr7k89r4mgpclivnzx8434wsxd44y7qab12079dq4vvkivfaf"
   }
  },
  {
@@ -102212,15 +103447,29 @@
   "repo": "jixiuf/vterm-toggle",
   "unstable": {
    "version": [
-    20200614,
-    1452
+    20200914,
+    1425
    ],
    "deps": [
-    "projectile",
     "vterm"
    ],
-   "commit": "7f762d216fc7311bac4182f650e0207574c29357",
-   "sha256": "0nz3qcd2jmjfky0xn62fkhnxchf9nap3li5blis0jgi6igj47ykq"
+   "commit": "974ab2382d8bf6f40e6a1c221f28f6b1f93df3a4",
+   "sha256": "196gwsgs91j6mrr47wf68k7gdls433x27am20iafzizb9lqaqzf5"
+  }
+ },
+ {
+  "ename": "vtm",
+  "commit": "4e4f8793e78e488db863ddfc163390281c18e2c3",
+  "sha256": "1r1nyzcqx9gjmsh0qykmbc69gdn2k6rbzbsvb5rhrlxivl9pgajc",
+  "fetcher": "github",
+  "repo": "laishulu/emacs-vterm-manager",
+  "unstable": {
+   "version": [
+    20200921,
+    338
+   ],
+   "commit": "d770fd8cff7c24688199392ad93c01485c6a9569",
+   "sha256": "1xyhwlmh7mqdhr45y63qh5k71jsgh9sj08bvwsk7znh2zgzqy954"
   }
  },
  {
@@ -102363,11 +103612,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20200818,
-    141
+    20200915,
+    2331
    ],
-   "commit": "7dcbab77334c5adf8309c7a93512c9f95a2c64e4",
-   "sha256": "0in8ir99b33d83nfxsnpj2dgyv4f558yrid77bp7f9k0qpgpj4zk"
+   "commit": "6ed57faedf7b0459c41438bf2077a7ff4946e742",
+   "sha256": "0hkx5yxydw789zks6570z7fidfczgnwa7hkpyk4rrq7vzhjfbb9b"
   }
  },
  {
@@ -102574,14 +103823,14 @@
   "repo": "wanderlust/wanderlust",
   "unstable": {
    "version": [
-    20200124,
-    858
+    20200831,
+    1157
    ],
    "deps": [
     "semi"
    ],
-   "commit": "7af0d582cd48a37469e0606ea35887740d78c8b5",
-   "sha256": "08gr4q5i4z1bs5qbfxmf9imjin1v1qvsk7x37qvr84p16kdr9vxn"
+   "commit": "c7043e6446a302fee41b531d2daaa388c4d833a7",
+   "sha256": "06026nwb6hpai89h99i6jzll0awraw5pz27yvl2fmnr21i7zamal"
   }
  },
  {
@@ -102841,11 +104090,11 @@
   "repo": "fxbois/web-mode",
   "unstable": {
    "version": [
-    20200612,
-    1038
+    20200826,
+    1954
    ],
-   "commit": "60ffd878c4371644bd964f00fea38054645e3e47",
-   "sha256": "0la14k422jqcny1bxgvv8yidanl3pv5kkdfbiwq8skxsd6m2xfq5"
+   "commit": "da53553fd4e876ac121994cc48e54ab54fa3ace7",
+   "sha256": "0z4rqq592z9609xp14r55bnlrc2xxw16rlnwhr7xx5w3qgjw0c7q"
   },
   "stable": {
    "version": [
@@ -102985,28 +104234,28 @@
   "repo": "etu/webpaste.el",
   "unstable": {
    "version": [
-    20200503,
-    1919
+    20200820,
+    1034
    ],
    "deps": [
     "cl-lib",
     "request"
    ],
-   "commit": "5e963e8ef17e937745b8f3b64f29690290c7a5c0",
-   "sha256": "1i9scalpinp87wnapgpdw51p1q0y9wjf6nv4jbskzn7irvlkhhzx"
+   "commit": "2decf1e8187377c86982173a13482072bd418790",
+   "sha256": "0n5l701bxj19hyxpgarp2qvlkcdyhg5srq5shcjglzybx5vd5k4m"
   },
   "stable": {
    "version": [
     3,
     1,
-    1
+    2
    ],
    "deps": [
     "cl-lib",
     "request"
    ],
-   "commit": "5e963e8ef17e937745b8f3b64f29690290c7a5c0",
-   "sha256": "1i9scalpinp87wnapgpdw51p1q0y9wjf6nv4jbskzn7irvlkhhzx"
+   "commit": "2decf1e8187377c86982173a13482072bd418790",
+   "sha256": "0n5l701bxj19hyxpgarp2qvlkcdyhg5srq5shcjglzybx5vd5k4m"
   }
  },
  {
@@ -103023,8 +104272,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "5aaf9d12068f98fb4efa772a3e5f4bb350b79a99",
-   "sha256": "13qwvjid9d67kk4ggvc2hvm6j4wy1jassd02krp8as91h5hr0y36"
+   "commit": "55681147816744e05311347ce30b06f037ef24bd",
+   "sha256": "1crr36iwr0zhqcwwqskm8ca3qwdwc9crzmvca58665pjirrvfsbx"
   },
   "stable": {
    "version": [
@@ -103141,11 +104390,11 @@
   "repo": "jstaursky/weyland-yutani-theme",
   "unstable": {
    "version": [
-    20200818,
-    2225
+    20200921,
+    2005
    ],
-   "commit": "d17297aee3a15b326e813d6c12831b587f6267fd",
-   "sha256": "0brixf1j1hdmj0wvd3qzlmr844fvd61nxgc5adczpy0qivc1c1c9"
+   "commit": "bee9cb0f397fad312c59ccaa192ea565a54f86df",
+   "sha256": "130vymshrvy52m8wiz30rvka3q8bb24bfjx23fqckfcpmyq8bmhb"
   }
  },
  {
@@ -103315,20 +104564,20 @@
   "repo": "justbur/emacs-which-key",
   "unstable": {
    "version": [
-    20200817,
-    2358
+    20200908,
+    2301
    ],
-   "commit": "e48e190a75a0c176e1deac218b891e77792d6921",
-   "sha256": "1wr5lqjc5si0s0rn266jxfwln93l7aw79885w66gbjcynfy8rji3"
+   "commit": "ae59b7edb0d82aa0251803fdfbde6b865083c8b8",
+   "sha256": "13lgjsm9pwgjsxg7lzc1c9sw2bzssxikfj6grnshqfll8kz8yr4r"
   },
   "stable": {
    "version": [
     3,
-    4,
+    5,
     0
    ],
-   "commit": "1e3640e48c31f8062f018b5fc84acad696a0ea2a",
-   "sha256": "1ahgb7dqdc75farkl0fg0a6hvx2067gdvjq99cd3z2dz56km0p05"
+   "commit": "ae59b7edb0d82aa0251803fdfbde6b865083c8b8",
+   "sha256": "13lgjsm9pwgjsxg7lzc1c9sw2bzssxikfj6grnshqfll8kz8yr4r"
   }
  },
  {
@@ -103500,19 +104749,25 @@
   "repo": "purcell/whole-line-or-region",
   "unstable": {
    "version": [
-    20200305,
-    221
+    20200924,
+    129
    ],
-   "commit": "9791ae59f8bd8b9375d2dede92de8eba5f0d89fb",
-   "sha256": "0fk2nhcjkwrni8np8788z9aanrj1hxchg37a1j1z9ds42f0ghj6h"
+   "deps": [
+    "cl-lib"
+   ],
+   "commit": "f0051d301f83d6dd26ce30a8ea039a8510c79cc0",
+   "sha256": "0y02938a02mb6imlljsz2i9d2ki37hiqyhlyq341la2dr6iwn8sl"
   },
   "stable": {
    "version": [
-    1,
-    6
+    2,
+    0
    ],
-   "commit": "0d11174ba5e1145167000aa8f65c273a3d0db6b3",
-   "sha256": "1zw4aabadhsn81i3bwdl4717fq6a0njypavw2riyzbz465axd60i"
+   "deps": [
+    "cl-lib"
+   ],
+   "commit": "4189d03cfda752f04364e2abc0117080ed4112cd",
+   "sha256": "09jy46qxq5whk8l6znkvghjyc55cmi6z734aagmhiw33wmiyadm4"
   }
  },
  {
@@ -103820,11 +105075,11 @@
   "repo": "Javyre/winds.el",
   "unstable": {
    "version": [
-    20200501,
-    419
+    20200817,
+    2036
    ],
-   "commit": "720a0cedfdc20940f4c740e74fa0e16983cb0367",
-   "sha256": "00s0c2ilmypygqlrfa0ajig25h5jijxwwzpcfxgwbjf71wn5g9mg"
+   "commit": "b383004d190d4f18cd8ddb62135c60ae1944728b",
+   "sha256": "07bkj7gqgqnddwwyva337psf4li4ffpbvs4ifydv6z4q9ksmfh59"
   }
  },
  {
@@ -104021,8 +105276,8 @@
    "deps": [
     "async"
    ],
-   "commit": "efafd482c21b90decbb0b682ed3159c86014d4f3",
-   "sha256": "1z3214zjf3dassb31k14gq4nbr3q8g5x87ydfah28hm4j08v0wb3"
+   "commit": "590ff0b6443a5d0c433527a0231a31e99af6287c",
+   "sha256": "0vjkh466i36cj3fbdlwp39fhrfb0f5qvlbskgmd5ywg02gyl5ag6"
   },
   "stable": {
    "version": [
@@ -104094,26 +105349,26 @@
   "repo": "p3r7/with-shell-interpreter",
   "unstable": {
    "version": [
-    20200527,
-    828
+    20200828,
+    1217
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f8a01beda6260bd2eff3f9fe154ddc16da7b6504",
-   "sha256": "1xwmg85211s6fvc9agb8ib06klbk6cn890gpjq33bns6ldjsq41s"
+   "commit": "45b7d6ad63165c82a95966b291abbfe305d3ada2",
+   "sha256": "0amqw629ah23ngw99iciiljycgikzsrcwpskgbzg0xbv0zzbyjgn"
   },
   "stable": {
    "version": [
     0,
     2,
-    3
+    4
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "eb2b629c885ca002b7225e20d03231835910d6be",
-   "sha256": "0b6z516lwcl08gnhlw99z9sdw15qxk3kanicpp0l0hcbmzann46k"
+   "commit": "45b7d6ad63165c82a95966b291abbfe305d3ada2",
+   "sha256": "0amqw629ah23ngw99iciiljycgikzsrcwpskgbzg0xbv0zzbyjgn"
   }
  },
  {
@@ -104638,20 +105893,20 @@
   "repo": "redguardtoo/wucuo",
   "unstable": {
    "version": [
-    20200710,
-    932
+    20200912,
+    1320
    ],
-   "commit": "54143769dbea06d34792687eadbc6c7a1cd89ea2",
-   "sha256": "1a6jy8vixc6ls6cjwxjy3ifmiw8xw3c0kfichgd1b6v20xqdvhh3"
+   "commit": "a56b7af80776f33eb202bf83711d975d850bb9c9",
+   "sha256": "075crn8ag7myl2x7xzxppvb86xmcn4v7d5akp8rcchjk2n1kj2yn"
   },
   "stable": {
    "version": [
     0,
     2,
-    6
+    7
    ],
-   "commit": "54143769dbea06d34792687eadbc6c7a1cd89ea2",
-   "sha256": "1a6jy8vixc6ls6cjwxjy3ifmiw8xw3c0kfichgd1b6v20xqdvhh3"
+   "commit": "0effe297ee70585cf1ad3b00920b1fe228b9004f",
+   "sha256": "1iw4jdlqvki95gh7bzl7hjidc2kz9qyc1zjd7klh63gvk0z09700"
   }
  },
  {
@@ -104762,11 +106017,11 @@
   "repo": "xahlee/xah-css-mode",
   "unstable": {
    "version": [
-    20200627,
-    1652
+    20200905,
+    2218
    ],
-   "commit": "98e550db52865d6de141d5bbb85f8b4e68b56b39",
-   "sha256": "0km4b9praqpkv4n6sixmxjfvisp5640zyd1x85q43vkxrm39p7ah"
+   "commit": "0a5f7b9e83cc88af23377f37fa8a0621bf093445",
+   "sha256": "05brna7mk1kz2h61kcc9rj3awyr1inf1gs82746pdd8qb3zshzr8"
   }
  },
  {
@@ -104777,11 +106032,11 @@
   "repo": "xahlee/xah-elisp-mode",
   "unstable": {
    "version": [
-    20200719,
-    1648
+    20200908,
+    2328
    ],
-   "commit": "a051862622c56b7cad2057a95d8201ab38b50752",
-   "sha256": "00kan9rb133mf11qq0grdkph6ghv0hgwvdx3b21890mad20zmk1w"
+   "commit": "7f4b09ce5a9f8a8aaccdd0e122a0f6bda9b4c2e9",
+   "sha256": "01rjz29jsrcaa4rj39kc0li9zmpmg5vdydfyi2hcm8imyjvjnyf0"
   }
  },
  {
@@ -104807,11 +106062,11 @@
   "repo": "xahlee/xah-fly-keys",
   "unstable": {
    "version": [
-    20200707,
-    1310
+    20200925,
+    702
    ],
-   "commit": "8c9c4df25e1406b093a32c87da19803337e4e09c",
-   "sha256": "10d1xvyd2mbvhmlf1x5snqn4d22xg0p53nq601s8b4f1gws6zs59"
+   "commit": "0fd1a4537d505960b2e942f3d8d88a76a84c2f2f",
+   "sha256": "0r7lwcyyk428n8rydh1lvg8bkzdsld2fimhbz4041mppmavj3jdh"
   }
  },
  {
@@ -104867,11 +106122,11 @@
   "repo": "xahlee/xah-reformat-code",
   "unstable": {
    "version": [
-    20170821,
-    1111
+    20200913,
+    1701
    ],
-   "commit": "7fec8b28e46b8cc2813fac5149e3bbb56c0aa6b1",
-   "sha256": "0mz47laig0p7fwwiv66x60f5jg0kh8zvjd1vg3nnn3xvk37lv2cw"
+   "commit": "c4682148759051b8c27f7be573981f8fc92447e9",
+   "sha256": "0kj0aj4vqfpxcn84fvl83wh5c96iw5hr1ycq50x65f0zkyxx59gv"
   }
  },
  {
@@ -104980,11 +106235,11 @@
   "repo": "dkogan/xcscope.el",
   "unstable": {
    "version": [
-    20190723,
-    629
+    20200828,
+    1027
    ],
-   "commit": "f3e2c84bd92f5a78182cc8d81f5358979a6c241c",
-   "sha256": "0w2bxrnidladpzrd82z3w3gvjhajs71k5vjk2y03r09i9fwn2ykc"
+   "commit": "b9bd846f0c9dcc8acfe7d1046eafc3d0e87473ad",
+   "sha256": "0kpxlgqiyzaxk2dwk2c5s2dmaplv9r1wf3ql1dvrpvb9zv63nwgh"
   },
   "stable": {
    "version": [
@@ -105003,8 +106258,8 @@
   "repo": "dandavison/xenops",
   "unstable": {
    "version": [
-    20200730,
-    1646
+    20200903,
+    1447
    ],
    "deps": [
     "aio",
@@ -105015,8 +106270,8 @@
     "f",
     "s"
    ],
-   "commit": "78cbe16b74480ac6304865c9c3cfad36b5d49d1d",
-   "sha256": "1rpcckp60pw1blkxs7wlp60pvpr847b6g2rcd6p0hpf5sx9wirgv"
+   "commit": "5daef6aa70ab893a70ffd65dc1030f48a8eee3b4",
+   "sha256": "1pirlsq5ngjfpbg1y7vmddyq33g3jylq3n4ainj9cfh8c3n49wwa"
   }
  },
  {
@@ -105119,20 +106374,20 @@
   "repo": "xml-rpc-el/xml-rpc-el",
   "unstable": {
    "version": [
-    20181002,
-    1353
+    20200907,
+    42
    ],
-   "commit": "8f624f8b964e9145acb504e4457c9510e87dd93c",
-   "sha256": "0xa54z52rsfl3n0xgmbycj4zazp8ksgdwcq56swzs6wp72zlalmj"
+   "commit": "8020ccd176986d8e49e0bb5dd9f4e756cf12eafc",
+   "sha256": "07vgwnk96i1vpsv2glg6kbkamjcs72xiznsa6xk7nl0nranzr3hd"
   },
   "stable": {
    "version": [
     1,
     6,
-    13
+    15
    ],
-   "commit": "8f624f8b964e9145acb504e4457c9510e87dd93c",
-   "sha256": "0xa54z52rsfl3n0xgmbycj4zazp8ksgdwcq56swzs6wp72zlalmj"
+   "commit": "8020ccd176986d8e49e0bb5dd9f4e756cf12eafc",
+   "sha256": "07vgwnk96i1vpsv2glg6kbkamjcs72xiznsa6xk7nl0nranzr3hd"
   }
  },
  {
@@ -105166,19 +106421,19 @@
   "repo": "ndw/xmlunicode",
   "unstable": {
    "version": [
-    20200812,
-    747
+    20200823,
+    755
    ],
-   "commit": "8ae84ded4341aaa303903b4da142ef3ea456391e",
-   "sha256": "0ki8i41jkkzk791dg5wvpl6nfa4py2bfcs6lf3wmw8y768vx6mbg"
+   "commit": "0c2ee59888042d516f79a7b96526cbeae611c9bc",
+   "sha256": "026srs8nf6d5ksq30s3qy1jx4x65bdnyxz8p8nnsqlf81lbmhwq5"
   },
   "stable": {
    "version": [
     1,
-    22
+    23
    ],
-   "commit": "852bcbd0bd014f62c41ac78648e4f6664209b40b",
-   "sha256": "03b18jhfpbhkaq5fj30k6drwpcpvrb6gf1l43ja1mnqyrilvni2x"
+   "commit": "0c2ee59888042d516f79a7b96526cbeae611c9bc",
+   "sha256": "026srs8nf6d5ksq30s3qy1jx4x65bdnyxz8p8nnsqlf81lbmhwq5"
   }
  },
  {
@@ -105237,20 +106492,20 @@
   "repo": "paddymcall/xquery-tool.el",
   "unstable": {
    "version": [
-    20190523,
-    1119
+    20200907,
+    811
    ],
-   "commit": "7f0859cc722607240689e57e14de8e0719052016",
-   "sha256": "03vip403ifz9r4xkpiyi4mvb2plrn1f8906msdas84y13alhwnhq"
+   "commit": "bfbe9a70fb9fc7fdd24dcfa7085b16fb01f14501",
+   "sha256": "1bmsrj24apag8lwqzgs3gyfmxwmraq4psfcr8szib1f71yzq9sli"
   },
   "stable": {
    "version": [
     0,
-    1,
-    11
+    2,
+    0
    ],
-   "commit": "7f0859cc722607240689e57e14de8e0719052016",
-   "sha256": "03vip403ifz9r4xkpiyi4mvb2plrn1f8906msdas84y13alhwnhq"
+   "commit": "bd48e0f56b58e36309f7966dcf67db69d65100a4",
+   "sha256": "1c97pxkq9fq3bzycp02zmwldli3svqrg9lkxgfm95xd1b0qbigf6"
   }
  },
  {
@@ -105424,11 +106679,11 @@
   "repo": "canatella/xwwp",
   "unstable": {
    "version": [
-    20200413,
-    757
+    20200917,
+    643
    ],
-   "commit": "dcf6f9430dd9745e5f2705c0f42e013fab961c0e",
-   "sha256": "1aks12zbfcq4m4s1baxcdg2xjn2y9f4dw19576yp35hg2cb550v6"
+   "commit": "f67e070a6e1b233e60274deb717274b000923231",
+   "sha256": "1ikhgi3gc86w7y3cjmw875c8ccsmj22yn1zm3abprdzbjqlyzhhg"
   }
  },
  {
@@ -105439,14 +106694,14 @@
   "repo": "canatella/xwwp",
   "unstable": {
    "version": [
-    20200331,
-    800
+    20200917,
+    642
    ],
    "deps": [
     "xwwp"
    ],
-   "commit": "dcf6f9430dd9745e5f2705c0f42e013fab961c0e",
-   "sha256": "1aks12zbfcq4m4s1baxcdg2xjn2y9f4dw19576yp35hg2cb550v6"
+   "commit": "f67e070a6e1b233e60274deb717274b000923231",
+   "sha256": "1ikhgi3gc86w7y3cjmw875c8ccsmj22yn1zm3abprdzbjqlyzhhg"
   }
  },
  {
@@ -105457,14 +106712,14 @@
   "repo": "canatella/xwwp",
   "unstable": {
    "version": [
-    20200331,
-    800
+    20200917,
+    642
    ],
    "deps": [
     "xwwp"
    ],
-   "commit": "dcf6f9430dd9745e5f2705c0f42e013fab961c0e",
-   "sha256": "1aks12zbfcq4m4s1baxcdg2xjn2y9f4dw19576yp35hg2cb550v6"
+   "commit": "f67e070a6e1b233e60274deb717274b000923231",
+   "sha256": "1ikhgi3gc86w7y3cjmw875c8ccsmj22yn1zm3abprdzbjqlyzhhg"
   }
  },
  {
@@ -105732,11 +106987,11 @@
   "repo": "binjo/yara-mode",
   "unstable": {
    "version": [
-    20190423,
-    710
+    20200916,
+    1341
    ],
-   "commit": "cd8093b1bc4fc260462f5284b157008fefa84880",
-   "sha256": "04pl0kbx5g8wz00x7bhpi9w29wmxdmy5dhdq3j4rk3nys5njxr8v"
+   "commit": "03976d2c01e1295e179f279f73c0cea117ccba32",
+   "sha256": "1r3l6fbzihj4ac1pzk35kgl78p6cnbbzh6hnq5l9rp2crc0615v9"
   }
  },
  {
@@ -105886,15 +107141,15 @@
   "repo": "AndreaCrotti/yasnippet-snippets",
   "unstable": {
    "version": [
-    20200802,
-    1658
+    20200909,
+    1058
    ],
    "deps": [
     "s",
     "yasnippet"
    ],
-   "commit": "b83c0f2f3bd068aa93c8f4c0c07f0b0a137d9cda",
-   "sha256": "0j1955y6gc3ddv783pd9kx834vvicpdsj49smkkpk4rj4s7pfxkz"
+   "commit": "281752335ec797cfb2f8ab17d01e9293eab3f137",
+   "sha256": "1qzfnwja44mgrrkivgy85n93w8wdqgz0yi99wmrd7lipnzwdiir8"
   },
   "stable": {
    "version": [
@@ -106179,11 +107434,11 @@
   "repo": "ryuslash/yoshi-theme",
   "unstable": {
    "version": [
-    20200422,
-    208
+    20200909,
+    513
    ],
-   "commit": "caa83e4475885a2c9a126630f0feec1ce2eb0c4e",
-   "sha256": "0sga52lz54c2v08j6m9v3ddv7rlpdcgi9lkxn1cvajm5h60b20r8"
+   "commit": "1ca48766209d941f0300d725ce9bec5a8bc2d642",
+   "sha256": "1abzv19aghgjkzc15wcii3fvapjx221imap48gfn2d3ckbppy8lb"
   },
   "stable": {
    "version": [
@@ -106388,11 +107643,11 @@
   "repo": "bbatsov/zenburn-emacs",
   "unstable": {
    "version": [
-    20200701,
-    1333
+    20200909,
+    1617
    ],
-   "commit": "c09dbd9a36bbc0062b90be182f2b4cac64128cee",
-   "sha256": "0lr73kghsi1f5awhgsbvh4snkbdkkpjn5bwf6s6ypbybmjf6kjxd"
+   "commit": "58097fa44cc747b212501a70ad9d30b8a4f6b7d2",
+   "sha256": "0wcnxi2pgpfr8bkwx5h4fc8xcmfzf93njqnvxbr32907nm2xxnhh"
   },
   "stable": {
    "version": [
@@ -106547,15 +107802,15 @@
   "repo": "EFLS/zetteldeft",
   "unstable": {
    "version": [
-    20200812,
-    2159
+    20200922,
+    712
    ],
    "deps": [
     "ace-window",
     "deft"
    ],
-   "commit": "2c4ddbf3e30e2f3ae6e877e08fd824b325fa7a62",
-   "sha256": "029fh32d2vilxlqs5jl3wc907ykxdkv36jjfzappyghd1qkp0iyi"
+   "commit": "ea0d603d0f2ed022599e1ce8dced8e3ef8677f12",
+   "sha256": "04y2cvrm2fpllz8wan9xggvrs02sr0yh4h8c9kgynilhfwzmgz23"
   },
   "stable": {
    "version": [
@@ -106577,15 +107832,15 @@
   "repo": "damon-kwok/zetz-mode",
   "unstable": {
    "version": [
-    20200812,
-    957
+    20200823,
+    536
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "3bd2cdb4f6c6e8400d58fa1001d0513e39ce38bb",
-   "sha256": "0v1aa0hr607afxd03p44m1abx2c8a5k91i047q7nv8sv0cd65ack"
+   "commit": "04da33f4ffa9db5b3556f423276f4fd1db13ec67",
+   "sha256": "07cl2y6qdxbhjawg93l3yxkx6skmcnl9278qq1aksvh17v4ajydv"
   },
   "stable": {
    "version": [
@@ -106624,8 +107879,8 @@
   "repo": "WillForan/zim-wiki-mode",
   "unstable": {
    "version": [
-    20200316,
-    1223
+    20200908,
+    218
    ],
    "deps": [
     "dokuwiki-mode",
@@ -106634,8 +107889,8 @@
     "link-hint",
     "pretty-hydra"
    ],
-   "commit": "410fa67d5947b8801b03a58fcb2bd414cb5294f7",
-   "sha256": "14dmda7ahnflv0db9yzssz7bidz3zsdnxxwnby0y48vcjv94nnl5"
+   "commit": "f65a2da6ea762532355fc726319ba3e3dd217ec2",
+   "sha256": "0m18giykwldj21zgv5rbni0pbpbrx5mnmkj5jyd2zpgwi1n7w3im"
   }
  },
  {
@@ -106646,14 +107901,14 @@
   "repo": "schmir/zimports.el",
   "unstable": {
    "version": [
-    20200606,
-    1700
+    20200809,
+    2035
    ],
    "deps": [
     "projectile"
    ],
-   "commit": "a96e9b993c9aaccf1fd07c8fddfc247c4e07618c",
-   "sha256": "1bzfdwyc4aybvnh20q7ypghpi3zrhhs0v8488lksjl26j23mhrwk"
+   "commit": "4067b20a2ea25327504b0a42f443903728aa7966",
+   "sha256": "01ljp3cpslkmp8kxm24ayp5jlg6r431vpk6dm1b9ylr4x4p1klgx"
   }
  },
  {
@@ -106679,14 +107934,14 @@
   "repo": "dzop/emacs-zmq",
   "unstable": {
    "version": [
-    20200305,
-    2345
+    20200912,
+    1126
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "2aed40aee51d19cbca83d1f1edc23a5f1522dd8d",
-   "sha256": "1viz4sw4vmnjhhqw68wp8a4ks1751s2dk09gx2gyl8gy5vw2fcg6"
+   "commit": "eb4e01715cbf2f356a8ae5e678ffec3380a907dc",
+   "sha256": "0s21w3yc41hvrd881f5y8w6jczyd3bq7nbw5m13xr96yrv1d24mz"
   },
   "stable": {
    "version": [


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

We had an issue where our application would
start to early and crashed because redis connections
weren't available yet.

Adding this should ensure connections can be made to
redis. (and we can safely requires= ["redis.service"])


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

