### PR TITLE
tunefish: init at unstable 2020-08-13

### DIFF
--- a/pkgs/applications/audio/tunefish/default.nix
+++ b/pkgs/applications/audio/tunefish/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, pkg-config, python3
+, alsaLib, curl, freetype, gtk3, libGL, libX11, libXext, libXinerama, webkitgtk
+}:
+
+stdenv.mkDerivation {
+  pname = "tunefish";
+  version = "unstable-2020-08-13";
+
+  src = fetchFromGitHub {
+    owner = "jpcima";
+    repo = "tunefish";
+    rev = "b3d83cc66201619f6399500f6897fbeb1786d9ed";
+    fetchSubmodules = true;
+    sha256 = "0rjpq3s609fblzkvnc9729glcnfinmxljh0z8ldpzr245h367zxh";
+  };
+
+  nativeBuildInputs = [ pkg-config python3 ];
+  buildInputs = [ alsaLib curl freetype gtk3 libGL libX11 libXext libXinerama webkitgtk ];
+
+  postPatch = ''
+    patchShebangs src/tunefish4/generate-lv2-ttl.py
+  '';
+
+  makeFlags = [
+    "-C" "src/tunefish4/Builds/LinuxMakefile"
+    "CONFIG=Release"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib/lv2
+    cp -r src/tunefish4/Builds/LinuxMakefile/build/Tunefish4.lv2 $out/lib/lv2
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://tunefish-synth.com/";
+    description = "Virtual analog synthesizer LV2 plugin";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ orivej ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23340,6 +23340,10 @@ in
 
   tudu = callPackage ../applications/office/tudu { };
 
+  tunefish = callPackage ../applications/audio/tunefish {
+    stdenv = clangStdenv; # https://github.com/jpcima/tunefish/issues/4
+  };
+
   tut = callPackage ../applications/misc/tut { };
 
   tuxguitar = callPackage ../applications/editors/music/tuxguitar { };


### PR DESCRIPTION
###### Motivation for this change

A good sounding synth with thousand presets.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @magnetophon