### PR TITLE
python3Packages.catalogue: 2.0.0 -> 2.0.1

### DIFF
--- a/pkgs/development/python-modules/catalogue/default.nix
+++ b/pkgs/development/python-modules/catalogue/default.nix
@@ -2,26 +2,30 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
+, pytestCheckHook
 , importlib-metadata
 }:
 
 buildPythonPackage rec {
   pname = "catalogue";
-  version = "2.0.0";
+  version = "2.0.1";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "34f8416ec5e7ed08e55c10414416e67c3f4d66edf83bc67320c3290775293816";
+    sha256 = "0d01077dbfca7aa53f3ef4adecccce636bce4f82e5b52237703ab2f56478e56e";
   };
 
   propagatedBuildInputs = [ importlib-metadata ];
 
+  checkInputs = [ pytestCheckHook ];
+
   meta = with stdenv.lib; {
     description = "Tiny library for adding function or object registries";
     homepage = "https://github.com/explosion/catalogue";
+    changelog = "https://github.com/explosion/catalogue/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ danieldk ];
-    };
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Changelog:
https://github.com/explosion/catalogue/releases/tag/v2.0.1

Also add meta.changelog.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).