### PR TITLE
catt: fix pychromecast version

### DIFF
--- a/pkgs/applications/video/catt/default.nix
+++ b/pkgs/applications/video/catt/default.nix
@@ -1,12 +1,19 @@
-{ buildPythonApplication, fetchPypi, lib
-, youtube-dl
-, PyChromecast
-, click
-, ifaddr
-, requests
-}:
+{ lib, python3 }:
 
-buildPythonApplication rec {
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+      PyChromecast = super.PyChromecast.overridePythonAttrs (oldAttrs: rec {
+        version = "6.0.0";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "05f8r3b2pdqbl76hwi5sv2xdi1r7g9lgm69x8ja5g22mn7ysmghm";
+        };
+      });
+    };
+  };
+
+in with py.pkgs; buildPythonApplication rec {
   pname = "catt";
   version = "0.11.0";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19635,7 +19635,7 @@ in
 
   catimg = callPackage ../tools/misc/catimg { };
 
-  catt = python3Packages.callPackage ../applications/video/catt { };
+  catt = callPackage ../applications/video/catt { };
 
   cava = callPackage ../applications/audio/cava { };
 


### PR DESCRIPTION

###### Motivation for this change
fix https://github.com/NixOS/nixpkgs/pull/92502#issuecomment-681356049

cc @bqv 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
