### PR TITLE
python3Packages.cvxpy: 1.1.4 -> 1.1.5

### DIFF
--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -11,18 +11,19 @@
 , scs
 , six
   # Check inputs
+, pytestCheckHook
 , nose
 }:
 
 buildPythonPackage rec {
   pname = "cvxpy";
-  version = "1.1.4";
+  version = "1.1.5";
 
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1f37da2f891508ebc2bbb2b75c46a2076be39a60a45c8a88261e000e8aabeef2";
+    sha256 = "7c826a874db2e4cefe54e63ebd3a3763d0d72e55a17c7d1cfec80008a87b8d81";
   };
 
   propagatedBuildInputs = [
@@ -36,15 +37,19 @@ buildPythonPackage rec {
     six
   ];
 
-  checkInputs = [ nose ];
-  checkPhase = ''
-    nosetests cvxpy
-  '';
+  checkInputs = [ pytestCheckHook nose ];
+  pytestFlagsArray = [ "./cvxpy" ];
+  # Disable the slowest benchmarking tests, cuts test time in half
+  disabledTests = [
+    "test_tv_inpainting"
+    "test_diffcp_sdp_example"
+  ];
 
   meta = with lib; {
     description = "A domain-specific language for modeling convex optimization problems in Python.";
     homepage = "https://www.cvxpy.org/";
     downloadPage = "https://github.com/cvxgrp/cvxpy/releases";
+    changelog = "https://github.com/cvxgrp/cvxpy/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest version of ``python3Packages.cvxpy``: https://github.com/cvxgrp/cvxpy/releases/tag/v1.1.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
