### PR TITLE
pythonPackages.spotipy: fix build

### DIFF
--- a/pkgs/development/python-modules/spotipy/default.nix
+++ b/pkgs/development/python-modules/spotipy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, requests }:
+{ stdenv, buildPythonPackage, fetchPypi, requests, six, mock }:
 
 buildPythonPackage rec {
   pname = "spotipy";
@@ -9,7 +9,15 @@ buildPythonPackage rec {
     sha256 = "d1a85b8831ed60d2290ab9bbba289c548fb9680889757252c02dab2f2327d865";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [ requests six ];
+  checkInputs = [ mock ];
+
+  preConfigure = ''
+    substituteInPlace setup.py \
+      --replace "mock==2.0.0" "mock"
+  '';
+
+  pythonImportsCheck = [ "spotipy" ];
 
   meta = with stdenv.lib; {
     homepage = "https://spotipy.readthedocs.org/";


### PR DESCRIPTION
###### Motivation for this change
spotipy does not build

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
