### PR TITLE
noaa-apt: init at 1.2.0

### DIFF
--- a/pkgs/applications/radio/noaa-apt/default.nix
+++ b/pkgs/applications/radio/noaa-apt/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, atk
+, cairo
+, gdk-pixbuf
+, glib
+, gtk3
+, openssl
+, pango
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "noaa-apt";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "martinber";
+    repo = "noaa-apt";
+    rev = "v${version}";
+    sha256 = "0fqki4a9c54rixdz5bpswvn433f9saw6yazgw4av3xdd7g2fdvvj";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    atk
+    cairo
+    gdk-pixbuf
+    glib
+    gtk3
+    openssl
+    pango
+  ];
+
+  cargoSha256 = "1pzcq31inazmc9cz31fspzqkp0lpkjid8ai3g17sin1pfzby5jlh";
+
+  preBuild = ''
+    # Used by macro pointing to resource location at compile time.
+    export NOAA_APT_RES_DIR=$out/share/noaa-apt
+  '';
+
+  postInstall = ''
+    # Resources.
+    mkdir -p $out/share/noaa-apt
+    cp -R $src/res/* $out/share/noaa-apt/
+
+    # Desktop icon.
+    install -Dm644 -t $out/share/applications $src/debian/ar.com.mbernardi.noaa-apt.desktop
+    install -Dm644 -t $out/share/icons/hicolor/48x48/apps $src/debian/noaa-apt.png
+    install -Dm644 -t $out/share/icons/hicolor/scalable/apps $src/debian/noaa-apt.svg
+  '';
+
+  meta = with lib; {
+    description = "NOAA APT image decoder.";
+    homepage = "http://noaa-apt.mbernardi.com.ar/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ trepetti ];
+    changelog = "https://github.com/martinber/noaa-apt/releases/tag/v${version}";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21848,6 +21848,8 @@ in
 
   nixos-shell = callPackage ../tools/virtualization/nixos-shell {};
 
+  noaa-apt = callPackage ../applications/radio/noaa-apt { };
+
   node-problem-detector = callPackage ../applications/networking/cluster/node-problem-detector { };
 
   ninjas2 = callPackage ../applications/audio/ninjas2 {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[noaa-apt](https://noaa-apt.mbernardi.com.ar/) is decoding software that enables the conversion of audio recordings of NOAA weather satellite APT protocol transmissions into a variety of image formats. Typically this recording is done using software defined radios (SDRs) like RTLSDR, HackRF, etc., which are already well supported in Nix. This software would complement the growing suite of SDR tools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
