### PR TITLE
xonsh: 0.9.19 -> 0.9.20

### DIFF
--- a/pkgs/shells/xonsh/default.nix
+++ b/pkgs/shells/xonsh/default.nix
@@ -4,21 +4,31 @@
 , glibcLocales
 , coreutils
 , git
+, fetchpatch
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "xonsh";
-  version = "0.9.19";
+  version = "0.9.20";
 
   # fetch from github because the pypi package ships incomplete tests
   src = fetchFromGitHub {
     owner  = "xonsh";
     repo   = "xonsh";
     rev    = version;
-    sha256 = "1s7nb23zh4may4k3c9yfiizfdflm97hf5q2aww4j6ibykgcydv64";
+    sha256 = "05phrwqd1c64531y78zxkxd4w1cli8yj3x2cqch7nkzbyz93608p";
   };
 
   LC_ALL = "en_US.UTF-8";
+
+  patches = [
+    # Fix vox tests. Remove with the next release
+    (fetchpatch {
+      url = "https://github.com/xonsh/xonsh/commit/00aeb7645af97134495cc6bc5fe2f41922df8676.patch";
+      sha256 = "0hx5jk22wxgmjzmqbxr2pjs3mwh7p0jwld0xhslc1s6whbjml25h";
+    })
+  ];
+
   postPatch = ''
     sed -ie "s|/bin/ls|${coreutils}/bin/ls|" tests/test_execer.py
     sed -ie "s|SHELL=xonsh|SHELL=$out/bin/xonsh|" tests/test_integrations.py


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/xonsh/xonsh/releases/tag/0.9.20


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
