### PR TITLE
dot-http: init at 0.2.0

### DIFF
--- a/pkgs/development/tools/dot-http/default.nix
+++ b/pkgs/development/tools/dot-http/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, rustPlatform, fetchFromGitHub, pkg-config, openssl, libiconv, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "dot-http";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "bayne";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1s2q4kdldhb5gd14g2h6vzrbjgbbbs9zp2dgmna0rhk1h4qv0mml";
+  };
+
+  cargoSha256 = "0an3hskq1k2j4gdn8wvhfb9pqsc34ibs5bv7sjznkp5jma6fdr9w";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    libiconv Security
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Text-based scriptable HTTP client";
+    homepage = "https://github.com/bayne/dot-http";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -985,6 +985,10 @@ in
 
   dpt-rp1-py = callPackage ../tools/misc/dpt-rp1-py { };
 
+  dot-http = callPackage ../development/tools/dot-http {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   doona = callPackage ../tools/security/doona { };
 
   ecdsautils = callPackage ../tools/security/ecdsautils { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
