### PR TITLE
ocamlPackages.elpi: 1.11.2 -> 1.11.4

### DIFF
--- a/pkgs/development/coq-modules/coq-elpi/default.nix
+++ b/pkgs/development/coq-modules/coq-elpi/default.nix
@@ -2,14 +2,14 @@
 
 let params = {
   "8.11" = rec {
-    version = "1.5.0";
+    version = "1.6.0_8.11";
     rev = "v${version}";
-    sha256 = "0dlw869j6ib58i8fhbr7x3hq2cy088arihhfanv8i08djqml6g8x";
+    sha256 = "0ahxjnzmd7kl3gl38kyjqzkfgllncr2ybnw8bvgrc6iddgga7bpq";
   };
   "8.12" = rec {
-    version = "1.5.1";
+    version = "1.6.0";
     rev = "v${version}";
-    sha256 = "1znjc8c8rivsawmz5bgm9ddl69p62p2pwxphvpap1gfmi5cp8lwi";
+    sha256 = "0kf99i43mlf750fr7fric764mm495a53mg5kahnbp6zcjcxxrm0b";
   };
 };
   param = params.${coq.coq-version};

--- a/pkgs/development/ocaml-modules/elpi/default.nix
+++ b/pkgs/development/ocaml-modules/elpi/default.nix
@@ -1,19 +1,19 @@
 { lib, fetchzip, buildDunePackage, camlp5
-, ppx_tools_versioned, ppx_deriving, re
+, ppxlib, ppx_deriving, re, perl, ncurses
 }:
 
 buildDunePackage rec {
   pname = "elpi";
-  version = "1.11.2";
+  version = "1.11.4";
 
    src = fetchzip {
      url = "https://github.com/LPCIC/elpi/releases/download/v${version}/elpi-v${version}.tbz";
-     sha256 = "15hamy9ifr05kczadwh3yj2gmr12a9z1jwppmp5yrns0vykjbj76";
+     sha256 = "1hmjp2z52j17vwhhdkj45n9jx11jxkdg2dwa0n04yyw0qqy4m7c1";
    };
 
   minimumOCamlVersion = "4.04";
 
-  buildInputs = [ ppx_tools_versioned ];
+  buildInputs = [ perl ncurses ppxlib ];
 
   propagatedBuildInputs = [ camlp5 ppx_deriving re ];
 
@@ -23,6 +23,10 @@ buildDunePackage rec {
     maintainers = [ lib.maintainers.vbgl ];
     homepage = "https://github.com/LPCIC/elpi";
   };
+
+  postPatch = ''
+    substituteInPlace elpi_REPL.ml --replace "tput cols" "${ncurses}/bin/tput cols"
+  '';
 
   useDune2 = true;
 }


### PR DESCRIPTION
and fixing dependencies


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upgrading elpi and coq-elpi

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).