### PR TITLE
expo-cli: init + implement overrideNodeAttrs

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -59,6 +59,12 @@ let
       buildInputs = [ pkgs.phantomjs2 ];
     };
 
+    expo-cli = super."expo-cli".overrideNodeAttrs (attrs: {
+      __acceptOverrideNodeAttrsCanBeDroppedAnytime = true;
+      # The traveling-fastlane-darwin optional dependency aborts build on Linux.
+      dependencies = builtins.filter (d: d.packageName != "@expo/traveling-fastlane-${if stdenv.isLinux then "darwin" else "linux"}") attrs.dependencies;
+    });
+
     git-ssb = super.git-ssb.override {
       buildInputs = [ self.node-gyp-build ];
       meta.broken = since "10";

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -71,6 +71,7 @@
 , "escape-string-regexp"
 , "eslint"
 , "eslint_d"
+, "expo-cli"
 , {"fast-cli": "1.x"}
 , "fkill-cli"
 , "forever"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -22,13 +22,13 @@ let
         sha512 = "t4WmWoGV9gyzypwG3y3JlcK2t8fKLtvzBA7xEoFTj9SMPvOuLsf13uh4ikK0RRaaa9RPPWLgFUdOyIRaQvCpwQ==";
       };
     };
-    "@angular-devkit/architect-0.1001.3" = {
+    "@angular-devkit/architect-0.1001.4" = {
       name = "_at_angular-devkit_slash_architect";
       packageName = "@angular-devkit/architect";
-      version = "0.1001.3";
+      version = "0.1001.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1001.3.tgz";
-        sha512 = "WS5IAN6I73jKapiHKYz3U05Kka4eVRmwCk++GWM2uGChluiZsI87eK8vxMS3KWDIqTnAOuMpDt3XWxlASv1nlQ==";
+        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1001.4.tgz";
+        sha512 = "0U/w+61vWxnEe9Ln/hNOH6O27FVcU+s/sbJAuPREbP875R4bQzK2PX0eYRlISzkDtQyw16GzlsikLWOoJ3vjTA==";
       };
     };
     "@angular-devkit/core-10.0.7" = {
@@ -40,13 +40,13 @@ let
         sha512 = "pXaZgsQ8LHpRx4QGAUYDE8GwBQLAtoqPh6oUCwRJwBExm5rl13OGPTBWewHiq0ysV/SnFXvOjxwAaHQvC1AgZw==";
       };
     };
-    "@angular-devkit/core-10.1.3" = {
+    "@angular-devkit/core-10.1.4" = {
       name = "_at_angular-devkit_slash_core";
       packageName = "@angular-devkit/core";
-      version = "10.1.3";
+      version = "10.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-10.1.3.tgz";
-        sha512 = "Ub31/eqFtSuQy3V+B74Jt0jAUw8fs8sbd0ZL2UHYUJyrwm20iIRam+mOD3Sj8HFrDGLR8m56KsxJ12KvC1oxtQ==";
+        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-10.1.4.tgz";
+        sha512 = "B1cwVcfChBvmEacydE2uqZ1UC2ez1G+KY0GyVnCQKpAb/DdfDgtaYjTx9JLvGQjE/BlVklEj8YCKDjVV0WPE5g==";
       };
     };
     "@angular-devkit/core-9.1.12" = {
@@ -67,13 +67,13 @@ let
         sha512 = "eyyYPgpjtr3h7WbnNbkDubJ/p+8TgKU6abWd+NmBfTvyeHrpVFUYZabNRcdXwUDSVzfTQKdmLynIkESj/KROrg==";
       };
     };
-    "@angular-devkit/schematics-10.1.3" = {
+    "@angular-devkit/schematics-10.1.4" = {
       name = "_at_angular-devkit_slash_schematics";
       packageName = "@angular-devkit/schematics";
-      version = "10.1.3";
+      version = "10.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-10.1.3.tgz";
-        sha512 = "5+E2bBBsphuz1KfloC5yA+hXSEbxMokkp5UEp+X9VC7zUGTXV8sxuvcbBo+JVutaoNHezJGu2JUx/LqNrKd58w==";
+        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-10.1.4.tgz";
+        sha512 = "NIueJQYZ8OY3Yr3TGfxcGgP9ZGGsbtM7sa7sf9hSqxEAXdiGQdDJk5nChhtGtoGxUImterwqR8OiGmLcK5lg5g==";
       };
     };
     "@angular-devkit/schematics-9.1.12" = {
@@ -310,6 +310,15 @@ let
         sha512 = "vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==";
       };
     };
+    "@babel/code-frame-7.8.3" = {
+      name = "_at_babel_slash_code-frame";
+      packageName = "@babel/code-frame";
+      version = "7.8.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz";
+        sha512 = "a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==";
+      };
+    };
     "@babel/compat-data-7.11.0" = {
       name = "_at_babel_slash_compat-data";
       packageName = "@babel/compat-data";
@@ -326,6 +335,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz";
         sha512 = "Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==";
+      };
+    };
+    "@babel/core-7.9.0" = {
+      name = "_at_babel_slash_core";
+      packageName = "@babel/core";
+      version = "7.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz";
+        sha512 = "kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==";
       };
     };
     "@babel/generator-7.11.6" = {
@@ -625,6 +643,15 @@ let
         sha512 = "up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==";
       };
     };
+    "@babel/plugin-proposal-export-default-from-7.10.4" = {
+      name = "_at_babel_slash_plugin-proposal-export-default-from";
+      packageName = "@babel/plugin-proposal-export-default-from";
+      version = "7.10.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.10.4.tgz";
+        sha512 = "G1l00VvDZ7Yk2yRlC5D8Ybvu3gmeHS3rCHoUYdjrqGYUtdeOBoRypnvDZ5KQqxyaiiGHWnVDeSEzA5F9ozItig==";
+      };
+    };
     "@babel/plugin-proposal-export-namespace-from-7.10.4" = {
       name = "_at_babel_slash_plugin-proposal-export-namespace-from";
       packageName = "@babel/plugin-proposal-export-namespace-from";
@@ -749,6 +776,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz";
         sha512 = "5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==";
+      };
+    };
+    "@babel/plugin-syntax-export-default-from-7.10.4" = {
+      name = "_at_babel_slash_plugin-syntax-export-default-from";
+      packageName = "@babel/plugin-syntax-export-default-from";
+      version = "7.10.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.10.4.tgz";
+        sha512 = "79V6r6Pgudz0RnuMGp5xidu6Z+bPFugh8/Q9eDHonmLp4wKFAZDwygJwYgCzuDu8lFA/sYyT+mc5y2wkd7bTXA==";
       };
     };
     "@babel/plugin-syntax-export-namespace-from-7.8.3" = {
@@ -1057,6 +1093,15 @@ let
         sha512 = "YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==";
       };
     };
+    "@babel/plugin-transform-object-assign-7.10.4" = {
+      name = "_at_babel_slash_plugin-transform-object-assign";
+      packageName = "@babel/plugin-transform-object-assign";
+      version = "7.10.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.10.4.tgz";
+        sha512 = "6zccDhYEICfMeQqIjuY5G09/yhKzG30DKHJeYBQUHIsJH7c2jXSGvgwRalufLAXAq432OSlsEfAOLlzEsQzxVw==";
+      };
+    };
     "@babel/plugin-transform-object-super-7.10.4" = {
       name = "_at_babel_slash_plugin-transform-object-super";
       packageName = "@babel/plugin-transform-object-super";
@@ -1084,6 +1129,15 @@ let
         sha512 = "ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==";
       };
     };
+    "@babel/plugin-transform-react-display-name-7.10.4" = {
+      name = "_at_babel_slash_plugin-transform-react-display-name";
+      packageName = "@babel/plugin-transform-react-display-name";
+      version = "7.10.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.4.tgz";
+        sha512 = "Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==";
+      };
+    };
     "@babel/plugin-transform-react-jsx-7.10.4" = {
       name = "_at_babel_slash_plugin-transform-react-jsx";
       packageName = "@babel/plugin-transform-react-jsx";
@@ -1091,6 +1145,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz";
         sha512 = "L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==";
+      };
+    };
+    "@babel/plugin-transform-react-jsx-source-7.10.5" = {
+      name = "_at_babel_slash_plugin-transform-react-jsx-source";
+      packageName = "@babel/plugin-transform-react-jsx-source";
+      version = "7.10.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.10.5.tgz";
+        sha512 = "wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==";
       };
     };
     "@babel/plugin-transform-regenerator-7.10.4" = {
@@ -1264,6 +1327,15 @@ let
         sha512 = "TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==";
       };
     };
+    "@babel/runtime-7.9.0" = {
+      name = "_at_babel_slash_runtime";
+      packageName = "@babel/runtime";
+      version = "7.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.0.tgz";
+        sha512 = "cTIudHnzuWLS56ik4DnRnqqNf8MkdUzV4iFFI1h7Jo9xvrpQROYaAnaSd2mHLQAzzZAPfATynX5ord6YlNYNMA==";
+      };
+    };
     "@babel/template-7.10.4" = {
       name = "_at_babel_slash_template";
       packageName = "@babel/template";
@@ -1300,13 +1372,13 @@ let
         sha512 = "bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==";
       };
     };
-    "@bugsnag/browser-7.3.5" = {
+    "@bugsnag/browser-7.4.0" = {
       name = "_at_bugsnag_slash_browser";
       packageName = "@bugsnag/browser";
-      version = "7.3.5";
+      version = "7.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.3.5.tgz";
-        sha512 = "Zs54UH7rXJTQbcuKDr6a4Qn2SDHr7cq7XLd5EHuLCJ6OMBktBlM8vZSf1sOiCBE2EE2g/kC2rk6VJktsRIaUEA==";
+        url = "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.4.0.tgz";
+        sha512 = "WmBJLCFvM2dvj0ZUCCx2QO9xxKJ1V7qZC4zE3kzxBdEgG1UKmKe2MSOJv8Igr933t6gY7Wzd5e7j6EpRuyvIyg==";
       };
     };
     "@bugsnag/core-7.3.5" = {
@@ -1327,13 +1399,13 @@ let
         sha512 = "LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg==";
       };
     };
-    "@bugsnag/js-7.3.5" = {
+    "@bugsnag/js-7.4.0" = {
       name = "_at_bugsnag_slash_js";
       packageName = "@bugsnag/js";
-      version = "7.3.5";
+      version = "7.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@bugsnag/js/-/js-7.3.5.tgz";
-        sha512 = "5KCeFEM7ntww2UbxbgW94TEwLHKzVLepDd8TNZeae2rdInt+fTc4o9oS0QxgubdLZHdLo9LNt8GTghl6F/9NwQ==";
+        url = "https://registry.npmjs.org/@bugsnag/js/-/js-7.4.0.tgz";
+        sha512 = "v+LA3d1DJf5Oxpy93K+/2TBGHNQoVldNaiN0du/9sUTuc8thkx9tgtaj/BiUWINIEX6y3j7y28cRKUhfffdsIQ==";
       };
     };
     "@bugsnag/node-7.3.5" = {
@@ -1471,6 +1543,33 @@ let
         sha512 = "+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==";
       };
     };
+    "@devicefarmer/adbkit-2.11.3" = {
+      name = "_at_devicefarmer_slash_adbkit";
+      packageName = "@devicefarmer/adbkit";
+      version = "2.11.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@devicefarmer/adbkit/-/adbkit-2.11.3.tgz";
+        sha512 = "rsgWREAvSRQjdP9/3GoAV6Tq+o97haywgbTfCgt5yUqiDpaaq3hlH9FTo9XsdG8x+Jd0VQ9nTC2IXsDu8JGRSA==";
+      };
+    };
+    "@devicefarmer/adbkit-logcat-1.1.0" = {
+      name = "_at_devicefarmer_slash_adbkit-logcat";
+      packageName = "@devicefarmer/adbkit-logcat";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@devicefarmer/adbkit-logcat/-/adbkit-logcat-1.1.0.tgz";
+        sha512 = "K90P5gUXM/w+yzLvJIRQ+tJooNU6ipUPPQkljtPJ0laR66TGtpt4Gqsjm0n9dPHK1W5KGgU1R5wnCd6RTSlPNA==";
+      };
+    };
+    "@devicefarmer/adbkit-monkey-1.0.1" = {
+      name = "_at_devicefarmer_slash_adbkit-monkey";
+      packageName = "@devicefarmer/adbkit-monkey";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@devicefarmer/adbkit-monkey/-/adbkit-monkey-1.0.1.tgz";
+        sha512 = "HilPrVrCosYWqSyjfpDtaaN1kJwdlBpS+IAflP3z+e7nsEgk3JGJf1Vg0NgHJooTf5HDfXSyZqMVg+5jvXCK0g==";
+      };
+    };
     "@emmetio/extract-abbreviation-0.1.6" = {
       name = "_at_emmetio_slash_extract-abbreviation";
       packageName = "@emmetio/extract-abbreviation";
@@ -1588,6 +1687,321 @@ let
         sha512 = "W98NvvOe/Med3o66xTO03pd7a2omZebH79PV64gSE+ceDdU8uxQhFTa7ISiD1kseyqyOrMyW5/MNdsGEU02i3Q==";
       };
     };
+    "@expo/babel-preset-cli-0.2.18" = {
+      name = "_at_expo_slash_babel-preset-cli";
+      packageName = "@expo/babel-preset-cli";
+      version = "0.2.18";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/babel-preset-cli/-/babel-preset-cli-0.2.18.tgz";
+        sha512 = "y2IZFynVtRxMQ4uxXYUnrnXZa+pvSH1R1aSUAfC6RsUb2UNOxC6zRehdLGSOyF4s9Wy+j3/CPm6fC0T5UJYoQg==";
+      };
+    };
+    "@expo/bunyan-3.0.2" = {
+      name = "_at_expo_slash_bunyan";
+      packageName = "@expo/bunyan";
+      version = "3.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/bunyan/-/bunyan-3.0.2.tgz";
+        sha512 = "fQRc4+RG+rEw1IdjFx/5t2AvOlJT8ktv2dfObD3aW838ohZxCx1QvFUY/Gdx5JA1JY/KrHRGuEqQLH9ayiexyg==";
+      };
+    };
+    "@expo/config-3.3.9" = {
+      name = "_at_expo_slash_config";
+      packageName = "@expo/config";
+      version = "3.3.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/config/-/config-3.3.9.tgz";
+        sha512 = "AeM7CNUsvG0tN4vKwdcqQjl0x8nyYS2Xcao+9HWQf30+V2Kt2qAy5RjZUElR/H7sWapluudRjiyLQ7/ThgXTuQ==";
+      };
+    };
+    "@expo/config-types-40.0.0-beta.1" = {
+      name = "_at_expo_slash_config-types";
+      packageName = "@expo/config-types";
+      version = "40.0.0-beta.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/config-types/-/config-types-40.0.0-beta.1.tgz";
+        sha512 = "hTp+6ZIKK57O8qhVoO+GBCkx0UCdOhwcWxaXfjpsELIR8LfXDGz8OmCxTzGvb7nnadcrGCccHBX5dO1NmPBbmg==";
+      };
+    };
+    "@expo/configure-splash-screen-0.2.1" = {
+      name = "_at_expo_slash_configure-splash-screen";
+      packageName = "@expo/configure-splash-screen";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/configure-splash-screen/-/configure-splash-screen-0.2.1.tgz";
+        sha512 = "6n7ji1WKDCdLe2Mto4u4W72kTLhAbhXhC7ydVk1HxDYCcbewNLfgiwhchPtPGyUMnSDizVWph5aDoiKxqVHqNQ==";
+      };
+    };
+    "@expo/dev-server-0.1.34" = {
+      name = "_at_expo_slash_dev-server";
+      packageName = "@expo/dev-server";
+      version = "0.1.34";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/dev-server/-/dev-server-0.1.34.tgz";
+        sha512 = "tBvir/IZ2Zhvz6WZpDEhEHGg3p6fwG4eB+b46e1wtJX6YkZ5mReaWlJOnorfOmm80RgugLZEqHAy+YJOYPP+1Q==";
+      };
+    };
+    "@expo/dev-tools-0.13.52" = {
+      name = "_at_expo_slash_dev-tools";
+      packageName = "@expo/dev-tools";
+      version = "0.13.52";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/dev-tools/-/dev-tools-0.13.52.tgz";
+        sha512 = "SicYMGGsHIEpvC6yy8lj+wvtOiDrAwQQwW1rKz+9cJi27Z1CmTM7Ke5I82J4h/dmRE17kiEpb7gnBBubLxlqUQ==";
+      };
+    };
+    "@expo/eas-build-job-0.1.0" = {
+      name = "_at_expo_slash_eas-build-job";
+      packageName = "@expo/eas-build-job";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/eas-build-job/-/eas-build-job-0.1.0.tgz";
+        sha512 = "yoJhhpc1GSP7l65pIIY9kc/IlvJKgQJ9SyUHl0QCu96DCHqCp51OEKaTBy0J+wxQ/7UKbQ8YvHbtYxwKrUR7nw==";
+      };
+    };
+    "@expo/image-utils-0.3.7" = {
+      name = "_at_expo_slash_image-utils";
+      packageName = "@expo/image-utils";
+      version = "0.3.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.3.7.tgz";
+        sha512 = "Vo1p5uv1JlRacgVIiVa+83oRoHfC7grSU8cypAtgvOYpbmdCWR8+3F4v+vaabHe6ktvIKRE78jh6vHMGwv2aOA==";
+      };
+    };
+    "@expo/json-file-8.2.24" = {
+      name = "_at_expo_slash_json-file";
+      packageName = "@expo/json-file";
+      version = "8.2.24";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.24.tgz";
+        sha512 = "i34lfcMVt5Wv2Cf5apZUj3o9JlFt8WOPSZjrECryunBQ9/BsQQYY5NHgGjhhZnnRE+6JFf0CPQTjXdoQ1w3w0w==";
+      };
+    };
+    "@expo/metro-config-0.1.34" = {
+      name = "_at_expo_slash_metro-config";
+      packageName = "@expo/metro-config";
+      version = "0.1.34";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.1.34.tgz";
+        sha512 = "jmUb0UVM53hu17PqSmayCFEuq3R6X2/inlXiUO9v+9jlcmusaJqe9Nh/M6SYgmy+hDlx6cwgR9MNlpvWfIE1kw==";
+      };
+    };
+    "@expo/ngrok-2.4.3" = {
+      name = "_at_expo_slash_ngrok";
+      packageName = "@expo/ngrok";
+      version = "2.4.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok/-/ngrok-2.4.3.tgz";
+        sha512 = "JOct+0BMTOTkTb2RreQc6uzhwCjX8Z/EYRo3EcbHMr5/3Zk+0YuujaM4Z84GeZcWz2sBMhnJj0LeJnhEkmd95Q==";
+      };
+    };
+    "@expo/ngrok-bin-2.2.8-beta.3" = {
+      name = "_at_expo_slash_ngrok-bin";
+      packageName = "@expo/ngrok-bin";
+      version = "2.2.8-beta.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok-bin/-/ngrok-bin-2.2.8-beta.3.tgz";
+        sha512 = "VzL67ybSvSYhFJxwBm19VMEHAcgg6bDhE9p8HKDOXL2tdHIzqYtqAYxOyhv2mS263WYqdomtoAChSOb449of+g==";
+      };
+    };
+    "@expo/ngrok-bin-darwin-ia32-2.2.8" = {
+      name = "_at_expo_slash_ngrok-bin-darwin-ia32";
+      packageName = "@expo/ngrok-bin-darwin-ia32";
+      version = "2.2.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok-bin-darwin-ia32/-/ngrok-bin-darwin-ia32-2.2.8.tgz";
+        sha512 = "Mgept4WvXobcNQbxV0f8Nqrukl4HsAM4ExfFOC5BJ1PinlZisb1lQYp+PGu/3DuOYAinAspbL/3m77JkhT5Oow==";
+      };
+    };
+    "@expo/ngrok-bin-darwin-x64-2.2.8" = {
+      name = "_at_expo_slash_ngrok-bin-darwin-x64";
+      packageName = "@expo/ngrok-bin-darwin-x64";
+      version = "2.2.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok-bin-darwin-x64/-/ngrok-bin-darwin-x64-2.2.8.tgz";
+        sha512 = "hEVxBAKTT9G+jCy+2NOjgFrPrrzmdxljLhz3cQIb4izjooQXGCbTFvnEntB0odgsf6Dpa2jWNNt18H6t2nneOQ==";
+      };
+    };
+    "@expo/ngrok-bin-freebsd-ia32-2.2.8" = {
+      name = "_at_expo_slash_ngrok-bin-freebsd-ia32";
+      packageName = "@expo/ngrok-bin-freebsd-ia32";
+      version = "2.2.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok-bin-freebsd-ia32/-/ngrok-bin-freebsd-ia32-2.2.8.tgz";
+        sha512 = "yGdq06wUxreCPxXnhqlL3GzvLtArJ6eDOQinv4SiDK+ftQPY4TloEMQr/rwohvtx63O+bT9jAtgJW44jlfIQ2Q==";
+      };
+    };
+    "@expo/ngrok-bin-freebsd-x64-2.2.8" = {
+      name = "_at_expo_slash_ngrok-bin-freebsd-x64";
+      packageName = "@expo/ngrok-bin-freebsd-x64";
+      version = "2.2.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok-bin-freebsd-x64/-/ngrok-bin-freebsd-x64-2.2.8.tgz";
+        sha512 = "1uSZRastddaUIrK/2B5MANhV7LDKJ8/4cSQxn+E2+U296VKkU6n1ZfZ207a7hA1ctQeBcvwkRx9biFxDa99How==";
+      };
+    };
+    "@expo/ngrok-bin-linux-arm-2.2.8" = {
+      name = "_at_expo_slash_ngrok-bin-linux-arm";
+      packageName = "@expo/ngrok-bin-linux-arm";
+      version = "2.2.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok-bin-linux-arm/-/ngrok-bin-linux-arm-2.2.8.tgz";
+        sha512 = "qruRsoEuFvaVsSSlhNtHR8uWgF7aA6jdRtCuVKO4pMW32lTZfGS+U/y6hB0YBxXv4xhEn8o1x/15oLU7cNUxEA==";
+      };
+    };
+    "@expo/ngrok-bin-linux-arm64-2.2.8" = {
+      name = "_at_expo_slash_ngrok-bin-linux-arm64";
+      packageName = "@expo/ngrok-bin-linux-arm64";
+      version = "2.2.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok-bin-linux-arm64/-/ngrok-bin-linux-arm64-2.2.8.tgz";
+        sha512 = "9iXr88LlzBCp7+NwfPDsSg2sIy5GfWFXrhU8+vGLnFvZ5MO6ZoRmXbw2VRPFm7ekMa0Losddny4aiLDJkr9hXw==";
+      };
+    };
+    "@expo/ngrok-bin-linux-ia32-2.2.8" = {
+      name = "_at_expo_slash_ngrok-bin-linux-ia32";
+      packageName = "@expo/ngrok-bin-linux-ia32";
+      version = "2.2.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok-bin-linux-ia32/-/ngrok-bin-linux-ia32-2.2.8.tgz";
+        sha512 = "Cm3BH4nv55A6KF+XjrK8oLe1Ktn4WrUabd6TcErQRM6/2454A+vh1r6CEKWOVWy4bg7ceTbjgHhCdj9WMv8WTg==";
+      };
+    };
+    "@expo/ngrok-bin-linux-x64-2.2.8" = {
+      name = "_at_expo_slash_ngrok-bin-linux-x64";
+      packageName = "@expo/ngrok-bin-linux-x64";
+      version = "2.2.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok-bin-linux-x64/-/ngrok-bin-linux-x64-2.2.8.tgz";
+        sha512 = "jNhnnfMR/yAgUV1LnAheq/WWB/Tkdgm5sxZhN0fjN00CeiYTVyNuCsii2tdjXJCGrxdpb6RzvOxjLGstIT0mUQ==";
+      };
+    };
+    "@expo/ngrok-bin-sunos-x64-2.2.8" = {
+      name = "_at_expo_slash_ngrok-bin-sunos-x64";
+      packageName = "@expo/ngrok-bin-sunos-x64";
+      version = "2.2.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok-bin-sunos-x64/-/ngrok-bin-sunos-x64-2.2.8.tgz";
+        sha512 = "Ogcn/6jNN2PMMaZ1PJu7JBiZz92Yowa119cclI2E2RKyIqQaOYol2g72oHzm8SQ49KfzEJMGDmQA4Xh29cKmrQ==";
+      };
+    };
+    "@expo/ngrok-bin-win32-ia32-2.2.8-beta.1" = {
+      name = "_at_expo_slash_ngrok-bin-win32-ia32";
+      packageName = "@expo/ngrok-bin-win32-ia32";
+      version = "2.2.8-beta.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok-bin-win32-ia32/-/ngrok-bin-win32-ia32-2.2.8-beta.1.tgz";
+        sha512 = "Pva9ZNjUieD2/RVav7LYGAXZ1O6MVXlvOnJmHSmjP4rhreek7/Ez7b5HsCEN3YLjZIcPHH8SV8Duix1NO2zB5A==";
+      };
+    };
+    "@expo/ngrok-bin-win32-x64-2.2.8-beta.1" = {
+      name = "_at_expo_slash_ngrok-bin-win32-x64";
+      packageName = "@expo/ngrok-bin-win32-x64";
+      version = "2.2.8-beta.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/ngrok-bin-win32-x64/-/ngrok-bin-win32-x64-2.2.8-beta.1.tgz";
+        sha512 = "tVn0jkRC7cbDL502FU7iVI4jbaEKcbTER7pYo2xdUZgM02n4u0AS+FFuzUN+irDiRYZQIFdmDIhxDGl+SHkzbA==";
+      };
+    };
+    "@expo/osascript-2.0.24" = {
+      name = "_at_expo_slash_osascript";
+      packageName = "@expo/osascript";
+      version = "2.0.24";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/osascript/-/osascript-2.0.24.tgz";
+        sha512 = "oqar3vmvxkVx1OBG7hTjTbCaVVUX2o+aEMLxZWLUiubL0ly1qxgQKEt5p3g3pzkxTft+b1oMf8bT7jMi6iOv+Q==";
+      };
+    };
+    "@expo/package-manager-0.0.33" = {
+      name = "_at_expo_slash_package-manager";
+      packageName = "@expo/package-manager";
+      version = "0.0.33";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/package-manager/-/package-manager-0.0.33.tgz";
+        sha512 = "zhY1a67/Fsg9FjKj2AajNDywpcbERACA7kw9eR3uJEzQwdwYiqX9cmMO8K69UKJUY2kpba4edJY9/PEMJFfPiQ==";
+      };
+    };
+    "@expo/plist-0.0.10" = {
+      name = "_at_expo_slash_plist";
+      packageName = "@expo/plist";
+      version = "0.0.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/plist/-/plist-0.0.10.tgz";
+        sha512 = "uKbi7ANPCNJqeAvxLa+ZcS/Qf0fTPOySMqw5T2L4TrycSAdiAxV1VUZ69IzIbUsWb7GdriUVR2i38M/xa6+BvA==";
+      };
+    };
+    "@expo/results-1.0.0" = {
+      name = "_at_expo_slash_results";
+      packageName = "@expo/results";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/results/-/results-1.0.0.tgz";
+        sha512 = "qECzzXX5oJot3m2Gu9pfRDz50USdBieQVwYAzeAtQRUTD3PVeTK1tlRUoDcrK8PSruDLuVYdKkLebX4w/o55VA==";
+      };
+    };
+    "@expo/schemer-1.3.21" = {
+      name = "_at_expo_slash_schemer";
+      packageName = "@expo/schemer";
+      version = "1.3.21";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/schemer/-/schemer-1.3.21.tgz";
+        sha512 = "8rk1P9bFmTLZa4yr/6rNMP5QOJy/BDu+73c/vKpAr/JXgJwxRnlaLYe/rZkwQFMl5aPyaa4JsattVBU4IdxAiA==";
+      };
+    };
+    "@expo/simple-spinner-1.0.2" = {
+      name = "_at_expo_slash_simple-spinner";
+      packageName = "@expo/simple-spinner";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/simple-spinner/-/simple-spinner-1.0.2.tgz";
+        sha1 = "b31447de60e5102837a4edf702839fcc8f7f31f3";
+      };
+    };
+    "@expo/spawn-async-1.5.0" = {
+      name = "_at_expo_slash_spawn-async";
+      packageName = "@expo/spawn-async";
+      version = "1.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.5.0.tgz";
+        sha512 = "LB7jWkqrHo+5fJHNrLAFdimuSXQ2MQ4lA7SQW5bf/HbsXuV2VrT/jN/M8f/KoWt0uJMGN4k/j7Opx4AvOOxSew==";
+      };
+    };
+    "@expo/traveling-fastlane-darwin-1.15.1" = {
+      name = "_at_expo_slash_traveling-fastlane-darwin";
+      packageName = "@expo/traveling-fastlane-darwin";
+      version = "1.15.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.15.1.tgz";
+        sha512 = "7sjG83+o9BT4MVPNq2UVqy1Oyg3n47FpEIDxc0M9CQvbC1WgYsAKloOJ85g5GRXZAjqzPOPUZF+lBhGbOwmQvg==";
+      };
+    };
+    "@expo/traveling-fastlane-linux-1.15.1" = {
+      name = "_at_expo_slash_traveling-fastlane-linux";
+      packageName = "@expo/traveling-fastlane-linux";
+      version = "1.15.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.15.1.tgz";
+        sha512 = "YaFAYYOOxImYNx9s6X3tY6fC1y6rka0KXstrs2zrS+vHyyBD8IOhNtIUvybHScM3jUL+qukgKElAb+7gzlF6Eg==";
+      };
+    };
+    "@expo/webpack-config-0.12.38" = {
+      name = "_at_expo_slash_webpack-config";
+      packageName = "@expo/webpack-config";
+      version = "0.12.38";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/webpack-config/-/webpack-config-0.12.38.tgz";
+        sha512 = "WUuzeubJPcHW/Qs7Ano8k2ZDqoe8h13IosWywGlyVPqMMgzT75qK2SStqhsPV3nUnnZ5owWhFSYQey8nNrFKFg==";
+      };
+    };
+    "@expo/xdl-58.0.13" = {
+      name = "_at_expo_slash_xdl";
+      packageName = "@expo/xdl";
+      version = "58.0.13";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@expo/xdl/-/xdl-58.0.13.tgz";
+        sha512 = "ToCCTrj8NeupX0e9tpBtbZsESHlIEKbpRNU5IUy/2IKD9No5DXGxHG/FDsbEz595gawDzTv4isdzbOOulCoUcQ==";
+      };
+    };
     "@fluentui/date-time-utilities-7.9.0" = {
       name = "_at_fluentui_slash_date-time-utilities";
       packageName = "@fluentui/date-time-utilities";
@@ -1615,22 +2029,22 @@ let
         sha512 = "t3yIbbPKJubb22vQ/FIWwS9vFAzaPYzFxKWPHVWLtxs/P+5yL+LD3B16DRtYreWAdl9CZvEbos58ChLZ0KHwSQ==";
       };
     };
-    "@fluentui/react-7.143.0" = {
+    "@fluentui/react-7.145.0" = {
       name = "_at_fluentui_slash_react";
       packageName = "@fluentui/react";
-      version = "7.143.0";
+      version = "7.145.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@fluentui/react/-/react-7.143.0.tgz";
-        sha512 = "5HMFiQ+VszMPlu8zn6hT0pQSqsaPa0Q2T7uQQ0/cXakEMac4Y2iHngspzFIyn1OWS7yT2RU2Y5gSdzJFxobOXA==";
+        url = "https://registry.npmjs.org/@fluentui/react/-/react-7.145.0.tgz";
+        sha512 = "RNYTWwRQhIFKoMHmDkMLF48KcH91brHV/WXCEboIxsmtHm4HyYVG4Zpjib6UG2XOS1zk9sBefHao/zTx3pdG8Q==";
       };
     };
-    "@fluentui/react-focus-7.16.9" = {
+    "@fluentui/react-focus-7.16.10" = {
       name = "_at_fluentui_slash_react-focus";
       packageName = "@fluentui/react-focus";
-      version = "7.16.9";
+      version = "7.16.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.16.9.tgz";
-        sha512 = "XT+W3+hSQi2PzEi3biNqAcUvBj4sZqLp/ERXD+jIF1Ux+CxdlLtf8WvS36u7/0B6jjvoMaIcpdsqGjqgU+8NGA==";
+        url = "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.16.10.tgz";
+        sha512 = "+4aP36KjD2RrijRBr6aPYNiBm9M9+33DOHpAdcE0K93TToLIlQ/WIwZGDNbM/6dPFD6vgUj+ya5rvfy6sbibjw==";
       };
     };
     "@fluentui/react-window-provider-0.3.3" = {
@@ -1642,31 +2056,31 @@ let
         sha512 = "MVPf2hqOQ17LAZsuvGcr3oOHksAskUm+fCYdXFhbVoAgsCDVTIuH6i8XgHFd6YjBtzjZmI4+k/3NTQfDqBX8EQ==";
       };
     };
-    "@fluentui/theme-1.2.1" = {
+    "@fluentui/theme-1.3.0" = {
       name = "_at_fluentui_slash_theme";
       packageName = "@fluentui/theme";
-      version = "1.2.1";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@fluentui/theme/-/theme-1.2.1.tgz";
-        sha512 = "18biLzW/E48HKgN1e5APP0znhMgUVpXq7h4B0LJjI7TTQZPuPTR96FA/LcHDwcTL3YR1rEMmnGgCFitWtsbA2A==";
+        url = "https://registry.npmjs.org/@fluentui/theme/-/theme-1.3.0.tgz";
+        sha512 = "OVN3yPdJShOGhTakalI5DC9+8myOhLPKzY/ZlICnNoKhh7cbPVrvdCnv2fLcDyZYMQg0CnB3oAaghBHiIW3jmA==";
       };
     };
-    "@graphql-cli/common-4.0.0" = {
+    "@graphql-cli/common-4.1.0" = {
       name = "_at_graphql-cli_slash_common";
       packageName = "@graphql-cli/common";
-      version = "4.0.0";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@graphql-cli/common/-/common-4.0.0.tgz";
-        sha512 = "1webMsg9tmVQX9YA1wYeCVxNdWNrCrgVmpD0JyzroSsSEjt5hrHZR2x2vzuHK5CthH9I99GdvRtuMixmd1S9bQ==";
+        url = "https://registry.npmjs.org/@graphql-cli/common/-/common-4.1.0.tgz";
+        sha512 = "OiP2kHf6eBdENnpmWCLBeWFk6t5+gPLhLBiAVSYreOG/8xhjNSvnvPrOPUqwtD1N21g2X9xKTm4LLc4GIVbufw==";
       };
     };
-    "@graphql-cli/init-4.0.0" = {
+    "@graphql-cli/init-4.1.0" = {
       name = "_at_graphql-cli_slash_init";
       packageName = "@graphql-cli/init";
-      version = "4.0.0";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@graphql-cli/init/-/init-4.0.0.tgz";
-        sha512 = "oJZb4PScX25ZGObpw9n7/bJBE7R0oF6hJ4ABe+WvMqSCI3kxaReMTgJJNIrxpmbXscxWM8U1ndLefP5IjPcU7Q==";
+        url = "https://registry.npmjs.org/@graphql-cli/init/-/init-4.1.0.tgz";
+        sha512 = "RNhQk0jMz6fZB4Ilu37PZj6YUQgSEZJrppXlaHpw/xYyDelcjYKZg/z9eMvYo6rxQPR2mGXjoj6by+zew1WgOw==";
       };
     };
     "@graphql-tools/delegate-6.2.4" = {
@@ -1732,13 +2146,13 @@ let
         sha512 = "rh+14lSY1q8IPbEv2J9x8UBFJ5NrDX9W5asXEUlPp+7vraLp/Tiox4GXdgyA92JhwpYco3nTf5Bo2JDMt1KnAQ==";
       };
     };
-    "@graphql-tools/url-loader-6.2.4" = {
+    "@graphql-tools/url-loader-6.3.0" = {
       name = "_at_graphql-tools_slash_url-loader";
       packageName = "@graphql-tools/url-loader";
-      version = "6.2.4";
+      version = "6.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-6.2.4.tgz";
-        sha512 = "T14Ng02H2gzK5IRVNLKHM1ncQ2d+ou6+twGRNat3ETSP6arkS3jg0LPtJfu+8r6Op/4C3EXM6QbdaSNIkvatAQ==";
+        url = "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-6.3.0.tgz";
+        sha512 = "lX6A22Rhbqj8FHmkCVSDflolOGy7UtCJGtGbfRuv8/VqD94JfJLnGVFxC1jODURFdj+yrs/97Wm/ntRcpy7nDA==";
       };
     };
     "@graphql-tools/utils-6.2.4" = {
@@ -1786,6 +2200,15 @@ let
         sha512 = "QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==";
       };
     };
+    "@hapi/address-4.1.0" = {
+      name = "_at_hapi_slash_address";
+      packageName = "@hapi/address";
+      version = "4.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz";
+        sha512 = "SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==";
+      };
+    };
     "@hapi/bourne-1.3.2" = {
       name = "_at_hapi_slash_bourne";
       packageName = "@hapi/bourne";
@@ -1793,6 +2216,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz";
         sha512 = "1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==";
+      };
+    };
+    "@hapi/formula-2.0.0" = {
+      name = "_at_hapi_slash_formula";
+      packageName = "@hapi/formula";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz";
+        sha512 = "V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==";
       };
     };
     "@hapi/hoek-8.5.1" = {
@@ -1804,6 +2236,15 @@ let
         sha512 = "yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==";
       };
     };
+    "@hapi/hoek-9.1.0" = {
+      name = "_at_hapi_slash_hoek";
+      packageName = "@hapi/hoek";
+      version = "9.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz";
+        sha512 = "i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==";
+      };
+    };
     "@hapi/joi-15.1.1" = {
       name = "_at_hapi_slash_joi";
       packageName = "@hapi/joi";
@@ -1813,6 +2254,24 @@ let
         sha512 = "entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==";
       };
     };
+    "@hapi/joi-17.1.1" = {
+      name = "_at_hapi_slash_joi";
+      packageName = "@hapi/joi";
+      version = "17.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz";
+        sha512 = "p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==";
+      };
+    };
+    "@hapi/pinpoint-2.0.0" = {
+      name = "_at_hapi_slash_pinpoint";
+      packageName = "@hapi/pinpoint";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz";
+        sha512 = "vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==";
+      };
+    };
     "@hapi/topo-3.1.6" = {
       name = "_at_hapi_slash_topo";
       packageName = "@hapi/topo";
@@ -1820,6 +2279,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz";
         sha512 = "tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==";
+      };
+    };
+    "@hapi/topo-5.0.0" = {
+      name = "_at_hapi_slash_topo";
+      packageName = "@hapi/topo";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz";
+        sha512 = "tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==";
       };
     };
     "@iarna/toml-2.2.5" = {
@@ -1975,6 +2443,285 @@ let
         sha512 = "OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==";
       };
     };
+    "@jimp/bmp-0.9.8" = {
+      name = "_at_jimp_slash_bmp";
+      packageName = "@jimp/bmp";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.9.8.tgz";
+        sha512 = "CZYQPEC3iUBMuaGWrtIG+GKNl93q/PkdudrCKJR/B96dfNngsmoosEm3LuFgJHEcJIfvnJkNqKw74l+zEiqCbg==";
+      };
+    };
+    "@jimp/core-0.9.8" = {
+      name = "_at_jimp_slash_core";
+      packageName = "@jimp/core";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/core/-/core-0.9.8.tgz";
+        sha512 = "N4GCjcXb0QwR5GBABDK2xQ3cKyaF7LlCYeJEG9mV7G/ynBoRqJe4JA6YKU9Ww9imGkci/4A594nQo8tUIqdcBw==";
+      };
+    };
+    "@jimp/custom-0.9.8" = {
+      name = "_at_jimp_slash_custom";
+      packageName = "@jimp/custom";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/custom/-/custom-0.9.8.tgz";
+        sha512 = "1UpJjI7fhX02BWLJ/KEqPwkHH60eNkCNeD6hEd+IZdTwLXfZCfFiM5BVlpgiZYZJSsVoRiAL4ne2Q5mCiKPKyw==";
+      };
+    };
+    "@jimp/gif-0.9.8" = {
+      name = "_at_jimp_slash_gif";
+      packageName = "@jimp/gif";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/gif/-/gif-0.9.8.tgz";
+        sha512 = "LEbfpcO1sBJIQCJHchZjNlyNxzPjZQQ4X32klpQHZJG58n9FvL7Uuh1rpkrJRbqv3cU3P0ENNtTrsBDxsYwcfA==";
+      };
+    };
+    "@jimp/jpeg-0.9.8" = {
+      name = "_at_jimp_slash_jpeg";
+      packageName = "@jimp/jpeg";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.9.8.tgz";
+        sha512 = "5u29SUzbZ32ZMmOaz3gO0hXatwSCnsvEAXRCKZoPPgbsPoyFAiZKVxjfLzjkeQF6awkvJ8hZni5chM15SNMg+g==";
+      };
+    };
+    "@jimp/plugin-blit-0.9.8" = {
+      name = "_at_jimp_slash_plugin-blit";
+      packageName = "@jimp/plugin-blit";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.9.8.tgz";
+        sha512 = "6xTDomxJybhBcby1IUVaPydZFhxf+V0DRgfDlVK81kR9kSCoshJpzWqDuWrMqjNEPspPE7jRQwHMs0FdU7mVwQ==";
+      };
+    };
+    "@jimp/plugin-blur-0.9.8" = {
+      name = "_at_jimp_slash_plugin-blur";
+      packageName = "@jimp/plugin-blur";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.9.8.tgz";
+        sha512 = "dqbxuNFBRbmt35iIRacdgma7nlXklmPThsKcGWNTDmqb/hniK5IC+0xSPzBV4qMI2fLGP39LWHqqDZ0xDz14dA==";
+      };
+    };
+    "@jimp/plugin-circle-0.9.8" = {
+      name = "_at_jimp_slash_plugin-circle";
+      packageName = "@jimp/plugin-circle";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.9.8.tgz";
+        sha512 = "+UStXUPCzPqzTixLC8eVqcFcEa6TS+BEM/6/hyM11TDb9sbiMGeUtgpwZP/euR5H5gfpAQDA1Ppzqhh5fuMDlw==";
+      };
+    };
+    "@jimp/plugin-color-0.9.8" = {
+      name = "_at_jimp_slash_plugin-color";
+      packageName = "@jimp/plugin-color";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.9.8.tgz";
+        sha512 = "SDHxOQsJHpt75hk6+sSlCPc2B3UJlXosFW+iLZ11xX1Qr0IdDtbfYlIoPmjKQFIDUNzqLSue/z7sKQ1OMZr/QA==";
+      };
+    };
+    "@jimp/plugin-contain-0.9.8" = {
+      name = "_at_jimp_slash_plugin-contain";
+      packageName = "@jimp/plugin-contain";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.9.8.tgz";
+        sha512 = "oK52CPt7efozuLYCML7qOmpFeDt3zpU8qq8UZlnjsDs15reU6L8EiUbwYpJvzoEnEOh1ZqamB8F/gymViEO5og==";
+      };
+    };
+    "@jimp/plugin-cover-0.9.8" = {
+      name = "_at_jimp_slash_plugin-cover";
+      packageName = "@jimp/plugin-cover";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.9.8.tgz";
+        sha512 = "nnamtHzMrNd5j5HRSPd1VzpZ8v9YYtUJPtvCdHOOiIjqG72jxJ2kTBlsS3oG5XS64h/2MJwpl/fmmMs1Tj1CmQ==";
+      };
+    };
+    "@jimp/plugin-crop-0.9.8" = {
+      name = "_at_jimp_slash_plugin-crop";
+      packageName = "@jimp/plugin-crop";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.9.8.tgz";
+        sha512 = "Nv/6AIp4aJmbSIH2uiIqm+kSoShKM8eaX2fyrUTj811kio0hwD3f/vIxrWebvAqwDZjAFIAmMufFoFCVg6caoQ==";
+      };
+    };
+    "@jimp/plugin-displace-0.9.8" = {
+      name = "_at_jimp_slash_plugin-displace";
+      packageName = "@jimp/plugin-displace";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.9.8.tgz";
+        sha512 = "0OgPjkOVa2xdbqI8P6gBKX/UK36RbaYVrFyXL8Jy9oNF69+LYWyTskuCu9YbGxzlCVjY/JFqQOvrKDbxgMYAKA==";
+      };
+    };
+    "@jimp/plugin-dither-0.9.8" = {
+      name = "_at_jimp_slash_plugin-dither";
+      packageName = "@jimp/plugin-dither";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.9.8.tgz";
+        sha512 = "jGM/4ByniZJnmV2fv8hKwyyydXZe/YzvgBcnB8XxzCq8kVR3Imcn+qnd2PEPZzIPKOTH4Cig/zo9Vk9Bs+m5FQ==";
+      };
+    };
+    "@jimp/plugin-fisheye-0.9.8" = {
+      name = "_at_jimp_slash_plugin-fisheye";
+      packageName = "@jimp/plugin-fisheye";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.9.8.tgz";
+        sha512 = "VnsalrD05f4pxG1msjnkwIFi5QveOqRm4y7VkoZKNX+iqs4TvRnH5+HpBnfdMzX/RXBi+Lf/kpTtuZgbOu/QWw==";
+      };
+    };
+    "@jimp/plugin-flip-0.9.8" = {
+      name = "_at_jimp_slash_plugin-flip";
+      packageName = "@jimp/plugin-flip";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.9.8.tgz";
+        sha512 = "XbiZ4OfHD6woc0f6Sk7XxB6a7IyMjTRQ4pNU7APjaNxsl3L6qZC8qfCQphWVe3DHx7f3y7jEiPMvNnqRDP1xgA==";
+      };
+    };
+    "@jimp/plugin-gaussian-0.9.8" = {
+      name = "_at_jimp_slash_plugin-gaussian";
+      packageName = "@jimp/plugin-gaussian";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.9.8.tgz";
+        sha512 = "ZBl5RA6+4XAD+mtqLfiG7u+qd8W5yqq3RBNca8eFqUSVo1v+eB2tzeLel0CWfVC/z6cw93Awm/nVnm6/CL2Oew==";
+      };
+    };
+    "@jimp/plugin-invert-0.9.8" = {
+      name = "_at_jimp_slash_plugin-invert";
+      packageName = "@jimp/plugin-invert";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.9.8.tgz";
+        sha512 = "ESploqCoF6qUv5IWhVLaO5fEcrYZEsAWPFflh6ROiD2mmFKQxfeK+vHnk3IDLHtUwWTkAZQNbk89BVq7xvaNpQ==";
+      };
+    };
+    "@jimp/plugin-mask-0.9.8" = {
+      name = "_at_jimp_slash_plugin-mask";
+      packageName = "@jimp/plugin-mask";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.9.8.tgz";
+        sha512 = "zSvEisTV4iGsBReitEdnQuGJq9/1xB5mPATadYZmIlp8r5HpD72HQb0WdEtb51/pu9Odt8KAxUf0ASg/PRVUiQ==";
+      };
+    };
+    "@jimp/plugin-normalize-0.9.8" = {
+      name = "_at_jimp_slash_plugin-normalize";
+      packageName = "@jimp/plugin-normalize";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.9.8.tgz";
+        sha512 = "dPFBfwTa67K1tRw1leCidQT25R3ozrTUUOpO4jcGFHqXvBTWaR8sML1qxdfOBWs164mE5YpfdTvu6MM/junvCg==";
+      };
+    };
+    "@jimp/plugin-print-0.9.8" = {
+      name = "_at_jimp_slash_plugin-print";
+      packageName = "@jimp/plugin-print";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.9.8.tgz";
+        sha512 = "nLLPv1/faehRsOjecXXUb6kzhRcZzImO55XuFZ0c90ZyoiHm4UFREwO5sKxHGvpLXS6RnkhvSav4+IWD2qGbEQ==";
+      };
+    };
+    "@jimp/plugin-resize-0.9.8" = {
+      name = "_at_jimp_slash_plugin-resize";
+      packageName = "@jimp/plugin-resize";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.9.8.tgz";
+        sha512 = "L80NZ+HKsiKFyeDc6AfneC4+5XACrdL2vnyAVfAAsb3pmamgT/jDInWvvGhyI0Y76vx2w6XikplzEznW/QQvWg==";
+      };
+    };
+    "@jimp/plugin-rotate-0.9.8" = {
+      name = "_at_jimp_slash_plugin-rotate";
+      packageName = "@jimp/plugin-rotate";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.9.8.tgz";
+        sha512 = "bpqzQheISYnBXKyU1lIj46uR7mRs0UhgEREWK70HnvFJSlRshdcoNMIrKamyrJeFdJrkYPSfR/a6D0d5zsWf1Q==";
+      };
+    };
+    "@jimp/plugin-scale-0.9.8" = {
+      name = "_at_jimp_slash_plugin-scale";
+      packageName = "@jimp/plugin-scale";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.9.8.tgz";
+        sha512 = "QU3ZS4Lre8nN66U9dKCOC4FNfaOh/QJFYUmQPKpPS924oYbtnm4OlmsdfpK2hVMSVVyVOis8M+xpA1rDBnIp7w==";
+      };
+    };
+    "@jimp/plugin-shadow-0.9.8" = {
+      name = "_at_jimp_slash_plugin-shadow";
+      packageName = "@jimp/plugin-shadow";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.9.8.tgz";
+        sha512 = "t/pE+QS3r1ZUxGIQNmwWDI3c5+/hLU+gxXD+C3EEC47/qk3gTBHpj/xDdGQBoObdT/HRjR048vC2BgBfzjj2hg==";
+      };
+    };
+    "@jimp/plugin-threshold-0.9.8" = {
+      name = "_at_jimp_slash_plugin-threshold";
+      packageName = "@jimp/plugin-threshold";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.9.8.tgz";
+        sha512 = "WWmC3lnIwOTPvkKu55w4DUY8Ehlzf3nU98bY0QtIzkqxkAOZU5m+lvgC/JxO5FyGiA57j9FLMIf0LsWkjARj7g==";
+      };
+    };
+    "@jimp/plugins-0.9.8" = {
+      name = "_at_jimp_slash_plugins";
+      packageName = "@jimp/plugins";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.9.8.tgz";
+        sha512 = "tD+cxS9SuEZaQ1hhAkNKw9TkUAqfoBAhdWPBrEZDr/GvGPrvJR4pYmmpSYhc5IZmMbXfQayHTTGqjj8D18bToA==";
+      };
+    };
+    "@jimp/png-0.9.8" = {
+      name = "_at_jimp_slash_png";
+      packageName = "@jimp/png";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/png/-/png-0.9.8.tgz";
+        sha512 = "9CqR8d40zQCDhbnXHqcwkAMnvlV0vk9xSyE6LHjkYHS7x18Unsz5txQdsaEkEcXxCrOQSoWyITfLezlrWXRJAA==";
+      };
+    };
+    "@jimp/tiff-0.9.8" = {
+      name = "_at_jimp_slash_tiff";
+      packageName = "@jimp/tiff";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.9.8.tgz";
+        sha512 = "eMxcpJivJqMByn2dZxUHLeh6qvVs5J/52kBF3TFa3C922OJ97D9l1C1h0WKUCBqFMWzMYapQQ4vwnLgpJ5tkow==";
+      };
+    };
+    "@jimp/types-0.9.8" = {
+      name = "_at_jimp_slash_types";
+      packageName = "@jimp/types";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/types/-/types-0.9.8.tgz";
+        sha512 = "H5y/uqt0lqJ/ZN8pWqFG+pv8jPAppMKkTMByuC8YBIjWSsornwv44hjiWl93sbYhduLZY8ubz/CbX9jH2X6EwA==";
+      };
+    };
+    "@jimp/utils-0.9.8" = {
+      name = "_at_jimp_slash_utils";
+      packageName = "@jimp/utils";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@jimp/utils/-/utils-0.9.8.tgz";
+        sha512 = "UK0Fu0eevQlpRXq5ff4o/71HJlpX9wJMddJjMYg9vUqCCl8ZnumRAljfShHFhGyO+Vc9IzN6dd8Y5JZZTp1KOw==";
+      };
+    };
     "@josh-brown/vector-3.4.0" = {
       name = "_at_josh-brown_slash_vector";
       packageName = "@josh-brown/vector";
@@ -1982,15 +2729,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@josh-brown/vector/-/vector-3.4.0.tgz";
         sha512 = "E2FcWwiAMXwr4MUv+SkxmtKsgwgaEaCNK7IlyCfQ1Rz1QzeaV36SooA8/GNkLh0WnlIda59WmDDSL7S1S73lUg==";
-      };
-    };
-    "@kwsites/exec-p-0.4.0" = {
-      name = "_at_kwsites_slash_exec-p";
-      packageName = "@kwsites/exec-p";
-      version = "0.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@kwsites/exec-p/-/exec-p-0.4.0.tgz";
-        sha512 = "44DWNv5gDR9EwrCTVQ4ZC99yPqVS0VCWrYIBl45qNR8XQy+4lbl0IQG8kBDf6NHwj4Ib4c2z1Fq1IUJOCbkZcw==";
       };
     };
     "@kwsites/file-exists-1.1.1" = {
@@ -2542,13 +3280,13 @@ let
         sha512 = "RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==";
       };
     };
-    "@microsoft/load-themed-styles-1.10.101" = {
+    "@microsoft/load-themed-styles-1.10.108" = {
       name = "_at_microsoft_slash_load-themed-styles";
       packageName = "@microsoft/load-themed-styles";
-      version = "1.10.101";
+      version = "1.10.108";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.101.tgz";
-        sha512 = "TERGxGXEmQ6lIQqgR/1MMMJCMXwk5sTN/Nt4PJnw28ZKa7T6mGAzxRDp6QLCxJCqST1YquTJoayv6ELhQSPFlQ==";
+        url = "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.108.tgz";
+        sha512 = "ETEADhZJwttKGPABitB7lDD/22ULL8AG1SKrn9uhYxjF1w1IaS6YS/yCPlDVALeh20zF8LJEEZ2MGb7DgVVYUw==";
       };
     };
     "@mrmlnc/readdir-enhanced-2.2.1" = {
@@ -2587,13 +3325,13 @@ let
         sha512 = "b+MGNyP9/LXkapreJzNUzcvuzZslj/RGgdVVJ16P2wSlYatfLycPObImqVJSmNAdyeShvNeM/pl3sVZsObFueg==";
       };
     };
-    "@netlify/build-4.5.2" = {
+    "@netlify/build-4.8.3" = {
       name = "_at_netlify_slash_build";
       packageName = "@netlify/build";
-      version = "4.5.2";
+      version = "4.8.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/build/-/build-4.5.2.tgz";
-        sha512 = "xKhRtqsWSwIFWTZTQCrNu2PBlJ57Lp7VVVwGk6IcJbbIiv5FyfwkjzW7hBcD/b16TFfy2HozLNVJ5KbD/EQ9VA==";
+        url = "https://registry.npmjs.org/@netlify/build/-/build-4.8.3.tgz";
+        sha512 = "5n/AF34wJIvDLjceB6mlviooF6l3ptgw/h5Y1MTpvmpW5bLv9DiVkPC0pyjlBC5EThmd4gwNmjwybATs24b61w==";
       };
     };
     "@netlify/cache-utils-1.0.3" = {
@@ -2614,13 +3352,13 @@ let
         sha512 = "Z7yzbx5qCX2I5RLlNyo0MMQ6GKJc8o5Nej9yspCavjqgYlUS7VJfbeE67WNxC26FXwDUqq00zJ0MrCS0Un1YOw==";
       };
     };
-    "@netlify/config-2.2.1" = {
+    "@netlify/config-2.3.2" = {
       name = "_at_netlify_slash_config";
       packageName = "@netlify/config";
-      version = "2.2.1";
+      version = "2.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/config/-/config-2.2.1.tgz";
-        sha512 = "kYWXTFs05wQeVCYahPPmf8Pf6guoZJC6hEpxoL2uuA/u9xsIA6hQoO1FjBRARiiFeht1hNzpV1L7UOaC0cMF1Q==";
+        url = "https://registry.npmjs.org/@netlify/config/-/config-2.3.2.tgz";
+        sha512 = "Y0ClAW+EgtbyMae/D1v2JZSIfWMniA7oRgrjkYULYPWdZnLwVsp+3akJ15b6fp79p0vPBZAzHdwJzo8QMuzD8g==";
       };
     };
     "@netlify/functions-utils-1.2.9" = {
@@ -2641,22 +3379,22 @@ let
         sha512 = "rqaCUHlJFYwvcCL8l+wp/YMhGkuXo2ceEf9fpHCN8GFOlU3kSu0NLRlKFohIFk1pdrymG1D3M7Pt+s62EKLjwA==";
       };
     };
-    "@netlify/open-api-0.16.1" = {
+    "@netlify/open-api-0.18.0" = {
       name = "_at_netlify_slash_open-api";
       packageName = "@netlify/open-api";
-      version = "0.16.1";
+      version = "0.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.16.1.tgz";
-        sha512 = "lIU1on/4xF+Gz2bpnLry/3E6Ns3ICGgCP62n3LmL3eSKo94wCqiO/9nyq5NILawYVSRUZeIvEVi5DgnVyLWyww==";
+        url = "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.18.0.tgz";
+        sha512 = "2pgw9SngxtxNcg0g4OJzhHRWmXE/sGpjBn0KfeyKH6kyrY4a3XcKwIZLKuxVLuHxgkpdoBbsFlJBTlsj61g8Dw==";
       };
     };
-    "@netlify/plugin-edge-handlers-1.6.0" = {
+    "@netlify/plugin-edge-handlers-1.8.0" = {
       name = "_at_netlify_slash_plugin-edge-handlers";
       packageName = "@netlify/plugin-edge-handlers";
-      version = "1.6.0";
+      version = "1.8.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/plugin-edge-handlers/-/plugin-edge-handlers-1.6.0.tgz";
-        sha512 = "pm+XQ926g6J1Tl1dzFkxnUiQmWI/j1PIELuGGk4qPiHdM8kXWCEeRkNPRpDtwDmXJUVSVVmJQVFpX5VXJ3ijWg==";
+        url = "https://registry.npmjs.org/@netlify/plugin-edge-handlers/-/plugin-edge-handlers-1.8.0.tgz";
+        sha512 = "eOU3P8GgRSMKXZWBxMeLZYX3UUwq/w5Hn6BiUyroJ57UkxHFzMsIcsIryt/KW5vKEiLo/pvYZyU0S4WVcbHbWA==";
       };
     };
     "@netlify/run-utils-1.0.1" = {
@@ -2803,6 +3541,15 @@ let
         sha512 = "Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==";
       };
     };
+    "@npmcli/node-gyp-1.0.1" = {
+      name = "_at_npmcli_slash_node-gyp";
+      packageName = "@npmcli/node-gyp";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.1.tgz";
+        sha512 = "pBqoKPWmuk9iaEcXlLBVRIA6I1kG9JiICU+sG0NuD6NAR461F+02elHJS4WkQxHW2W5rnsfvP/ClKwmsZ9RaaA==";
+      };
+    };
     "@npmcli/promise-spawn-1.2.0" = {
       name = "_at_npmcli_slash_promise-spawn";
       packageName = "@npmcli/promise-spawn";
@@ -2812,13 +3559,13 @@ let
         sha512 = "nFtqjVETliApiRdjbYwKwhlSHx2ZMagyj5b9YbNt0BWeeOVxJd47ZVE2u16vxDHyTOZvk+YLV7INwfAE9a2uow==";
       };
     };
-    "@npmcli/run-script-1.6.0" = {
+    "@npmcli/run-script-1.7.2" = {
       name = "_at_npmcli_slash_run-script";
       packageName = "@npmcli/run-script";
-      version = "1.6.0";
+      version = "1.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.6.0.tgz";
-        sha512 = "2BHum2b8MBXkiWGR6c1JOQ+2eAnE8kygwtT8F5bRam7ErDJqxxcHZSksIU6/qxqnA3WuiuyvxNdnptIJr8YQ8Q==";
+        url = "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.7.2.tgz";
+        sha512 = "EZO9uXrZrfzdIJsNi/WwrP2jt1P0lbFSxOq15ljgYn1/rr4UyQXUKBZRURioFVbUb7Z1BJDEKswnWrtRybZPzw==";
       };
     };
     "@oclif/color-0.1.2" = {
@@ -2947,13 +3694,13 @@ let
         sha512 = "jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==";
       };
     };
-    "@octokit/endpoint-6.0.6" = {
+    "@octokit/endpoint-6.0.8" = {
       name = "_at_octokit_slash_endpoint";
       packageName = "@octokit/endpoint";
-      version = "6.0.6";
+      version = "6.0.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.6.tgz";
-        sha512 = "7Cc8olaCoL/mtquB7j/HTbPM+sY6Ebr4k2X2y4JoXpVKQ7r5xB4iGQE0IoO58wIPsUk4AzoT65AMEpymSbWTgQ==";
+        url = "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.8.tgz";
+        sha512 = "MuRrgv+bM4Q+e9uEvxAB/Kf+Sj0O2JAOBA131uo1o6lgdq1iS8ejKwtqHgdfY91V3rN9R/hdGKFiQYMzVzVBEQ==";
       };
     };
     "@octokit/plugin-enterprise-rest-6.0.1" = {
@@ -3091,13 +3838,22 @@ let
         sha512 = "USSjRAAQYsZFlv43FUPdD+jEGML5/8oLF0rUzPQTtK4q9kvaXr49F5ZplyLz5lox78cLZ0TxN2bIDQ1xhOkulQ==";
       };
     };
-    "@prettier/plugin-pug-1.7.0" = {
+    "@pmmmwh/react-refresh-webpack-plugin-0.3.3" = {
+      name = "_at_pmmmwh_slash_react-refresh-webpack-plugin";
+      packageName = "@pmmmwh/react-refresh-webpack-plugin";
+      version = "0.3.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.3.3.tgz";
+        sha512 = "uc6FmPEegAZawSHjUMFQwU7EjaDn7zy1iD/KD/wBROL9F4378OES8MKMYHoRAKT61Fk7LxVKZSDR5VespMQiqw==";
+      };
+    };
+    "@prettier/plugin-pug-1.8.1" = {
       name = "_at_prettier_slash_plugin-pug";
       packageName = "@prettier/plugin-pug";
-      version = "1.7.0";
+      version = "1.8.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@prettier/plugin-pug/-/plugin-pug-1.7.0.tgz";
-        sha512 = "iv1m8Qrsd1R+m1t4k2i81m2cDiuteB2z3IMyO792WgctyjSeWselFfwKdwBDO4l+4U+HU9b1MvckDL+aAaD9cg==";
+        url = "https://registry.npmjs.org/@prettier/plugin-pug/-/plugin-pug-1.8.1.tgz";
+        sha512 = "lXyGIECz6XsggTNfjqaQxeOB4PqoAL2pmhJ7koV7ibKA3JPlQeEkk91PcnUsSNFyFtLzfFBwaHepoBmJb5FNWQ==";
       };
     };
     "@primer/octicons-11.0.0" = {
@@ -3199,6 +3955,51 @@ let
         sha1 = "a777360b5b39a1a2e5106f8e858f2fd2d060c570";
       };
     };
+    "@react-native-community/cli-debugger-ui-4.9.0" = {
+      name = "_at_react-native-community_slash_cli-debugger-ui";
+      packageName = "@react-native-community/cli-debugger-ui";
+      version = "4.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.9.0.tgz";
+        sha512 = "fBFGamHm4VUrDqkBGnsrwQL8OC6Om7K6EBQb4xj0nWekpXt1HSa3ScylYHTTWwYcpRf9htGMRGiv4dQDY/odAw==";
+      };
+    };
+    "@react-native-community/cli-platform-android-4.13.0" = {
+      name = "_at_react-native-community_slash_cli-platform-android";
+      packageName = "@react-native-community/cli-platform-android";
+      version = "4.13.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-4.13.0.tgz";
+        sha512 = "3i8sX8GklEytUZwPnojuoFbCjIRzMugCdzDIdZ9UNmi/OhD4/8mLGO0dgXfT4sMWjZwu3qjy45sFfk2zOAgHbA==";
+      };
+    };
+    "@react-native-community/cli-platform-ios-4.13.0" = {
+      name = "_at_react-native-community_slash_cli-platform-ios";
+      packageName = "@react-native-community/cli-platform-ios";
+      version = "4.13.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-4.13.0.tgz";
+        sha512 = "6THlTu8zp62efkzimfGr3VIuQJ2514o+vScZERJCV1xgEi8XtV7mb/ZKt9o6Y9WGxKKkc0E0b/aVAtgy+L27CA==";
+      };
+    };
+    "@react-native-community/cli-server-api-4.9.0" = {
+      name = "_at_react-native-community_slash_cli-server-api";
+      packageName = "@react-native-community/cli-server-api";
+      version = "4.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-4.9.0.tgz";
+        sha512 = "lKBIXJjFLyu4+6Vhhj/QzD41aQGkVi8xWLqTYCgi26d61kjLuuZs0Xer02DPJK3+YADKExVdWrJzVHfJ7zYlTA==";
+      };
+    };
+    "@react-native-community/cli-tools-4.13.0" = {
+      name = "_at_react-native-community_slash_cli-tools";
+      packageName = "@react-native-community/cli-tools";
+      version = "4.13.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-4.13.0.tgz";
+        sha512 = "s4f489h5+EJksn4CfheLgv5PGOM0CDmK1UEBLw2t/ncWs3cW2VI7vXzndcd/WJHTv3GntJhXDcJMuL+Z2IAOgg==";
+      };
+    };
     "@rollup/plugin-babel-5.2.1" = {
       name = "_at_rollup_slash_plugin-babel";
       packageName = "@rollup/plugin-babel";
@@ -3224,6 +4025,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.1.0.tgz";
         sha512 = "xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==";
+      };
+    };
+    "@rollup/plugin-inject-4.0.2" = {
+      name = "_at_rollup_slash_plugin-inject";
+      packageName = "@rollup/plugin-inject";
+      version = "4.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.2.tgz";
+        sha512 = "TSLMA8waJ7Dmgmoc8JfPnwUwVZgLjjIAM6MqeIFqPO2ODK36JqE0Cf2F54UTgCUuW8da93Mvoj75a6KAVWgylw==";
       };
     };
     "@rollup/plugin-json-4.1.0" = {
@@ -3280,13 +4090,13 @@ let
         sha512 = "c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==";
       };
     };
-    "@schematics/angular-10.1.3" = {
+    "@schematics/angular-10.1.4" = {
       name = "_at_schematics_slash_angular";
       packageName = "@schematics/angular";
-      version = "10.1.3";
+      version = "10.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/angular/-/angular-10.1.3.tgz";
-        sha512 = "X3tNnpfF/jkl1KcyCC8PaOYogQlTZ9s7Yuz0va0DAVOptIqorpf8e6+lY0PPLKshaK9TSiFUcQ8SYYnjAVKcdA==";
+        url = "https://registry.npmjs.org/@schematics/angular/-/angular-10.1.4.tgz";
+        sha512 = "MWxyrKEiXqNCZ0Uh3zM/iWouQTOWalGy2gFn6Fx6UBgm7nPYgeXoX7wYiCAKIryoehaOFfs/Pw3zfCGgp/gUOw==";
       };
     };
     "@schematics/schematics-0.1000.7" = {
@@ -3298,13 +4108,22 @@ let
         sha512 = "mucBf5EkhME9O0TvxPeiUTEuudRvEOSjhF/YFHEp/9NZB1JH9lXtBQ60IN6xtCLEbxJmAzhZSns9QPPrHaZRrw==";
       };
     };
-    "@schematics/update-0.1001.3" = {
+    "@schematics/update-0.1001.4" = {
       name = "_at_schematics_slash_update";
       packageName = "@schematics/update";
-      version = "0.1001.3";
+      version = "0.1001.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/update/-/update-0.1001.3.tgz";
-        sha512 = "ah4YHjEXACmpX0i3cAn5OguH5S430HD+zbxlMu4AC93A8W52ll97vqvUVF8NLZ6RKcOV/8tXmzgzvJDe07i8yQ==";
+        url = "https://registry.npmjs.org/@schematics/update/-/update-0.1001.4.tgz";
+        sha512 = "E2xIPWQoHgv+CRAYWV0LSNoa8JmOcgyxlrQvn44f6A80ySNDyrfcRP8VNzpk1UnGkBcjwEVhYeLuY+F0aguC3g==";
+      };
+    };
+    "@segment/loosely-validate-event-2.0.0" = {
+      name = "_at_segment_slash_loosely-validate-event";
+      packageName = "@segment/loosely-validate-event";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz";
+        sha512 = "ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==";
       };
     };
     "@serverless/cli-1.5.2" = {
@@ -3550,22 +4369,13 @@ let
         sha512 = "nI7ELxukf7pT4/VraL4iabtNNMz8mUo7EXlqCFld8O5z6mIMLX9llps24iPpaIZOwArkY3FWA+4t+ixyvtTSIA==";
       };
     };
-    "@snyk/java-call-graph-builder-1.13.2" = {
+    "@snyk/java-call-graph-builder-1.16.0" = {
       name = "_at_snyk_slash_java-call-graph-builder";
       packageName = "@snyk/java-call-graph-builder";
-      version = "1.13.2";
+      version = "1.16.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.13.2.tgz";
-        sha512 = "YN3a93ttscqFQRUeThrxa7i2SJkFPfYn0VpFqdPB6mIJz2fRVLxUkMtlCbG0aSEUvWiLnGVHN0IYxwWEzhq11w==";
-      };
-    };
-    "@snyk/java-call-graph-builder-1.14.0" = {
-      name = "_at_snyk_slash_java-call-graph-builder";
-      packageName = "@snyk/java-call-graph-builder";
-      version = "1.14.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.14.0.tgz";
-        sha512 = "EuqY22cxCoU+Ze+3KFLR/kFnL2UBOipAUX+39iNXUMTJal3LqN9RIvYGjpUjzecSMRhGyCLRnuizH/NxluhgvA==";
+        url = "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.16.0.tgz";
+        sha512 = "bHbBR7NKCxLPxlsSdJ2pn2gBSfguBr9SAdo/2re9bEvHO/0hTefQiS0h/EJ4OpMCJbPyUN1BW4eaFq00MzgMtA==";
       };
     };
     "@snyk/rpm-parser-2.0.0" = {
@@ -3692,6 +4502,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@starptech/webparser/-/webparser-0.10.0.tgz";
         sha512 = "vA/p1LTVfuK8dP+EhBglMS7ll3dZahBjnvjwUiJ8NNUCqH5pSAj3tcRtOG3k7k1Wx1hWHJpGgZVj0VNQIo99bA==";
+      };
+    };
+    "@stylelint/postcss-css-in-js-0.37.2" = {
+      name = "_at_stylelint_slash_postcss-css-in-js";
+      packageName = "@stylelint/postcss-css-in-js";
+      version = "0.37.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz";
+        sha512 = "nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==";
+      };
+    };
+    "@stylelint/postcss-markdown-0.36.1" = {
+      name = "_at_stylelint_slash_postcss-markdown";
+      packageName = "@stylelint/postcss-markdown";
+      version = "0.36.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.1.tgz";
+        sha512 = "iDxMBWk9nB2BPi1VFQ+Dc5+XpvODBHw2n3tYpaBZuEAFQlbtF9If0Qh5LTTwSi/XwdbJ2jt+0dis3i8omyggpw==";
       };
     };
     "@szmarczak/http-timer-1.1.2" = {
@@ -3991,13 +4819,13 @@ let
         sha512 = "d/aS/lPOnUSruPhgNtT8jW39fHRVTLQy9sodysP1kkG8EdAtdZu1vt8NJaYA8w/6Z9j8izkAsx1A/yJhcYR1CA==";
       };
     };
-    "@types/color-name-1.1.1" = {
-      name = "_at_types_slash_color-name";
-      packageName = "@types/color-name";
-      version = "1.1.1";
+    "@types/configstore-2.1.1" = {
+      name = "_at_types_slash_configstore";
+      packageName = "@types/configstore";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz";
-        sha512 = "rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==";
+        url = "https://registry.npmjs.org/@types/configstore/-/configstore-2.1.1.tgz";
+        sha1 = "cd1e8553633ad3185c3f2f239ecff5d2643e92b6";
       };
     };
     "@types/connect-3.4.33" = {
@@ -4043,6 +4871,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/cors/-/cors-2.8.7.tgz";
         sha512 = "sOdDRU3oRS7LBNTIqwDkPJyq0lpHYcbMTt0TrjzsXbk/e37hcLTH6eZX7CdbDeN0yJJvzw9hFBZkbtCSbk/jAQ==";
+      };
+    };
+    "@types/debug-0.0.30" = {
+      name = "_at_types_slash_debug";
+      packageName = "@types/debug";
+      version = "0.0.30";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz";
+        sha512 = "orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==";
       };
     };
     "@types/debug-4.1.5" = {
@@ -4117,6 +4954,15 @@ let
         sha512 = "jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==";
       };
     };
+    "@types/events-3.0.0" = {
+      name = "_at_types_slash_events";
+      packageName = "@types/events";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz";
+        sha512 = "EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==";
+      };
+    };
     "@types/express-4.17.7" = {
       name = "_at_types_slash_express";
       packageName = "@types/express";
@@ -4169,6 +5015,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz";
         sha512 = "FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==";
+      };
+    };
+    "@types/get-port-3.2.0" = {
+      name = "_at_types_slash_get-port";
+      packageName = "@types/get-port";
+      version = "3.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/get-port/-/get-port-3.2.0.tgz";
+        sha512 = "TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q==";
+      };
+    };
+    "@types/glob-5.0.36" = {
+      name = "_at_types_slash_glob";
+      packageName = "@types/glob";
+      version = "5.0.36";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/glob/-/glob-5.0.36.tgz";
+        sha512 = "KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==";
       };
     };
     "@types/glob-7.1.3" = {
@@ -4232,6 +5096,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/hosted-git-info/-/hosted-git-info-2.7.0.tgz";
         sha512 = "OW/D8GqCyQtH8F7xDdDxzPJTBgknZeZhlCakUcBCya2rYPRN53F+0YJVwSPyiyAhrknnjkl3P9qVk0oBI4S1qw==";
+      };
+    };
+    "@types/html-minifier-terser-5.1.1" = {
+      name = "_at_types_slash_html-minifier-terser";
+      packageName = "@types/html-minifier-terser";
+      version = "5.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz";
+        sha512 = "giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==";
       };
     };
     "@types/http-assert-1.5.1" = {
@@ -4306,13 +5179,13 @@ let
         sha512 = "P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==";
       };
     };
-    "@types/jquery-3.5.1" = {
+    "@types/jquery-3.5.2" = {
       name = "_at_types_slash_jquery";
       packageName = "@types/jquery";
-      version = "3.5.1";
+      version = "3.5.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.1.tgz";
-        sha512 = "Tyctjh56U7eX2b9udu3wG853ASYP0uagChJcQJXLUXEU6C/JiW5qt5dl8ao01VRj1i5pgXPAf8f1mq4+FDLRQg==";
+        url = "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.2.tgz";
+        sha512 = "+MFOdKF5Zr41t3y2wfzJvK1PrUK0KtPLAFwYownp/0nCoMIANDDu5aFSpWfb8S0ZajCSNeaBnMrBGxksXK5yeg==";
       };
     };
     "@types/js-yaml-3.12.5" = {
@@ -4513,13 +5386,13 @@ let
         sha512 = "1GJnq7RwuFPRicMHdT53vza5v39nep9OKIbozxNUpFXP04CydcdWrqpZQ+MlVdlLFCisWnnt09xughajjWpFsw==";
       };
     };
-    "@types/node-10.17.35" = {
+    "@types/node-10.17.37" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "10.17.35";
+      version = "10.17.37";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz";
-        sha512 = "gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==";
+        url = "https://registry.npmjs.org/@types/node/-/node-10.17.37.tgz";
+        sha512 = "4c38N7p9k9yqdcANh/WExTahkBgOTmggCyrTvVcbE8ByqO3g8evt/407v/I4X/gdfUkIyZBSQh/Rc3tvuwlVGw==";
       };
     };
     "@types/node-12.7.12" = {
@@ -4531,13 +5404,13 @@ let
         sha512 = "KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==";
       };
     };
-    "@types/node-13.13.21" = {
+    "@types/node-13.13.23" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "13.13.21";
+      version = "13.13.23";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-13.13.21.tgz";
-        sha512 = "tlFWakSzBITITJSxHV4hg4KvrhR/7h3xbJdSFbYJBVzKubrASbnnIFuSgolUh7qKGo/ZeJPKUfbZ0WS6Jp14DQ==";
+        url = "https://registry.npmjs.org/@types/node/-/node-13.13.23.tgz";
+        sha512 = "L31WmMJYKb15PDqFWutn8HNwrNK6CE6bkWgSB0dO1XpNoHrszVKV1Clcnfgd6c/oG54TVF8XQEvY2gQrW8K6Mw==";
       };
     };
     "@types/node-14.0.26" = {
@@ -4549,13 +5422,13 @@ let
         sha512 = "W+fpe5s91FBGE0pEa0lnqGLL4USgpLgs4nokw16SrBBco/gQxuua7KnArSEOd5iaMqbbSHV10vUDkJYJJqpXKA==";
       };
     };
-    "@types/node-14.11.2" = {
+    "@types/node-14.11.5" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "14.11.2";
+      version = "14.11.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz";
-        sha512 = "jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==";
+        url = "https://registry.npmjs.org/@types/node/-/node-14.11.5.tgz";
+        sha512 = "jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ==";
       };
     };
     "@types/node-6.14.12" = {
@@ -4574,6 +5447,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/node/-/node-8.10.64.tgz";
         sha512 = "/EwBIb+imu8Qi/A3NF9sJ9iuKo7yV+pryqjmeRqaU0C4wBAOhas5mdvoYeJ5PCKrh6thRSJHdoasFqh3BQGILA==";
+      };
+    };
+    "@types/node-9.6.59" = {
+      name = "_at_types_slash_node";
+      packageName = "@types/node";
+      version = "9.6.59";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/node/-/node-9.6.59.tgz";
+        sha512 = "TX/dHK9lFrXoMFtHdF3oyEw6EpfYfu+8AZ1zP6Oj3rOiQGbit2rgQlJzvBRx712b9ReaCfkSNPRXYzZDYI4YSw==";
       };
     };
     "@types/node-fetch-2.5.7" = {
@@ -4702,6 +5584,24 @@ let
         sha512 = "85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==";
       };
     };
+    "@types/retry-0.12.0" = {
+      name = "_at_types_slash_retry";
+      packageName = "@types/retry";
+      version = "0.12.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz";
+        sha512 = "wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==";
+      };
+    };
+    "@types/rimraf-2.0.4" = {
+      name = "_at_types_slash_rimraf";
+      packageName = "@types/rimraf";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.4.tgz";
+        sha512 = "8gBudvllD2A/c0CcEX/BivIDorHFt5UI5m46TsNj8DjWCCTTZT74kEe4g+QsY7P/B9WdO98d82zZgXO/RQzu2Q==";
+      };
+    };
     "@types/semver-5.5.0" = {
       name = "_at_types_slash_semver";
       packageName = "@types/semver";
@@ -4783,6 +5683,15 @@ let
         sha512 = "W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==";
       };
     };
+    "@types/text-table-0.2.1" = {
+      name = "_at_types_slash_text-table";
+      packageName = "@types/text-table";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/text-table/-/text-table-0.2.1.tgz";
+        sha512 = "dchbFCWfVgUSWEvhOkXGS7zjm+K7jCUvGrQkAHPk2Fmslfofp4HQTH2pqnQ3Pw5GPYv0zWa2AQjKtsfZThuemQ==";
+      };
+    };
     "@types/through-0.0.30" = {
       name = "_at_types_slash_through";
       packageName = "@types/through";
@@ -4790,6 +5699,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz";
         sha512 = "FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==";
+      };
+    };
+    "@types/tmp-0.0.33" = {
+      name = "_at_types_slash_tmp";
+      packageName = "@types/tmp";
+      version = "0.0.33";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz";
+        sha1 = "1073c4bc824754ae3d10cfab88ab0237ba964e4d";
       };
     };
     "@types/tough-cookie-4.0.0" = {
@@ -4864,13 +5782,22 @@ let
         sha512 = "2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==";
       };
     };
-    "@types/webpack-sources-1.4.2" = {
+    "@types/webpack-4.41.22" = {
+      name = "_at_types_slash_webpack";
+      packageName = "@types/webpack";
+      version = "4.41.22";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.22.tgz";
+        sha512 = "JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==";
+      };
+    };
+    "@types/webpack-sources-2.0.0" = {
       name = "_at_types_slash_webpack-sources";
       packageName = "@types/webpack-sources";
-      version = "1.4.2";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.2.tgz";
-        sha512 = "77T++JyKow4BQB/m9O96n9d/UUHWLQHlcqXb9Vsf4F1+wKNrrlWNFPDLKNT92RJnCSL6CieTc+NDXtCVZswdTw==";
+        url = "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.0.0.tgz";
+        sha512 = "a5kPx98CNFRKQ+wqawroFunvFqv7GHm/3KOI52NY9xWADgc8smu4R6prt4EU/M4QfVjvgBkMqU4fBhw3QfMVkg==";
       };
     };
     "@types/websocket-1.0.1" = {
@@ -5008,22 +5935,22 @@ let
         sha512 = "9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==";
       };
     };
-    "@uifabric/foundation-7.9.9" = {
+    "@uifabric/foundation-7.9.10" = {
       name = "_at_uifabric_slash_foundation";
       packageName = "@uifabric/foundation";
-      version = "7.9.9";
+      version = "7.9.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.9.tgz";
-        sha512 = "cpFsDrHIG3f952+WsBCLLPKT+06ywoMBTi0Z42KFBxAeQjFfJFZ4YnHRztXZMrFbwHsvokzV8GmOm+Nc2kectQ==";
+        url = "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.10.tgz";
+        sha512 = "DeKN+beoqn6HsMW+Ezici1umj7j8aaNykOhLjqg11XRevJh7ifKQOrpePXM+m13B2VAdm2nPyfO3d7eYFvu7Zw==";
       };
     };
-    "@uifabric/icons-7.5.8" = {
+    "@uifabric/icons-7.5.9" = {
       name = "_at_uifabric_slash_icons";
       packageName = "@uifabric/icons";
-      version = "7.5.8";
+      version = "7.5.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.8.tgz";
-        sha512 = "3YIp2nKHpuKeqPQnyOUPUvoKq18N81t1+2c/NVJXnlSOP4VyEy9PC2JXCmxoZZOdrGKwQ1Is99PfLY0XsIssEQ==";
+        url = "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.9.tgz";
+        sha512 = "kiFw2hm2++OwcVT8ZkHm/UIsyA+4CXBgttmtMaEXMB6/VSt6mfAc+3gs0ehnfXbrBTLUIM9omxXUrrtULSWLTw==";
       };
     };
     "@uifabric/merge-styles-7.19.1" = {
@@ -5035,13 +5962,13 @@ let
         sha512 = "yqUwmk62Kgu216QNPE9vOfS3h0kiSbTvoqM5QcZi+IzpqsBOlzZx3A9Er9UiDaqHRd5lsYF5pO/jeUULmBWF/A==";
       };
     };
-    "@uifabric/react-hooks-7.13.5" = {
+    "@uifabric/react-hooks-7.13.6" = {
       name = "_at_uifabric_slash_react-hooks";
       packageName = "@uifabric/react-hooks";
-      version = "7.13.5";
+      version = "7.13.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.5.tgz";
-        sha512 = "5Ucq3wH5bZud/TCKZE6IS+v1XpaxP65iiSk3ZxPi+RAi5Gt8NeKwmaMZTPWgLrRjkOTwy59jR4dJ6MzZVmSe7A==";
+        url = "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.6.tgz";
+        sha512 = "DvfphxrTsjo3oYioRZ0D8mXdpxWQhhIHeWk1cfdq0MVGqRyKM+cm++9pJpvItFvnTNba38jzKdggqRSUWi+clg==";
       };
     };
     "@uifabric/set-version-7.0.23" = {
@@ -5053,58 +5980,67 @@ let
         sha512 = "9E+YKtnH2kyMKnK9XZZsqyM8OCxEJIIfxtaThTlQpYOzrWAGJxQADFbZ7+Usi0U2xHnWNPFROjq+B9ocEzhqMA==";
       };
     };
-    "@uifabric/styling-7.16.9" = {
+    "@uifabric/styling-7.16.10" = {
       name = "_at_uifabric_slash_styling";
       packageName = "@uifabric/styling";
-      version = "7.16.9";
+      version = "7.16.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@uifabric/styling/-/styling-7.16.9.tgz";
-        sha512 = "vouh7WeayCWvjbCo4VlqJfEYRvkRwq2fL9YyicPIJomIvKxs9lmkJJP+drUOxX78TV9DoGIMnbr+DMFpNsGcdA==";
+        url = "https://registry.npmjs.org/@uifabric/styling/-/styling-7.16.10.tgz";
+        sha512 = "qhTJME41VM63paw690xp9SxD3NJP7a4YGUQTifLU0q2GM0e7AMQVDPQ+Cd8Fv9YBS1lJKHi069hVRwSfBejlwg==";
       };
     };
-    "@uifabric/utilities-7.32.3" = {
+    "@uifabric/utilities-7.32.4" = {
       name = "_at_uifabric_slash_utilities";
       packageName = "@uifabric/utilities";
-      version = "7.32.3";
+      version = "7.32.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.32.3.tgz";
-        sha512 = "H0SWX6X0yZAd1XcdS/ZcPLKw3BWnT6/4eavVOD0NdWO+Dd168exfMHmV/nwgJ1yJjsUsG1o7x7x22QPRl6NQ6Q==";
+        url = "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.32.4.tgz";
+        sha512 = "IKZc03uyfTrgcCGSPAUWfFl9CyxzpSrxrYwAuO4NgDEySdOlkYBRwsRUh6UwWfM+sJdhg7Y3nupzNU3VSC/arg==";
       };
     };
-    "@vue/cli-shared-utils-4.5.6" = {
+    "@ungap/from-entries-0.2.1" = {
+      name = "_at_ungap_slash_from-entries";
+      packageName = "@ungap/from-entries";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@ungap/from-entries/-/from-entries-0.2.1.tgz";
+        sha512 = "CAqefTFAfnUPwYqsWHXpOxHaq1Zo5UQ3m9Zm2p09LggGe57rqHoBn3c++xcoomzXKynAUuiBMDUCQvKMnXjUpA==";
+      };
+    };
+    "@vue/cli-shared-utils-4.5.7" = {
       name = "_at_vue_slash_cli-shared-utils";
       packageName = "@vue/cli-shared-utils";
-      version = "4.5.6";
+      version = "4.5.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.5.6.tgz";
-        sha512 = "p6ePDlEa7Xc0GEt99KDOCwPZtR7UnoEaZLMfwPYU5LAWkdCmtAw8HPAY/WWcjtoiaAkY4k9tz7ZehQasZ9mJxg==";
+        url = "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.5.7.tgz";
+        sha512 = "oicFfx9PvgupxN/LW0s2ktdn1U6bBu8J4lPcW2xj6TtTWUkkxwzis4Tm+XOvgvZnu44+d7216y0Y4TX90q645w==";
       };
     };
-    "@vue/cli-ui-4.5.6" = {
+    "@vue/cli-ui-4.5.7" = {
       name = "_at_vue_slash_cli-ui";
       packageName = "@vue/cli-ui";
-      version = "4.5.6";
+      version = "4.5.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-4.5.6.tgz";
-        sha512 = "AmirESDgjeeTIvFc/OgQeNtYh1cfollyFdF3JSGaAy27rJJlbWfYRgHJoPFp7SD61FQQuqE+TOyiNjplHHt/Rg==";
+        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-4.5.7.tgz";
+        sha512 = "3K+KGGOtkpxpvrkq1Q7FAo1i4CmzCyB6MtOrs5rU6Uqt8eZUjdBu7m7ElsIDRNvprAERKmarTyu89ErgxrkC4g==";
       };
     };
-    "@vue/cli-ui-addon-webpack-4.5.6" = {
+    "@vue/cli-ui-addon-webpack-4.5.7" = {
       name = "_at_vue_slash_cli-ui-addon-webpack";
       packageName = "@vue/cli-ui-addon-webpack";
-      version = "4.5.6";
+      version = "4.5.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-4.5.6.tgz";
-        sha512 = "wjgzU4+cl93YXDrnSdZQmYRHyvCSgq24wPQFsfdXrobfP6a76wx+QedrLm7o2o0/BCHNCkDrTQLHxHvPiVm9PA==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-4.5.7.tgz";
+        sha512 = "FTB7Oc+IXFuDPA7Q8m3bY0c70+J/wJbBFUZyqFDdSRgd09t3sG3PJ9/4jzW5KJKyBB2uyttvhk1atZuNPuUNaw==";
       };
     };
-    "@vue/cli-ui-addon-widgets-4.5.6" = {
+    "@vue/cli-ui-addon-widgets-4.5.7" = {
       name = "_at_vue_slash_cli-ui-addon-widgets";
       packageName = "@vue/cli-ui-addon-widgets";
-      version = "4.5.6";
+      version = "4.5.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-4.5.6.tgz";
-        sha512 = "4Lpf59lr0pycIzKdTlZsgubJxCHDkAqcc4I60Gp6rggueksuhz2q3rAp7kfxwCzaZlAXXsqy6hoeyj+3sukqDQ==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-4.5.7.tgz";
+        sha512 = "9EyKQKj/KhRcReWHa8G4j5d6YG/+dUppHo1IjeTbAhRdFmPgVJ3B51y+epK136s8KqS9p/bcsXXuIs8gZIxcjw==";
       };
     };
     "@vue/compiler-core-3.0.0" = {
@@ -5197,6 +6133,15 @@ let
         sha512 = "C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==";
       };
     };
+    "@webassemblyjs/ast-1.9.1" = {
+      name = "_at_webassemblyjs_slash_ast";
+      packageName = "@webassemblyjs/ast";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.1.tgz";
+        sha512 = "uMu1nCWn2Wxyy126LlGqRVlhdTOsO/bsBRI4dNq3+6SiSuRKRQX6ejjKgh82LoGAPSq72lDUiQ4FWVaf0PecYw==";
+      };
+    };
     "@webassemblyjs/floating-point-hex-parser-1.8.1" = {
       name = "_at_webassemblyjs_slash_floating-point-hex-parser";
       packageName = "@webassemblyjs/floating-point-hex-parser";
@@ -5215,6 +6160,15 @@ let
         sha512 = "TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==";
       };
     };
+    "@webassemblyjs/floating-point-hex-parser-1.9.1" = {
+      name = "_at_webassemblyjs_slash_floating-point-hex-parser";
+      packageName = "@webassemblyjs/floating-point-hex-parser";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.1.tgz";
+        sha512 = "5VEKu024RySmLKTTBl9q1eO/2K5jk9ZS+2HXDBLA9s9p5IjkaXxWiDb/+b7wSQp6FRdLaH1IVGIfOex58Na2pg==";
+      };
+    };
     "@webassemblyjs/helper-api-error-1.8.1" = {
       name = "_at_webassemblyjs_slash_helper-api-error";
       packageName = "@webassemblyjs/helper-api-error";
@@ -5231,6 +6185,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz";
         sha512 = "NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==";
+      };
+    };
+    "@webassemblyjs/helper-api-error-1.9.1" = {
+      name = "_at_webassemblyjs_slash_helper-api-error";
+      packageName = "@webassemblyjs/helper-api-error";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.1.tgz";
+        sha512 = "y1lGmfm38djrScwpeL37rRR9f1D6sM8RhMpvM7CYLzOlHVboouZokXK/G88BpzW0NQBSvCCOnW5BFhten4FPfA==";
       };
     };
     "@webassemblyjs/helper-buffer-1.8.1" = {
@@ -5269,22 +6232,31 @@ let
         sha512 = "ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==";
       };
     };
-    "@webassemblyjs/helper-compiler-1.9.0" = {
-      name = "_at_webassemblyjs_slash_helper-compiler";
-      packageName = "@webassemblyjs/helper-compiler";
-      version = "1.9.0";
+    "@webassemblyjs/helper-code-frame-1.9.1" = {
+      name = "_at_webassemblyjs_slash_helper-code-frame";
+      packageName = "@webassemblyjs/helper-code-frame";
+      version = "1.9.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/helper-compiler/-/helper-compiler-1.9.0.tgz";
-        sha512 = "Gm32kroeSnrlIm9jZfW6m9weOkOyazvtDgZLjiepkKwWfdAAzseERKjmnsldlHxSVtEfP+CHxJAQePQEr40EcA==";
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.1.tgz";
+        sha512 = "ZQ2ZT6Evk4DPIfD+92AraGYaFIqGm4U20e7FpXwl7WUo2Pn1mZ1v8VGH8i+Y++IQpxPbQo/UyG0Khs7eInskzA==";
       };
     };
-    "@webassemblyjs/helper-flatten-ast-1.9.0" = {
+    "@webassemblyjs/helper-compiler-1.9.1" = {
+      name = "_at_webassemblyjs_slash_helper-compiler";
+      packageName = "@webassemblyjs/helper-compiler";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-compiler/-/helper-compiler-1.9.1.tgz";
+        sha512 = "Qad79JaN6Qgv+lWd3sLqt206o6WRne5AynNPuLQlTlvDh8P/QsqVzf6RAJnjn9snJczXxkdN3BhWg9jSgb1sUw==";
+      };
+    };
+    "@webassemblyjs/helper-flatten-ast-1.9.1" = {
       name = "_at_webassemblyjs_slash_helper-flatten-ast";
       packageName = "@webassemblyjs/helper-flatten-ast";
-      version = "1.9.0";
+      version = "1.9.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/helper-flatten-ast/-/helper-flatten-ast-1.9.0.tgz";
-        sha512 = "DXR+7uFteadxravaiv8B4Fzq5W7sgf4eFAUyCt884mypznTra7Fig9tvxDinODmWXcsLs6z82iBMqMbmFlSqNg==";
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-flatten-ast/-/helper-flatten-ast-1.9.1.tgz";
+        sha512 = "wb7ZvGAzfMdgPYAR5zQwu9R/M+kmJDYXKPCJ9vCMfUn3qMoa69Tn5J+Y9u+HzX7nt3TgPvJFcVZKWxCMIhuP7w==";
       };
     };
     "@webassemblyjs/helper-fsm-1.8.1" = {
@@ -5305,6 +6277,15 @@ let
         sha512 = "OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==";
       };
     };
+    "@webassemblyjs/helper-fsm-1.9.1" = {
+      name = "_at_webassemblyjs_slash_helper-fsm";
+      packageName = "@webassemblyjs/helper-fsm";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.1.tgz";
+        sha512 = "J32HGpveEqqcKFS0YbgicB0zAlpfIxJa5MjxDxhu3i5ltPcVfY5EPvKQ1suRguFPehxiUs+/hfkwPEXom/l0lw==";
+      };
+    };
     "@webassemblyjs/helper-module-context-1.8.1" = {
       name = "_at_webassemblyjs_slash_helper-module-context";
       packageName = "@webassemblyjs/helper-module-context";
@@ -5323,6 +6304,15 @@ let
         sha512 = "MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==";
       };
     };
+    "@webassemblyjs/helper-module-context-1.9.1" = {
+      name = "_at_webassemblyjs_slash_helper-module-context";
+      packageName = "@webassemblyjs/helper-module-context";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.1.tgz";
+        sha512 = "IEH2cMmEQKt7fqelLWB5e/cMdZXf2rST1JIrzWmf4XBt3QTxGdnnLvV4DYoN8pJjOx0VYXsWg+yF16MmJtolZg==";
+      };
+    };
     "@webassemblyjs/helper-wasm-bytecode-1.8.1" = {
       name = "_at_webassemblyjs_slash_helper-wasm-bytecode";
       packageName = "@webassemblyjs/helper-wasm-bytecode";
@@ -5339,6 +6329,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz";
         sha512 = "R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==";
+      };
+    };
+    "@webassemblyjs/helper-wasm-bytecode-1.9.1" = {
+      name = "_at_webassemblyjs_slash_helper-wasm-bytecode";
+      packageName = "@webassemblyjs/helper-wasm-bytecode";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.1.tgz";
+        sha512 = "i2rGTBqFUcSXxyjt2K4vm/3kkHwyzG6o427iCjcIKjOqpWH8SEem+xe82jUk1iydJO250/CvE5o7hzNAMZf0dQ==";
       };
     };
     "@webassemblyjs/helper-wasm-section-1.8.1" = {
@@ -5377,6 +6376,15 @@ let
         sha512 = "dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==";
       };
     };
+    "@webassemblyjs/ieee754-1.9.1" = {
+      name = "_at_webassemblyjs_slash_ieee754";
+      packageName = "@webassemblyjs/ieee754";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.1.tgz";
+        sha512 = "EvTG9M78zP1MmkBpUjGQHZc26DzPGZSLIPxYHCjQsBMo60Qy2W34qf8z0exRDtxBbRIoiKa5dFyWer/7r1aaSQ==";
+      };
+    };
     "@webassemblyjs/leb128-1.8.1" = {
       name = "_at_webassemblyjs_slash_leb128";
       packageName = "@webassemblyjs/leb128";
@@ -5393,6 +6401,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz";
         sha512 = "ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==";
+      };
+    };
+    "@webassemblyjs/leb128-1.9.1" = {
+      name = "_at_webassemblyjs_slash_leb128";
+      packageName = "@webassemblyjs/leb128";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.1.tgz";
+        sha512 = "Oc04ub0vFfLnF+2/+ki3AE+anmW4sv9uNBqb+79fgTaPv6xJsOT0dhphNfL3FrME84CbX/D1T9XT8tjFo0IIiw==";
       };
     };
     "@webassemblyjs/utf8-1.8.1" = {
@@ -5413,13 +6430,22 @@ let
         sha512 = "GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==";
       };
     };
-    "@webassemblyjs/validation-1.9.0" = {
+    "@webassemblyjs/utf8-1.9.1" = {
+      name = "_at_webassemblyjs_slash_utf8";
+      packageName = "@webassemblyjs/utf8";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.1.tgz";
+        sha512 = "llkYtppagjCodFjo0alWOUhAkfOiQPQDIc5oA6C9sFAXz7vC9QhZf/f8ijQIX+A9ToM3c9Pq85X0EX7nx9gVhg==";
+      };
+    };
+    "@webassemblyjs/validation-1.9.1" = {
       name = "_at_webassemblyjs_slash_validation";
       packageName = "@webassemblyjs/validation";
-      version = "1.9.0";
+      version = "1.9.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/validation/-/validation-1.9.0.tgz";
-        sha512 = "ysKeFNEWX8r45OXHtH0UPkqFM5qeUd+887+KnDob6kCrryqjNNyW3Ew+fTI8u1vzg7VUXYOJqxXplRUF6cfsfA==";
+        url = "https://registry.npmjs.org/@webassemblyjs/validation/-/validation-1.9.1.tgz";
+        sha512 = "a/Vh1fKuvuqff0KqA9TYATTyk/FihoVcc5vp4qhXHfKjS4J9BIW548gh5YZ81ZB39yg5TKiApRy8zMRa82Ij/A==";
       };
     };
     "@webassemblyjs/wasm-edit-1.9.0" = {
@@ -5476,6 +6502,15 @@ let
         sha512 = "9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==";
       };
     };
+    "@webassemblyjs/wasm-parser-1.9.1" = {
+      name = "_at_webassemblyjs_slash_wasm-parser";
+      packageName = "@webassemblyjs/wasm-parser";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.1.tgz";
+        sha512 = "ImM4N2T1MEIond0MyE3rXvStVxEmivQrDKf/ggfh5pP6EHu3lL/YTAoSrR7shrbKNPpeKpGesW1LIK/L4kqduw==";
+      };
+    };
     "@webassemblyjs/wast-parser-1.8.1" = {
       name = "_at_webassemblyjs_slash_wast-parser";
       packageName = "@webassemblyjs/wast-parser";
@@ -5494,6 +6529,15 @@ let
         sha512 = "qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==";
       };
     };
+    "@webassemblyjs/wast-parser-1.9.1" = {
+      name = "_at_webassemblyjs_slash_wast-parser";
+      packageName = "@webassemblyjs/wast-parser";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.1.tgz";
+        sha512 = "2xVxejXSvj3ls/o2TR/zI6p28qsGupjHhnHL6URULQRcXmryn3w7G83jQMcT7PHqUfyle65fZtWLukfdLdE7qw==";
+      };
+    };
     "@webassemblyjs/wast-printer-1.8.1" = {
       name = "_at_webassemblyjs_slash_wast-printer";
       packageName = "@webassemblyjs/wast-printer";
@@ -5510,6 +6554,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz";
         sha512 = "2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==";
+      };
+    };
+    "@webassemblyjs/wast-printer-1.9.1" = {
+      name = "_at_webassemblyjs_slash_wast-printer";
+      packageName = "@webassemblyjs/wast-printer";
+      version = "1.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.1.tgz";
+        sha512 = "tDV8V15wm7mmbAH6XvQRU1X+oPGmeOzYsd6h7hlRLz6QpV4Ec/KKxM8OpLtFmQPLCreGxTp+HuxtH4pRIZyL9w==";
       };
     };
     "@wry/context-0.4.4" = {
@@ -5683,6 +6736,15 @@ let
         sha1 = "c22822f87e1c939f579887504d9c109c4173829d";
       };
     };
+    "abstract-leveldown-0.12.4" = {
+      name = "abstract-leveldown";
+      packageName = "abstract-leveldown";
+      version = "0.12.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz";
+        sha1 = "29e18e632e60e4e221d5810247852a63d7b2e410";
+      };
+    };
     "abstract-leveldown-6.0.3" = {
       name = "abstract-leveldown";
       packageName = "abstract-leveldown";
@@ -5782,22 +6844,22 @@ let
         sha512 = "1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==";
       };
     };
-    "acorn-6.4.1" = {
+    "acorn-6.4.2" = {
       name = "acorn";
       packageName = "acorn";
-      version = "6.4.1";
+      version = "6.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz";
-        sha512 = "ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==";
+        url = "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz";
+        sha512 = "XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==";
       };
     };
-    "acorn-7.4.0" = {
+    "acorn-7.4.1" = {
       name = "acorn";
       packageName = "acorn";
-      version = "7.4.0";
+      version = "7.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz";
-        sha512 = "+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==";
+        url = "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz";
+        sha512 = "nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==";
       };
     };
     "acorn-globals-1.0.9" = {
@@ -5917,13 +6979,13 @@ let
         sha1 = "f291be701a2efc567a63fc7aa6afcded31430be1";
       };
     };
-    "addons-linter-2.5.0" = {
+    "addons-linter-2.7.0" = {
       name = "addons-linter";
       packageName = "addons-linter";
-      version = "2.5.0";
+      version = "2.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/addons-linter/-/addons-linter-2.5.0.tgz";
-        sha512 = "d3GGf27ibN9ioxmjEiAFkGQRdyw5W+Gb2/9G55AZ6YygtBjtJDotTnSsE6Tz+mEFY4QKo/OaVs1XKjcZEl2fJA==";
+        url = "https://registry.npmjs.org/addons-linter/-/addons-linter-2.7.0.tgz";
+        sha512 = "kH+0fAKSc461PnCyYQ0/SeKcxEQ2zxCZwG2GB6xjvfkMiMAwwic87VP62Cffc8H/zHEfYuT8uFmy42ayH5mqEQ==";
       };
     };
     "addr-to-ip-port-1.5.1" = {
@@ -5933,6 +6995,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/addr-to-ip-port/-/addr-to-ip-port-1.5.1.tgz";
         sha512 = "bA+dyydTNuQtrEDJ0g9eR7XabNhvrM5yZY0hvTbNK3yvoeC73ZqMES6E1cEqH9WPxs4uMtMsOjfwS4FmluhsAA==";
+      };
+    };
+    "address-1.1.2" = {
+      name = "address";
+      packageName = "address";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/address/-/address-1.1.2.tgz";
+        sha512 = "aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==";
       };
     };
     "adm-zip-0.4.13" = {
@@ -6241,6 +7312,15 @@ let
         sha1 = "4a5282ac164729e93619bcfd3ad151f817ce91f5";
       };
     };
+    "analytics-node-3.3.0" = {
+      name = "analytics-node";
+      packageName = "analytics-node";
+      version = "3.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/analytics-node/-/analytics-node-3.3.0.tgz";
+        sha512 = "wxrsmibvZVysy5CfkLItYrYMGbNVXDBccWurz+hgLUg98pbijiS2/QQdRc0SjHWVEqByxReEJ2T2MGhgb4jk3A==";
+      };
+    };
     "ansi-0.3.1" = {
       name = "ansi";
       packageName = "ansi";
@@ -6365,6 +7445,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz";
         sha512 = "JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==";
+      };
+    };
+    "ansi-fragments-0.2.1" = {
+      name = "ansi-fragments";
+      packageName = "ansi-fragments";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-fragments/-/ansi-fragments-0.2.1.tgz";
+        sha512 = "DykbNHxuXQwUDRv5ibc2b0x7uw7wmwOGLBUd5RmaQ5z8Lhx19vwvKV+FAsM5rEA6dEcHxX+/Ad5s9eF2k2bB+w==";
       };
     };
     "ansi-gray-0.1.1" = {
@@ -6493,13 +7582,13 @@ let
         sha512 = "VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==";
       };
     };
-    "ansi-styles-4.2.1" = {
+    "ansi-styles-4.3.0" = {
       name = "ansi-styles";
       packageName = "ansi-styles";
-      version = "4.2.1";
+      version = "4.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz";
-        sha512 = "9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==";
+        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz";
+        sha512 = "zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==";
       };
     };
     "ansi-term-0.0.2" = {
@@ -6536,6 +7625,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz";
         sha1 = "665597de86a9ffe3aa9bfbe6cae5c6ea426b4979";
+      };
+    };
+    "any-base-1.1.0" = {
+      name = "any-base";
+      packageName = "any-base";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz";
+        sha512 = "uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==";
       };
     };
     "any-observable-0.3.0" = {
@@ -6736,6 +7834,15 @@ let
         sha512 = "n1o1QmQ6hQcl5Rx+K23yO9MrDcF94Xygychn1pxJG5xKEZ8kkKxqNqjUhjFxIN908LJ4yuFjTW6OEtEym4haxg==";
       };
     };
+    "apollo-link-1.2.1" = {
+      name = "apollo-link";
+      packageName = "apollo-link";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.1.tgz";
+        sha512 = "6Ghf+j3cQLCIvjXd2dJrLw+16HZbWbwmB1qlTc41BviB2hv+rK1nJr17Y9dWK0UD4p3i9Hfddx3tthpMKrueHg==";
+      };
+    };
     "apollo-link-1.2.14" = {
       name = "apollo-link";
       packageName = "apollo-link";
@@ -6826,13 +7933,13 @@ let
         sha512 = "HUcP3TlgRsuGgeTOn8QMbkdx0hLPXyEJehZIPrcof0ATz7j7aTPA4at7gaiFHCo8gk07DaWYGB3PFgjboXRcWQ==";
       };
     };
-    "apollo-server-core-2.18.1" = {
+    "apollo-server-core-2.18.2" = {
       name = "apollo-server-core";
       packageName = "apollo-server-core";
-      version = "2.18.1";
+      version = "2.18.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.18.1.tgz";
-        sha512 = "Bv08AyJ3WSms59loE31haVRBctDn6MGyjtaPnfLlQV5//wMdwS5MXX8RcMCmXxv0Utp5TlhoD+pHLO5Ool+LRw==";
+        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.18.2.tgz";
+        sha512 = "phz57BFBukMa3Ta7ZVW7pj1pdUne9KYLbcBdEcITr+I0+nbhy+YM8gcgpOnjrokWYiEZgIe52XeM3m4BMLw5dg==";
       };
     };
     "apollo-server-env-2.4.5" = {
@@ -6853,13 +7960,13 @@ let
         sha512 = "FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==";
       };
     };
-    "apollo-server-express-2.18.1" = {
+    "apollo-server-express-2.18.2" = {
       name = "apollo-server-express";
       packageName = "apollo-server-express";
-      version = "2.18.1";
+      version = "2.18.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.18.1.tgz";
-        sha512 = "qAkSlhKSvPx7sWT+Thk7bfHqjWNNm+uP66zNZlnsvKlR4++84KfcFrij3MaCm67mu4h0MBv2dvlsoOrXehrYtg==";
+        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.18.2.tgz";
+        sha512 = "9P5YOSE2amcNdkXqxqU3oulp+lpwoIBdwS2vOP69kl6ix+n7vEWHde4ulHwwl4xLdtZ88yyxgdKJEIkhaepiNw==";
       };
     };
     "apollo-server-plugin-base-0.10.1" = {
@@ -6970,6 +8077,15 @@ let
         sha1 = "dcfca9e509300e4c3b2d467965fe50c56fc75e66";
       };
     };
+    "application-config-path-0.1.0" = {
+      name = "application-config-path";
+      packageName = "application-config-path";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/application-config-path/-/application-config-path-0.1.0.tgz";
+        sha1 = "193c5f0a86541a4c66fba1e2dc38583362ea5e8f";
+      };
+    };
     "aproba-1.2.0" = {
       name = "aproba";
       packageName = "aproba";
@@ -7006,15 +8122,6 @@ let
         sha1 = "f92e72233056dfc6969472749c267bdb046b1d70";
       };
     };
-    "archiver-2.1.1" = {
-      name = "archiver";
-      packageName = "archiver";
-      version = "2.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz";
-        sha1 = "ff662b4a78201494a3ee544d3a33fe7496509ebc";
-      };
-    };
     "archiver-3.1.1" = {
       name = "archiver";
       packageName = "archiver";
@@ -7040,15 +8147,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/archiver/-/archiver-5.0.2.tgz";
         sha512 = "Tq3yV/T4wxBsD2Wign8W9VQKhaUxzzRmjEiSoOK0SLqPgDP/N1TKdYyBeIEu56T4I9iO4fKTTR0mN9NWkBA0sg==";
-      };
-    };
-    "archiver-utils-1.3.0" = {
-      name = "archiver-utils";
-      packageName = "archiver-utils";
-      version = "1.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz";
-        sha1 = "e50b4c09c70bf3d680e32ff1b7994e9f9d895174";
       };
     };
     "archiver-utils-2.1.0" = {
@@ -7472,33 +8570,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz";
         sha512 = "ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==";
-      };
-    };
-    "array-to-error-1.1.1" = {
-      name = "array-to-error";
-      packageName = "array-to-error";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/array-to-error/-/array-to-error-1.1.1.tgz";
-        sha1 = "d68812926d14097a205579a667eeaf1856a44c07";
-      };
-    };
-    "array-to-sentence-1.1.0" = {
-      name = "array-to-sentence";
-      packageName = "array-to-sentence";
-      version = "1.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/array-to-sentence/-/array-to-sentence-1.1.0.tgz";
-        sha1 = "c804956dafa53232495b205a9452753a258d39fc";
-      };
-    };
-    "array-to-sentence-2.0.0" = {
-      name = "array-to-sentence";
-      packageName = "array-to-sentence";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/array-to-sentence/-/array-to-sentence-2.0.0.tgz";
-        sha512 = "rflEVg2oIxO0XgL5erRPr8GlInIORqIXrep6+b9RyrvztFcrawqIOxbWR5hYy1v7KzNvTWsSdHe8D9/XZ/rbMw==";
       };
     };
     "array-union-1.0.2" = {
@@ -8149,13 +9220,13 @@ let
         sha1 = "00f35b2d27ac91b1f0d3ef2084c98cf1d1f0adc3";
       };
     };
-    "aws-sdk-2.763.0" = {
+    "aws-sdk-2.768.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.763.0";
+      version = "2.768.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.763.0.tgz";
-        sha512 = "uHb+yfsH21wR8ZInj/GQwxCmWJjrL3sOwqwZ2lf9hDxh1P0lsMKDjf0e+8ICgRBY4x28XNWXs3/O15EID6Rsqw==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.768.0.tgz";
+        sha512 = "yIY1Fbj8kvyP3cEHOCvvw59IRqcYq84/aB0BGfuWPQzPVRjTYVxA8zP/iytM4Zo+NO8xkCq9Wc9OoMfwZZb+GQ==";
       };
     };
     "aws-sign2-0.6.0" = {
@@ -8185,6 +9256,15 @@ let
         sha512 = "zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==";
       };
     };
+    "axios-0.17.1" = {
+      name = "axios";
+      packageName = "axios";
+      version = "0.17.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz";
+        sha1 = "2d8e3e5d0bdbd7327f91bc814f5c57660f81824d";
+      };
+    };
     "axios-0.18.1" = {
       name = "axios";
       packageName = "axios";
@@ -8194,6 +9274,15 @@ let
         sha512 = "0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==";
       };
     };
+    "axios-0.19.0" = {
+      name = "axios";
+      packageName = "axios";
+      version = "0.19.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz";
+        sha512 = "1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==";
+      };
+    };
     "axios-0.19.2" = {
       name = "axios";
       packageName = "axios";
@@ -8201,6 +9290,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz";
         sha512 = "fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==";
+      };
+    };
+    "axios-retry-3.1.9" = {
+      name = "axios-retry";
+      packageName = "axios-retry";
+      version = "3.1.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.9.tgz";
+        sha512 = "NFCoNIHq8lYkJa6ku4m+V1837TP6lCa7n79Iuf8/AqATAHYB0ISaAS1eyIenDOfHOLtym34W65Sjke2xjg2fsA==";
       };
     };
     "azure-devops-node-api-7.2.0" = {
@@ -8246,6 +9344,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz";
         sha512 = "z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==";
+      };
+    };
+    "babel-extract-comments-1.0.0" = {
+      name = "babel-extract-comments";
+      packageName = "babel-extract-comments";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz";
+        sha512 = "qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==";
       };
     };
     "babel-helper-evaluate-path-0.5.0" = {
@@ -8482,6 +9589,24 @@ let
         sha1 = "0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946";
       };
     };
+    "babel-plugin-syntax-object-rest-spread-6.13.0" = {
+      name = "babel-plugin-syntax-object-rest-spread";
+      packageName = "babel-plugin-syntax-object-rest-spread";
+      version = "6.13.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz";
+        sha1 = "fd6536f2bce13836ffa3a5458c4903a597bb3bf5";
+      };
+    };
+    "babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0" = {
+      name = "babel-plugin-syntax-trailing-function-commas";
+      packageName = "babel-plugin-syntax-trailing-function-commas";
+      version = "7.0.0-beta.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz";
+        sha512 = "Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==";
+      };
+    };
     "babel-plugin-transform-flow-strip-types-6.22.0" = {
       name = "babel-plugin-transform-flow-strip-types";
       packageName = "babel-plugin-transform-flow-strip-types";
@@ -8525,6 +9650,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz";
         sha1 = "acbb3e56a3555dd23928e4b582d285162dd2b198";
+      };
+    };
+    "babel-plugin-transform-object-rest-spread-6.26.0" = {
+      name = "babel-plugin-transform-object-rest-spread";
+      packageName = "babel-plugin-transform-object-rest-spread";
+      version = "6.26.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz";
+        sha1 = "0f36692d50fef6b7e2d4b3ac1478137a963b7b06";
       };
     };
     "babel-plugin-transform-property-literals-6.9.4" = {
@@ -8599,13 +9733,22 @@ let
         sha1 = "8364ca62df8eafb830499f699177466c3b03499d";
       };
     };
-    "babel-preset-current-node-syntax-0.1.3" = {
+    "babel-preset-current-node-syntax-0.1.4" = {
       name = "babel-preset-current-node-syntax";
       packageName = "babel-preset-current-node-syntax";
-      version = "0.1.3";
+      version = "0.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz";
-        sha512 = "uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==";
+        url = "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz";
+        sha512 = "5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==";
+      };
+    };
+    "babel-preset-fbjs-3.3.0" = {
+      name = "babel-preset-fbjs";
+      packageName = "babel-preset-fbjs";
+      version = "3.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.3.0.tgz";
+        sha512 = "7QTLTCd2gwB2qGoi5epSULMHugSVgpcVt5YAeiFO9ABLrutDQzKfGwzxgZHLpugq8qMdg/DhRZDZ5CLKxBkEbw==";
       };
     };
     "babel-preset-jest-25.5.0" = {
@@ -8750,6 +9893,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz";
         sha1 = "780a99c84e7d600260361511c4877613bf24f6bb";
+      };
+    };
+    "base32.js-0.1.0" = {
+      name = "base32.js";
+      packageName = "base32.js";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz";
+        sha1 = "b582dec693c2f11e893cf064ee6ac5b6131a2202";
       };
     };
     "base62-0.1.1" = {
@@ -9238,6 +10390,15 @@ let
         sha512 = "5LhLQeGxdVFumJTbveJS16Rc+Vzh/nbC6o80UMj6ZRvSkiVkk+4L782OMYI0VG1JTfUxiRFP4f+CZBFyuclLBg==";
       };
     };
+    "bl-0.8.2" = {
+      name = "bl";
+      packageName = "bl";
+      version = "0.8.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz";
+        sha1 = "c9b6bca08d1bc2ea00fc8afb4f1a5fd1e1c66e4e";
+      };
+    };
     "bl-1.2.3" = {
       name = "bl";
       packageName = "bl";
@@ -9400,6 +10561,15 @@ let
         sha512 = "vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q==";
       };
     };
+    "bmp-js-0.1.0" = {
+      name = "bmp-js";
+      packageName = "bmp-js";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz";
+        sha1 = "e05a63f796a6c1ff25f4771ec7adadc148c07233";
+      };
+    };
     "bn.js-4.11.9" = {
       name = "bn.js";
       packageName = "bn.js";
@@ -9452,6 +10622,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/body-parser/-/body-parser-1.12.4.tgz";
         sha1 = "090700c4ba28862a8520ef378395fdee5f61c229";
+      };
+    };
+    "body-parser-1.18.3" = {
+      name = "body-parser";
+      packageName = "body-parser";
+      version = "1.18.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz";
+        sha1 = "5b292198ffdd553b3a0f20ded0592b956955c8b4";
       };
     };
     "body-parser-1.19.0" = {
@@ -9589,6 +10768,15 @@ let
         sha512 = "cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==";
       };
     };
+    "boxen-4.1.0" = {
+      name = "boxen";
+      packageName = "boxen";
+      version = "4.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/boxen/-/boxen-4.1.0.tgz";
+        sha512 = "Iwq1qOkmEsl0EVABa864Bbj3HCL4186DRZgFW/NrFs5y5GMM3ljsxzMLgOHdWISDRvcM8beh8q4tTNzXz+mSKg==";
+      };
+    };
     "boxen-4.2.0" = {
       name = "boxen";
       packageName = "boxen";
@@ -9605,6 +10793,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.6.tgz";
         sha1 = "fef069bee85975b2ddcc2264aaa7c50dc17a3c7e";
+      };
+    };
+    "bplist-creator-0.0.8" = {
+      name = "bplist-creator";
+      packageName = "bplist-creator";
+      version = "0.0.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz";
+        sha512 = "Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==";
       };
     };
     "bplist-parser-0.1.1" = {
@@ -9796,6 +10993,15 @@ let
         sha512 = "BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==";
       };
     };
+    "browserify-fs-1.0.0" = {
+      name = "browserify-fs";
+      packageName = "browserify-fs";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/browserify-fs/-/browserify-fs-1.0.0.tgz";
+        sha1 = "f075aa8a729d4d1716d066620e386fcc1311a96f";
+      };
+    };
     "browserify-incremental-3.1.1" = {
       name = "browserify-incremental";
       packageName = "browserify-incremental";
@@ -9857,6 +11063,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz";
         sha512 = "yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==";
+      };
+    };
+    "browserslist-4.10.0" = {
+      name = "browserslist";
+      packageName = "browserslist";
+      version = "4.10.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.10.0.tgz";
+        sha512 = "TpfK0TDgv71dzuTsEAlQiHeWQ/tiPqgNZVdv046fvNtBZrjbv2O3TsWCDU0AWGJJKCF/KsjNdLzR9hXOsh/CfA==";
       };
     };
     "browserslist-4.14.5" = {
@@ -10010,6 +11225,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz";
         sha1 = "0353b54fd07fd9564170671ae6f66b9cf10d27f5";
+      };
+    };
+    "buffer-es6-4.9.3" = {
+      name = "buffer-es6";
+      packageName = "buffer-es6";
+      version = "4.9.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-es6/-/buffer-es6-4.9.3.tgz";
+        sha1 = "f26347b82df76fd37e18bcb5288c4970cfd5c404";
       };
     };
     "buffer-fill-1.0.0" = {
@@ -10624,13 +11848,13 @@ let
         sha512 = "bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==";
       };
     };
-    "caniuse-lite-1.0.30001140" = {
+    "caniuse-lite-1.0.30001144" = {
       name = "caniuse-lite";
       packageName = "caniuse-lite";
-      version = "1.0.30001140";
+      version = "1.0.30001144";
       src = fetchurl {
-        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001140.tgz";
-        sha512 = "xFtvBtfGrpjTOxTpjP5F2LmN04/ZGfYV8EQzUIC/RmKpdrmzJrjqlJ4ho7sGuAMPko2/Jl08h7x9uObCfBFaAA==";
+        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001144.tgz";
+        sha512 = "4GQTEWNMnVZVOFG3BK0xvGeaDAtiPAbG2N8yuMXuXzx/c2Vd4XoMPO8+E918zeXn5IF0FRVtGShBfkfQea2wHQ==";
       };
     };
     "canvas-2.6.1" = {
@@ -11452,6 +12676,15 @@ let
         sha512 = "RHxtgFvXsRQ+1AM7dlozLDY7ssmvUUh0XEnfnyhYgJTO6beNZHBogiaCwGM9Q3rFrUkYxOtsZRC0zAturg5bjg==";
       };
     };
+    "clean-webpack-plugin-3.0.0" = {
+      name = "clean-webpack-plugin";
+      packageName = "clean-webpack-plugin";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz";
+        sha512 = "MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==";
+      };
+    };
     "cli-1.0.1" = {
       name = "cli";
       packageName = "cli";
@@ -11585,6 +12818,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz";
         sha512 = "7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==";
+      };
+    };
+    "cli-table3-0.6.0" = {
+      name = "cli-table3";
+      packageName = "cli-table3";
+      version = "0.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz";
+        sha512 = "gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==";
       };
     };
     "cli-truncate-0.2.1" = {
@@ -11801,6 +13043,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/clivas/-/clivas-0.2.0.tgz";
         sha1 = "b8d19188b3243e390f302410bd0cb1622db82649";
+      };
+    };
+    "clone-0.1.19" = {
+      name = "clone";
+      packageName = "clone";
+      version = "0.1.19";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz";
+        sha1 = "613fb68639b26a494ac53253e15b1a6bd88ada85";
       };
     };
     "clone-0.1.5" = {
@@ -12424,6 +13675,15 @@ let
         sha512 = "6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==";
       };
     };
+    "commander-2.20.0" = {
+      name = "commander";
+      packageName = "commander";
+      version = "2.20.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz";
+        sha512 = "7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==";
+      };
+    };
     "commander-2.20.3" = {
       name = "commander";
       packageName = "commander";
@@ -12649,13 +13909,13 @@ let
         sha1 = "645fc4adf58b72b649d5cae65135619db26ff143";
       };
     };
-    "compress-commons-1.2.2" = {
-      name = "compress-commons";
-      packageName = "compress-commons";
-      version = "1.2.2";
+    "component-type-1.2.1" = {
+      name = "component-type";
+      packageName = "component-type";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz";
-        sha1 = "524a9f10903f3a813389b0225d27c48bb751890f";
+        url = "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz";
+        sha1 = "8a47901700238e4fc32269771230226f24b415a9";
       };
     };
     "compress-commons-2.1.1" = {
@@ -12899,6 +14159,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/connections/-/connections-1.4.2.tgz";
         sha1 = "7890482bf5c71af6c5ca192be3136aed74428aad";
+      };
+    };
+    "consola-2.15.0" = {
+      name = "consola";
+      packageName = "consola";
+      version = "2.15.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz";
+        sha512 = "vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ==";
       };
     };
     "console-browserify-1.1.0" = {
@@ -13352,6 +14621,15 @@ let
         sha512 = "xkXSJhvKz4MfLbVkZ7GyCaFo4ciB3uKI/HHzkGwj1eyTH5+7RTFxW5CE0irWAZgV5oFcO9hd6+NVXAtY9hlo7Q==";
       };
     };
+    "copy-webpack-plugin-6.0.4" = {
+      name = "copy-webpack-plugin";
+      packageName = "copy-webpack-plugin";
+      version = "6.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.0.4.tgz";
+        sha512 = "zCazfdYAh3q/O4VzZFiadWGpDA2zTs6FC6D7YTHD6H1J40pzo0H4z22h1NYMCl4ArQP4CK8y/KWqPrJ4rVkZ5A==";
+      };
+    };
     "cordova-app-hello-world-5.0.0" = {
       name = "cordova-app-hello-world";
       packageName = "cordova-app-hello-world";
@@ -13505,6 +14783,15 @@ let
         sha512 = "xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==";
       };
     };
+    "cosmiconfig-7.0.0" = {
+      name = "cosmiconfig";
+      packageName = "cosmiconfig";
+      version = "7.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz";
+        sha512 = "pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==";
+      };
+    };
     "couch-login-0.1.20" = {
       name = "couch-login";
       packageName = "couch-login";
@@ -13577,15 +14864,6 @@ let
         sha512 = "1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==";
       };
     };
-    "crc32-stream-2.0.0" = {
-      name = "crc32-stream";
-      packageName = "crc32-stream";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz";
-        sha1 = "e3cdd3b4df3168dd74e3de3fbbcb7b297fe908f4";
-      };
-    };
     "crc32-stream-3.0.1" = {
       name = "crc32-stream";
       packageName = "crc32-stream";
@@ -13620,6 +14898,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz";
         sha1 = "06be7abef947a3f14a30fd610671d401bca8b7b6";
+      };
+    };
+    "create-graphback-1.0.1" = {
+      name = "create-graphback";
+      packageName = "create-graphback";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/create-graphback/-/create-graphback-1.0.1.tgz";
+        sha512 = "zbxPH0+Yh21hjWtD3zaiTl84N/4JV+ix62T2kNWzHTd0lbmI/4R1DaoswZdGvUSC62jDuEz8tJISx4J1u66rZQ==";
       };
     };
     "create-hash-1.2.0" = {
@@ -13674,15 +14961,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/cross-env/-/cross-env-7.0.0.tgz";
         sha512 = "rV6M9ldNgmwP7bx5u6rZsTbYidzwvrwIYZnT08hSGLcQCcggofgFW+sNe7IhA1SRauPS0QuLbbX+wdNtpqE5CQ==";
-      };
-    };
-    "cross-fetch-3.0.4" = {
-      name = "cross-fetch";
-      packageName = "cross-fetch";
-      version = "3.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz";
-        sha512 = "MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==";
       };
     };
     "cross-fetch-3.0.6" = {
@@ -13865,6 +15143,15 @@ let
         sha512 = "BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==";
       };
     };
+    "css-loader-3.6.0" = {
+      name = "css-loader";
+      packageName = "css-loader";
+      version = "3.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz";
+        sha512 = "M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==";
+      };
+    };
     "css-modules-loader-core-1.1.0" = {
       name = "css-modules-loader-core";
       packageName = "css-modules-loader-core";
@@ -13964,13 +15251,13 @@ let
         sha512 = "a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==";
       };
     };
-    "css-what-3.3.0" = {
+    "css-what-3.4.1" = {
       name = "css-what";
       packageName = "css-what";
-      version = "3.3.0";
+      version = "3.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/css-what/-/css-what-3.3.0.tgz";
-        sha512 = "pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==";
+        url = "https://registry.npmjs.org/css-what/-/css-what-3.4.1.tgz";
+        sha512 = "wHOppVDKl4vTAOWzJt5Ek37Sgd9qq1Bmj/T1OjvicWbU5W7ru7Pqbn0Jdqii3Drx/h+dixHKXNhZYx7blthL7g==";
       };
     };
     "cssauron-1.4.0" = {
@@ -14855,6 +16142,15 @@ let
         sha1 = "aa24ffb9ac3df9a2351837cfb2d279360cd78492";
       };
     };
+    "decache-4.4.0" = {
+      name = "decache";
+      packageName = "decache";
+      version = "4.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/decache/-/decache-4.4.0.tgz";
+        sha1 = "6f6df6b85d7e7c4410a932ffc26489b78e9acd13";
+      };
+    };
     "decamelize-1.2.0" = {
       name = "decamelize";
       packageName = "decamelize";
@@ -15026,13 +16322,13 @@ let
         sha512 = "yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==";
       };
     };
-    "deep-equal-2.0.3" = {
+    "deep-equal-2.0.4" = {
       name = "deep-equal";
       packageName = "deep-equal";
-      version = "2.0.3";
+      version = "2.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.3.tgz";
-        sha512 = "Spqdl4H+ky45I9ByyJtXteOm9CaIrPmnIPmOhrkKGNYWeDgCvJ8jNYVCTjChxW4FqGuZnLHADc8EKRMX6+CgvA==";
+        url = "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.4.tgz";
+        sha512 = "BUfaXrVoCfgkOQY/b09QdO9L3XNoF2XH0A3aY9IQwQL/ZjLOe8FQgCNVl1wiolhsFo8kFdO9zdPViCPbmaJA5w==";
       };
     };
     "deep-extend-0.2.11" = {
@@ -15098,6 +16394,15 @@ let
         sha1 = "b369d6fb5dbc13eecf524f91b070feedc357cf34";
       };
     };
+    "deep-scope-analyser-1.7.0" = {
+      name = "deep-scope-analyser";
+      packageName = "deep-scope-analyser";
+      version = "1.7.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deep-scope-analyser/-/deep-scope-analyser-1.7.0.tgz";
+        sha512 = "rl5Dmt2IZkFpZo6XbEY1zG8st2Wpq8Pi/dV2gz8ZF6BDYt3fnor2JNxHwdO1WLo0k6JbmYp0x8MNy8kE4l1NtA==";
+      };
+    };
     "deepcopy-2.1.0" = {
       name = "deepcopy";
       packageName = "deepcopy";
@@ -15105,6 +16410,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/deepcopy/-/deepcopy-2.1.0.tgz";
         sha512 = "8cZeTb1ZKC3bdSCP6XOM1IsTczIO73fdqtwa2B0N15eAz7gmyhQo+mc5gnFuulsgN3vIQYmTgbmQVKalH1dKvQ==";
+      };
+    };
+    "deepmerge-1.5.2" = {
+      name = "deepmerge";
+      packageName = "deepmerge";
+      version = "1.5.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz";
+        sha512 = "95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==";
       };
     };
     "deepmerge-2.1.0" = {
@@ -15222,6 +16536,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/deferred/-/deferred-0.7.11.tgz";
         sha512 = "8eluCl/Blx4YOGwMapBvXRKxHXhA8ejDXYzEaK8+/gtcm8hRMhSLmXSqDmNUKNc/C8HNSmuyyp/hflhqDAvK2A==";
+      };
+    };
+    "deferred-leveldown-0.2.0" = {
+      name = "deferred-leveldown";
+      packageName = "deferred-leveldown";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz";
+        sha1 = "2cef1f111e1c57870d8bbb8af2650e587cd2f5b4";
       };
     };
     "deferred-leveldown-5.3.0" = {
@@ -15348,6 +16671,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/delay/-/delay-4.4.0.tgz";
         sha512 = "txgOrJu3OdtOfTiEOT2e76dJVfG/1dz2NZ4F0Pyt4UGZJryssMRp5vdM5wQoLwSOBNdrJv3F9PAhp/heqd7vrA==";
+      };
+    };
+    "delay-async-1.2.0" = {
+      name = "delay-async";
+      packageName = "delay-async";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/delay-async/-/delay-async-1.2.0.tgz";
+        sha512 = "BDhPL4k42yL2c0b5zTUlMIM3/wmv77HOgZi4ya/8tOHw16GZ1i9Qj7Tmy3xt0jWb4VmpQtklLPReUtOUZUuzuQ==";
       };
     };
     "delayed-stream-1.0.0" = {
@@ -15566,6 +16898,15 @@ let
         sha512 = "ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==";
       };
     };
+    "detect-port-alt-1.1.6" = {
+      name = "detect-port-alt";
+      packageName = "detect-port-alt";
+      version = "1.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz";
+        sha512 = "5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==";
+      };
+    };
     "detective-4.7.1" = {
       name = "detective";
       packageName = "detective";
@@ -15663,6 +17004,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/detective-typescript/-/detective-typescript-5.8.0.tgz";
         sha512 = "SrsUCfCaDTF64QVMHMidRal+kmkbIc5zP8cxxZPsomWx9vuEUjBlSJNhf7/ypE5cLdJJDI4qzKDmyzqQ+iz/xg==";
+      };
+    };
+    "devcert-1.1.3" = {
+      name = "devcert";
+      packageName = "devcert";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/devcert/-/devcert-1.1.3.tgz";
+        sha512 = "7/nIzKdQ8y2K0imjIP7dyg2GJ2h38Ps6VOMXWZHIarNDV3p6mTXyEugKFnkmsZ2DD58JEG34ILyVb3qdOMmP9w==";
       };
     };
     "devtools-protocol-0.0.799653" = {
@@ -15926,13 +17276,13 @@ let
         sha512 = "EAyaxl8hy4Ph07kzlzGTfpbZMNAAAHXSZtNEMwdlnSd1noHzvA6HsgKt4fEMSvaEXQYLSphe5rPMxN4WOj0hcQ==";
       };
     };
-    "dispensary-0.55.0" = {
+    "dispensary-0.57.0" = {
       name = "dispensary";
       packageName = "dispensary";
-      version = "0.55.0";
+      version = "0.57.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dispensary/-/dispensary-0.55.0.tgz";
-        sha512 = "5+6E0kQNVWIZCGwTw34B48bJQyUuvwJD6hsI/b7ScKbjfrzUIgod/ROsTX6t9d3O031A9O5RPVHIqkX4ZzcAfw==";
+        url = "https://registry.npmjs.org/dispensary/-/dispensary-0.57.0.tgz";
+        sha512 = "vgRaZa9Ok8QdrAVtx+s6heBgI1RGT+Y6VA336oPWYADZZz83K+5NOTpLamEKRyJdRY5pYLaWhV2Js7bau1JyKg==";
       };
     };
     "diveSync-0.3.0" = {
@@ -16124,6 +17474,15 @@ let
         sha1 = "ea80b106a87538774e8a3a4a5afe293de489e0a9";
       };
     };
+    "dom-converter-0.2.0" = {
+      name = "dom-converter";
+      packageName = "dom-converter";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz";
+        sha512 = "gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==";
+      };
+    };
     "dom-serialize-2.2.1" = {
       name = "dom-serialize";
       packageName = "dom-serialize";
@@ -16259,13 +17618,13 @@ let
         sha512 = "JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==";
       };
     };
-    "domhandler-3.2.0" = {
+    "domhandler-3.3.0" = {
       name = "domhandler";
       packageName = "domhandler";
-      version = "3.2.0";
+      version = "3.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/domhandler/-/domhandler-3.2.0.tgz";
-        sha512 = "FnT5pxGpykNI10uuwyqae65Ysw7XBQJKDjDjlHgE/rsNtjr1FyGNVNQCVlM5hwcq9wkyWSqB+L5Z+Qa4khwLuA==";
+        url = "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz";
+        sha512 = "J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==";
       };
     };
     "domino-2.1.6" = {
@@ -16313,13 +17672,13 @@ let
         sha512 = "Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==";
       };
     };
-    "domutils-2.4.1" = {
+    "domutils-2.4.2" = {
       name = "domutils";
       packageName = "domutils";
-      version = "2.4.1";
+      version = "2.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/domutils/-/domutils-2.4.1.tgz";
-        sha512 = "AA5r2GD1Dljhxc+k4zD2HYQaDkDPBhTqmqF55wLNlxfhFQlqaYME8Jhmo2nKNBb+CNfPXE8SAjtF6SsZ0cza/w==";
+        url = "https://registry.npmjs.org/domutils/-/domutils-2.4.2.tgz";
+        sha512 = "NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==";
       };
     };
     "dot-case-3.0.3" = {
@@ -16754,13 +18113,13 @@ let
         sha512 = "dldq3ZfFtgVTJMLjOe+/3sROTzALlL9E34V4/sDtUd/KlBSS0s6U1/+WPE1B4sj9CXHJpL1M6rhNJnc9Wbal9w==";
       };
     };
-    "electron-to-chromium-1.3.576" = {
+    "electron-to-chromium-1.3.578" = {
       name = "electron-to-chromium";
       packageName = "electron-to-chromium";
-      version = "1.3.576";
+      version = "1.3.578";
       src = fetchurl {
-        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.576.tgz";
-        sha512 = "uSEI0XZ//5ic+0NdOqlxp0liCD44ck20OAGyLMSymIWTEAtHKVJi6JM18acOnRgUgX7Q65QqnI+sNncNvIy8ew==";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.578.tgz";
+        sha512 = "z4gU6dA1CbBJsAErW5swTGAaU2TBzc2mPAonJb00zqW1rOraDo2zfBMDRvaz9cVic+0JEZiYbHWPw/fTaZlG2Q==";
       };
     };
     "elegant-spinner-1.0.1" = {
@@ -16888,6 +18247,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz";
         sha512 = "5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==";
+      };
+    };
+    "emojis-list-2.1.0" = {
+      name = "emojis-list";
+      packageName = "emojis-list";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz";
+        sha1 = "4daa4d9db00f9819880c79fa457ae5b09a1fd389";
       };
     };
     "emojis-list-3.0.0" = {
@@ -17160,6 +18528,15 @@ let
         sha512 = "AOiNZ3lmxrtva3r/roqaYDF+1PX2V+ouUzuGqJf7KNxyyYkuU+CsfFbbUeibQPdixxjI/lP6eDtvtkX1/wymJw==";
       };
     };
+    "env-editor-0.4.1" = {
+      name = "env-editor";
+      packageName = "env-editor";
+      version = "0.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/env-editor/-/env-editor-0.4.1.tgz";
+        sha512 = "suh+Vm00GnPQgXpmONTkcUT9LgBSL6sJrRnJxbykT0j+ONjzmIS+1U3ne467ArdZN/42/npp+GnhtwkLQ+vUjw==";
+      };
+    };
     "env-paths-1.0.0" = {
       name = "env-paths";
       packageName = "env-paths";
@@ -17203,6 +18580,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/envinfo/-/envinfo-7.7.3.tgz";
         sha512 = "46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==";
+      };
+    };
+    "eol-0.9.1" = {
+      name = "eol";
+      packageName = "eol";
+      version = "0.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz";
+        sha512 = "Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==";
       };
     };
     "epidemic-broadcast-trees-7.0.0" = {
@@ -17286,22 +18672,22 @@ let
         sha512 = "rcOwbfvP1WTViVoUjcfZicVzjhjTuhSMntHh6mW3IrEiyE6mJyXvsToJUJGlGlw/2xU9P5whlWNGlIDVeCiT4A==";
       };
     };
-    "es-abstract-1.17.6" = {
+    "es-abstract-1.17.7" = {
       name = "es-abstract";
       packageName = "es-abstract";
-      version = "1.17.6";
+      version = "1.17.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz";
-        sha512 = "Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==";
+        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz";
+        sha512 = "VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==";
       };
     };
-    "es-abstract-1.18.0-next.0" = {
+    "es-abstract-1.18.0-next.1" = {
       name = "es-abstract";
       packageName = "es-abstract";
-      version = "1.18.0-next.0";
+      version = "1.18.0-next.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz";
-        sha512 = "elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==";
+        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz";
+        sha512 = "I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==";
       };
     };
     "es-array-method-boxes-properly-1.0.0" = {
@@ -17347,6 +18733,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz";
         sha1 = "aba8d9e1943a895ac96837a62a39b3f55ecd94ab";
+      };
+    };
+    "es6-error-3.2.0" = {
+      name = "es6-error";
+      packageName = "es6-error";
+      version = "3.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/es6-error/-/es6-error-3.2.0.tgz";
+        sha1 = "e567cfdcb324d4e7ae5922a3700ada5de879a0ca";
       };
     };
     "es6-error-4.1.1" = {
@@ -17664,13 +19059,13 @@ let
         sha512 = "Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==";
       };
     };
-    "eslint-plugin-vue-7.0.0" = {
+    "eslint-plugin-vue-7.0.1" = {
       name = "eslint-plugin-vue";
       packageName = "eslint-plugin-vue";
-      version = "7.0.0";
+      version = "7.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.0.0.tgz";
-        sha512 = "SFcM8ZMdVRUQKrAryl6Q5razrJtloATUOKTZoK/8yvQig1c1L3VRoMLL9AXiV3VNsKXolkk6yeMIiqGf33/Iew==";
+        url = "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.0.1.tgz";
+        sha512 = "Pzl88S8Gue9BPcvSg+K/Av2V5UlwGeBxiZW5cLYbDngHm7vLnSuO/q2n54kIyCqfPmuD5PKlJrNSzoN+Ur9HRg==";
       };
     };
     "eslint-scope-3.7.3" = {
@@ -18186,6 +19581,15 @@ let
         sha512 = "/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==";
       };
     };
+    "exec-async-2.2.0" = {
+      name = "exec-async";
+      packageName = "exec-async";
+      version = "2.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/exec-async/-/exec-async-2.2.0.tgz";
+        sha1 = "c7c5ad2eef3478d38390c6dd3acfe8af0efc8301";
+      };
+    };
     "exec-sh-0.2.2" = {
       name = "exec-sh";
       packageName = "exec-sh";
@@ -18294,6 +19698,24 @@ let
         sha512 = "8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==";
       };
     };
+    "exeunt-1.1.0" = {
+      name = "exeunt";
+      packageName = "exeunt";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/exeunt/-/exeunt-1.1.0.tgz";
+        sha1 = "af72db6f94b3cb75e921aee375d513049843d284";
+      };
+    };
+    "exif-parser-0.1.12" = {
+      name = "exif-parser";
+      packageName = "exif-parser";
+      version = "0.1.12";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz";
+        sha1 = "58a9d2d72c02c1f6f02a0ef4a9166272b7760922";
+      };
+    };
     "exit-0.1.2" = {
       name = "exit";
       packageName = "exit";
@@ -18375,6 +19797,15 @@ let
         sha1 = "a793d3ac0cad4c6ab571e9968fbbab6cb2532929";
       };
     };
+    "expo-pwa-0.0.44" = {
+      name = "expo-pwa";
+      packageName = "expo-pwa";
+      version = "0.0.44";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/expo-pwa/-/expo-pwa-0.0.44.tgz";
+        sha512 = "GB5HKftWXh3G43kftpD/ZhuHIKSukW+7eA1UdxkIKkNVqHy2Co3CNrVQFogDl5H3XY744rJKXJj5Jnz/jMxOtg==";
+      };
+    };
     "express-2.5.11" = {
       name = "express";
       packageName = "express";
@@ -18391,6 +19822,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/express/-/express-3.4.4.tgz";
         sha1 = "0b63ae626c96b71b78d13dfce079c10351635a86";
+      };
+    };
+    "express-4.16.4" = {
+      name = "express";
+      packageName = "express";
+      version = "4.16.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/express/-/express-4.16.4.tgz";
+        sha512 = "j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==";
       };
     };
     "express-4.17.1" = {
@@ -18870,13 +20310,13 @@ let
         sha1 = "3d8a5c66883a16a30ca8643e851f19baa7797917";
       };
     };
-    "fast-redact-2.0.0" = {
+    "fast-redact-2.1.0" = {
       name = "fast-redact";
       packageName = "fast-redact";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz";
-        sha512 = "zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA==";
+        url = "https://registry.npmjs.org/fast-redact/-/fast-redact-2.1.0.tgz";
+        sha512 = "0LkHpTLyadJavq9sRzzyqIoMZemWli77K2/MGOkafrR64B9ItrvZ9aT+jluvNDsv0YEHjSNhlMBtbokuoqii4A==";
       };
     };
     "fast-safe-stringify-1.2.3" = {
@@ -19050,6 +20490,15 @@ let
         sha512 = "0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==";
       };
     };
+    "figlet-1.5.0" = {
+      name = "figlet";
+      packageName = "figlet";
+      version = "1.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/figlet/-/figlet-1.5.0.tgz";
+        sha512 = "ZQJM4aifMpz6H19AW1VqvZ7l4pOE9p7i/3LyxgO2kp+PO/VcDYNqIHEMtkccqIhTXMKci4kjueJr/iCQEaT/Ww==";
+      };
+    };
     "figures-1.7.0" = {
       name = "figures";
       packageName = "figures";
@@ -19093,6 +20542,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz";
         sha512 = "bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==";
+      };
+    };
+    "file-loader-6.0.0" = {
+      name = "file-loader";
+      packageName = "file-loader";
+      version = "6.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/file-loader/-/file-loader-6.0.0.tgz";
+        sha512 = "/aMOAYEFXDdjG0wytpTL5YQLfZnnTmLNjn+AIrJ/6HVnTfDqLsVKUUwkDf4I4kgex36BvjuXEn/TX9B/1ESyqQ==";
       };
     };
     "file-size-0.0.5" = {
@@ -19176,6 +20634,15 @@ let
         sha512 = "qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==";
       };
     };
+    "file-type-9.0.0" = {
+      name = "file-type";
+      packageName = "file-type";
+      version = "9.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz";
+        sha512 = "Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==";
+      };
+    };
     "file-uri-to-path-1.0.0" = {
       name = "file-uri-to-path";
       packageName = "file-uri-to-path";
@@ -19248,6 +20715,15 @@ let
         sha512 = "7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==";
       };
     };
+    "filesize-6.0.1" = {
+      name = "filesize";
+      packageName = "filesize";
+      version = "6.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz";
+        sha512 = "u4AYWPgbI5GBhs6id1KdImZWn5yfyFrrQ8OWZdN7ZMfA8Bf4HcO0BGo9bmUIEV8yrp8I1xVfJ/dn90GtFNNJcg==";
+      };
+    };
     "filesize-6.1.0" = {
       name = "filesize";
       packageName = "filesize";
@@ -19300,6 +20776,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/filter-obj/-/filter-obj-2.0.1.tgz";
         sha512 = "yDEp513p7+iLdFHWBVdZFnRiOYwg8ZqmpaAiZCMjzqsbo7tCS4Qm4ulXOht337NGzkukKa9u3W4wqQ9tQPm3Ug==";
+      };
+    };
+    "finalhandler-1.1.1" = {
+      name = "finalhandler";
+      packageName = "finalhandler";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz";
+        sha512 = "Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==";
       };
     };
     "finalhandler-1.1.2" = {
@@ -19410,6 +20895,15 @@ let
         sha512 = "dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==";
       };
     };
+    "find-yarn-workspace-root-2.0.0" = {
+      name = "find-yarn-workspace-root";
+      packageName = "find-yarn-workspace-root";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz";
+        sha512 = "1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==";
+      };
+    };
     "findit-1.2.0" = {
       name = "findit";
       packageName = "findit";
@@ -19455,13 +20949,13 @@ let
         sha512 = "ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==";
       };
     };
-    "firefox-profile-2.0.0" = {
+    "firefox-profile-4.0.0" = {
       name = "firefox-profile";
       packageName = "firefox-profile";
-      version = "2.0.0";
+      version = "4.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/firefox-profile/-/firefox-profile-2.0.0.tgz";
-        sha512 = "BPfcUISOV6+UwF6uqo5QS8iuFL6XZvHCm+1iuynIJ7fe1zea69Is77/n/098fp0a9sZ94lvT8rpYB15S/riSaA==";
+        url = "https://registry.npmjs.org/firefox-profile/-/firefox-profile-4.0.0.tgz";
+        sha512 = "Vw31AsjfLDbcApMDwwnhZcz3tWjV6lxB9BNf84FaV44rZXtU87cVbFMBzPEtrJdUDbwPYiuYzprp6yksYGwjSw==";
       };
     };
     "first-chunk-stream-2.0.0" = {
@@ -19626,13 +21120,13 @@ let
         sha512 = "jlbUu0XkbpXeXhan5xyTqVK1jmEKNxE8hpzznI3TThHTr76GiFwK0iRzhDo4KNy+S9h/KxHaqVhTP86vA6wHCg==";
       };
     };
-    "flow-parser-0.134.0" = {
+    "flow-parser-0.135.0" = {
       name = "flow-parser";
       packageName = "flow-parser";
-      version = "0.134.0";
+      version = "0.135.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.134.0.tgz";
-        sha512 = "VmRba5YXKmVqIH3xNzUJ4pNobxXEOl6h36m+0f5dZ6/av9YlRpls/yBnPESQ4qBUbyyp7iqoc1Feo1lFw3u1YQ==";
+        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.135.0.tgz";
+        sha512 = "ev8SvmG+XU9D6WgHVezP4kY3Myr1tJvTUTEi7mbhhj+rn889K7YXdakte6oqXNLIJYJ2f5Fuw18zXTVa1NO8Kw==";
       };
     };
     "fluent-ffmpeg-2.1.2" = {
@@ -19905,6 +21399,15 @@ let
         sha512 = "47VfT5AYpxn1bnsnH6UfpBWKpMVnSz42MZwH+hwz/wACd9THyUu/fRoCRIT758fzCAbRoHIlkVUAL+WmlxSKeg==";
       };
     };
+    "fork-ts-checker-webpack-plugin-3.1.1" = {
+      name = "fork-ts-checker-webpack-plugin";
+      packageName = "fork-ts-checker-webpack-plugin";
+      version = "3.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-3.1.1.tgz";
+        sha512 = "DuVkPNrM12jR41KM2e+N+styka0EgLkTnXmNcXdgOM37vtGeY+oCBK/Jx0hzSeEU6memFCtWb4htrHPMDfwwUQ==";
+      };
+    };
     "fork-ts-checker-webpack-plugin-5.1.0" = {
       name = "fork-ts-checker-webpack-plugin";
       packageName = "fork-ts-checker-webpack-plugin";
@@ -20056,6 +21559,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/freelist/-/freelist-1.0.3.tgz";
         sha1 = "006775509f3935701784d3ed2fc9f12c9df1bab2";
+      };
+    };
+    "freeport-async-2.0.0" = {
+      name = "freeport-async";
+      packageName = "freeport-async";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/freeport-async/-/freeport-async-2.0.0.tgz";
+        sha512 = "K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==";
       };
     };
     "fresh-0.1.0" = {
@@ -20472,6 +21984,15 @@ let
         sha1 = "979e22f9451b4b38f051f7937c919dbacc692958";
       };
     };
+    "fwd-stream-1.0.4" = {
+      name = "fwd-stream";
+      packageName = "fwd-stream";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fwd-stream/-/fwd-stream-1.0.4.tgz";
+        sha1 = "ed281cabed46feecf921ee32dc4c50b372ac7cfa";
+      };
+    };
     "fx-runner-1.0.13" = {
       name = "fx-runner";
       packageName = "fx-runner";
@@ -20643,6 +22164,15 @@ let
         sha1 = "ead774abee72e20409433a066366023dd6887a41";
       };
     };
+    "get-own-enumerable-property-symbols-3.0.2" = {
+      name = "get-own-enumerable-property-symbols";
+      packageName = "get-own-enumerable-property-symbols";
+      version = "3.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz";
+        sha512 = "I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==";
+      };
+    };
     "get-package-type-0.1.0" = {
       name = "get-package-type";
       packageName = "get-package-type";
@@ -20803,6 +22333,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz";
         sha1 = "dc15ca1c672387ca76bd37ac0a395ba2042a2c28";
+      };
+    };
+    "getenv-0.7.0" = {
+      name = "getenv";
+      packageName = "getenv";
+      version = "0.7.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/getenv/-/getenv-0.7.0.tgz";
+        sha1 = "39b91838707e2086fd1cf6ef8777d1c93e14649e";
       };
     };
     "getmac-5.16.0" = {
@@ -21670,6 +23209,15 @@ let
         sha512 = "jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==";
       };
     };
+    "graphql-0.13.2" = {
+      name = "graphql";
+      packageName = "graphql";
+      version = "0.13.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz";
+        sha512 = "QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==";
+      };
+    };
     "graphql-14.7.0" = {
       name = "graphql";
       packageName = "graphql";
@@ -21733,6 +23281,15 @@ let
         sha512 = "VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==";
       };
     };
+    "graphql-tools-3.0.0" = {
+      name = "graphql-tools";
+      packageName = "graphql-tools";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/graphql-tools/-/graphql-tools-3.0.0.tgz";
+        sha512 = "orcLQm0pc6dcIvFyAudgmno/akZy07bbMalTv5dj6B8uW2ZPmwIANr7pDEJoiumb67h2kZjsU9yvgTwmF0kMPQ==";
+      };
+    };
     "graphql-tools-4.0.8" = {
       name = "graphql-tools";
       packageName = "graphql-tools";
@@ -21740,15 +23297,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.8.tgz";
         sha512 = "MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==";
-      };
-    };
-    "graphql-type-json-0.2.4" = {
-      name = "graphql-type-json";
-      packageName = "graphql-type-json";
-      version = "0.2.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.2.4.tgz";
-        sha512 = "/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w==";
       };
     };
     "graphql-type-json-0.3.2" = {
@@ -21956,6 +23504,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.2.tgz";
         sha512 = "4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==";
+      };
+    };
+    "gzip-size-5.1.1" = {
+      name = "gzip-size";
+      packageName = "gzip-size";
+      version = "5.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz";
+        sha512 = "FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==";
       };
     };
     "handle-thing-2.0.1" = {
@@ -22264,6 +23821,15 @@ let
         sha512 = "UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==";
       };
     };
+    "hasbin-1.2.3" = {
+      name = "hasbin";
+      packageName = "hasbin";
+      version = "1.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hasbin/-/hasbin-1.2.3.tgz";
+        sha1 = "78c5926893c80215c2b568ae1fd3fcab7a2696b0";
+      };
+    };
     "hash-base-3.1.0" = {
       name = "hash-base";
       packageName = "hash-base";
@@ -22316,6 +23882,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/hasher/-/hasher-1.2.0.tgz";
         sha1 = "8b5341c3496124b0724ac8555fbb8ca363ebbb73";
+      };
+    };
+    "hashids-1.1.4" = {
+      name = "hashids";
+      packageName = "hashids";
+      version = "1.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hashids/-/hashids-1.1.4.tgz";
+        sha512 = "U/fnTE3edW0AV92ZI/BfEluMZuVcu3MDOopsN7jS+HqDYcarQo8rXQiWlsBlm0uX48/taYSdxRsfzh2HRg5Z6w==";
       };
     };
     "hashish-0.0.4" = {
@@ -22624,6 +24199,15 @@ let
         sha1 = "20bb7403d3cea398e91dc4710a8ff1b8274a25ed";
       };
     };
+    "hoek-4.2.1" = {
+      name = "hoek";
+      packageName = "hoek";
+      version = "4.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz";
+        sha512 = "QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==";
+      };
+    };
     "hogan.js-3.0.2" = {
       name = "hogan.js";
       packageName = "hogan.js";
@@ -22741,6 +24325,15 @@ let
         sha512 = "rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==";
       };
     };
+    "html-loader-1.1.0" = {
+      name = "html-loader";
+      packageName = "html-loader";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/html-loader/-/html-loader-1.1.0.tgz";
+        sha512 = "zwLbEgy+i7sgIYTlxI9M7jwkn29IvdsV6f1y7a2aLv/w8l1RigVk0PFijBZLLFsdi2gvL8sf2VJhTjLlfnK8sA==";
+      };
+    };
     "html-minifier-3.5.21" = {
       name = "html-minifier";
       packageName = "html-minifier";
@@ -22748,6 +24341,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz";
         sha512 = "LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==";
+      };
+    };
+    "html-minifier-terser-5.1.1" = {
+      name = "html-minifier-terser";
+      packageName = "html-minifier-terser";
+      version = "5.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz";
+        sha512 = "ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==";
       };
     };
     "html-tags-1.2.0" = {
@@ -22784,6 +24386,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz";
         sha512 = "uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==";
+      };
+    };
+    "html-webpack-plugin-4.3.0" = {
+      name = "html-webpack-plugin";
+      packageName = "html-webpack-plugin";
+      version = "4.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.3.0.tgz";
+        sha512 = "C0fzKN8yQoVLTelcJxZfJCE+aAvQiY2VUf3UuKrR4a9k5UMWYOtpDLsaXwATbcVCnI05hUS7L9ULQHWLZhyi3w==";
       };
     };
     "html-whitespace-sensitive-tag-names-1.0.3" = {
@@ -23291,6 +24902,15 @@ let
         sha512 = "98ELn/dqep00DQ/v1E1gpM21HNN6nqU3mS85mYKd9P7lXrhfUcuysPaa3HviKSFb3WPdjf7avuAST3P0dhNp/A==";
       };
     };
+    "iconv-lite-0.4.23" = {
+      name = "iconv-lite";
+      packageName = "iconv-lite";
+      version = "0.4.23";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz";
+        sha512 = "neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==";
+      };
+    };
     "iconv-lite-0.4.24" = {
       name = "iconv-lite";
       packageName = "iconv-lite";
@@ -23343,6 +24963,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/idb-kv-store/-/idb-kv-store-4.5.0.tgz";
         sha512 = "snvtAQRforYUI+C2+45L2LBJy/0/uQUffxv8/uwiS98fSUoXHVrFPClgzWZWxT0drwkLHJRm9inZcYzTR42GLA==";
+      };
+    };
+    "idb-wrapper-1.7.2" = {
+      name = "idb-wrapper";
+      packageName = "idb-wrapper";
+      version = "1.7.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz";
+        sha512 = "zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg==";
+      };
+    };
+    "idx-2.4.0" = {
+      name = "idx";
+      packageName = "idx";
+      version = "2.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/idx/-/idx-2.4.0.tgz";
+        sha512 = "FnV6fXF1/cXvam/OXAz98v3GbhQVws+ecMEVLxyQ1aXgK2nooTkTDqex5Lks84wiCsS1So6QtwwCYT6H+vIKkw==";
       };
     };
     "ieee754-1.1.13" = {
@@ -23478,6 +25116,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/immediate-chunk-store/-/immediate-chunk-store-2.1.0.tgz";
         sha512 = "QshP0SFpsy/bHQBjYMgzCcnLoqTj6PHFg8ZkPi2WbTw1qddNy0puuPDaFlXyrsZAdWMT3QziPDMzfj+mzCVMYg==";
+      };
+    };
+    "immer-1.10.0" = {
+      name = "immer";
+      packageName = "immer";
+      version = "1.10.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz";
+        sha512 = "O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==";
       };
     };
     "import-cwd-2.1.0" = {
@@ -23741,13 +25388,13 @@ let
         sha512 = "zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==";
       };
     };
-    "ink-3.0.6" = {
+    "ink-3.0.7" = {
       name = "ink";
       packageName = "ink";
-      version = "3.0.6";
+      version = "3.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ink/-/ink-3.0.6.tgz";
-        sha512 = "MOaRUKlDdyzBr6IhiBpBA5+9tv+OlVvQrEErQlN2dfofJ0Q52Xc3gZ5YtgGj0UVD24Ex79WL2QZGJh0emz+jDQ==";
+        url = "https://registry.npmjs.org/ink/-/ink-3.0.7.tgz";
+        sha512 = "DF/Ena9E8af4+dYu4rrk60WwWB54CPL4s4OspDnBk0uZqntmNZLfc4PftreHeW3sUeQJK+2MdQvPLORro7mDQQ==";
       };
     };
     "ink-text-input-4.0.1" = {
@@ -23885,13 +25532,13 @@ let
         sha512 = "JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==";
       };
     };
-    "inquirer-autocomplete-prompt-1.1.0" = {
+    "inquirer-autocomplete-prompt-1.2.0" = {
       name = "inquirer-autocomplete-prompt";
       packageName = "inquirer-autocomplete-prompt";
-      version = "1.1.0";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.1.0.tgz";
-        sha512 = "mrSeUSFGnTSid/DCKG+E+IcN4MaOnT2bW7NuSagZAguD4k3hZ0UladdYNP4EstZOwgeqv0C3M1zYa1QIIf0Oyg==";
+        url = "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.2.0.tgz";
+        sha512 = "t8A0gFq0mOKGz8wmGBPh+M/AC8KSMMcn7dnHXzLWyKvLiRYWswQ6rg7d938hoR5tVP1GpHVmHOR6YP8G5dYhhQ==";
       };
     };
     "insert-module-globals-7.2.0" = {
@@ -23973,15 +25620,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/inspect-property/-/inspect-property-0.0.6.tgz";
         sha512 = "LgjHkRl9W6bj2n+kWrAOgvCYPTYt+LanE4rtd/vKNq6yEb+SvVV7UTLzoSPpDX6/U1cAz7VfqPr+lPAIz7wHaQ==";
-      };
-    };
-    "inspect-with-kind-1.0.5" = {
-      name = "inspect-with-kind";
-      packageName = "inspect-with-kind";
-      version = "1.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/inspect-with-kind/-/inspect-with-kind-1.0.5.tgz";
-        sha512 = "MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==";
       };
     };
     "int53-1.0.0" = {
@@ -24207,6 +25845,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz";
         sha1 = "2ca9b033651111855412f16be5d77c62a458a766";
+      };
+    };
+    "is-0.2.7" = {
+      name = "is";
+      packageName = "is";
+      version = "0.2.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is/-/is-0.2.7.tgz";
+        sha1 = "3b34a2c48f359972f35042849193ae7264b63562";
       };
     };
     "is-3.3.0" = {
@@ -24902,6 +26549,15 @@ let
         sha512 = "96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==";
       };
     };
+    "is-npm-5.0.0" = {
+      name = "is-npm";
+      packageName = "is-npm";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz";
+        sha512 = "WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==";
+      };
+    };
     "is-number-2.1.0" = {
       name = "is-number";
       packageName = "is-number";
@@ -24963,6 +26619,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz";
         sha512 = "drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==";
+      };
+    };
+    "is-object-0.1.2" = {
+      name = "is-object";
+      packageName = "is-object";
+      version = "0.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz";
+        sha1 = "00efbc08816c33cfc4ac8251d132e10dc65098d7";
       };
     };
     "is-object-1.0.1" = {
@@ -25073,6 +26738,15 @@ let
         sha512 = "VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==";
       };
     };
+    "is-port-reachable-2.0.1" = {
+      name = "is-port-reachable";
+      packageName = "is-port-reachable";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-2.0.1.tgz";
+        sha512 = "SqU55C5gkitgOhl2ccd2v23MbkbcOFa5e4aPo8h8VGqOifh7iDwG44bQBWGW/lZulTjl9AWIKP0NiUWpa+TtWA==";
+      };
+    };
     "is-posix-bracket-0.1.1" = {
       name = "is-posix-bracket";
       packageName = "is-posix-bracket";
@@ -25116,6 +26790,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz";
         sha1 = "57fe1c4e48474edd65b09911f26b1cd4095dda84";
+      };
+    };
+    "is-reachable-4.0.0" = {
+      name = "is-reachable";
+      packageName = "is-reachable";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-reachable/-/is-reachable-4.0.0.tgz";
+        sha512 = "eCTBKm9K6nO3H1S3BrJBAqZJIVXKNdwDuGl6KHf1bnf/bn02BvEe+l+MypjsxbqZ7mt5oMhu+bS/mm7G2FRW3A==";
       };
     };
     "is-redirect-1.0.0" = {
@@ -25233,6 +26916,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz";
         sha1 = "07b6c233bc394cd9d02ba15c966bd6660d6342d5";
+      };
+    };
+    "is-root-2.1.0" = {
+      name = "is-root";
+      packageName = "is-root";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz";
+        sha512 = "AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==";
       };
     };
     "is-scoped-1.0.0" = {
@@ -25541,6 +27233,15 @@ let
         sha512 = "ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg==";
       };
     };
+    "isbuffer-0.0.0" = {
+      name = "isbuffer";
+      packageName = "isbuffer";
+      version = "0.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/isbuffer/-/isbuffer-0.0.0.tgz";
+        sha1 = "38c146d9df528b8bf9b0701c3d43cf12df3fc39b";
+      };
+    };
     "isemail-3.2.0" = {
       name = "isemail";
       packageName = "isemail";
@@ -25683,6 +27384,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz";
         sha512 = "1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==";
+      };
+    };
+    "iterall-1.2.2" = {
+      name = "iterall";
+      packageName = "iterall";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz";
+        sha512 = "yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==";
       };
     };
     "iterall-1.3.0" = {
@@ -25856,13 +27566,22 @@ let
         sha512 = "/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==";
       };
     };
-    "jest-worker-26.3.0" = {
+    "jest-worker-26.5.0" = {
       name = "jest-worker";
       packageName = "jest-worker";
-      version = "26.3.0";
+      version = "26.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz";
-        sha512 = "Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==";
+        url = "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz";
+        sha512 = "kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==";
+      };
+    };
+    "jetifier-1.6.6" = {
+      name = "jetifier";
+      packageName = "jetifier";
+      version = "1.6.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jetifier/-/jetifier-1.6.6.tgz";
+        sha512 = "JNAkmPeB/GS2tCRqUzRPsTOHpGDah7xP18vGJfIjZC+W2sxEHbxgJxetIjIqhjQ3yYbYNEELkM/spKLtwoOSUQ==";
       };
     };
     "jetpack-id-1.0.0" = {
@@ -25872,6 +27591,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/jetpack-id/-/jetpack-id-1.0.0.tgz";
         sha1 = "2cf9fbae46d8074fc16b7de0071c8efebca473a6";
+      };
+    };
+    "jimp-0.9.8" = {
+      name = "jimp";
+      packageName = "jimp";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jimp/-/jimp-0.9.8.tgz";
+        sha512 = "DHN4apKMwLIvD/TKO9tFfPuankNuVK98vCwHm/Jv9z5cJnrd38xhi+4I7IAGmDU3jIDlrEVhzTkFH1Ymv5yTQQ==";
       };
     };
     "jju-1.4.0" = {
@@ -25901,6 +27629,24 @@ let
         sha1 = "06d4912255093419477d425633606e0e90782967";
       };
     };
+    "joi-11.4.0" = {
+      name = "joi";
+      packageName = "joi";
+      version = "11.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz";
+        sha512 = "O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==";
+      };
+    };
+    "join-component-1.1.0" = {
+      name = "join-component";
+      packageName = "join-component";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz";
+        sha1 = "b8417b750661a392bee2c2537c68b2a9d4977cd5";
+      };
+    };
     "joplin-turndown-4.0.29" = {
       name = "joplin-turndown";
       packageName = "joplin-turndown";
@@ -25917,6 +27663,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/joplin-turndown-plugin-gfm/-/joplin-turndown-plugin-gfm-1.0.12.tgz";
         sha512 = "qL4+1iycQjZ1fs8zk3jSRk7cg3ROBUHk7GKtiLAQLFzLPKErnILUvz5DLszSQvz3s1sTjPbywLDISVUtBY6HaA==";
+      };
+    };
+    "jpeg-js-0.3.7" = {
+      name = "jpeg-js";
+      packageName = "jpeg-js";
+      version = "0.3.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz";
+        sha512 = "9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==";
       };
     };
     "jpeg-js-0.4.2" = {
@@ -26252,6 +28007,15 @@ let
         sha512 = "3OvjqKdCBvH41DLpV4iSt6v2XhZXV1bPB4OROuknvUXI7ZQNofieCPkmE26stEJ9zdQuvIxDHCuYhfgxFAAs+Q==";
       };
     };
+    "json-ptr-1.3.2" = {
+      name = "json-ptr";
+      packageName = "json-ptr";
+      version = "1.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/json-ptr/-/json-ptr-1.3.2.tgz";
+        sha512 = "tFH40YQ+lG7mgYYM1kGZOhQngO4SbOEHZJlA4W+NtetWZ20EUU3BPU+30uWRKumuAJoSo5eqrsXD2h72ioS8ew==";
+      };
+    };
     "json-refs-2.1.7" = {
       name = "json-refs";
       packageName = "json-refs";
@@ -26549,13 +28313,13 @@ let
         sha1 = "3f4dae4a91fac315f71062f8521cc239f1366280";
       };
     };
-    "jsonpath-plus-3.0.0" = {
+    "jsonpath-plus-4.0.0" = {
       name = "jsonpath-plus";
       packageName = "jsonpath-plus";
-      version = "3.0.0";
+      version = "4.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-3.0.0.tgz";
-        sha512 = "WQwgWEBgn+SJU1tlDa/GiY5/ngRpa9yrSj8n4BYPHcwoxTDaMEaYCHMOn42hIHHDd3CrUoRr3+HpsK0hCKoxzA==";
+        url = "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-4.0.0.tgz";
+        sha512 = "e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==";
       };
     };
     "jsonpointer-4.1.0" = {
@@ -26738,6 +28502,15 @@ let
         sha1 = "7d86bd56679f58ce6a84704a657dd392bba81a79";
       };
     };
+    "jwt-decode-3.0.0" = {
+      name = "jwt-decode";
+      packageName = "jwt-decode";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.0.0.tgz";
+        sha512 = "RBQv2MTm3FNKQkdzhEyQwh5MbdNgMa+FyIJIK5RMWEn6hRgRHr7j55cRxGhRe6vGJDElyi6f6u/yfkP7AoXddA==";
+      };
+    };
     "k-bucket-0.6.0" = {
       name = "k-bucket";
       packageName = "k-bucket";
@@ -26899,6 +28672,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/keyboardevent-key-polyfill/-/keyboardevent-key-polyfill-1.1.0.tgz";
         sha1 = "8a319d8e45a13172fca56286372f90c1d4c7014c";
+      };
+    };
+    "keychain-1.3.0" = {
+      name = "keychain";
+      packageName = "keychain";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/keychain/-/keychain-1.3.0.tgz";
+        sha1 = "ccb8ddc64a62f34d541ac25e612186442a432410";
       };
     };
     "keygrip-1.1.0" = {
@@ -27063,13 +28845,13 @@ let
         sha512 = "wRJ9I4az0QcsH7A4v4l0enUpkS++MBx0BnL/68KaLzJg7x1qmbjSlwEoCNol7KTYZ+pmtI7Eh2J0Nu6/2Z5J/Q==";
       };
     };
-    "known-css-properties-0.14.0" = {
+    "known-css-properties-0.19.0" = {
       name = "known-css-properties";
       packageName = "known-css-properties";
-      version = "0.14.0";
+      version = "0.19.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.14.0.tgz";
-        sha512 = "P+0a/gBzLgVlCnK8I7VcD0yuYJscmWn66wH9tlKsQnmVdg689tLEmziwB9PuazZYLkcm07fvWOKCJJqI55sD5Q==";
+        url = "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.19.0.tgz";
+        sha512 = "eYboRV94Vco725nKMlpkn3nV2+96p9c3gKXRsYqAJSswSENvBhN7n5L+uDhY58xQa0UukWsDMTGELzmD8Q+wTA==";
       };
     };
     "known-css-properties-0.5.0" = {
@@ -27133,6 +28915,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lambda-local/-/lambda-local-1.7.3.tgz";
         sha512 = "T+iwIkuQT0JvTQhvNBTikLhpEJk3ovNoC33niE4QNmYOUrCOdo86PcPkgppOZl+NJXXHebdPHDJ40zqBJ9VMzg==";
+      };
+    };
+    "last-call-webpack-plugin-3.0.0" = {
+      name = "last-call-webpack-plugin";
+      packageName = "last-call-webpack-plugin";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz";
+        sha512 = "7KI2l2GIZa9p2spzPIVZBYyNKkN+e/SQPpnjlTiPhdbDW3F86tdKKELxKpzJ5sgU19wQWsACULZmpTPYHeWO5w==";
       };
     };
     "last-one-wins-1.0.4" = {
@@ -27360,6 +29151,15 @@ let
         sha512 = "psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==";
       };
     };
+    "level-blobs-0.1.7" = {
+      name = "level-blobs";
+      packageName = "level-blobs";
+      version = "0.1.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-blobs/-/level-blobs-0.1.7.tgz";
+        sha1 = "9ab9b97bb99f1edbf9f78a3433e21ed56386bdaf";
+      };
+    };
     "level-codec-6.2.0" = {
       name = "level-codec";
       packageName = "level-codec";
@@ -27396,6 +29196,42 @@ let
         sha512 = "UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==";
       };
     };
+    "level-filesystem-1.2.0" = {
+      name = "level-filesystem";
+      packageName = "level-filesystem";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-filesystem/-/level-filesystem-1.2.0.tgz";
+        sha1 = "a00aca9919c4a4dfafdca6a8108d225aadff63b3";
+      };
+    };
+    "level-fix-range-1.0.2" = {
+      name = "level-fix-range";
+      packageName = "level-fix-range";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-fix-range/-/level-fix-range-1.0.2.tgz";
+        sha1 = "bf15b915ae36d8470c821e883ddf79cd16420828";
+      };
+    };
+    "level-fix-range-2.0.0" = {
+      name = "level-fix-range";
+      packageName = "level-fix-range";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-fix-range/-/level-fix-range-2.0.0.tgz";
+        sha1 = "c417d62159442151a19d9a2367868f1724c2d548";
+      };
+    };
+    "level-hooks-4.5.0" = {
+      name = "level-hooks";
+      packageName = "level-hooks";
+      version = "4.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-hooks/-/level-hooks-4.5.0.tgz";
+        sha1 = "1b9ae61922930f3305d1a61fc4d83c8102c0dd93";
+      };
+    };
     "level-iterator-stream-4.0.2" = {
       name = "level-iterator-stream";
       packageName = "level-iterator-stream";
@@ -27403,6 +29239,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz";
         sha512 = "ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==";
+      };
+    };
+    "level-js-2.2.4" = {
+      name = "level-js";
+      packageName = "level-js";
+      version = "2.2.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz";
+        sha1 = "bc055f4180635d4489b561c9486fa370e8c11697";
       };
     };
     "level-js-4.0.2" = {
@@ -27432,6 +29277,15 @@ let
         sha512 = "HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==";
       };
     };
+    "level-peek-1.0.6" = {
+      name = "level-peek";
+      packageName = "level-peek";
+      version = "1.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-peek/-/level-peek-1.0.6.tgz";
+        sha1 = "bec51c72a82ee464d336434c7c876c3fcbcce77f";
+      };
+    };
     "level-post-1.0.7" = {
       name = "level-post";
       packageName = "level-post";
@@ -27439,6 +29293,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz";
         sha512 = "PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==";
+      };
+    };
+    "level-sublevel-5.2.3" = {
+      name = "level-sublevel";
+      packageName = "level-sublevel";
+      version = "5.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-sublevel/-/level-sublevel-5.2.3.tgz";
+        sha1 = "744c12c72d2e72be78dde3b9b5cd84d62191413a";
       };
     };
     "level-supports-1.0.1" = {
@@ -27457,6 +29320,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/leveldown/-/leveldown-5.6.0.tgz";
         sha512 = "iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==";
+      };
+    };
+    "levelup-0.18.6" = {
+      name = "levelup";
+      packageName = "levelup";
+      version = "0.18.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/levelup/-/levelup-0.18.6.tgz";
+        sha1 = "e6a01cb089616c8ecc0291c2a9bd3f0c44e3e5eb";
       };
     };
     "levelup-4.4.0" = {
@@ -27720,6 +29592,15 @@ let
         sha512 = "04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==";
       };
     };
+    "load-bmfont-1.4.1" = {
+      name = "load-bmfont";
+      packageName = "load-bmfont";
+      version = "1.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz";
+        sha512 = "8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==";
+      };
+    };
     "load-ip-set-2.1.0" = {
       name = "load-ip-set";
       packageName = "load-ip-set";
@@ -27781,6 +29662,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz";
         sha512 = "Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==";
+      };
+    };
+    "loader-utils-1.2.3" = {
+      name = "loader-utils";
+      packageName = "loader-utils";
+      version = "1.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz";
+        sha512 = "fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==";
       };
     };
     "loader-utils-1.4.0" = {
@@ -27846,6 +29736,15 @@ let
         sha512 = "iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==";
       };
     };
+    "lock-0.1.4" = {
+      name = "lock";
+      packageName = "lock";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lock/-/lock-0.1.4.tgz";
+        sha1 = "fec7deaef17e7c3a0a55e1da042803e25d91745d";
+      };
+    };
     "locks-0.2.2" = {
       name = "locks";
       packageName = "locks";
@@ -27855,13 +29754,13 @@ let
         sha1 = "259933d1327cbaf0fd3662f8fffde36809d84ced";
       };
     };
-    "locutus-2.0.12" = {
+    "locutus-2.0.14" = {
       name = "locutus";
       packageName = "locutus";
-      version = "2.0.12";
+      version = "2.0.14";
       src = fetchurl {
-        url = "https://registry.npmjs.org/locutus/-/locutus-2.0.12.tgz";
-        sha512 = "wnzhY9xOdDb2djr17kQhTh9oZgEfp78zI27KRRiiV1GnPXWA2xfVODbpH3QgpIuUMLupM02+6X/rJXvktTpnoA==";
+        url = "https://registry.npmjs.org/locutus/-/locutus-2.0.14.tgz";
+        sha512 = "0H1o1iHNEp3kJ5rW57bT/CAP5g6Qm0Zd817Wcx2+rOMTYyIJoc482Ja1v9dB6IUjwvWKcBNdYi7x2lRXtlJ3bA==";
       };
     };
     "lodash-2.4.2" = {
@@ -27898,6 +29797,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz";
         sha1 = "d22c9ac660288f3843e16ba7d2b5d06cca27d777";
+      };
+    };
+    "lodash-4.17.15" = {
+      name = "lodash";
+      packageName = "lodash";
+      version = "4.17.15";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz";
+        sha512 = "8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==";
       };
     };
     "lodash-4.17.19" = {
@@ -29097,6 +31005,15 @@ let
         sha512 = "Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==";
       };
     };
+    "logfmt-1.3.2" = {
+      name = "logfmt";
+      packageName = "logfmt";
+      version = "1.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/logfmt/-/logfmt-1.3.2.tgz";
+        sha512 = "U0lelcaGWEfEITZQXs8y5HrJp2xa0BJ+KDfkkLJRmuKbQIEVGNv145FbaNekY4ZYHJSBBx8NLJitaPtRqLEkxQ==";
+      };
+    };
     "logform-2.2.0" = {
       name = "logform";
       packageName = "logform";
@@ -29104,6 +31021,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz";
         sha512 = "N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==";
+      };
+    };
+    "logkitty-0.7.1" = {
+      name = "logkitty";
+      packageName = "logkitty";
+      version = "0.7.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/logkitty/-/logkitty-0.7.1.tgz";
+        sha512 = "/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==";
       };
     };
     "loglevel-1.7.0" = {
@@ -30213,6 +32139,15 @@ let
         sha512 = "xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==";
       };
     };
+    "md5hex-1.0.0" = {
+      name = "md5hex";
+      packageName = "md5hex";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/md5hex/-/md5hex-1.0.0.tgz";
+        sha1 = "ed74b477a2ee9369f75efee2f08d5915e52a42e8";
+      };
+    };
     "mdast-comment-marker-1.1.2" = {
       name = "mdast-comment-marker";
       packageName = "mdast-comment-marker";
@@ -30258,13 +32193,13 @@ let
         sha1 = "c04891883c28c83602e1d06b05a11037e359b4c8";
       };
     };
-    "mdn-browser-compat-data-1.0.35" = {
+    "mdn-browser-compat-data-1.0.39" = {
       name = "mdn-browser-compat-data";
       packageName = "mdn-browser-compat-data";
-      version = "1.0.35";
+      version = "1.0.39";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.35.tgz";
-        sha512 = "7SMAEZgBaElDNcqFhmInBnSo+c+MOzprt7hrGNcEo9hMhDiPQ7L4dwEt6gunudjI0jXenPJaW0S8U4ckeP2uhw==";
+        url = "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.39.tgz";
+        sha512 = "1U5Lt+pjYxJ1mosBIdK5fr3guzV4v81f8yy0rLAj/cu7ki3ciCe85LVJJ0RLK0lP6VwFtjpXSOESfwAEpz0FyQ==";
       };
     };
     "mdn-data-2.0.4" = {
@@ -30708,6 +32643,51 @@ let
         sha1 = "5529a4d67654134edcc5266656835b0f851afcee";
       };
     };
+    "metro-babel-transformer-0.58.0" = {
+      name = "metro-babel-transformer";
+      packageName = "metro-babel-transformer";
+      version = "0.58.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.58.0.tgz";
+        sha512 = "yBX3BkRhw2TCNPhe+pmLSgsAEA3huMvnX08UwjFqSXXI1aiqzRQobn92uKd1U5MM1Vx8EtXVomlJb95ZHNAv6A==";
+      };
+    };
+    "metro-react-native-babel-preset-0.58.0" = {
+      name = "metro-react-native-babel-preset";
+      packageName = "metro-react-native-babel-preset";
+      version = "0.58.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.58.0.tgz";
+        sha512 = "MRriNW+fF6jxABsgPphocUY6mIhmCm8idcrQZ58fT3Iti2vCdtkaK32TyCGUNUptzhUe2/cbE57j4aC+eaodAA==";
+      };
+    };
+    "metro-react-native-babel-transformer-0.58.0" = {
+      name = "metro-react-native-babel-transformer";
+      packageName = "metro-react-native-babel-transformer";
+      version = "0.58.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.58.0.tgz";
+        sha512 = "3A73+cRq1eUPQ8g+hPNGgMUMCGmtQjwqHfoG1DwinAoJ/kr4WOXWWbGZo0xHJNBe/zdHGl0uHcDCp2knPglTdQ==";
+      };
+    };
+    "metro-source-map-0.58.0" = {
+      name = "metro-source-map";
+      packageName = "metro-source-map";
+      version = "0.58.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.58.0.tgz";
+        sha512 = "yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==";
+      };
+    };
+    "metro-symbolicate-0.58.0" = {
+      name = "metro-symbolicate";
+      packageName = "metro-symbolicate";
+      version = "0.58.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.58.0.tgz";
+        sha512 = "uIVxUQC1E26qOMj13dKROhwAa2FmZk5eR0NcBqej/aXmQhpr8LjJg2sondkoLKUp827Tf/Fm9+pS4icb5XiqCw==";
+      };
+    };
     "micro-api-client-3.3.0" = {
       name = "micro-api-client";
       packageName = "micro-api-client";
@@ -30742,6 +32722,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz";
         sha1 = "a12bdb0103681e8b126a9b071eba4c467c78fffe";
+      };
+    };
+    "microevent.ts-0.1.1" = {
+      name = "microevent.ts";
+      packageName = "microevent.ts";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz";
+        sha512 = "jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==";
       };
     };
     "micromatch-2.3.11" = {
@@ -30823,6 +32812,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz";
         sha1 = "115f9e3b6b3daf2959983cb38f149a2d40eb5d53";
+      };
+    };
+    "mime-1.4.1" = {
+      name = "mime";
+      packageName = "mime";
+      version = "1.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz";
+        sha512 = "KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==";
       };
     };
     "mime-1.6.0" = {
@@ -30960,6 +32958,15 @@ let
         sha512 = "I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==";
       };
     };
+    "mini-css-extract-plugin-0.5.0" = {
+      name = "mini-css-extract-plugin";
+      packageName = "mini-css-extract-plugin";
+      version = "0.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz";
+        sha512 = "IuaLjruM0vMKhUUT51fQdQzBYTX49dLj8w68ALEAe2A4iYNpIC4eMac67mt3NzycvjOlf07/kYxJDc0RTl1Wqw==";
+      };
+    };
     "minicap-prebuilt-2.3.0" = {
       name = "minicap-prebuilt";
       packageName = "minicap-prebuilt";
@@ -31086,6 +33093,15 @@ let
         sha512 = "1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==";
       };
     };
+    "minipass-2.3.5" = {
+      name = "minipass";
+      packageName = "minipass";
+      version = "2.3.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz";
+        sha512 = "Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==";
+      };
+    };
     "minipass-2.9.0" = {
       name = "minipass";
       packageName = "minipass";
@@ -31113,13 +33129,13 @@ let
         sha512 = "6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==";
       };
     };
-    "minipass-fetch-1.3.1" = {
+    "minipass-fetch-1.3.2" = {
       name = "minipass-fetch";
       packageName = "minipass-fetch";
-      version = "1.3.1";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.1.tgz";
-        sha512 = "N0ddPAD8OZnoAHUYj1ZH4ZJVna+ucy7if777LrdeIV1ko8f46af4jbyM5EC1gN4xc9Wq5c3C38GnxRJ2gneXRA==";
+        url = "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.2.tgz";
+        sha512 = "/i4fX1ss+Dtwyk++OsAI6SEV+eE1dvI6W+0hORdjfruQ7VD5uYTetJIHcEMjWiEiszWjn2aAtP1CB/Q4KfeoYA==";
       };
     };
     "minipass-flush-1.0.5" = {
@@ -31446,13 +33462,13 @@ let
         sha512 = "Z5KOjYmnHyd/ukynmFd/WwyXHd7L4J9vTI/nn5Ap9AVUgaAE15VvQ9MOGmJJygEUklupqIrFnor/tjTwRU+tQw==";
       };
     };
-    "moment-2.29.0" = {
+    "moment-2.29.1" = {
       name = "moment";
       packageName = "moment";
-      version = "2.29.0";
+      version = "2.29.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/moment/-/moment-2.29.0.tgz";
-        sha512 = "z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA==";
+        url = "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz";
+        sha512 = "kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==";
       };
     };
     "moment-2.7.0" = {
@@ -32166,6 +34182,15 @@ let
         sha512 = "9nRjinI9bmz+S7dgNtf4A70+/vPhnd+2krGpy4SUlADuOuSa24IDkNaZ+R/QT1wQ6S8jBdi6wE7fLekFZNfUpQ==";
       };
     };
+    "native-url-0.2.6" = {
+      name = "native-url";
+      packageName = "native-url";
+      version = "0.2.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/native-url/-/native-url-0.2.6.tgz";
+        sha512 = "k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==";
+      };
+    };
     "natives-1.1.6" = {
       name = "natives";
       packageName = "natives";
@@ -32428,13 +34453,13 @@ let
         sha512 = "AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==";
       };
     };
-    "netlify-4.6.0" = {
+    "netlify-4.7.0" = {
       name = "netlify";
       packageName = "netlify";
-      version = "4.6.0";
+      version = "4.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/netlify/-/netlify-4.6.0.tgz";
-        sha512 = "wmx0bs64TQH1DtJs+5NyYUy9f+VvrBRRpGXNgzFYyaVsect/lxycdkDZwWQFrcvTlCf9lGHlRu2Gr0uC6+/k6Q==";
+        url = "https://registry.npmjs.org/netlify/-/netlify-4.7.0.tgz";
+        sha512 = "ylGfihIjzVrimuLo6Pl/pGwIIZ9IHxHEemtUu2YBv8fnZzj5rDTHZCNNLaYLDMGo6Oe0o83yR7fnd0pnBHf2Aw==";
       };
     };
     "netlify-redirect-parser-2.5.0" = {
@@ -32753,15 +34778,6 @@ let
         sha512 = "OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==";
       };
     };
-    "node-fetch-2.6.0" = {
-      name = "node-fetch";
-      packageName = "node-fetch";
-      version = "2.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz";
-        sha512 = "8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==";
-      };
-    };
     "node-fetch-2.6.1" = {
       name = "node-fetch";
       packageName = "node-fetch";
@@ -32895,6 +34911,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz";
         sha512 = "MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==";
+      };
+    };
+    "node-html-parser-1.3.1" = {
+      name = "node-html-parser";
+      packageName = "node-html-parser";
+      version = "1.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.3.1.tgz";
+        sha512 = "AwYVI6GyEKj9NGoyMfSx4j5l7Axf7obQgLWGxtasLjED6RggTTQoq5ZRzjwSUfgSZ+Mv8Nzbi3pID0gFGqNUsA==";
       };
     };
     "node-int64-0.4.0" = {
@@ -33437,6 +35462,15 @@ let
         sha512 = "EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==";
       };
     };
+    "npm-package-arg-6.1.0" = {
+      name = "npm-package-arg";
+      packageName = "npm-package-arg";
+      version = "6.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz";
+        sha512 = "zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==";
+      };
+    };
     "npm-package-arg-6.1.1" = {
       name = "npm-package-arg";
       packageName = "npm-package-arg";
@@ -33444,6 +35478,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz";
         sha512 = "qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==";
+      };
+    };
+    "npm-package-arg-7.0.0" = {
+      name = "npm-package-arg";
+      packageName = "npm-package-arg";
+      version = "7.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-7.0.0.tgz";
+        sha512 = "xXxr8y5U0kl8dVkz2oK7yZjPBvqM2fwaO5l3Yg13p03v8+E3qQcD0JNhHzjL1vyGgxcKkD0cco+NLR72iuPk3g==";
       };
     };
     "npm-package-arg-8.0.1" = {
@@ -33743,6 +35786,15 @@ let
         sha512 = "l/SxykuACi2U51osSsBXTxdsFc8Fw41xI7AsZkzgVgWJAzoEFaaNptt35WgY9C3757RUclsm6ye5GvSyYoozLQ==";
       };
     };
+    "oas-validator-5.0.2" = {
+      name = "oas-validator";
+      packageName = "oas-validator";
+      version = "5.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.2.tgz";
+        sha512 = "KVyNNWtZut1sZVBy4mBt1Iq6vQt0km+vJvaPanx4xV33ylpWpuQnMsb9UNQ6MuZVmOzBLl9SbNyvlNjzicty9Q==";
+      };
+    };
     "oauth-0.9.15" = {
       name = "oauth";
       packageName = "oauth";
@@ -33787,6 +35839,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/oauth2orize/-/oauth2orize-1.11.0.tgz";
         sha1 = "793cef251d45ebdeac32ae40a8b6814faab1d483";
+      };
+    };
+    "ob1-0.58.0" = {
+      name = "ob1";
+      packageName = "ob1";
+      version = "0.58.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ob1/-/ob1-0.58.0.tgz";
+        sha512 = "uZP44cbowAfHafP1k4skpWItk5iHCoRevMfrnUvYCfyNNPPJd3rfDCyj0exklWi2gDXvjlj2ObsfiqP/bs/J7Q==";
       };
     };
     "object-assign-1.0.0" = {
@@ -33888,13 +35949,22 @@ let
         sha512 = "jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==";
       };
     };
-    "object-is-1.1.2" = {
+    "object-is-1.1.3" = {
       name = "object-is";
       packageName = "object-is";
-      version = "1.1.2";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz";
-        sha512 = "5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==";
+        url = "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz";
+        sha512 = "teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==";
+      };
+    };
+    "object-keys-0.2.0" = {
+      name = "object-keys";
+      packageName = "object-keys";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz";
+        sha1 = "cddec02998b091be42bf1035ae32e49f1cb6ea67";
       };
     };
     "object-keys-0.4.0" = {
@@ -33976,6 +36046,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz";
         sha1 = "3a7f868334b407dea06da16d88d5cd29e435fecf";
+      };
+    };
+    "object.entries-1.1.2" = {
+      name = "object.entries";
+      packageName = "object.entries";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz";
+        sha512 = "BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==";
       };
     };
     "object.getownpropertydescriptors-2.1.0" = {
@@ -34086,6 +36165,15 @@ let
         sha512 = "c+EtVwT2IpXz5we2mR40aPLJ1s0eNOsxYeaYbaHhmsY6kWKo3IRkpwpBU5ck0aHfqfKUUEiKabC6rzsrG/hSHw==";
       };
     };
+    "octal-1.0.0" = {
+      name = "octal";
+      packageName = "octal";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/octal/-/octal-1.0.0.tgz";
+        sha1 = "63e7162a68efbeb9e213588d58e989d1e5c4530b";
+      };
+    };
     "octokit-pagination-methods-1.1.0" = {
       name = "octokit-pagination-methods";
       packageName = "octokit-pagination-methods";
@@ -34095,13 +36183,13 @@ let
         sha512 = "fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==";
       };
     };
-    "office-ui-fabric-react-7.143.0" = {
+    "office-ui-fabric-react-7.145.0" = {
       name = "office-ui-fabric-react";
       packageName = "office-ui-fabric-react";
-      version = "7.143.0";
+      version = "7.145.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.143.0.tgz";
-        sha512 = "wXYvx0/tPKCQB1l1E8dUCE9udsx+M5TWKoM0sTKoKnBM0qf8q1FvROA+ZEoQ9tlEEohmRpxxiRdrZjCDyV/U3Q==";
+        url = "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.145.0.tgz";
+        sha512 = "+eAo/bZpnTXmirwsPZxIbPhjQk+C34f0W/8tAHYWYASrRio9DWWDB0PRsSGUNrn1QubWxjudW294fovkewPeAQ==";
       };
     };
     "omggif-1.0.10" = {
@@ -34311,15 +36399,6 @@ let
         sha512 = "IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==";
       };
     };
-    "open-7.0.4" = {
-      name = "open";
-      packageName = "open";
-      version = "7.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/open/-/open-7.0.4.tgz";
-        sha512 = "brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==";
-      };
-    };
     "open-7.1.0" = {
       name = "open";
       packageName = "open";
@@ -34509,13 +36588,13 @@ let
         sha512 = "fiRJE2Z5F0tY9QBssBX9g8Txtr0oj1BOU0nOZ6QHHXQdCYxebszGgcXD63uy0UJQwzwVOMs/AlCnKNVS/yMSEg==";
       };
     };
-    "openapi-to-graphql-2.1.0" = {
+    "openapi-to-graphql-2.2.5" = {
       name = "openapi-to-graphql";
       packageName = "openapi-to-graphql";
-      version = "2.1.0";
+      version = "2.2.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/openapi-to-graphql/-/openapi-to-graphql-2.1.0.tgz";
-        sha512 = "Su7/ckttN192x/XTJfaXlzpYK2m+6UEobGS2E0fXK5iLjIwreEZol2uIwjctkFz6oSuKvBgMGCjkBeXGuvPl2A==";
+        url = "https://registry.npmjs.org/openapi-to-graphql/-/openapi-to-graphql-2.2.5.tgz";
+        sha512 = "HlCCs/D7wMtraNZVYR8fgqv2Fr4afWgWKVf38uwwMEdhTuVHadn+1ILYfmZV6AdejFw7ViQpjNGVRcdrN2wzFg==";
       };
     };
     "openapi-types-1.3.4" = {
@@ -34669,6 +36748,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz";
         sha1 = "da3ea74686fa21a19a111c326e90eb15a0196686";
+      };
+    };
+    "optimize-css-assets-webpack-plugin-5.0.4" = {
+      name = "optimize-css-assets-webpack-plugin";
+      packageName = "optimize-css-assets-webpack-plugin";
+      version = "5.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.4.tgz";
+        sha512 = "wqd6FdI2a5/FdoiCNNkEvLeA//lHHfG24Ln2Xm2qqdIk4aOlsR18jwpyOihqQ8849W3qu2DX8fOYxpvTMj+93A==";
       };
     };
     "optionator-0.3.0" = {
@@ -35220,6 +37308,15 @@ let
         sha512 = "XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==";
       };
     };
+    "p-retry-4.1.0" = {
+      name = "p-retry";
+      packageName = "p-retry";
+      version = "4.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/p-retry/-/p-retry-4.1.0.tgz";
+        sha512 = "oepllyG9gX1qH4Sm20YAKxg1GA7L7puhvGnTfimi31P07zSIj7SDV6YtuAx9nbJF51DES+2CIIRkXs8GKqWJxA==";
+      };
+    };
     "p-some-4.1.0" = {
       name = "p-some";
       packageName = "p-some";
@@ -35245,6 +37342,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz";
         sha512 = "88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==";
+      };
+    };
+    "p-timeout-3.1.0" = {
+      name = "p-timeout";
+      packageName = "p-timeout";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/p-timeout/-/p-timeout-3.1.0.tgz";
+        sha512 = "C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==";
       };
     };
     "p-timeout-3.2.0" = {
@@ -35328,6 +37434,15 @@ let
         sha512 = "EeHQFFTlEmLrkIQoxbE9w0FuAWHoc1XpthDqnZ/i9keOt701cteyXwAxQFLpVqVjj3feh2TodkihjLaRUtIgLg==";
       };
     };
+    "package-json-6.4.0" = {
+      name = "package-json";
+      packageName = "package-json";
+      version = "6.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/package-json/-/package-json-6.4.0.tgz";
+        sha512 = "bd1T8OBG7hcvMd9c/udgv6u5v9wISP3Oyl9Cm7Weop8EFwrtcQDnS2sb6zhwqus2WslSr5wSTIPiTTpxxmPm7Q==";
+      };
+    };
     "package-json-6.5.0" = {
       name = "package-json";
       packageName = "package-json";
@@ -35371,6 +37486,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/packet-stream-codec/-/packet-stream-codec-1.1.2.tgz";
         sha1 = "79b302fc144cdfbb4ab6feba7040e6a5d99c79c7";
+      };
+    };
+    "pacote-11.1.0" = {
+      name = "pacote";
+      packageName = "pacote";
+      version = "11.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pacote/-/pacote-11.1.0.tgz";
+        sha512 = "JcMmHiK6h6rcncj2HLayiyJZg28iJXJafXcmEGw2NjKH3WE8ZgSwyMZs7+f+aliPD57PDhB31IEgUtLXp0YZxA==";
       };
     };
     "pacote-11.1.11" = {
@@ -35506,6 +37630,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz";
         sha512 = "RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==";
+      };
+    };
+    "parse-bmfont-ascii-1.0.6" = {
+      name = "parse-bmfont-ascii";
+      packageName = "parse-bmfont-ascii";
+      version = "1.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz";
+        sha1 = "11ac3c3ff58f7c2020ab22769079108d4dfa0285";
+      };
+    };
+    "parse-bmfont-binary-1.0.6" = {
+      name = "parse-bmfont-binary";
+      packageName = "parse-bmfont-binary";
+      version = "1.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz";
+        sha1 = "d038b476d3e9dd9db1e11a0b0e53a22792b69006";
+      };
+    };
+    "parse-bmfont-xml-1.1.4" = {
+      name = "parse-bmfont-xml";
+      packageName = "parse-bmfont-xml";
+      version = "1.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz";
+        sha512 = "bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==";
       };
     };
     "parse-english-4.1.3" = {
@@ -35715,6 +37866,15 @@ let
         sha512 = "HSqVz6iuXSiL8C1ku5Gl1Z5cwDd9Wo0q8CoffdAghP6bz8pJa1tcMC+m4N+z6VAS8QdksnIGq1TB6EgR4vPR6w==";
       };
     };
+    "parse-png-2.1.0" = {
+      name = "parse-png";
+      packageName = "parse-png";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parse-png/-/parse-png-2.1.0.tgz";
+        sha512 = "Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ==";
+      };
+    };
     "parse-semver-1.1.1" = {
       name = "parse-semver";
       packageName = "parse-semver";
@@ -35722,6 +37882,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz";
         sha1 = "9a4afd6df063dc4826f93fba4a99cf223f666cb8";
+      };
+    };
+    "parse-srcset-1.0.2" = {
+      name = "parse-srcset";
+      packageName = "parse-srcset";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz";
+        sha1 = "f2bd221f6cc970a938d88556abc589caaaa2bde1";
       };
     };
     "parse-torrent-4.1.0" = {
@@ -35893,6 +38062,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz";
         sha512 = "CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==";
+      };
+    };
+    "pascal-case-2.0.1" = {
+      name = "pascal-case";
+      packageName = "pascal-case";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz";
+        sha1 = "2d578d3455f660da65eca18ef95b4e0de912761e";
       };
     };
     "pascal-case-3.1.1" = {
@@ -36399,13 +38577,13 @@ let
         sha512 = "jQPKWHWxbI09s/Z9aUvoTbvGgoj98AU7FDCcQ7kdejupn/TcNpx56v2gaOTzXkzOajmOEJEdi9eTh9cA2RVAjQ==";
       };
     };
-    "pg-connection-string-2.3.0" = {
+    "pg-connection-string-2.4.0" = {
       name = "pg-connection-string";
       packageName = "pg-connection-string";
-      version = "2.3.0";
+      version = "2.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.3.0.tgz";
-        sha512 = "ukMTJXLI7/hZIwTW7hGMZJ0Lj0S2XQBCJ4Shv4y1zgQ/vqVea+FLhzywvPj0ujSuofu+yA4MYHGZPTsgjBgJ+w==";
+        url = "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz";
+        sha512 = "3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==";
       };
     };
     "pg-int8-1.0.1" = {
@@ -36426,13 +38604,13 @@ let
         sha512 = "BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA==";
       };
     };
-    "pg-protocol-1.2.5" = {
+    "pg-protocol-1.3.0" = {
       name = "pg-protocol";
       packageName = "pg-protocol";
-      version = "1.2.5";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.5.tgz";
-        sha512 = "1uYCckkuTfzz/FCefvavRywkowa6M5FohNMF5OjKrqo9PSR8gYc8poVmwwYQaBxhmQdBjhtP514eXy9/Us2xKg==";
+        url = "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.3.0.tgz";
+        sha512 = "64/bYByMrhWULUaCd+6/72c9PMWhiVFs3EVxl9Ct6a3v/U8+rKgqP2w+kKg/BIGgMJyB+Bk/eNivT32Al+Jghw==";
       };
     };
     "pg-types-2.2.0" = {
@@ -36460,6 +38638,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz";
         sha1 = "efd212a4a3966d3647684ea8ba788549be2aefef";
+      };
+    };
+    "phin-2.9.3" = {
+      name = "phin";
+      packageName = "phin";
+      version = "2.9.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz";
+        sha512 = "CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==";
       };
     };
     "physical-cpu-count-2.0.0" = {
@@ -36622,6 +38809,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz";
         sha512 = "WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==";
+      };
+    };
+    "pixelmatch-4.0.2" = {
+      name = "pixelmatch";
+      packageName = "pixelmatch";
+      version = "4.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz";
+        sha1 = "8f47dcec5011b477b67db03c243bc1f3085e8854";
       };
     };
     "pkg-conf-1.1.3" = {
@@ -36840,6 +39036,15 @@ let
         sha1 = "1cc7c212303acabe74263ec3ac78009580242d93";
       };
     };
+    "pngjs-3.4.0" = {
+      name = "pngjs";
+      packageName = "pngjs";
+      version = "3.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz";
+        sha512 = "NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==";
+      };
+    };
     "pngjs-5.0.0" = {
       name = "pngjs";
       packageName = "pngjs";
@@ -36847,6 +39052,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz";
         sha512 = "40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==";
+      };
+    };
+    "pnp-webpack-plugin-1.6.4" = {
+      name = "pnp-webpack-plugin";
+      packageName = "pnp-webpack-plugin";
+      version = "1.6.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz";
+        sha512 = "7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==";
       };
     };
     "polished-3.6.7" = {
@@ -36931,13 +39145,13 @@ let
         sha512 = "3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==";
       };
     };
-    "postcss-calc-7.0.4" = {
+    "postcss-calc-7.0.5" = {
       name = "postcss-calc";
       packageName = "postcss-calc";
-      version = "7.0.4";
+      version = "7.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.4.tgz";
-        sha512 = "0I79VRAd1UTkaHzY9w83P39YGO/M3bG7/tNLrHGEunBolfoGM0hSjrGvjoeaj0JE/zIw5GsI2KZ0UwDJqv5hjw==";
+        url = "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.5.tgz";
+        sha512 = "1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==";
       };
     };
     "postcss-colormin-4.0.3" = {
@@ -37012,15 +39226,6 @@ let
         sha512 = "HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==";
       };
     };
-    "postcss-jsx-0.36.4" = {
-      name = "postcss-jsx";
-      packageName = "postcss-jsx";
-      version = "0.36.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.4.tgz";
-        sha512 = "jwO/7qWUvYuWYnpOb0+4bIIgJt7003pgU3P6nETBLaOyBXuTD55ho21xnals5nBrlpTIFodyd3/jBi6UO3dHvA==";
-      };
-    };
     "postcss-less-1.1.5" = {
       name = "postcss-less";
       packageName = "postcss-less";
@@ -37046,15 +39251,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.2.tgz";
         sha512 = "/rDeGV6vMUo3mwJZmeHfEDvwnTKKqQ0S7OHUi/kJvvtx3aWtyWG2/0ZWnzCt2keEclwN6Tf0DST2v9kITdOKYw==";
-      };
-    };
-    "postcss-markdown-0.36.0" = {
-      name = "postcss-markdown";
-      packageName = "postcss-markdown";
-      version = "0.36.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.36.0.tgz";
-        sha512 = "rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==";
       };
     };
     "postcss-media-query-parser-0.2.3" = {
@@ -37318,15 +39514,6 @@ let
         sha512 = "rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==";
       };
     };
-    "postcss-reporter-6.0.1" = {
-      name = "postcss-reporter";
-      packageName = "postcss-reporter";
-      version = "6.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz";
-        sha512 = "LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==";
-      };
-    };
     "postcss-reporter-7.0.1" = {
       name = "postcss-reporter";
       packageName = "postcss-reporter";
@@ -37372,13 +39559,13 @@ let
         sha512 = "cUmYzkP747fPCQE6d+CH2l1L4VSyIlAzZsok3HPjb5Gzsq3jE+VjpAdGlPsnQ310WKWI42sw+ar0UNN59/f3hg==";
       };
     };
-    "postcss-sass-0.3.5" = {
+    "postcss-sass-0.4.4" = {
       name = "postcss-sass";
       packageName = "postcss-sass";
-      version = "0.3.5";
+      version = "0.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.5.tgz";
-        sha512 = "B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==";
+        url = "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.4.tgz";
+        sha512 = "BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==";
       };
     };
     "postcss-scss-1.0.6" = {
@@ -37624,6 +39811,15 @@ let
         sha1 = "e92434bfa5ea8c19f41cdfd401d741a3c819d897";
       };
     };
+    "prepend-http-3.0.1" = {
+      name = "prepend-http";
+      packageName = "prepend-http";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/prepend-http/-/prepend-http-3.0.1.tgz";
+        sha512 = "BLxfZh+m6UiAiCPZFJ4+vYoL7NrRs5XgCTRrjseATAggXhdZKKxn+JUNmuVYWY23bDHgaEHodxw8mnmtVEDtHw==";
+      };
+    };
     "preserve-0.2.0" = {
       name = "preserve";
       packageName = "preserve";
@@ -37714,6 +39910,15 @@ let
         sha512 = "urhX7U/F+fu8sztEs/Z7CxNS8PdEytEwGKhQaH5fxxCdRmHGT45FoClyDlcZrMk9cK/8JpX/asFmTOHtSGJfLg==";
       };
     };
+    "pretty-bytes-4.0.2" = {
+      name = "pretty-bytes";
+      packageName = "pretty-bytes";
+      version = "4.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz";
+        sha1 = "b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9";
+      };
+    };
     "pretty-bytes-5.4.1" = {
       name = "pretty-bytes";
       packageName = "pretty-bytes";
@@ -37721,6 +39926,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz";
         sha512 = "s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==";
+      };
+    };
+    "pretty-error-2.1.1" = {
+      name = "pretty-error";
+      packageName = "pretty-error";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz";
+        sha1 = "5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3";
       };
     };
     "pretty-format-23.6.0" = {
@@ -37739,6 +39953,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz";
         sha512 = "00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==";
+      };
+    };
+    "pretty-format-25.5.0" = {
+      name = "pretty-format";
+      packageName = "pretty-format";
+      version = "25.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz";
+        sha512 = "kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==";
       };
     };
     "pretty-hash-1.0.1" = {
@@ -37766,6 +39989,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pretty-ms/-/pretty-ms-5.1.0.tgz";
         sha512 = "4gaK1skD2gwscCfkswYQRmddUb2GJZtzDGRjHWadVHtK/DIKFufa12MvES6/xu1tVbUYeia5bmLcwJtZJQUqnw==";
+      };
+    };
+    "pretty-time-1.1.0" = {
+      name = "pretty-time";
+      packageName = "pretty-time";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz";
+        sha512 = "28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==";
       };
     };
     "prettyjson-1.2.1" = {
@@ -37849,6 +40081,24 @@ let
         sha512 = "abAuk3ZDyQvPLY6MygtwaDTUBIZ0C5wMMuX1jXa0svazV+keTwn7cPobRv4WYA9ctsDUztm/9CYu4y2TPL08xw==";
       };
     };
+    "probe-image-size-3.2.0" = {
+      name = "probe-image-size";
+      packageName = "probe-image-size";
+      version = "3.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/probe-image-size/-/probe-image-size-3.2.0.tgz";
+        sha512 = "LE7mIvfDoEeOgIH9TbMNv5txJh+K0/UVandiXHk+Hm4VKqNV5qxoeDzdW3QiMIlqXsIEm3K+SzeAedT6fZKjtQ==";
+      };
+    };
+    "probe-image-size-4.0.0" = {
+      name = "probe-image-size";
+      packageName = "probe-image-size";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/probe-image-size/-/probe-image-size-4.0.0.tgz";
+        sha512 = "nm7RvWUxps+2+jZKNLkd04mNapXNariS6G5WIEVzvAqjx7EUuKcY1Dp3e6oUK7GLwzJ+3gbSbPLFAASHFQrPcQ==";
+      };
+    };
     "probe-image-size-5.0.0" = {
       name = "probe-image-size";
       packageName = "probe-image-size";
@@ -37883,6 +40133,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/process/-/process-0.5.2.tgz";
         sha1 = "1638d8a8e34c2f440a91db95ab9aeb677fc185cf";
+      };
+    };
+    "process-es6-0.11.6" = {
+      name = "process-es6";
+      packageName = "process-es6";
+      version = "0.11.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/process-es6/-/process-es6-0.11.6.tgz";
+        sha1 = "c6bb389f9a951f82bd4eb169600105bd2ff9c778";
       };
     };
     "process-exists-3.1.0" = {
@@ -38225,6 +40484,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz";
         sha1 = "a3fdf1befb730f951965872ac2f6074c61477a56";
+      };
+    };
+    "prr-0.0.0" = {
+      name = "prr";
+      packageName = "prr";
+      version = "0.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz";
+        sha1 = "1a84b85908325501411853d0081ee3fa86e2926a";
       };
     };
     "prr-1.0.1" = {
@@ -39109,6 +41377,15 @@ let
         sha512 = "8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==";
       };
     };
+    "qrcode-terminal-0.11.0" = {
+      name = "qrcode-terminal";
+      packageName = "qrcode-terminal";
+      version = "0.11.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.11.0.tgz";
+        sha1 = "ffc6c28a2fc0bfb47052b47e23f4f446a5fbdb9e";
+      };
+    };
     "qs-0.4.2" = {
       name = "qs";
       packageName = "qs";
@@ -39523,6 +41800,15 @@ let
         sha512 = "PPYLwZ63lXi6Tv2EZ8w3M4FzC0rVqvxivaOVS8pXSp5FMIHFnvi4MWHL3UdFLhwSy50aNtJsgjY0mBC6oFL26Q==";
       };
     };
+    "raven-2.6.3" = {
+      name = "raven";
+      packageName = "raven";
+      version = "2.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/raven/-/raven-2.6.3.tgz";
+        sha512 = "bKre7qlDW+y1+G2bUtCuntdDYc8o5v1T233t0vmJfbj8ttGOgLrGRlYB8saelVMW9KUAJNLrhFkAKOwFWFJonw==";
+      };
+    };
     "raven-js-3.27.2" = {
       name = "raven-js";
       packageName = "raven-js";
@@ -39548,6 +41834,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/raw-body/-/raw-body-2.0.2.tgz";
         sha1 = "a2c2f98c8531cee99c63d8d238b7de97bb659fca";
+      };
+    };
+    "raw-body-2.3.3" = {
+      name = "raw-body";
+      packageName = "raw-body";
+      version = "2.3.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz";
+        sha512 = "9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==";
       };
     };
     "raw-body-2.4.0" = {
@@ -39613,6 +41908,15 @@ let
         sha512 = "YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==";
       };
     };
+    "react-dev-utils-10.2.1" = {
+      name = "react-dev-utils";
+      packageName = "react-dev-utils";
+      version = "10.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz";
+        sha512 = "XxTbgJnYZmxuPtY3y/UV0D8/65NKkmaia4rXzViknVnZeVlklSh8u6TnaEYPfAi/Gh1TP4mEOXHI6jQOPbeakQ==";
+      };
+    };
     "react-devtools-core-4.8.2" = {
       name = "react-devtools-core";
       packageName = "react-devtools-core";
@@ -39638,6 +41942,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/react-dropdown/-/react-dropdown-1.9.0.tgz";
         sha512 = "BDApCUhs0qHqnFW3b54SuqI200FOOsmiy0dejdmtdTn/MMY11jcou3CLX1oT2Qa1PdN7viTyAGT8YCpK5qb9xg==";
+      };
+    };
+    "react-error-overlay-6.0.7" = {
+      name = "react-error-overlay";
+      packageName = "react-error-overlay";
+      version = "6.0.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz";
+        sha512 = "TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==";
       };
     };
     "react-hot-loader-4.13.0" = {
@@ -39674,6 +41987,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.24.0.tgz";
         sha512 = "gAGnwWkf+NOTig9oOowqid9O0HjTDC+XVGBCAmJYYJ2A2cN/O4gDdIuuUQjv8A4v6GDwVfJkagpBBLW5OW9HSw==";
+      };
+    };
+    "react-refresh-0.4.3" = {
+      name = "react-refresh";
+      packageName = "react-refresh";
+      version = "0.4.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz";
+        sha512 = "Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==";
+      };
+    };
+    "react-refresh-0.8.3" = {
+      name = "react-refresh";
+      packageName = "react-refresh";
+      version = "0.8.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz";
+        sha512 = "X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==";
       };
     };
     "react-tabs-3.1.1" = {
@@ -39728,6 +42059,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz";
         sha512 = "v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==";
+      };
+    };
+    "read-last-lines-1.6.0" = {
+      name = "read-last-lines";
+      packageName = "read-last-lines";
+      version = "1.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/read-last-lines/-/read-last-lines-1.6.0.tgz";
+        sha512 = "PLKEiyUBMqRMvPu+vfL1XQmkRE5g/TurxrsoNEURqfHbP6eOJaE/2K6+H2IXSfc6/flG5LIj+MtxahclzVvsAA==";
       };
     };
     "read-metadata-1.0.0" = {
@@ -39928,13 +42268,13 @@ let
         sha512 = "+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA==";
       };
     };
-    "readdir-glob-1.1.0" = {
+    "readdir-glob-1.1.1" = {
       name = "readdir-glob";
       packageName = "readdir-glob";
-      version = "1.1.0";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.0.tgz";
-        sha512 = "KgT0oXPIDQRRRYFf+06AUaodICTep2Q5635BORLzTEzp7rEqcR14a47j3Vzm3ix7FeI1lp8mYyG7r8lTB06Pyg==";
+        url = "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.1.tgz";
+        sha512 = "91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==";
       };
     };
     "readdir-scoped-modules-1.1.0" = {
@@ -40414,13 +42754,13 @@ let
         sha512 = "b7wGPo7o2KE/g7SqkJDDbav6zmrEeP4TK2VpITU72J/M949TLe/23y/ZHJo+pskcGM52xIfFoT9hydwmgr1AEg==";
       };
     };
-    "remark-10.0.1" = {
+    "remark-12.0.1" = {
       name = "remark";
       packageName = "remark";
-      version = "10.0.1";
+      version = "12.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz";
-        sha512 = "E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==";
+        url = "https://registry.npmjs.org/remark/-/remark-12.0.1.tgz";
+        sha512 = "gS7HDonkdIaHmmP/+shCPejCEEW+liMp/t/QwmF0Xt47Rpuhl32lLtDV1uKWvGoq+kxr5jSgg5oAIpGuyULjUw==";
       };
     };
     "remark-3.2.3" = {
@@ -40522,15 +42862,6 @@ let
         sha512 = "b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==";
       };
     };
-    "remark-parse-6.0.3" = {
-      name = "remark-parse";
-      packageName = "remark-parse";
-      version = "6.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz";
-        sha512 = "QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==";
-      };
-    };
     "remark-parse-8.0.3" = {
       name = "remark-parse";
       packageName = "remark-parse";
@@ -40565,15 +42896,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/remark-stringify/-/remark-stringify-4.0.0.tgz";
         sha512 = "xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==";
-      };
-    };
-    "remark-stringify-6.0.4" = {
-      name = "remark-stringify";
-      packageName = "remark-stringify";
-      version = "6.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz";
-        sha512 = "eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==";
       };
     };
     "remark-stringify-8.1.1" = {
@@ -40639,6 +42961,15 @@ let
         sha1 = "c24bce2a283adad5bc3f58e0d48249b92379d8ef";
       };
     };
+    "remove-trailing-slash-0.1.1" = {
+      name = "remove-trailing-slash";
+      packageName = "remove-trailing-slash";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz";
+        sha512 = "o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==";
+      };
+    };
     "render-media-3.4.3" = {
       name = "render-media";
       packageName = "render-media";
@@ -40646,6 +42977,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/render-media/-/render-media-3.4.3.tgz";
         sha512 = "Gyk9CYWqGmG2W83ZfQnK8ZGZbmKkrxnHHHiWxF32vH5Afd19IIPZFZADtlmeXVA2petJgCB9L1EbPUc6dS8jDg==";
+      };
+    };
+    "renderkid-2.0.3" = {
+      name = "renderkid";
+      packageName = "renderkid";
+      version = "2.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz";
+        sha512 = "z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==";
       };
     };
     "repeat-element-1.1.3" = {
@@ -40709,6 +43049,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz";
         sha1 = "e87f6d513b928dde808260c12be7fec6ff6e798c";
+      };
+    };
+    "replace-string-1.1.0" = {
+      name = "replace-string";
+      packageName = "replace-string";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/replace-string/-/replace-string-1.1.0.tgz";
+        sha1 = "87062117f823fe5800c306bacb2cfa359b935fea";
       };
     };
     "replaceall-0.1.6" = {
@@ -41422,6 +43771,15 @@ let
         sha512 = "jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==";
       };
     };
+    "rollup-plugin-node-builtins-2.1.2" = {
+      name = "rollup-plugin-node-builtins";
+      packageName = "rollup-plugin-node-builtins";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/rollup-plugin-node-builtins/-/rollup-plugin-node-builtins-2.1.2.tgz";
+        sha1 = "24a1fed4a43257b6b64371d8abc6ce1ab14597e9";
+      };
+    };
     "rollup-plugin-node-resolve-5.2.0" = {
       name = "rollup-plugin-node-resolve";
       packageName = "rollup-plugin-node-resolve";
@@ -41483,6 +43841,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/router/-/router-0.6.2.tgz";
         sha1 = "6f04063a2d04eba3303a1bbc6765eef63037cf3d";
+      };
+    };
+    "router-ips-1.0.0" = {
+      name = "router-ips";
+      packageName = "router-ips";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/router-ips/-/router-ips-1.0.0.tgz";
+        sha1 = "44e00858ebebc0133d58e40b2cd8a1fbb04203f5";
       };
     };
     "rss-parser-3.7.1" = {
@@ -41863,13 +44230,13 @@ let
         sha512 = "y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==";
       };
     };
-    "sass-1.26.11" = {
+    "sass-1.26.12" = {
       name = "sass";
       packageName = "sass";
-      version = "1.26.11";
+      version = "1.26.12";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sass/-/sass-1.26.11.tgz";
-        sha512 = "W1l/+vjGjIamsJ6OnTe0K37U2DBO/dgsv2Z4c89XQ8ZOO6l/VwkqwLSqoYzJeJs6CLuGSTRWc91GbQFL3lvrvw==";
+        url = "https://registry.npmjs.org/sass/-/sass-1.26.12.tgz";
+        sha512 = "hmSwtBOWoS9zwe0yAS+QmaseVCUELiGV22gXHDR7+9stEsVuEuxfY1GhC8XmUpC+Ir3Hwq7NxSUNbnmkznnF7g==";
       };
     };
     "sass-formatter-0.4.15" = {
@@ -41942,6 +44309,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz";
         sha512 = "n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==";
+      };
+    };
+    "schema-utils-0.4.7" = {
+      name = "schema-utils";
+      packageName = "schema-utils";
+      version = "0.4.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz";
+        sha512 = "v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==";
       };
     };
     "schema-utils-1.0.0" = {
@@ -42169,6 +44545,15 @@ let
         sha512 = "sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==";
       };
     };
+    "semver-6.1.1" = {
+      name = "semver";
+      packageName = "semver";
+      version = "6.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz";
+        sha512 = "rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==";
+      };
+    };
     "semver-6.3.0" = {
       name = "semver";
       packageName = "semver";
@@ -42295,6 +44680,15 @@ let
         sha1 = "be70d8d1be01de61821af13780b50345a4f71abd";
       };
     };
+    "send-0.16.2" = {
+      name = "send";
+      packageName = "send";
+      version = "0.16.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/send/-/send-0.16.2.tgz";
+        sha512 = "E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==";
+      };
+    };
     "send-0.17.1" = {
       name = "send";
       packageName = "send";
@@ -42347,6 +44741,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/seq/-/seq-0.3.5.tgz";
         sha1 = "ae02af3a424793d8ccbf212d69174e0c54dffe38";
+      };
+    };
+    "serialize-error-5.0.0" = {
+      name = "serialize-error";
+      packageName = "serialize-error";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz";
+        sha512 = "/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==";
+      };
+    };
+    "serialize-error-6.0.0" = {
+      name = "serialize-error";
+      packageName = "serialize-error";
+      version = "6.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/serialize-error/-/serialize-error-6.0.0.tgz";
+        sha512 = "3vmBkMZLQO+BR4RPHcyRGdE09XCF6cvxzk2N2qn8Er3F91cy8Qt7VvEbZBOpaL53qsBbe2cFOefU6tRY6WDelA==";
       };
     };
     "serialize-error-7.0.1" = {
@@ -42410,6 +44822,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz";
         sha1 = "d3768d69b1e7d82e5ce050fff5b453bea12a9239";
+      };
+    };
+    "serve-static-1.13.2" = {
+      name = "serve-static";
+      packageName = "serve-static";
+      version = "1.13.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz";
+        sha512 = "p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==";
       };
     };
     "serve-static-1.14.1" = {
@@ -42880,22 +45301,13 @@ let
         sha512 = "xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==";
       };
     };
-    "simple-git-2.20.1" = {
+    "simple-git-2.21.0" = {
       name = "simple-git";
       packageName = "simple-git";
-      version = "2.20.1";
+      version = "2.21.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-git/-/simple-git-2.20.1.tgz";
-        sha512 = "aa9s2ZLjXlHCVGbDXQLInMLvLkxKEclqMU9X5HMXi3tLWLxbWObz1UgtyZha6ocHarQtFp0OjQW9KHVR1g6wbA==";
-      };
-    };
-    "simple-git-2.5.0" = {
-      name = "simple-git";
-      packageName = "simple-git";
-      version = "2.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/simple-git/-/simple-git-2.5.0.tgz";
-        sha512 = "4gmtMqfIL9bsBNJDP/rDwZe3GsQL/tp85Qv5cmRc8iIDNOZJS4IX1oPfcqp9b7BGPc5bfuw4yd1i3lQacvuqDQ==";
+        url = "https://registry.npmjs.org/simple-git/-/simple-git-2.21.0.tgz";
+        sha512 = "rohCHmEjD/ESXFLxF4bVeqgdb4Awc65ZyyuCKl3f7BvgMbZOBa/Ye3HN/GFnvruiUOAWWNupxhz3Rz5/3vJLTg==";
       };
     };
     "simple-markdown-0.4.4" = {
@@ -42923,6 +45335,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/simple-peer/-/simple-peer-9.7.2.tgz";
         sha512 = "xeMyxa9B4V0eA6mf17fVr8nm2QhAYFu+ZZv8zkSFFTjJETGF227CshwobrIYZuspJglMD63egcevQXGOrTIsuA==";
+      };
+    };
+    "simple-plist-1.1.1" = {
+      name = "simple-plist";
+      packageName = "simple-plist";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/simple-plist/-/simple-plist-1.1.1.tgz";
+        sha512 = "pKMCVKvZbZTsqYR6RKgLfBHkh2cV89GXcA/0CVPje3sOiNOnXA8+rp/ciAMZ7JRaUdLzlEM6JFfUn+fS6Nt3hg==";
       };
     };
     "simple-sha1-2.1.2" = {
@@ -43114,6 +45535,15 @@ let
         sha512 = "pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==";
       };
     };
+    "slice-ansi-4.0.0" = {
+      name = "slice-ansi";
+      packageName = "slice-ansi";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz";
+        sha512 = "qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==";
+      };
+    };
     "sliced-1.0.1" = {
       name = "sliced";
       packageName = "sliced";
@@ -43139,6 +45569,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/slug/-/slug-3.3.5.tgz";
         sha512 = "d/9yTbJDtSIhJThaNRP/U5uxwCl0mWIlV42JmKSfvg8t7DiVt69G8rAWTc0FWhaQOier0fiNAWVs7ctvVhK1RA==";
+      };
+    };
+    "slugid-1.1.0" = {
+      name = "slugid";
+      packageName = "slugid";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/slugid/-/slugid-1.1.0.tgz";
+        sha1 = "e09f00899c09f5a7058edc36dd49f046fd50a82a";
       };
     };
     "slugify-1.4.5" = {
@@ -43276,13 +45715,13 @@ let
         sha512 = "/xcDy8H5wxhk+4E9e8zDDGfcNo5g+zpwy585sCDkH5KpHdZHmguPi0GmZ9ZCBTuGIodeTIqsDqkBiA1WXSH7+w==";
       };
     };
-    "snyk-docker-plugin-3.24.0" = {
+    "snyk-docker-plugin-3.26.2" = {
       name = "snyk-docker-plugin";
       packageName = "snyk-docker-plugin";
-      version = "3.24.0";
+      version = "3.26.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-3.24.0.tgz";
-        sha512 = "ZKYNZkfCv90/SzBvZcQlEbfJ5ctOvfltZ5Km/z6N5IF+Peetos6VRwxcX8Jenq204ec0bTnBQ0h0OpTIGkMQnQ==";
+        url = "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-3.26.2.tgz";
+        sha512 = "66t+KkAbaHcJJUDUXj5TBeiFkId9SfdChrsYiI7srRLWNU3PG20V3JrjNx7hjEqJpCJCsucnUjTwouZWg39eUg==";
       };
     };
     "snyk-go-parser-1.4.1" = {
@@ -43303,13 +45742,13 @@ let
         sha512 = "FAM56z3bl1iuxeqkCEA/jyZ2hpwkQK8xQxQbhR+QppEK5lole7w1PQyWYgZAJ9oRY/BU32zdRAJwGuZbhk7G2Q==";
       };
     };
-    "snyk-gradle-plugin-3.7.0" = {
+    "snyk-gradle-plugin-3.9.0" = {
       name = "snyk-gradle-plugin";
       packageName = "snyk-gradle-plugin";
-      version = "3.7.0";
+      version = "3.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.7.0.tgz";
-        sha512 = "j2HJCX0RCvRsYLvF+MkA5io175QIWh6jVjHNXRYOL6ls0ZOhn0BLLs1Ilm8WkT+jTmaZt+Wnh8wBHDMhKlGcew==";
+        url = "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.9.0.tgz";
+        sha512 = "oux2M/GhnfyZW3ngs3BO/uKlZTVLErGBY83j6ctGti3d54Ax8GZvS6iHjXd3FNrTd+9o5mfFzZyUHq/ujiakMw==";
       };
     };
     "snyk-module-1.9.1" = {
@@ -43339,13 +45778,13 @@ let
         sha512 = "HHuOYEAACpUpkFgU8HT57mmxmonaJ4O3YADoSkVhnhkmJ+AowqZyJOau703dYHNrq2DvQ7qYw81H7yyxS1Nfjw==";
       };
     };
-    "snyk-mvn-plugin-2.19.4" = {
+    "snyk-mvn-plugin-2.22.0" = {
       name = "snyk-mvn-plugin";
       packageName = "snyk-mvn-plugin";
-      version = "2.19.4";
+      version = "2.22.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.19.4.tgz";
-        sha512 = "kYPUKOugnNd31PFqx1YHJTo90pospELYHME4AzBx8dkMDgs5ZPjAmQXSxegQ3AMUqfqcETMSTzlKHe6uHujI8A==";
+        url = "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.22.0.tgz";
+        sha512 = "5gs9SPN3niqJWktfsZFw31bqAAQ85MfJWrTurdGjjn2RHtdOfirc68VrJNY4gFJdFrlkWzxKm2kEzJIs5MCsdQ==";
       };
     };
     "snyk-nodejs-lockfile-parser-1.28.1" = {
@@ -43508,6 +45947,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz";
         sha512 = "cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==";
+      };
+    };
+    "socket.io-client-2.3.1" = {
+      name = "socket.io-client";
+      packageName = "socket.io-client";
+      version = "2.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.1.tgz";
+        sha512 = "YXmXn3pA8abPOY//JtYxou95Ihvzmg8U6kQyolArkIyLd0pgVhrfor/iMsox8cn07WCOOvvuJ6XKegzIucPutQ==";
       };
     };
     "socket.io-parser-2.1.2" = {
@@ -43859,6 +46307,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz";
         sha512 = "Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==";
+      };
+    };
+    "source-map-support-0.4.18" = {
+      name = "source-map-support";
+      packageName = "source-map-support";
+      version = "0.4.18";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz";
+        sha512 = "try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==";
       };
     };
     "source-map-support-0.5.19" = {
@@ -44842,6 +47299,15 @@ let
         sha1 = "cbd243953cc42effd548b5d22388ed689ec639bd";
       };
     };
+    "statuses-1.4.0" = {
+      name = "statuses";
+      packageName = "statuses";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz";
+        sha512 = "zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==";
+      };
+    };
     "statuses-1.5.0" = {
       name = "statuses";
       packageName = "statuses";
@@ -44849,6 +47315,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz";
         sha1 = "161c7dac177659fd9811f43771fa99381478628c";
+      };
+    };
+    "std-env-2.2.1" = {
+      name = "std-env";
+      packageName = "std-env";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/std-env/-/std-env-2.2.1.tgz";
+        sha512 = "IjYQUinA3lg5re/YMlwlfhqNRTzMZMqE+pezevdcTaHceqx8ngEi1alX9nNCk9Sc81fy1fLDeQoaCzeiW1yBOQ==";
       };
     };
     "stealthy-require-1.1.1" = {
@@ -45247,6 +47722,15 @@ let
         sha1 = "3aaad855b3e9735c5e412dfe72198ccf99c7f48e";
       };
     };
+    "string-range-1.2.2" = {
+      name = "string-range";
+      packageName = "string-range";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/string-range/-/string-range-1.2.2.tgz";
+        sha1 = "a893ed347e72299bc83befbbf2a692a8d239d5dd";
+      };
+    };
     "string-similarity-2.0.0" = {
       name = "string-similarity";
       packageName = "string-similarity";
@@ -45398,6 +47882,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.0.1.tgz";
         sha512 = "Lsk3ISA2++eJYqBMPKcr/8eby1I6L0gP0NlxF8Zja6c05yr/yCYyb2c9PwXjd08Ib3If1vn1rbs1H5ZtVuOfvQ==";
+      };
+    };
+    "stringify-object-3.3.0" = {
+      name = "stringify-object";
+      packageName = "stringify-object";
+      version = "3.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz";
+        sha512 = "rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==";
       };
     };
     "stringify-package-1.0.1" = {
@@ -45571,6 +48064,15 @@ let
         sha1 = "e5211e9224369fbb81d633a2f00044dc8cedad92";
       };
     };
+    "strip-comments-1.0.2" = {
+      name = "strip-comments";
+      packageName = "strip-comments";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz";
+        sha512 = "kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==";
+      };
+    };
     "strip-dirs-2.1.0" = {
       name = "strip-dirs";
       packageName = "strip-dirs";
@@ -45733,6 +48235,15 @@ let
         sha1 = "dd802425e0f53dc4a6e7aca3752901a1ccda7af5";
       };
     };
+    "style-loader-1.2.1" = {
+      name = "style-loader";
+      packageName = "style-loader";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/style-loader/-/style-loader-1.2.1.tgz";
+        sha512 = "ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==";
+      };
+    };
     "style-search-0.1.0" = {
       name = "style-search";
       packageName = "style-search";
@@ -45760,13 +48271,13 @@ let
         sha512 = "7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==";
       };
     };
-    "stylelint-10.1.0" = {
+    "stylelint-13.7.2" = {
       name = "stylelint";
       packageName = "stylelint";
-      version = "10.1.0";
+      version = "13.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stylelint/-/stylelint-10.1.0.tgz";
-        sha512 = "OmlUXrgzEMLQYj1JPTpyZPR9G4bl0StidfHnGJEMpdiQ0JyTq0MPg1xkHk1/xVJ2rTPESyJCDWjG8Kbpoo7Kuw==";
+        url = "https://registry.npmjs.org/stylelint/-/stylelint-13.7.2.tgz";
+        sha512 = "mmieorkfmO+ZA6CNDu1ic9qpt4tFvH2QUB7vqXgrMVHe5ENU69q7YDq0YUg/UHLuCsZOWhUAvcMcLzLDIERzSg==";
       };
     };
     "stylelint-8.4.0" = {
@@ -45776,24 +48287,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/stylelint/-/stylelint-8.4.0.tgz";
         sha512 = "56hPH5mTFnk8LzlEuTWq0epa34fHuS54UFYQidBOFt563RJBNi1nz1F2HK2MoT1X1waq47milvRsRahFCCJs/Q==";
-      };
-    };
-    "stylelint-vscode-7.0.0-21" = {
-      name = "stylelint-vscode";
-      packageName = "stylelint-vscode";
-      version = "7.0.0-21";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/stylelint-vscode/-/stylelint-vscode-7.0.0-21.tgz";
-        sha512 = "M7tnqBendVqPAAR3CWSJswMRV6/ZRypW3iQz4S4gxUTkmrBS/+8QW3bJ4ltKAJif7u89CYVG12hBqY0kGacFCw==";
-      };
-    };
-    "stylelint-warning-to-vscode-diagnostic-1.0.1" = {
-      name = "stylelint-warning-to-vscode-diagnostic";
-      packageName = "stylelint-warning-to-vscode-diagnostic";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/stylelint-warning-to-vscode-diagnostic/-/stylelint-warning-to-vscode-diagnostic-1.0.1.tgz";
-        sha512 = "Lqze501k5gMdCJg/InZV+TU7MgJyxu+gHLBQjQcTluoZRtMoWyJ4ywPCRpZdaHA2LAI1OCqJCEl93FMuZhA1/A==";
       };
     };
     "stylint-2.0.0" = {
@@ -45850,6 +48343,15 @@ let
         sha512 = "tztzcBTNoEbuErsVQpTN2xUNN/efAZXyCyL5m3x4t6SKrEiTL2N8SaKWBFWM4u56pL79ULif3zjyeq+oV+nOaA==";
       };
     };
+    "subscriptions-transport-ws-0.9.8" = {
+      name = "subscriptions-transport-ws";
+      packageName = "subscriptions-transport-ws";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.8.tgz";
+        sha1 = "3a26ab96e06f78cf4ace8d083f6227fa55970947";
+      };
+    };
     "sudo-block-1.2.0" = {
       name = "sudo-block";
       packageName = "sudo-block";
@@ -45857,6 +48359,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sudo-block/-/sudo-block-1.2.0.tgz";
         sha1 = "cc539bf8191624d4f507d83eeb45b4cea27f3463";
+      };
+    };
+    "sudo-prompt-8.2.5" = {
+      name = "sudo-prompt";
+      packageName = "sudo-prompt";
+      version = "8.2.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-8.2.5.tgz";
+        sha512 = "rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw==";
+      };
+    };
+    "sudo-prompt-9.1.1" = {
+      name = "sudo-prompt";
+      packageName = "sudo-prompt";
+      version = "9.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.1.1.tgz";
+        sha512 = "es33J1g2HjMpyAhz8lOR+ICmXXAqTuKbuXuUWLhOLew20oN9oUCgCJx615U/v7aioZg7IX5lIh9x34vwneu4pA==";
       };
     };
     "suf-cli-0.1.3" = {
@@ -46165,13 +48685,13 @@ let
         sha512 = "hAu/ig5N8i0trXXbrC7rwbXV4DhpEAsZhYXDs1305OjmDgjGC0thINbb0197idy3Pp+B6w7u426SUM43GAP7qw==";
       };
     };
-    "swagger-ui-dist-3.34.0" = {
+    "swagger-ui-dist-3.35.0" = {
       name = "swagger-ui-dist";
       packageName = "swagger-ui-dist";
-      version = "3.34.0";
+      version = "3.35.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.34.0.tgz";
-        sha512 = "xk5CMbwoQVI53rTq9o/iMojAqXP5NT4/+TMeTP4uXWDIH18pB9AXgO5Olqt0RXuf3jH032DA4DS4qzem6XdXAw==";
+        url = "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.35.0.tgz";
+        sha512 = "VdjOd7Lpj3LU6V/SG9BHZHTJ5cTk+uoyHBrGAeEP70SYf7GflLYqw7USUNxoraEx72vIA1wqogMv4GiRqMr8lA==";
       };
     };
     "swagger2openapi-5.4.0" = {
@@ -46181,6 +48701,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-5.4.0.tgz";
         sha512 = "f5QqfXawiVijhjMtYqWZ55ESHPZFqrPC8L9idhIiuSX8O2qsa1i4MVGtCM3TQF+Smzr/6WfT/7zBuzG3aTgPAA==";
+      };
+    };
+    "swagger2openapi-7.0.2" = {
+      name = "swagger2openapi";
+      packageName = "swagger2openapi";
+      version = "7.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.2.tgz";
+        sha512 = "EG9h+hq+mX4S6mh0IHf/K4Bd8cLFVvRFxt6YiuoQCKycbCoa8Cjr8hbzy1oDNpGYwjT29js/PrHffgJDuDlgQw==";
       };
     };
     "sway-1.0.0" = {
@@ -46255,13 +48784,13 @@ let
         sha512 = "YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==";
       };
     };
-    "systeminformation-4.27.5" = {
+    "systeminformation-4.27.7" = {
       name = "systeminformation";
       packageName = "systeminformation";
-      version = "4.27.5";
+      version = "4.27.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.27.5.tgz";
-        sha512 = "EysogxKqREk54ZYDEFcsCODv8GymKZcyiSfegYit8dKhPjzuQr+KX4GFHjssWjYrWFEIM2bYNsFrZX5eufeAXg==";
+        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.27.7.tgz";
+        sha512 = "3ozUwGSf5jmrhGgOXlX/O6hk1KQ28XPb7d3NiPZX267QmimuDq3TuIgnkw+vICUrGJGKWPLKmXVASnuJ3w07nw==";
       };
     };
     "syswide-cas-5.3.0" = {
@@ -46307,6 +48836,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/table/-/table-5.4.6.tgz";
         sha512 = "wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==";
+      };
+    };
+    "table-6.0.3" = {
+      name = "table";
+      packageName = "table";
+      version = "6.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/table/-/table-6.0.3.tgz";
+        sha512 = "8321ZMcf1B9HvVX/btKv8mMZahCjn2aYrDlpqHaBFCfnox64edeH9kEid0vTLTRR8gWR2A20aDgeuTTea4sVtw==";
       };
     };
     "table-layout-0.4.5" = {
@@ -46443,6 +48981,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz";
         sha512 = "w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==";
+      };
+    };
+    "tar-4.4.6" = {
+      name = "tar";
+      packageName = "tar";
+      version = "4.4.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz";
+        sha512 = "tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==";
       };
     };
     "tar-5.0.5" = {
@@ -46688,6 +49235,15 @@ let
         sha512 = "OuPvQzx6oxr3oE2Y78NgRy0TetmurGa/vshYV02Kd6XDWctHO/sHpjnLe3Jhi8FrUkL0XAZMGlxjLeDtRFL4wg==";
       };
     };
+    "terminal-link-2.1.1" = {
+      name = "terminal-link";
+      packageName = "terminal-link";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz";
+        sha512 = "un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==";
+      };
+    };
     "terser-3.17.0" = {
       name = "terser";
       packageName = "terser";
@@ -46706,13 +49262,13 @@ let
         sha512 = "EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==";
       };
     };
-    "terser-5.3.3" = {
+    "terser-5.3.4" = {
       name = "terser";
       packageName = "terser";
-      version = "5.3.3";
+      version = "5.3.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/terser/-/terser-5.3.3.tgz";
-        sha512 = "vRQDIlD+2Pg8YMwVK9kMM3yGylG95EIwzBai1Bw7Ot4OBfn3VP1TZn3EWx4ep2jERN/AmnVaTiGuelZSN7ds/A==";
+        url = "https://registry.npmjs.org/terser/-/terser-5.3.4.tgz";
+        sha512 = "dxuB8KQo8Gt6OVOeLg/rxfcxdNZI/V1G6ze1czFUzPeCFWZRtvZMgSzlZZ5OYBZ4HoG607F6pFPNLekJyV+yVw==";
       };
     };
     "terser-webpack-plugin-1.4.5" = {
@@ -46731,6 +49287,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-3.0.7.tgz";
         sha512 = "5JqibUOctE6Ou4T00IVGYTQJBOhu24jz0PpqYeitQJJ3hlZY2ZKSwzzuqjmBH8MzbdWMgIefpmHwTkvwm6Q4CQ==";
+      };
+    };
+    "terser-webpack-plugin-3.1.0" = {
+      name = "terser-webpack-plugin";
+      packageName = "terser-webpack-plugin";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-3.1.0.tgz";
+        sha512 = "cjdZte66fYkZ65rQ2oJfrdCAkkhJA7YLYk5eGOcGCSGlq0ieZupRdjedSQXYknMPo2IveQL+tPdrxUkERENCFA==";
       };
     };
     "test-exclude-6.0.0" = {
@@ -47057,13 +49622,13 @@ let
         sha1 = "f32eacac5a175bea25d7fab565ab3ed8741ef56f";
       };
     };
-    "timeout-refresh-1.0.2" = {
+    "timeout-refresh-1.0.3" = {
       name = "timeout-refresh";
       packageName = "timeout-refresh";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-1.0.2.tgz";
-        sha512 = "lsO23gD/EeW53AvEoTOleUFqTIapZTu5NPzD6ndUGs0+G1IuN0+hu2kT6I3AmNX2fiOrcC6umtzMEv1XQmajgQ==";
+        url = "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-1.0.3.tgz";
+        sha512 = "Mz0CX4vBGM5lj8ttbIFt7o4ZMxk/9rgudJRh76EvB7xXZMur7T/cjRiH2w4Fmkq0zxf2QpM8IFvOSRn8FEu3gA==";
       };
     };
     "timers-browserify-1.4.2" = {
@@ -47091,6 +49656,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz";
         sha512 = "b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==";
+      };
+    };
+    "timm-1.7.1" = {
+      name = "timm";
+      packageName = "timm";
+      version = "1.7.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz";
+        sha512 = "IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==";
       };
     };
     "timsort-0.3.0" = {
@@ -47127,6 +49701,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz";
         sha1 = "320b5a52d83abb5978d81a3e887d4aefb15a6164";
+      };
+    };
+    "tinycolor2-1.4.2" = {
+      name = "tinycolor2";
+      packageName = "tinycolor2";
+      version = "1.4.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz";
+        sha512 = "vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==";
       };
     };
     "titleize-1.0.1" = {
@@ -47505,6 +50088,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/too-wordy/-/too-wordy-0.2.2.tgz";
         sha512 = "ePZfjs1ajL4b8jT4MeVId+9Ci5hJCzAtNIEXIHyFYmKmQuX+eHC/RNv6tuLMUhrGrhJ+sYWW/lBF/LKILHGZEA==";
+      };
+    };
+    "topo-2.0.2" = {
+      name = "topo";
+      packageName = "topo";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz";
+        sha1 = "cd5615752539057c0dc0491a621c3bc6fbe1d182";
       };
     };
     "topojson-client-3.1.0" = {
@@ -47894,6 +50486,15 @@ let
         sha512 = "ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==";
       };
     };
+    "ts-pnp-1.2.0" = {
+      name = "ts-pnp";
+      packageName = "ts-pnp";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz";
+        sha512 = "csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==";
+      };
+    };
     "ts-process-promises-1.0.2" = {
       name = "ts-process-promises";
       packageName = "ts-process-promises";
@@ -47930,22 +50531,22 @@ let
         sha512 = "aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==";
       };
     };
-    "tslib-1.13.0" = {
+    "tslib-1.14.0" = {
       name = "tslib";
       packageName = "tslib";
-      version = "1.13.0";
+      version = "1.14.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz";
-        sha512 = "i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==";
+        url = "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz";
+        sha512 = "+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw==";
       };
     };
-    "tslib-2.0.1" = {
+    "tslib-2.0.2" = {
       name = "tslib";
       packageName = "tslib";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz";
-        sha512 = "SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==";
+        url = "https://registry.npmjs.org/tslib/-/tslib-2.0.2.tgz";
+        sha512 = "wAH28hcEKwna96/UacuWaVspVLkg4x1aDM9JlzqaQTOFczCktkVAb5fmXChgandR1EraDPs2w8P+ozM+oafwxg==";
       };
     };
     "tslint-5.20.1" = {
@@ -48254,6 +50855,15 @@ let
         sha512 = "cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==";
       };
     };
+    "type-fest-0.5.2" = {
+      name = "type-fest";
+      packageName = "type-fest";
+      version = "0.5.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz";
+        sha512 = "DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==";
+      };
+    };
     "type-fest-0.6.0" = {
       name = "type-fest";
       packageName = "type-fest";
@@ -48297,6 +50907,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz";
         sha1 = "867ac74e3864187b1d3d47d996a78ec5c8830777";
+      };
+    };
+    "typedarray-to-buffer-1.0.4" = {
+      name = "typedarray-to-buffer";
+      packageName = "typedarray-to-buffer";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz";
+        sha1 = "9bb8ba0e841fb3f4cf1fe7c245e9f3fa8a5fe99c";
       };
     };
     "typedarray-to-buffer-3.1.5" = {
@@ -48443,13 +51062,13 @@ let
         sha512 = "Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==";
       };
     };
-    "uglify-js-3.11.0" = {
+    "uglify-js-3.11.1" = {
       name = "uglify-js";
       packageName = "uglify-js";
-      version = "3.11.0";
+      version = "3.11.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.0.tgz";
-        sha512 = "e1KQFRCpOxnrJsJVqDUCjURq+wXvIn7cK2sRAx9XL3HYLL9aezOP4Pb1+Y3/o693EPk111Yj2Q+IUXxcpHlygQ==";
+        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.1.tgz";
+        sha512 = "OApPSuJcxcnewwjSGGfWOjx3oix5XpmrK9Z2j0fTRlHGoZ49IU6kExfZTM0++fCArOOCet+vIfWwFHbvWqwp6g==";
       };
     };
     "uglify-js-3.4.10" = {
@@ -48983,6 +51602,15 @@ let
         sha512 = "lWgIc3rrTMTlK1Y0hEuL+k+ApzFk78h+lsaa2gHf63Gp5Ww+mt11huDniuaoq1H+XMK2lIIjjPkncxXcDp3QDw==";
       };
     };
+    "unist-util-find-all-after-3.0.1" = {
+      name = "unist-util-find-all-after";
+      packageName = "unist-util-find-all-after";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.1.tgz";
+        sha512 = "0GICgc++sRJesLwEYDjFVJPJttBpVQaTNgc6Jw0Jhzvfs+jtKePEMu+uD+PqkRUrAvGQqwhpDwLGWo1PK8PDEw==";
+      };
+    };
     "unist-util-inspect-4.1.4" = {
       name = "unist-util-inspect";
       packageName = "unist-util-inspect";
@@ -49361,6 +51989,15 @@ let
         sha512 = "1TrmYLuLj/5ZovwUS7fFd1jMH3NnFDN1y1A8dboedIDt7zs/zJMo6TwwlhYKkSeEwzleeiSBV5/3c9ufAQWDaQ==";
       };
     };
+    "update-check-1.5.3" = {
+      name = "update-check";
+      packageName = "update-check";
+      version = "1.5.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/update-check/-/update-check-1.5.3.tgz";
+        sha512 = "6KLU4/dd0Tg/l0xwL+f9V7kEIPSL1vOIbnNnhSLiRDlj4AVG6Ks9Zoc9Jgt9kIgWFPZ/wp2AHgmG7xNf15TJOA==";
+      };
+    };
     "update-notifier-2.5.0" = {
       name = "update-notifier";
       packageName = "update-notifier";
@@ -49379,15 +52016,6 @@ let
         sha512 = "grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==";
       };
     };
-    "update-notifier-4.1.1" = {
-      name = "update-notifier";
-      packageName = "update-notifier";
-      version = "4.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.1.tgz";
-        sha512 = "9y+Kds0+LoLG6yN802wVXoIfxYEwh3FlZwzMwpCZp62S2i1/Jzeqb9Eeeju3NSHccGGasfGlK5/vEHbAifYRDg==";
-      };
-    };
     "update-notifier-4.1.3" = {
       name = "update-notifier";
       packageName = "update-notifier";
@@ -49395,6 +52023,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz";
         sha512 = "Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==";
+      };
+    };
+    "update-notifier-5.0.0" = {
+      name = "update-notifier";
+      packageName = "update-notifier";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/update-notifier/-/update-notifier-5.0.0.tgz";
+        sha512 = "8tqsiVrMv7aZsKNSjqA6DdBLKJpZG1hRpkj1RbOJu1PgyP69OX+EInAnP1EK/ShX5YdPFgwWdk19oquZ0HTM8g==";
       };
     };
     "upnp-device-client-1.0.2" = {
@@ -49431,6 +52068,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/upper-case/-/upper-case-2.0.1.tgz";
         sha512 = "laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==";
+      };
+    };
+    "upper-case-first-1.1.2" = {
+      name = "upper-case-first";
+      packageName = "upper-case-first";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz";
+        sha1 = "5d79bedcff14419518fd2edb0a0507c9b6859115";
       };
     };
     "upper-case-first-2.0.1" = {
@@ -49523,6 +52169,15 @@ let
         sha1 = "5af22f18c052a000a48d7b82c5e9c2e2feeda728";
       };
     };
+    "url-join-4.0.0" = {
+      name = "url-join";
+      packageName = "url-join";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz";
+        sha1 = "4d3340e807d3773bda9991f8305acdcc2a665d2a";
+      };
+    };
     "url-join-4.0.1" = {
       name = "url-join";
       packageName = "url-join";
@@ -49530,6 +52185,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz";
         sha512 = "jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==";
+      };
+    };
+    "url-loader-4.1.0" = {
+      name = "url-loader";
+      packageName = "url-loader";
+      version = "4.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/url-loader/-/url-loader-4.1.0.tgz";
+        sha512 = "IzgAAIC8wRrg6NYkFIJY09vtktQcsvU8V6HhtQj9PTefbYImzLB1hufqo4m+RyM5N3mLx5BqJKccgxJS+W3kqw==";
       };
     };
     "url-parse-1.4.7" = {
@@ -49685,6 +52349,15 @@ let
         sha1 = "d52b2fd632a99eca8d9d4a39eece014a6a2b0048";
       };
     };
+    "utif-2.0.1" = {
+      name = "utif";
+      packageName = "utif";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz";
+        sha512 = "Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==";
+      };
+    };
     "util-0.10.3" = {
       name = "util";
       packageName = "util";
@@ -49739,6 +52412,15 @@ let
         sha1 = "3c2236476c4d32c5ff3c47002add7c13b9a82a53";
       };
     };
+    "util.promisify-1.0.0" = {
+      name = "util.promisify";
+      packageName = "util.promisify";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz";
+        sha512 = "i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==";
+      };
+    };
     "util.promisify-1.0.1" = {
       name = "util.promisify";
       packageName = "util.promisify";
@@ -49746,6 +52428,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz";
         sha512 = "g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==";
+      };
+    };
+    "utila-0.4.0" = {
+      name = "utila";
+      packageName = "utila";
+      version = "0.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz";
+        sha1 = "8a16a05d445657a3aea5eecc5b12a4fa5379772c";
       };
     };
     "utile-0.2.1" = {
@@ -49802,6 +52493,24 @@ let
         sha512 = "7GvD4gjGyL1GaNtZAaBVHn8SeWgx9/xIVE1LufMR0m2pWUs1EVx5WiOCXrCHyt7e15+5SquBMoQfj888pJySxA==";
       };
     };
+    "uuid-2.0.3" = {
+      name = "uuid";
+      packageName = "uuid";
+      version = "2.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz";
+        sha1 = "67e2e863797215530dff318e5bf9dcebfd47b21a";
+      };
+    };
+    "uuid-3.0.0" = {
+      name = "uuid";
+      packageName = "uuid";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz";
+        sha1 = "6728fc0459c450d796a99c31837569bdf672d728";
+      };
+    };
     "uuid-3.3.2" = {
       name = "uuid";
       packageName = "uuid";
@@ -49836,6 +52545,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz";
         sha512 = "fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==";
+      };
+    };
+    "uuid-8.3.1" = {
+      name = "uuid";
+      packageName = "uuid";
+      version = "8.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz";
+        sha512 = "FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==";
       };
     };
     "v8-compile-cache-2.1.1" = {
@@ -49926,6 +52644,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz";
         sha512 = "X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==";
+      };
+    };
+    "validator-10.5.0" = {
+      name = "validator";
+      packageName = "validator";
+      version = "10.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/validator/-/validator-10.5.0.tgz";
+        sha512 = "6OOi+eV2mOxCFLq0f2cJDrdB6lrtLXEUxabhNRGjgOLT/l3SSll9J49Cl+LIloUqkWWTPraK/mucEQ3dc2jStQ==";
+      };
+    };
+    "validator-11.0.0" = {
+      name = "validator";
+      packageName = "validator";
+      version = "11.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/validator/-/validator-11.0.0.tgz";
+        sha512 = "+wnGLYqaKV2++nUv60uGzUJyJQwYVOin6pn1tgEiFCeCQO60yeu3Og9/yPccbBX574kxIcEJicogkzx6s6eyag==";
       };
     };
     "validator-5.7.0" = {
@@ -50054,22 +52790,22 @@ let
         sha1 = "cfde751860a15822db3b132bc59b116a4adaf01b";
       };
     };
-    "vega-5.16.1" = {
+    "vega-5.17.0" = {
       name = "vega";
       packageName = "vega";
-      version = "5.16.1";
+      version = "5.17.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vega/-/vega-5.16.1.tgz";
-        sha512 = "bqovD23iKvIgFnTkP9WqapJbaejhgdED6YjAVWIwG8hsDq5Lf/ZNstJJWPiSDu3j785GQU/o6ZU3RXywdH4dJA==";
+        url = "https://registry.npmjs.org/vega/-/vega-5.17.0.tgz";
+        sha512 = "2Rm9aS3cSMXE55YgjfkuOmvSBMtiM/85/qX/WHLc+YiJacKGiwY9yzeC+w2Ft50JUs3nKZc1KB90ePgf5mfo0Q==";
       };
     };
-    "vega-canvas-1.2.5" = {
+    "vega-canvas-1.2.6" = {
       name = "vega-canvas";
       packageName = "vega-canvas";
-      version = "1.2.5";
+      version = "1.2.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.5.tgz";
-        sha512 = "6+jFEd6s7G088npH0+YuN1JTRxMYsjb1uXbwqcJ8zSP7gFR4f3tg/yA/BHU0+JbvLnxnScr61HYpDXAQ59YW3w==";
+        url = "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.6.tgz";
+        sha512 = "rgeYUpslYn/amIfnuv3Sw6n4BGns94OjjZNtUc9IDji6b+K8LGS/kW+Lvay8JX/oFqtulBp8RLcHN6QjqPLA9Q==";
       };
     };
     "vega-crossfilter-4.0.5" = {
@@ -50171,13 +52907,13 @@ let
         sha512 = "hCdm2pcHgkKgxnzW9GvX5JmYNiUMlOXOibtMmBzvFBQHX3NiV9giQ5nsPiQiFbV08VxEPtM+VYXr2HyrIcq5zQ==";
       };
     };
-    "vega-loader-4.3.3" = {
+    "vega-loader-4.4.0" = {
       name = "vega-loader";
       packageName = "vega-loader";
-      version = "4.3.3";
+      version = "4.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vega-loader/-/vega-loader-4.3.3.tgz";
-        sha512 = "ZcAMi6C7yfbA3gpxDnFe3PvsP/jcDwUjgPIpZ2IYsaQS+JijZAj5g3i4mpQCao0Atc+C/g7htg0Ir3twFLPjkQ==";
+        url = "https://registry.npmjs.org/vega-loader/-/vega-loader-4.4.0.tgz";
+        sha512 = "e5enQECdau7rJob0NFB5pGumh3RaaSWWm90+boxMy3ay2b4Ki/3XIvo+C4F1Lx04qSxvQF7tO2LJcklRm6nqRA==";
       };
     };
     "vega-parser-6.1.0" = {
@@ -50286,6 +53022,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/vega-util/-/vega-util-1.15.3.tgz";
         sha512 = "NCbfCPMVgdP4geLrFtCDN9PTEXrgZgJBBLvpyos7HGv2xSe9bGjDCysv6qcueHrc1myEeCQzrHDFaShny6wXDg==";
+      };
+    };
+    "vega-util-1.16.0" = {
+      name = "vega-util";
+      packageName = "vega-util";
+      version = "1.16.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vega-util/-/vega-util-1.16.0.tgz";
+        sha512 = "6mmz6mI+oU4zDMeKjgvE2Fjz0Oh6zo6WGATcvCfxH2gXBzhBHmy5d25uW5Zjnkc6QBXSWPLV9Xa6SiqMsrsKog==";
       };
     };
     "vega-view-5.9.0" = {
@@ -50621,6 +53366,15 @@ let
         sha512 = "DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==";
       };
     };
+    "vlq-1.0.1" = {
+      name = "vlq";
+      packageName = "vlq";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz";
+        sha512 = "gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==";
+      };
+    };
     "vls-0.5.4" = {
       name = "vls";
       packageName = "vls";
@@ -50657,13 +53411,13 @@ let
         sha1 = "c066afb582bb1cb4128d60ea92392e94d5e9dbec";
       };
     };
-    "vsce-1.80.0" = {
+    "vsce-1.81.1" = {
       name = "vsce";
       packageName = "vsce";
-      version = "1.80.0";
+      version = "1.81.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vsce/-/vsce-1.80.0.tgz";
-        sha512 = "pnJT0LttCd5k1fJRsTOer8NvgesMYxLZYTUwuVWVOgONK9w+U5Yf32rtm4cX374TsHZbBwUr6ZFLP36wyDD8/g==";
+        url = "https://registry.npmjs.org/vsce/-/vsce-1.81.1.tgz";
+        sha512 = "1yWAYRxTx/PKSFZnuELe7GPyIo70H/XKJqf6wGikofUK3f3TCNGI6F9xkTQFvXKNe0AygUuxN7kITyPIQGMP+w==";
       };
     };
     "vscode-css-languageservice-3.0.13" = {
@@ -50783,6 +53537,15 @@ let
         sha512 = "JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==";
       };
     };
+    "vscode-jsonrpc-5.1.0-next.1" = {
+      name = "vscode-jsonrpc";
+      packageName = "vscode-jsonrpc";
+      version = "5.1.0-next.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.1.0-next.1.tgz";
+        sha512 = "mwLDojZkbmpizSJSmp690oa9FB9jig18SIDGZeBCvFc2/LYSRvMm/WwWtMBJuJ1MfFh7rZXfQige4Uje5Z9NzA==";
+      };
+    };
     "vscode-jsonrpc-6.0.0-next.5" = {
       name = "vscode-jsonrpc";
       packageName = "vscode-jsonrpc";
@@ -50864,6 +53627,15 @@ let
         sha512 = "DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==";
       };
     };
+    "vscode-languageserver-6.2.0-next.2" = {
+      name = "vscode-languageserver";
+      packageName = "vscode-languageserver";
+      version = "6.2.0-next.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.2.0-next.2.tgz";
+        sha512 = "UCXULa/RmT2zxcb6auNezl9ZIPwYHS15+a0XzybrpT2+xA0RbHEYQCsIQkTRYjGv8cm3yS9iPJMmxLilP+y1Xw==";
+      };
+    };
     "vscode-languageserver-7.0.0-next.7" = {
       name = "vscode-languageserver";
       packageName = "vscode-languageserver";
@@ -50889,6 +53661,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz";
         sha512 = "zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==";
+      };
+    };
+    "vscode-languageserver-protocol-3.16.0-next.2" = {
+      name = "vscode-languageserver-protocol";
+      packageName = "vscode-languageserver-protocol";
+      version = "3.16.0-next.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.2.tgz";
+        sha512 = "atmkGT/W6tF0cx4SaWFYtFs2UeSeC28RPiap9myv2YZTaTCFvTBEPNWrU5QRKfkyM0tbgtGo6T3UCQ8tkDpjzA==";
       };
     };
     "vscode-languageserver-protocol-3.16.0-next.7" = {
@@ -50952,6 +53733,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz";
         sha512 = "+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==";
+      };
+    };
+    "vscode-languageserver-types-3.16.0-next.1" = {
+      name = "vscode-languageserver-types";
+      packageName = "vscode-languageserver-types";
+      version = "3.16.0-next.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.1.tgz";
+        sha512 = "tZFUSbyjUcrh+qQf13ALX4QDdOfDX0cVaBFgy7ktJ0VwS7AW/yRKgGPSxVqqP9OCMNPdqP57O5q47w2pEwfaUg==";
       };
     };
     "vscode-languageserver-types-3.16.0-next.2" = {
@@ -51314,13 +54104,13 @@ let
         sha512 = "n1CfuJcJ+dynIx/fmavB6haPx37N3GZvY5HIGIselymDiSwNRC+8pAxOzoB4eVwUBJnbP3+aA8vWttrAZbgs7A==";
       };
     };
-    "webassemblyjs-1.9.0" = {
+    "webassemblyjs-1.9.1" = {
       name = "webassemblyjs";
       packageName = "webassemblyjs";
-      version = "1.9.0";
+      version = "1.9.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webassemblyjs/-/webassemblyjs-1.9.0.tgz";
-        sha512 = "KTRXdxjv0R5fPnD3Nxeu3UX99egbq53/XLh6YV8/aHXgxtfq9LgEXqGy5OUGt0aWCve0Y463WgDM2MLDfkDlug==";
+        url = "https://registry.npmjs.org/webassemblyjs/-/webassemblyjs-1.9.1.tgz";
+        sha512 = "x0YxqLnuk8PjeZf5NOkmdQ4FwIRa7NlX3WIRhbpzSaGCih6la55TaATY4BpS81lMyjZvpdfKAQlLVzvd5G57fg==";
       };
     };
     "webidl-conversions-2.0.1" = {
@@ -51348,6 +54138,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz";
         sha512 = "qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==";
+      };
+    };
+    "webpack-4.43.0" = {
+      name = "webpack";
+      packageName = "webpack";
+      version = "4.43.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz";
+        sha512 = "GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==";
       };
     };
     "webpack-4.44.0" = {
@@ -51395,6 +54194,15 @@ let
         sha1 = "fc571588c8558da77be9efb6debdc5a3b172bdc2";
       };
     };
+    "webpack-deep-scope-plugin-1.6.0" = {
+      name = "webpack-deep-scope-plugin";
+      packageName = "webpack-deep-scope-plugin";
+      version = "1.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/webpack-deep-scope-plugin/-/webpack-deep-scope-plugin-1.6.0.tgz";
+        sha512 = "ZYldKNeWQtk9SoV70x7Eb2NRmvHMtNBOjscs0wUdg/pfymntiF+0W/D9v2o76ztufjND6RNFjNVnyFQww25AZg==";
+      };
+    };
     "webpack-dev-middleware-3.7.2" = {
       name = "webpack-dev-middleware";
       packageName = "webpack-dev-middleware";
@@ -51404,6 +54212,15 @@ let
         sha512 = "1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==";
       };
     };
+    "webpack-dev-server-3.11.0" = {
+      name = "webpack-dev-server";
+      packageName = "webpack-dev-server";
+      version = "3.11.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz";
+        sha512 = "PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==";
+      };
+    };
     "webpack-log-2.0.0" = {
       name = "webpack-log";
       packageName = "webpack-log";
@@ -51411,6 +54228,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz";
         sha512 = "cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==";
+      };
+    };
+    "webpack-manifest-plugin-2.2.0" = {
+      name = "webpack-manifest-plugin";
+      packageName = "webpack-manifest-plugin";
+      version = "2.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz";
+        sha512 = "9S6YyKKKh/Oz/eryM1RyLVDVmy3NSPV0JXMRhZ18fJsq+AwGxUY34X54VNwkzYcEmEkDwNxuEOboCZEebJXBAQ==";
       };
     };
     "webpack-node-externals-2.5.1" = {
@@ -51438,6 +54264,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/webpack-stream/-/webpack-stream-5.2.1.tgz";
         sha512 = "WvyVU0K1/VB1NZ7JfsaemVdG0PXAQUqbjUNW4A58th4pULvKMQxG+y33HXTL02JvD56ko2Cub+E2NyPwrLBT/A==";
+      };
+    };
+    "webpackbar-4.0.0" = {
+      name = "webpackbar";
+      packageName = "webpackbar";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/webpackbar/-/webpackbar-4.0.0.tgz";
+        sha512 = "k1qRoSL/3BVuINzngj09nIwreD8wxV4grcuhHTD8VJgUbGcy8lQSPqv+bM00B7F+PffwIsQ8ISd4mIwRbr23eQ==";
       };
     };
     "websocket-1.0.32" = {
@@ -51510,15 +54345,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz";
         sha512 = "b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==";
-      };
-    };
-    "whatwg-fetch-3.0.0" = {
-      name = "whatwg-fetch";
-      packageName = "whatwg-fetch";
-      version = "3.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz";
-        sha512 = "9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==";
       };
     };
     "whatwg-mimetype-2.3.0" = {
@@ -51944,6 +54770,141 @@ let
         sha512 = "mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==";
       };
     };
+    "workbox-background-sync-3.6.3" = {
+      name = "workbox-background-sync";
+      packageName = "workbox-background-sync";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.6.3.tgz";
+        sha512 = "ypLo0B6dces4gSpaslmDg5wuoUWrHHVJfFWwl1udvSylLdXvnrfhFfriCS42SNEe5lsZtcNZF27W/SMzBlva7Q==";
+      };
+    };
+    "workbox-broadcast-cache-update-3.6.3" = {
+      name = "workbox-broadcast-cache-update";
+      packageName = "workbox-broadcast-cache-update";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.6.3.tgz";
+        sha512 = "pJl4lbClQcvp0SyTiEw0zLSsVYE1RDlCPtpKnpMjxFtu8lCFTAEuVyzxp9w7GF4/b3P4h5nyQ+q7V9mIR7YzGg==";
+      };
+    };
+    "workbox-build-3.6.3" = {
+      name = "workbox-build";
+      packageName = "workbox-build";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-build/-/workbox-build-3.6.3.tgz";
+        sha512 = "w0clZ/pVjL8VXy6GfthefxpEXs0T8uiRuopZSFVQ8ovfbH6c6kUpEh6DcYwm/Y6dyWPiCucdyAZotgjz+nRz8g==";
+      };
+    };
+    "workbox-cache-expiration-3.6.3" = {
+      name = "workbox-cache-expiration";
+      packageName = "workbox-cache-expiration";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.6.3.tgz";
+        sha512 = "+ECNph/6doYx89oopO/UolYdDmQtGUgo8KCgluwBF/RieyA1ZOFKfrSiNjztxOrGJoyBB7raTIOlEEwZ1LaHoA==";
+      };
+    };
+    "workbox-cacheable-response-3.6.3" = {
+      name = "workbox-cacheable-response";
+      packageName = "workbox-cacheable-response";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.6.3.tgz";
+        sha512 = "QpmbGA9SLcA7fklBLm06C4zFg577Dt8u3QgLM0eMnnbaVv3rhm4vbmDpBkyTqvgK/Ly8MBDQzlXDtUCswQwqqg==";
+      };
+    };
+    "workbox-core-3.6.3" = {
+      name = "workbox-core";
+      packageName = "workbox-core";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-core/-/workbox-core-3.6.3.tgz";
+        sha512 = "cx9cx0nscPkIWs8Pt98HGrS9/aORuUcSkWjG25GqNWdvD/pSe7/5Oh3BKs0fC+rUshCiyLbxW54q0hA+GqZeSQ==";
+      };
+    };
+    "workbox-google-analytics-3.6.3" = {
+      name = "workbox-google-analytics";
+      packageName = "workbox-google-analytics";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.6.3.tgz";
+        sha512 = "RQBUo/6SXtIaQTRFj4RQZ9e1gAl7D8oS5S+Hi173Kk70/BgJjzPwXpC5A249Jv5YfkCOLMQCeF9A27BiD0b0ig==";
+      };
+    };
+    "workbox-navigation-preload-3.6.3" = {
+      name = "workbox-navigation-preload";
+      packageName = "workbox-navigation-preload";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-3.6.3.tgz";
+        sha512 = "dd26xTX16DUu0i+MhqZK/jQXgfIitu0yATM4jhRXEmpMqQ4MxEeNvl2CgjDMOHBnCVMax+CFZQWwxMx/X/PqCw==";
+      };
+    };
+    "workbox-precaching-3.6.3" = {
+      name = "workbox-precaching";
+      packageName = "workbox-precaching";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.6.3.tgz";
+        sha512 = "aBqT66BuMFviPTW6IpccZZHzpA8xzvZU2OM1AdhmSlYDXOJyb1+Z6blVD7z2Q8VNtV1UVwQIdImIX+hH3C3PIw==";
+      };
+    };
+    "workbox-range-requests-3.6.3" = {
+      name = "workbox-range-requests";
+      packageName = "workbox-range-requests";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-3.6.3.tgz";
+        sha512 = "R+yLWQy7D9aRF9yJ3QzwYnGFnGDhMUij4jVBUVtkl67oaVoP1ymZ81AfCmfZro2kpPRI+vmNMfxxW531cqdx8A==";
+      };
+    };
+    "workbox-routing-3.6.3" = {
+      name = "workbox-routing";
+      packageName = "workbox-routing";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.6.3.tgz";
+        sha512 = "bX20i95OKXXQovXhFOViOK63HYmXvsIwZXKWbSpVeKToxMrp0G/6LZXnhg82ijj/S5yhKNRf9LeGDzaqxzAwMQ==";
+      };
+    };
+    "workbox-strategies-3.6.3" = {
+      name = "workbox-strategies";
+      packageName = "workbox-strategies";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.6.3.tgz";
+        sha512 = "Pg5eulqeKet2y8j73Yw6xTgLdElktcWExGkzDVCGqfV9JCvnGuEpz5eVsCIK70+k4oJcBCin9qEg3g3CwEIH3g==";
+      };
+    };
+    "workbox-streams-3.6.3" = {
+      name = "workbox-streams";
+      packageName = "workbox-streams";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-streams/-/workbox-streams-3.6.3.tgz";
+        sha512 = "rqDuS4duj+3aZUYI1LsrD2t9hHOjwPqnUIfrXSOxSVjVn83W2MisDF2Bj+dFUZv4GalL9xqErcFW++9gH+Z27w==";
+      };
+    };
+    "workbox-sw-3.6.3" = {
+      name = "workbox-sw";
+      packageName = "workbox-sw";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.6.3.tgz";
+        sha512 = "IQOUi+RLhvYCiv80RP23KBW/NTtIvzvjex28B8NW1jOm+iV4VIu3VXKXTA6er5/wjjuhmtB28qEAUqADLAyOSg==";
+      };
+    };
+    "workbox-webpack-plugin-3.6.3" = {
+      name = "workbox-webpack-plugin";
+      packageName = "workbox-webpack-plugin";
+      version = "3.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-3.6.3.tgz";
+        sha512 = "RwmKjc7HFHUFHoOlKoZUq9349u0QN3F8W5tZZU0vc1qsBZDINWXRiIBCAKvo/Njgay5sWz7z4I2adnyTo97qIQ==";
+      };
+    };
     "worker-farm-1.7.0" = {
       name = "worker-farm";
       packageName = "worker-farm";
@@ -51951,6 +54912,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz";
         sha512 = "rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==";
+      };
+    };
+    "worker-loader-2.0.0" = {
+      name = "worker-loader";
+      packageName = "worker-loader";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz";
+        sha512 = "tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==";
+      };
+    };
+    "worker-rpc-0.1.1" = {
+      name = "worker-rpc";
+      packageName = "worker-rpc";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.1.1.tgz";
+        sha512 = "P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==";
       };
     };
     "workerpool-6.0.0" = {
@@ -52214,6 +55193,24 @@ let
         sha1 = "c9af18876f7a175801d564fe70ad9e8317784934";
       };
     };
+    "xcode-2.1.0" = {
+      name = "xcode";
+      packageName = "xcode";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xcode/-/xcode-2.1.0.tgz";
+        sha512 = "uCrmPITrqTEzhn0TtT57fJaNaw8YJs1aCzs+P/QqxsDbvPZSv7XMPPwXrKvHtD6pLjBM/NaVwraWJm8q83Y4iQ==";
+      };
+    };
+    "xcode-3.0.1" = {
+      name = "xcode";
+      packageName = "xcode";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz";
+        sha512 = "kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==";
+      };
+    };
     "xdg-basedir-2.0.0" = {
       name = "xdg-basedir";
       packageName = "xdg-basedir";
@@ -52295,6 +55292,15 @@ let
         sha1 = "3904c143fa8eb3a0030ec646d2902a2f1b706c44";
       };
     };
+    "xml-js-1.6.11" = {
+      name = "xml-js";
+      packageName = "xml-js";
+      version = "1.6.11";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz";
+        sha512 = "7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==";
+      };
+    };
     "xml-name-validator-2.0.1" = {
       name = "xml-name-validator";
       packageName = "xml-name-validator";
@@ -52311,6 +55317,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz";
         sha512 = "A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==";
+      };
+    };
+    "xml-parse-from-string-1.0.1" = {
+      name = "xml-parse-from-string";
+      packageName = "xml-parse-from-string";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz";
+        sha1 = "a9029e929d3dbcded169f3c6e28238d95a5d5a28";
       };
     };
     "xml2js-0.2.4" = {
@@ -52385,6 +55400,15 @@ let
         sha512 = "fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==";
       };
     };
+    "xmlbuilder-14.0.0" = {
+      name = "xmlbuilder";
+      packageName = "xmlbuilder";
+      version = "14.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz";
+        sha512 = "ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==";
+      };
+    };
     "xmlbuilder-2.5.2" = {
       name = "xmlbuilder";
       packageName = "xmlbuilder";
@@ -52430,6 +55454,15 @@ let
         sha512 = "HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==";
       };
     };
+    "xmldoc-1.1.2" = {
+      name = "xmldoc";
+      packageName = "xmldoc";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xmldoc/-/xmldoc-1.1.2.tgz";
+        sha512 = "ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==";
+      };
+    };
     "xmldom-0.1.19" = {
       name = "xmldom";
       packageName = "xmldom";
@@ -52437,6 +55470,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz";
         sha1 = "631fc07776efd84118bf25171b37ed4d075a0abc";
+      };
+    };
+    "xmldom-0.1.27" = {
+      name = "xmldom";
+      packageName = "xmldom";
+      version = "0.1.27";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz";
+        sha1 = "d501f97b3bdb403af8ef9ecc20573187aadac0e9";
       };
     };
     "xmldom-0.1.31" = {
@@ -52566,6 +55608,15 @@ let
         sha512 = "IiTO53rJ+Y5Jj7qMq0f3nwWU1KsajkJkzudTXJa/f3DQ1ifw5O6z/IFZuYF4osfPKhU85jyGaSfY3zqdiMNTVw==";
       };
     };
+    "xtend-2.0.6" = {
+      name = "xtend";
+      packageName = "xtend";
+      version = "2.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz";
+        sha1 = "5ea657a6dba447069c2e59c58a1138cb0c5e6cee";
+      };
+    };
     "xtend-2.1.2" = {
       name = "xtend";
       packageName = "xtend";
@@ -52573,6 +55624,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz";
         sha1 = "6efecc2a4dad8e6962c4901b337ce7ba87b5d28b";
+      };
+    };
+    "xtend-2.2.0" = {
+      name = "xtend";
+      packageName = "xtend";
+      version = "2.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz";
+        sha1 = "eef6b1f198c1c8deafad8b1765a04dad4a01c5a9";
+      };
+    };
+    "xtend-3.0.0" = {
+      name = "xtend";
+      packageName = "xtend";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz";
+        sha1 = "5cce7407baf642cba7becda568111c493f59665a";
       };
     };
     "xtend-4.0.2" = {
@@ -52602,13 +55671,13 @@ let
         sha512 = "r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==";
       };
     };
-    "y18n-5.0.1" = {
+    "y18n-5.0.2" = {
       name = "y18n";
       packageName = "y18n";
-      version = "5.0.1";
+      version = "5.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/y18n/-/y18n-5.0.1.tgz";
-        sha512 = "/jJ831jEs4vGDbYPQp4yGKDYPSCCEQ45uZWJHE1AoYBzqdZi8+LDWas0z4HrmJXmKdpFsTiowSHXdxyFhpmdMg==";
+        url = "https://registry.npmjs.org/y18n/-/y18n-5.0.2.tgz";
+        sha512 = "CkwaeZw6dQgqgPGeTWKMXCRmMcBgETFlTml1+ZOO+q7kGst8NREJ+eWwFNPVUQ4QGdAaklbqCZHH6Zuep1RjiA==";
       };
     };
     "yaeti-0.0.6" = {
@@ -52881,13 +55950,13 @@ let
         sha1 = "85568de3cf150ff49fa51825f03a8c880ddcc5c4";
       };
     };
-    "yargs-parser-20.2.0" = {
+    "yargs-parser-20.2.1" = {
       name = "yargs-parser";
       packageName = "yargs-parser";
-      version = "20.2.0";
+      version = "20.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.0.tgz";
-        sha512 = "2agPoRFPoIcFzOIp6656gcvsg2ohtscpw2OINr/q46+Sq41xz2OYLqx5HRHabmFU1OARIPAYH5uteICE7mn/5A==";
+        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz";
+        sha512 = "yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==";
       };
     };
     "yargs-parser-4.2.1" = {
@@ -53034,13 +56103,13 @@ let
         sha512 = "Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==";
       };
     };
-    "yoga-layout-prebuilt-1.9.6" = {
+    "yoga-layout-prebuilt-1.10.0" = {
       name = "yoga-layout-prebuilt";
       packageName = "yoga-layout-prebuilt";
-      version = "1.9.6";
+      version = "1.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.9.6.tgz";
-        sha512 = "Wursw6uqLXLMjBAO4SEShuzj8+EJXhCF71/rJ7YndHTkRAYSU0GY3OghRqfAk9HPUAAFMuqp3U1Wl+01vmGRQQ==";
+        url = "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.10.0.tgz";
+        sha512 = "YnOmtSbv4MTf7RGJMK0FvZ+KD8OEe/J5BNnR0GHhD8J/XcG/Qvxgszm0Un6FTHWW4uHlTgP0IztiXQnGyIR45g==";
       };
     };
     "yosay-2.0.2" = {
@@ -53106,15 +56175,6 @@ let
         sha1 = "253f907aead62a21acd8721d8b88032b2411c051";
       };
     };
-    "zip-stream-1.2.0" = {
-      name = "zip-stream";
-      packageName = "zip-stream";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz";
-        sha1 = "a8bc45f4c1b49699c6b90198baacaacdbcd4ba04";
-      };
-    };
     "zip-stream-2.1.3" = {
       name = "zip-stream";
       packageName = "zip-stream";
@@ -53166,18 +56226,17 @@ in
   "@angular/cli" = nodeEnv.buildNodePackage {
     name = "_at_angular_slash_cli";
     packageName = "@angular/cli";
-    version = "10.1.3";
+    version = "10.1.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@angular/cli/-/cli-10.1.3.tgz";
-      sha512 = "wj+ZcTLRzM94asLUZRO5U96CLEsnWosa3Iqub+1AH1/C8Wv2w/2njUKDM7ifQeebYzjPb5EcN4EIAGcHAGyeWw==";
+      url = "https://registry.npmjs.org/@angular/cli/-/cli-10.1.4.tgz";
+      sha512 = "Q61cqx3qMAtMugE28aWAtAaj+c31pRjGlq7xSH2LhQSmaGyoAq7v6qah6gqH1Ik8nlpF9T7jBIozKyqX9aXysg==";
     };
     dependencies = [
-      sources."@angular-devkit/architect-0.1001.3"
-      sources."@angular-devkit/core-10.1.3"
-      sources."@angular-devkit/schematics-10.1.3"
-      sources."@schematics/angular-10.1.3"
-      sources."@schematics/update-0.1001.3"
-      sources."@types/color-name-1.1.1"
+      sources."@angular-devkit/architect-0.1001.4"
+      sources."@angular-devkit/core-10.1.4"
+      sources."@angular-devkit/schematics-10.1.4"
+      sources."@schematics/angular-10.1.4"
+      sources."@schematics/update-0.1001.4"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."JSONStream-1.3.5"
       sources."agent-base-4.3.0"
@@ -53186,7 +56245,7 @@ in
       sources."ansi-colors-4.1.1"
       sources."ansi-escapes-4.3.1"
       sources."ansi-regex-5.0.0"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."aproba-1.2.0"
       sources."asap-2.0.6"
       sources."asn1-0.2.4"
@@ -53244,7 +56303,7 @@ in
       })
       sources."end-of-stream-1.4.4"
       sources."err-code-1.1.2"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.17.7"
       sources."es-to-primitive-1.2.1"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
@@ -53378,7 +56437,7 @@ in
       sources."object-keys-1.1.1"
       (sources."object.assign-4.1.1" // {
         dependencies = [
-          sources."es-abstract-1.18.0-next.0"
+          sources."es-abstract-1.18.0-next.1"
         ];
       })
       sources."object.getownpropertydescriptors-2.1.0"
@@ -53483,7 +56542,7 @@ in
       sources."through2-2.0.5"
       sources."tmp-0.0.33"
       sources."tough-cookie-2.5.0"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-fest-0.11.0"
@@ -53646,7 +56705,7 @@ in
         ];
       })
       sources."end-of-stream-1.4.4"
-      sources."es-abstract-1.18.0-next.0"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-2.0.0"
       sources."esprima-4.0.1"
@@ -53820,12 +56879,12 @@ in
       sources."stream-shift-1.0.1"
       (sources."string.prototype.trimend-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       (sources."string.prototype.trimstart-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."string_decoder-1.3.0"
@@ -53851,7 +56910,7 @@ in
         ];
       })
       sources."to-utf8-0.0.1"
-      sources."uglify-js-3.11.0"
+      sources."uglify-js-3.11.1"
       sources."unc-path-regex-0.1.2"
       sources."unique-stream-2.3.1"
       sources."universalify-0.1.2"
@@ -53898,7 +56957,7 @@ in
     };
     dependencies = [
       sources."abab-2.0.5"
-      sources."acorn-6.4.1"
+      sources."acorn-6.4.2"
       sources."acorn-globals-4.3.4"
       sources."acorn-walk-6.2.0"
       sources."agent-base-5.1.1"
@@ -54025,7 +57084,7 @@ in
       sources."tmp-0.0.33"
       sources."tough-cookie-2.5.0"
       sources."tr46-1.0.1"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-check-0.3.2"
@@ -54091,10 +57150,9 @@ in
       })
       sources."@schematics/schematics-0.1000.7"
       sources."@types/anymatch-1.3.1"
-      sources."@types/color-name-1.1.1"
       sources."@types/json-schema-7.0.6"
       sources."@types/json5-0.0.29"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/parse-json-4.0.0"
       sources."@types/source-list-map-0.1.2"
       sources."@types/tapable-1.0.6"
@@ -54108,7 +57166,7 @@ in
           sources."source-map-0.6.1"
         ];
       })
-      sources."@types/webpack-sources-1.4.2"
+      sources."@types/webpack-sources-2.0.0"
       sources."@webassemblyjs/ast-1.9.0"
       sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
       sources."@webassemblyjs/helper-api-error-1.9.0"
@@ -54129,7 +57187,7 @@ in
       sources."@webassemblyjs/wast-printer-1.9.0"
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.2"
-      sources."acorn-6.4.1"
+      sources."acorn-6.4.2"
       sources."ajv-6.12.3"
       sources."ajv-errors-1.0.1"
       sources."ajv-keywords-3.5.2"
@@ -54200,7 +57258,7 @@ in
       sources."callsites-3.1.0"
       (sources."chalk-3.0.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
@@ -54351,7 +57409,7 @@ in
       sources."for-in-1.0.2"
       (sources."fork-ts-checker-webpack-plugin-5.1.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -54402,7 +57460,7 @@ in
       sources."inherits-2.0.4"
       (sources."inquirer-7.3.3" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."cli-width-3.0.0"
           sources."color-convert-2.0.1"
@@ -54539,7 +57597,7 @@ in
       sources."onetime-5.1.2"
       (sources."ora-5.0.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -54729,7 +57787,7 @@ in
           sources."chalk-2.4.2"
         ];
       })
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tty-browserify-0.0.0"
       sources."type-fest-0.11.0"
       sources."typedarray-0.0.6"
@@ -54819,17 +57877,17 @@ in
   "@vue/cli" = nodeEnv.buildNodePackage {
     name = "_at_vue_slash_cli";
     packageName = "@vue/cli";
-    version = "4.5.6";
+    version = "4.5.7";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@vue/cli/-/cli-4.5.6.tgz";
-      sha512 = "S3CToCDtuqkcUyPrPTYKdic9aiOsVairCP8dEydyYjvLUIYVVK3GWJqBfThkNdaMjeB/fVPt8qlYjGqvSs55GQ==";
+      url = "https://registry.npmjs.org/@vue/cli/-/cli-4.5.7.tgz";
+      sha512 = "rx6yzQQ0DLxtJGxvGti8R1ND/wF5ISIv+hwyh1qB2R9gO6WobhT9sUBB/8Rth5hxRj7/MuCIz6KgmTc2hW+u2g==";
     };
     dependencies = [
       sources."@akryum/winattr-3.0.0"
       sources."@apollo/federation-0.20.2"
       (sources."@apollo/protobufjs-1.0.5" // {
         dependencies = [
-          sources."@types/node-10.17.35"
+          sources."@types/node-10.17.37"
         ];
       })
       sources."@apollographql/apollo-tools-0.4.8"
@@ -55004,7 +58062,7 @@ in
         dependencies = [
           (sources."chalk-3.0.0" // {
             dependencies = [
-              sources."ansi-styles-4.2.1"
+              sources."ansi-styles-4.3.0"
               sources."supports-color-7.2.0"
             ];
           })
@@ -55024,12 +58082,12 @@ in
         dependencies = [
           sources."globby-11.0.1"
           sources."is-wsl-2.2.0"
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
         ];
       })
       (sources."@oclif/errors-1.3.3" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."clean-stack-3.0.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -55069,7 +58127,7 @@ in
           sources."npm-run-path-3.1.0"
           sources."path-key-3.1.1"
           sources."semver-7.3.2"
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
         ];
       })
       (sources."@oclif/plugin-warn-if-update-available-1.7.0" // {
@@ -55092,7 +58150,6 @@ in
       sources."@sindresorhus/is-0.7.0"
       sources."@types/accepts-1.3.5"
       sources."@types/body-parser-1.19.0"
-      sources."@types/color-name-1.1.1"
       sources."@types/connect-3.4.33"
       sources."@types/content-disposition-0.5.3"
       sources."@types/cookies-0.7.4"
@@ -55123,7 +58180,7 @@ in
       sources."@types/long-4.0.1"
       sources."@types/mime-2.0.3"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       (sources."@types/node-fetch-2.5.7" // {
         dependencies = [
           sources."form-data-3.0.0"
@@ -55136,14 +58193,14 @@ in
       sources."@types/through-0.0.30"
       sources."@types/ws-7.2.7"
       sources."@types/zen-observable-0.8.1"
-      sources."@vue/cli-shared-utils-4.5.6"
-      (sources."@vue/cli-ui-4.5.6" // {
+      sources."@vue/cli-shared-utils-4.5.7"
+      (sources."@vue/cli-ui-4.5.7" // {
         dependencies = [
           sources."clone-2.1.2"
         ];
       })
-      sources."@vue/cli-ui-addon-webpack-4.5.6"
-      sources."@vue/cli-ui-addon-widgets-4.5.6"
+      sources."@vue/cli-ui-addon-webpack-4.5.7"
+      sources."@vue/cli-ui-addon-widgets-4.5.7"
       (sources."@vue/compiler-core-3.0.0" // {
         dependencies = [
           sources."@babel/types-7.11.5"
@@ -55223,7 +58280,7 @@ in
             ];
           })
           sources."source-map-0.6.1"
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
         ];
       })
       sources."apollo-codegen-flow-0.36.0"
@@ -55244,14 +58301,14 @@ in
       sources."apollo-link-ws-1.0.20"
       sources."apollo-reporting-protobuf-0.6.0"
       sources."apollo-server-caching-0.5.2"
-      (sources."apollo-server-core-2.18.1" // {
+      (sources."apollo-server-core-2.18.2" // {
         dependencies = [
-          sources."uuid-8.3.0"
+          sources."uuid-8.3.1"
         ];
       })
       sources."apollo-server-env-2.4.5"
       sources."apollo-server-errors-2.4.2"
-      sources."apollo-server-express-2.18.1"
+      sources."apollo-server-express-2.18.2"
       sources."apollo-server-plugin-base-0.10.1"
       sources."apollo-server-types-0.6.0"
       sources."apollo-tracing-0.11.4"
@@ -55277,7 +58334,7 @@ in
       sources."assign-symbols-1.0.0"
       (sources."ast-types-0.14.2" // {
         dependencies = [
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
         ];
       })
       sources."astral-regex-1.0.0"
@@ -55323,7 +58380,7 @@ in
               sources."string-width-3.1.0"
             ];
           })
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."camelcase-5.3.1"
           sources."chalk-3.0.0"
           sources."cli-boxes-2.2.1"
@@ -55367,7 +58424,7 @@ in
       sources."callsites-2.0.0"
       sources."camel-case-4.1.1"
       sources."camelcase-4.1.0"
-      sources."caniuse-lite-1.0.30001140"
+      sources."caniuse-lite-1.0.30001144"
       sources."capital-case-1.0.3"
       sources."capture-stack-trace-1.0.1"
       sources."cardinal-2.1.1"
@@ -55424,7 +58481,7 @@ in
       (sources."cli-ux-5.5.0" // {
         dependencies = [
           sources."ansi-escapes-4.3.1"
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."clean-stack-3.0.0"
           sources."color-convert-2.0.1"
@@ -55437,7 +58494,7 @@ in
           sources."semver-7.3.2"
           sources."supports-color-7.2.0"
           sources."supports-hyperlinks-2.1.0"
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
           sources."type-fest-0.11.0"
         ];
       })
@@ -55445,7 +58502,7 @@ in
       sources."clipboard-2.0.6"
       (sources."cliui-6.0.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."wrap-ansi-6.2.0"
@@ -55575,7 +58632,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."ejs-2.7.4"
-      sources."electron-to-chromium-1.3.576"
+      sources."electron-to-chromium-1.3.578"
       sources."elegant-spinner-1.0.1"
       sources."emoji-regex-8.0.0"
       sources."emojis-list-3.0.0"
@@ -55585,7 +58642,7 @@ in
       sources."env-ci-3.2.2"
       sources."envinfo-7.7.3"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.17.7"
       sources."es-to-primitive-1.2.1"
       sources."escalade-3.1.0"
       sources."escape-html-1.0.3"
@@ -55666,7 +58723,7 @@ in
       })
       sources."find-up-3.0.0"
       sources."fkill-6.2.0"
-      sources."flow-parser-0.134.0"
+      sources."flow-parser-0.135.0"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -55825,7 +58882,7 @@ in
       (sources."inquirer-7.3.3" // {
         dependencies = [
           sources."ansi-escapes-4.3.1"
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."cli-cursor-3.1.0"
           sources."color-convert-2.0.1"
@@ -56099,7 +59156,7 @@ in
       sources."object-visit-1.0.1"
       (sources."object.assign-4.1.1" // {
         dependencies = [
-          sources."es-abstract-1.18.0-next.0"
+          sources."es-abstract-1.18.0-next.1"
         ];
       })
       sources."object.getownpropertydescriptors-2.1.0"
@@ -56497,7 +59554,7 @@ in
       sources."trim-repeated-1.0.0"
       sources."ts-invariant-0.4.4"
       sources."ts-node-8.10.2"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tty-1.0.1"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
@@ -56647,31 +59704,31 @@ in
   "@webassemblyjs/cli" = nodeEnv.buildNodePackage {
     name = "_at_webassemblyjs_slash_cli";
     packageName = "@webassemblyjs/cli";
-    version = "1.9.0";
+    version = "1.9.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@webassemblyjs/cli/-/cli-1.9.0.tgz";
-      sha512 = "Gw6ToOlVAdmzjR1Xf+PHZflT5HOLaghWDanAHrZMJ0v+FVGRSGC8QAdnLneVDqgse7snzwGwkBu9AUwT4gNc4A==";
+      url = "https://registry.npmjs.org/@webassemblyjs/cli/-/cli-1.9.1.tgz";
+      sha512 = "OMu4uSrLdv1bJRrV+zbl6DszJiYaSUwfeigoGMkZvVHzh686pmzka9Bbz85es9Az/dnantDDIokEPSx1FQYm4A==";
     };
     dependencies = [
-      sources."@webassemblyjs/ast-1.9.0"
-      sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
-      sources."@webassemblyjs/helper-api-error-1.9.0"
-      sources."@webassemblyjs/helper-code-frame-1.9.0"
-      sources."@webassemblyjs/helper-compiler-1.9.0"
-      sources."@webassemblyjs/helper-flatten-ast-1.9.0"
-      sources."@webassemblyjs/helper-fsm-1.9.0"
-      sources."@webassemblyjs/helper-module-context-1.9.0"
-      sources."@webassemblyjs/helper-wasm-bytecode-1.9.0"
-      sources."@webassemblyjs/ieee754-1.9.0"
-      sources."@webassemblyjs/leb128-1.9.0"
-      sources."@webassemblyjs/utf8-1.9.0"
-      sources."@webassemblyjs/validation-1.9.0"
-      sources."@webassemblyjs/wasm-parser-1.9.0"
-      sources."@webassemblyjs/wast-parser-1.9.0"
-      sources."@webassemblyjs/wast-printer-1.9.0"
+      sources."@webassemblyjs/ast-1.9.1"
+      sources."@webassemblyjs/floating-point-hex-parser-1.9.1"
+      sources."@webassemblyjs/helper-api-error-1.9.1"
+      sources."@webassemblyjs/helper-code-frame-1.9.1"
+      sources."@webassemblyjs/helper-compiler-1.9.1"
+      sources."@webassemblyjs/helper-flatten-ast-1.9.1"
+      sources."@webassemblyjs/helper-fsm-1.9.1"
+      sources."@webassemblyjs/helper-module-context-1.9.1"
+      sources."@webassemblyjs/helper-wasm-bytecode-1.9.1"
+      sources."@webassemblyjs/ieee754-1.9.1"
+      sources."@webassemblyjs/leb128-1.9.1"
+      sources."@webassemblyjs/utf8-1.9.1"
+      sources."@webassemblyjs/validation-1.9.1"
+      sources."@webassemblyjs/wasm-parser-1.9.1"
+      sources."@webassemblyjs/wast-parser-1.9.1"
+      sources."@webassemblyjs/wast-printer-1.9.1"
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.2"
-      sources."webassemblyjs-1.9.0"
+      sources."webassemblyjs-1.9.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -56686,31 +59743,31 @@ in
   "@webassemblyjs/repl" = nodeEnv.buildNodePackage {
     name = "_at_webassemblyjs_slash_repl";
     packageName = "@webassemblyjs/repl";
-    version = "1.9.0";
+    version = "1.9.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@webassemblyjs/repl/-/repl-1.9.0.tgz";
-      sha512 = "y7eF4UgamWDu29cZL9kDg8dr9yRR+uOFNgwBwu7qrHJ0nmV7cMx2rhw8NHNEOr8VfCSKNhTpT9aewbT8aTdR3g==";
+      url = "https://registry.npmjs.org/@webassemblyjs/repl/-/repl-1.9.1.tgz";
+      sha512 = "190S+kS/qWfwt/c/QSpRmZpZV57WEL4Cbz2KZu+z5HAg+e53LXxC4XfpxHdsw+1Lo8Z4QB7nI+5xIr2mH+2ZjQ==";
     };
     dependencies = [
-      sources."@webassemblyjs/ast-1.9.0"
-      sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
-      sources."@webassemblyjs/helper-api-error-1.9.0"
-      sources."@webassemblyjs/helper-code-frame-1.9.0"
-      sources."@webassemblyjs/helper-compiler-1.9.0"
-      sources."@webassemblyjs/helper-flatten-ast-1.9.0"
-      sources."@webassemblyjs/helper-fsm-1.9.0"
-      sources."@webassemblyjs/helper-module-context-1.9.0"
-      sources."@webassemblyjs/helper-wasm-bytecode-1.9.0"
-      sources."@webassemblyjs/ieee754-1.9.0"
-      sources."@webassemblyjs/leb128-1.9.0"
-      sources."@webassemblyjs/utf8-1.9.0"
-      sources."@webassemblyjs/validation-1.9.0"
-      sources."@webassemblyjs/wasm-parser-1.9.0"
-      sources."@webassemblyjs/wast-parser-1.9.0"
-      sources."@webassemblyjs/wast-printer-1.9.0"
+      sources."@webassemblyjs/ast-1.9.1"
+      sources."@webassemblyjs/floating-point-hex-parser-1.9.1"
+      sources."@webassemblyjs/helper-api-error-1.9.1"
+      sources."@webassemblyjs/helper-code-frame-1.9.1"
+      sources."@webassemblyjs/helper-compiler-1.9.1"
+      sources."@webassemblyjs/helper-flatten-ast-1.9.1"
+      sources."@webassemblyjs/helper-fsm-1.9.1"
+      sources."@webassemblyjs/helper-module-context-1.9.1"
+      sources."@webassemblyjs/helper-wasm-bytecode-1.9.1"
+      sources."@webassemblyjs/ieee754-1.9.1"
+      sources."@webassemblyjs/leb128-1.9.1"
+      sources."@webassemblyjs/utf8-1.9.1"
+      sources."@webassemblyjs/validation-1.9.1"
+      sources."@webassemblyjs/wasm-parser-1.9.1"
+      sources."@webassemblyjs/wast-parser-1.9.1"
+      sources."@webassemblyjs/wast-printer-1.9.1"
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.2"
-      sources."webassemblyjs-1.9.0"
+      sources."webassemblyjs-1.9.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -56762,10 +59819,10 @@ in
   "@webassemblyjs/wasm-text-gen" = nodeEnv.buildNodePackage {
     name = "_at_webassemblyjs_slash_wasm-text-gen";
     packageName = "@webassemblyjs/wasm-text-gen";
-    version = "1.9.0";
+    version = "1.9.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@webassemblyjs/wasm-text-gen/-/wasm-text-gen-1.9.0.tgz";
-      sha512 = "O+nGHNGmkxo6g0X8BgsN5pSTi+iaYJ0noo28Vwwqgugdelcy6FNZmGWXR68KDQdnMXSjwD3eQVJTz21PCN9Qng==";
+      url = "https://registry.npmjs.org/@webassemblyjs/wasm-text-gen/-/wasm-text-gen-1.9.1.tgz";
+      sha512 = "RzgRzhCQJ/DBak+Yoy2bo4W6dUdqiswX8PN7qXsIZpNLYMcOOkcaq2o5gkiT/Y2HM3Rt08GxnBBlanXTrryTKQ==";
     };
     dependencies = [
       sources."@babel/code-frame-7.10.4"
@@ -56775,19 +59832,19 @@ in
       sources."@babel/parser-7.11.5"
       sources."@babel/template-7.10.4"
       sources."@babel/types-7.11.5"
-      sources."@webassemblyjs/ast-1.9.0"
-      sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
-      sources."@webassemblyjs/helper-api-error-1.9.0"
-      sources."@webassemblyjs/helper-code-frame-1.9.0"
-      sources."@webassemblyjs/helper-fsm-1.9.0"
-      sources."@webassemblyjs/helper-module-context-1.9.0"
-      sources."@webassemblyjs/helper-wasm-bytecode-1.9.0"
-      sources."@webassemblyjs/ieee754-1.9.0"
-      sources."@webassemblyjs/leb128-1.9.0"
-      sources."@webassemblyjs/utf8-1.9.0"
-      sources."@webassemblyjs/wasm-parser-1.9.0"
-      sources."@webassemblyjs/wast-parser-1.9.0"
-      sources."@webassemblyjs/wast-printer-1.9.0"
+      sources."@webassemblyjs/ast-1.9.1"
+      sources."@webassemblyjs/floating-point-hex-parser-1.9.1"
+      sources."@webassemblyjs/helper-api-error-1.9.1"
+      sources."@webassemblyjs/helper-code-frame-1.9.1"
+      sources."@webassemblyjs/helper-fsm-1.9.1"
+      sources."@webassemblyjs/helper-module-context-1.9.1"
+      sources."@webassemblyjs/helper-wasm-bytecode-1.9.1"
+      sources."@webassemblyjs/ieee754-1.9.1"
+      sources."@webassemblyjs/leb128-1.9.1"
+      sources."@webassemblyjs/utf8-1.9.1"
+      sources."@webassemblyjs/wasm-parser-1.9.1"
+      sources."@webassemblyjs/wast-parser-1.9.1"
+      sources."@webassemblyjs/wast-printer-1.9.1"
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.2"
       sources."ansi-styles-3.2.1"
@@ -56817,21 +59874,21 @@ in
   "@webassemblyjs/wast-refmt" = nodeEnv.buildNodePackage {
     name = "_at_webassemblyjs_slash_wast-refmt";
     packageName = "@webassemblyjs/wast-refmt";
-    version = "1.9.0";
+    version = "1.9.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@webassemblyjs/wast-refmt/-/wast-refmt-1.9.0.tgz";
-      sha512 = "TgYUlxP6Lk2MXHZuO6evze/4kso/iZI1/DuGDybICqeiHO3aMWV0xPw7amHY617l3X9Cu6Su4InLo03F4c2sAA==";
+      url = "https://registry.npmjs.org/@webassemblyjs/wast-refmt/-/wast-refmt-1.9.1.tgz";
+      sha512 = "+JfTZZV25LhdJspgw5xznFr/2QiFnHrKvb8CXmEV/s3PNFRpNDUlRPw0ZUZk2cwooZdiWNpC+WKfRPQb8tMx8w==";
     };
     dependencies = [
-      sources."@webassemblyjs/ast-1.9.0"
-      sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
-      sources."@webassemblyjs/helper-api-error-1.9.0"
-      sources."@webassemblyjs/helper-code-frame-1.9.0"
-      sources."@webassemblyjs/helper-fsm-1.9.0"
-      sources."@webassemblyjs/helper-module-context-1.9.0"
-      sources."@webassemblyjs/helper-wasm-bytecode-1.9.0"
-      sources."@webassemblyjs/wast-parser-1.9.0"
-      sources."@webassemblyjs/wast-printer-1.9.0"
+      sources."@webassemblyjs/ast-1.9.1"
+      sources."@webassemblyjs/floating-point-hex-parser-1.9.1"
+      sources."@webassemblyjs/helper-api-error-1.9.1"
+      sources."@webassemblyjs/helper-code-frame-1.9.1"
+      sources."@webassemblyjs/helper-fsm-1.9.1"
+      sources."@webassemblyjs/helper-module-context-1.9.1"
+      sources."@webassemblyjs/helper-wasm-bytecode-1.9.1"
+      sources."@webassemblyjs/wast-parser-1.9.1"
+      sources."@webassemblyjs/wast-printer-1.9.1"
       sources."@xtuc/long-4.2.2"
     ];
     buildInputs = globalBuildInputs;
@@ -56980,7 +60037,7 @@ in
     dependencies = [
       sources."@types/glob-7.1.3"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
       sources."chromium-pickle-js-0.2.0"
@@ -57018,7 +60075,7 @@ in
       sources."acorn-5.7.4"
       (sources."acorn-globals-4.3.4" // {
         dependencies = [
-          sources."acorn-6.4.1"
+          sources."acorn-6.4.2"
         ];
       })
       sources."acorn-walk-6.2.0"
@@ -57303,7 +60360,7 @@ in
     };
     dependencies = [
       sources."JSONStream-1.3.5"
-      sources."acorn-7.4.0"
+      sources."acorn-7.4.1"
       sources."acorn-node-1.8.2"
       sources."acorn-walk-7.2.0"
       (sources."asn1.js-5.4.1" // {
@@ -57520,7 +60577,7 @@ in
       sources."@protobufjs/pool-1.1.0"
       sources."@protobufjs/utf8-1.1.0"
       sources."@types/long-4.0.1"
-      sources."@types/node-13.13.21"
+      sources."@types/node-13.13.23"
       sources."addr-to-ip-port-1.5.1"
       sources."airplay-js-0.2.16"
       sources."ajv-6.12.5"
@@ -58038,7 +61095,7 @@ in
     dependencies = [
       sources."isexe-2.0.0"
       sources."node-fetch-2.6.1"
-      sources."tslib-2.0.1"
+      sources."tslib-2.0.2"
       sources."vscode-uri-2.1.2"
       sources."which-2.0.2"
     ];
@@ -58145,10 +61202,10 @@ in
   coc-json = nodeEnv.buildNodePackage {
     name = "coc-json";
     packageName = "coc-json";
-    version = "1.3.1";
+    version = "1.3.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-json/-/coc-json-1.3.1.tgz";
-      sha512 = "VKCzzCMZYxqjU89EMh8g58ytbhXXQcMSyWx385NXiijjK3Amtuvz775lPfiUeIAeVNr2VM+yeKimUw4pbE/lug==";
+      url = "https://registry.npmjs.org/coc-json/-/coc-json-1.3.2.tgz";
+      sha512 = "4wSADhO6oE2lxyYJw1cZqz6eYTrJWI4wHLETSTwhkkpZrPCNJA7mSmuB6oowxt7kJRmDVAIZP2mFyLTXU0jU6w==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -58221,7 +61278,7 @@ in
       sources."define-properties-1.1.3"
       sources."duplexer2-0.1.4"
       sources."end-of-stream-1.4.4"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.17.7"
       sources."es-to-primitive-1.2.1"
       sources."event-lite-0.1.2"
       sources."execa-1.0.0"
@@ -58297,7 +61354,7 @@ in
       sources."object-keys-1.1.1"
       (sources."object.assign-4.1.1" // {
         dependencies = [
-          sources."es-abstract-1.18.0-next.0"
+          sources."es-abstract-1.18.0-next.1"
         ];
       })
       sources."once-1.4.0"
@@ -58332,7 +61389,7 @@ in
       sources."strip-json-comments-2.0.1"
       sources."tar-6.0.5"
       sources."traverse-0.3.9"
-      sources."tslib-2.0.1"
+      sources."tslib-2.0.2"
       sources."universalify-0.1.2"
       sources."unzipper-0.10.11"
       sources."util-deprecate-1.0.2"
@@ -58387,7 +61444,6 @@ in
       sources."@babel/highlight-7.10.4"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
-      sources."@types/color-name-1.1.1"
       sources."@types/eslint-visitor-keys-1.0.0"
       sources."@types/json-schema-7.0.6"
       sources."@typescript-eslint/experimental-utils-3.10.1"
@@ -58395,7 +61451,7 @@ in
       sources."@typescript-eslint/types-3.10.1"
       sources."@typescript-eslint/typescript-estree-3.10.1"
       sources."@typescript-eslint/visitor-keys-3.10.1"
-      sources."acorn-7.4.0"
+      sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
       sources."ajv-6.12.5"
       sources."ajv-keywords-3.5.2"
@@ -58457,7 +61513,7 @@ in
       sources."callsites-3.1.0"
       sources."camelcase-2.1.1"
       sources."camelcase-keys-2.1.0"
-      sources."caniuse-lite-1.0.30001140"
+      sources."caniuse-lite-1.0.30001144"
       sources."capture-stack-trace-1.0.1"
       sources."ccount-1.0.5"
       sources."chalk-2.4.2"
@@ -58554,7 +61610,7 @@ in
       sources."domutils-1.7.0"
       sources."dot-prop-5.3.0"
       sources."duplexer3-0.1.4"
-      sources."electron-to-chromium-1.3.576"
+      sources."electron-to-chromium-1.3.578"
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
       sources."entities-1.1.2"
@@ -58738,7 +61794,7 @@ in
       sources."ini-1.3.5"
       (sources."inquirer-7.3.3" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -59235,7 +62291,7 @@ in
       sources."trim-newlines-1.0.0"
       sources."trim-trailing-lines-1.1.3"
       sources."trough-1.0.5"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       (sources."tslint-5.20.1" // {
         dependencies = [
           sources."semver-5.7.1"
@@ -59394,10 +62450,10 @@ in
   coc-rust-analyzer = nodeEnv.buildNodePackage {
     name = "coc-rust-analyzer";
     packageName = "coc-rust-analyzer";
-    version = "0.8.2";
+    version = "0.9.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-rust-analyzer/-/coc-rust-analyzer-0.8.2.tgz";
-      sha512 = "eTRAjbX2HgnqR+iu+xE41osKxlodln4aLSki2+sRc2dulIvCtB0y9E7u3auX6Y8au6IKfnjmn/GLNAWIz4oPQw==";
+      url = "https://registry.npmjs.org/coc-rust-analyzer/-/coc-rust-analyzer-0.9.0.tgz";
+      sha512 = "//DKmHGTR4u7tPoFBU+8apTuaXidWIJf+squdnVb/DX6J1fO9BSI6M6TBTlfY6IC1V1FOa6bUE6GNcQDyH1hYQ==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -59464,10 +62520,10 @@ in
   coc-stylelint = nodeEnv.buildNodePackage {
     name = "coc-stylelint";
     packageName = "coc-stylelint";
-    version = "1.1.0";
+    version = "1.2.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-stylelint/-/coc-stylelint-1.1.0.tgz";
-      sha512 = "+dVV5p9OBXyBGKFPQAS5a1SFvikSbYtYXyzPCkvYqYAqDiJlmFVEyi1aP+FI17Y/094u7mFeDQJlSd7IXVgO7w==";
+      url = "https://registry.npmjs.org/coc-stylelint/-/coc-stylelint-1.2.0.tgz";
+      sha512 = "+GYR6KTvHQnqu0j1kXT30hRZMuCwG/G52wG/19LSPE+p9Q0i8XFH6582T0btTu39xz2TPsDOGjT1VgyRw2urug==";
     };
     dependencies = [
       sources."@babel/code-frame-7.10.4"
@@ -59484,106 +62540,63 @@ in
       sources."@babel/helper-split-export-declaration-7.11.0"
       sources."@babel/helper-validator-identifier-7.10.4"
       sources."@babel/helpers-7.10.4"
-      sources."@babel/highlight-7.10.4"
+      (sources."@babel/highlight-7.10.4" // {
+        dependencies = [
+          sources."chalk-2.4.2"
+        ];
+      })
       sources."@babel/parser-7.11.5"
       sources."@babel/template-7.10.4"
       sources."@babel/traverse-7.11.5"
       sources."@babel/types-7.11.5"
-      sources."@mrmlnc/readdir-enhanced-2.2.1"
-      sources."@nodelib/fs.stat-1.1.3"
-      sources."@types/glob-7.1.3"
-      sources."@types/minimatch-3.0.3"
-      sources."@types/node-14.11.2"
+      sources."@nodelib/fs.scandir-2.1.3"
+      sources."@nodelib/fs.stat-2.0.3"
+      sources."@nodelib/fs.walk-1.2.4"
+      sources."@stylelint/postcss-css-in-js-0.37.2"
+      sources."@stylelint/postcss-markdown-0.36.1"
+      sources."@types/minimist-1.2.0"
+      sources."@types/normalize-package-data-2.4.0"
+      sources."@types/parse-json-4.0.0"
       sources."@types/unist-2.0.3"
-      sources."@types/vfile-3.0.2"
-      sources."@types/vfile-message-2.0.0"
       sources."ajv-6.12.5"
       sources."ansi-regex-5.0.0"
       sources."ansi-styles-3.2.1"
-      sources."argparse-1.0.10"
-      sources."arr-diff-4.0.0"
-      sources."arr-flatten-1.1.0"
-      sources."arr-union-3.1.0"
-      sources."array-find-index-1.0.2"
-      (sources."array-to-error-1.1.1" // {
-        dependencies = [
-          sources."array-to-sentence-1.1.0"
-        ];
-      })
-      sources."array-to-sentence-2.0.0"
-      sources."array-union-1.0.2"
-      sources."array-uniq-1.0.3"
-      sources."array-unique-0.3.2"
+      sources."array-union-2.1.0"
       sources."arrify-1.0.1"
-      sources."assign-symbols-1.0.0"
-      sources."astral-regex-1.0.0"
-      sources."atob-2.1.2"
-      (sources."autoprefixer-9.8.6" // {
-        dependencies = [
-          sources."postcss-value-parser-4.1.0"
-        ];
-      })
+      sources."astral-regex-2.0.0"
+      sources."autoprefixer-9.8.6"
       sources."bail-1.0.5"
       sources."balanced-match-1.0.0"
-      (sources."base-0.11.2" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-        ];
-      })
       sources."brace-expansion-1.1.11"
-      (sources."braces-2.3.2" // {
+      sources."braces-3.0.2"
+      sources."browserslist-4.14.5"
+      sources."callsites-3.1.0"
+      sources."camelcase-5.3.1"
+      sources."camelcase-keys-6.2.2"
+      sources."caniuse-lite-1.0.30001144"
+      sources."ccount-1.0.5"
+      (sources."chalk-4.1.0" // {
         dependencies = [
-          sources."extend-shallow-2.0.1"
+          sources."ansi-styles-4.3.0"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+          sources."has-flag-4.0.0"
+          sources."supports-color-7.2.0"
         ];
       })
-      sources."browserslist-4.14.5"
-      sources."cache-base-1.0.1"
-      sources."call-me-maybe-1.0.1"
-      sources."caller-callsite-2.0.0"
-      sources."caller-path-2.0.0"
-      sources."callsites-2.0.0"
-      sources."camelcase-4.1.0"
-      sources."camelcase-keys-4.2.0"
-      sources."caniuse-lite-1.0.30001140"
-      sources."ccount-1.0.5"
-      sources."chalk-2.4.2"
       sources."character-entities-1.2.4"
       sources."character-entities-html4-1.1.4"
       sources."character-entities-legacy-1.1.4"
       sources."character-reference-invalid-1.1.4"
-      (sources."class-utils-0.3.6" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
       sources."clone-regexp-2.2.0"
       sources."collapse-white-space-1.0.6"
-      sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."colorette-1.2.1"
-      sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
-      (sources."convert-source-map-1.7.0" // {
-        dependencies = [
-          sources."safe-buffer-5.1.2"
-        ];
-      })
-      sources."copy-descriptor-0.1.1"
-      sources."cosmiconfig-5.2.1"
-      sources."currently-unhandled-0.4.1"
+      sources."convert-source-map-1.7.0"
+      sources."cosmiconfig-7.0.0"
+      sources."cssesc-3.0.0"
       sources."debug-4.3.0"
       sources."decamelize-1.2.0"
       (sources."decamelize-keys-1.1.0" // {
@@ -59591,9 +62604,7 @@ in
           sources."map-obj-1.0.1"
         ];
       })
-      sources."decode-uri-component-0.2.0"
-      sources."define-property-2.0.2"
-      sources."dir-glob-2.2.2"
+      sources."dir-glob-3.0.1"
       (sources."dom-serializer-0.2.2" // {
         dependencies = [
           sources."domelementtype-2.0.2"
@@ -59603,431 +62614,238 @@ in
       sources."domelementtype-1.3.1"
       sources."domhandler-2.4.2"
       sources."domutils-1.7.0"
-      sources."dot-prop-5.3.0"
-      sources."electron-to-chromium-1.3.576"
+      sources."electron-to-chromium-1.3.578"
       sources."emoji-regex-8.0.0"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
       sources."escalade-3.1.0"
       sources."escape-string-regexp-1.0.5"
-      sources."esprima-4.0.1"
       sources."execall-2.0.0"
-      (sources."expand-brackets-2.1.4" // {
-        dependencies = [
-          sources."debug-2.6.9"
-          sources."define-property-0.2.5"
-          sources."extend-shallow-2.0.1"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-          sources."ms-2.0.0"
-        ];
-      })
       sources."extend-3.0.2"
-      (sources."extend-shallow-3.0.2" // {
-        dependencies = [
-          sources."is-extendable-1.0.1"
-        ];
-      })
-      (sources."extglob-2.0.4" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-          sources."extend-shallow-2.0.1"
-        ];
-      })
       sources."fast-deep-equal-3.1.3"
-      (sources."fast-glob-2.2.7" // {
-        dependencies = [
-          sources."micromatch-3.1.10"
-        ];
-      })
+      sources."fast-diff-1.2.0"
+      sources."fast-glob-3.2.4"
       sources."fast-json-stable-stringify-2.1.0"
+      sources."fastest-levenshtein-1.0.12"
+      sources."fastq-1.8.0"
       sources."file-entry-cache-5.0.1"
-      (sources."fill-range-4.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
-      sources."find-up-2.1.0"
+      sources."fill-range-7.0.1"
+      sources."find-up-4.1.0"
       sources."flat-cache-2.0.1"
       sources."flatted-2.0.2"
-      sources."for-in-1.0.2"
-      sources."fragment-cache-0.2.1"
       sources."fs.realpath-1.0.0"
       sources."gensync-1.0.0-beta.1"
-      sources."get-stdin-7.0.0"
-      sources."get-value-2.0.6"
+      sources."get-stdin-8.0.0"
       sources."glob-7.1.6"
-      (sources."glob-parent-3.1.0" // {
-        dependencies = [
-          sources."is-glob-3.1.0"
-        ];
-      })
-      sources."glob-to-regexp-0.3.0"
+      sources."glob-parent-5.1.1"
       sources."global-modules-2.0.0"
       sources."global-prefix-3.0.0"
       sources."globals-11.12.0"
-      (sources."globby-9.2.0" // {
-        dependencies = [
-          sources."ignore-4.0.6"
-          sources."slash-2.0.0"
-        ];
-      })
+      sources."globby-11.0.1"
       sources."globjoin-0.1.4"
       sources."gonzales-pe-4.3.0"
-      sources."graceful-fs-4.2.4"
+      sources."hard-rejection-2.1.0"
       sources."has-flag-3.0.0"
-      sources."has-value-1.0.0"
-      (sources."has-values-1.0.0" // {
-        dependencies = [
-          sources."kind-of-4.0.0"
-        ];
-      })
       sources."hosted-git-info-2.8.8"
       sources."html-tags-3.1.0"
       sources."htmlparser2-3.10.1"
       sources."ignore-5.1.8"
-      (sources."import-fresh-2.0.0" // {
+      (sources."import-fresh-3.2.1" // {
         dependencies = [
-          sources."resolve-from-3.0.0"
+          sources."resolve-from-4.0.0"
         ];
       })
       sources."import-lazy-4.0.0"
       sources."imurmurhash-0.1.4"
-      sources."indent-string-3.2.0"
+      sources."indent-string-4.0.0"
       sources."indexes-of-1.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      sources."inspect-with-kind-1.0.5"
-      sources."is-accessor-descriptor-1.0.0"
       sources."is-alphabetical-1.0.4"
       sources."is-alphanumeric-1.0.0"
       sources."is-alphanumerical-1.0.4"
       sources."is-arrayish-0.2.1"
-      sources."is-buffer-1.1.6"
-      sources."is-data-descriptor-1.0.0"
+      sources."is-buffer-2.0.4"
       sources."is-decimal-1.0.4"
-      sources."is-descriptor-1.0.2"
-      sources."is-directory-0.3.1"
-      sources."is-extendable-0.1.1"
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-3.0.0"
       sources."is-glob-4.0.1"
       sources."is-hexadecimal-1.0.4"
-      (sources."is-number-3.0.0" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."is-obj-2.0.0"
-      sources."is-plain-obj-1.1.0"
-      sources."is-plain-object-2.0.4"
+      sources."is-number-7.0.0"
+      sources."is-plain-obj-2.1.0"
       sources."is-regexp-2.1.0"
+      sources."is-typedarray-1.0.0"
       sources."is-whitespace-character-1.0.4"
-      sources."is-windows-1.0.2"
       sources."is-word-character-1.0.4"
-      sources."isarray-1.0.0"
       sources."isexe-2.0.0"
-      sources."isobject-3.0.1"
       sources."js-tokens-4.0.0"
-      sources."js-yaml-3.14.0"
       sources."jsesc-2.5.2"
-      sources."json-parse-better-errors-1.0.2"
+      sources."json-parse-even-better-errors-2.3.1"
       sources."json-schema-traverse-0.4.1"
       sources."json5-2.1.3"
       sources."kind-of-6.0.3"
-      sources."known-css-properties-0.14.0"
-      sources."leven-3.1.0"
-      (sources."load-json-file-4.0.0" // {
-        dependencies = [
-          sources."pify-3.0.0"
-        ];
-      })
-      sources."locate-path-2.0.0"
+      sources."known-css-properties-0.19.0"
+      sources."lines-and-columns-1.1.6"
+      sources."locate-path-5.0.0"
       sources."lodash-4.17.20"
-      sources."log-symbols-3.0.0"
+      sources."log-symbols-4.0.0"
       sources."longest-streak-2.0.4"
-      sources."loud-rejection-1.6.0"
-      sources."map-cache-0.2.2"
-      sources."map-obj-2.0.0"
-      sources."map-visit-1.0.0"
+      sources."map-obj-4.1.0"
       sources."markdown-escapes-1.0.4"
-      sources."markdown-table-1.1.3"
+      sources."markdown-table-2.0.0"
       sources."mathml-tag-names-2.1.3"
-      sources."mdast-util-compact-1.0.4"
-      sources."meow-5.0.0"
+      sources."mdast-util-compact-2.0.1"
+      sources."meow-7.1.1"
       sources."merge2-1.4.1"
-      (sources."micromatch-4.0.2" // {
-        dependencies = [
-          sources."braces-3.0.2"
-          sources."fill-range-7.0.1"
-          sources."is-number-7.0.0"
-          sources."to-regex-range-5.0.1"
-        ];
-      })
+      sources."micromatch-4.0.2"
+      sources."min-indent-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
-      sources."minimist-options-3.0.2"
-      (sources."mixin-deep-1.3.2" // {
+      (sources."minimist-options-4.1.0" // {
         dependencies = [
-          sources."is-extendable-1.0.1"
+          sources."is-plain-obj-1.1.0"
         ];
       })
       sources."mkdirp-0.5.5"
       sources."ms-2.1.2"
-      sources."nanomatch-1.2.13"
       sources."node-releases-1.1.61"
       sources."normalize-package-data-2.5.0"
       sources."normalize-range-0.1.2"
       sources."normalize-selector-0.2.0"
       sources."num2fraction-1.2.2"
-      (sources."object-copy-0.1.0" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."is-accessor-descriptor-0.1.6"
-          sources."is-data-descriptor-0.1.4"
-          (sources."is-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-5.1.0"
-            ];
-          })
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."object-visit-1.0.1"
-      sources."object.pick-1.3.0"
       sources."once-1.4.0"
-      sources."p-limit-1.3.0"
-      sources."p-locate-2.0.0"
-      sources."p-try-1.0.0"
-      sources."parse-entities-1.2.2"
-      sources."parse-json-4.0.0"
-      sources."pascalcase-0.1.1"
-      sources."path-dirname-1.0.2"
-      sources."path-exists-3.0.0"
+      sources."p-limit-2.3.0"
+      sources."p-locate-4.1.0"
+      sources."p-try-2.2.0"
+      sources."parent-module-1.0.1"
+      sources."parse-entities-2.0.0"
+      sources."parse-json-5.1.0"
+      sources."path-exists-4.0.0"
       sources."path-is-absolute-1.0.1"
+      sources."path-is-inside-1.0.2"
       sources."path-parse-1.0.6"
-      (sources."path-type-3.0.0" // {
-        dependencies = [
-          sources."pify-3.0.0"
-        ];
-      })
+      sources."path-type-4.0.0"
       sources."picomatch-2.2.2"
-      sources."pify-4.0.1"
-      sources."posix-character-classes-0.1.1"
       (sources."postcss-7.0.35" // {
         dependencies = [
+          (sources."chalk-2.4.2" // {
+            dependencies = [
+              sources."supports-color-5.5.0"
+            ];
+          })
           sources."source-map-0.6.1"
           sources."supports-color-6.1.0"
         ];
       })
       sources."postcss-html-0.36.0"
-      sources."postcss-jsx-0.36.4"
       sources."postcss-less-3.1.4"
-      sources."postcss-markdown-0.36.0"
       sources."postcss-media-query-parser-0.2.3"
-      (sources."postcss-reporter-6.0.1" // {
-        dependencies = [
-          sources."log-symbols-2.2.0"
-        ];
-      })
       sources."postcss-resolve-nested-selector-0.1.1"
       sources."postcss-safe-parser-4.0.2"
-      sources."postcss-sass-0.3.5"
+      sources."postcss-sass-0.4.4"
       sources."postcss-scss-2.1.1"
-      sources."postcss-selector-parser-3.1.2"
+      sources."postcss-selector-parser-6.0.4"
       sources."postcss-syntax-0.36.2"
-      sources."postcss-value-parser-3.3.1"
+      sources."postcss-value-parser-4.1.0"
       sources."punycode-2.1.1"
-      sources."quick-lru-1.1.0"
-      sources."read-pkg-3.0.0"
-      sources."read-pkg-up-3.0.0"
+      sources."quick-lru-4.0.1"
+      (sources."read-pkg-5.2.0" // {
+        dependencies = [
+          sources."type-fest-0.6.0"
+        ];
+      })
+      (sources."read-pkg-up-7.0.1" // {
+        dependencies = [
+          sources."type-fest-0.8.1"
+        ];
+      })
       sources."readable-stream-3.6.0"
-      sources."redent-2.0.0"
-      sources."regex-not-1.0.2"
-      sources."remark-10.0.1"
-      sources."remark-parse-6.0.3"
-      sources."remark-stringify-6.0.4"
-      sources."repeat-element-1.1.3"
+      sources."redent-3.0.0"
+      sources."remark-12.0.1"
+      sources."remark-parse-8.0.3"
+      sources."remark-stringify-8.1.1"
       sources."repeat-string-1.6.1"
       sources."replace-ext-1.0.0"
       sources."resolve-1.17.0"
       sources."resolve-from-5.0.0"
-      sources."resolve-url-0.2.1"
-      sources."ret-0.1.15"
+      sources."reusify-1.0.4"
       sources."rimraf-2.6.3"
-      sources."safe-buffer-5.2.1"
-      sources."safe-regex-1.1.0"
+      sources."run-parallel-1.1.9"
+      sources."safe-buffer-5.1.2"
       sources."semver-5.7.1"
-      (sources."set-value-2.0.1" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
       sources."signal-exit-3.0.3"
       sources."slash-3.0.0"
-      (sources."slice-ansi-2.1.0" // {
+      (sources."slice-ansi-4.0.0" // {
         dependencies = [
-          sources."is-fullwidth-code-point-2.0.0"
-        ];
-      })
-      (sources."snapdragon-0.8.2" // {
-        dependencies = [
-          sources."debug-2.6.9"
-          sources."define-property-0.2.5"
-          sources."extend-shallow-2.0.1"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-          sources."ms-2.0.0"
-        ];
-      })
-      (sources."snapdragon-node-2.1.1" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-        ];
-      })
-      (sources."snapdragon-util-3.0.1" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
+          sources."ansi-styles-4.3.0"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
         ];
       })
       sources."source-map-0.5.7"
-      sources."source-map-resolve-0.5.3"
-      sources."source-map-url-0.4.0"
       sources."spdx-correct-3.1.1"
       sources."spdx-exceptions-2.3.0"
       sources."spdx-expression-parse-3.0.1"
       sources."spdx-license-ids-3.0.6"
       sources."specificity-0.4.1"
-      sources."split-string-3.1.0"
-      sources."sprintf-js-1.0.3"
       sources."state-toggle-1.0.3"
-      (sources."static-extend-0.1.2" // {
+      sources."string-width-4.2.0"
+      (sources."string_decoder-1.3.0" // {
         dependencies = [
-          sources."define-property-0.2.5"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
+          sources."safe-buffer-5.2.1"
         ];
       })
-      (sources."string-width-4.2.0" // {
-        dependencies = [
-          sources."strip-ansi-6.0.0"
-        ];
-      })
-      sources."string_decoder-1.3.0"
-      sources."stringify-entities-1.3.2"
-      (sources."strip-ansi-5.2.0" // {
-        dependencies = [
-          sources."ansi-regex-4.1.0"
-        ];
-      })
-      sources."strip-bom-3.0.0"
-      sources."strip-indent-2.0.0"
+      sources."stringify-entities-3.0.1"
+      sources."strip-ansi-6.0.0"
+      sources."strip-indent-3.0.0"
       sources."style-search-0.1.0"
-      sources."stylelint-10.1.0"
-      sources."stylelint-vscode-7.0.0-21"
-      sources."stylelint-warning-to-vscode-diagnostic-1.0.1"
+      sources."stylelint-13.7.2"
       sources."sugarss-2.0.0"
       sources."supports-color-5.5.0"
       sources."svg-tags-1.0.0"
-      (sources."table-5.4.6" // {
-        dependencies = [
-          sources."emoji-regex-7.0.3"
-          sources."is-fullwidth-code-point-2.0.0"
-          sources."string-width-3.1.0"
-        ];
-      })
+      sources."table-6.0.3"
       sources."to-fast-properties-2.0.0"
-      (sources."to-object-path-0.3.0" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."to-regex-3.0.2"
-      sources."to-regex-range-2.1.1"
+      sources."to-regex-range-5.0.1"
       sources."trim-0.0.1"
-      sources."trim-newlines-2.0.0"
+      sources."trim-newlines-3.0.0"
       sources."trim-trailing-lines-1.1.3"
       sources."trough-1.0.5"
+      sources."type-fest-0.13.1"
+      sources."typedarray-to-buffer-3.1.5"
       sources."unherit-1.1.3"
-      sources."unified-7.1.0"
-      sources."union-value-1.0.1"
+      sources."unified-9.2.0"
       sources."uniq-1.0.1"
-      sources."unist-util-find-all-after-1.0.5"
-      sources."unist-util-is-3.0.0"
-      sources."unist-util-remove-position-1.1.4"
+      sources."unist-util-find-all-after-3.0.1"
+      sources."unist-util-is-4.0.2"
+      sources."unist-util-remove-position-2.0.1"
       sources."unist-util-stringify-position-2.0.3"
-      sources."unist-util-visit-1.4.1"
-      sources."unist-util-visit-parents-2.1.2"
-      (sources."unset-value-1.0.0" // {
-        dependencies = [
-          (sources."has-value-0.3.1" // {
-            dependencies = [
-              sources."isobject-2.1.0"
-            ];
-          })
-          sources."has-values-0.1.4"
-        ];
-      })
+      sources."unist-util-visit-2.0.3"
+      sources."unist-util-visit-parents-3.1.0"
       sources."uri-js-4.4.0"
-      sources."urix-0.1.0"
-      sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
+      sources."v8-compile-cache-2.1.1"
       sources."validate-npm-package-license-3.0.4"
-      (sources."vfile-3.0.1" // {
-        dependencies = [
-          sources."is-buffer-2.0.4"
-          sources."unist-util-stringify-position-1.1.2"
-          sources."vfile-message-1.1.1"
-        ];
-      })
-      sources."vfile-location-2.0.6"
+      sources."vfile-4.2.0"
+      sources."vfile-location-3.1.0"
       sources."vfile-message-2.0.4"
-      sources."vscode-jsonrpc-4.0.0"
-      sources."vscode-languageserver-5.2.1"
-      (sources."vscode-languageserver-protocol-3.14.1" // {
+      sources."vscode-jsonrpc-5.1.0-next.1"
+      sources."vscode-languageserver-6.2.0-next.2"
+      (sources."vscode-languageserver-protocol-3.16.0-next.2" // {
         dependencies = [
-          sources."vscode-languageserver-types-3.14.0"
+          sources."vscode-languageserver-types-3.16.0-next.1"
         ];
       })
-      sources."vscode-languageserver-types-3.15.1"
-      sources."vscode-uri-1.0.8"
+      sources."vscode-languageserver-textdocument-1.0.1"
+      sources."vscode-languageserver-types-3.16.0-next.3"
+      sources."vscode-uri-2.1.2"
       sources."which-1.3.1"
       sources."wrappy-1.0.2"
       sources."write-1.0.3"
-      sources."x-is-string-0.1.0"
+      sources."write-file-atomic-3.0.3"
       sources."xtend-4.0.2"
-      sources."yargs-parser-10.1.0"
+      sources."yaml-1.10.0"
+      sources."yargs-parser-18.1.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -60097,7 +62915,7 @@ in
       sources."semver-5.7.1"
       sources."sprintf-js-1.0.3"
       sources."supports-color-5.5.0"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tslint-5.20.1"
       sources."tsutils-2.29.0"
       sources."typescript-3.9.7"
@@ -60149,13 +62967,13 @@ in
   coc-tsserver = nodeEnv.buildNodePackage {
     name = "coc-tsserver";
     packageName = "coc-tsserver";
-    version = "1.5.7";
+    version = "1.5.8";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-tsserver/-/coc-tsserver-1.5.7.tgz";
-      sha512 = "VP/xLBnChBWZPrURULJsy5fi9gt+Fsvv5qWXZrLorBsh/14ppnPqfdyyKRuK+mDrxi9gcnSbAwTHOJ4yl5e9ag==";
+      url = "https://registry.npmjs.org/coc-tsserver/-/coc-tsserver-1.5.8.tgz";
+      sha512 = "rh1/curdq4ygQxsqPxJ7lgZR1zcEC3uWjLuDM4aiexzVAIO5QxtCFmKkfQHPzlOMHm6Gp5WvSJzgncS3Fj2Z+Q==";
     };
     dependencies = [
-      sources."typescript-3.9.7"
+      sources."typescript-4.0.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -60195,7 +63013,7 @@ in
       })
       sources."@nodelib/fs.stat-1.1.3"
       sources."@nodelib/fs.walk-1.2.4"
-      sources."@prettier/plugin-pug-1.7.0"
+      sources."@prettier/plugin-pug-1.8.1"
       sources."@sindresorhus/is-0.14.0"
       sources."@sorg/log-2.2.0"
       sources."@starptech/expression-parser-0.10.0"
@@ -60217,13 +63035,12 @@ in
       sources."@starptech/rehype-webparser-0.10.0"
       sources."@starptech/webparser-0.10.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/color-name-1.1.1"
       sources."@types/eslint-visitor-keys-1.0.0"
       sources."@types/glob-7.1.3"
       sources."@types/json-schema-7.0.6"
       sources."@types/minimatch-3.0.3"
       sources."@types/minimist-1.2.0"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/unist-2.0.3"
       sources."@types/vfile-3.0.2"
@@ -60239,7 +63056,7 @@ in
       })
       sources."@typescript-eslint/visitor-keys-3.10.1"
       sources."abbrev-1.1.1"
-      sources."acorn-7.4.0"
+      sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
       (sources."aggregate-error-3.1.0" // {
         dependencies = [
@@ -60452,7 +63269,7 @@ in
       (sources."eslint-7.10.0" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -60470,7 +63287,7 @@ in
           sources."which-2.0.2"
         ];
       })
-      (sources."eslint-plugin-vue-7.0.0" // {
+      (sources."eslint-plugin-vue-7.0.1" // {
         dependencies = [
           sources."semver-7.3.2"
         ];
@@ -60623,7 +63440,7 @@ in
       (sources."inquirer-7.3.3" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -61083,7 +63900,7 @@ in
       sources."trim-newlines-2.0.0"
       sources."trim-trailing-lines-1.1.3"
       sources."trough-1.0.5"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       (sources."tslint-5.20.1" // {
         dependencies = [
           sources."tsutils-2.29.0"
@@ -61323,10 +64140,10 @@ in
   coc-yank = nodeEnv.buildNodePackage {
     name = "coc-yank";
     packageName = "coc-yank";
-    version = "1.1.7";
+    version = "1.1.8";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-yank/-/coc-yank-1.1.7.tgz";
-      sha512 = "5WCpa1k96mlhcC8acPqljkDhmoVFfFzTRi2bO+QJDakgQfZxN5UqMcVrnh4ZDKFQuE09zEpn8quwEjvU1W5VMQ==";
+      url = "https://registry.npmjs.org/coc-yank/-/coc-yank-1.1.8.tgz";
+      sha512 = "jDBtzTnFb3TnwmsqQt5b6KFRcXB7J5pdsebzdovqroaKwKT9YH19CG4qPeuJleT3dJ/AwfUw3WP3yZWkwvLbFg==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -61487,7 +64304,6 @@ in
       sources."@nodelib/fs.walk-1.2.4"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/color-name-1.1.1"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
       sources."ajv-6.12.5"
@@ -61499,7 +64315,7 @@ in
       })
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-3.0.0"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."array-find-index-1.0.2"
       sources."array-flatten-1.1.1"
       sources."array-union-2.1.0"
@@ -61899,7 +64715,7 @@ in
       sources."strip-final-newline-2.0.0"
       sources."strip-json-comments-2.0.1"
       sources."supports-color-7.2.0"
-      sources."systeminformation-4.27.5"
+      sources."systeminformation-4.27.7"
       sources."term-size-2.2.0"
       sources."through-2.3.8"
       sources."tmp-0.2.1"
@@ -61907,7 +64723,7 @@ in
       sources."to-regex-range-5.0.1"
       sources."toidentifier-1.0.0"
       sources."tough-cookie-3.0.1"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-fest-0.8.1"
@@ -61986,7 +64802,7 @@ in
       sources."@types/glob-7.1.3"
       sources."@types/minimatch-3.0.3"
       sources."@types/minimist-1.2.0"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/normalize-package-data-2.4.0"
       sources."aggregate-error-3.1.0"
       sources."ansi-styles-3.2.1"
@@ -62354,7 +65170,7 @@ in
       sources."@cycle/run-3.4.0"
       sources."@cycle/time-0.10.1"
       sources."@types/cookiejar-2.1.1"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/superagent-3.8.2"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-2.1.1"
@@ -62501,10 +65317,9 @@ in
       sha512 = "i0Zxiqj8Q2tMJkMousrZdB/vlvtoAZyN49bgAfM4yHhWQUzrpM1rZU7TX1Rg5bbDQ1R8Gk/usNnpkDzEHJdVXg==";
     };
     dependencies = [
-      sources."@types/color-name-1.1.1"
       sources."ansi-escapes-4.3.1"
       sources."ansi-regex-5.0.0"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."balanced-match-1.0.0"
       sources."block-stream-0.0.9"
       sources."brace-expansion-1.1.11"
@@ -62607,7 +65422,7 @@ in
         ];
       })
       sources."tmp-0.1.0"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."type-fest-0.11.0"
       sources."uid-number-0.0.6"
       sources."universalify-0.1.2"
@@ -63234,7 +66049,7 @@ in
       sources."throttle-1.0.3"
       sources."thunky-1.1.0"
       sources."timed-out-4.0.1"
-      sources."timeout-refresh-1.0.2"
+      sources."timeout-refresh-1.0.3"
       sources."to-buffer-1.1.1"
       (sources."to-object-path-0.3.0" // {
         dependencies = [
@@ -63325,10 +66140,10 @@ in
   dhcp = nodeEnv.buildNodePackage {
     name = "dhcp";
     packageName = "dhcp";
-    version = "0.2.19";
+    version = "0.2.20";
     src = fetchurl {
-      url = "https://registry.npmjs.org/dhcp/-/dhcp-0.2.19.tgz";
-      sha512 = "RQhzFYjO955zR6YUqP2NbaE6owt9sq33ACWydyKS0v7Tec71Gf2+ewNLyE91UqCtw3wmQhTAYDsWdrqzsxVNig==";
+      url = "https://registry.npmjs.org/dhcp/-/dhcp-0.2.20.tgz";
+      sha512 = "SfKVTg5qqe5aXSrSAXABM1yJl3OjekhSg6ryJyLjK1015waNj9fmMq8SrHI6qWuICtiprfYbh/f55giBJcC9Ag==";
     };
     dependencies = [
       sources."minimist-1.2.5"
@@ -63407,7 +66222,7 @@ in
       sources."temp-dir-2.0.0"
       sources."tempy-0.7.1"
       sources."to-regex-range-5.0.1"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."type-fest-0.16.0"
       sources."unique-string-2.0.0"
       sources."vscode-jsonrpc-5.0.1"
@@ -63474,7 +66289,7 @@ in
       sources."assert-plus-1.0.0"
       sources."async-2.6.3"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.763.0"
+      sources."aws-sdk-2.768.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.10.1"
       sources."base64-js-1.3.1"
@@ -63649,11 +66464,10 @@ in
       sources."@sindresorhus/is-3.1.2"
       sources."@szmarczak/http-timer-4.0.5"
       sources."@types/cacheable-request-6.0.1"
-      sources."@types/color-name-1.1.1"
       sources."@types/http-cache-semantics-4.0.0"
       sources."@types/keyv-3.1.1"
       sources."@types/minimist-1.2.0"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/responselike-1.0.0"
       sources."@types/yoga-layout-1.9.2"
@@ -63748,9 +66562,9 @@ in
       sources."indent-string-4.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      (sources."ink-3.0.6" // {
+      (sources."ink-3.0.7" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -63760,7 +66574,7 @@ in
       })
       (sources."ink-text-input-4.0.1" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -63790,7 +66604,6 @@ in
       sources."lines-and-columns-1.1.6"
       sources."locate-path-3.0.0"
       sources."lodash-4.17.20"
-      sources."lodash.throttle-4.1.1"
       sources."loose-envify-1.4.0"
       sources."lowercase-keys-2.0.0"
       (sources."make-dir-3.1.0" // {
@@ -63884,7 +66697,7 @@ in
       sources."skin-tone-1.0.0"
       (sources."slice-ansi-3.0.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
         ];
@@ -63921,7 +66734,7 @@ in
       sources."widest-line-3.1.0"
       (sources."wrap-ansi-6.2.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
         ];
@@ -63929,7 +66742,7 @@ in
       sources."wrappy-1.0.2"
       sources."ws-7.3.1"
       sources."yargs-parser-18.1.3"
-      sources."yoga-layout-prebuilt-1.9.6"
+      sources."yoga-layout-prebuilt-1.10.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -63970,10 +66783,10 @@ in
       sources."@fluentui/date-time-utilities-7.9.0"
       sources."@fluentui/dom-utilities-1.1.1"
       sources."@fluentui/keyboard-key-0.2.12"
-      sources."@fluentui/react-7.143.0"
-      sources."@fluentui/react-focus-7.16.9"
+      sources."@fluentui/react-7.145.0"
+      sources."@fluentui/react-focus-7.16.10"
       sources."@fluentui/react-window-provider-0.3.3"
-      sources."@fluentui/theme-1.2.1"
+      sources."@fluentui/theme-1.3.0"
       (sources."@gulp-sourcemaps/identity-map-1.0.2" // {
         dependencies = [
           sources."normalize-path-2.1.1"
@@ -63985,7 +66798,7 @@ in
           sources."normalize-path-2.1.1"
         ];
       })
-      sources."@microsoft/load-themed-styles-1.10.101"
+      sources."@microsoft/load-themed-styles-1.10.108"
       sources."@nodelib/fs.scandir-2.1.3"
       sources."@nodelib/fs.stat-2.0.3"
       sources."@nodelib/fs.walk-1.2.4"
@@ -64026,13 +66839,13 @@ in
       sources."@types/sqlite3-3.1.6"
       sources."@types/tough-cookie-4.0.0"
       sources."@types/url-join-4.0.0"
-      sources."@uifabric/foundation-7.9.9"
-      sources."@uifabric/icons-7.5.8"
+      sources."@uifabric/foundation-7.9.10"
+      sources."@uifabric/icons-7.5.9"
       sources."@uifabric/merge-styles-7.19.1"
-      sources."@uifabric/react-hooks-7.13.5"
+      sources."@uifabric/react-hooks-7.13.6"
       sources."@uifabric/set-version-7.0.23"
-      sources."@uifabric/styling-7.16.9"
-      sources."@uifabric/utilities-7.32.3"
+      sources."@uifabric/styling-7.16.10"
+      sources."@uifabric/utilities-7.32.4"
       sources."@webassemblyjs/ast-1.9.0"
       sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
       sources."@webassemblyjs/helper-api-error-1.9.0"
@@ -64425,7 +67238,7 @@ in
       sources."enhanced-resolve-4.3.0"
       sources."errno-0.1.7"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.18.0-next.0"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."es5-ext-0.10.53"
       sources."es6-iterator-2.0.3"
@@ -64715,7 +67528,7 @@ in
       sources."isexe-2.0.0"
       sources."isobject-3.0.1"
       sources."isstream-0.1.2"
-      (sources."jest-worker-26.3.0" // {
+      (sources."jest-worker-26.5.0" // {
         dependencies = [
           sources."has-flag-4.0.0"
           sources."supports-color-7.2.0"
@@ -64853,7 +67666,7 @@ in
         ];
       })
       sources."mkdirp-1.0.4"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       (sources."morgan-1.10.0" // {
         dependencies = [
           sources."depd-2.0.0"
@@ -64948,7 +67761,7 @@ in
       sources."object.map-1.0.1"
       sources."object.pick-1.3.0"
       sources."object.reduce-1.0.1"
-      sources."office-ui-fabric-react-7.143.0"
+      sources."office-ui-fabric-react-7.145.0"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
@@ -65052,10 +67865,10 @@ in
           sources."semver-4.3.2"
         ];
       })
-      sources."pg-connection-string-2.3.0"
+      sources."pg-connection-string-2.4.0"
       sources."pg-int8-1.0.1"
       sources."pg-pool-3.2.1"
-      sources."pg-protocol-1.2.5"
+      sources."pg-protocol-1.3.0"
       sources."pg-types-2.2.0"
       sources."pgpass-1.0.2"
       sources."picomatch-2.2.2"
@@ -65159,7 +67972,7 @@ in
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
-      sources."sass-1.26.11"
+      sources."sass-1.26.12"
       sources."sax-1.2.4"
       sources."scheduler-0.19.1"
       sources."schema-utils-2.7.1"
@@ -65302,12 +68115,12 @@ in
       sources."string-width-1.0.2"
       (sources."string.prototype.trimend-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       (sources."string.prototype.trimstart-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."string_decoder-1.1.1"
@@ -65359,7 +68172,7 @@ in
         ];
       })
       sources."ts-log-2.2.3"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       (sources."tslint-6.1.2" // {
         dependencies = [
           sources."mkdirp-0.5.5"
@@ -65439,7 +68252,7 @@ in
       sources."watchpack-chokidar2-2.0.0"
       (sources."webpack-4.44.0" // {
         dependencies = [
-          sources."acorn-6.4.1"
+          sources."acorn-6.4.2"
           sources."braces-2.3.2"
           sources."cacache-12.0.4"
           sources."chownr-1.1.4"
@@ -65540,8 +68353,7 @@ in
         ];
       })
       sources."@eslint/eslintrc-0.1.3"
-      sources."@types/color-name-1.1.1"
-      sources."acorn-7.4.0"
+      sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
       sources."ajv-6.12.5"
       sources."ansi-colors-4.1.1"
@@ -65554,7 +68366,7 @@ in
       sources."callsites-3.1.0"
       (sources."chalk-4.1.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
@@ -65683,8 +68495,7 @@ in
         ];
       })
       sources."@eslint/eslintrc-0.1.3"
-      sources."@types/color-name-1.1.1"
-      sources."acorn-7.4.0"
+      sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
       sources."ajv-6.12.5"
       sources."ansi-colors-4.1.1"
@@ -65697,7 +68508,7 @@ in
       sources."callsites-3.1.0"
       (sources."chalk-4.1.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
@@ -65806,6 +68617,2722 @@ in
     meta = {
       description = "Makes eslint the fastest linter on the planet";
       homepage = https://github.com/mantoni/eslint_d.js;
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
+  expo-cli = nodeEnv.buildNodePackage {
+    name = "expo-cli";
+    packageName = "expo-cli";
+    version = "3.27.14";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/expo-cli/-/expo-cli-3.27.14.tgz";
+      sha512 = "1/avJnfrvOEM31Bfu/8wSGnSxscxKJ+MusqjTgy7q/LEes8M0VqtdMWb8ZPXJ8weaIEV6o98EGoomkYayJTyJw==";
+    };
+    dependencies = [
+      sources."@babel/code-frame-7.10.4"
+      sources."@babel/compat-data-7.11.0"
+      sources."@babel/core-7.9.0"
+      sources."@babel/generator-7.11.6"
+      sources."@babel/helper-annotate-as-pure-7.10.4"
+      sources."@babel/helper-builder-binary-assignment-operator-visitor-7.10.4"
+      sources."@babel/helper-builder-react-jsx-7.10.4"
+      sources."@babel/helper-builder-react-jsx-experimental-7.11.5"
+      sources."@babel/helper-compilation-targets-7.10.4"
+      sources."@babel/helper-create-class-features-plugin-7.10.5"
+      sources."@babel/helper-create-regexp-features-plugin-7.10.4"
+      (sources."@babel/helper-define-map-7.10.5" // {
+        dependencies = [
+          sources."lodash-4.17.20"
+        ];
+      })
+      sources."@babel/helper-explode-assignable-expression-7.11.4"
+      sources."@babel/helper-function-name-7.10.4"
+      sources."@babel/helper-get-function-arity-7.10.4"
+      sources."@babel/helper-hoist-variables-7.10.4"
+      sources."@babel/helper-member-expression-to-functions-7.11.0"
+      sources."@babel/helper-module-imports-7.10.4"
+      (sources."@babel/helper-module-transforms-7.11.0" // {
+        dependencies = [
+          sources."lodash-4.17.20"
+        ];
+      })
+      sources."@babel/helper-optimise-call-expression-7.10.4"
+      sources."@babel/helper-plugin-utils-7.10.4"
+      (sources."@babel/helper-regex-7.10.5" // {
+        dependencies = [
+          sources."lodash-4.17.20"
+        ];
+      })
+      sources."@babel/helper-remap-async-to-generator-7.11.4"
+      sources."@babel/helper-replace-supers-7.10.4"
+      sources."@babel/helper-simple-access-7.10.4"
+      sources."@babel/helper-skip-transparent-expression-wrappers-7.11.0"
+      sources."@babel/helper-split-export-declaration-7.11.0"
+      sources."@babel/helper-validator-identifier-7.10.4"
+      sources."@babel/helper-wrap-function-7.10.4"
+      sources."@babel/helpers-7.10.4"
+      (sources."@babel/highlight-7.10.4" // {
+        dependencies = [
+          sources."chalk-2.4.2"
+        ];
+      })
+      sources."@babel/parser-7.11.5"
+      sources."@babel/plugin-proposal-async-generator-functions-7.10.5"
+      sources."@babel/plugin-proposal-class-properties-7.10.4"
+      sources."@babel/plugin-proposal-dynamic-import-7.10.4"
+      sources."@babel/plugin-proposal-export-default-from-7.10.4"
+      sources."@babel/plugin-proposal-export-namespace-from-7.10.4"
+      sources."@babel/plugin-proposal-json-strings-7.10.4"
+      sources."@babel/plugin-proposal-logical-assignment-operators-7.11.0"
+      sources."@babel/plugin-proposal-nullish-coalescing-operator-7.10.4"
+      sources."@babel/plugin-proposal-numeric-separator-7.10.4"
+      sources."@babel/plugin-proposal-object-rest-spread-7.11.0"
+      sources."@babel/plugin-proposal-optional-catch-binding-7.10.4"
+      sources."@babel/plugin-proposal-optional-chaining-7.11.0"
+      sources."@babel/plugin-proposal-private-methods-7.10.4"
+      sources."@babel/plugin-proposal-unicode-property-regex-7.10.4"
+      sources."@babel/plugin-syntax-async-generators-7.8.4"
+      sources."@babel/plugin-syntax-class-properties-7.10.4"
+      sources."@babel/plugin-syntax-dynamic-import-7.8.3"
+      sources."@babel/plugin-syntax-export-default-from-7.10.4"
+      sources."@babel/plugin-syntax-export-namespace-from-7.8.3"
+      sources."@babel/plugin-syntax-flow-7.10.4"
+      sources."@babel/plugin-syntax-json-strings-7.8.3"
+      sources."@babel/plugin-syntax-jsx-7.10.4"
+      sources."@babel/plugin-syntax-logical-assignment-operators-7.10.4"
+      sources."@babel/plugin-syntax-nullish-coalescing-operator-7.8.3"
+      sources."@babel/plugin-syntax-numeric-separator-7.10.4"
+      sources."@babel/plugin-syntax-object-rest-spread-7.8.3"
+      sources."@babel/plugin-syntax-optional-catch-binding-7.8.3"
+      sources."@babel/plugin-syntax-optional-chaining-7.8.3"
+      sources."@babel/plugin-syntax-top-level-await-7.10.4"
+      sources."@babel/plugin-syntax-typescript-7.10.4"
+      sources."@babel/plugin-transform-arrow-functions-7.10.4"
+      sources."@babel/plugin-transform-async-to-generator-7.10.4"
+      sources."@babel/plugin-transform-block-scoped-functions-7.10.4"
+      sources."@babel/plugin-transform-block-scoping-7.11.1"
+      sources."@babel/plugin-transform-classes-7.10.4"
+      sources."@babel/plugin-transform-computed-properties-7.10.4"
+      sources."@babel/plugin-transform-destructuring-7.10.4"
+      sources."@babel/plugin-transform-dotall-regex-7.10.4"
+      sources."@babel/plugin-transform-duplicate-keys-7.10.4"
+      sources."@babel/plugin-transform-exponentiation-operator-7.10.4"
+      sources."@babel/plugin-transform-flow-strip-types-7.10.4"
+      sources."@babel/plugin-transform-for-of-7.10.4"
+      sources."@babel/plugin-transform-function-name-7.10.4"
+      sources."@babel/plugin-transform-literals-7.10.4"
+      sources."@babel/plugin-transform-member-expression-literals-7.10.4"
+      sources."@babel/plugin-transform-modules-amd-7.10.5"
+      sources."@babel/plugin-transform-modules-commonjs-7.10.4"
+      sources."@babel/plugin-transform-modules-systemjs-7.10.5"
+      sources."@babel/plugin-transform-modules-umd-7.10.4"
+      sources."@babel/plugin-transform-named-capturing-groups-regex-7.10.4"
+      sources."@babel/plugin-transform-new-target-7.10.4"
+      sources."@babel/plugin-transform-object-assign-7.10.4"
+      sources."@babel/plugin-transform-object-super-7.10.4"
+      sources."@babel/plugin-transform-parameters-7.10.5"
+      sources."@babel/plugin-transform-property-literals-7.10.4"
+      sources."@babel/plugin-transform-react-display-name-7.10.4"
+      sources."@babel/plugin-transform-react-jsx-7.10.4"
+      sources."@babel/plugin-transform-react-jsx-source-7.10.5"
+      sources."@babel/plugin-transform-regenerator-7.10.4"
+      sources."@babel/plugin-transform-reserved-words-7.10.4"
+      (sources."@babel/plugin-transform-runtime-7.11.5" // {
+        dependencies = [
+          sources."semver-5.7.1"
+        ];
+      })
+      sources."@babel/plugin-transform-shorthand-properties-7.10.4"
+      sources."@babel/plugin-transform-spread-7.11.0"
+      sources."@babel/plugin-transform-sticky-regex-7.10.4"
+      sources."@babel/plugin-transform-template-literals-7.10.5"
+      sources."@babel/plugin-transform-typeof-symbol-7.10.4"
+      sources."@babel/plugin-transform-typescript-7.11.0"
+      sources."@babel/plugin-transform-unicode-escapes-7.10.4"
+      sources."@babel/plugin-transform-unicode-regex-7.10.4"
+      sources."@babel/preset-env-7.11.5"
+      sources."@babel/preset-modules-0.1.4"
+      sources."@babel/preset-typescript-7.10.4"
+      sources."@babel/runtime-7.11.2"
+      sources."@babel/template-7.10.4"
+      (sources."@babel/traverse-7.11.5" // {
+        dependencies = [
+          sources."lodash-4.17.20"
+        ];
+      })
+      (sources."@babel/types-7.11.5" // {
+        dependencies = [
+          sources."lodash-4.17.20"
+        ];
+      })
+      sources."@expo/babel-preset-cli-0.2.18"
+      (sources."@expo/bunyan-3.0.2" // {
+        dependencies = [
+          sources."uuid-3.4.0"
+        ];
+      })
+      (sources."@expo/config-3.3.9" // {
+        dependencies = [
+          sources."semver-7.3.2"
+          sources."uuid-3.4.0"
+          sources."xcode-2.1.0"
+        ];
+      })
+      sources."@expo/config-types-40.0.0-beta.1"
+      (sources."@expo/configure-splash-screen-0.2.1" // {
+        dependencies = [
+          sources."commander-5.1.0"
+          sources."pngjs-5.0.0"
+        ];
+      })
+      (sources."@expo/dev-server-0.1.34" // {
+        dependencies = [
+          sources."body-parser-1.19.0"
+          sources."bytes-3.1.0"
+          sources."debug-2.6.9"
+          sources."http-errors-1.7.2"
+          sources."iconv-lite-0.4.24"
+          sources."inherits-2.0.3"
+          sources."ms-2.0.0"
+          sources."qs-6.7.0"
+          sources."raw-body-2.4.0"
+          sources."serialize-error-6.0.0"
+          sources."setprototypeof-1.1.1"
+          sources."statuses-1.5.0"
+        ];
+      })
+      sources."@expo/dev-tools-0.13.52"
+      sources."@expo/eas-build-job-0.1.0"
+      (sources."@expo/image-utils-0.3.7" // {
+        dependencies = [
+          sources."semver-6.1.1"
+        ];
+      })
+      (sources."@expo/json-file-8.2.24" // {
+        dependencies = [
+          sources."json5-1.0.1"
+        ];
+      })
+      sources."@expo/metro-config-0.1.34"
+      (sources."@expo/ngrok-2.4.3" // {
+        dependencies = [
+          sources."uuid-3.4.0"
+        ];
+      })
+      sources."@expo/ngrok-bin-2.2.8-beta.3"
+      sources."@expo/ngrok-bin-darwin-ia32-2.2.8"
+      sources."@expo/ngrok-bin-darwin-x64-2.2.8"
+      sources."@expo/ngrok-bin-freebsd-ia32-2.2.8"
+      sources."@expo/ngrok-bin-freebsd-x64-2.2.8"
+      sources."@expo/ngrok-bin-linux-arm-2.2.8"
+      sources."@expo/ngrok-bin-linux-arm64-2.2.8"
+      sources."@expo/ngrok-bin-linux-ia32-2.2.8"
+      sources."@expo/ngrok-bin-linux-x64-2.2.8"
+      sources."@expo/ngrok-bin-sunos-x64-2.2.8"
+      sources."@expo/ngrok-bin-win32-ia32-2.2.8-beta.1"
+      sources."@expo/ngrok-bin-win32-x64-2.2.8-beta.1"
+      sources."@expo/osascript-2.0.24"
+      (sources."@expo/package-manager-0.0.33" // {
+        dependencies = [
+          sources."ansi-regex-5.0.0"
+          sources."npm-package-arg-7.0.0"
+          sources."rimraf-3.0.2"
+          sources."semver-5.7.1"
+        ];
+      })
+      (sources."@expo/plist-0.0.10" // {
+        dependencies = [
+          sources."xmlbuilder-14.0.0"
+        ];
+      })
+      sources."@expo/results-1.0.0"
+      (sources."@expo/schemer-1.3.21" // {
+        dependencies = [
+          sources."ajv-5.5.2"
+          sources."es6-error-4.1.1"
+          sources."fast-deep-equal-1.1.0"
+          sources."get-stream-3.0.0"
+          sources."got-6.7.1"
+          sources."json-schema-traverse-0.3.1"
+          sources."probe-image-size-3.2.0"
+        ];
+      })
+      sources."@expo/simple-spinner-1.0.2"
+      sources."@expo/spawn-async-1.5.0"
+      sources."@expo/traveling-fastlane-darwin-1.15.1"
+      sources."@expo/traveling-fastlane-linux-1.15.1"
+      (sources."@expo/webpack-config-0.12.38" // {
+        dependencies = [
+          sources."@babel/runtime-7.9.0"
+          sources."is-wsl-2.2.0"
+          sources."react-refresh-0.8.3"
+        ];
+      })
+      (sources."@expo/xdl-58.0.13" // {
+        dependencies = [
+          sources."chownr-1.1.4"
+          sources."es6-error-4.1.1"
+          (sources."fs-minipass-1.2.7" // {
+            dependencies = [
+              sources."minipass-2.9.0"
+            ];
+          })
+          sources."indent-string-3.2.0"
+          sources."lru-cache-5.1.1"
+          (sources."minizlib-1.3.3" // {
+            dependencies = [
+              sources."minipass-2.9.0"
+            ];
+          })
+          sources."mkdirp-1.0.4"
+          (sources."npm-package-arg-8.0.1" // {
+            dependencies = [
+              sources."semver-7.3.2"
+            ];
+          })
+          (sources."pacote-11.1.0" // {
+            dependencies = [
+              sources."minipass-3.1.3"
+              sources."semver-7.3.2"
+              (sources."tar-6.0.5" // {
+                dependencies = [
+                  sources."chownr-2.0.0"
+                ];
+              })
+              sources."yallist-4.0.0"
+            ];
+          })
+          (sources."tar-4.4.6" // {
+            dependencies = [
+              sources."mkdirp-0.5.5"
+            ];
+          })
+          sources."uuid-3.3.2"
+          sources."validator-11.0.0"
+          sources."which-2.0.2"
+          sources."xcode-2.1.0"
+          sources."xmldom-0.1.27"
+          sources."yallist-3.1.1"
+        ];
+      })
+      sources."@hapi/address-4.1.0"
+      sources."@hapi/formula-2.0.0"
+      sources."@hapi/hoek-9.1.0"
+      sources."@hapi/joi-17.1.1"
+      sources."@hapi/pinpoint-2.0.0"
+      sources."@hapi/topo-5.0.0"
+      (sources."@jest/types-25.5.0" // {
+        dependencies = [
+          sources."ansi-styles-4.3.0"
+          sources."chalk-3.0.0"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+          sources."has-flag-4.0.0"
+          sources."supports-color-7.2.0"
+        ];
+      })
+      sources."@jimp/bmp-0.9.8"
+      sources."@jimp/core-0.9.8"
+      sources."@jimp/custom-0.9.8"
+      sources."@jimp/gif-0.9.8"
+      sources."@jimp/jpeg-0.9.8"
+      sources."@jimp/plugin-blit-0.9.8"
+      sources."@jimp/plugin-blur-0.9.8"
+      sources."@jimp/plugin-circle-0.9.8"
+      sources."@jimp/plugin-color-0.9.8"
+      sources."@jimp/plugin-contain-0.9.8"
+      sources."@jimp/plugin-cover-0.9.8"
+      sources."@jimp/plugin-crop-0.9.8"
+      sources."@jimp/plugin-displace-0.9.8"
+      sources."@jimp/plugin-dither-0.9.8"
+      sources."@jimp/plugin-fisheye-0.9.8"
+      sources."@jimp/plugin-flip-0.9.8"
+      sources."@jimp/plugin-gaussian-0.9.8"
+      sources."@jimp/plugin-invert-0.9.8"
+      sources."@jimp/plugin-mask-0.9.8"
+      sources."@jimp/plugin-normalize-0.9.8"
+      sources."@jimp/plugin-print-0.9.8"
+      sources."@jimp/plugin-resize-0.9.8"
+      sources."@jimp/plugin-rotate-0.9.8"
+      sources."@jimp/plugin-scale-0.9.8"
+      sources."@jimp/plugin-shadow-0.9.8"
+      sources."@jimp/plugin-threshold-0.9.8"
+      sources."@jimp/plugins-0.9.8"
+      sources."@jimp/png-0.9.8"
+      sources."@jimp/tiff-0.9.8"
+      sources."@jimp/types-0.9.8"
+      sources."@jimp/utils-0.9.8"
+      sources."@mrmlnc/readdir-enhanced-2.2.1"
+      sources."@nodelib/fs.scandir-2.1.3"
+      sources."@nodelib/fs.stat-2.0.3"
+      sources."@nodelib/fs.walk-1.2.4"
+      sources."@npmcli/ci-detect-1.3.0"
+      (sources."@npmcli/git-2.0.4" // {
+        dependencies = [
+          sources."mkdirp-1.0.4"
+          sources."semver-7.3.2"
+          sources."which-2.0.2"
+        ];
+      })
+      sources."@npmcli/installed-package-contents-1.0.5"
+      (sources."@npmcli/move-file-1.0.1" // {
+        dependencies = [
+          sources."mkdirp-1.0.4"
+        ];
+      })
+      sources."@npmcli/node-gyp-1.0.1"
+      sources."@npmcli/promise-spawn-1.2.0"
+      sources."@npmcli/run-script-1.7.2"
+      sources."@pmmmwh/react-refresh-webpack-plugin-0.3.3"
+      sources."@react-native-community/cli-debugger-ui-4.9.0"
+      (sources."@react-native-community/cli-platform-android-4.13.0" // {
+        dependencies = [
+          sources."ansi-styles-4.3.0"
+          sources."chalk-3.0.0"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+          sources."fs-extra-8.1.0"
+          sources."has-flag-4.0.0"
+          sources."slash-3.0.0"
+          sources."supports-color-7.2.0"
+        ];
+      })
+      (sources."@react-native-community/cli-platform-ios-4.13.0" // {
+        dependencies = [
+          sources."ansi-styles-4.3.0"
+          sources."chalk-3.0.0"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+          sources."has-flag-4.0.0"
+          sources."supports-color-7.2.0"
+          sources."uuid-3.4.0"
+          sources."xcode-2.1.0"
+        ];
+      })
+      (sources."@react-native-community/cli-server-api-4.9.0" // {
+        dependencies = [
+          sources."ultron-1.0.2"
+          sources."ws-1.1.5"
+        ];
+      })
+      (sources."@react-native-community/cli-tools-4.13.0" // {
+        dependencies = [
+          sources."ansi-styles-4.3.0"
+          sources."chalk-3.0.0"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+          sources."has-flag-4.0.0"
+          sources."supports-color-7.2.0"
+        ];
+      })
+      sources."@segment/loosely-validate-event-2.0.0"
+      sources."@sindresorhus/is-0.14.0"
+      sources."@szmarczak/http-timer-1.1.2"
+      sources."@tootallnate/once-1.1.2"
+      sources."@types/anymatch-1.3.1"
+      sources."@types/cacheable-request-6.0.1"
+      sources."@types/configstore-2.1.1"
+      sources."@types/debug-0.0.30"
+      sources."@types/events-3.0.0"
+      sources."@types/get-port-3.2.0"
+      sources."@types/glob-7.1.3"
+      sources."@types/html-minifier-terser-5.1.1"
+      sources."@types/http-cache-semantics-4.0.0"
+      sources."@types/istanbul-lib-coverage-2.0.3"
+      sources."@types/istanbul-lib-report-3.0.0"
+      sources."@types/istanbul-reports-1.1.2"
+      sources."@types/json-schema-7.0.6"
+      sources."@types/keyv-3.1.1"
+      sources."@types/lodash-4.14.161"
+      sources."@types/minimatch-3.0.3"
+      sources."@types/mkdirp-0.5.2"
+      sources."@types/node-9.6.59"
+      sources."@types/q-1.5.4"
+      sources."@types/responselike-1.0.0"
+      sources."@types/retry-0.12.0"
+      sources."@types/rimraf-2.0.4"
+      sources."@types/source-list-map-0.1.2"
+      sources."@types/tapable-1.0.6"
+      sources."@types/text-table-0.2.1"
+      sources."@types/tmp-0.0.33"
+      (sources."@types/uglify-js-3.11.0" // {
+        dependencies = [
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."@types/webpack-4.41.22" // {
+        dependencies = [
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."@types/webpack-sources-2.0.0" // {
+        dependencies = [
+          sources."source-map-0.7.3"
+        ];
+      })
+      sources."@types/yargs-15.0.7"
+      sources."@types/yargs-parser-15.0.0"
+      sources."@webassemblyjs/ast-1.9.0"
+      sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
+      sources."@webassemblyjs/helper-api-error-1.9.0"
+      sources."@webassemblyjs/helper-buffer-1.9.0"
+      sources."@webassemblyjs/helper-code-frame-1.9.0"
+      sources."@webassemblyjs/helper-fsm-1.9.0"
+      sources."@webassemblyjs/helper-module-context-1.9.0"
+      sources."@webassemblyjs/helper-wasm-bytecode-1.9.0"
+      sources."@webassemblyjs/helper-wasm-section-1.9.0"
+      sources."@webassemblyjs/ieee754-1.9.0"
+      sources."@webassemblyjs/leb128-1.9.0"
+      sources."@webassemblyjs/utf8-1.9.0"
+      sources."@webassemblyjs/wasm-edit-1.9.0"
+      sources."@webassemblyjs/wasm-gen-1.9.0"
+      sources."@webassemblyjs/wasm-opt-1.9.0"
+      sources."@webassemblyjs/wasm-parser-1.9.0"
+      sources."@webassemblyjs/wast-parser-1.9.0"
+      sources."@webassemblyjs/wast-printer-1.9.0"
+      sources."@wry/equality-0.1.11"
+      sources."@xtuc/ieee754-1.2.0"
+      sources."@xtuc/long-4.2.2"
+      sources."abbrev-1.1.1"
+      sources."accepts-1.3.7"
+      sources."acorn-6.4.2"
+      sources."address-1.1.2"
+      sources."agent-base-6.0.1"
+      sources."agentkeepalive-4.1.3"
+      sources."aggregate-error-3.1.0"
+      sources."ajv-6.12.5"
+      sources."ajv-errors-1.0.1"
+      sources."ajv-keywords-3.5.2"
+      sources."alphanum-sort-1.0.2"
+      (sources."analytics-node-3.3.0" // {
+        dependencies = [
+          sources."axios-0.17.1"
+          sources."uuid-3.4.0"
+        ];
+      })
+      (sources."ansi-align-3.0.0" // {
+        dependencies = [
+          sources."emoji-regex-7.0.3"
+          sources."string-width-3.1.0"
+          sources."strip-ansi-5.2.0"
+        ];
+      })
+      sources."ansi-colors-3.2.4"
+      (sources."ansi-escapes-4.3.1" // {
+        dependencies = [
+          sources."type-fest-0.11.0"
+        ];
+      })
+      (sources."ansi-fragments-0.2.1" // {
+        dependencies = [
+          sources."strip-ansi-5.2.0"
+        ];
+      })
+      sources."ansi-html-0.0.7"
+      sources."ansi-regex-4.1.0"
+      sources."ansi-styles-3.2.1"
+      sources."any-base-1.1.0"
+      sources."any-promise-1.3.0"
+      sources."anymatch-3.1.1"
+      sources."apollo-link-1.2.1"
+      sources."apollo-utilities-1.3.4"
+      sources."application-config-path-0.1.0"
+      sources."aproba-1.2.0"
+      sources."arch-2.1.2"
+      sources."are-we-there-yet-1.1.5"
+      sources."argparse-1.0.10"
+      sources."arr-diff-4.0.0"
+      sources."arr-flatten-1.1.0"
+      sources."arr-union-3.1.0"
+      sources."array-filter-0.0.1"
+      sources."array-flatten-1.1.1"
+      sources."array-map-0.0.0"
+      sources."array-reduce-0.0.0"
+      sources."array-union-1.0.2"
+      sources."array-uniq-1.0.3"
+      sources."array-unique-0.3.2"
+      sources."arrify-2.0.1"
+      sources."asap-2.0.6"
+      sources."asn1-0.2.4"
+      (sources."asn1.js-5.4.1" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
+      (sources."assert-1.5.0" // {
+        dependencies = [
+          sources."inherits-2.0.1"
+          sources."util-0.10.3"
+        ];
+      })
+      sources."assert-plus-1.0.0"
+      sources."assign-symbols-1.0.0"
+      sources."astral-regex-1.0.0"
+      sources."async-0.9.2"
+      sources."async-each-1.0.3"
+      sources."async-limiter-1.0.1"
+      sources."asynckit-0.4.0"
+      sources."at-least-node-1.0.0"
+      sources."atob-2.1.2"
+      (sources."available-typed-arrays-1.0.2" // {
+        dependencies = [
+          sources."array-filter-1.0.0"
+        ];
+      })
+      sources."aws-sign2-0.7.0"
+      sources."aws4-1.10.1"
+      (sources."axios-0.19.0" // {
+        dependencies = [
+          sources."debug-3.1.0"
+          sources."follow-redirects-1.5.10"
+          sources."is-buffer-2.0.4"
+          sources."ms-2.0.0"
+        ];
+      })
+      sources."axios-retry-3.1.9"
+      (sources."babel-code-frame-6.26.0" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+          sources."ansi-styles-2.2.1"
+          sources."chalk-1.1.3"
+          sources."js-tokens-3.0.2"
+          sources."strip-ansi-3.0.1"
+          sources."supports-color-2.0.0"
+        ];
+      })
+      sources."babel-extract-comments-1.0.0"
+      sources."babel-loader-8.1.0"
+      sources."babel-plugin-dynamic-import-node-2.3.3"
+      sources."babel-plugin-syntax-object-rest-spread-6.13.0"
+      sources."babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0"
+      sources."babel-plugin-transform-object-rest-spread-6.26.0"
+      sources."babel-preset-fbjs-3.3.0"
+      (sources."babel-runtime-6.26.0" // {
+        dependencies = [
+          sources."core-js-2.6.11"
+          sources."regenerator-runtime-0.11.1"
+        ];
+      })
+      sources."babylon-6.18.0"
+      sources."backo2-1.0.2"
+      sources."balanced-match-1.0.0"
+      (sources."base-0.11.2" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+        ];
+      })
+      sources."base32.js-0.1.0"
+      sources."base64-js-1.3.1"
+      sources."base64url-3.0.1"
+      sources."batch-0.6.1"
+      sources."bcrypt-pbkdf-1.0.2"
+      sources."big-integer-1.6.48"
+      sources."big.js-5.2.2"
+      sources."binary-extensions-2.1.0"
+      sources."bindings-1.5.0"
+      sources."bluebird-3.7.2"
+      sources."bmp-js-0.1.0"
+      sources."bn.js-5.1.3"
+      (sources."body-parser-1.18.3" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+        ];
+      })
+      (sources."bonjour-3.5.0" // {
+        dependencies = [
+          sources."array-flatten-2.1.2"
+          sources."deep-equal-1.1.1"
+        ];
+      })
+      sources."boolbase-1.0.0"
+      (sources."boxen-4.1.0" // {
+        dependencies = [
+          sources."chalk-2.4.2"
+          sources."type-fest-0.5.2"
+        ];
+      })
+      sources."bplist-creator-0.0.8"
+      sources."bplist-parser-0.2.0"
+      sources."brace-expansion-1.1.11"
+      sources."braces-3.0.2"
+      sources."brorand-1.1.0"
+      sources."browserify-aes-1.2.0"
+      sources."browserify-cipher-1.0.1"
+      sources."browserify-des-1.0.2"
+      (sources."browserify-rsa-4.0.1" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
+      (sources."browserify-sign-4.2.1" // {
+        dependencies = [
+          sources."readable-stream-3.6.0"
+          sources."safe-buffer-5.2.1"
+        ];
+      })
+      sources."browserify-zlib-0.2.0"
+      sources."browserslist-4.14.5"
+      sources."buffer-5.6.0"
+      sources."buffer-equal-0.0.1"
+      sources."buffer-from-1.1.1"
+      sources."buffer-indexof-1.1.1"
+      sources."buffer-xor-1.0.3"
+      sources."builtin-status-codes-3.0.0"
+      sources."builtins-1.0.3"
+      sources."bytes-3.0.0"
+      (sources."cacache-15.0.5" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+          sources."mkdirp-1.0.4"
+          sources."p-map-4.0.0"
+          sources."rimraf-3.0.2"
+        ];
+      })
+      sources."cache-base-1.0.1"
+      sources."cacheable-lookup-5.0.3"
+      (sources."cacheable-request-6.1.0" // {
+        dependencies = [
+          sources."get-stream-5.2.0"
+          sources."lowercase-keys-2.0.0"
+          sources."normalize-url-4.5.0"
+        ];
+      })
+      sources."call-me-maybe-1.0.1"
+      sources."caller-callsite-2.0.0"
+      sources."caller-path-2.0.0"
+      sources."callsite-1.0.0"
+      sources."callsites-2.0.0"
+      (sources."camel-case-4.1.1" // {
+        dependencies = [
+          sources."pascal-case-3.1.1"
+        ];
+      })
+      sources."camelcase-5.3.1"
+      sources."caniuse-api-3.0.0"
+      sources."caniuse-lite-1.0.30001144"
+      sources."capture-stack-trace-1.0.1"
+      sources."caseless-0.12.0"
+      (sources."chalk-4.1.0" // {
+        dependencies = [
+          sources."ansi-styles-4.3.0"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+          sources."has-flag-4.0.0"
+          sources."supports-color-7.2.0"
+        ];
+      })
+      sources."chardet-0.4.2"
+      sources."charenc-0.0.2"
+      sources."chokidar-3.4.2"
+      sources."chownr-2.0.0"
+      sources."chrome-trace-event-1.0.2"
+      sources."ci-info-1.6.0"
+      sources."cipher-base-1.0.4"
+      (sources."class-utils-0.3.6" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      (sources."clean-css-4.2.3" // {
+        dependencies = [
+          sources."source-map-0.6.1"
+        ];
+      })
+      sources."clean-stack-2.2.0"
+      sources."clean-webpack-plugin-3.0.0"
+      sources."cli-boxes-2.2.1"
+      sources."cli-cursor-2.1.0"
+      sources."cli-spinners-2.4.0"
+      sources."cli-table3-0.6.0"
+      sources."cli-width-2.2.1"
+      (sources."clipboardy-2.3.0" // {
+        dependencies = [
+          sources."is-wsl-2.2.0"
+        ];
+      })
+      sources."cliui-6.0.0"
+      sources."clone-1.0.4"
+      sources."clone-response-1.0.2"
+      sources."co-4.6.0"
+      (sources."coa-2.0.2" // {
+        dependencies = [
+          sources."chalk-2.4.2"
+        ];
+      })
+      sources."code-point-at-1.1.0"
+      sources."collection-visit-1.0.0"
+      sources."color-3.1.2"
+      sources."color-convert-1.9.3"
+      sources."color-name-1.1.3"
+      sources."color-string-1.5.3"
+      sources."colorette-1.2.1"
+      sources."colors-1.4.0"
+      sources."combined-stream-1.0.8"
+      sources."command-exists-1.2.9"
+      sources."commander-2.17.1"
+      sources."common-tags-1.8.0"
+      sources."commondir-1.0.1"
+      sources."component-emitter-1.3.0"
+      sources."component-type-1.2.1"
+      sources."compressible-2.0.18"
+      (sources."compression-1.7.4" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+        ];
+      })
+      sources."concat-map-0.0.1"
+      sources."concat-stream-1.6.2"
+      (sources."connect-3.7.0" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."finalhandler-1.1.2"
+          sources."ms-2.0.0"
+          sources."statuses-1.5.0"
+        ];
+      })
+      sources."connect-history-api-fallback-1.6.0"
+      sources."consola-2.15.0"
+      sources."console-browserify-1.2.0"
+      sources."console-control-strings-1.1.0"
+      sources."constants-browserify-1.0.0"
+      sources."content-disposition-0.5.2"
+      sources."content-type-1.0.4"
+      sources."convert-source-map-1.7.0"
+      sources."cookie-0.3.1"
+      sources."cookie-signature-1.0.6"
+      (sources."copy-concurrently-1.0.5" // {
+        dependencies = [
+          sources."rimraf-2.7.1"
+        ];
+      })
+      sources."copy-descriptor-0.1.1"
+      (sources."copy-webpack-plugin-6.0.4" // {
+        dependencies = [
+          sources."array-union-2.1.0"
+          sources."find-cache-dir-3.3.1"
+          sources."globby-11.0.1"
+          sources."loader-utils-2.0.0"
+          sources."make-dir-3.1.0"
+          sources."p-limit-3.0.2"
+          sources."pkg-dir-4.2.0"
+          sources."semver-6.3.0"
+          sources."slash-3.0.0"
+        ];
+      })
+      sources."core-js-3.6.5"
+      (sources."core-js-compat-3.6.5" // {
+        dependencies = [
+          sources."semver-7.0.0"
+        ];
+      })
+      sources."core-util-is-1.0.2"
+      sources."cosmiconfig-5.2.1"
+      (sources."create-ecdh-4.0.4" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
+      sources."create-error-class-3.0.2"
+      sources."create-hash-1.2.0"
+      sources."create-hmac-1.1.7"
+      sources."cross-spawn-6.0.5"
+      sources."crypt-0.0.2"
+      sources."crypto-browserify-3.12.0"
+      sources."crypto-random-string-1.0.0"
+      sources."css-color-names-0.0.4"
+      sources."css-declaration-sorter-4.0.1"
+      (sources."css-loader-3.6.0" // {
+        dependencies = [
+          sources."semver-6.3.0"
+        ];
+      })
+      (sources."css-select-1.2.0" // {
+        dependencies = [
+          (sources."dom-serializer-0.2.2" // {
+            dependencies = [
+              sources."domelementtype-2.0.2"
+            ];
+          })
+          sources."domelementtype-1.3.1"
+          sources."domutils-1.5.1"
+        ];
+      })
+      sources."css-select-base-adapter-0.1.1"
+      (sources."css-tree-1.0.0-alpha.37" // {
+        dependencies = [
+          sources."source-map-0.6.1"
+        ];
+      })
+      sources."css-what-2.1.3"
+      sources."cssesc-3.0.0"
+      sources."cssnano-4.1.10"
+      sources."cssnano-preset-default-4.0.7"
+      sources."cssnano-util-get-arguments-4.0.0"
+      sources."cssnano-util-get-match-4.0.0"
+      sources."cssnano-util-raw-cache-4.0.1"
+      sources."cssnano-util-same-parent-4.0.1"
+      (sources."csso-4.0.3" // {
+        dependencies = [
+          sources."css-tree-1.0.0-alpha.39"
+          sources."mdn-data-2.0.6"
+          sources."source-map-0.6.1"
+        ];
+      })
+      sources."cyclist-1.0.1"
+      sources."dashdash-1.14.1"
+      sources."dateformat-3.0.3"
+      sources."dayjs-1.9.1"
+      sources."debug-4.3.0"
+      sources."debuglog-1.0.1"
+      sources."decache-4.4.0"
+      sources."decamelize-1.2.0"
+      sources."decode-uri-component-0.2.0"
+      sources."decompress-response-3.3.0"
+      sources."deep-equal-2.0.4"
+      sources."deep-extend-0.6.0"
+      sources."deep-scope-analyser-1.7.0"
+      sources."deepmerge-1.5.2"
+      sources."default-gateway-4.2.0"
+      sources."defaults-1.0.3"
+      sources."defer-to-connect-1.1.3"
+      sources."define-properties-1.1.3"
+      sources."define-property-2.0.2"
+      (sources."del-4.1.1" // {
+        dependencies = [
+          sources."p-map-2.1.0"
+          sources."rimraf-2.7.1"
+        ];
+      })
+      sources."delay-async-1.2.0"
+      sources."delayed-stream-1.0.0"
+      sources."delegates-1.0.0"
+      sources."depd-1.1.2"
+      sources."deprecated-decorator-0.1.6"
+      sources."des.js-1.0.1"
+      sources."destroy-1.0.4"
+      sources."detect-node-2.0.4"
+      (sources."detect-port-alt-1.1.6" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+        ];
+      })
+      (sources."devcert-1.1.3" // {
+        dependencies = [
+          sources."@types/glob-5.0.36"
+          sources."@types/node-8.10.64"
+          sources."debug-3.2.6"
+          sources."rimraf-2.7.1"
+          sources."sudo-prompt-8.2.5"
+        ];
+      })
+      sources."dezalgo-1.0.3"
+      (sources."diffie-hellman-5.0.3" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
+      sources."dir-glob-3.0.1"
+      sources."dns-equal-1.0.0"
+      sources."dns-packet-1.3.1"
+      sources."dns-txt-2.0.2"
+      sources."dom-converter-0.2.0"
+      sources."dom-serializer-1.1.0"
+      sources."dom-walk-0.1.2"
+      sources."domain-browser-1.2.0"
+      sources."domelementtype-2.0.2"
+      sources."domhandler-3.3.0"
+      sources."domutils-2.4.2"
+      sources."dot-case-3.0.3"
+      sources."dot-prop-5.3.0"
+      sources."duplexer-0.1.2"
+      sources."duplexer3-0.1.4"
+      sources."duplexify-3.7.1"
+      sources."ecc-jsbn-0.1.2"
+      sources."ee-first-1.1.1"
+      sources."electron-to-chromium-1.3.578"
+      (sources."elliptic-6.5.3" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
+      sources."emoji-regex-8.0.0"
+      sources."emojis-list-3.0.0"
+      sources."encodeurl-1.0.2"
+      (sources."encoding-0.1.13" // {
+        dependencies = [
+          sources."iconv-lite-0.6.2"
+        ];
+      })
+      sources."end-of-stream-1.4.4"
+      (sources."enhanced-resolve-4.3.0" // {
+        dependencies = [
+          sources."memory-fs-0.5.0"
+        ];
+      })
+      sources."entities-2.0.3"
+      sources."env-editor-0.4.1"
+      sources."env-paths-2.2.0"
+      sources."envinfo-7.5.0"
+      sources."eol-0.9.1"
+      sources."err-code-1.1.2"
+      sources."errno-0.1.7"
+      (sources."error-ex-1.3.2" // {
+        dependencies = [
+          sources."is-arrayish-0.2.1"
+        ];
+      })
+      sources."error-stack-parser-2.0.6"
+      sources."errorhandler-1.5.1"
+      sources."es-abstract-1.18.0-next.1"
+      (sources."es-get-iterator-1.1.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      sources."es-to-primitive-1.2.1"
+      sources."es6-error-3.2.0"
+      sources."escalade-3.1.0"
+      sources."escape-html-1.0.3"
+      sources."escape-string-regexp-1.0.5"
+      sources."eslint-scope-4.0.3"
+      sources."esprima-4.0.1"
+      (sources."esrecurse-4.3.0" // {
+        dependencies = [
+          sources."estraverse-5.2.0"
+        ];
+      })
+      sources."estraverse-4.3.0"
+      sources."esutils-2.0.3"
+      sources."etag-1.8.1"
+      sources."eventemitter3-2.0.3"
+      sources."events-3.2.0"
+      sources."eventsource-1.0.7"
+      sources."evp_bytestokey-1.0.3"
+      sources."exec-async-2.2.0"
+      sources."execa-1.0.0"
+      sources."exeunt-1.1.0"
+      sources."exif-parser-0.1.12"
+      (sources."expand-brackets-2.1.4" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
+        ];
+      })
+      (sources."expo-pwa-0.0.44" // {
+        dependencies = [
+          sources."commander-2.20.0"
+        ];
+      })
+      (sources."express-4.16.4" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+        ];
+      })
+      sources."extend-3.0.2"
+      (sources."extend-shallow-3.0.2" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      sources."external-editor-2.2.0"
+      (sources."extglob-2.0.4" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."extsprintf-1.3.0"
+      sources."fast-deep-equal-3.1.3"
+      sources."fast-glob-3.2.4"
+      sources."fast-json-stable-stringify-2.1.0"
+      sources."fastq-1.8.0"
+      sources."faye-websocket-0.10.0"
+      sources."figgy-pudding-3.5.2"
+      sources."figures-3.2.0"
+      (sources."file-loader-6.0.0" // {
+        dependencies = [
+          sources."loader-utils-2.0.0"
+        ];
+      })
+      sources."file-type-9.0.0"
+      sources."file-uri-to-path-1.0.0"
+      sources."filesize-6.0.1"
+      sources."fill-range-7.0.1"
+      (sources."finalhandler-1.1.1" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+        ];
+      })
+      sources."find-cache-dir-2.1.0"
+      sources."find-up-4.1.0"
+      sources."find-yarn-workspace-root-2.0.0"
+      sources."flush-write-stream-1.1.1"
+      sources."follow-redirects-1.13.0"
+      sources."for-in-1.0.2"
+      sources."foreach-2.0.5"
+      sources."forever-agent-0.6.1"
+      (sources."fork-ts-checker-webpack-plugin-3.1.1" // {
+        dependencies = [
+          sources."braces-2.3.2"
+          sources."chalk-2.4.2"
+          sources."extend-shallow-2.0.1"
+          sources."fill-range-4.0.0"
+          sources."is-number-3.0.0"
+          sources."kind-of-3.2.2"
+          sources."micromatch-3.1.10"
+          sources."semver-5.7.1"
+          sources."to-regex-range-2.1.1"
+        ];
+      })
+      (sources."form-data-2.3.2" // {
+        dependencies = [
+          sources."combined-stream-1.0.6"
+        ];
+      })
+      sources."forwarded-0.1.2"
+      sources."fragment-cache-0.2.1"
+      sources."freeport-async-2.0.0"
+      sources."fresh-0.5.2"
+      sources."from2-2.3.0"
+      (sources."fs-extra-9.0.0" // {
+        dependencies = [
+          sources."jsonfile-6.0.1"
+          sources."universalify-1.0.0"
+        ];
+      })
+      (sources."fs-minipass-2.1.0" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+        ];
+      })
+      sources."fs-write-stream-atomic-1.0.10"
+      sources."fs.realpath-1.0.0"
+      sources."fsevents-2.1.3"
+      sources."function-bind-1.1.1"
+      (sources."gauge-2.7.4" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+          sources."is-fullwidth-code-point-1.0.0"
+          sources."string-width-1.0.2"
+          sources."strip-ansi-3.0.1"
+        ];
+      })
+      sources."gensync-1.0.0-beta.1"
+      sources."get-caller-file-2.0.5"
+      sources."get-own-enumerable-property-symbols-3.0.2"
+      sources."get-port-3.2.0"
+      sources."get-stream-4.1.0"
+      sources."get-value-2.0.6"
+      sources."getenv-0.7.0"
+      sources."getpass-0.1.7"
+      sources."glob-7.1.6"
+      sources."glob-parent-5.1.1"
+      sources."glob-to-regexp-0.3.0"
+      sources."global-4.3.2"
+      sources."global-modules-2.0.0"
+      sources."global-prefix-3.0.0"
+      sources."globals-11.12.0"
+      (sources."globby-6.1.0" // {
+        dependencies = [
+          sources."pify-2.3.0"
+        ];
+      })
+      (sources."got-11.7.0" // {
+        dependencies = [
+          sources."@sindresorhus/is-3.1.2"
+          sources."@szmarczak/http-timer-4.0.5"
+          sources."cacheable-request-7.0.1"
+          sources."decompress-response-6.0.0"
+          sources."defer-to-connect-2.0.0"
+          sources."get-stream-5.2.0"
+          sources."json-buffer-3.0.1"
+          sources."keyv-4.0.3"
+          sources."lowercase-keys-2.0.0"
+          sources."mimic-response-3.1.0"
+          sources."normalize-url-4.5.0"
+          sources."p-cancelable-2.0.0"
+          sources."responselike-2.0.0"
+        ];
+      })
+      sources."graceful-fs-4.2.4"
+      sources."graphql-0.13.2"
+      (sources."graphql-tools-3.0.0" // {
+        dependencies = [
+          sources."uuid-3.4.0"
+        ];
+      })
+      sources."gzip-size-5.1.1"
+      sources."handle-thing-2.0.1"
+      sources."har-schema-2.0.0"
+      sources."har-validator-5.1.5"
+      sources."has-1.0.3"
+      (sources."has-ansi-2.0.0" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+        ];
+      })
+      sources."has-flag-3.0.0"
+      sources."has-symbols-1.0.1"
+      sources."has-unicode-2.0.1"
+      sources."has-value-1.0.0"
+      (sources."has-values-1.0.0" // {
+        dependencies = [
+          (sources."is-number-3.0.0" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."kind-of-4.0.0"
+        ];
+      })
+      (sources."hasbin-1.2.3" // {
+        dependencies = [
+          sources."async-1.5.2"
+        ];
+      })
+      (sources."hash-base-3.1.0" // {
+        dependencies = [
+          sources."readable-stream-3.6.0"
+          sources."safe-buffer-5.2.1"
+        ];
+      })
+      sources."hash.js-1.1.7"
+      sources."hashids-1.1.4"
+      sources."he-1.2.0"
+      sources."hex-color-regex-1.1.0"
+      sources."hmac-drbg-1.0.1"
+      sources."hoek-4.2.1"
+      sources."hosted-git-info-3.0.5"
+      sources."hpack.js-2.1.6"
+      sources."hsl-regex-1.0.0"
+      sources."hsla-regex-1.0.0"
+      sources."html-comment-regex-1.1.2"
+      sources."html-entities-1.3.1"
+      (sources."html-loader-1.1.0" // {
+        dependencies = [
+          sources."loader-utils-2.0.0"
+        ];
+      })
+      (sources."html-minifier-terser-5.1.1" // {
+        dependencies = [
+          sources."commander-4.1.1"
+        ];
+      })
+      sources."html-webpack-plugin-4.3.0"
+      sources."htmlparser2-4.1.0"
+      sources."http-cache-semantics-4.1.0"
+      sources."http-deceiver-1.2.7"
+      (sources."http-errors-1.6.3" // {
+        dependencies = [
+          sources."inherits-2.0.3"
+        ];
+      })
+      (sources."http-proxy-1.18.1" // {
+        dependencies = [
+          sources."eventemitter3-4.0.7"
+        ];
+      })
+      sources."http-proxy-agent-4.0.1"
+      (sources."http-proxy-middleware-0.19.1" // {
+        dependencies = [
+          sources."braces-2.3.2"
+          sources."extend-shallow-2.0.1"
+          sources."fill-range-4.0.0"
+          sources."is-number-3.0.0"
+          sources."kind-of-3.2.2"
+          sources."micromatch-3.1.10"
+          sources."to-regex-range-2.1.1"
+        ];
+      })
+      sources."http-signature-1.2.0"
+      sources."http2-wrapper-1.0.0-beta.5.2"
+      sources."https-browserify-1.0.0"
+      sources."https-proxy-agent-5.0.0"
+      sources."humanize-ms-1.2.1"
+      sources."iconv-lite-0.4.23"
+      sources."icss-utils-4.1.1"
+      sources."idx-2.4.0"
+      sources."ieee754-1.1.13"
+      sources."iferr-0.1.5"
+      sources."ignore-5.1.8"
+      sources."ignore-walk-3.0.3"
+      sources."immer-1.10.0"
+      (sources."import-fresh-2.0.0" // {
+        dependencies = [
+          sources."resolve-from-3.0.0"
+        ];
+      })
+      sources."import-local-2.0.0"
+      sources."imurmurhash-0.1.4"
+      sources."indent-string-4.0.0"
+      sources."indexes-of-1.0.1"
+      sources."infer-owner-1.0.4"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.4"
+      sources."ini-1.3.5"
+      (sources."inquirer-5.2.0" // {
+        dependencies = [
+          sources."ansi-escapes-3.2.0"
+          sources."ansi-regex-3.0.0"
+          sources."chalk-2.4.2"
+          sources."figures-2.0.0"
+          sources."string-width-2.1.1"
+          sources."strip-ansi-4.0.0"
+        ];
+      })
+      sources."internal-ip-4.3.0"
+      sources."invariant-2.2.4"
+      sources."ip-1.1.5"
+      sources."ip-regex-2.1.0"
+      sources."ipaddr.js-1.9.1"
+      sources."is-absolute-url-2.1.0"
+      sources."is-accessor-descriptor-1.0.0"
+      sources."is-arguments-1.0.4"
+      sources."is-arrayish-0.3.2"
+      sources."is-bigint-1.0.0"
+      sources."is-binary-path-2.1.0"
+      sources."is-boolean-object-1.0.1"
+      sources."is-buffer-1.1.6"
+      sources."is-callable-1.2.2"
+      sources."is-color-stop-1.1.0"
+      sources."is-data-descriptor-1.0.0"
+      sources."is-date-object-1.0.2"
+      sources."is-descriptor-1.0.2"
+      sources."is-directory-0.3.1"
+      sources."is-docker-2.1.1"
+      sources."is-extendable-0.1.1"
+      sources."is-extglob-2.1.1"
+      sources."is-fullwidth-code-point-2.0.0"
+      sources."is-function-1.0.2"
+      sources."is-glob-4.0.1"
+      sources."is-lambda-1.0.1"
+      sources."is-map-2.0.1"
+      sources."is-negative-zero-2.0.0"
+      sources."is-number-7.0.0"
+      sources."is-number-object-1.0.4"
+      sources."is-obj-2.0.0"
+      sources."is-path-cwd-2.2.0"
+      sources."is-path-in-cwd-2.1.0"
+      sources."is-path-inside-2.1.0"
+      sources."is-plain-object-2.0.4"
+      sources."is-port-reachable-2.0.1"
+      (sources."is-reachable-4.0.0" // {
+        dependencies = [
+          sources."got-9.6.0"
+          sources."p-timeout-3.2.0"
+          sources."prepend-http-3.0.1"
+          (sources."url-parse-lax-3.0.0" // {
+            dependencies = [
+              sources."prepend-http-2.0.0"
+            ];
+          })
+        ];
+      })
+      sources."is-redirect-1.0.0"
+      sources."is-regex-1.1.1"
+      sources."is-regexp-1.0.0"
+      sources."is-resolvable-1.1.0"
+      sources."is-retry-allowed-1.2.0"
+      sources."is-root-2.1.0"
+      sources."is-set-2.0.1"
+      sources."is-stream-1.1.0"
+      sources."is-string-1.0.5"
+      sources."is-svg-3.0.0"
+      sources."is-symbol-1.0.3"
+      (sources."is-typed-array-1.1.3" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      sources."is-typedarray-1.0.0"
+      sources."is-weakmap-2.0.1"
+      sources."is-weakset-2.0.1"
+      sources."is-windows-1.0.2"
+      sources."is-wsl-1.1.0"
+      sources."isarray-2.0.5"
+      sources."isemail-3.2.0"
+      sources."isexe-2.0.0"
+      sources."isobject-3.0.1"
+      sources."isstream-0.1.2"
+      sources."iterall-1.2.2"
+      (sources."jest-worker-26.5.0" // {
+        dependencies = [
+          sources."has-flag-4.0.0"
+          sources."supports-color-7.2.0"
+        ];
+      })
+      sources."jetifier-1.6.6"
+      sources."jimp-0.9.8"
+      sources."joi-11.4.0"
+      sources."join-component-1.1.0"
+      sources."jpeg-js-0.3.7"
+      sources."js-tokens-4.0.0"
+      sources."js-yaml-3.14.0"
+      sources."jsbn-0.1.1"
+      sources."jsesc-2.5.2"
+      sources."json-buffer-3.0.0"
+      sources."json-parse-better-errors-1.0.2"
+      sources."json-parse-even-better-errors-2.3.1"
+      sources."json-schema-0.2.3"
+      sources."json-schema-traverse-0.4.1"
+      sources."json-stable-stringify-1.0.1"
+      sources."json-stringify-safe-5.0.1"
+      sources."json3-3.3.3"
+      sources."json5-2.1.3"
+      sources."jsonfile-4.0.0"
+      sources."jsonify-0.0.0"
+      sources."jsonparse-1.3.1"
+      sources."jsprim-1.4.1"
+      sources."keychain-1.3.0"
+      sources."keyv-3.1.0"
+      sources."killable-1.0.1"
+      sources."kind-of-6.0.3"
+      sources."klaw-sync-6.0.0"
+      sources."kleur-3.0.3"
+      sources."last-call-webpack-plugin-3.0.0"
+      sources."latest-version-5.1.0"
+      sources."leven-3.1.0"
+      sources."levenary-1.1.1"
+      (sources."load-bmfont-1.4.1" // {
+        dependencies = [
+          sources."mime-1.6.0"
+        ];
+      })
+      sources."loader-runner-2.4.0"
+      (sources."loader-utils-1.4.0" // {
+        dependencies = [
+          sources."json5-1.0.1"
+        ];
+      })
+      sources."locate-path-5.0.0"
+      sources."lock-0.1.4"
+      sources."lodash-4.17.15"
+      sources."lodash._reinterpolate-3.0.0"
+      sources."lodash.assign-4.2.0"
+      sources."lodash.debounce-4.0.8"
+      sources."lodash.isobject-3.0.2"
+      sources."lodash.isstring-4.0.1"
+      sources."lodash.memoize-4.1.2"
+      sources."lodash.template-4.5.0"
+      sources."lodash.templatesettings-4.2.0"
+      sources."lodash.uniq-4.5.0"
+      (sources."log-symbols-2.2.0" // {
+        dependencies = [
+          sources."chalk-2.4.2"
+        ];
+      })
+      (sources."logfmt-1.3.2" // {
+        dependencies = [
+          sources."split-0.2.10"
+        ];
+      })
+      sources."logkitty-0.7.1"
+      sources."loglevel-1.7.0"
+      sources."loose-envify-1.4.0"
+      sources."lower-case-2.0.1"
+      sources."lowercase-keys-1.0.1"
+      sources."lru-cache-6.0.0"
+      (sources."make-dir-2.1.0" // {
+        dependencies = [
+          sources."semver-5.7.1"
+        ];
+      })
+      (sources."make-fetch-happen-8.0.9" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+        ];
+      })
+      sources."map-cache-0.2.2"
+      sources."map-visit-1.0.0"
+      sources."md5-2.3.0"
+      sources."md5-file-5.0.0"
+      sources."md5.js-1.3.5"
+      sources."md5hex-1.0.0"
+      sources."mdn-data-2.0.4"
+      sources."media-typer-0.3.0"
+      sources."memory-fs-0.4.1"
+      sources."merge-descriptors-1.0.1"
+      sources."merge-stream-2.0.0"
+      sources."merge2-1.4.1"
+      sources."methods-1.1.2"
+      sources."metro-babel-transformer-0.58.0"
+      sources."metro-react-native-babel-preset-0.58.0"
+      sources."metro-react-native-babel-transformer-0.58.0"
+      sources."metro-source-map-0.58.0"
+      sources."metro-symbolicate-0.58.0"
+      sources."microevent.ts-0.1.1"
+      sources."micromatch-4.0.2"
+      (sources."miller-rabin-4.0.1" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
+      sources."mime-2.4.6"
+      sources."mime-db-1.44.0"
+      sources."mime-types-2.1.27"
+      sources."mimic-fn-1.2.0"
+      sources."mimic-response-1.0.1"
+      sources."min-document-2.19.0"
+      (sources."mini-css-extract-plugin-0.5.0" // {
+        dependencies = [
+          sources."schema-utils-1.0.0"
+        ];
+      })
+      sources."minimalistic-assert-1.0.1"
+      sources."minimalistic-crypto-utils-1.0.1"
+      sources."minimatch-3.0.4"
+      sources."minimist-1.2.5"
+      (sources."minipass-2.3.5" // {
+        dependencies = [
+          sources."yallist-3.1.1"
+        ];
+      })
+      (sources."minipass-collect-1.0.2" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+        ];
+      })
+      (sources."minipass-fetch-1.3.2" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+        ];
+      })
+      (sources."minipass-flush-1.0.5" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+        ];
+      })
+      (sources."minipass-json-stream-1.0.1" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+        ];
+      })
+      (sources."minipass-pipeline-1.2.4" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+        ];
+      })
+      (sources."minipass-sized-1.0.3" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+        ];
+      })
+      (sources."minizlib-2.1.2" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+        ];
+      })
+      sources."mississippi-3.0.0"
+      (sources."mixin-deep-1.3.2" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      sources."mkdirp-0.5.5"
+      sources."moment-2.29.1"
+      (sources."move-concurrently-1.0.1" // {
+        dependencies = [
+          sources."rimraf-2.7.1"
+        ];
+      })
+      sources."ms-2.1.2"
+      sources."multicast-dns-6.2.3"
+      sources."multicast-dns-service-types-1.1.0"
+      sources."mute-stream-0.0.7"
+      sources."mv-2.1.1"
+      sources."mz-2.7.0"
+      sources."nan-2.14.1"
+      sources."nanomatch-1.2.13"
+      sources."native-url-0.2.6"
+      sources."ncp-2.0.0"
+      sources."negotiator-0.6.2"
+      sources."neo-async-2.6.2"
+      sources."next-tick-1.1.0"
+      sources."nice-try-1.0.5"
+      sources."no-case-3.0.3"
+      sources."node-fetch-2.6.1"
+      sources."node-forge-0.7.6"
+      (sources."node-gyp-7.1.0" // {
+        dependencies = [
+          sources."rimraf-2.7.1"
+          sources."semver-7.3.2"
+          sources."which-2.0.2"
+        ];
+      })
+      sources."node-html-parser-1.3.1"
+      (sources."node-libs-browser-2.2.1" // {
+        dependencies = [
+          sources."buffer-4.9.2"
+          sources."isarray-1.0.0"
+          sources."process-0.11.10"
+          sources."punycode-1.4.1"
+        ];
+      })
+      sources."node-releases-1.1.61"
+      sources."nopt-4.0.3"
+      sources."normalize-path-3.0.0"
+      sources."normalize-url-3.3.0"
+      sources."npm-bundled-1.1.1"
+      (sources."npm-install-checks-4.0.0" // {
+        dependencies = [
+          sources."semver-7.3.2"
+        ];
+      })
+      sources."npm-normalize-package-bin-1.0.1"
+      (sources."npm-package-arg-6.1.0" // {
+        dependencies = [
+          sources."hosted-git-info-2.8.8"
+        ];
+      })
+      sources."npm-packlist-2.1.2"
+      (sources."npm-pick-manifest-6.1.0" // {
+        dependencies = [
+          sources."npm-package-arg-8.0.1"
+          sources."semver-7.3.2"
+        ];
+      })
+      (sources."npm-registry-fetch-8.1.4" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+          sources."npm-package-arg-8.0.1"
+          sources."semver-7.3.2"
+        ];
+      })
+      sources."npm-run-path-2.0.2"
+      sources."npmlog-4.1.2"
+      sources."nth-check-1.0.2"
+      sources."number-is-nan-1.0.1"
+      sources."oauth-sign-0.9.0"
+      sources."ob1-0.58.0"
+      sources."object-assign-4.1.1"
+      (sources."object-copy-0.1.0" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          sources."is-accessor-descriptor-0.1.6"
+          sources."is-data-descriptor-0.1.4"
+          (sources."is-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-5.1.0"
+            ];
+          })
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."object-inspect-1.8.0"
+      sources."object-is-1.1.3"
+      sources."object-keys-1.1.1"
+      sources."object-visit-1.0.1"
+      sources."object.assign-4.1.1"
+      (sources."object.entries-1.1.2" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      (sources."object.getownpropertydescriptors-2.1.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      sources."object.pick-1.3.0"
+      (sources."object.values-1.1.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      sources."obuf-1.1.2"
+      sources."omggif-1.0.10"
+      sources."on-finished-2.3.0"
+      sources."on-headers-1.0.2"
+      sources."once-1.4.0"
+      sources."onetime-2.0.1"
+      sources."open-6.4.0"
+      sources."opn-5.5.0"
+      sources."optimize-css-assets-webpack-plugin-5.0.4"
+      sources."options-0.0.6"
+      (sources."ora-3.4.0" // {
+        dependencies = [
+          sources."chalk-2.4.2"
+          sources."strip-ansi-5.2.0"
+        ];
+      })
+      sources."original-1.0.2"
+      sources."os-browserify-0.3.0"
+      sources."os-homedir-1.0.2"
+      sources."os-tmpdir-1.0.2"
+      sources."osenv-0.1.5"
+      (sources."p-any-2.1.0" // {
+        dependencies = [
+          sources."p-cancelable-2.0.0"
+          sources."type-fest-0.3.1"
+        ];
+      })
+      sources."p-cancelable-1.1.0"
+      sources."p-finally-1.0.0"
+      sources."p-limit-2.3.0"
+      sources."p-locate-4.1.0"
+      sources."p-map-3.0.0"
+      sources."p-retry-4.1.0"
+      (sources."p-some-4.1.0" // {
+        dependencies = [
+          sources."p-cancelable-2.0.0"
+        ];
+      })
+      sources."p-timeout-3.1.0"
+      sources."p-try-2.2.0"
+      (sources."package-json-6.4.0" // {
+        dependencies = [
+          sources."got-9.6.0"
+          sources."prepend-http-2.0.0"
+          sources."registry-auth-token-3.4.0"
+          sources."registry-url-5.1.0"
+          sources."semver-6.3.0"
+          sources."url-parse-lax-3.0.0"
+        ];
+      })
+      (sources."pacote-11.1.11" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+          sources."mkdirp-1.0.4"
+          sources."npm-package-arg-8.0.1"
+          sources."rimraf-3.0.2"
+          sources."semver-7.3.2"
+        ];
+      })
+      sources."pako-1.0.11"
+      sources."parallel-transform-1.2.0"
+      sources."param-case-3.0.3"
+      sources."parse-asn1-5.1.6"
+      sources."parse-bmfont-ascii-1.0.6"
+      sources."parse-bmfont-binary-1.0.6"
+      sources."parse-bmfont-xml-1.1.4"
+      sources."parse-headers-2.0.3"
+      sources."parse-json-4.0.0"
+      sources."parse-png-2.1.0"
+      sources."parse-srcset-1.0.2"
+      sources."parseurl-1.3.3"
+      (sources."pascal-case-2.0.1" // {
+        dependencies = [
+          sources."camel-case-3.0.0"
+          sources."lower-case-1.1.4"
+          sources."no-case-2.3.2"
+        ];
+      })
+      sources."pascalcase-0.1.1"
+      (sources."password-prompt-1.1.2" // {
+        dependencies = [
+          sources."ansi-escapes-3.2.0"
+        ];
+      })
+      sources."path-browserify-0.0.1"
+      sources."path-dirname-1.0.2"
+      sources."path-exists-4.0.0"
+      sources."path-is-absolute-1.0.1"
+      sources."path-is-inside-1.0.2"
+      sources."path-key-2.0.1"
+      sources."path-parse-1.0.6"
+      sources."path-to-regexp-0.1.7"
+      sources."path-type-4.0.0"
+      sources."pbkdf2-3.1.1"
+      sources."performance-now-2.1.0"
+      sources."phin-2.9.3"
+      sources."picomatch-2.2.2"
+      sources."pify-4.0.1"
+      sources."pinkie-2.0.4"
+      sources."pinkie-promise-2.0.1"
+      sources."pixelmatch-4.0.2"
+      (sources."pkg-dir-3.0.0" // {
+        dependencies = [
+          sources."find-up-3.0.0"
+          sources."locate-path-3.0.0"
+          sources."p-locate-3.0.0"
+          sources."path-exists-3.0.0"
+        ];
+      })
+      (sources."pkg-up-3.1.0" // {
+        dependencies = [
+          sources."find-up-3.0.0"
+          sources."locate-path-3.0.0"
+          sources."p-locate-3.0.0"
+          sources."path-exists-3.0.0"
+        ];
+      })
+      sources."plist-3.0.1"
+      sources."pngjs-3.4.0"
+      sources."pnp-webpack-plugin-1.6.4"
+      (sources."portfinder-1.0.28" // {
+        dependencies = [
+          sources."async-2.6.3"
+          sources."debug-3.2.6"
+        ];
+      })
+      sources."posix-character-classes-0.1.1"
+      (sources."postcss-7.0.35" // {
+        dependencies = [
+          (sources."chalk-2.4.2" // {
+            dependencies = [
+              sources."supports-color-5.5.0"
+            ];
+          })
+          sources."source-map-0.6.1"
+          sources."supports-color-6.1.0"
+        ];
+      })
+      sources."postcss-calc-7.0.5"
+      (sources."postcss-colormin-4.0.3" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-convert-values-4.0.1" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      sources."postcss-discard-comments-4.0.2"
+      sources."postcss-discard-duplicates-4.0.2"
+      sources."postcss-discard-empty-4.0.1"
+      sources."postcss-discard-overridden-4.0.1"
+      (sources."postcss-merge-longhand-4.0.11" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-merge-rules-4.0.3" // {
+        dependencies = [
+          sources."postcss-selector-parser-3.1.2"
+        ];
+      })
+      (sources."postcss-minify-font-values-4.0.2" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-minify-gradients-4.0.2" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-minify-params-4.0.2" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-minify-selectors-4.0.2" // {
+        dependencies = [
+          sources."postcss-selector-parser-3.1.2"
+        ];
+      })
+      sources."postcss-modules-extract-imports-2.0.0"
+      sources."postcss-modules-local-by-default-3.0.3"
+      sources."postcss-modules-scope-2.2.0"
+      sources."postcss-modules-values-3.0.0"
+      sources."postcss-normalize-charset-4.0.1"
+      (sources."postcss-normalize-display-values-4.0.2" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-normalize-positions-4.0.2" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-normalize-repeat-style-4.0.2" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-normalize-string-4.0.2" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-normalize-timing-functions-4.0.2" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-normalize-unicode-4.0.1" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-normalize-url-4.0.1" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-normalize-whitespace-4.0.2" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      (sources."postcss-ordered-values-4.1.2" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      sources."postcss-reduce-initial-4.0.3"
+      (sources."postcss-reduce-transforms-4.0.2" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      sources."postcss-safe-parser-4.0.2"
+      sources."postcss-selector-parser-6.0.4"
+      (sources."postcss-svgo-4.0.2" // {
+        dependencies = [
+          sources."postcss-value-parser-3.3.1"
+        ];
+      })
+      sources."postcss-unique-selectors-4.0.1"
+      sources."postcss-value-parser-4.1.0"
+      sources."prepend-http-1.0.4"
+      sources."pretty-bytes-5.4.1"
+      sources."pretty-error-2.1.1"
+      (sources."pretty-format-25.5.0" // {
+        dependencies = [
+          sources."ansi-regex-5.0.0"
+          sources."ansi-styles-4.3.0"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+        ];
+      })
+      sources."pretty-time-1.1.0"
+      (sources."probe-image-size-4.0.0" // {
+        dependencies = [
+          sources."deepmerge-2.2.1"
+        ];
+      })
+      sources."process-0.5.2"
+      sources."process-nextick-args-2.0.1"
+      sources."progress-2.0.3"
+      sources."promise-inflight-1.0.1"
+      (sources."promise-retry-1.1.1" // {
+        dependencies = [
+          sources."retry-0.10.1"
+        ];
+      })
+      sources."prompts-2.3.2"
+      sources."proxy-addr-2.0.6"
+      sources."prr-1.0.1"
+      sources."psl-1.8.0"
+      (sources."public-encrypt-4.0.3" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
+      sources."pump-3.0.0"
+      (sources."pumpify-1.5.1" // {
+        dependencies = [
+          sources."pump-2.0.1"
+        ];
+      })
+      sources."punycode-2.1.1"
+      sources."q-1.5.1"
+      sources."qrcode-terminal-0.11.0"
+      sources."qs-6.5.2"
+      sources."querystring-0.2.0"
+      sources."querystring-es3-0.2.1"
+      sources."querystringify-2.2.0"
+      sources."quick-lru-5.1.1"
+      sources."randombytes-2.1.0"
+      sources."randomfill-1.0.4"
+      sources."range-parser-1.2.1"
+      (sources."raven-2.6.3" // {
+        dependencies = [
+          sources."uuid-3.0.0"
+        ];
+      })
+      sources."raw-body-2.3.3"
+      sources."rc-1.2.8"
+      (sources."react-dev-utils-10.2.1" // {
+        dependencies = [
+          sources."@babel/code-frame-7.8.3"
+          sources."@nodelib/fs.stat-1.1.3"
+          sources."arrify-1.0.1"
+          sources."braces-2.3.2"
+          sources."browserslist-4.10.0"
+          (sources."chalk-2.4.2" // {
+            dependencies = [
+              sources."escape-string-regexp-1.0.5"
+            ];
+          })
+          sources."chardet-0.7.0"
+          sources."cli-cursor-3.1.0"
+          sources."cross-spawn-7.0.1"
+          sources."dir-glob-2.0.0"
+          sources."emojis-list-2.1.0"
+          sources."escape-string-regexp-2.0.0"
+          sources."extend-shallow-2.0.1"
+          sources."external-editor-3.1.0"
+          sources."fast-glob-2.2.7"
+          sources."fill-range-4.0.0"
+          sources."glob-parent-3.1.0"
+          sources."globby-8.0.2"
+          sources."iconv-lite-0.4.24"
+          sources."ignore-3.3.10"
+          (sources."inquirer-7.0.4" // {
+            dependencies = [
+              sources."strip-ansi-5.2.0"
+            ];
+          })
+          sources."is-glob-3.1.0"
+          sources."is-number-3.0.0"
+          sources."is-wsl-2.2.0"
+          sources."json5-1.0.1"
+          sources."kind-of-3.2.2"
+          sources."loader-utils-1.2.3"
+          sources."micromatch-3.1.10"
+          sources."mimic-fn-2.1.0"
+          sources."mute-stream-0.0.8"
+          sources."onetime-5.1.2"
+          sources."open-7.3.0"
+          sources."path-key-3.1.1"
+          sources."path-type-3.0.0"
+          sources."pify-3.0.0"
+          sources."restore-cursor-3.1.0"
+          sources."rxjs-6.6.3"
+          sources."shebang-command-2.0.0"
+          sources."shebang-regex-3.0.0"
+          sources."shell-quote-1.7.2"
+          sources."to-regex-range-2.1.1"
+          sources."which-2.0.2"
+        ];
+      })
+      sources."react-error-overlay-6.0.7"
+      sources."react-is-16.13.1"
+      sources."react-refresh-0.4.3"
+      sources."read-chunk-3.2.0"
+      sources."read-last-lines-1.6.0"
+      sources."read-package-json-fast-1.2.1"
+      (sources."readable-stream-2.3.7" // {
+        dependencies = [
+          sources."isarray-1.0.0"
+        ];
+      })
+      sources."readdir-scoped-modules-1.1.0"
+      sources."readdirp-3.4.0"
+      sources."recursive-readdir-2.2.2"
+      sources."regenerate-1.4.1"
+      sources."regenerate-unicode-properties-8.2.0"
+      sources."regenerator-runtime-0.13.7"
+      sources."regenerator-transform-0.14.5"
+      sources."regex-not-1.0.2"
+      (sources."regexp.prototype.flags-1.3.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      sources."regexpu-core-4.7.1"
+      sources."registry-auth-token-3.3.2"
+      sources."registry-url-3.1.0"
+      sources."regjsgen-0.5.2"
+      (sources."regjsparser-0.6.4" // {
+        dependencies = [
+          sources."jsesc-0.5.0"
+        ];
+      })
+      sources."relateurl-0.2.7"
+      sources."remove-trailing-separator-1.1.0"
+      sources."remove-trailing-slash-0.1.1"
+      (sources."renderkid-2.0.3" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+          (sources."dom-serializer-0.2.2" // {
+            dependencies = [
+              sources."domelementtype-2.0.2"
+              sources."entities-2.0.3"
+            ];
+          })
+          sources."domelementtype-1.3.1"
+          sources."domhandler-2.4.2"
+          sources."domutils-1.7.0"
+          sources."entities-1.1.2"
+          sources."htmlparser2-3.10.1"
+          sources."readable-stream-3.6.0"
+          sources."strip-ansi-3.0.1"
+        ];
+      })
+      sources."repeat-element-1.1.3"
+      sources."repeat-string-1.6.1"
+      sources."replace-string-1.1.0"
+      (sources."request-2.88.2" // {
+        dependencies = [
+          sources."uuid-3.4.0"
+        ];
+      })
+      sources."require-directory-2.1.1"
+      sources."require-from-string-2.0.2"
+      sources."require-main-filename-2.0.0"
+      sources."requires-port-1.0.0"
+      sources."resolve-1.17.0"
+      sources."resolve-alpn-1.0.0"
+      (sources."resolve-cwd-2.0.0" // {
+        dependencies = [
+          sources."resolve-from-3.0.0"
+        ];
+      })
+      sources."resolve-from-5.0.0"
+      sources."resolve-url-0.2.1"
+      sources."responselike-1.0.2"
+      sources."restore-cursor-2.0.0"
+      sources."ret-0.1.15"
+      sources."retry-0.12.0"
+      sources."reusify-1.0.4"
+      sources."rgb-regex-1.0.1"
+      sources."rgba-regex-1.0.0"
+      (sources."rimraf-2.4.5" // {
+        dependencies = [
+          sources."glob-6.0.4"
+        ];
+      })
+      sources."ripemd160-2.0.2"
+      sources."router-ips-1.0.0"
+      sources."run-async-2.4.1"
+      sources."run-parallel-1.1.9"
+      sources."run-queue-1.0.3"
+      (sources."rxjs-5.5.12" // {
+        dependencies = [
+          sources."symbol-observable-1.0.1"
+        ];
+      })
+      sources."safe-buffer-5.1.2"
+      sources."safe-json-stringify-1.2.0"
+      sources."safe-regex-1.1.0"
+      sources."safer-buffer-2.1.2"
+      sources."sax-1.2.4"
+      sources."schema-utils-2.7.1"
+      sources."select-hose-2.0.0"
+      (sources."selfsigned-1.10.8" // {
+        dependencies = [
+          sources."node-forge-0.10.0"
+        ];
+      })
+      sources."semver-5.5.0"
+      (sources."send-0.16.2" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."mime-1.4.1"
+          sources."ms-2.0.0"
+        ];
+      })
+      (sources."serialize-error-5.0.0" // {
+        dependencies = [
+          sources."type-fest-0.8.1"
+        ];
+      })
+      sources."serialize-javascript-4.0.0"
+      (sources."serve-index-1.9.1" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+        ];
+      })
+      sources."serve-static-1.13.2"
+      sources."set-blocking-2.0.0"
+      (sources."set-value-2.0.1" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."setimmediate-1.0.5"
+      sources."setprototypeof-1.1.0"
+      sources."sha.js-2.4.11"
+      sources."shebang-command-1.2.0"
+      sources."shebang-regex-1.0.0"
+      sources."shell-quote-1.6.1"
+      sources."side-channel-1.0.3"
+      sources."signal-exit-3.0.3"
+      sources."simple-plist-1.1.1"
+      sources."simple-swizzle-0.2.2"
+      sources."sisteransi-1.0.5"
+      sources."slash-1.0.0"
+      sources."slice-ansi-2.1.0"
+      (sources."slugid-1.1.0" // {
+        dependencies = [
+          sources."uuid-2.0.3"
+        ];
+      })
+      sources."slugify-1.4.5"
+      sources."smart-buffer-4.1.0"
+      (sources."snapdragon-0.8.2" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
+        ];
+      })
+      (sources."snapdragon-node-2.1.1" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+        ];
+      })
+      (sources."snapdragon-util-3.0.1" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
+      (sources."sockjs-0.3.20" // {
+        dependencies = [
+          sources."uuid-3.4.0"
+        ];
+      })
+      (sources."sockjs-client-1.4.0" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."faye-websocket-0.11.3"
+        ];
+      })
+      sources."socks-2.4.4"
+      sources."socks-proxy-agent-5.0.0"
+      sources."source-list-map-2.0.1"
+      sources."source-map-0.5.7"
+      sources."source-map-resolve-0.5.3"
+      sources."source-map-support-0.4.18"
+      sources."source-map-url-0.4.0"
+      sources."spdy-4.0.2"
+      (sources."spdy-transport-3.0.0" // {
+        dependencies = [
+          sources."readable-stream-3.6.0"
+        ];
+      })
+      sources."split-1.0.1"
+      sources."split-string-3.1.0"
+      sources."sprintf-js-1.0.3"
+      sources."sshpk-1.16.1"
+      (sources."ssri-8.0.0" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+        ];
+      })
+      sources."stable-0.1.8"
+      sources."stack-trace-0.0.10"
+      sources."stackframe-1.2.0"
+      (sources."static-extend-0.1.2" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      sources."statuses-1.4.0"
+      sources."std-env-2.2.1"
+      sources."stream-browserify-2.0.2"
+      sources."stream-buffers-2.2.0"
+      sources."stream-each-1.2.3"
+      sources."stream-http-2.8.3"
+      (sources."stream-parser-0.3.1" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+        ];
+      })
+      sources."stream-shift-1.0.1"
+      (sources."string-width-4.2.0" // {
+        dependencies = [
+          sources."is-fullwidth-code-point-3.0.0"
+        ];
+      })
+      (sources."string.prototype.trimend-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      (sources."string.prototype.trimstart-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      sources."string_decoder-1.1.1"
+      (sources."stringify-object-3.3.0" // {
+        dependencies = [
+          sources."is-obj-1.0.1"
+        ];
+      })
+      (sources."strip-ansi-6.0.0" // {
+        dependencies = [
+          sources."ansi-regex-5.0.0"
+        ];
+      })
+      sources."strip-comments-1.0.2"
+      sources."strip-eof-1.0.0"
+      sources."strip-json-comments-2.0.1"
+      (sources."style-loader-1.2.1" // {
+        dependencies = [
+          sources."loader-utils-2.0.0"
+        ];
+      })
+      (sources."stylehacks-4.0.3" // {
+        dependencies = [
+          sources."postcss-selector-parser-3.1.2"
+        ];
+      })
+      sources."subscriptions-transport-ws-0.9.8"
+      sources."sudo-prompt-9.1.1"
+      sources."supports-color-5.5.0"
+      (sources."supports-hyperlinks-2.1.0" // {
+        dependencies = [
+          sources."has-flag-4.0.0"
+          sources."supports-color-7.2.0"
+        ];
+      })
+      (sources."svgo-1.3.2" // {
+        dependencies = [
+          sources."chalk-2.4.2"
+          sources."css-select-2.1.0"
+          sources."css-what-3.4.1"
+          (sources."dom-serializer-0.2.2" // {
+            dependencies = [
+              sources."domelementtype-2.0.2"
+            ];
+          })
+          sources."domelementtype-1.3.1"
+          sources."domutils-1.7.0"
+        ];
+      })
+      sources."symbol-observable-1.2.0"
+      sources."tapable-1.1.3"
+      (sources."tar-6.0.5" // {
+        dependencies = [
+          sources."minipass-3.1.3"
+          sources."mkdirp-1.0.4"
+        ];
+      })
+      sources."temp-dir-1.0.0"
+      (sources."tempy-0.3.0" // {
+        dependencies = [
+          sources."type-fest-0.3.1"
+        ];
+      })
+      sources."term-size-2.2.0"
+      sources."terminal-link-2.1.1"
+      (sources."terser-4.8.0" // {
+        dependencies = [
+          sources."commander-2.20.3"
+          sources."source-map-0.6.1"
+          sources."source-map-support-0.5.19"
+        ];
+      })
+      (sources."terser-webpack-plugin-3.1.0" // {
+        dependencies = [
+          sources."find-cache-dir-3.3.1"
+          sources."make-dir-3.1.0"
+          sources."p-limit-3.0.2"
+          sources."pkg-dir-4.2.0"
+          sources."semver-6.3.0"
+          sources."source-map-0.6.1"
+        ];
+      })
+      sources."text-table-0.2.0"
+      sources."thenify-3.3.1"
+      sources."thenify-all-1.6.0"
+      sources."through-2.3.8"
+      sources."through2-2.0.5"
+      sources."thunky-1.1.0"
+      sources."timed-out-4.0.1"
+      sources."timers-browserify-2.0.11"
+      sources."timm-1.7.1"
+      sources."timsort-0.3.0"
+      sources."tinycolor2-1.4.2"
+      sources."tmp-0.0.33"
+      sources."to-arraybuffer-1.0.1"
+      sources."to-fast-properties-2.0.0"
+      (sources."to-object-path-0.3.0" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."to-readable-stream-1.0.0"
+      sources."to-regex-3.0.2"
+      sources."to-regex-range-5.0.1"
+      sources."toidentifier-1.0.0"
+      sources."topo-2.0.2"
+      sources."tough-cookie-2.5.0"
+      sources."tree-kill-1.2.2"
+      sources."ts-invariant-0.4.4"
+      sources."ts-pnp-1.2.0"
+      sources."tslib-1.14.0"
+      sources."tty-browserify-0.0.0"
+      sources."tunnel-agent-0.6.0"
+      sources."tweetnacl-0.14.5"
+      sources."type-fest-0.12.0"
+      sources."type-is-1.6.18"
+      sources."typedarray-0.0.6"
+      sources."ultron-1.1.1"
+      sources."unicode-canonical-property-names-ecmascript-1.0.4"
+      sources."unicode-match-property-ecmascript-1.0.4"
+      sources."unicode-match-property-value-ecmascript-1.2.0"
+      sources."unicode-property-aliases-ecmascript-1.1.0"
+      sources."union-value-1.0.1"
+      sources."uniq-1.0.1"
+      sources."uniqs-2.0.0"
+      sources."unique-filename-1.1.1"
+      sources."unique-slug-2.0.2"
+      sources."unique-string-1.0.0"
+      sources."universalify-0.1.2"
+      sources."unpipe-1.0.0"
+      sources."unquote-1.1.1"
+      (sources."unset-value-1.0.0" // {
+        dependencies = [
+          (sources."has-value-0.3.1" // {
+            dependencies = [
+              sources."isobject-2.1.0"
+            ];
+          })
+          sources."has-values-0.1.4"
+          sources."isarray-1.0.0"
+        ];
+      })
+      sources."untildify-3.0.3"
+      sources."unzip-response-2.0.1"
+      sources."upath-1.2.0"
+      sources."update-check-1.5.3"
+      sources."upper-case-1.1.3"
+      sources."upper-case-first-1.1.2"
+      sources."uri-js-4.4.0"
+      sources."urix-0.1.0"
+      (sources."url-0.11.0" // {
+        dependencies = [
+          sources."punycode-1.3.2"
+        ];
+      })
+      sources."url-join-4.0.0"
+      (sources."url-loader-4.1.0" // {
+        dependencies = [
+          sources."loader-utils-2.0.0"
+        ];
+      })
+      sources."url-parse-1.4.7"
+      sources."url-parse-lax-1.0.0"
+      sources."use-3.1.1"
+      sources."utif-2.0.1"
+      (sources."util-0.11.1" // {
+        dependencies = [
+          sources."inherits-2.0.3"
+        ];
+      })
+      sources."util-deprecate-1.0.2"
+      sources."util.promisify-1.0.0"
+      sources."utila-0.4.0"
+      sources."utils-merge-1.0.1"
+      sources."uuid-8.3.1"
+      sources."validate-npm-package-name-3.0.0"
+      sources."validator-10.5.0"
+      sources."vary-1.1.2"
+      sources."vendors-1.0.4"
+      sources."verror-1.10.0"
+      sources."vlq-1.0.1"
+      sources."vm-browserify-1.1.2"
+      sources."watchpack-1.7.4"
+      (sources."watchpack-chokidar2-2.0.0" // {
+        dependencies = [
+          sources."anymatch-2.0.0"
+          sources."binary-extensions-1.13.1"
+          sources."braces-2.3.2"
+          sources."chokidar-2.1.8"
+          sources."extend-shallow-2.0.1"
+          sources."fill-range-4.0.0"
+          sources."fsevents-1.2.13"
+          sources."glob-parent-3.1.0"
+          sources."is-binary-path-1.0.1"
+          sources."is-glob-3.1.0"
+          sources."is-number-3.0.0"
+          sources."kind-of-3.2.2"
+          sources."micromatch-3.1.10"
+          sources."normalize-path-2.1.1"
+          sources."readdirp-2.2.1"
+          sources."to-regex-range-2.1.1"
+        ];
+      })
+      sources."wbuf-1.7.3"
+      sources."wcwidth-1.0.1"
+      (sources."webpack-4.43.0" // {
+        dependencies = [
+          (sources."braces-2.3.2" // {
+            dependencies = [
+              sources."extend-shallow-2.0.1"
+            ];
+          })
+          sources."cacache-12.0.4"
+          sources."chownr-1.1.4"
+          (sources."fill-range-4.0.0" // {
+            dependencies = [
+              sources."extend-shallow-2.0.1"
+            ];
+          })
+          (sources."is-number-3.0.0" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."lru-cache-5.1.1"
+          sources."micromatch-3.1.10"
+          sources."rimraf-2.7.1"
+          sources."schema-utils-1.0.0"
+          sources."source-map-0.6.1"
+          sources."ssri-6.0.1"
+          sources."terser-webpack-plugin-1.4.5"
+          sources."to-regex-range-2.1.1"
+          sources."yallist-3.1.1"
+        ];
+      })
+      sources."webpack-deep-scope-plugin-1.6.0"
+      sources."webpack-dev-middleware-3.7.2"
+      (sources."webpack-dev-server-3.11.0" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+          sources."anymatch-2.0.0"
+          sources."binary-extensions-1.13.1"
+          (sources."body-parser-1.19.0" // {
+            dependencies = [
+              sources."debug-2.6.9"
+            ];
+          })
+          sources."braces-2.3.2"
+          sources."bytes-3.1.0"
+          sources."chokidar-2.1.8"
+          (sources."cliui-5.0.0" // {
+            dependencies = [
+              sources."ansi-regex-4.1.0"
+              sources."strip-ansi-5.2.0"
+            ];
+          })
+          sources."content-disposition-0.5.3"
+          sources."cookie-0.4.0"
+          sources."emoji-regex-7.0.3"
+          (sources."express-4.17.1" // {
+            dependencies = [
+              sources."debug-2.6.9"
+            ];
+          })
+          sources."extend-shallow-2.0.1"
+          sources."fill-range-4.0.0"
+          (sources."finalhandler-1.1.2" // {
+            dependencies = [
+              sources."debug-2.6.9"
+            ];
+          })
+          sources."find-up-3.0.0"
+          sources."fsevents-1.2.13"
+          sources."glob-parent-3.1.0"
+          sources."http-errors-1.7.2"
+          sources."iconv-lite-0.4.24"
+          sources."inherits-2.0.3"
+          sources."is-absolute-url-3.0.3"
+          sources."is-binary-path-1.0.1"
+          sources."is-glob-3.1.0"
+          sources."is-number-3.0.0"
+          sources."kind-of-3.2.2"
+          sources."locate-path-3.0.0"
+          sources."micromatch-3.1.10"
+          sources."mime-1.6.0"
+          sources."ms-2.0.0"
+          sources."normalize-path-2.1.1"
+          sources."p-locate-3.0.0"
+          sources."p-retry-3.0.1"
+          sources."path-exists-3.0.0"
+          sources."qs-6.7.0"
+          sources."raw-body-2.4.0"
+          sources."readdirp-2.2.1"
+          sources."schema-utils-1.0.0"
+          sources."semver-6.3.0"
+          (sources."send-0.17.1" // {
+            dependencies = [
+              (sources."debug-2.6.9" // {
+                dependencies = [
+                  sources."ms-2.0.0"
+                ];
+              })
+              sources."ms-2.1.1"
+            ];
+          })
+          sources."serve-static-1.14.1"
+          sources."setprototypeof-1.1.1"
+          sources."statuses-1.5.0"
+          (sources."string-width-3.1.0" // {
+            dependencies = [
+              sources."ansi-regex-4.1.0"
+              sources."strip-ansi-5.2.0"
+            ];
+          })
+          sources."strip-ansi-3.0.1"
+          sources."supports-color-6.1.0"
+          sources."to-regex-range-2.1.1"
+          (sources."wrap-ansi-5.1.0" // {
+            dependencies = [
+              sources."ansi-regex-4.1.0"
+              sources."strip-ansi-5.2.0"
+            ];
+          })
+          sources."ws-6.2.1"
+          sources."yargs-13.3.2"
+          sources."yargs-parser-13.1.2"
+        ];
+      })
+      (sources."webpack-log-2.0.0" // {
+        dependencies = [
+          sources."uuid-3.4.0"
+        ];
+      })
+      (sources."webpack-manifest-plugin-2.2.0" // {
+        dependencies = [
+          sources."fs-extra-7.0.1"
+        ];
+      })
+      (sources."webpack-sources-1.4.3" // {
+        dependencies = [
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."webpackbar-4.0.0" // {
+        dependencies = [
+          sources."chalk-2.4.2"
+        ];
+      })
+      sources."websocket-driver-0.6.5"
+      sources."websocket-extensions-0.1.4"
+      sources."which-1.3.1"
+      sources."which-boxed-primitive-1.0.1"
+      sources."which-collection-1.0.1"
+      sources."which-module-2.0.0"
+      (sources."which-typed-array-1.1.2" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      (sources."wide-align-1.1.3" // {
+        dependencies = [
+          sources."ansi-regex-3.0.0"
+          sources."string-width-2.1.1"
+          sources."strip-ansi-4.0.0"
+        ];
+      })
+      sources."widest-line-3.1.0"
+      sources."with-open-file-0.1.7"
+      sources."wordwrap-1.0.0"
+      sources."workbox-background-sync-3.6.3"
+      sources."workbox-broadcast-cache-update-3.6.3"
+      (sources."workbox-build-3.6.3" // {
+        dependencies = [
+          sources."fs-extra-4.0.3"
+          sources."pretty-bytes-4.0.2"
+        ];
+      })
+      sources."workbox-cache-expiration-3.6.3"
+      sources."workbox-cacheable-response-3.6.3"
+      sources."workbox-core-3.6.3"
+      sources."workbox-google-analytics-3.6.3"
+      sources."workbox-navigation-preload-3.6.3"
+      sources."workbox-precaching-3.6.3"
+      sources."workbox-range-requests-3.6.3"
+      sources."workbox-routing-3.6.3"
+      sources."workbox-strategies-3.6.3"
+      sources."workbox-streams-3.6.3"
+      sources."workbox-sw-3.6.3"
+      sources."workbox-webpack-plugin-3.6.3"
+      sources."worker-farm-1.7.0"
+      (sources."worker-loader-2.0.0" // {
+        dependencies = [
+          sources."schema-utils-0.4.7"
+        ];
+      })
+      sources."worker-rpc-0.1.1"
+      (sources."wrap-ansi-6.2.0" // {
+        dependencies = [
+          sources."ansi-styles-4.3.0"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+        ];
+      })
+      sources."wrappy-1.0.2"
+      sources."write-file-atomic-2.4.3"
+      sources."ws-3.3.3"
+      (sources."xcode-3.0.1" // {
+        dependencies = [
+          sources."uuid-7.0.3"
+        ];
+      })
+      sources."xhr-2.5.0"
+      sources."xml-js-1.6.11"
+      sources."xml-parse-from-string-1.0.1"
+      (sources."xml2js-0.4.23" // {
+        dependencies = [
+          sources."xmlbuilder-11.0.1"
+        ];
+      })
+      sources."xmlbuilder-9.0.7"
+      sources."xmldoc-1.1.2"
+      sources."xmldom-0.1.31"
+      sources."xtend-4.0.2"
+      sources."y18n-4.0.0"
+      sources."yallist-4.0.0"
+      sources."yargs-15.4.1"
+      sources."yargs-parser-18.1.3"
+      sources."zen-observable-0.8.15"
+      sources."zen-observable-ts-0.8.21"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "The command-line tool for creating and publishing Expo apps";
+      homepage = "https://github.com/expo/expo-cli/tree/master/packages/expo-cli#readme";
       license = "MIT";
     };
     production = true;
@@ -66015,13 +71542,12 @@ in
           sources."supports-color-5.5.0"
         ];
       })
-      sources."@types/color-name-1.1.1"
       sources."@types/minimist-1.2.0"
       sources."@types/normalize-package-data-2.4.0"
       sources."aggregate-error-3.1.0"
       sources."ansi-escapes-4.3.1"
       sources."ansi-regex-5.0.0"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."arrify-2.0.1"
       sources."astral-regex-2.0.0"
       sources."camelcase-5.3.1"
@@ -66067,7 +71593,7 @@ in
           sources."chalk-4.1.0"
         ];
       })
-      (sources."inquirer-autocomplete-prompt-1.1.0" // {
+      (sources."inquirer-autocomplete-prompt-1.2.0" // {
         dependencies = [
           sources."chalk-4.1.0"
         ];
@@ -66171,7 +71697,7 @@ in
       sources."through-2.3.8"
       sources."tmp-0.0.33"
       sources."trim-newlines-3.0.0"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."type-fest-0.11.0"
       sources."validate-npm-package-license-3.0.4"
       sources."which-2.0.2"
@@ -66281,7 +71807,7 @@ in
       sources."defined-0.0.0"
       sources."director-1.2.7"
       sources."duplexer-0.1.2"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."event-stream-3.3.4"
       sources."eventemitter2-0.4.14"
@@ -66414,14 +71940,10 @@ in
         ];
       })
       sources."object-inspect-1.8.0"
-      sources."object-is-1.1.2"
+      sources."object-is-1.1.3"
       sources."object-keys-1.1.1"
       sources."object-visit-1.0.1"
-      (sources."object.assign-4.1.1" // {
-        dependencies = [
-          sources."es-abstract-1.18.0-next.0"
-        ];
-      })
+      sources."object.assign-4.1.1"
       sources."object.pick-1.3.0"
       sources."once-1.4.0"
       sources."optimist-0.6.0"
@@ -66450,7 +71972,11 @@ in
       sources."readable-stream-2.3.7"
       sources."readdirp-2.2.1"
       sources."regex-not-1.0.2"
-      sources."regexp.prototype.flags-1.3.0"
+      (sources."regexp.prototype.flags-1.3.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."remove-trailing-separator-1.1.0"
       sources."repeat-element-1.1.3"
       sources."repeat-string-1.6.1"
@@ -66523,8 +72049,16 @@ in
       })
       sources."stream-combiner-0.0.4"
       sources."string-width-1.0.2"
-      sources."string.prototype.trimend-1.0.1"
-      sources."string.prototype.trimstart-1.0.1"
+      (sources."string.prototype.trimend-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      (sources."string.prototype.trimstart-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."string_decoder-1.1.1"
       sources."strip-ansi-3.0.1"
       sources."strip-json-comments-0.1.3"
@@ -66699,7 +72233,7 @@ in
       sources."mime-types-2.1.27"
       sources."minimist-1.2.5"
       sources."mkdirp-0.5.5"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."moo-0.5.1"
       sources."ms-2.1.2"
       sources."multicb-1.2.2"
@@ -66875,7 +72409,6 @@ in
       })
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/color-name-1.1.1"
       sources."@types/minimist-1.2.0"
       sources."@types/normalize-package-data-2.4.0"
       sources."ajv-6.12.5"
@@ -66890,7 +72423,7 @@ in
       })
       sources."ansi-escapes-4.3.1"
       sources."ansi-regex-5.0.0"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."arrify-1.0.1"
       sources."atomically-1.3.2"
       (sources."boxen-4.2.0" // {
@@ -66967,7 +72500,7 @@ in
       sources."indent-string-4.0.0"
       sources."ini-1.3.5"
       sources."inquirer-7.3.3"
-      sources."inquirer-autocomplete-prompt-1.1.0"
+      sources."inquirer-autocomplete-prompt-1.2.0"
       sources."is-arrayish-0.2.1"
       sources."is-ci-2.0.0"
       sources."is-fullwidth-code-point-3.0.0"
@@ -67098,7 +72631,7 @@ in
       sources."tmp-0.0.33"
       sources."to-readable-stream-1.0.0"
       sources."trim-newlines-3.0.0"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."type-fest-0.11.0"
       sources."typedarray-to-buffer-3.1.5"
       sources."unique-string-2.0.0"
@@ -67131,10 +72664,10 @@ in
   graphql-cli = nodeEnv.buildNodePackage {
     name = "graphql-cli";
     packageName = "graphql-cli";
-    version = "4.0.0";
+    version = "4.1.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/graphql-cli/-/graphql-cli-4.0.0.tgz";
-      sha512 = "O3UHyNJ3nYBNfgC+R5hvJPADiZztZHgWoYfdX0vAtXf0yWyqNgtJQzkcY3RufW1Yi+Bq2Yo8ptyYr2i573GPTQ==";
+      url = "https://registry.npmjs.org/graphql-cli/-/graphql-cli-4.1.0.tgz";
+      sha512 = "VmA5VrjEJZdHsG8JcIdofFtSWspdYlDtJobn6F+gWgRf6cXRbJwuzszcnx4yvhhwc7EcfRP29NLA2652SNhpgQ==";
     };
     dependencies = [
       sources."@ardatan/aggregate-error-0.0.6"
@@ -67150,56 +72683,38 @@ in
           sources."supports-color-5.5.0"
         ];
       })
-      sources."@babel/runtime-7.11.2"
       sources."@exodus/schemasafe-1.0.0-rc.2"
-      sources."@graphql-cli/common-4.0.0"
-      sources."@graphql-cli/init-4.0.0"
+      sources."@graphql-cli/common-4.1.0"
+      sources."@graphql-cli/init-4.1.0"
       sources."@graphql-tools/delegate-6.2.4"
-      (sources."@graphql-tools/graphql-file-loader-6.2.4" // {
-        dependencies = [
-          sources."fs-extra-9.0.1"
-        ];
-      })
-      (sources."@graphql-tools/import-6.2.4" // {
-        dependencies = [
-          sources."fs-extra-9.0.1"
-        ];
-      })
-      (sources."@graphql-tools/json-file-loader-6.2.4" // {
-        dependencies = [
-          sources."fs-extra-9.0.1"
-        ];
-      })
+      sources."@graphql-tools/graphql-file-loader-6.2.4"
+      sources."@graphql-tools/import-6.2.4"
+      sources."@graphql-tools/json-file-loader-6.2.4"
       sources."@graphql-tools/load-6.2.4"
       sources."@graphql-tools/merge-6.2.4"
       sources."@graphql-tools/schema-6.2.4"
-      (sources."@graphql-tools/url-loader-6.2.4" // {
-        dependencies = [
-          sources."cross-fetch-3.0.6"
-          sources."node-fetch-2.6.1"
-        ];
-      })
+      sources."@graphql-tools/url-loader-6.3.0"
       sources."@graphql-tools/utils-6.2.4"
       sources."@graphql-tools/wrap-6.2.4"
-      sources."@kwsites/exec-p-0.4.0"
+      sources."@kwsites/file-exists-1.1.1"
+      sources."@kwsites/promise-deferred-1.1.1"
       sources."@nodelib/fs.scandir-2.1.3"
       sources."@nodelib/fs.stat-2.0.3"
       sources."@nodelib/fs.walk-1.2.4"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/color-name-1.1.1"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/parse-json-4.0.0"
       sources."@types/websocket-1.0.1"
       sources."aggregate-error-3.1.0"
-      sources."ajv-5.5.2"
+      sources."ajv-6.12.5"
       (sources."ansi-escapes-4.3.1" // {
         dependencies = [
           sources."type-fest-0.11.0"
         ];
       })
-      sources."ansi-regex-5.0.0"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-regex-4.1.0"
+      sources."ansi-styles-4.3.0"
       sources."argparse-1.0.10"
       sources."array-filter-1.0.0"
       sources."array-union-2.1.0"
@@ -67214,16 +72729,6 @@ in
       sources."backo2-1.0.2"
       sources."balanced-match-1.0.0"
       sources."bcrypt-pbkdf-1.0.2"
-      (sources."better-ajv-errors-0.6.7" // {
-        dependencies = [
-          sources."ansi-styles-3.2.1"
-          sources."chalk-2.4.2"
-          sources."color-convert-1.9.3"
-          sources."color-name-1.1.3"
-          sources."has-flag-3.0.0"
-          sources."supports-color-5.5.0"
-        ];
-      })
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
       sources."bufferutil-4.0.1"
@@ -67237,38 +72742,44 @@ in
       sources."callsites-3.1.0"
       (sources."camel-case-4.1.1" // {
         dependencies = [
-          sources."tslib-1.13.0"
+          sources."tslib-1.14.0"
         ];
       })
       sources."camelcase-5.3.1"
       sources."caseless-0.12.0"
-      sources."chalk-4.0.0"
+      sources."chalk-4.1.0"
       sources."chardet-0.7.0"
+      sources."chownr-2.0.0"
       sources."clean-stack-2.2.0"
-      sources."cli-cursor-3.1.0"
+      sources."cli-cursor-2.1.0"
       sources."cli-spinners-2.4.0"
-      sources."cli-width-2.2.1"
-      (sources."cliui-4.1.0" // {
+      sources."cli-width-3.0.0"
+      (sources."cliui-6.0.0" // {
         dependencies = [
-          sources."ansi-regex-3.0.0"
-          sources."is-fullwidth-code-point-2.0.0"
-          sources."string-width-2.1.1"
-          sources."strip-ansi-4.0.0"
+          sources."ansi-regex-5.0.0"
+          sources."strip-ansi-6.0.0"
         ];
       })
       sources."clone-1.0.4"
       sources."clone-response-1.0.2"
-      sources."co-4.6.0"
-      sources."code-error-fragment-0.0.230"
-      sources."code-point-at-1.1.0"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
       sources."combined-stream-1.0.8"
       sources."concat-map-0.0.1"
-      sources."core-js-3.6.5"
       sources."core-util-is-1.0.2"
-      sources."cosmiconfig-6.0.0"
-      sources."cross-fetch-3.0.4"
+      sources."cosmiconfig-7.0.0"
+      (sources."create-graphback-1.0.1" // {
+        dependencies = [
+          sources."ansi-styles-3.2.1"
+          sources."chalk-2.4.2"
+          sources."color-convert-1.9.3"
+          sources."color-name-1.1.3"
+          sources."has-flag-3.0.0"
+          sources."ora-3.4.0"
+          sources."supports-color-5.5.0"
+        ];
+      })
+      sources."cross-fetch-3.0.6"
       sources."cross-spawn-6.0.5"
       sources."d-1.0.1"
       sources."dashdash-1.14.1"
@@ -67276,7 +72787,7 @@ in
       sources."debug-4.3.0"
       sources."decamelize-1.2.0"
       sources."decompress-response-3.3.0"
-      sources."deep-equal-2.0.3"
+      sources."deep-equal-2.0.4"
       sources."deep-extend-0.6.0"
       sources."defaults-1.0.3"
       sources."defer-to-connect-1.1.3"
@@ -67288,13 +72799,18 @@ in
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.17.6"
-      sources."es-get-iterator-1.1.0"
+      sources."es-abstract-1.18.0-next.1"
+      (sources."es-get-iterator-1.1.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."es-to-primitive-1.2.1"
       sources."es5-ext-0.10.53"
       sources."es6-iterator-2.0.3"
       sources."es6-promise-3.3.1"
       sources."es6-symbol-3.1.3"
+      sources."escalade-3.1.0"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
       sources."eventemitter3-3.1.2"
@@ -67311,24 +72827,26 @@ in
         ];
       })
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-3.1.3"
       sources."fast-glob-3.2.4"
       sources."fast-json-stable-stringify-2.1.0"
       sources."fast-safe-stringify-2.0.7"
       sources."fastq-1.8.0"
+      sources."figlet-1.5.0"
       sources."figures-3.2.0"
       sources."fill-range-7.0.1"
       sources."filter-obj-2.0.1"
-      sources."find-up-3.0.0"
+      sources."find-up-4.1.0"
       sources."foreach-2.0.5"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."form-urlencoded-4.2.1"
-      sources."fs-extra-9.0.0"
+      sources."fs-extra-9.0.1"
+      sources."fs-minipass-2.1.0"
       sources."fs.realpath-1.0.0"
       sources."fullname-4.0.1"
       sources."function-bind-1.1.1"
-      sources."get-caller-file-1.0.3"
+      sources."get-caller-file-2.0.5"
       sources."get-stream-4.1.0"
       sources."getpass-0.1.7"
       sources."glob-7.1.6"
@@ -67340,19 +72858,16 @@ in
         ];
       })
       sources."graceful-fs-4.2.4"
-      sources."grapheme-splitter-1.0.4"
       sources."graphql-15.3.0"
-      sources."graphql-config-3.0.3"
-      sources."graphql-subscriptions-1.1.0"
-      sources."graphql-type-json-0.2.4"
-      sources."har-schema-2.0.0"
-      (sources."har-validator-5.1.5" // {
+      (sources."graphql-config-3.0.3" // {
         dependencies = [
-          sources."ajv-6.12.5"
-          sources."fast-deep-equal-3.1.3"
-          sources."json-schema-traverse-0.4.1"
+          sources."cosmiconfig-6.0.0"
         ];
       })
+      sources."graphql-subscriptions-1.1.0"
+      sources."graphql-type-json-0.3.2"
+      sources."har-schema-2.0.0"
+      sources."har-validator-5.1.5"
       sources."has-1.0.3"
       sources."has-flag-4.0.0"
       sources."has-symbols-1.0.1"
@@ -67371,12 +72886,16 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      (sources."inquirer-7.1.0" // {
+      (sources."inquirer-7.3.3" // {
         dependencies = [
-          sources."chalk-3.0.0"
+          sources."ansi-regex-5.0.0"
+          sources."cli-cursor-3.1.0"
+          sources."mimic-fn-2.1.0"
+          sources."onetime-5.1.2"
+          sources."restore-cursor-3.1.0"
+          sources."strip-ansi-6.0.0"
         ];
       })
-      sources."invert-kv-2.0.0"
       sources."is-arguments-1.0.4"
       sources."is-arrayish-0.2.1"
       sources."is-bigint-1.0.0"
@@ -67398,7 +72917,11 @@ in
       sources."is-stream-1.1.0"
       sources."is-string-1.0.5"
       sources."is-symbol-1.0.3"
-      sources."is-typed-array-1.1.3"
+      (sources."is-typed-array-1.1.3" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."is-typedarray-1.0.0"
       sources."is-weakmap-2.0.1"
       sources."is-weakset-2.0.1"
@@ -67412,22 +72935,20 @@ in
       sources."jsbn-0.1.1"
       sources."json-buffer-3.0.0"
       sources."json-parse-even-better-errors-2.3.1"
+      sources."json-ptr-1.3.2"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
-      sources."json-to-ast-2.1.0"
       sources."jsonfile-6.0.1"
-      sources."jsonpath-plus-3.0.0"
-      sources."jsonpointer-4.1.0"
+      sources."jsonpath-plus-4.0.0"
       sources."jsprim-1.4.1"
       sources."keyv-3.1.0"
       sources."latest-version-5.1.0"
-      sources."lcid-2.0.0"
-      sources."leven-3.1.0"
       sources."lines-and-columns-1.1.6"
-      sources."locate-path-3.0.0"
+      sources."locate-path-5.0.0"
       sources."lodash-4.17.20"
-      (sources."log-symbols-3.0.0" // {
+      sources."lodash.toarray-4.4.0"
+      (sources."log-symbols-2.2.0" // {
         dependencies = [
           sources."ansi-styles-3.2.1"
           sources."chalk-2.4.2"
@@ -67439,63 +72960,71 @@ in
       })
       (sources."lower-case-2.0.1" // {
         dependencies = [
-          sources."tslib-1.13.0"
+          sources."tslib-1.14.0"
         ];
       })
       sources."lowercase-keys-1.0.1"
       sources."map-age-cleaner-0.1.3"
-      sources."mem-5.1.1"
+      (sources."mem-5.1.1" // {
+        dependencies = [
+          sources."mimic-fn-2.1.0"
+        ];
+      })
       sources."merge2-1.4.1"
       sources."micromatch-4.0.2"
       sources."mime-db-1.44.0"
       sources."mime-types-2.1.27"
-      sources."mimic-fn-2.1.0"
+      sources."mimic-fn-1.2.0"
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
+      sources."minipass-3.1.3"
+      sources."minizlib-2.1.2"
+      sources."mkdirp-1.0.4"
       sources."ms-2.1.2"
       sources."mute-stream-0.0.8"
       sources."next-tick-1.0.0"
       sources."nice-try-1.0.5"
       (sources."no-case-3.0.3" // {
         dependencies = [
-          sources."tslib-1.13.0"
+          sources."tslib-1.14.0"
         ];
       })
-      sources."node-fetch-2.6.0"
+      sources."node-emoji-1.10.0"
+      sources."node-fetch-2.6.1"
       sources."node-fetch-h2-2.3.0"
       sources."node-gyp-build-3.7.0"
       sources."node-readfiles-0.2.0"
       sources."normalize-path-2.1.1"
       sources."normalize-url-4.5.0"
       sources."npm-run-path-2.0.2"
-      sources."number-is-nan-1.0.1"
       sources."oas-kit-common-1.0.8"
       sources."oas-linter-3.2.0"
-      sources."oas-resolver-2.5.1"
+      (sources."oas-resolver-2.5.1" // {
+        dependencies = [
+          sources."yargs-15.4.1"
+        ];
+      })
       sources."oas-schema-walker-1.1.5"
-      sources."oas-validator-3.4.0"
+      sources."oas-validator-5.0.2"
       sources."oauth-sign-0.9.0"
       sources."object-inspect-1.8.0"
-      sources."object-is-1.1.2"
+      sources."object-is-1.1.3"
       sources."object-keys-1.1.1"
-      (sources."object.assign-4.1.1" // {
-        dependencies = [
-          sources."es-abstract-1.18.0-next.0"
-        ];
-      })
+      sources."object.assign-4.1.1"
       sources."once-1.4.0"
-      sources."onetime-5.1.2"
-      sources."open-7.0.4"
-      sources."openapi-to-graphql-2.1.0"
-      (sources."ora-4.0.4" // {
+      sources."onetime-2.0.1"
+      sources."open-7.3.0"
+      sources."openapi-to-graphql-2.2.5"
+      (sources."ora-5.1.0" // {
         dependencies = [
-          sources."chalk-3.0.0"
-        ];
-      })
-      (sources."os-locale-3.1.0" // {
-        dependencies = [
-          sources."mem-4.3.0"
+          sources."ansi-regex-5.0.0"
+          sources."cli-cursor-3.1.0"
+          sources."log-symbols-4.0.0"
+          sources."mimic-fn-2.1.0"
+          sources."onetime-5.1.2"
+          sources."restore-cursor-3.1.0"
+          sources."strip-ansi-6.0.0"
         ];
       })
       sources."os-tmpdir-1.0.2"
@@ -67505,7 +73034,7 @@ in
       sources."p-finally-1.0.0"
       sources."p-is-promise-2.1.0"
       sources."p-limit-3.0.2"
-      (sources."p-locate-3.0.0" // {
+      (sources."p-locate-4.1.0" // {
         dependencies = [
           sources."p-limit-2.3.0"
         ];
@@ -67518,14 +73047,15 @@ in
         ];
       })
       sources."parent-module-1.0.1"
+      sources."parse-github-url-1.0.2"
       sources."parse-json-5.1.0"
       (sources."pascal-case-3.1.1" // {
         dependencies = [
-          sources."tslib-1.13.0"
+          sources."tslib-1.14.0"
         ];
       })
       sources."passwd-user-3.0.0"
-      sources."path-exists-3.0.0"
+      sources."path-exists-4.0.0"
       sources."path-is-absolute-1.0.1"
       sources."path-key-2.0.1"
       sources."path-type-4.0.0"
@@ -67539,24 +73069,27 @@ in
       sources."qs-6.5.2"
       sources."rc-1.2.8"
       sources."reftools-1.1.6"
-      sources."regenerator-runtime-0.13.7"
-      sources."regexp.prototype.flags-1.3.0"
+      (sources."regexp.prototype.flags-1.3.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."registry-auth-token-4.2.0"
       sources."registry-url-5.1.0"
       sources."remove-trailing-separator-1.1.0"
       sources."request-2.88.2"
       sources."require-directory-2.1.1"
-      sources."require-main-filename-1.0.1"
+      sources."require-main-filename-2.0.0"
       sources."resolve-from-5.0.0"
       sources."responselike-1.0.2"
-      sources."restore-cursor-3.1.0"
+      sources."restore-cursor-2.0.0"
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
       sources."run-async-2.4.1"
       sources."run-parallel-1.1.9"
       (sources."rxjs-6.6.3" // {
         dependencies = [
-          sources."tslib-1.13.0"
+          sources."tslib-1.14.0"
         ];
       })
       sources."safe-buffer-5.2.1"
@@ -67571,41 +73104,47 @@ in
       sources."should-type-1.4.0"
       sources."should-type-adaptors-1.1.0"
       sources."should-util-1.0.1"
-      (sources."side-channel-1.0.3" // {
-        dependencies = [
-          sources."es-abstract-1.18.0-next.0"
-        ];
-      })
+      sources."side-channel-1.0.3"
       sources."signal-exit-3.0.3"
-      sources."simple-git-2.5.0"
+      sources."simple-git-2.21.0"
       sources."slash-3.0.0"
       sources."sprintf-js-1.0.3"
       sources."sshpk-1.16.1"
       sources."string-env-interpolation-1.0.1"
-      sources."string-width-4.2.0"
-      sources."string.prototype.trimend-1.0.1"
-      sources."string.prototype.trimstart-1.0.1"
-      sources."strip-ansi-6.0.0"
+      (sources."string-width-4.2.0" // {
+        dependencies = [
+          sources."ansi-regex-5.0.0"
+          sources."strip-ansi-6.0.0"
+        ];
+      })
+      (sources."string.prototype.trimend-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      (sources."string.prototype.trimstart-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      sources."strip-ansi-5.2.0"
       sources."strip-eof-1.0.0"
       sources."strip-json-comments-2.0.1"
       sources."subscriptions-transport-ws-0.9.18"
       sources."supports-color-7.2.0"
-      (sources."swagger2openapi-5.4.0" // {
+      (sources."swagger2openapi-7.0.2" // {
         dependencies = [
-          sources."ansi-regex-3.0.0"
-          sources."is-fullwidth-code-point-2.0.0"
-          sources."string-width-2.1.1"
-          sources."strip-ansi-4.0.0"
-          sources."yargs-12.0.5"
+          sources."yargs-15.4.1"
         ];
       })
       sources."symbol-observable-1.2.0"
+      sources."tar-6.0.5"
       sources."through-2.3.8"
       sources."tmp-0.2.1"
       sources."to-readable-stream-1.0.0"
       sources."to-regex-range-5.0.1"
       sources."tough-cookie-2.5.0"
-      sources."tslib-2.0.1"
+      sources."tslib-2.0.2"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-1.2.0"
@@ -67626,40 +73165,38 @@ in
           sources."ms-2.0.0"
         ];
       })
-      sources."whatwg-fetch-3.0.0"
       sources."which-1.3.1"
       sources."which-boxed-primitive-1.0.1"
       sources."which-collection-1.0.1"
       sources."which-module-2.0.0"
-      sources."which-typed-array-1.1.2"
-      (sources."wrap-ansi-2.1.0" // {
+      (sources."which-typed-array-1.1.2" // {
         dependencies = [
-          sources."ansi-regex-2.1.1"
-          sources."is-fullwidth-code-point-1.0.0"
-          sources."string-width-1.0.2"
-          sources."strip-ansi-3.0.1"
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      (sources."wrap-ansi-6.2.0" // {
+        dependencies = [
+          sources."ansi-regex-5.0.0"
+          sources."strip-ansi-6.0.0"
         ];
       })
       sources."wrappy-1.0.2"
       sources."ws-5.2.2"
       sources."y18n-4.0.0"
       sources."yaeti-0.0.6"
+      sources."yallist-4.0.0"
       sources."yaml-1.10.0"
-      (sources."yargs-15.4.1" // {
+      (sources."yargs-16.0.3" // {
         dependencies = [
-          sources."cliui-6.0.0"
-          sources."find-up-4.1.0"
-          sources."get-caller-file-2.0.5"
-          sources."locate-path-5.0.0"
-          sources."p-limit-2.3.0"
-          sources."p-locate-4.1.0"
-          sources."path-exists-4.0.0"
-          sources."require-main-filename-2.0.0"
-          sources."wrap-ansi-6.2.0"
-          sources."yargs-parser-18.1.3"
+          sources."ansi-regex-5.0.0"
+          sources."cliui-7.0.1"
+          sources."strip-ansi-6.0.0"
+          sources."wrap-ansi-7.0.0"
+          sources."y18n-5.0.2"
+          sources."yargs-parser-20.2.1"
         ];
       })
-      sources."yargs-parser-11.1.1"
+      sources."yargs-parser-18.1.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -67946,7 +73483,6 @@ in
       sha512 = "Dn/8Kt57CsFLHd9vJIqWuhzXETpm+J86tD444rOz04uUu0kQBUTEBXmwu7zOVntb+TRr4EuyRxBo2tecJAPFmA==";
     };
     dependencies = [
-      sources."@types/color-name-1.1.1"
       sources."abbrev-1.1.1"
       sources."ansi-escapes-4.3.1"
       sources."ansi-regex-2.1.1"
@@ -67986,7 +73522,7 @@ in
       sources."marked-0.7.0"
       (sources."marked-terminal-4.1.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."supports-color-7.2.0"
         ];
@@ -68010,7 +73546,7 @@ in
           sources."supports-color-7.2.0"
         ];
       })
-      sources."systeminformation-4.27.5"
+      sources."systeminformation-4.27.7"
       sources."term-canvas-0.0.5"
       sources."type-fest-0.11.0"
       sources."wordwrap-0.0.3"
@@ -68146,7 +73682,7 @@ in
       sources."each-props-1.3.2"
       sources."end-of-stream-1.4.4"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.18.0-next.0"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."es5-ext-0.10.53"
       sources."es6-iterator-2.0.3"
@@ -68438,12 +73974,12 @@ in
       sources."string-width-1.0.2"
       (sources."string.prototype.trimend-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       (sources."string.prototype.trimstart-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."string_decoder-1.1.1"
@@ -68576,7 +74112,7 @@ in
       sources."detect-file-1.0.0"
       sources."each-props-1.3.2"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.18.0-next.0"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."es5-ext-0.10.53"
       sources."es6-iterator-2.0.3"
@@ -68825,12 +74361,12 @@ in
       sources."string-width-1.0.2"
       (sources."string.prototype.trimend-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       (sources."string.prototype.trimstart-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."string_decoder-1.1.1"
@@ -68917,7 +74453,7 @@ in
       sources."param-case-2.1.1"
       sources."relateurl-0.2.7"
       sources."source-map-0.6.1"
-      sources."uglify-js-3.11.0"
+      sources."uglify-js-3.11.1"
       sources."upper-case-1.1.3"
     ];
     buildInputs = globalBuildInputs;
@@ -68939,9 +74475,8 @@ in
       sha512 = "VWKrljlwF8tEKH48YPfC30zYKhrsMqm70d7vXswivEqd3DSva8ZlIzfeCa3YWFEFRIIhiXKgKurlqEpCtYMCAA==";
     };
     dependencies = [
-      sources."@types/color-name-1.1.1"
       sources."ajv-6.12.5"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."async-3.2.0"
@@ -69155,7 +74690,7 @@ in
           sources."minimist-1.2.5"
         ];
       })
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."mv-2.1.1"
       sources."nan-2.14.1"
       sources."ncp-2.0.0"
@@ -69222,7 +74757,7 @@ in
       sha512 = "Oac190s8AGYOYDvAP7PLNFm3gA+dtSoHl5yYGf9sgvMB+I8bRPfSNI6q4kra1QubpN5+/ARfGjGjAFUu10QsIg==";
     };
     dependencies = [
-      sources."@types/jquery-3.5.1"
+      sources."@types/jquery-3.5.2"
       sources."@types/sizzle-2.3.2"
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
@@ -69287,14 +74822,13 @@ in
       sources."@ionic/utils-stream-2.0.5"
       sources."@ionic/utils-subprocess-1.0.13"
       sources."@ionic/utils-terminal-1.1.2"
-      sources."@types/color-name-1.1.1"
       sources."agent-base-4.3.0"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-4.1.0"
       sources."ansi-styles-3.2.1"
       (sources."ast-types-0.14.2" // {
         dependencies = [
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
         ];
       })
       sources."astral-regex-2.0.0"
@@ -69304,7 +74838,7 @@ in
       sources."bytes-3.1.0"
       (sources."chalk-3.0.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
         ];
@@ -69409,7 +74943,7 @@ in
       (sources."inquirer-7.3.3" // {
         dependencies = [
           sources."ansi-escapes-4.3.1"
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."cli-cursor-3.1.0"
           sources."color-convert-2.0.1"
@@ -69509,7 +75043,7 @@ in
       sources."signal-exit-3.0.3"
       (sources."slice-ansi-3.0.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."is-fullwidth-code-point-3.0.0"
@@ -69560,7 +75094,7 @@ in
       sources."tmp-0.0.33"
       sources."toidentifier-1.0.0"
       sources."tree-kill-1.2.2"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."type-check-0.3.2"
       sources."type-fest-0.11.0"
       sources."typedarray-to-buffer-3.1.5"
@@ -69574,7 +75108,7 @@ in
       sources."word-wrap-1.2.3"
       (sources."wrap-ansi-6.2.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
         ];
@@ -69603,7 +75137,6 @@ in
     dependencies = [
       sources."@iarna/toml-2.2.5"
       sources."@josh-brown/vector-3.4.0"
-      sources."@types/color-name-1.1.1"
       sources."JSONStream-1.3.5"
       sources."abbrev-1.1.1"
       sources."ajv-6.12.5"
@@ -69891,7 +75424,7 @@ in
       sources."tough-cookie-2.5.0"
       sources."traverse-0.3.9"
       sources."ts-process-promises-1.0.2"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."ttf2woff-2.0.2"
       sources."ttf2woff2-3.0.0"
       sources."tunnel-agent-0.6.0"
@@ -69909,13 +75442,13 @@ in
       sources."validate-npm-package-license-3.0.4"
       (sources."verda-1.1.1" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
           sources."supports-color-7.2.0"
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
         ];
       })
       sources."verror-1.10.0"
@@ -69933,7 +75466,7 @@ in
       sources."wordwrap-0.0.3"
       (sources."wrap-ansi-6.2.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
         ];
@@ -70085,10 +75618,10 @@ in
       sources."@yarnpkg/lockfile-1.1.0"
       sources."abab-2.0.5"
       sources."abbrev-1.1.1"
-      sources."acorn-7.4.0"
+      sources."acorn-7.4.1"
       (sources."acorn-globals-4.3.4" // {
         dependencies = [
-          sources."acorn-6.4.1"
+          sources."acorn-6.4.2"
         ];
       })
       sources."acorn-walk-6.2.0"
@@ -70127,7 +75660,7 @@ in
       sources."async-mutex-0.1.4"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
-      (sources."aws-sdk-2.763.0" // {
+      (sources."aws-sdk-2.768.0" // {
         dependencies = [
           sources."sax-1.2.1"
           sources."uuid-3.3.2"
@@ -70369,8 +75902,8 @@ in
         dependencies = [
           sources."dom-serializer-1.1.0"
           sources."domelementtype-2.0.2"
-          sources."domhandler-3.2.0"
-          sources."domutils-2.4.1"
+          sources."domhandler-3.3.0"
+          sources."domutils-2.4.2"
           sources."entities-2.0.3"
         ];
       })
@@ -70534,7 +76067,7 @@ in
       })
       sources."mkdirp-0.5.5"
       sources."mkdirp-classic-0.5.3"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."ms-2.0.0"
       sources."multiparty-4.2.2"
       sources."nan-2.14.1"
@@ -71177,32 +76710,24 @@ in
   json-server = nodeEnv.buildNodePackage {
     name = "json-server";
     packageName = "json-server";
-    version = "0.16.1";
+    version = "0.16.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/json-server/-/json-server-0.16.1.tgz";
-      sha512 = "aVUTdpt+X27iIuWuxBChJywykPSP4opEiFrH044pG+34Gde3eHZRTzeMyx8ts5/kY2gK1Ru2YBmF2k/vI0lQug==";
+      url = "https://registry.npmjs.org/json-server/-/json-server-0.16.2.tgz";
+      sha512 = "USmSODvmBvt9Z7M3e4AHGHzLBcFlNkQMVOOqtB/h/k79JQI4saPcWniYvD5zf0kE3oGNR9VJzcHKzT8fZ9kEtw==";
     };
     dependencies = [
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/color-name-1.1.1"
       sources."accepts-1.3.7"
-      sources."ajv-6.12.5"
       (sources."ansi-align-3.0.0" // {
         dependencies = [
           sources."string-width-3.1.0"
         ];
       })
       sources."ansi-regex-4.1.0"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."array-flatten-1.1.1"
-      sources."asn1-0.2.4"
-      sources."assert-plus-1.0.0"
-      sources."asynckit-0.4.0"
-      sources."aws-sign2-0.7.0"
-      sources."aws4-1.10.1"
       sources."basic-auth-2.0.1"
-      sources."bcrypt-pbkdf-1.0.2"
       sources."body-parser-1.19.0"
       sources."boxen-4.2.0"
       sources."bytes-3.1.0"
@@ -71213,7 +76738,6 @@ in
         ];
       })
       sources."camelcase-5.3.1"
-      sources."caseless-0.12.0"
       sources."chalk-3.0.0"
       sources."ci-info-2.0.0"
       sources."cli-boxes-2.2.1"
@@ -71226,7 +76750,6 @@ in
       sources."clone-response-1.0.2"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
-      sources."combined-stream-1.0.8"
       sources."compressible-2.0.18"
       (sources."compression-1.7.4" // {
         dependencies = [
@@ -71239,21 +76762,17 @@ in
       sources."content-type-1.0.4"
       sources."cookie-0.4.0"
       sources."cookie-signature-1.0.6"
-      sources."core-util-is-1.0.2"
       sources."cors-2.8.5"
       sources."crypto-random-string-2.0.0"
-      sources."dashdash-1.14.1"
       sources."debug-2.6.9"
       sources."decamelize-1.2.0"
       sources."decompress-response-3.3.0"
       sources."deep-extend-0.6.0"
       sources."defer-to-connect-1.1.3"
-      sources."delayed-stream-1.0.0"
       sources."depd-1.1.2"
       sources."destroy-1.0.4"
       sources."dot-prop-5.3.0"
       sources."duplexer3-0.1.4"
-      sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."emoji-regex-7.0.3"
       sources."encodeurl-1.0.2"
@@ -71268,29 +76787,19 @@ in
           sources."path-to-regexp-1.8.0"
         ];
       })
-      sources."extend-3.0.2"
-      sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-3.1.3"
-      sources."fast-json-stable-stringify-2.1.0"
       sources."finalhandler-1.1.2"
       sources."find-up-4.1.0"
-      sources."forever-agent-0.6.1"
-      sources."form-data-2.3.3"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
       sources."get-caller-file-2.0.5"
       sources."get-stream-4.1.0"
-      sources."getpass-0.1.7"
       sources."global-dirs-2.0.1"
       sources."got-9.6.0"
       sources."graceful-fs-4.2.4"
-      sources."har-schema-2.0.0"
-      sources."har-validator-5.1.5"
       sources."has-flag-4.0.0"
       sources."has-yarn-2.1.0"
       sources."http-cache-semantics-4.1.0"
       sources."http-errors-1.7.2"
-      sources."http-signature-1.2.0"
       sources."iconv-lite-0.4.24"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
@@ -71307,15 +76816,9 @@ in
       sources."is-typedarray-1.0.0"
       sources."is-yarn-global-0.3.0"
       sources."isarray-0.0.1"
-      sources."isstream-0.1.2"
       sources."jju-1.4.0"
-      sources."jsbn-0.1.1"
       sources."json-buffer-3.0.0"
       sources."json-parse-helpfulerror-1.0.3"
-      sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.4.1"
-      sources."json-stringify-safe-5.0.1"
-      sources."jsprim-1.4.1"
       sources."keyv-3.1.0"
       sources."latest-version-5.1.0"
       sources."locate-path-5.0.0"
@@ -71346,7 +76849,6 @@ in
       sources."nanoid-2.1.11"
       sources."negotiator-0.6.2"
       sources."normalize-url-4.5.0"
-      sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
@@ -71359,15 +76861,12 @@ in
       sources."parseurl-1.3.3"
       sources."path-exists-4.0.0"
       sources."path-to-regexp-0.1.7"
-      sources."performance-now-2.1.0"
       sources."pify-3.0.0"
       sources."please-upgrade-node-3.2.0"
       sources."pluralize-8.0.0"
       sources."prepend-http-2.0.0"
       sources."proxy-addr-2.0.6"
-      sources."psl-1.8.0"
       sources."pump-3.0.0"
-      sources."punycode-2.1.1"
       sources."pupa-2.0.1"
       sources."qs-6.7.0"
       sources."range-parser-1.2.1"
@@ -71375,11 +76874,6 @@ in
       sources."rc-1.2.8"
       sources."registry-auth-token-4.2.0"
       sources."registry-url-5.1.0"
-      (sources."request-2.88.2" // {
-        dependencies = [
-          sources."qs-6.5.2"
-        ];
-      })
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
       sources."responselike-1.0.2"
@@ -71398,7 +76892,6 @@ in
       sources."set-blocking-2.0.0"
       sources."setprototypeof-1.1.1"
       sources."signal-exit-3.0.3"
-      sources."sshpk-1.16.1"
       sources."statuses-1.5.0"
       sources."steno-0.4.4"
       (sources."string-width-4.2.0" // {
@@ -71415,21 +76908,15 @@ in
       sources."term-size-2.2.0"
       sources."to-readable-stream-1.0.0"
       sources."toidentifier-1.0.0"
-      sources."tough-cookie-2.5.0"
-      sources."tunnel-agent-0.6.0"
-      sources."tweetnacl-0.14.5"
       sources."type-fest-0.8.1"
       sources."type-is-1.6.18"
       sources."typedarray-to-buffer-3.1.5"
       sources."unique-string-2.0.0"
       sources."unpipe-1.0.0"
       sources."update-notifier-4.1.3"
-      sources."uri-js-4.4.0"
       sources."url-parse-lax-3.0.0"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.4.0"
       sources."vary-1.1.2"
-      sources."verror-1.10.0"
       sources."which-module-2.0.0"
       sources."widest-line-3.1.0"
       (sources."wrap-ansi-6.2.0" // {
@@ -71490,11 +76977,10 @@ in
       sha512 = "tHdyFADhVVPBorIKCX8A37iLHxc6RBRphkSoQ+MLKdAtFn1k97tD8WUGi1KlEtDZKL3hui0qhsY9HXUfSNDYPQ==";
     };
     dependencies = [
-      sources."@types/color-name-1.1.1"
       sources."accepts-1.3.7"
       sources."after-0.8.2"
       sources."ansi-regex-5.0.0"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."anymatch-3.1.1"
       sources."arraybuffer.slice-0.0.7"
       sources."async-limiter-1.0.1"
@@ -71713,7 +77199,7 @@ in
       sources."define-properties-1.1.3"
       sources."duplexify-3.7.1"
       sources."end-of-stream-1.4.4"
-      sources."es-abstract-1.18.0-next.0"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."extend-3.0.2"
       sources."flush-write-stream-1.1.1"
@@ -71770,12 +77256,12 @@ in
       sources."stream-shift-1.0.1"
       (sources."string.prototype.trimend-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       (sources."string.prototype.trimstart-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."string_decoder-1.1.1"
@@ -71926,7 +77412,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."mute-stream-0.0.8"
       (sources."nconf-0.10.0" // {
         dependencies = [
@@ -72167,7 +77653,7 @@ in
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
       sources."@octokit/auth-token-2.4.2"
-      (sources."@octokit/endpoint-6.0.6" // {
+      (sources."@octokit/endpoint-6.0.8" // {
         dependencies = [
           sources."is-plain-object-5.0.0"
           sources."universal-user-agent-6.0.0"
@@ -72202,7 +77688,7 @@ in
       sources."@types/glob-7.1.3"
       sources."@types/minimatch-3.0.3"
       sources."@types/minimist-1.2.0"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/normalize-package-data-2.4.0"
       sources."@zkochan/cmd-shim-3.1.0"
       sources."JSONStream-1.3.5"
@@ -72396,7 +77882,7 @@ in
       sources."envinfo-7.7.3"
       sources."err-code-1.1.2"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.17.7"
       sources."es-to-primitive-1.2.1"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
@@ -72775,7 +78261,7 @@ in
       sources."object-visit-1.0.1"
       (sources."object.assign-4.1.1" // {
         dependencies = [
-          sources."es-abstract-1.18.0-next.0"
+          sources."es-abstract-1.18.0-next.1"
         ];
       })
       sources."object.getownpropertydescriptors-2.1.0"
@@ -73005,12 +78491,12 @@ in
       sources."tr46-1.0.1"
       sources."trim-newlines-3.0.0"
       sources."trim-off-newlines-1.0.1"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-fest-0.3.1"
       sources."typedarray-0.0.6"
-      sources."uglify-js-3.11.0"
+      sources."uglify-js-3.11.1"
       sources."uid-number-0.0.6"
       sources."umask-1.1.0"
       sources."union-value-1.0.1"
@@ -73108,7 +78594,7 @@ in
       sources."prr-1.0.1"
       sources."semver-5.7.1"
       sources."source-map-0.6.1"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -74110,14 +79596,13 @@ in
       sources."@types/babel__generator-7.6.2"
       sources."@types/babel__template-7.0.3"
       sources."@types/babel__traverse-7.0.15"
-      sources."@types/color-name-1.1.1"
       sources."@types/estree-0.0.45"
       sources."@types/graceful-fs-4.1.3"
       sources."@types/istanbul-lib-coverage-2.0.3"
       sources."@types/istanbul-lib-report-3.0.0"
       sources."@types/istanbul-reports-1.1.2"
       sources."@types/json-schema-7.0.6"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/resolve-0.0.8"
       sources."@types/yargs-15.0.7"
@@ -74144,7 +79629,7 @@ in
       sources."@xtuc/long-4.2.2"
       sources."JSONStream-1.3.5"
       sources."ace.improved-0.2.1"
-      sources."acorn-7.4.0"
+      sources."acorn-7.4.1"
       sources."acorn-node-1.8.2"
       sources."acorn-walk-7.2.0"
       sources."ajv-6.12.5"
@@ -74223,7 +79708,7 @@ in
       sources."babel-plugin-transform-remove-undefined-0.5.0"
       sources."babel-plugin-transform-simplify-comparison-operators-6.9.4"
       sources."babel-plugin-transform-undefined-to-void-6.9.4"
-      sources."babel-preset-current-node-syntax-0.1.3"
+      sources."babel-preset-current-node-syntax-0.1.4"
       sources."babel-preset-jest-25.5.0"
       sources."babel-preset-minify-0.5.1"
       (sources."babel-runtime-6.26.0" // {
@@ -74294,12 +79779,12 @@ in
       sources."cache-base-1.0.1"
       sources."cached-path-relative-1.0.2"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30001140"
+      sources."caniuse-lite-1.0.30001144"
       sources."capture-exit-2.0.0"
       sources."caseless-0.12.0"
       (sources."chalk-3.0.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
@@ -74416,7 +79901,7 @@ in
       sources."duplexer2-0.1.4"
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
-      sources."electron-to-chromium-1.3.576"
+      sources."electron-to-chromium-1.3.578"
       (sources."elliptic-6.5.3" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -74432,7 +79917,7 @@ in
       })
       sources."errno-0.1.7"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.18.0-next.0"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."escalade-3.1.0"
       sources."escape-string-regexp-1.0.5"
@@ -74979,12 +80464,12 @@ in
       sources."string-width-3.1.0"
       (sources."string.prototype.trimend-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       (sources."string.prototype.trimstart-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       (sources."string_decoder-1.3.0" // {
@@ -75029,7 +80514,7 @@ in
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
       sources."tough-cookie-2.5.0"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tty-browserify-0.0.1"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
@@ -75094,7 +80579,7 @@ in
       })
       (sources."webpack-4.44.2" // {
         dependencies = [
-          sources."acorn-6.4.1"
+          sources."acorn-6.4.2"
           sources."micromatch-3.1.10"
           sources."mkdirp-0.5.5"
           sources."schema-utils-1.0.0"
@@ -75196,9 +80681,8 @@ in
       sha512 = "Q9LTCwBjWcQR9dd6LNMXg9GFewkRiVEaU/+Y2ZcCbOb0lVqIfeJworWYGakG7bFj8HJQILBTRnAnEK9DDKfdPA==";
     };
     dependencies = [
-      sources."@types/color-name-1.1.1"
       sources."ajv-6.12.5"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."async-3.2.0"
@@ -75621,17 +81105,16 @@ in
   "@mermaid-js/mermaid-cli" = nodeEnv.buildNodePackage {
     name = "_at_mermaid-js_slash_mermaid-cli";
     packageName = "@mermaid-js/mermaid-cli";
-    version = "8.8.0";
+    version = "8.8.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-8.8.0.tgz";
-      sha512 = "vHmikrgrYlaQFqYLFEShIjpAcz26vpXTA08c7QnAR8PN+6aIs9q2RREKcOTbd0Cm/0JoHZ0UwbCviaJIB3Ex1Q==";
+      url = "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-8.8.1.tgz";
+      sha512 = "cESM33+QjLuHUcMk9B2qpsplx4h+97adwI/P0/2SvFwFlhVsFfi82a53vV1638hIBLac+RxGG2aT+Fq8YYHHRQ==";
     };
     dependencies = [
-      sources."@types/color-name-1.1.1"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/yauzl-2.9.1"
       sources."agent-base-5.1.1"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."balanced-match-1.0.0"
       sources."base64-js-1.3.1"
       sources."bl-4.0.3"
@@ -75711,20 +81194,20 @@ in
       sources."@fluentui/date-time-utilities-7.9.0"
       sources."@fluentui/dom-utilities-1.1.1"
       sources."@fluentui/keyboard-key-0.2.12"
-      sources."@fluentui/react-7.143.0"
-      sources."@fluentui/react-focus-7.16.9"
+      sources."@fluentui/react-7.145.0"
+      sources."@fluentui/react-focus-7.16.10"
       sources."@fluentui/react-window-provider-0.3.3"
-      sources."@fluentui/theme-1.2.1"
-      sources."@microsoft/load-themed-styles-1.10.101"
+      sources."@fluentui/theme-1.3.0"
+      sources."@microsoft/load-themed-styles-1.10.108"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@uifabric/foundation-7.9.9"
-      sources."@uifabric/icons-7.5.8"
+      sources."@uifabric/foundation-7.9.10"
+      sources."@uifabric/icons-7.5.9"
       sources."@uifabric/merge-styles-7.19.1"
-      sources."@uifabric/react-hooks-7.13.5"
+      sources."@uifabric/react-hooks-7.13.6"
       sources."@uifabric/set-version-7.0.23"
-      sources."@uifabric/styling-7.16.9"
-      sources."@uifabric/utilities-7.32.3"
+      sources."@uifabric/styling-7.16.10"
+      sources."@uifabric/utilities-7.32.4"
       sources."accepts-1.3.7"
       sources."ajv-6.12.5"
       sources."ansi-escapes-1.4.0"
@@ -75850,7 +81333,7 @@ in
       sources."node-fetch-1.6.3"
       sources."normalize-url-4.5.0"
       sources."object-assign-4.1.1"
-      sources."office-ui-fabric-react-7.143.0"
+      sources."office-ui-fabric-react-7.145.0"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
@@ -75949,14 +81432,14 @@ in
       sources."strip-json-comments-2.0.1"
       sources."supports-color-2.0.0"
       sources."swagger-schema-official-2.0.0-bab6bed"
-      sources."swagger-ui-dist-3.34.0"
+      sources."swagger-ui-dist-3.35.0"
       sources."tail-2.0.4"
       sources."through-2.3.8"
       sources."tmp-0.0.33"
       sources."to-readable-stream-1.0.0"
       sources."toidentifier-1.0.0"
       sources."ts-log-2.2.3"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."type-is-1.6.18"
       sources."unpipe-1.0.0"
       sources."uri-js-4.4.0"
@@ -75986,10 +81469,9 @@ in
       sha512 = "ZbaYib4hT4PpF4bdSO2DohooKXIn4lDeiYqB+vTmCdr6l2woW0b6H3pf5x4sM5nwQMru9RvjjHYWVGltR50ZBw==";
     };
     dependencies = [
-      sources."@types/color-name-1.1.1"
       sources."ansi-colors-4.1.1"
       sources."ansi-regex-3.0.0"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."anymatch-3.1.1"
       sources."argparse-1.0.10"
       sources."array.prototype.map-1.0.2"
@@ -76016,7 +81498,12 @@ in
       sources."define-properties-1.1.3"
       sources."diff-4.0.2"
       sources."emoji-regex-7.0.3"
-      sources."es-abstract-1.17.6"
+      (sources."es-abstract-1.17.7" // {
+        dependencies = [
+          sources."es-abstract-1.18.0-next.1"
+          sources."object.assign-4.1.1"
+        ];
+      })
       sources."es-array-method-boxes-properly-1.0.0"
       sources."es-get-iterator-1.1.0"
       sources."es-to-primitive-1.2.1"
@@ -76047,6 +81534,7 @@ in
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
       sources."is-map-2.0.1"
+      sources."is-negative-zero-2.0.0"
       sources."is-number-7.0.0"
       sources."is-plain-obj-1.1.0"
       sources."is-regex-1.1.1"
@@ -76270,10 +81758,10 @@ in
   netlify-cli = nodeEnv.buildNodePackage {
     name = "netlify-cli";
     packageName = "netlify-cli";
-    version = "2.64.1";
+    version = "2.65.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/netlify-cli/-/netlify-cli-2.64.1.tgz";
-      sha512 = "Lo1DX//zdGzbiRaDfcRd+RyjenNw7UvnZbFpSDiPUq+88BmTY2e9UinFCKoFmymG+o0+lYnRA+wynozknjFUQw==";
+      url = "https://registry.npmjs.org/netlify-cli/-/netlify-cli-2.65.1.tgz";
+      sha512 = "JdcOuoz6LCNmw9BgDqFgOsQrKP1F4TeUNgX3h81DxKr7apJeXJxZwXJfR8l+5BM9zn3l907DYO2zQ46hh8WQlg==";
     };
     dependencies = [
       sources."@babel/code-frame-7.10.4"
@@ -76385,23 +81873,23 @@ in
       sources."@babel/template-7.10.4"
       sources."@babel/traverse-7.11.5"
       sources."@babel/types-7.11.5"
-      sources."@bugsnag/browser-7.3.5"
+      sources."@bugsnag/browser-7.4.0"
       sources."@bugsnag/core-7.3.5"
       sources."@bugsnag/cuid-3.0.0"
-      sources."@bugsnag/js-7.3.5"
+      sources."@bugsnag/js-7.4.0"
       sources."@bugsnag/node-7.3.5"
       sources."@bugsnag/safe-json-stringify-6.0.0"
       sources."@dabh/diagnostics-2.0.2"
       sources."@jest/types-24.9.0"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
-      (sources."@netlify/build-4.5.2" // {
+      (sources."@netlify/build-4.8.3" // {
         dependencies = [
           sources."chalk-3.0.0"
           sources."resolve-2.0.0-next.1"
         ];
       })
       sources."@netlify/cache-utils-1.0.3"
-      (sources."@netlify/config-2.2.1" // {
+      (sources."@netlify/config-2.3.2" // {
         dependencies = [
           sources."chalk-3.0.0"
         ];
@@ -76416,8 +81904,8 @@ in
           sources."to-regex-range-5.0.1"
         ];
       })
-      sources."@netlify/open-api-0.16.1"
-      sources."@netlify/plugin-edge-handlers-1.6.0"
+      sources."@netlify/open-api-0.18.0"
+      sources."@netlify/plugin-edge-handlers-1.8.0"
       sources."@netlify/run-utils-1.0.1"
       (sources."@netlify/zip-it-and-ship-it-1.3.12" // {
         dependencies = [
@@ -76436,7 +81924,7 @@ in
           sources."ansi-styles-3.2.1"
           (sources."chalk-3.0.0" // {
             dependencies = [
-              sources."ansi-styles-4.2.1"
+              sources."ansi-styles-4.3.0"
               sources."supports-color-7.2.0"
             ];
           })
@@ -76473,7 +81961,7 @@ in
           sources."micromatch-4.0.2"
           sources."slash-3.0.0"
           sources."to-regex-range-5.0.1"
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
         ];
       })
       (sources."@oclif/errors-1.3.3" // {
@@ -76528,13 +82016,13 @@ in
           sources."jsonfile-4.0.0"
           sources."npm-run-path-3.1.0"
           sources."path-key-3.1.1"
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
           sources."universalify-0.1.2"
         ];
       })
       sources."@oclif/screen-1.0.4"
       sources."@octokit/auth-token-2.4.2"
-      (sources."@octokit/endpoint-6.0.6" // {
+      (sources."@octokit/endpoint-6.0.8" // {
         dependencies = [
           sources."is-plain-object-5.0.0"
           sources."universal-user-agent-6.0.0"
@@ -76571,6 +82059,7 @@ in
           sources."estree-walker-2.0.1"
         ];
       })
+      sources."@rollup/plugin-inject-4.0.2"
       sources."@rollup/plugin-json-4.1.0"
       sources."@rollup/plugin-node-resolve-9.0.0"
       sources."@rollup/pluginutils-3.1.0"
@@ -76582,7 +82071,6 @@ in
         ];
       })
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/color-name-1.1.1"
       sources."@types/decompress-4.2.3"
       sources."@types/download-6.2.4"
       sources."@types/estree-0.0.39"
@@ -76594,7 +82082,7 @@ in
       sources."@types/istanbul-reports-1.1.2"
       sources."@types/minimatch-3.0.3"
       sources."@types/mkdirp-0.5.2"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/node-fetch-2.5.7"
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/resolve-1.17.1"
@@ -76602,6 +82090,12 @@ in
       sources."@types/yargs-13.0.11"
       sources."@types/yargs-parser-15.0.0"
       sources."@typescript-eslint/typescript-estree-2.34.0"
+      sources."@ungap/from-entries-0.2.1"
+      (sources."abstract-leveldown-0.12.4" // {
+        dependencies = [
+          sources."xtend-3.0.0"
+        ];
+      })
       sources."accepts-1.3.7"
       sources."agent-base-6.0.1"
       sources."aggregate-error-3.1.0"
@@ -76615,7 +82109,7 @@ in
       })
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-4.1.0"
-      (sources."ansi-styles-4.2.1" // {
+      (sources."ansi-styles-4.3.0" // {
         dependencies = [
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -76628,13 +82122,12 @@ in
           sources."file-type-4.4.0"
         ];
       })
-      sources."archiver-4.0.2"
-      (sources."archiver-utils-2.1.0" // {
+      (sources."archiver-4.0.2" // {
         dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
+          sources."readable-stream-3.6.0"
         ];
       })
+      sources."archiver-utils-2.1.0"
       sources."argparse-1.0.10"
       sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
@@ -76646,6 +82139,11 @@ in
       sources."array-unique-0.3.2"
       sources."arrify-2.0.1"
       sources."ascii-table-0.0.9"
+      (sources."asn1.js-5.4.1" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
       sources."assign-symbols-1.0.0"
       sources."ast-module-types-2.6.0"
       sources."async-3.2.0"
@@ -76653,7 +82151,7 @@ in
       sources."at-least-node-1.0.0"
       sources."atob-2.1.2"
       sources."atob-lite-2.0.0"
-      (sources."aws-sdk-2.763.0" // {
+      (sources."aws-sdk-2.768.0" // {
         dependencies = [
           sources."buffer-4.9.2"
           sources."uuid-3.3.2"
@@ -76670,7 +82168,14 @@ in
       sources."base64-js-1.3.1"
       sources."before-after-hook-2.1.0"
       sources."binary-extensions-2.1.0"
-      sources."bl-4.0.3"
+      (sources."bl-0.8.2" // {
+        dependencies = [
+          sources."isarray-0.0.1"
+          sources."readable-stream-1.0.34"
+          sources."string_decoder-0.10.31"
+        ];
+      })
+      sources."bn.js-5.1.3"
       (sources."body-parser-1.19.0" // {
         dependencies = [
           sources."debug-2.6.9"
@@ -76688,14 +82193,31 @@ in
           sources."extend-shallow-2.0.1"
         ];
       })
+      sources."brorand-1.1.0"
+      sources."browserify-aes-1.2.0"
+      sources."browserify-cipher-1.0.1"
+      sources."browserify-des-1.0.2"
+      sources."browserify-fs-1.0.0"
+      (sources."browserify-rsa-4.0.1" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
+      (sources."browserify-sign-4.2.1" // {
+        dependencies = [
+          sources."readable-stream-3.6.0"
+        ];
+      })
       sources."browserslist-4.14.5"
       sources."btoa-lite-1.0.0"
       sources."buffer-5.6.0"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
       sources."buffer-crc32-0.2.13"
+      sources."buffer-es6-4.9.3"
       sources."buffer-fill-1.0.0"
       sources."buffer-from-1.1.1"
+      sources."buffer-xor-1.0.3"
       sources."builtin-modules-3.1.0"
       sources."builtins-1.0.3"
       sources."byline-5.0.0"
@@ -76709,7 +82231,7 @@ in
       sources."cachedir-2.3.0"
       sources."call-me-maybe-1.0.1"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30001140"
+      sources."caniuse-lite-1.0.30001144"
       sources."cardinal-2.1.1"
       sources."caw-2.0.1"
       (sources."chalk-2.4.2" // {
@@ -76731,6 +82253,7 @@ in
         ];
       })
       sources."ci-info-2.0.0"
+      sources."cipher-base-1.0.4"
       (sources."class-utils-0.3.6" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -76762,13 +82285,13 @@ in
           sources."extract-stack-2.0.0"
           sources."fs-extra-9.0.1"
           sources."supports-hyperlinks-2.1.0"
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
           sources."type-fest-0.11.0"
         ];
       })
       sources."cli-width-2.2.1"
       sources."cliui-6.0.0"
-      sources."clone-1.0.4"
+      sources."clone-0.1.19"
       sources."clone-response-1.0.2"
       sources."collection-visit-1.0.0"
       sources."color-3.0.0"
@@ -76782,13 +82305,9 @@ in
       sources."common-path-prefix-2.0.0"
       sources."commondir-1.0.1"
       sources."component-emitter-1.3.0"
-      (sources."compress-commons-3.0.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-        ];
-      })
+      sources."compress-commons-3.0.0"
       sources."concat-map-0.0.1"
+      sources."concat-stream-1.6.2"
       (sources."concordance-4.0.0" // {
         dependencies = [
           sources."semver-5.7.1"
@@ -76813,9 +82332,7 @@ in
       (sources."copy-template-dir-1.4.0" // {
         dependencies = [
           sources."pump-1.0.3"
-          sources."readable-stream-2.3.7"
           sources."readdirp-2.2.1"
-          sources."safe-buffer-5.1.2"
         ];
       })
       (sources."core-js-compat-3.6.5" // {
@@ -76831,13 +82348,25 @@ in
         ];
       })
       sources."crc-3.8.0"
-      sources."crc32-stream-3.0.1"
+      (sources."crc32-stream-3.0.1" // {
+        dependencies = [
+          sources."readable-stream-3.6.0"
+        ];
+      })
+      (sources."create-ecdh-4.0.4" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
+      sources."create-hash-1.2.0"
+      sources."create-hmac-1.1.7"
       (sources."cross-spawn-6.0.5" // {
         dependencies = [
           sources."semver-5.7.1"
           sources."which-1.3.1"
         ];
       })
+      sources."crypto-browserify-3.12.0"
       sources."crypto-random-string-2.0.0"
       sources."cyclist-1.0.1"
       sources."date-time-2.1.0"
@@ -76863,9 +82392,8 @@ in
         dependencies = [
           sources."bl-1.2.3"
           sources."file-type-5.2.0"
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
           sources."tar-stream-1.6.2"
+          sources."xtend-4.0.2"
         ];
       })
       (sources."decompress-tarbz2-4.1.1" // {
@@ -76888,8 +82416,13 @@ in
       sources."deep-extend-0.6.0"
       sources."deep-is-0.1.3"
       sources."deepmerge-4.2.2"
-      sources."defaults-1.0.3"
+      (sources."defaults-1.0.3" // {
+        dependencies = [
+          sources."clone-1.0.4"
+        ];
+      })
       sources."defer-to-connect-1.1.3"
+      sources."deferred-leveldown-0.2.0"
       sources."define-properties-1.1.3"
       sources."define-property-2.0.2"
       (sources."del-5.1.0" // {
@@ -76900,6 +82433,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."depd-1.1.2"
       sources."deprecation-2.3.1"
+      sources."des.js-1.0.1"
       sources."destroy-1.0.4"
       sources."detective-amd-3.0.0"
       sources."detective-cjs-3.1.1"
@@ -76910,6 +82444,11 @@ in
       sources."detective-scss-2.0.1"
       sources."detective-stylus-1.0.0"
       sources."detective-typescript-5.8.0"
+      (sources."diffie-hellman-5.0.3" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
       (sources."dir-glob-2.2.2" // {
         dependencies = [
           sources."path-type-3.0.0"
@@ -76939,16 +82478,22 @@ in
       })
       sources."duplexer3-0.1.4"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.576"
+      sources."electron-to-chromium-1.3.578"
       sources."elf-tools-1.1.2"
+      (sources."elliptic-6.5.3" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
       sources."emoji-regex-8.0.0"
       sources."enabled-2.0.0"
       sources."encodeurl-1.0.2"
       sources."end-of-stream-1.4.4"
       sources."envinfo-7.7.3"
+      sources."errno-0.1.7"
       sources."error-ex-1.3.2"
       sources."error-stack-parser-2.0.6"
-      sources."es-abstract-1.18.0-next.0"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."escalade-3.1.0"
       sources."escape-goat-2.1.1"
@@ -76967,6 +82512,7 @@ in
       sources."etag-1.8.1"
       sources."eventemitter3-4.0.7"
       sources."events-1.1.1"
+      sources."evp_bytestokey-1.0.3"
       (sources."execa-3.4.0" // {
         dependencies = [
           sources."cross-spawn-7.0.3"
@@ -77055,21 +82601,21 @@ in
       })
       sources."find-up-4.1.0"
       sources."flatten-1.0.3"
-      sources."flush-write-stream-2.0.0"
+      (sources."flush-write-stream-2.0.0" // {
+        dependencies = [
+          sources."readable-stream-3.6.0"
+        ];
+      })
       sources."fn.name-1.1.0"
       sources."folder-walker-3.2.0"
       sources."follow-redirects-1.13.0"
       sources."for-in-1.0.2"
+      sources."foreach-2.0.5"
       sources."form-data-3.0.0"
       sources."forwarded-0.1.2"
       sources."fragment-cache-0.2.1"
       sources."fresh-0.5.2"
-      (sources."from2-2.3.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-        ];
-      })
+      sources."from2-2.3.0"
       sources."from2-array-0.0.4"
       sources."fs-constants-1.0.0"
       (sources."fs-extra-8.1.0" // {
@@ -77082,6 +82628,13 @@ in
       sources."fsevents-2.1.3"
       sources."function-bind-1.1.1"
       sources."fuzzy-0.1.3"
+      (sources."fwd-stream-1.0.4" // {
+        dependencies = [
+          sources."isarray-0.0.1"
+          sources."readable-stream-1.0.34"
+          sources."string_decoder-0.10.31"
+        ];
+      })
       sources."gensync-1.0.0-beta.1"
       sources."get-amd-module-type-3.0.0"
       sources."get-caller-file-2.0.5"
@@ -77152,11 +82705,18 @@ in
         ];
       })
       sources."has-yarn-2.1.0"
+      (sources."hash-base-3.1.0" // {
+        dependencies = [
+          sources."readable-stream-3.6.0"
+        ];
+      })
+      sources."hash.js-1.1.7"
       (sources."hasha-5.2.1" // {
         dependencies = [
           sources."is-stream-2.0.0"
         ];
       })
+      sources."hmac-drbg-1.0.1"
       sources."hosted-git-info-2.8.8"
       sources."http-cache-semantics-4.1.0"
       (sources."http-call-5.3.0" // {
@@ -77184,12 +82744,14 @@ in
       sources."human-signals-1.1.1"
       sources."hyperlinker-1.0.0"
       sources."iconv-lite-0.4.24"
+      sources."idb-wrapper-1.7.2"
       sources."ieee754-1.1.13"
       sources."ignore-4.0.6"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
       sources."indent-string-4.0.0"
       sources."indexes-of-1.0.1"
+      sources."indexof-0.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
@@ -77211,7 +82773,7 @@ in
           })
         ];
       })
-      (sources."inquirer-autocomplete-prompt-1.1.0" // {
+      (sources."inquirer-autocomplete-prompt-1.2.0" // {
         dependencies = [
           sources."ansi-escapes-4.3.1"
           sources."chalk-4.1.0"
@@ -77221,6 +82783,7 @@ in
       sources."into-stream-3.1.0"
       sources."invariant-2.2.4"
       sources."ipaddr.js-1.9.1"
+      sources."is-0.2.7"
       sources."is-accessor-descriptor-1.0.0"
       sources."is-arrayish-0.2.1"
       sources."is-binary-path-2.1.0"
@@ -77247,7 +82810,7 @@ in
         ];
       })
       sources."is-obj-2.0.0"
-      sources."is-object-1.0.1"
+      sources."is-object-0.1.2"
       sources."is-path-cwd-2.2.0"
       sources."is-path-inside-3.0.2"
       sources."is-plain-obj-2.1.0"
@@ -77263,13 +82826,18 @@ in
       sources."is-wsl-2.2.0"
       sources."is-yarn-global-0.3.0"
       sources."isarray-1.0.0"
+      sources."isbuffer-0.0.0"
       sources."iserror-0.0.2"
       sources."isexe-2.0.0"
       sources."isobject-3.0.1"
-      sources."isurl-1.0.0"
+      (sources."isurl-1.0.0" // {
+        dependencies = [
+          sources."is-object-1.0.1"
+        ];
+      })
       sources."jest-get-type-24.9.0"
       sources."jest-validate-24.9.0"
-      sources."jest-worker-26.3.0"
+      sources."jest-worker-26.5.0"
       sources."jmespath-0.15.0"
       sources."js-string-escape-1.0.1"
       sources."js-tokens-4.0.0"
@@ -77281,7 +82849,7 @@ in
       sources."json5-2.1.3"
       sources."jsonfile-6.0.1"
       sources."junk-3.1.0"
-      sources."jwt-decode-2.2.0"
+      sources."jwt-decode-3.0.0"
       sources."keep-func-props-3.0.1"
       sources."keyv-3.1.0"
       sources."kind-of-6.0.3"
@@ -77292,10 +82860,42 @@ in
         ];
       })
       sources."latest-version-5.1.0"
-      (sources."lazystream-1.0.0" // {
+      sources."lazystream-1.0.0"
+      (sources."level-blobs-0.1.7" // {
         dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
+          sources."isarray-0.0.1"
+          sources."readable-stream-1.1.14"
+          sources."string_decoder-0.10.31"
+        ];
+      })
+      sources."level-filesystem-1.2.0"
+      sources."level-fix-range-2.0.0"
+      sources."level-hooks-4.5.0"
+      (sources."level-js-2.2.4" // {
+        dependencies = [
+          sources."object-keys-0.4.0"
+          sources."xtend-2.1.2"
+        ];
+      })
+      (sources."level-peek-1.0.6" // {
+        dependencies = [
+          sources."level-fix-range-1.0.2"
+        ];
+      })
+      (sources."level-sublevel-5.2.3" // {
+        dependencies = [
+          sources."object-keys-0.2.0"
+          sources."xtend-2.0.6"
+        ];
+      })
+      (sources."levelup-0.18.6" // {
+        dependencies = [
+          sources."isarray-0.0.1"
+          sources."prr-0.0.0"
+          sources."readable-stream-1.0.34"
+          sources."semver-2.3.2"
+          sources."string_decoder-0.10.31"
+          sources."xtend-3.0.0"
         ];
       })
       sources."leven-3.1.0"
@@ -77348,6 +82948,7 @@ in
       })
       sources."loose-envify-1.4.0"
       sources."lowercase-keys-1.0.1"
+      sources."ltgt-2.2.1"
       sources."macos-release-2.4.1"
       sources."magic-string-0.25.7"
       (sources."make-dir-3.1.0" // {
@@ -77366,6 +82967,7 @@ in
       })
       sources."md5-hex-2.0.0"
       sources."md5-o-matic-0.1.1"
+      sources."md5.js-1.3.5"
       sources."media-typer-0.3.0"
       sources."memoize-one-5.1.1"
       sources."merge-descriptors-1.0.1"
@@ -77375,11 +82977,18 @@ in
       sources."micro-api-client-3.3.0"
       sources."micro-memoize-2.1.2"
       sources."micromatch-3.1.10"
+      (sources."miller-rabin-4.0.1" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
       sources."mime-1.6.0"
       sources."mime-db-1.44.0"
       sources."mime-types-2.1.27"
       sources."mimic-fn-3.1.0"
       sources."mimic-response-1.0.1"
+      sources."minimalistic-assert-1.0.1"
+      sources."minimalistic-crypto-utils-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
       (sources."mixin-deep-1.3.2" // {
@@ -77413,7 +83022,7 @@ in
       sources."natural-orderby-2.0.3"
       sources."negotiator-0.6.2"
       sources."nested-error-stacks-2.1.0"
-      (sources."netlify-4.6.0" // {
+      (sources."netlify-4.7.0" // {
         dependencies = [
           sources."qs-6.9.4"
         ];
@@ -77464,10 +83073,11 @@ in
       sources."object.assign-4.1.1"
       (sources."object.getownpropertydescriptors-2.1.0" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."object.pick-1.3.0"
+      sources."octal-1.0.0"
       sources."octokit-pagination-methods-1.1.0"
       sources."omit.js-2.0.2"
       sources."on-finished-2.3.0"
@@ -77479,11 +83089,7 @@ in
           sources."mimic-fn-2.1.0"
         ];
       })
-      (sources."open-6.4.0" // {
-        dependencies = [
-          sources."is-wsl-1.1.0"
-        ];
-      })
+      sources."open-7.3.0"
       (sources."opn-5.5.0" // {
         dependencies = [
           sources."is-wsl-1.1.0"
@@ -77526,12 +83132,8 @@ in
           sources."semver-6.3.0"
         ];
       })
-      (sources."parallel-transform-1.2.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-        ];
-      })
+      sources."parallel-transform-1.2.0"
+      sources."parse-asn1-5.1.6"
       sources."parse-github-url-1.0.2"
       sources."parse-gitignore-1.0.1"
       sources."parse-json-5.1.0"
@@ -77546,6 +83148,7 @@ in
       sources."path-parse-1.0.6"
       sources."path-to-regexp-0.1.7"
       sources."path-type-4.0.0"
+      sources."pbkdf2-3.1.1"
       sources."pend-1.2.0"
       sources."picomatch-2.2.2"
       sources."pify-4.0.1"
@@ -77572,9 +83175,16 @@ in
       })
       sources."pretty-ms-5.1.0"
       sources."prettyjson-1.2.1"
+      sources."process-es6-0.11.6"
       sources."process-nextick-args-2.0.1"
       sources."proto-list-1.2.4"
       sources."proxy-addr-2.0.6"
+      sources."prr-1.0.1"
+      (sources."public-encrypt-4.0.3" // {
+        dependencies = [
+          sources."bn.js-4.11.9"
+        ];
+      })
       sources."pump-3.0.0"
       sources."punycode-1.3.2"
       sources."pupa-2.0.1"
@@ -77584,6 +83194,7 @@ in
       sources."random-bytes-1.0.0"
       sources."random-item-3.0.0"
       sources."randombytes-2.1.0"
+      sources."randomfill-1.0.4"
       sources."range-parser-1.2.1"
       (sources."raw-body-2.4.1" // {
         dependencies = [
@@ -77598,7 +83209,11 @@ in
         ];
       })
       sources."read-pkg-up-7.0.1"
-      sources."readable-stream-3.6.0"
+      (sources."readable-stream-2.3.7" // {
+        dependencies = [
+          sources."safe-buffer-5.1.2"
+        ];
+      })
       sources."readdirp-3.4.0"
       sources."redeyed-2.1.1"
       sources."regenerate-1.4.1"
@@ -77634,7 +83249,9 @@ in
       sources."ret-0.1.15"
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
+      sources."ripemd160-2.0.2"
       sources."rollup-2.28.2"
+      sources."rollup-plugin-node-builtins-2.1.2"
       sources."rollup-plugin-terser-7.0.2"
       sources."run-async-2.4.1"
       sources."run-parallel-1.1.9"
@@ -77671,6 +83288,7 @@ in
         ];
       })
       sources."setprototypeof-1.1.1"
+      sources."sha.js-2.4.11"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.3"
@@ -77764,15 +83382,16 @@ in
       sources."statsd-client-0.4.5"
       sources."statuses-1.5.0"
       sources."strict-uri-encode-1.1.0"
+      sources."string-range-1.2.2"
       sources."string-width-4.2.0"
       (sources."string.prototype.trimend-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       (sources."string.prototype.trimstart-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       (sources."string_decoder-1.1.1" // {
@@ -77807,7 +83426,12 @@ in
           })
         ];
       })
-      sources."tar-stream-2.1.4"
+      (sources."tar-stream-2.1.4" // {
+        dependencies = [
+          sources."bl-4.0.3"
+          sources."readable-stream-3.6.0"
+        ];
+      })
       sources."temp-dir-1.0.0"
       (sources."tempy-0.3.0" // {
         dependencies = [
@@ -77817,7 +83441,7 @@ in
         ];
       })
       sources."term-size-2.2.0"
-      (sources."terser-5.3.3" // {
+      (sources."terser-5.3.4" // {
         dependencies = [
           sources."source-map-0.7.3"
         ];
@@ -77826,12 +83450,19 @@ in
       sources."through-2.3.8"
       (sources."through2-2.0.5" // {
         dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
+          sources."xtend-4.0.2"
         ];
       })
-      sources."through2-filter-3.0.0"
-      sources."through2-map-3.0.0"
+      (sources."through2-filter-3.0.0" // {
+        dependencies = [
+          sources."xtend-4.0.2"
+        ];
+      })
+      (sources."through2-map-3.0.0" // {
+        dependencies = [
+          sources."xtend-4.0.2"
+        ];
+      })
       sources."time-zone-1.0.0"
       sources."timed-out-4.0.1"
       sources."tmp-0.2.1"
@@ -77856,13 +83487,14 @@ in
         ];
       })
       sources."triple-beam-1.3.0"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tsutils-3.17.1"
       sources."tunnel-agent-0.6.0"
       sources."type-check-0.3.2"
       sources."type-fest-0.8.1"
       sources."type-is-1.6.18"
-      sources."typedarray-to-buffer-3.1.5"
+      sources."typedarray-0.0.6"
+      sources."typedarray-to-buffer-1.0.4"
       sources."typescript-3.9.7"
       sources."uid-safe-2.1.5"
       sources."unbzip2-stream-1.4.3"
@@ -77904,11 +83536,11 @@ in
       sources."util-deprecate-1.0.2"
       (sources."util.promisify-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."utils-merge-1.0.1"
-      sources."uuid-8.3.0"
+      sources."uuid-8.3.1"
       sources."validate-npm-package-license-3.0.4"
       sources."validate-npm-package-name-3.0.0"
       sources."vary-1.1.2"
@@ -77931,28 +83563,32 @@ in
       (sources."winston-3.3.3" // {
         dependencies = [
           sources."is-stream-2.0.0"
+          sources."readable-stream-3.6.0"
         ];
       })
-      (sources."winston-transport-4.4.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-        ];
-      })
+      sources."winston-transport-4.4.0"
       sources."word-wrap-1.2.3"
       sources."wrap-ansi-6.2.0"
       sources."wrappy-1.0.2"
-      sources."write-file-atomic-3.0.3"
+      (sources."write-file-atomic-3.0.3" // {
+        dependencies = [
+          sources."typedarray-to-buffer-3.1.5"
+        ];
+      })
       sources."xdg-basedir-4.0.0"
       sources."xml2js-0.4.19"
       sources."xmlbuilder-9.0.7"
-      sources."xtend-4.0.2"
+      sources."xtend-2.2.0"
       sources."y18n-4.0.0"
       sources."yargs-15.4.1"
       sources."yargs-parser-18.1.3"
       sources."yarn-1.22.10"
       sources."yauzl-2.10.0"
-      sources."zip-stream-3.0.1"
+      (sources."zip-stream-3.0.1" // {
+        dependencies = [
+          sources."readable-stream-3.6.0"
+        ];
+      })
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -78808,7 +84444,7 @@ in
       })
       sources."minizlib-1.3.3"
       sources."mkdirp-0.5.5"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."moment-timezone-0.5.31"
       (sources."mqtt-2.18.8" // {
         dependencies = [
@@ -79207,7 +84843,6 @@ in
     dependencies = [
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/color-name-1.1.1"
       sources."abbrev-1.1.1"
       (sources."ansi-align-3.0.0" // {
         dependencies = [
@@ -79215,7 +84850,7 @@ in
         ];
       })
       sources."ansi-regex-4.1.0"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."anymatch-3.1.1"
       sources."balanced-match-1.0.0"
       sources."binary-extensions-2.1.0"
@@ -79381,22 +85016,22 @@ in
   npm-check-updates = nodeEnv.buildNodePackage {
     name = "npm-check-updates";
     packageName = "npm-check-updates";
-    version = "9.0.3";
+    version = "9.0.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-9.0.3.tgz";
-      sha512 = "/pO7pFcPd8EUPvipS5aeiwGHIa0HXvl2+IJOZ9rlS/jXYJmHE7Y1V/jxZEN5gOVUT8fCAdJRMmN57ydeH+Mv0Q==";
+      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-9.0.4.tgz";
+      sha512 = "kqevC9RXRsaosPZHg4Pm5CNwnOAG2ymvhU7Q3QIX01SDUID4fpoSAQIuXQH9V3Nnu96kSUz5bDPzQSku33Mz0A==";
     };
     dependencies = [
       sources."@npmcli/ci-detect-1.3.0"
       sources."@npmcli/git-2.0.4"
       sources."@npmcli/installed-package-contents-1.0.5"
       sources."@npmcli/move-file-1.0.1"
+      sources."@npmcli/node-gyp-1.0.1"
       sources."@npmcli/promise-spawn-1.2.0"
-      sources."@npmcli/run-script-1.6.0"
+      sources."@npmcli/run-script-1.7.2"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@tootallnate/once-1.1.2"
-      sources."@types/color-name-1.1.1"
       sources."abbrev-1.1.1"
       sources."agent-base-6.0.1"
       sources."agentkeepalive-4.1.3"
@@ -79411,7 +85046,7 @@ in
         ];
       })
       sources."ansi-regex-2.1.1"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."aproba-1.2.0"
       sources."are-we-there-yet-1.1.5"
       sources."argparse-1.0.10"
@@ -79526,7 +85161,7 @@ in
       sources."is-fullwidth-code-point-1.0.0"
       sources."is-installed-globally-0.3.2"
       sources."is-lambda-1.0.1"
-      sources."is-npm-4.0.0"
+      sources."is-npm-5.0.0"
       sources."is-obj-2.0.0"
       sources."is-path-inside-3.0.2"
       sources."is-typedarray-1.0.0"
@@ -79576,7 +85211,7 @@ in
       sources."minimist-1.2.5"
       sources."minipass-3.1.3"
       sources."minipass-collect-1.0.2"
-      sources."minipass-fetch-1.3.1"
+      sources."minipass-fetch-1.3.2"
       sources."minipass-flush-1.0.5"
       sources."minipass-json-stream-1.0.1"
       sources."minipass-pipeline-1.2.4"
@@ -79680,11 +85315,7 @@ in
       sources."unique-filename-1.1.1"
       sources."unique-slug-2.0.2"
       sources."unique-string-2.0.0"
-      (sources."update-notifier-4.1.3" // {
-        dependencies = [
-          sources."chalk-3.0.0"
-        ];
-      })
+      sources."update-notifier-5.0.0"
       sources."uri-js-4.4.0"
       sources."url-parse-lax-3.0.0"
       sources."util-deprecate-1.0.2"
@@ -80059,10 +85690,10 @@ in
       sources."@parcel/workers-1.11.0"
       sources."@types/q-1.5.4"
       sources."abab-2.0.5"
-      sources."acorn-7.4.0"
+      sources."acorn-7.4.1"
       (sources."acorn-globals-4.3.4" // {
         dependencies = [
-          sources."acorn-6.4.1"
+          sources."acorn-6.4.2"
         ];
       })
       sources."acorn-walk-6.2.0"
@@ -80166,7 +85797,7 @@ in
       sources."caller-path-2.0.0"
       sources."callsites-2.0.0"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30001140"
+      sources."caniuse-lite-1.0.30001144"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chokidar-2.1.8"
@@ -80230,7 +85861,7 @@ in
       sources."css-select-base-adapter-0.1.1"
       sources."css-selector-tokenizer-0.7.3"
       sources."css-tree-1.0.0-alpha.37"
-      sources."css-what-3.3.0"
+      sources."css-what-3.4.1"
       sources."cssesc-3.0.0"
       sources."cssnano-4.1.10"
       sources."cssnano-preset-default-4.0.7"
@@ -80300,7 +85931,7 @@ in
       sources."duplexer2-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.576"
+      sources."electron-to-chromium-1.3.578"
       (sources."elliptic-6.5.3" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -80310,7 +85941,7 @@ in
       sources."entities-1.1.2"
       sources."envinfo-7.7.3"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.18.0-next.0"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."escalade-3.1.0"
       sources."escape-html-1.0.3"
@@ -80473,7 +86104,7 @@ in
       sources."jsbn-0.1.1"
       (sources."jsdom-14.1.0" // {
         dependencies = [
-          sources."acorn-6.4.1"
+          sources."acorn-6.4.2"
           sources."escodegen-1.14.3"
           sources."esprima-4.0.1"
           sources."ws-6.2.1"
@@ -80568,13 +86199,13 @@ in
       sources."object.assign-4.1.1"
       (sources."object.getownpropertydescriptors-2.1.0" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."object.pick-1.3.0"
       (sources."object.values-1.1.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."on-finished-2.3.0"
@@ -80605,7 +86236,7 @@ in
           sources."supports-color-6.1.0"
         ];
       })
-      (sources."postcss-calc-7.0.4" // {
+      (sources."postcss-calc-7.0.5" // {
         dependencies = [
           sources."postcss-value-parser-4.1.0"
         ];
@@ -80807,12 +86438,12 @@ in
       sources."stream-http-2.8.3"
       (sources."string.prototype.trimend-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       (sources."string.prototype.trimstart-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."string_decoder-1.1.1"
@@ -80892,7 +86523,7 @@ in
       sources."util-deprecate-1.0.2"
       (sources."util.promisify-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."uuid-3.4.0"
@@ -81005,7 +86636,7 @@ in
       sources."encodeurl-1.0.2"
       sources."entities-1.1.2"
       sources."errno-0.1.7"
-      sources."es-abstract-1.18.0-next.0"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."escape-html-1.0.3"
       sources."esprima-4.0.1"
@@ -81089,7 +86720,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
       sources."mkdirp-0.5.5"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."ms-2.0.0"
       sources."msgpack5-3.6.0"
       sources."mv-2.1.1"
@@ -81173,12 +86804,12 @@ in
       sources."string-width-3.1.0"
       (sources."string.prototype.trimend-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       (sources."string.prototype.trimstart-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."string_decoder-1.1.1"
@@ -81188,7 +86819,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.18"
-      sources."uglify-js-3.11.0"
+      sources."uglify-js-3.11.1"
       sources."unix-dgram-2.0.4"
       sources."unpipe-1.0.0"
       sources."uri-js-4.4.0"
@@ -81573,7 +87204,7 @@ in
       sources."dns-txt-2.0.2"
       sources."end-of-stream-1.4.4"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."external-editor-2.2.0"
@@ -81665,13 +87296,9 @@ in
       sources."numeral-2.0.6"
       sources."object-assign-4.1.1"
       sources."object-inspect-1.8.0"
-      sources."object-is-1.1.2"
+      sources."object-is-1.1.3"
       sources."object-keys-1.1.1"
-      (sources."object.assign-4.1.1" // {
-        dependencies = [
-          sources."es-abstract-1.18.0-next.0"
-        ];
-      })
+      sources."object.assign-4.1.1"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
       sources."open-0.0.5"
@@ -81723,7 +87350,11 @@ in
       sources."read-pkg-up-1.0.1"
       sources."readable-stream-2.3.7"
       sources."redent-1.0.0"
-      sources."regexp.prototype.flags-1.3.0"
+      (sources."regexp.prototype.flags-1.3.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."repeating-2.0.1"
       sources."resolve-1.17.0"
       sources."restore-cursor-2.0.0"
@@ -81757,8 +87388,16 @@ in
       sources."speedometer-0.1.4"
       sources."stream-buffers-2.2.0"
       sources."string-width-1.0.2"
-      sources."string.prototype.trimend-1.0.1"
-      sources."string.prototype.trimstart-1.0.1"
+      (sources."string.prototype.trimend-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      (sources."string.prototype.trimstart-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       (sources."string2compact-1.3.0" // {
         dependencies = [
           sources."ipaddr.js-1.9.1"
@@ -82224,9 +87863,8 @@ in
       sources."@nodelib/fs.scandir-2.1.3"
       sources."@nodelib/fs.stat-2.0.3"
       sources."@nodelib/fs.walk-1.2.4"
-      sources."@types/color-name-1.1.1"
       sources."ansi-regex-5.0.0"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."anymatch-3.1.1"
       sources."argparse-1.0.10"
       sources."array-union-2.1.0"
@@ -82304,9 +87942,9 @@ in
       sources."to-regex-range-5.0.1"
       sources."universalify-1.0.0"
       sources."wrap-ansi-7.0.0"
-      sources."y18n-5.0.1"
+      sources."y18n-5.0.2"
       sources."yargs-16.0.3"
-      sources."yargs-parser-20.2.0"
+      sources."yargs-parser-20.2.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -82383,7 +88021,7 @@ in
     };
     dependencies = [
       sources."JSONStream-1.3.5"
-      sources."acorn-7.4.0"
+      sources."acorn-7.4.1"
       sources."acorn-node-1.8.2"
       sources."acorn-walk-7.2.0"
       (sources."asn1.js-5.4.1" // {
@@ -82644,10 +88282,10 @@ in
   purescript-language-server = nodeEnv.buildNodePackage {
     name = "purescript-language-server";
     packageName = "purescript-language-server";
-    version = "0.14.2";
+    version = "0.14.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/purescript-language-server/-/purescript-language-server-0.14.2.tgz";
-      sha512 = "4dLL/PvePCi4GvI88OjcT1lERIj4jpspXeUvivkYvGxI2NypkmrADuxa32Y3kIZ0D+bAM2ZR6MyOqAyztmRKcg==";
+      url = "https://registry.npmjs.org/purescript-language-server/-/purescript-language-server-0.14.3.tgz";
+      sha512 = "nt5N6EusQO2dqEnbkma/z7fXxKuVCgMQ8BSJEGZdRiM9W8pa/AV8f8UyPFsN8AMpwZbZv6P9T9LDL6Q3+61S3Q==";
     };
     dependencies = [
       sources."isexe-2.0.0"
@@ -82674,10 +88312,10 @@ in
   purescript-psa = nodeEnv.buildNodePackage {
     name = "purescript-psa";
     packageName = "purescript-psa";
-    version = "0.7.3";
+    version = "0.8.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/purescript-psa/-/purescript-psa-0.7.3.tgz";
-      sha512 = "qcnhruybTHVunhJqAuurOEWnz1BOOc/7mpcnyH5yxm5caYCejxq8GOE4ZNWbiPMeTlcG79qUPIOz7gx5OVmk2Q==";
+      url = "https://registry.npmjs.org/purescript-psa/-/purescript-psa-0.8.0.tgz";
+      sha512 = "N76JjHcBbJMf4/rs8dnCniFi7TL9iBbV0BycXuwEtSYnmiaogng0tFmnliqubQyZ5FpDU9ET8Bq1NjH3Hmx5PA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -82710,10 +88348,10 @@ in
   pyright = nodeEnv.buildNodePackage {
     name = "pyright";
     packageName = "pyright";
-    version = "1.1.75";
+    version = "1.1.78";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pyright/-/pyright-1.1.75.tgz";
-      sha512 = "mwIUq71cfiVKep0QGB3cO+rjaU5t7v9D5CPIKWkBI9VJ6ENRpx8pwUrO+oANDHGCrCLtpDnJXA7n+4GcoXVojg==";
+      url = "https://registry.npmjs.org/pyright/-/pyright-1.1.78.tgz";
+      sha512 = "sKh6AbVIysi0CzgL3M8iaKBy/2yopDxyB0VptIYTIGpGcGKJce0KrsJ7OSR3bgx3S4MYMWKF004ws0tosJy+kA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -82745,10 +88383,14 @@ in
       sources."colors-0.6.2"
       sources."concat-map-0.0.1"
       sources."cycle-1.0.3"
-      sources."deep-equal-2.0.3"
+      sources."deep-equal-2.0.4"
       sources."define-properties-1.1.3"
-      sources."es-abstract-1.17.6"
-      sources."es-get-iterator-1.1.0"
+      sources."es-abstract-1.18.0-next.1"
+      (sources."es-get-iterator-1.1.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."eyes-0.1.8"
@@ -82774,7 +88416,11 @@ in
       sources."is-set-2.0.1"
       sources."is-string-1.0.5"
       sources."is-symbol-1.0.3"
-      sources."is-typed-array-1.1.3"
+      (sources."is-typed-array-1.1.3" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."is-weakmap-2.0.1"
       sources."is-weakset-2.0.1"
       sources."isarray-2.0.5"
@@ -82785,36 +88431,44 @@ in
       sources."mute-stream-0.0.8"
       sources."ncp-0.4.2"
       sources."object-inspect-1.8.0"
-      sources."object-is-1.1.2"
+      sources."object-is-1.1.3"
       sources."object-keys-1.1.1"
-      (sources."object.assign-4.1.1" // {
-        dependencies = [
-          sources."es-abstract-1.18.0-next.0"
-        ];
-      })
+      sources."object.assign-4.1.1"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."pkginfo-0.4.1"
       sources."prompt-0.2.14"
       sources."read-1.0.7"
-      sources."regexp.prototype.flags-1.3.0"
+      (sources."regexp.prototype.flags-1.3.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."revalidator-0.1.8"
       sources."rimraf-2.7.1"
       sources."semver-5.7.1"
-      (sources."side-channel-1.0.3" // {
+      sources."side-channel-1.0.3"
+      sources."stack-trace-0.0.10"
+      (sources."string.prototype.trimend-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.18.0-next.0"
+          sources."es-abstract-1.17.7"
         ];
       })
-      sources."stack-trace-0.0.10"
-      sources."string.prototype.trimend-1.0.1"
-      sources."string.prototype.trimstart-1.0.1"
+      (sources."string.prototype.trimstart-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."strip-ansi-3.0.1"
       sources."supports-color-2.0.0"
       sources."utile-0.2.1"
       sources."which-boxed-primitive-1.0.1"
       sources."which-collection-1.0.1"
-      sources."which-typed-array-1.1.2"
+      (sources."which-typed-array-1.1.2" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       (sources."winston-0.8.3" // {
         dependencies = [
           sources."pkginfo-0.3.1"
@@ -82918,7 +88572,6 @@ in
       sources."@emotion/stylis-0.8.5"
       sources."@emotion/unitless-0.7.5"
       sources."@exodus/schemasafe-1.0.0-rc.2"
-      sources."@types/color-name-1.1.1"
       sources."ajv-5.5.2"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
@@ -83175,7 +88828,7 @@ in
       sources."readdirp-3.4.0"
       (sources."redoc-2.0.0-rc.8-1" // {
         dependencies = [
-          sources."tslib-1.13.0"
+          sources."tslib-1.14.0"
         ];
       })
       sources."reftools-1.1.6"
@@ -83227,9 +88880,9 @@ in
       sources."to-arraybuffer-1.0.1"
       sources."to-fast-properties-2.0.0"
       sources."to-regex-range-5.0.1"
-      sources."tslib-2.0.1"
+      sources."tslib-2.0.2"
       sources."tty-browserify-0.0.0"
-      sources."uglify-js-3.11.0"
+      sources."uglify-js-3.11.1"
       (sources."url-0.11.0" // {
         dependencies = [
           sources."punycode-1.3.2"
@@ -83259,7 +88912,7 @@ in
       (sources."yargs-15.4.1" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."cliui-6.0.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -83344,7 +88997,6 @@ in
       sources."@rollup/plugin-commonjs-13.0.2"
       sources."@rollup/plugin-node-resolve-8.4.0"
       sources."@rollup/pluginutils-3.1.0"
-      sources."@types/color-name-1.1.1"
       sources."@types/eslint-visitor-keys-1.0.0"
       sources."@types/estree-0.0.39"
       sources."@types/glob-7.1.3"
@@ -83369,7 +89021,7 @@ in
         ];
       })
       sources."@typescript-eslint/visitor-keys-3.10.1"
-      sources."acorn-7.4.0"
+      sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
       sources."agent-base-4.3.0"
       sources."ajv-6.12.5"
@@ -83394,7 +89046,7 @@ in
       sources."camelcase-5.3.1"
       (sources."chalk-4.1.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
@@ -83441,7 +89093,12 @@ in
       sources."emoji-regex-7.0.3"
       sources."enquirer-2.3.6"
       sources."entities-1.1.2"
-      sources."es-abstract-1.17.6"
+      (sources."es-abstract-1.17.7" // {
+        dependencies = [
+          sources."es-abstract-1.18.0-next.1"
+          sources."object.assign-4.1.1"
+        ];
+      })
       sources."es-array-method-boxes-properly-1.0.0"
       sources."es-get-iterator-1.1.0"
       sources."es-to-primitive-1.2.1"
@@ -83522,6 +89179,7 @@ in
       sources."is-glob-4.0.1"
       sources."is-map-2.0.1"
       sources."is-module-1.0.0"
+      sources."is-negative-zero-2.0.0"
       sources."is-number-7.0.0"
       sources."is-plain-obj-1.1.0"
       sources."is-reference-1.2.1"
@@ -83639,10 +89297,10 @@ in
       sources."text-table-0.2.0"
       sources."tmp-0.0.29"
       sources."to-regex-range-5.0.1"
-      sources."tslib-2.0.1"
+      sources."tslib-2.0.2"
       (sources."tsutils-3.17.1" // {
         dependencies = [
-          sources."tslib-1.13.0"
+          sources."tslib-1.14.0"
         ];
       })
       sources."tunnel-0.0.4"
@@ -83657,9 +89315,10 @@ in
       sources."url-join-1.1.0"
       sources."util-deprecate-1.0.2"
       sources."v8-compile-cache-2.1.1"
-      (sources."vsce-1.80.0" // {
+      (sources."vsce-1.81.1" // {
         dependencies = [
           sources."chalk-2.4.2"
+          sources."commander-6.1.0"
           sources."semver-5.7.1"
         ];
       })
@@ -83979,10 +89638,10 @@ in
   serverless = nodeEnv.buildNodePackage {
     name = "serverless";
     packageName = "serverless";
-    version = "2.3.0";
+    version = "2.5.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/serverless/-/serverless-2.3.0.tgz";
-      sha512 = "glI1JOC5c4HBWRgo+mlhBv/PdFCNSGQDsmLdC5l1jj+yTL3zVMVSu+M0/ZizcyxCWu157H5V1pYRGyNbhP7slg==";
+      url = "https://registry.npmjs.org/serverless/-/serverless-2.5.0.tgz";
+      sha512 = "2JxwILnVqCY9mSw+QcPSKh2OJXsCmL5BZ9xHXYAOaKbI8G/TlxwooeCmw9LT91kdtM8Wh69rJsxRzzpP4MhWyQ==";
     };
     dependencies = [
       sources."2-thenable-1.0.0"
@@ -84068,12 +89727,11 @@ in
       sources."@tencent-sdk/capi-1.1.4"
       sources."@types/cacheable-request-6.0.1"
       sources."@types/caseless-0.12.2"
-      sources."@types/color-name-1.1.1"
       sources."@types/http-cache-semantics-4.0.0"
       sources."@types/keyv-3.1.1"
       sources."@types/lodash-4.14.161"
       sources."@types/long-4.0.1"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/request-2.48.5"
       sources."@types/request-promise-native-1.0.17"
       sources."@types/responselike-1.0.0"
@@ -84121,7 +89779,7 @@ in
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."at-least-node-1.0.0"
-      (sources."aws-sdk-2.763.0" // {
+      (sources."aws-sdk-2.768.0" // {
         dependencies = [
           sources."buffer-4.9.2"
           sources."isarray-1.0.0"
@@ -84133,17 +89791,16 @@ in
       sources."axios-0.19.2"
       sources."backo2-1.0.2"
       sources."balanced-match-1.0.0"
-      sources."base64-arraybuffer-0.1.5"
+      sources."base64-arraybuffer-0.1.4"
       sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
-      sources."better-assert-1.0.2"
       sources."binary-extensions-2.1.0"
       sources."bl-4.0.3"
       sources."blob-0.0.5"
       sources."bluebird-3.7.2"
       (sources."boxen-4.2.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-3.0.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -84169,12 +89826,11 @@ in
         ];
       })
       sources."cachedir-2.3.0"
-      sources."callsite-1.0.0"
       sources."camelcase-5.3.1"
       sources."caseless-0.12.0"
       (sources."chalk-4.1.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
@@ -84203,7 +89859,7 @@ in
       sources."combined-stream-1.0.8"
       sources."commander-2.19.0"
       sources."component-bind-1.0.0"
-      sources."component-emitter-1.2.1"
+      sources."component-emitter-1.3.0"
       sources."component-inherit-0.0.3"
       sources."compress-commons-4.0.1"
       sources."concat-map-0.0.1"
@@ -84298,17 +89954,10 @@ in
       sources."end-of-stream-1.4.4"
       (sources."engine.io-client-3.4.4" // {
         dependencies = [
-          sources."component-emitter-1.3.0"
-          sources."parseqs-0.0.6"
-          sources."parseuri-0.0.6"
           sources."ws-6.1.4"
         ];
       })
-      (sources."engine.io-parser-2.2.1" // {
-        dependencies = [
-          sources."base64-arraybuffer-0.1.4"
-        ];
-      })
+      sources."engine.io-parser-2.2.1"
       sources."env-variable-0.0.6"
       sources."es5-ext-0.10.53"
       sources."es6-iterator-2.0.3"
@@ -84417,7 +90066,7 @@ in
           sources."strip-ansi-6.0.0"
         ];
       })
-      sources."inquirer-autocomplete-prompt-1.1.0"
+      sources."inquirer-autocomplete-prompt-1.2.0"
       sources."into-stream-3.1.0"
       sources."is-arrayish-0.3.2"
       sources."is-binary-path-2.1.0"
@@ -84510,7 +90159,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
       sources."mkdirp-0.5.5"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."ms-2.0.0"
       sources."mute-stream-0.0.8"
       sources."nanoid-2.1.11"
@@ -84524,7 +90173,6 @@ in
       sources."normalize-url-4.5.0"
       sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
-      sources."object-component-0.0.3"
       sources."object-hash-2.0.3"
       sources."once-1.4.0"
       sources."one-time-0.0.4"
@@ -84549,8 +90197,8 @@ in
         ];
       })
       sources."pako-1.0.11"
-      sources."parseqs-0.0.5"
-      sources."parseuri-0.0.5"
+      sources."parseqs-0.0.6"
+      sources."parseuri-0.0.6"
       sources."path-is-absolute-1.0.1"
       sources."path-key-2.0.1"
       sources."path-loader-1.0.10"
@@ -84567,7 +90215,7 @@ in
       sources."promise-queue-2.2.5"
       (sources."protobufjs-6.10.1" // {
         dependencies = [
-          sources."@types/node-13.13.21"
+          sources."@types/node-13.13.23"
         ];
       })
       sources."psl-1.8.0"
@@ -84580,7 +90228,7 @@ in
       sources."ramda-0.26.1"
       sources."rc-1.2.8"
       sources."readable-stream-3.6.0"
-      sources."readdir-glob-1.1.0"
+      sources."readdir-glob-1.1.1"
       sources."readdirp-3.4.0"
       sources."regenerator-runtime-0.13.7"
       sources."registry-auth-token-4.2.0"
@@ -84611,7 +90259,7 @@ in
       sources."shebang-regex-1.0.0"
       sources."shortid-2.2.15"
       sources."signal-exit-3.0.3"
-      (sources."simple-git-2.20.1" // {
+      (sources."simple-git-2.21.0" // {
         dependencies = [
           sources."debug-4.3.0"
           sources."ms-2.1.2"
@@ -84619,17 +90267,8 @@ in
       })
       sources."simple-swizzle-0.2.2"
       sources."slash-3.0.0"
-      (sources."socket.io-client-2.3.0" // {
-        dependencies = [
-          sources."debug-4.1.1"
-          sources."ms-2.1.2"
-        ];
-      })
-      (sources."socket.io-parser-3.3.1" // {
-        dependencies = [
-          sources."component-emitter-1.3.0"
-        ];
-      })
+      sources."socket.io-client-2.3.1"
+      sources."socket.io-parser-3.3.1"
       sources."sort-keys-1.1.2"
       sources."sort-keys-length-1.0.1"
       sources."source-map-0.6.1"
@@ -84699,7 +90338,7 @@ in
       sources."traverse-0.6.6"
       sources."trim-repeated-1.0.0"
       sources."triple-beam-1.3.0"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-2.1.0"
@@ -84718,7 +90357,7 @@ in
       sources."url-to-options-1.0.1"
       sources."urlencode-1.1.0"
       sources."util-deprecate-1.0.2"
-      sources."uuid-8.3.0"
+      sources."uuid-8.3.1"
       sources."verror-1.10.0"
       sources."which-1.3.1"
       sources."widest-line-3.1.0"
@@ -84740,7 +90379,7 @@ in
       sources."xtend-4.0.2"
       sources."yaml-ast-parser-0.0.43"
       sources."yamljs-0.3.0"
-      sources."yargs-parser-20.2.0"
+      sources."yargs-parser-20.2.1"
       sources."yauzl-2.10.0"
       sources."yeast-0.1.2"
       sources."zip-stream-4.0.2"
@@ -85382,10 +91021,10 @@ in
   snyk = nodeEnv.buildNodePackage {
     name = "snyk";
     packageName = "snyk";
-    version = "1.405.0";
+    version = "1.410.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/snyk/-/snyk-1.405.0.tgz";
-      sha512 = "WHvO3XCKV/l5u27MhsWEfh21DbM8Bp7iQK27z+G2fONecg+OAMp7EabbS1a4NyvWsz3TuPQRykscMuCe7CxvsQ==";
+      url = "https://registry.npmjs.org/snyk/-/snyk-1.410.3.tgz";
+      sha512 = "BZ2w1uPCDyjgM2Y6XW071ZlVa1RAVU0xEe7oFY93cdf6ccjCZLyfDqsnbf0ahxAZJp8BZOrq/HsFAfEhm3P8hg==";
     };
     dependencies = [
       sources."@sindresorhus/is-2.1.1"
@@ -85395,11 +91034,11 @@ in
       sources."@snyk/dep-graph-1.19.4"
       sources."@snyk/docker-registry-v2-client-1.13.5"
       sources."@snyk/gemfile-1.2.0"
-      sources."@snyk/java-call-graph-builder-1.14.0"
+      sources."@snyk/java-call-graph-builder-1.16.0"
       sources."@snyk/rpm-parser-2.0.0"
       (sources."@snyk/snyk-cocoapods-plugin-2.5.1" // {
         dependencies = [
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
         ];
       })
       (sources."@snyk/snyk-docker-pull-3.2.0" // {
@@ -85409,14 +91048,13 @@ in
       })
       sources."@szmarczak/http-timer-4.0.5"
       sources."@types/cacheable-request-6.0.1"
-      sources."@types/color-name-1.1.1"
       sources."@types/debug-4.1.5"
       sources."@types/graphlib-2.1.7"
       sources."@types/hosted-git-info-2.7.0"
       sources."@types/http-cache-semantics-4.0.0"
       sources."@types/js-yaml-3.12.5"
       sources."@types/keyv-3.1.1"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/responselike-1.0.0"
       sources."@types/semver-5.5.0"
       sources."@yarnpkg/lockfile-1.1.0"
@@ -85439,7 +91077,7 @@ in
       sources."asn1-0.2.4"
       (sources."ast-types-0.14.2" // {
         dependencies = [
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
         ];
       })
       sources."async-1.5.2"
@@ -85455,7 +91093,7 @@ in
       })
       (sources."boxen-4.2.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."camelcase-5.3.1"
           sources."chalk-3.0.0"
           sources."color-convert-2.0.1"
@@ -85609,7 +91247,7 @@ in
       (sources."inquirer-7.3.3" // {
         dependencies = [
           sources."ansi-escapes-4.3.1"
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -85770,21 +91408,21 @@ in
       sources."snyk-config-3.1.1"
       (sources."snyk-cpp-plugin-2.0.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
           sources."supports-color-7.2.0"
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
         ];
       })
-      (sources."snyk-docker-plugin-3.24.0" // {
+      (sources."snyk-docker-plugin-3.26.2" // {
         dependencies = [
           sources."rimraf-3.0.2"
           sources."snyk-nodejs-lockfile-parser-1.29.0"
           sources."tmp-0.2.1"
-          sources."uuid-8.3.0"
+          sources."uuid-8.3.1"
         ];
       })
       sources."snyk-go-parser-1.4.1"
@@ -85794,14 +91432,14 @@ in
           sources."tmp-0.2.1"
         ];
       })
-      (sources."snyk-gradle-plugin-3.7.0" // {
+      (sources."snyk-gradle-plugin-3.9.0" // {
         dependencies = [
           (sources."@snyk/cli-interface-2.9.1" // {
             dependencies = [
-              sources."tslib-1.13.0"
+              sources."tslib-1.14.0"
             ];
           })
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-3.0.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -85809,14 +91447,13 @@ in
           sources."rimraf-3.0.2"
           sources."supports-color-7.2.0"
           sources."tmp-0.2.1"
-          sources."tslib-2.0.1"
+          sources."tslib-2.0.2"
         ];
       })
       sources."snyk-module-3.1.0"
-      (sources."snyk-mvn-plugin-2.19.4" // {
+      (sources."snyk-mvn-plugin-2.22.0" // {
         dependencies = [
           sources."@snyk/cli-interface-2.9.1"
-          sources."@snyk/java-call-graph-builder-1.13.2"
           sources."tmp-0.1.0"
           sources."tslib-1.11.1"
         ];
@@ -85927,7 +91564,7 @@ in
       sources."toidentifier-1.0.0"
       sources."toml-3.0.0"
       sources."tree-kill-1.2.2"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tweetnacl-0.14.5"
       sources."type-check-0.3.2"
       sources."type-fest-0.11.0"
@@ -85936,7 +91573,7 @@ in
       sources."unpipe-1.0.0"
       (sources."update-notifier-4.1.3" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-3.0.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -86385,9 +92022,10 @@ in
       })
       sources."epidemic-broadcast-trees-7.0.0"
       sources."errno-0.1.7"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.18.0-next.1"
       (sources."es-get-iterator-1.1.0" // {
         dependencies = [
+          sources."es-abstract-1.17.7"
           sources."isarray-2.0.5"
         ];
       })
@@ -86434,7 +92072,7 @@ in
       })
       (sources."flumeview-links-1.0.1" // {
         dependencies = [
-          sources."deep-equal-2.0.3"
+          sources."deep-equal-2.0.4"
           sources."flumeview-level-3.0.14"
           sources."isarray-2.0.5"
           sources."map-filter-reduce-3.2.2"
@@ -86543,7 +92181,11 @@ in
       sources."is-set-2.0.1"
       sources."is-string-1.0.5"
       sources."is-symbol-1.0.3"
-      sources."is-typed-array-1.1.3"
+      (sources."is-typed-array-1.1.3" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."is-typedarray-1.0.0"
       sources."is-valid-domain-0.0.15"
       sources."is-weakmap-2.0.1"
@@ -86653,18 +92295,14 @@ in
         ];
       })
       sources."object-inspect-1.8.0"
-      sources."object-is-1.1.2"
+      sources."object-is-1.1.3"
       sources."object-keys-1.1.1"
       (sources."object-visit-1.0.1" // {
         dependencies = [
           sources."isobject-3.0.1"
         ];
       })
-      (sources."object.assign-4.1.1" // {
-        dependencies = [
-          sources."es-abstract-1.18.0-next.0"
-        ];
-      })
+      sources."object.assign-4.1.1"
       sources."object.omit-2.0.1"
       (sources."object.pick-1.3.0" // {
         dependencies = [
@@ -86823,7 +92461,11 @@ in
       })
       sources."regex-cache-0.4.4"
       sources."regex-not-1.0.2"
-      sources."regexp.prototype.flags-1.3.0"
+      (sources."regexp.prototype.flags-1.3.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."relative-url-1.0.2"
       (sources."remark-3.2.3" // {
         dependencies = [
@@ -86863,11 +92505,7 @@ in
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."shellsubstitute-1.2.0"
-      (sources."side-channel-1.0.3" // {
-        dependencies = [
-          sources."es-abstract-1.18.0-next.0"
-        ];
-      })
+      sources."side-channel-1.0.3"
       sources."smart-buffer-4.1.0"
       (sources."snapdragon-0.8.2" // {
         dependencies = [
@@ -86983,13 +92621,17 @@ in
         ];
       })
       sources."string-width-1.0.2"
-      (sources."string.prototype.trim-1.2.2" // {
+      sources."string.prototype.trim-1.2.2"
+      (sources."string.prototype.trimend-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.18.0-next.0"
+          sources."es-abstract-1.17.7"
         ];
       })
-      sources."string.prototype.trimend-1.0.1"
-      sources."string.prototype.trimstart-1.0.1"
+      (sources."string.prototype.trimstart-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."string_decoder-1.1.1"
       sources."stringify-entities-1.3.2"
       sources."strip-ansi-3.0.1"
@@ -87056,7 +92698,11 @@ in
       sources."which-1.3.1"
       sources."which-boxed-primitive-1.0.1"
       sources."which-collection-1.0.1"
-      sources."which-typed-array-1.1.2"
+      (sources."which-typed-array-1.1.2" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."word-wrap-1.2.3"
       sources."wrap-fn-0.1.5"
       sources."wrappy-1.0.2"
@@ -87160,7 +92806,7 @@ in
       sources."async-1.5.2"
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
-      (sources."aws-sdk-2.763.0" // {
+      (sources."aws-sdk-2.768.0" // {
         dependencies = [
           sources."uuid-3.3.2"
         ];
@@ -87524,7 +93170,7 @@ in
       sources."minimist-1.2.5"
       sources."minitouch-prebuilt-1.2.0"
       sources."mkdirp-0.5.5"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."ms-2.1.2"
       sources."multer-1.4.2"
       sources."mustache-2.3.2"
@@ -87951,7 +93597,7 @@ in
       sources."css-select-2.1.0"
       sources."css-select-base-adapter-0.1.1"
       sources."css-tree-1.0.0-alpha.37"
-      sources."css-what-3.3.0"
+      sources."css-what-3.4.1"
       (sources."csso-4.0.3" // {
         dependencies = [
           sources."css-tree-1.0.0-alpha.39"
@@ -87967,7 +93613,7 @@ in
       sources."domelementtype-1.3.1"
       sources."domutils-1.7.0"
       sources."entities-2.0.3"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.17.7"
       sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
@@ -87989,7 +93635,7 @@ in
       sources."object-keys-1.1.1"
       (sources."object.assign-4.1.1" // {
         dependencies = [
-          sources."es-abstract-1.18.0-next.0"
+          sources."es-abstract-1.18.0-next.1"
         ];
       })
       sources."object.getownpropertydescriptors-2.1.0"
@@ -88587,7 +94233,7 @@ in
       sources."truncate-utf8-bytes-1.0.2"
       sources."type-is-1.6.18"
       sources."typedarray-0.0.6"
-      sources."uglify-js-3.11.0"
+      sources."uglify-js-3.11.1"
       sources."undefsafe-2.0.3"
       (sources."union-value-1.0.1" // {
         dependencies = [
@@ -88712,7 +94358,7 @@ in
       sources."mime-types-2.1.27"
       sources."minimist-1.2.5"
       sources."module-alias-2.2.2"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."ms-2.1.2"
       sources."node-fetch-2.6.1"
       sources."oauth-sign-0.9.0"
@@ -88776,7 +94422,7 @@ in
       sha512 = "Z8uvtdWIlFn1GWy0HW5FhZ8VDryZwoJUdnjZU25C7/PBOltLIn1uv+WF3rVq6S1761YbsmbZYRP/l0ZJBCkvrw==";
     };
     dependencies = [
-      sources."acorn-6.4.1"
+      sources."acorn-6.4.2"
       sources."acorn-loose-6.1.0"
       sources."acorn-walk-6.2.0"
       sources."balanced-match-1.0.0"
@@ -88873,7 +94519,7 @@ in
       sources."define-properties-1.1.3"
       sources."diff-4.0.2"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
@@ -88935,13 +94581,9 @@ in
       sources."normalize-package-data-2.5.0"
       sources."number-is-nan-1.0.1"
       sources."object-inspect-1.8.0"
-      sources."object-is-1.1.2"
+      sources."object-is-1.1.3"
       sources."object-keys-1.1.1"
-      (sources."object.assign-4.1.1" // {
-        dependencies = [
-          sources."es-abstract-1.18.0-next.0"
-        ];
-      })
+      sources."object.assign-4.1.1"
       sources."once-1.4.0"
       sources."optionator-0.8.3"
       sources."p-limit-1.3.0"
@@ -88973,7 +94615,11 @@ in
         ];
       })
       sources."readable-stream-2.3.7"
-      sources."regexp.prototype.flags-1.3.0"
+      (sources."regexp.prototype.flags-1.3.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."remark-frontmatter-1.3.3"
       sources."remark-parse-5.0.0"
       sources."repeat-string-1.6.1"
@@ -88995,8 +94641,16 @@ in
           sources."strip-ansi-3.0.1"
         ];
       })
-      sources."string.prototype.trimend-1.0.1"
-      sources."string.prototype.trimstart-1.0.1"
+      (sources."string.prototype.trimend-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      (sources."string.prototype.trimstart-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."string_decoder-1.1.1"
       (sources."strip-ansi-6.0.0" // {
         dependencies = [
@@ -89084,7 +94738,7 @@ in
     };
     dependencies = [
       sources."define-properties-1.1.3"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.17.7"
       sources."es-to-primitive-1.2.1"
       sources."function-bind-1.1.1"
       sources."has-1.0.3"
@@ -89099,7 +94753,7 @@ in
       sources."object-keys-1.1.1"
       (sources."object.assign-4.1.1" // {
         dependencies = [
-          sources."es-abstract-1.18.0-next.0"
+          sources."es-abstract-1.18.0-next.1"
         ];
       })
       sources."regexp.prototype.flags-1.3.0"
@@ -89132,7 +94786,6 @@ in
       sources."@szmarczak/http-timer-1.1.2"
       sources."@textlint/ast-node-types-4.3.4"
       sources."@textlint/types-1.4.5"
-      sources."@types/color-name-1.1.1"
       sources."@types/minimist-1.2.0"
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/parse5-5.0.3"
@@ -89153,7 +94806,7 @@ in
       sources."boundary-1.0.1"
       (sources."boxen-4.2.0" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-3.0.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -89497,7 +95150,7 @@ in
       sources."unist-util-visit-parents-3.1.0"
       (sources."update-notifier-4.1.3" // {
         dependencies = [
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."chalk-3.0.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -89673,7 +95326,7 @@ in
       sources."buffer-from-1.1.1"
       sources."concat-stream-2.0.0"
       sources."define-properties-1.1.3"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.17.7"
       sources."es-to-primitive-1.2.1"
       sources."function-bind-1.1.1"
       sources."has-1.0.3"
@@ -89689,7 +95342,7 @@ in
       sources."object-keys-1.1.1"
       (sources."object.assign-4.1.1" // {
         dependencies = [
-          sources."es-abstract-1.18.0-next.0"
+          sources."es-abstract-1.18.0-next.1"
         ];
       })
       sources."object.values-1.1.1"
@@ -89731,7 +95384,7 @@ in
       sources."define-properties-1.1.3"
       sources."emoji-regex-6.5.1"
       sources."end-with-1.0.2"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.17.7"
       sources."es-to-primitive-1.2.1"
       sources."function-bind-1.1.1"
       sources."has-1.0.3"
@@ -89745,7 +95398,7 @@ in
       sources."object-keys-1.1.1"
       (sources."object.assign-4.1.1" // {
         dependencies = [
-          sources."es-abstract-1.18.0-next.0"
+          sources."es-abstract-1.18.0-next.1"
         ];
       })
       sources."string.prototype.trimend-1.0.1"
@@ -89832,7 +95485,7 @@ in
     dependencies = [
       sources."array-includes-3.1.1"
       sources."define-properties-1.1.3"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.17.7"
       sources."es-to-primitive-1.2.1"
       sources."function-bind-1.1.1"
       sources."has-1.0.3"
@@ -89848,7 +95501,7 @@ in
       sources."object-keys-1.1.1"
       (sources."object.assign-4.1.1" // {
         dependencies = [
-          sources."es-abstract-1.18.0-next.0"
+          sources."es-abstract-1.18.0-next.1"
         ];
       })
       sources."string.prototype.trimend-1.0.1"
@@ -89879,7 +95532,7 @@ in
       sources."boundary-1.0.1"
       sources."define-properties-1.1.3"
       sources."e-prime-0.10.4"
-      sources."es-abstract-1.18.0-next.0"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."function-bind-1.1.1"
       sources."has-1.0.3"
@@ -89896,12 +95549,12 @@ in
       sources."passive-voice-0.1.0"
       (sources."string.prototype.trimend-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       (sources."string.prototype.trimstart-1.0.1" // {
         dependencies = [
-          sources."es-abstract-1.17.6"
+          sources."es-abstract-1.17.7"
         ];
       })
       sources."structured-source-3.0.2"
@@ -89936,11 +95589,10 @@ in
       sources."@szmarczak/http-timer-4.0.5"
       sources."@tokenizer/token-0.1.1"
       sources."@types/cacheable-request-6.0.1"
-      sources."@types/color-name-1.1.1"
       sources."@types/debug-4.1.5"
       sources."@types/http-cache-semantics-4.0.0"
       sources."@types/keyv-3.1.1"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/responselike-1.0.0"
       sources."abbrev-1.1.1"
       sources."abstract-logging-2.0.0"
@@ -89954,7 +95606,7 @@ in
       })
       sources."ajv-6.12.5"
       sources."ansi-regex-2.1.1"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."aproba-1.2.0"
       (sources."are-we-there-yet-1.1.5" // {
         dependencies = [
@@ -90374,10 +96026,10 @@ in
   three = nodeEnv.buildNodePackage {
     name = "three";
     packageName = "three";
-    version = "0.121.0";
+    version = "0.121.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/three/-/three-0.121.0.tgz";
-      sha512 = "12bkOFsSCsfHViuqDuxDccMBT8eJ/UH829P1J50f4mvI9pWNX4iurZq8Vbo+rs9rKkgrSBRq7ubE77dQ1Y1hzA==";
+      url = "https://registry.npmjs.org/three/-/three-0.121.1.tgz";
+      sha512 = "+rYhNpW5W1aBdLkPQDld/GA4Sj/uOKJJKVpCAZUbpk/HZEiYRUlPt8+s+9nmxRglWmRHdBa3ERvUwqg4nmoA5w==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -90475,7 +96127,7 @@ in
       sources."mime-db-1.44.0"
       sources."mime-types-2.1.27"
       sources."minimatch-3.0.4"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       (sources."node-appc-1.1.1" // {
         dependencies = [
           sources."async-3.2.0"
@@ -90513,7 +96165,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."universalify-1.0.0"
       sources."uri-js-4.4.0"
-      sources."uuid-8.3.0"
+      sources."uuid-8.3.1"
       sources."verror-1.10.0"
       (sources."winston-1.1.2" // {
         dependencies = [
@@ -90610,7 +96262,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."mooremachine-2.3.0"
       sources."mute-stream-0.0.8"
       sources."mv-2.1.1"
@@ -90768,7 +96420,7 @@ in
       sources."strip-ansi-3.0.1"
       sources."supports-color-2.0.0"
       sources."temp-0.8.4"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."wordwrap-0.0.3"
       sources."wrappy-1.0.2"
     ];
@@ -90862,10 +96514,10 @@ in
   uglify-js = nodeEnv.buildNodePackage {
     name = "uglify-js";
     packageName = "uglify-js";
-    version = "3.11.0";
+    version = "3.11.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.0.tgz";
-      sha512 = "e1KQFRCpOxnrJsJVqDUCjURq+wXvIn7cK2sRAx9XL3HYLL9aezOP4Pb1+Y3/o693EPk111Yj2Q+IUXxcpHlygQ==";
+      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.1.tgz";
+      sha512 = "OApPSuJcxcnewwjSGGfWOjx3oix5XpmrK9Z2j0fTRlHGoZ49IU6kExfZTM0++fCArOOCet+vIfWwFHbvWqwp6g==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -90890,13 +96542,12 @@ in
       sources."@primer/octicons-11.0.0"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/color-name-1.1.1"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
       sources."after-0.8.2"
       sources."ansi-regex-5.0.0"
-      (sources."ansi-styles-4.2.1" // {
+      (sources."ansi-styles-4.3.0" // {
         dependencies = [
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -91179,10 +96830,10 @@ in
       sources."wrappy-1.0.2"
       sources."ws-7.3.1"
       sources."xmlhttprequest-ssl-1.5.5"
-      sources."y18n-5.0.1"
+      sources."y18n-5.0.2"
       sources."yallist-2.1.2"
       sources."yargs-16.0.3"
-      sources."yargs-parser-20.2.0"
+      sources."yargs-parser-20.2.1"
       sources."yeast-0.1.2"
     ];
     buildInputs = globalBuildInputs;
@@ -91198,16 +96849,15 @@ in
   vega-cli = nodeEnv.buildNodePackage {
     name = "vega-cli";
     packageName = "vega-cli";
-    version = "5.16.1";
+    version = "5.17.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/vega-cli/-/vega-cli-5.16.1.tgz";
-      sha512 = "7CkUpjfRLvqANnDChd2/gYXzuJD/8v2ookj38nWrSPzrEPXlziDXiWeFycgr+cj9QdZTmlFF73fe+YhXF1c73Q==";
+      url = "https://registry.npmjs.org/vega-cli/-/vega-cli-5.17.0.tgz";
+      sha512 = "IMsPOtAnagoKK0czFoVdeVfDsGAKb8fPyDON68kEeWp9Jql71QAninG1ZqdjR2yHQy66szfP7ou9ksIIWyKGJw==";
     };
     dependencies = [
-      sources."@types/color-name-1.1.1"
       sources."abbrev-1.1.1"
       sources."ansi-regex-2.1.1"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."aproba-1.2.0"
       sources."are-we-there-yet-1.1.5"
       sources."balanced-match-1.0.0"
@@ -91314,8 +96964,8 @@ in
       sources."tar-4.4.13"
       sources."topojson-client-3.1.0"
       sources."util-deprecate-1.0.2"
-      sources."vega-5.16.1"
-      sources."vega-canvas-1.2.5"
+      sources."vega-5.17.0"
+      sources."vega-canvas-1.2.6"
       sources."vega-crossfilter-4.0.5"
       sources."vega-dataflow-5.7.3"
       sources."vega-encode-4.8.3"
@@ -91327,7 +96977,7 @@ in
       sources."vega-geo-4.3.7"
       sources."vega-hierarchy-4.0.9"
       sources."vega-label-1.0.0"
-      sources."vega-loader-4.3.3"
+      sources."vega-loader-4.4.0"
       sources."vega-parser-6.1.0"
       sources."vega-projection-1.4.5"
       sources."vega-regression-1.0.9"
@@ -91339,7 +96989,7 @@ in
       sources."vega-time-2.0.4"
       sources."vega-transforms-4.9.3"
       sources."vega-typings-0.19.1"
-      sources."vega-util-1.15.3"
+      sources."vega-util-1.16.0"
       sources."vega-view-5.9.0"
       sources."vega-view-transforms-4.5.8"
       sources."vega-voronoi-4.1.5"
@@ -91354,7 +97004,7 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."y18n-5.0.1"
+      sources."y18n-5.0.2"
       sources."yallist-3.1.1"
       (sources."yargs-16.0.3" // {
         dependencies = [
@@ -91364,7 +97014,7 @@ in
           sources."strip-ansi-6.0.0"
         ];
       })
-      sources."yargs-parser-20.2.0"
+      sources."yargs-parser-20.2.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -91386,10 +97036,9 @@ in
     };
     dependencies = [
       sources."@types/clone-2.1.0"
-      sources."@types/color-name-1.1.1"
       sources."@types/fast-json-stable-stringify-2.0.0"
       sources."ansi-regex-5.0.0"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."array-flat-polyfill-1.0.1"
       sources."cliui-7.0.1"
       sources."clone-2.1.2"
@@ -91405,14 +97054,14 @@ in
       sources."require-directory-2.1.1"
       sources."string-width-4.2.0"
       sources."strip-ansi-6.0.0"
-      sources."tslib-2.0.1"
+      sources."tslib-2.0.2"
       sources."vega-event-selector-2.0.6"
       sources."vega-expression-3.0.0"
       sources."vega-util-1.15.3"
       sources."wrap-ansi-7.0.0"
-      sources."y18n-5.0.1"
+      sources."y18n-5.0.2"
       sources."yargs-16.0.3"
-      sources."yargs-parser-20.2.0"
+      sources."yargs-parser-20.2.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -91590,7 +97239,7 @@ in
       sources."@webassemblyjs/wast-printer-1.9.0"
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.2"
-      sources."acorn-6.4.1"
+      sources."acorn-6.4.2"
       sources."ajv-6.12.5"
       sources."ajv-errors-1.0.1"
       sources."ajv-keywords-3.5.2"
@@ -91706,7 +97355,7 @@ in
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
-      sources."commander-2.20.3"
+      sources."commander-6.1.0"
       sources."commondir-1.0.1"
       sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
@@ -91771,7 +97420,12 @@ in
       sources."enhanced-resolve-4.3.0"
       sources."entities-1.1.2"
       sources."errno-0.1.7"
-      sources."es-abstract-1.17.6"
+      (sources."es-abstract-1.17.7" // {
+        dependencies = [
+          sources."es-abstract-1.18.0-next.1"
+          sources."object.assign-4.1.1"
+        ];
+      })
       sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."eslint-scope-4.0.3"
@@ -91924,6 +97578,7 @@ in
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
+      sources."is-negative-zero-2.0.0"
       sources."is-number-7.0.0"
       sources."is-plain-object-2.0.4"
       sources."is-regex-1.1.1"
@@ -92205,7 +97860,11 @@ in
       sources."strip-json-comments-2.0.1"
       sources."supports-color-6.0.0"
       sources."tapable-1.1.3"
-      sources."terser-4.8.0"
+      (sources."terser-4.8.0" // {
+        dependencies = [
+          sources."commander-2.20.3"
+        ];
+      })
       sources."terser-webpack-plugin-1.4.5"
       (sources."through2-2.0.5" // {
         dependencies = [
@@ -92230,7 +97889,7 @@ in
           sources."semver-6.3.0"
         ];
       })
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tty-browserify-0.0.0"
       sources."tunnel-0.0.4"
       sources."typed-rest-client-1.2.0"
@@ -92270,7 +97929,7 @@ in
       sources."util-deprecate-1.0.2"
       sources."v8-compile-cache-2.1.1"
       sources."vm-browserify-1.1.2"
-      sources."vsce-1.80.0"
+      sources."vsce-1.81.1"
       sources."vscode-debugadapter-testsupport-1.42.0"
       sources."vscode-debugprotocol-1.42.0"
       (sources."watchpack-1.7.4" // {
@@ -92619,10 +98278,10 @@ in
       sources."toml-2.3.6"
       sources."tough-cookie-2.5.0"
       sources."trim-repeated-1.0.0"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
-      sources."uglify-js-3.11.0"
+      sources."uglify-js-3.11.1"
       sources."uid-0.0.2"
       sources."unbzip2-stream-1.4.3"
       sources."unyield-0.0.1"
@@ -92681,12 +98340,12 @@ in
       sources."@starptech/rehype-webparser-0.10.0"
       sources."@starptech/webparser-0.10.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/unist-2.0.3"
       sources."@types/vfile-3.0.2"
       sources."@types/vfile-message-2.0.0"
       sources."abbrev-1.1.1"
-      sources."acorn-6.4.1"
+      sources."acorn-6.4.2"
       sources."acorn-jsx-5.3.1"
       sources."ajv-6.12.5"
       sources."ajv-keywords-2.1.1"
@@ -92877,7 +98536,7 @@ in
       })
       (sources."eslint-plugin-vue-6.2.2" // {
         dependencies = [
-          sources."acorn-7.4.0"
+          sources."acorn-7.4.1"
           sources."debug-4.3.0"
           sources."eslint-scope-5.1.1"
           sources."espree-6.2.1"
@@ -93465,7 +99124,7 @@ in
       sources."trim-newlines-2.0.0"
       sources."trim-trailing-lines-1.1.3"
       sources."trough-1.0.5"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tslint-5.20.1"
       sources."tsutils-2.29.0"
       sources."type-check-0.3.2"
@@ -93610,10 +99269,10 @@ in
   web-ext = nodeEnv.buildNodePackage {
     name = "web-ext";
     packageName = "web-ext";
-    version = "5.1.0";
+    version = "5.2.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/web-ext/-/web-ext-5.1.0.tgz";
-      sha512 = "Eupjwvif/9P4uGdZIddJziLLLD/RuzW8r8HEANGCW8e3dlPV4GJu5z815k9DLVshG0v+q/stUPR968Q2p7hhMQ==";
+      url = "https://registry.npmjs.org/web-ext/-/web-ext-5.2.0.tgz";
+      sha512 = "o/s206JW2U/vXHTe/XeBnsUQhIcuphsSVNVrJU+MoMFq8JlU9vI1VdS2RCW+u5NuqAsMvTyV+pA+4hLGB9CGCw==";
     };
     dependencies = [
       sources."@babel/code-frame-7.10.4"
@@ -93632,6 +99291,9 @@ in
       sources."@babel/runtime-7.11.2"
       sources."@cliqz-oss/firefox-client-0.3.1"
       sources."@cliqz-oss/node-firefox-connect-1.2.1"
+      sources."@devicefarmer/adbkit-2.11.3"
+      sources."@devicefarmer/adbkit-logcat-1.1.0"
+      sources."@devicefarmer/adbkit-monkey-1.0.1"
       (sources."@eslint/eslintrc-0.1.3" // {
         dependencies = [
           sources."debug-4.3.0"
@@ -93640,38 +99302,27 @@ in
       })
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/color-name-1.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."JSONSelect-0.2.1"
-      sources."acorn-7.4.0"
+      sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
-      sources."adbkit-2.11.1"
-      sources."adbkit-logcat-1.1.0"
-      sources."adbkit-monkey-1.0.1"
-      sources."addons-linter-2.5.0"
+      sources."addons-linter-2.7.0"
       sources."adm-zip-0.4.16"
       sources."ajv-6.12.5"
       sources."ajv-merge-patch-4.1.0"
       sources."ansi-align-3.0.0"
       sources."ansi-colors-4.1.1"
       sources."ansi-regex-2.1.1"
-      sources."ansi-styles-4.2.1"
+      sources."ansi-styles-4.3.0"
       sources."any-promise-1.3.0"
-      (sources."anymatch-3.1.1" // {
+      sources."anymatch-3.1.1"
+      (sources."archiver-5.0.2" // {
         dependencies = [
-          sources."normalize-path-3.0.0"
+          sources."async-3.2.0"
         ];
       })
-      (sources."archiver-2.1.1" // {
-        dependencies = [
-          sources."async-2.6.3"
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-          sources."string_decoder-1.1.1"
-        ];
-      })
-      (sources."archiver-utils-1.3.0" // {
+      (sources."archiver-utils-2.1.0" // {
         dependencies = [
           sources."readable-stream-2.3.7"
           sources."safe-buffer-5.1.2"
@@ -93711,20 +99362,7 @@ in
       sources."bcrypt-pbkdf-1.0.2"
       sources."binary-extensions-2.1.0"
       sources."bindings-1.5.0"
-      (sources."bl-1.2.3" // {
-        dependencies = [
-          (sources."readable-stream-2.3.7" // {
-            dependencies = [
-              sources."safe-buffer-5.1.2"
-            ];
-          })
-          (sources."string_decoder-1.1.1" // {
-            dependencies = [
-              sources."safe-buffer-5.1.2"
-            ];
-          })
-        ];
-      })
+      sources."bl-4.0.3"
       sources."bluebird-2.9.34"
       sources."boolbase-1.0.0"
       (sources."boxen-4.2.0" // {
@@ -93741,11 +99379,8 @@ in
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
       sources."buffer-5.6.0"
-      sources."buffer-alloc-1.2.0"
-      sources."buffer-alloc-unsafe-1.1.0"
       sources."buffer-crc32-0.2.13"
       sources."buffer-equal-constant-time-1.0.1"
-      sources."buffer-fill-1.0.0"
       sources."buffer-from-1.1.1"
       sources."bunyan-1.8.14"
       sources."cache-base-1.0.1"
@@ -93759,11 +99394,7 @@ in
       sources."caseless-0.12.0"
       sources."chalk-4.1.0"
       sources."cheerio-1.0.0-rc.3"
-      (sources."chokidar-3.4.2" // {
-        dependencies = [
-          sources."normalize-path-3.0.0"
-        ];
-      })
+      sources."chokidar-3.4.2"
       (sources."chrome-launcher-0.13.4" // {
         dependencies = [
           sources."mkdirp-0.5.5"
@@ -93809,13 +99440,7 @@ in
       sources."commander-2.20.3"
       sources."common-tags-1.8.0"
       sources."component-emitter-1.3.0"
-      (sources."compress-commons-1.2.2" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-          sources."string_decoder-1.1.1"
-        ];
-      })
+      sources."compress-commons-4.0.1"
       sources."concat-map-0.0.1"
       (sources."concat-stream-1.6.2" // {
         dependencies = [
@@ -93829,13 +99454,7 @@ in
       sources."core-js-2.6.11"
       sources."core-util-is-1.0.2"
       sources."crc-3.8.0"
-      (sources."crc32-stream-2.0.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-          sources."string_decoder-1.1.1"
-        ];
-      })
+      sources."crc32-stream-4.0.0"
       sources."cross-spawn-7.0.3"
       sources."crypto-random-string-2.0.0"
       sources."css-select-1.2.0"
@@ -93856,7 +99475,7 @@ in
       sources."define-properties-1.1.3"
       sources."define-property-2.0.2"
       sources."delayed-stream-1.0.0"
-      (sources."dispensary-0.55.0" // {
+      (sources."dispensary-0.57.0" // {
         dependencies = [
           sources."async-3.2.0"
         ];
@@ -93876,7 +99495,7 @@ in
       sources."enquirer-2.3.6"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."es6-error-4.1.1"
       sources."es6-promise-2.3.0"
@@ -93959,14 +99578,14 @@ in
       })
       sources."fast-json-stable-stringify-2.1.0"
       sources."fast-levenshtein-2.0.6"
-      sources."fast-redact-2.0.0"
+      sources."fast-redact-2.1.0"
       sources."fast-safe-stringify-2.0.7"
       sources."fd-slicer-1.1.0"
       sources."file-entry-cache-5.0.1"
       sources."file-uri-to-path-1.0.0"
       sources."fill-range-7.0.1"
       sources."find-up-4.1.0"
-      (sources."firefox-profile-2.0.0" // {
+      (sources."firefox-profile-4.0.0" // {
         dependencies = [
           sources."async-2.5.0"
           sources."fs-extra-4.0.3"
@@ -94064,7 +99683,7 @@ in
       sources."is-installed-globally-0.3.2"
       sources."is-mergeable-object-1.1.1"
       sources."is-negative-zero-2.0.0"
-      sources."is-npm-4.0.0"
+      sources."is-npm-5.0.0"
       sources."is-number-7.0.0"
       sources."is-obj-2.0.0"
       sources."is-path-inside-3.0.2"
@@ -94123,6 +99742,9 @@ in
       sources."lines-and-columns-1.1.6"
       sources."locate-path-5.0.0"
       sources."lodash-4.17.20"
+      sources."lodash.defaults-4.2.0"
+      sources."lodash.difference-4.5.0"
+      sources."lodash.flatten-4.4.0"
       sources."lodash.includes-4.3.0"
       sources."lodash.isboolean-3.0.3"
       sources."lodash.isinteger-4.0.4"
@@ -94131,6 +99753,7 @@ in
       sources."lodash.isstring-4.0.1"
       sources."lodash.once-4.1.1"
       sources."lodash.sortby-4.7.0"
+      sources."lodash.union-4.6.0"
       sources."lowercase-keys-1.0.1"
       (sources."make-dir-3.1.0" // {
         dependencies = [
@@ -94141,7 +99764,7 @@ in
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
       sources."marky-1.2.1"
-      sources."mdn-browser-compat-data-1.0.35"
+      sources."mdn-browser-compat-data-1.0.39"
       sources."mem-5.1.1"
       sources."merge-stream-2.0.0"
       (sources."micromatch-3.1.10" // {
@@ -94176,7 +99799,7 @@ in
         ];
       })
       sources."mkdirp-1.0.4"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."ms-2.0.0"
       sources."multimatch-4.0.0"
       (sources."mv-2.1.1" // {
@@ -94194,13 +99817,13 @@ in
       sources."ncp-2.0.0"
       sources."neo-async-2.6.2"
       sources."next-tick-1.1.0"
-      sources."node-forge-0.7.6"
+      sources."node-forge-0.10.0"
       (sources."node-notifier-8.0.0" // {
         dependencies = [
-          sources."uuid-8.3.0"
+          sources."uuid-8.3.1"
         ];
       })
-      sources."normalize-path-2.1.1"
+      sources."normalize-path-3.0.0"
       sources."normalize-url-4.5.0"
       sources."npm-run-path-4.0.1"
       sources."nth-check-1.0.2"
@@ -94220,18 +99843,14 @@ in
         ];
       })
       sources."object-inspect-1.8.0"
-      sources."object-is-1.1.2"
+      sources."object-is-1.1.3"
       sources."object-keys-1.1.1"
       sources."object-visit-1.0.1"
-      (sources."object.assign-4.1.1" // {
-        dependencies = [
-          sources."es-abstract-1.18.0-next.0"
-        ];
-      })
+      sources."object.assign-4.1.1"
       sources."object.pick-1.3.0"
       sources."once-1.4.0"
       sources."onetime-5.1.2"
-      sources."open-7.1.0"
+      sources."open-7.3.0"
       sources."optionator-0.9.1"
       sources."os-locale-5.0.0"
       sources."os-shim-0.1.3"
@@ -94261,7 +99880,7 @@ in
       sources."pino-6.6.1"
       sources."pino-std-serializers-2.5.0"
       sources."posix-character-classes-0.1.1"
-      (sources."postcss-7.0.32" // {
+      (sources."postcss-7.0.35" // {
         dependencies = [
           sources."ansi-styles-3.2.1"
           (sources."chalk-2.4.2" // {
@@ -94292,10 +99911,15 @@ in
         ];
       })
       sources."readable-stream-3.6.0"
+      sources."readdir-glob-1.1.1"
       sources."readdirp-3.4.0"
       sources."regenerator-runtime-0.13.7"
       sources."regex-not-1.0.2"
-      sources."regexp.prototype.flags-1.3.0"
+      (sources."regexp.prototype.flags-1.3.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."regexpp-3.1.0"
       sources."registry-auth-token-4.2.0"
       sources."registry-url-5.1.0"
@@ -94420,8 +100044,16 @@ in
           sources."strip-ansi-5.2.0"
         ];
       })
-      sources."string.prototype.trimend-1.0.1"
-      sources."string.prototype.trimstart-1.0.1"
+      (sources."string.prototype.trimend-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      (sources."string.prototype.trimstart-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."string_decoder-1.3.0"
       sources."strip-ansi-3.0.1"
       sources."strip-bom-4.0.0"
@@ -94435,13 +100067,7 @@ in
       sources."strip-json-comments-3.1.1"
       sources."supports-color-7.2.0"
       sources."table-5.4.6"
-      (sources."tar-stream-1.6.2" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-          sources."string_decoder-1.1.1"
-        ];
-      })
+      sources."tar-stream-2.1.4"
       sources."term-size-2.2.0"
       sources."text-table-0.2.0"
       sources."thenify-3.3.1"
@@ -94452,7 +100078,6 @@ in
           sources."rimraf-3.0.2"
         ];
       })
-      sources."to-buffer-1.1.1"
       (sources."to-object-path-0.3.0" // {
         dependencies = [
           sources."kind-of-3.2.2"
@@ -94486,11 +100111,7 @@ in
         ];
       })
       sources."upath-1.2.0"
-      (sources."update-notifier-4.1.1" // {
-        dependencies = [
-          sources."chalk-3.0.0"
-        ];
-      })
+      sources."update-notifier-5.0.0"
       sources."uri-js-4.4.0"
       sources."urix-0.1.0"
       sources."url-parse-lax-3.0.0"
@@ -94502,11 +100123,7 @@ in
       sources."watchpack-1.7.4"
       (sources."watchpack-chokidar2-2.0.0" // {
         dependencies = [
-          (sources."anymatch-2.0.0" // {
-            dependencies = [
-              sources."normalize-path-2.1.1"
-            ];
-          })
+          sources."anymatch-2.0.0"
           sources."binary-extensions-1.13.1"
           sources."braces-2.3.2"
           sources."chokidar-2.1.8"
@@ -94518,7 +100135,7 @@ in
           sources."is-glob-3.1.0"
           sources."is-number-3.0.0"
           sources."kind-of-3.2.2"
-          sources."normalize-path-3.0.0"
+          sources."normalize-path-2.1.1"
           sources."readable-stream-2.3.7"
           sources."readdirp-2.2.1"
           sources."safe-buffer-5.1.2"
@@ -94563,7 +100180,6 @@ in
       sources."xdg-basedir-4.0.0"
       sources."xml2js-0.4.23"
       sources."xmlbuilder-11.0.1"
-      sources."xtend-4.0.2"
       sources."y18n-4.0.0"
       (sources."yargs-15.4.1" // {
         dependencies = [
@@ -94587,13 +100203,7 @@ in
           sources."async-1.5.2"
         ];
       })
-      (sources."zip-stream-1.2.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-          sources."string_decoder-1.1.1"
-        ];
-      })
+      sources."zip-stream-4.0.2"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -94634,7 +100244,7 @@ in
       sources."@webassemblyjs/wast-printer-1.9.0"
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.2"
-      sources."acorn-6.4.1"
+      sources."acorn-6.4.2"
       sources."ajv-6.12.5"
       sources."ajv-errors-1.0.1"
       sources."ajv-keywords-3.5.2"
@@ -95070,7 +100680,7 @@ in
       })
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tty-browserify-0.0.0"
       sources."typedarray-0.0.6"
       sources."union-value-1.0.1"
@@ -95458,7 +101068,7 @@ in
     dependencies = [
       sources."@types/glob-7.1.3"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."accepts-1.3.7"
       sources."ajv-6.12.5"
       sources."ajv-errors-1.0.1"
@@ -95586,7 +101196,7 @@ in
       sources."encodeurl-1.0.2"
       sources."end-of-stream-1.4.4"
       sources."errno-0.1.7"
-      sources."es-abstract-1.17.6"
+      sources."es-abstract-1.18.0-next.1"
       sources."es-to-primitive-1.2.1"
       sources."escape-html-1.0.3"
       sources."etag-1.8.1"
@@ -95773,14 +101383,10 @@ in
         ];
       })
       sources."object-inspect-1.8.0"
-      sources."object-is-1.1.2"
+      sources."object-is-1.1.3"
       sources."object-keys-1.1.1"
       sources."object-visit-1.0.1"
-      (sources."object.assign-4.1.1" // {
-        dependencies = [
-          sources."es-abstract-1.18.0-next.0"
-        ];
-      })
+      sources."object.assign-4.1.1"
       sources."object.pick-1.3.0"
       sources."obuf-1.1.2"
       sources."on-finished-2.3.0"
@@ -95834,7 +101440,11 @@ in
       })
       sources."readdirp-2.2.1"
       sources."regex-not-1.0.2"
-      sources."regexp.prototype.flags-1.3.0"
+      (sources."regexp.prototype.flags-1.3.0" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       sources."remove-trailing-separator-1.1.0"
       sources."repeat-element-1.1.3"
       sources."repeat-string-1.6.1"
@@ -95956,8 +101566,16 @@ in
           sources."strip-ansi-5.2.0"
         ];
       })
-      sources."string.prototype.trimend-1.0.1"
-      sources."string.prototype.trimstart-1.0.1"
+      (sources."string.prototype.trimend-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
+      (sources."string.prototype.trimstart-1.0.1" // {
+        dependencies = [
+          sources."es-abstract-1.17.7"
+        ];
+      })
       (sources."string_decoder-1.1.1" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
@@ -96042,10 +101660,10 @@ in
   copy-webpack-plugin = nodeEnv.buildNodePackage {
     name = "copy-webpack-plugin";
     packageName = "copy-webpack-plugin";
-    version = "6.1.1";
+    version = "6.2.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.1.1.tgz";
-      sha512 = "4TlkHFYkrZ3WppLA5XkPmBLI5lnEpFsXvpeqxCf5PzkratZiVklNXsvoQkLhUU43q7ZL3AOXtaHAd9jLNJoU0w==";
+      url = "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.2.0.tgz";
+      sha512 = "1s/VbhIX73FBFBYF4D0KdeBLkjEnAlCQn0Ufo2a/IyJ41jHpQ9ZzM4JAfbE7yTOhbmwRFkARErJ/XIiLceja6Q==";
     };
     dependencies = [
       sources."@nodelib/fs.scandir-2.1.3"
@@ -96173,7 +101791,7 @@ in
       sources."@protobufjs/pool-1.1.0"
       sources."@protobufjs/utf8-1.1.0"
       sources."@types/long-4.0.1"
-      sources."@types/node-13.13.21"
+      sources."@types/node-13.13.23"
       sources."addr-to-ip-port-1.5.1"
       sources."airplay-js-0.3.0"
       sources."balanced-match-1.0.0"
@@ -96308,7 +101926,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
       sources."mkdirp-classic-0.5.3"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."mp4-box-encoding-1.4.1"
       sources."mp4-stream-3.1.0"
       sources."ms-2.0.0"
@@ -96588,10 +102206,9 @@ in
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
       sources."@sindresorhus/is-0.7.0"
-      sources."@types/color-name-1.1.1"
       sources."@types/glob-7.1.3"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-14.11.2"
+      sources."@types/node-14.11.5"
       sources."@types/normalize-package-data-2.4.0"
       sources."JSONStream-1.3.5"
       sources."aggregate-error-3.1.0"
@@ -96974,7 +102591,7 @@ in
         ];
       })
       sources."locate-path-2.0.0"
-      sources."locutus-2.0.12"
+      sources."locutus-2.0.14"
       sources."lodash-4.17.20"
       sources."lodash.debounce-4.0.8"
       sources."lodash.pad-4.5.1"
@@ -97033,7 +102650,7 @@ in
         ];
       })
       sources."mkdirp-0.5.5"
-      sources."moment-2.29.0"
+      sources."moment-2.29.1"
       sources."ms-2.0.0"
       (sources."multimatch-4.0.0" // {
         dependencies = [
@@ -97358,7 +102975,7 @@ in
       sources."to-regex-range-2.1.1"
       sources."tough-cookie-3.0.1"
       sources."trim-newlines-1.0.0"
-      sources."tslib-1.13.0"
+      sources."tslib-1.14.0"
       sources."tunnel-0.0.6"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
@@ -97429,7 +103046,7 @@ in
         dependencies = [
           sources."ansi-escapes-4.3.1"
           sources."ansi-regex-5.0.0"
-          sources."ansi-styles-4.2.1"
+          sources."ansi-styles-4.3.0"
           sources."cli-cursor-3.1.0"
           sources."cli-width-3.0.0"
           sources."color-convert-2.0.1"


### PR DESCRIPTION
###### Motivation for this change
Closes: https://github.com/NixOS/nixpkgs/issues/93399

Had to implement `overrideNodeAttrs` to filter out optional `@expo/traveling-fastlane-darwin` dependency that was intentionally aborting the build on Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
     - [x] Successfully ran react-native app on Android using this
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
