### PR TITLE
nix-prefetch-github: v2.4 -> v3.0

### DIFF
--- a/pkgs/development/python-modules/nix-prefetch-github/default.nix
+++ b/pkgs/development/python-modules/nix-prefetch-github/default.nix
@@ -15,16 +15,12 @@
 
 buildPythonPackage rec {
   pname = "nix-prefetch-github";
-  version = "2.4";
+  version = "3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-PVB/cL0NVB5pHxRMjg8TLatvIvHjfCvaRWBanVHYT+E=";
+    sha256 = "sha256-EN+EbVXUaf+id5UsK4EBm/9k9FYaH79g08kblvW60XA=";
   };
-
-  # The tests for this package require nix and network access.  That's
-  # why we cannot execute them inside the building process.
-  doCheck = false;
 
   propagatedBuildInputs = [
     attrs
@@ -34,6 +30,9 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [ pytestCheckHook pytest-black pytestcov pytest-isort git ];
+  checkPhase = ''
+    pytest -m 'not network'
+  '';
 
   # latest version of isort will cause tests to fail
   # ignore tests which are impure


### PR DESCRIPTION
###### Motivation for this change

`nix-prefetch-github` got an update upstream.  This PR addresses the version discrepancy with `nixpkgs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
