### PR TITLE
python3.pkgs.pyexcel: init at 0.6.4

### DIFF
--- a/pkgs/development/python-modules/lml/default.nix
+++ b/pkgs/development/python-modules/lml/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "lml";
+  version = "0.0.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6luoF7Styen1whclzSR1+RKTO34t/fB5Ku2AB3FU9j8=";
+  };
+
+  checkInputs = [
+    nose
+    mock
+  ];
+
+  checkPhase = "nosetests";
+
+  meta = {
+    description = "Load me later. A lazy plugin management system for Python";
+    homepage = "http://lml.readthedocs.io/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/python-modules/pyexcel-io/default.nix
+++ b/pkgs/development/python-modules/pyexcel-io/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, lml
+}:
+
+buildPythonPackage rec {
+  pname = "pyexcel-io";
+  version = "0.5.20";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "CN/jlVO5ljWbFD3j2exD4ZbxE41HyrtzrwShaCG4TXk=";
+  };
+
+  propagatedBuildInputs = [
+    lml
+  ];
+
+  # Tests depend on stuff that depends on this.
+  doCheck = false;
+
+  pythonImportsCheck = [ "pyexcel_io" ];
+
+  meta = {
+    description = "One interface to read and write the data in various excel formats, import the data into and export the data from databases";
+    homepage = "http://docs.pyexcel.org/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/python-modules/pyexcel-ods/default.nix
+++ b/pkgs/development/python-modules/pyexcel-ods/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyexcel-io
+, odfpy
+, nose
+, pyexcel
+, pyexcel-xls
+, psutil
+}:
+
+buildPythonPackage rec {
+  pname = "pyexcel-ods";
+  version = "0.5.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "O+Uv2KrdvYvJKG9+sUj0VT1MlyUtaVw6nse5XmZmoiM=";
+  };
+
+  propagatedBuildInputs = [
+    pyexcel-io
+    odfpy
+  ];
+
+  checkInputs = [
+    nose
+    pyexcel
+    pyexcel-xls
+    psutil
+  ];
+
+  checkPhase = "nosetests";
+
+  meta = {
+    description = "Plug-in to pyexcel providing the capbility to read, manipulate and write data in ods formats using odfpy";
+    homepage = "http://docs.pyexcel.org/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/python-modules/pyexcel-xls/default.nix
+++ b/pkgs/development/python-modules/pyexcel-xls/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyexcel-io
+, xlrd
+, xlwt
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "pyexcel-xls";
+  version = "0.5.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "LTPrS9ja37jHO1zMaiONZbORTomnVTsfObk5exfL5AI=";
+  };
+
+  propagatedBuildInputs = [
+    pyexcel-io
+    xlrd
+    xlwt
+  ];
+
+  # Tests are not included in the archive.
+  # https://github.com/pyexcel/pyexcel-xls/issues/35
+  doCheck = false;
+
+  pythonImportsCheck = [ "pyexcel_xls" ];
+
+  meta = {
+    description = "A wrapper library to read, manipulate and write data in xls using xlrd and xlwt";
+    homepage = "http://docs.pyexcel.org/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/python-modules/pyexcel/default.nix
+++ b/pkgs/development/python-modules/pyexcel/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, lml
+, pyexcel-io
+, texttable
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "pyexcel";
+  version = "0.6.4";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "pPNYnimHhW7SL6X6OLwagZoadTD7IdUSbO7vAqQPQu8=";
+  };
+
+  propagatedBuildInputs = [
+    lml
+    pyexcel-io
+    texttable
+  ];
+
+  checkInputs = [
+    nose
+  ];
+
+  # Tests depend on pyexcel-xls & co. causing circular dependency.
+  # https://github.com/pyexcel/pyexcel/blob/dev/tests/requirements.txt
+  doCheck = false;
+
+  pythonImportsCheck = [ "pyexcel" ];
+
+  checkPhase = "nosetests";
+
+  meta = {
+    description = "Single API for reading, manipulating and writing data in csv, ods, xls, xlsx and xlsm files";
+    homepage = "http://docs.pyexcel.org/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4693,6 +4693,8 @@ in {
     inherit (pkgs) fuse pkgconfig; # use "real" fuse and pkgconfig, not the python modules
   };
 
+  lml = callPackage ../development/python-modules/lml { };
+
   locustio = callPackage ../development/python-modules/locustio { };
 
   llvmlite = callPackage ../development/python-modules/llvmlite {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5580,6 +5580,8 @@ in {
 
   pyexcel-io = callPackage ../development/python-modules/pyexcel-io { };
 
+  pyexcel-xls = callPackage ../development/python-modules/pyexcel-xls { };
+
   pyexcelerator = callPackage ../development/python-modules/pyexcelerator { };
 
   pyext = callPackage ../development/python-modules/pyext { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5576,6 +5576,8 @@ in {
 
   pyenchant = callPackage ../development/python-modules/pyenchant { enchant2 = pkgs.enchant2; };
 
+  pyexcel-io = callPackage ../development/python-modules/pyexcel-io { };
+
   pyexcelerator = callPackage ../development/python-modules/pyexcelerator { };
 
   pyext = callPackage ../development/python-modules/pyext { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5576,6 +5576,8 @@ in {
 
   pyenchant = callPackage ../development/python-modules/pyenchant { enchant2 = pkgs.enchant2; };
 
+  pyexcel = callPackage ../development/python-modules/pyexcel { };
+
   pyexcel-io = callPackage ../development/python-modules/pyexcel-io { };
 
   pyexcelerator = callPackage ../development/python-modules/pyexcelerator { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5582,6 +5582,8 @@ in {
 
   pyexcel-xls = callPackage ../development/python-modules/pyexcel-xls { };
 
+  pyexcel-ods = callPackage ../development/python-modules/pyexcel-ods { };
+
   pyexcelerator = callPackage ../development/python-modules/pyexcelerator { };
 
   pyext = callPackage ../development/python-modules/pyext { };


### PR DESCRIPTION
###### Motivation for this change
Just needed this again so I finally packaged it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested using `nix-shell -I nixpkgs=$HOME/Projects/nixpkgs -p 'python3.withPackages(ps: with ps; [ pyexcel pyexcel-ods ])' --run 'python3 -c "import pyexcel; print(pyexcel.get_records(file_name=\"data.ods\", sheet_name=\"INFO\"))"'`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
