### PR TITLE
lcov: 1.14 -> 1.15

### DIFF
--- a/pkgs/development/tools/analysis/lcov/default.nix
+++ b/pkgs/development/tools/analysis/lcov/default.nix
@@ -1,23 +1,15 @@
- {stdenv, fetchurl, fetchpatch, perl, perlPackages, makeWrapper }:
+ {stdenv, fetchFromGitHub, perl, perlPackages, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "lcov-1.14";
+  pname = "lcov";
+  version = "1.15";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/ltp/${name}.tar.gz";
-    sha256 = "06h7ixyznf6vz1qvksjgy5f3q2nw9akf6zx59npf0h3l32cmd68l";
+  src = fetchFromGitHub {
+    owner = "linux-test-project";
+    repo = "lcov";
+    rev = "v${version}";
+    sha256 = "1kvc7fkp45w48f0bxwbxvxkicnjrrydki0hllg294n1wrp80zzyk";
   };
-
-  patches =
-    [ (fetchpatch {
-        url = "https://github.com/linux-test-project/lcov/commit/ebfeb3e179e450c69c3532f98cd5ea1fbf6ccba7.patch";
-        sha256 = "0dalkqbjb6a4vp1lcsxd39dpn5fzdf7ihsjbiviq285s15nxdj1j";
-      })
-      (fetchpatch {
-        url = "https://github.com/linux-test-project/lcov/commit/75fbae1cfc5027f818a0bb865bf6f96fab3202da.patch";
-        sha256 = "0v1hn0511dxqbf50ppwasc6vmg0m6rns7ydbdy2rdbn0j7gxw30x";
-      })
-    ];
 
   buildInputs = [ perl makeWrapper ];
 
@@ -28,6 +20,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/lcov --set PERL5LIB ${perlPackages.makeFullPerlPath [ perlPackages.PerlIOgzip perlPackages.JSON ]}
+    wrapProgram $out/bin/genpng --set PERL5LIB ${perlPackages.makeFullPerlPath [ perlPackages.GD ]}
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update lcov from 1.14 to 1.15. This removes some applied patches and adds support for gcc 9.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - Created project with 
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).\

Tested by making a small project and generating coverage:

```cpp
// main.cpp
#include <iostream>

int main(int argc, char* argv[]) {
  if (argc == 1)
    std::cout << "hello, world!\n";
  else
    std::cout << "goodbye, world\n";

  return 0;
}
```

```sh
# lcov.sh
#!/usr/bin/env bash

lcov --no-external --capture --initial --directory . --output-file /tmp/test_base.info
./build/test abc
lcov --no-external --capture --directory . --output-file /tmp/test_test.info

lcov --add-tracefile /tmp/test_base.info --add-tracefile /tmp/test_test.info --output-file /tmp/test_total.info
rm -rf /tmp/test-lcov/
mkdir /tmp/test-lcov/

genhtml --prefix . --ignore-errors source /tmp/test_total.info --legend --title "commit SHA1" --output-directory=/tmp/test-lcov
```

```cmake
# CMakeLists.txt
cmake_minimum_required(VERSION 3.17)
project(TestProject)

add_executable(test main.cpp)
target_compile_options(test PRIVATE -fprofile-arcs -ftest-coverage)
target_link_libraries(test -fprofile-arcs)

```
