### PR TITLE
ocamlPackages.ocp-index: 1.2 → 1.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/re/default.nix
+++ b/pkgs/development/ocaml-modules/re/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, buildDunePackage, ounit, seq }:
+{ lib, fetchzip, buildDunePackage, ocaml, ounit, seq }:
 
 buildDunePackage rec {
   pname = "re";
@@ -11,14 +11,14 @@ buildDunePackage rec {
     sha256 = "07ycb103mr4mrkxfd63cwlsn023xvcjp0ra0k7n2gwrg0mwxmfss";
   };
 
-  buildInputs = [ ounit ];
+  buildInputs = lib.optional doCheck ounit;
   propagatedBuildInputs = [ seq ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.04";
 
   meta = {
     homepage = "https://github.com/ocaml/ocaml-re";
     description = "Pure OCaml regular expressions, with support for Perl and POSIX-style strings";
-    license = stdenv.lib.licenses.lgpl2;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.lgpl2;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/tools/ocaml/ocp-index/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-index/default.nix
@@ -1,15 +1,15 @@
-{ lib, fetchurl, buildDunePackage, ocp-build, ocp-indent, cmdliner, re }:
+{ lib, fetchzip, buildDunePackage, cppo, ocp-indent, cmdliner, re }:
 
 buildDunePackage rec {
   pname = "ocp-index";
-  version = "1.2";
+  version = "1.2.1";
 
-  src = fetchurl {
-    url = "https://github.com/OCamlPro/ocp-index/releases/download/${version}/ocp-index-${version}.tbz";
-    sha256 = "1lchw02sakjjppmzr0rzlarwbg1lc2bl7pwcfpsiycnaz46x6gmr";
+  src = fetchzip {
+    url = "https://github.com/OCamlPro/ocp-index/archive/${version}.tar.gz";
+    sha256 = "08r7mxdnxmhff37fw4hmrpjgckgi5kaiiiirwp4rmdl594z0h9c8";
   };
 
-  buildInputs = [ ocp-build cmdliner re ];
+  buildInputs = [ cppo cmdliner re ];
 
   propagatedBuildInputs = [ ocp-indent ];
 


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
