### PR TITLE
patchelf: 0.11 -> 0.12

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -4,7 +4,6 @@
 , llvmPackages, libffi, libomxil-bellagio, libva-minimal
 , libelf, libvdpau, python3Packages
 , libglvnd
-, patchelf, autoreconfHook, fetchFromGitHub
 , enableRadv ? true
 , galliumDrivers ? ["auto"]
 , driDrivers ? ["auto"]
@@ -148,16 +147,6 @@ stdenv.mkDerivation {
   depsBuildBuild = [ pkgconfig ];
 
   nativeBuildInputs = [
-    (patchelf.overrideAttrs (pa: {
-      src = fetchFromGitHub {
-        owner = "NixOS";
-        repo = "patchelf";
-        rev = "61bc10176"; # current master; what matters is merge of #225
-        sha256 = "0cy77mn77w3mn64ggp20f4ygnbxfjmddhjjhfwkva53lsirg6w93";
-      };
-      nativeBuildInputs = pa.nativeBuildInputs or [] ++ [ autoreconfHook ];
-    }))
-  ] ++ [
     pkgconfig meson ninja
     intltool bison flex file
     python3Packages.python python3Packages.Mako

--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -6,11 +6,12 @@
 # files.
 
 stdenv.mkDerivation rec {
-  name = "patchelf-0.11";
+  pname = "patchelf";
+  version = "0.12";
 
   src = fetchurl {
-    url = "https://nixos.org/releases/patchelf/${name}/${name}.tar.bz2";
-    sha256 = "16ms3ijcihb88j3x6cl8cbvhia72afmfcphczb9cfwr0gbc22chx";
+    url = "https://github.com/NixOS/${pname}/releases/download/${version}/${pname}-${version}.tar.bz2";
+    sha256 = "14npmdxppmh0ci140w8i8cy7zg1pnqg81a1mdsnza711ab7k36k9";
   };
 
   setupHook = [ ./setup-hook.sh ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Fixes handling of `PT_NOTE` section, which broke Mesa (and has reportedly broken other things according to patchelf users, we might just not have noticed it or been lucky).
- Fixes handling of section alignment of ARMv8.

cc @domenkozar -- I see last time for the 0.9 -> 0.11 bump you used a special branch and probably a special Hydra jobset. Given that the 0.11 -> 0.12 delta is smaller, do you think we should go through that or is staging enough?

This PR also includes a cleanup to make Mesa use the default patchelf again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
