### PR TITLE
kak-powerline: 2019-07-23 -> 2020-08-22

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/kak-powerline.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-powerline.nix
@@ -1,12 +1,12 @@
 { stdenv, git, fetchFromGitHub }:
 stdenv.mkDerivation {
   name = "kak-powerline";
-  version = "2019-07-23";
+  version = "2020-08-22";
   src = fetchFromGitHub {
-    owner = "andreyorst";
+    owner = "jdugan6240";
     repo = "powerline.kak";
-    rev = "82b01eb6c97c7380b7da253db1fd484a5de13ea4";
-    sha256 = "1480wp2jc7c84z1wqmpf09lzny6kbnbhiiym2ffaddxrd4ns9i6z";
+    rev = "d641b2cd8024f872bcda23f9256e7aff36da02ae";
+    sha256 = "65948f5ef3ab2f46f6d186ad752665c251d887631d439949decc2654a67958a4";
   };
 
   configurePhase = ''
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib;
   { description = "Kakoune modeline, but with passion";
-    homepage = "https://github.com/andreyorst/powerline.kak";
+    homepage = "https://github.com/jdugan6240/powerline.kak";
     license = licenses.mit;
     maintainers = with maintainers; [ nrdxp ];
     platform = platforms.all;


### PR DESCRIPTION
cc @nrdxp 
###### Motivation for this change
The plugin is currently not maintained by its original creator.  I changed it to the current maintainer's fork and the most recent commit there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
