### PR TITLE
haskellPackages.haskell-language-server: Fix expression

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1462,7 +1462,7 @@ self: super: {
     # Test disabled: it seems to freeze (is it just that it takes a long time ?)
     ghcide = dontCheck super.hls-ghcide;
     # we are faster than stack here
-    hie-bios = dontCheck super.hie-bios_0_6_3;
+    hie-bios = dontCheck super.hie-bios_0_7_0;
     lsp-test = dontCheck super.lsp-test_0_11_0_4;
     # fourmolu can‘t compile with an older aeson
     aeson = dontCheck super.aeson_1_5_2_0;
@@ -1470,7 +1470,8 @@ self: super: {
     brittany = doJailbreak super.brittany;
   };
   in {
-    haskell-language-server = dontCheck (super.haskell-language-server.overrideScope hlsScopeOverride);
+    # jailbreaking for hie-bios 0.7.0 (upstream PR: https://github.com/haskell/haskell-language-server/pull/357)
+    haskell-language-server = dontCheck (doJailbreak (super.haskell-language-server.overrideScope hlsScopeOverride));
     hls-ghcide = dontCheck (super.hls-ghcide.overrideScope hlsScopeOverride);
     fourmolu = super.fourmolu.overrideScope hlsScopeOverride;
   }

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-ghcide.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-ghcide.nix
@@ -18,8 +18,8 @@ mkDerivation {
   version = "0.2.0";
   src = fetchgit {
     url = "https://github.com/wz1000/ghcide";
-    sha256 = "1zq7ngaak8il91a309rl51dghzasnk4m2sm3av6d93cyqyra1hfc";
-    rev = "078e3d3c0d319f83841ccbcdc60ff5f0e243f6be";
+    sha256 = "112bsk2660750n94gnsgrvd30rk0ccxb8dbhka606a11pcqv5cgx";
+    rev = "3f6cd4553279ec47d1599b502720791a4f4613cd";
     fetchSubmodules = true;
   };
   isLibrary = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes a derivation error because of new hie-bios release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
