### PR TITLE
netdata: 1.23.2 -> 1.24.0

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -14,14 +14,14 @@ with stdenv.lib;
 let
   go-d-plugin = callPackage ./go.d.plugin.nix {};
 in stdenv.mkDerivation rec {
-  version = "1.23.2";
+  version = "1.24.0";
   pname = "netdata";
 
   src = fetchFromGitHub {
     owner = "netdata";
     repo = "netdata";
     rev = "v${version}";
-    sha256 = "1vv92plk9dxk6fl76ik1zralpzc35ymrfyrf1cr6pv8q3agyy5k4";
+    sha256 = "19zr2wlsc8rbw6a7vjy4ivgq71l34lh70pcgwa0k5sp1vryj7r3d";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
@@ -36,12 +36,6 @@ in stdenv.mkDerivation rec {
 
   patches = [
     ./no-files-in-etc-and-var.patch
-  ] ++ stdenv.lib.optionals (!stdenv.cc.isGNU) [
-    # fix memcpy typo for non-gnu. Remove with the next release.
-    (fetchpatch {
-      url = "https://github.com/netdata/netdata/commit/da7f267196b489e9a75724b68897e8f2e6137d72.patch";
-      sha256 = "1j2sa06j6v491nw58bjx5nqqyfi1n2n9z3p3jiy4yh74m3asldlv";
-    })
   ];
 
   NIX_CFLAGS_COMPILE = optionalString withDebug "-O1 -ggdb -DNETDATA_INTERNAL_CHECKS=1";
@@ -84,5 +78,4 @@ in stdenv.mkDerivation rec {
     platforms = platforms.unix;
     maintainers = [ maintainers.lethalman ];
   };
-
 }

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -1,6 +1,7 @@
 { stdenv, callPackage, fetchFromGitHub, autoreconfHook, pkgconfig
 , CoreFoundation, IOKit, libossp_uuid
 , curl, libcap,  libuuid, lm_sensors, zlib, fetchpatch
+, nixosTests
 , withCups ? false, cups
 , withDBengine ? true, libuv, lz4, judy
 , withIpmi ? (!stdenv.isDarwin), freeipmi
@@ -70,6 +71,8 @@ in stdenv.mkDerivation rec {
   postFixup = ''
     rm -r $out/sbin
   '';
+
+  passthru.tests.netdata = nixosTests.netdata;
 
   meta = {
     description = "Real-time performance monitoring tool";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update to v1.24.0

cc @Mic92

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
