### PR TITLE
Elasticsearch 7.8.1

### DIFF
--- a/pkgs/development/tools/misc/kibana/7.x.nix
+++ b/pkgs/development/tools/misc/kibana/7.x.nix
@@ -18,12 +18,12 @@ let
   shas =
     if enableUnfree
     then {
-      x86_64-linux  = "1wq4fc2fifkg1qz7nxdfb4yi2biay8cgdz7kl5k0p37sxn0sbkja";
-      x86_64-darwin = "06346kj7bv49py49pmmnmh8m24322m88v1af19909pj9cxgd0p6v";
+      x86_64-linux  = "1v7ffvyxcmgzba2ny1dw5zh4i91s0jgi9vl14mvw1jzkkv2mw7pb";
+      x86_64-darwin = "03ny6gaf89gs2kpvkbj9c4bncydh0afg4xqz021jklkmik4jyd0g";
     }
     else {
-      x86_64-linux  = "0ygpmcm6wdcnvw8azwqc5257lyic7yw31rqvm2pw3afhpha62lpj";
-      x86_64-darwin = "0xy81g0bhxp47p29kkkh5llfzqkzqzr5dk50ap2hy0hjw33ld6g1";
+      x86_64-linux  = "06vbxg9346hkasy62fh9rygna4kp237563lcfc7zlncqaar0wsjr";
+      x86_64-darwin = "1y5fr2sq4g21vk0mnpdksgwqkm9cq9wgpyb6qj685ps06ccg3bng";
     };
 
 in stdenv.mkDerivation rec {

--- a/pkgs/misc/logging/beats/7.x.nix
+++ b/pkgs/misc/logging/beats/7.x.nix
@@ -8,7 +8,7 @@ let beat = package : extraArgs : buildGoPackage (rec {
         owner = "elastic";
         repo = "beats";
         rev = "v${version}";
-        sha256 = "192ygz3ppfah8d2b811x67jfqhcr5ivz7qh4vwrd729rjfr0bbgb";
+        sha256 = "0c75ar7wbhi57n33dy7mvk0v304gqidwc9lm5qa2a8h97pvajwwd";
       };
 
       goPackagePath = "github.com/elastic/beats";

--- a/pkgs/servers/search/elasticsearch/7.x.nix
+++ b/pkgs/servers/search/elasticsearch/7.x.nix
@@ -17,12 +17,12 @@ let
   shas =
     if enableUnfree
     then {
-      x86_64-linux  = "1s27bzx5y8vcd95qrw6av3fhyxb45219x9ahwaxa2cygmbpighrp";
-      x86_64-darwin = "1ia3byir3i5qaarmcaysrg3dhnxjmxnf0m0kzyf61g9aiy87gb7q";
+      x86_64-linux  = "07w6lvbapirpvpl5wa33fdzykg74hk8zyv97zs3if4zqj78kcwsg";
+      x86_64-darwin = "1ph2nv8dbr73zwvf5slzs2900sky5jjafif0gvdh2lj173ph12ic";
     }
     else {
-      x86_64-linux  = "005i7d7ag10qkn7bkx7md50iihvcvc84hay2j94wvsm7yghhbmi3";
-      x86_64-darwin = "01f81720rbzdqc0g1xymhz2lflldfbnb0rh7mpki99pss28vj9sh";
+      x86_64-linux  = "1idxlb14kspqvms9n1r3pc1ff4q4pj632433fm2dwiaslyvyv7kq";
+      x86_64-darwin = "0knjk01fliklv863l5dg1j3ps3pqf4gykya8p6ry97879p5pjvcr";
     };
 in
 stdenv.mkDerivation (rec {

--- a/pkgs/servers/search/elasticsearch/plugins.nix
+++ b/pkgs/servers/search/elasticsearch/plugins.nix
@@ -36,7 +36,7 @@ in {
     src = fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${version}.zip";
       sha256 =
-        if version == "7.5.1" then "0v6ynbk34g7pl9cwy8ga8bk1my18jb6pc3pqbjl8p93w38219vi6"
+        if version == "7.8.1" then "0fa2nkz9hak12bzjvla047318d9k6ggqjqbkqxnvqgw18gvs9mrg"
         else if version == "6.8.3" then "0vbaqyj0lfy3ijl1c9h92b0nh605h5mjs57bk2zhycdvbw5sx2lv"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -53,7 +53,7 @@ in {
     src = fetchurl {
       url = "https://github.com/vhyza/elasticsearch-${pluginName}/releases/download/v${version}/elasticsearch-${pluginName}-${version}-plugin.zip";
       sha256 =
-        if version == "7.5.1" then "0js8b9a9ma797448m3sy92qxbwziix8gkcka7hf17dqrb9k29v61"
+        if version == "7.8.1" then "17xq1mcfmc7msbxygmwzfxf6bhb1psxdlnh5vws1zpra75p1n9rz"
         else if version == "6.8.3" then "12bshvp01pp2lgwd0cn9l58axg8gdimsh4g9wfllxi1bdpv4cy53"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -70,7 +70,7 @@ in {
     src = fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${version}.zip";
       sha256 =
-        if version == "7.5.1" then "0znmbdf99bli4kvyb3vxr5x48yb6n64nl38gpa63iqsv3nlbi0hp"
+        if version == "7.8.1" then "1qjmrvbq37bpwqbr88xfbbwl2iym9crpphs1nlmi8wzivpa1p98v"
         else if version == "6.8.3" then "0ggdhf7w50bxsffmcznrjy14b578fps0f8arg3v54qvj94v9jc37"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -87,7 +87,7 @@ in {
     src = fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${version}.zip";
       sha256 =
-        if version == "7.5.1" then "09wl2bpng4xx384xns960rymnm64b5zn2cb1sp25n85pd0isp4p2"
+        if version == "7.8.1" then "0d2vnh75v4gxgpasl8wddmpjd9mncf8wv3la9l956r76dcfxvdfd"
         else if version == "6.8.3" then "0pmffz761dqjpvmkl7i7xsyw1iyyspqpddxp89rjsznfc9pak5im"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -104,7 +104,7 @@ in {
     src = fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${version}.zip";
       sha256 =
-        if version == "7.5.1" then "0hhwxkjlkw1yv5sp6pdn5k1y8bdv4mnmb6nby1z4367mig6rm8v9"
+        if version == "7.8.1" then "1j99lxjqnnlpr8n35ris0mqkyq4gravn2jw6fkpdxksx9s0vkh12"
         else if version == "6.8.3" then "0kfr4i2rcwinjn31xrc2piicasjanaqcgnbif9xc7lnak2nnzmll"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -121,7 +121,7 @@ in {
     src = fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${esVersion}.zip";
       sha256 =
-        if version == "7.5.1" then "1j1rgbha5lh0a02h55zqc5qn0mvvi16l2m5r8lmaswp97px056v9"
+        if version == "7.8.1" then "1ffaqrwif5q15jq240q1j4rj1nh04vq97nymjls7x2l936is24rb"
         else if version == "6.8.3" then "1mm6hj2m1db68n81rzsvlw6nisflr5ikzk5zv9nmk0z641n5vh1x"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -138,7 +138,7 @@ in {
     src = fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${esVersion}.zip";
       sha256 =
-        if version == "7.5.1" then "15g438zpxrcmsgddwmk3sccy92ha90cyq9c61kcw1q84wfi0a7jl"
+        if version == "7.8.1" then "055a5x91f20yf3q6rivj9md9hp27qgy6r9jmbf6ai6n6i3b7l8vs"
         else if version == "6.8.3" then "1s2klpvnhpkrk53p64zbga3b66czi7h1a13f58kfn2cn0zfavnbk"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };

--- a/pkgs/tools/misc/logstash/7.x.nix
+++ b/pkgs/tools/misc/logstash/7.x.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
     url = "https://artifacts.elastic.co/downloads/logstash/${name}.tar.gz";
     sha256 =
       if enableUnfree
-      then "01l6alwgsq6yf0z9d08i0hi8g708nph1vm78nl4xbpg8h964bybj"
-      else "0nlwgaw6rmhp5b68zpp1pzsjs30b0bjzdg8f7xy6rarpk338s8yb";
+      then "06wwl5miypf7gsnqg3k7w6mkjkaxz4zvp5057c7354pkdw7zn7i9"
+      else "0yfn5ibp91nnhr7zsk61xihq01cbrjmdn65j094zjqix9z13k02d";
   };
 
   dontBuild         = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3390,7 +3390,7 @@ in
   # The latest version used by elasticsearch, logstash, kibana and the the beats from elastic.
   # When updating make sure to update all plugins or they will break!
   elk6Version = "6.8.3";
-  elk7Version = "7.5.1";
+  elk7Version = "7.8.1";
 
   elasticsearch6 = callPackage ../servers/search/elasticsearch/6.x.nix {
     utillinux = utillinuxMinimal;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to a more recent version of the Elk stack in order to be able to load Kibana dashboards of parsedmarc (#92836).

*Known issues*: I am unable to locate a 7.8.1 compatible version of the search-guard plugin. There seems to be something called search-guard-suite but I am not sure whether this is the same. @offlinehacker you seem to have added it initially, can you provide some guidance?


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
