### PR TITLE
python.pkgs.black: 19.10b0 -> 20.8b1

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -1,42 +1,71 @@
-{ stdenv, buildPythonPackage, fetchPypi, pythonOlder
-, attrs, click, toml, appdirs, aiohttp, aiohttp-cors
-, glibcLocales, typed-ast, pathspec, regex
-, setuptools_scm, pytest }:
+{ stdenv, lib
+, buildPythonPackage, fetchPypi, pythonOlder, setuptools_scm, pytestCheckHook
+, aiohttp
+, aiohttp-cors
+, appdirs
+, attrs
+, click
+, mypy-extensions
+, pathspec
+, regex
+, toml
+, typed-ast
+, typing-extensions }:
 
 buildPythonPackage rec {
   pname = "black";
-  version = "19.10b0";
+  version = "20.8b1";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0f8mr0yzj78q1dx7v6ggbgfir2wv0n5z2shfbbvfdq7910xbgvf2";
+    sha256 = "1spv6sldp3mcxr740dh3ywp25lly9s8qlvs946fin44rl1x5a0hw";
   };
 
   nativeBuildInputs = [ setuptools_scm ];
-  checkInputs =  [ pytest glibcLocales ];
 
   # Necessary for the tests to pass on Darwin with sandbox enabled.
   # Black starts a local server and needs to bind a local address.
   __darwinAllowLocalNetworking = true;
 
-  # Don't know why these tests fails
-  # Disable test_expression_diff, because it fails on darwin
-  checkPhase = ''
-    LC_ALL="en_US.UTF-8" pytest \
-      --deselect tests/test_black.py::BlackTestCase::test_expression_diff \
-      --deselect tests/test_black.py::BlackTestCase::test_cache_multiple_files \
-      --deselect tests/test_black.py::BlackTestCase::test_failed_formatting_does_not_get_cached
+  checkInputs =  [ pytestCheckHook ];
+
+  preCheck = ''
+    export PATH="$PATH:$out/bin"
   '';
 
-  propagatedBuildInputs = [ attrs appdirs click toml aiohttp aiohttp-cors pathspec regex typed-ast ];
+  disabledTests = [
+    # Don't know why these tests fails
+    "test_cache_multiple_files"
+    "test_failed_formatting_does_not_get_cached"
+    # requires network access
+    "test_gen_check_output"
+    "test_process_queue"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # fails on darwin
+    "test_expression_diff"
+  ];
 
-  meta = with stdenv.lib; {
+  propagatedBuildInputs = [
+    aiohttp
+    aiohttp-cors
+    appdirs
+    attrs
+    click
+    mypy-extensions
+    pathspec
+    regex
+    toml
+    typed-ast
+    typing-extensions
+  ];
+
+  meta = with lib; {
     description = "The uncompromising Python code formatter";
     homepage    = "https://github.com/psf/black";
+    changelog   = "https://github.com/psf/black/blob/${version}/CHANGES.md";
     license     = licenses.mit;
     maintainers = with maintainers; [ sveitser ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
