### PR TITLE
cmake: fix CMAKE_FIND_FRAMEWORK

### DIFF
--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -56,8 +56,6 @@ mkDerivation rec {
     "-DLICENSING_PROVIDER:BOOL=OFF"
     "-DMapper_MANUAL_QTHELP:BOOL=OFF"
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
-    # Usually enabled on Darwin
-    "-DCMAKE_FIND_FRAMEWORK=never"
     # FindGDAL is broken and always finds /Library/Framework unless this is
     # specified
     "-DGDAL_INCLUDE_DIR=${gdal}/include"

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -44,7 +44,7 @@ let
         "-DENABLE_JAVASCRIPT=OFF"  # Requires v8 <= 3.24.3, https://github.com/weechat/weechat/issues/360
         "-DENABLE_PHP=OFF"
       ]
-        ++ optionals stdenv.isDarwin ["-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib" "-DCMAKE_FIND_FRAMEWORK=LAST"]
+        ++ optionals stdenv.isDarwin ["-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib"]
         ++ map (p: "-D${p.cmakeFlag}=" + (if p.enabled then "ON" else "OFF")) plugins
         ;
 

--- a/pkgs/applications/office/ledger/default.nix
+++ b/pkgs/applications/office/ledger/default.nix
@@ -27,10 +27,6 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DBUILD_DOCS:BOOL=ON"
     (lib.optionalString usePython "-DUSE_PYTHON=true")
-  ] ++ lib.optionals (usePython && stdenv.isDarwin) [
-    # Fix python lookup on Darwin. Not necessary after
-    # https://github.com/NixOS/nixpkgs/pull/94090 lands in master
-    "-DPython_ROOT_DIR=${python}"
   ];
 
   # by default, it will query the python interpreter for it's sitepackages location

--- a/pkgs/development/compilers/mozart/default.nix
+++ b/pkgs/development/compilers/mozart/default.nix
@@ -60,7 +60,7 @@ in stdenv.mkDerivation rec {
     # gcc together as compilers and we need clang for the sources generation.
     # However, clang emits tons of warnings about gcc's atomic-base library.
     "-DCMAKE_CXX_FLAGS=-Wno-braced-scalar-init"
-  ] ++ lib.optional stdenv.isDarwin "-DCMAKE_FIND_FRAMEWORK=LAST";
+  ];
 
   fixupPhase = ''
     wrapProgram $out/bin/oz --set OZEMACS ${emacs}/bin/emacs

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -48,7 +48,7 @@ cmakeConfigurePhase() {
 
     # on macOS we want to prefer Unix-style headers to Frameworks
     # because we usually do not package the framework
-    cmakeFlags="-DCMAKE_FIND_FRAMEWORK=last $cmakeFlags"
+    cmakeFlags="-DCMAKE_FIND_FRAMEWORK=LAST $cmakeFlags"
 
     # on macOS i686 was only relevant for 10.5 or earlier.
     cmakeFlags="-DCMAKE_OSX_ARCHITECTURES=x86_64 $cmakeFlags"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/94090 was reverted from `master`, but it didn't land into `staging`.

cc: @matthewbauer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
