### PR TITLE
linuxPackages.system76, system76-acpi, system76-io: init at 1.0.x

### DIFF
--- a/pkgs/os-specific/linux/system76-acpi/default.nix
+++ b/pkgs/os-specific/linux/system76-acpi/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, kernel }:
+let
+  version = "1.0.1";
+  sha256 = "0jmm9h607f7k20yassm6af9mh5l00yih5248wwv4i05bd68yw3p5";
+in
+stdenv.mkDerivation {
+  name = "system76-acpi-module-${version}-${kernel.version}";
+
+  passthru.moduleName = "system76_acpi";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "system76-acpi-dkms";
+    rev = version;
+    inherit sha256;
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  buildFlags = [
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    install -D system76_acpi.ko $out/lib/modules/${kernel.modDirVersion}/misc/system76_acpi.ko
+  '';
+
+  meta = with stdenv.lib; {
+    maintainers = [ maintainers.khumba ];
+    license = [ licenses.gpl2Only ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    broken = versionOlder kernel.version "4.14";
+    description = "System76 ACPI Driver (DKMS)";
+    homepage = "https://github.com/pop-os/system76-acpi-dkms";
+    longDescription = ''
+      This provides the system76_acpi in-tree driver for systems missing it.
+    '';
+  };
+}

--- a/pkgs/os-specific/linux/system76-io/default.nix
+++ b/pkgs/os-specific/linux/system76-io/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, kernel }:
+let
+  version = "1.0.1";
+  sha256 = "0qkgkkjy1isv6ws6hrcal75dxjz98rpnvqbm7agdcc6yv0c17wwh";
+in
+stdenv.mkDerivation {
+  name = "system76-io-module-${version}-${kernel.version}";
+
+  passthru.moduleName = "system76_io";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "system76-io-dkms";
+    rev = version;
+    inherit sha256;
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  buildFlags = [
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    install -D system76-io.ko $out/lib/modules/${kernel.modDirVersion}/misc/system76-io.ko
+  '';
+
+  meta = with stdenv.lib; {
+    maintainers = [ maintainers.khumba ];
+    license = [ licenses.gpl2Plus ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    broken = versionOlder kernel.version "4.14";
+    description = "DKMS module for controlling System76 I/O board";
+    homepage = "https://github.com/pop-os/system76-io-dkms";
+  };
+}

--- a/pkgs/os-specific/linux/system76/default.nix
+++ b/pkgs/os-specific/linux/system76/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, kernel }:
+let
+  version = "1.0.9";
+  sha256 = "0i4825y2vd679kdjv30ifzj1i1066d3x37z4lgk39hx16993k162";
+in
+stdenv.mkDerivation {
+  name = "system76-module-${version}-${kernel.version}";
+
+  passthru.moduleName = "system76";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "system76-dkms";
+    rev = version;
+    inherit sha256;
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  buildFlags = [
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    install -D system76.ko $out/lib/modules/${kernel.modDirVersion}/misc/system76.ko
+  '';
+
+  meta = with stdenv.lib; {
+    maintainers = [ maintainers.khumba ];
+    license = [ licenses.gpl2Plus ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    broken = versionOlder kernel.version "4.14";
+    description = "System76 DKMS driver";
+    homepage = "https://github.com/pop-os/system76-dkms";
+    longDescription = ''
+      The System76 DKMS driver. On newer System76 laptops, this driver controls
+      some of the hotkeys and allows for custom fan control.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17806,6 +17806,8 @@ in
 
     system76 = callPackage ../os-specific/linux/system76 { };
 
+    system76-acpi = callPackage ../os-specific/linux/system76-acpi { };
+
     tmon = callPackage ../os-specific/linux/tmon { };
 
     tp_smapi = callPackage ../os-specific/linux/tp_smapi { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17804,6 +17804,8 @@ in
 
     systemtap = callPackage ../development/tools/profiling/systemtap { };
 
+    system76 = callPackage ../os-specific/linux/system76 { };
+
     tmon = callPackage ../os-specific/linux/tmon { };
 
     tp_smapi = callPackage ../os-specific/linux/tp_smapi { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17808,6 +17808,8 @@ in
 
     system76-acpi = callPackage ../os-specific/linux/system76-acpi { };
 
+    system76-io = callPackage ../os-specific/linux/system76-io { };
+
     tmon = callPackage ../os-specific/linux/tmon { };
 
     tp_smapi = callPackage ../os-specific/linux/tp_smapi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This adds System76's kernel modules to Nixpkgs.  These modules provide support for hardware in System76 computers, enabling multimedia keys and keyboard backlight keys.  This is split off from a PR of mine in the nixos-hardware repo [here](https://github.com/NixOS/nixos-hardware/pull/186), to move the drivers into Nixpkgs itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
  - I've been running these patches on 20.03 for ~5 months and they work fine on my darp6.
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - system76-dkms: 88K
  - system76-acpi-dkms: 32K
  - system76-io-dkms: 44K
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
