### PR TITLE
libtorch-bin: init at 1.6.0

### DIFF
--- a/pkgs/development/libraries/science/math/libtorch/bin.nix
+++ b/pkgs/development/libraries/science/math/libtorch/bin.nix
@@ -1,0 +1,111 @@
+{ callPackage
+, stdenv
+, fetchzip
+, lib
+
+, addOpenGLRunpath
+, patchelf
+, fixDarwinDylibNames
+
+, cudaSupport
+, nvidia_x11
+}:
+
+let
+  version = "1.6.0";
+  device = if cudaSupport then "cuda" else "cpu";
+  srcs = import ./binary-hashes.nix;
+  unavailable = throw "libtorch is not available for this platform";
+in stdenv.mkDerivation {
+  inherit version;
+  pname = "libtorch";
+
+  src = fetchzip srcs."${stdenv.targetPlatform.system}-${device}" or unavailable;
+
+  nativeBuildInputs =
+    if stdenv.isDarwin then [ fixDarwinDylibNames ]
+    else [ addOpenGLRunpath patchelf ]
+      ++ stdenv.lib.optionals cudaSupport [ addOpenGLRunpath ];
+
+  buildInputs = [
+    stdenv.cc.cc
+  ] ++ lib.optionals cudaSupport [ nvidia_x11 ];
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontStrip = true;
+
+  installPhase = ''
+    # Copy headers and CMake files.
+    install -Dm755 -t $dev/lib lib/*.a
+    cp -r include $dev
+    cp -r share $dev
+
+    install -Dm755 -t $out/lib lib/*${stdenv.hostPlatform.extensions.sharedLibrary}*
+
+    # We do not care about Java support...
+    rm -f $out/lib/lib*jni* 2> /dev/null || true
+  '';
+
+  postFixup = let
+    libPaths = [ stdenv.cc.cc.lib ]
+      ++ stdenv.lib.optionals cudaSupport [ nvidia_x11 ];
+    rpath = stdenv.lib.makeLibraryPath libPaths;
+  in stdenv.lib.optionalString stdenv.isLinux ''
+    find $out/lib -type f \( -name '*.so' -or -name '*.so.*' \) | while read lib; do
+      echo "setting rpath for $lib..."
+      patchelf --set-rpath "${rpath}:$out/lib" "$lib"
+      ${lib.optionalString cudaSupport ''
+        addOpenGLRunpath "$lib"
+      ''}
+    done
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    install_name_tool -change @rpath/libshm.dylib $out/lib/libshm.dylib $out/lib/libtorch_python.dylib
+    install_name_tool -change @rpath/libc10.dylib $out/lib/libc10.dylib $out/lib/libtorch_python.dylib
+    install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libtorch_python.dylib
+    install_name_tool -change @rpath/libtorch.dylib $out/lib/libtorch.dylib $out/lib/libtorch_python.dylib
+    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libtorch_python.dylib
+
+    install_name_tool -change @rpath/libc10.dylib $out/lib/libc10.dylib $out/lib/libtorch.dylib
+    install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libtorch.dylib
+    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libtorch.dylib
+
+    install_name_tool -change @rpath/libc10.dylib $out/lib/libc10.dylib $out/lib/libtorch_cpu.dylib
+    install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libtorch_cpu.dylib
+    install_name_tool -change @rpath/libtensorpipe.dylib $out/lib/libtensorpipe.dylib $out/lib/libtorch_cpu.dylib
+
+    install_name_tool -change @rpath/libc10.dylib $out/lib/libc10.dylib $out/lib/libcaffe2_observers.dylib
+    install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libcaffe2_observers.dylib
+    install_name_tool -change @rpath/libtorch.dylib $out/lib/libtorch.dylib $out/lib/libcaffe2_observers.dylib
+    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libcaffe2_observers.dylib
+
+    install_name_tool -change @rpath/libc10.dylib $out/lib/libc10.dylib $out/lib/libcaffe2_module_test_dynamic.dylib
+    install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libcaffe2_module_test_dynamic.dylib
+    install_name_tool -change @rpath/libtorch.dylib $out/lib/libtorch.dylib $out/lib/libcaffe2_module_test_dynamic.dylib
+    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libcaffe2_module_test_dynamic.dylib
+
+    install_name_tool -change @rpath/libc10.dylib $out/lib/libc10.dylib $out/lib/libcaffe2_detectron_ops.dylib
+    install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libcaffe2_detectron_ops.dylib
+    install_name_tool -change @rpath/libtorch.dylib $out/lib/libtorch.dylib $out/lib/libcaffe2_detectron_ops.dylib
+    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libcaffe2_detectron_ops.dylib
+
+    install_name_tool -change @rpath/libc10.dylib $out/lib/libc10.dylib $out/lib/libshm.dylib
+    install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libshm.dylib
+    install_name_tool -change @rpath/libtorch.dylib $out/lib/libtorch.dylib $out/lib/libshm.dylib
+    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libshm.dylib
+
+    install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libtorch_global_deps.dylib
+    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libtorch_global_deps.dylib
+  '';
+
+  outputs = [ "out" "dev" ];
+
+  passthru.tests = callPackage ./test { };
+
+  meta = with stdenv.lib; {
+    description = "C++ API of the PyTorch machine learning framework";
+    homepage = "https://pytorch.org/";
+    license = licenses.unfree; # Includes CUDA and Intel MKL.
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
+++ b/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
@@ -1,0 +1,14 @@
+{
+  x86_64-darwin-cpu = {
+    url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.6.0.zip";
+    sha256 = "0d4n7la31qzl4s9pwvm07la7q6lhcwiww0yjpfz3kw6nvx84p22r";
+  };
+  x86_64-linux-cpu = {
+    url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.6.0%2Bcpu.zip";
+    sha256 = "1975b4zvyihzh89vnwspw0vf9qr05sxj8939vcrlmv3gzvdspcxz";
+  };
+  x86_64-linux-cuda = {
+    url = "https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.6.0.zip";
+    sha256 = "127qnfyi1faqbm40sbnsyqxjhrqj82bzwqyz7c1hs2bm0zgrrpya";
+  };
+}

--- a/pkgs/development/libraries/science/math/libtorch/test/CMakeLists.txt
+++ b/pkgs/development/libraries/science/math/libtorch/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+find_package(Torch REQUIRED)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
+add_executable(test test.cpp)
+target_link_libraries(test "${TORCH_LIBRARIES}")

--- a/pkgs/development/libraries/science/math/libtorch/test/default.nix
+++ b/pkgs/development/libraries/science/math/libtorch/test/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, cmake, libtorch-bin, symlinkJoin }:
+
+stdenv.mkDerivation {
+  pname = "libtorch-test";
+  version = libtorch-bin.version;
+
+  src = ./.;
+
+  postPatch = ''
+    cat CMakeLists.txt
+  '';
+
+  makeFlags = [ "VERBOSE=1" ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libtorch-bin ];
+
+  installPhase = ''
+    touch $out
+  '';
+
+  checkPhase = ''
+    ./test
+  '';
+}

--- a/pkgs/development/libraries/science/math/libtorch/test/test.cpp
+++ b/pkgs/development/libraries/science/math/libtorch/test/test.cpp
@@ -1,0 +1,7 @@
+#include <torch/torch.h>
+#include <iostream>
+
+int main() {
+  torch::Tensor tensor = torch::eye(3);
+  std::cout << tensor << std::endl;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1367,6 +1367,11 @@ in
     then python.pkgs.tensorflow.libtensorflow
     else libtensorflow-bin;
 
+  libtorch-bin = callPackage ../development/libraries/science/math/libtorch/bin.nix {
+    inherit (linuxPackages) nvidia_x11;
+    cudaSupport = pkgs.config.cudaSupport or false;
+  };
+
   behdad-fonts = callPackage ../data/fonts/behdad-fonts { };
 
   bless = callPackage ../applications/editors/bless { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

libtorch is available as python3Packages.pytorch.{out,dev}. However, I
think there are several good reasons for also providing upstream's
prebuilt libtorch:

- Upstream has a license to distribute PyTorch with MKL. I benchmarked
  one of my own natural language processing tools and this resulted in
  50% faster CPU inference. We support building with MKL in our
  PyTorch derivation, but that incurs a large build time.
- Upstream also has a license to distribute CUDA with MKL. Again, we
  support CUDA in our derivation, but it requires an expensive PyTorch
  build.
- No build time. This is nice for downstream users when the PyTorch
  derivation is temporarily broken, which is typically only found out
  somewhere during the build.
- Possibly breaks less often than builds of the PyTorch derivation.

Since the same libraries are distributed through PyPi, I would assume
that redistribution is fine. But I can ask upstream if necessary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).