### PR TITLE
pythonPackages.jupyterhub-tmpauthenticator: init at 0.6

### DIFF
--- a/pkgs/development/python-modules/jupyterhub-tmpauthenticator/default.nix
+++ b/pkgs/development/python-modules/jupyterhub-tmpauthenticator/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, jupyterhub
+}:
+
+buildPythonPackage rec {
+  pname = "jupyterhub-tmpauthenticator";
+  version = "0.6";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "064x1ypxwx1l270ic97p8czbzb7swl9758v40k3w2gaqf9762f0l";
+  };
+
+  propagatedBuildInputs = [ jupyterhub ];
+
+  # No tests available in the package
+  doCheck = false;
+
+  pythonImportsCheck = [ "tmpauthenticator" ];
+
+  meta = with lib; {
+    description = "Simple Jupyterhub authenticator that allows anyone to log in.";
+    license = with licenses; [ bsd3 ];
+    homepage = "https://github.com/jupyterhub/tmpauthenticator";
+    maintainers = with maintainers; [ chiroptical ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4544,6 +4544,8 @@ in {
 
   jupyterhub-ldapauthenticator = callPackage ../development/python-modules/jupyterhub-ldapauthenticator { };
 
+  jupyterhub-tmpauthenticator = callPackage ../development/python-modules/jupyterhub-tmpauthenticator { };
+
   jupyterhub-systemdspawner = callPackage ../development/python-modules/jupyterhub-systemdspawner {
     inherit (pkgs) bash;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This package provides a JupyterHub authenticator that allows any user to log in to JupyterHub. The package doesn't provide any tests and therefore I use `pythonImportsCheck`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
