### PR TITLE
Revert "buildGoPackage: remove references in $out/libexec"

### DIFF
--- a/pkgs/development/go-packages/generic/default.nix
+++ b/pkgs/development/go-packages/generic/default.nix
@@ -212,7 +212,6 @@ let
 
     preFixup = preFixup + ''
       find $out/bin -type f -exec ${removeExpr removeReferences} '{}' + || true
-      find $out/libexec -type f -exec ${removeExpr removeReferences} '{}' + || true
     '';
 
     strictDeps = true;


### PR DESCRIPTION
This reverts commit b9ac86e7520adee0f9d18a700f8838fca9fe637a.

Added in #92140 for docker which already has this:

https://github.com/NixOS/nixpkgs/blob/22c23f4371843b51289786dae6af0628de4e0276/pkgs/applications/virtualization/docker/default.nix#L182-L186