### PR TITLE
python3Packages.tldextract: fix build

### DIFF
--- a/pkgs/development/python-modules/tldextract/default.nix
+++ b/pkgs/development/python-modules/tldextract/default.nix
@@ -1,10 +1,18 @@
-{ lib, fetchPypi, buildPythonPackage
-, requests, requests-file, idna, pytest
+{ lib
+, fetchPypi
+, buildPythonPackage
+, setuptools_scm
+, requests
+, requests-file
+, idna
+, pytest-mock
+, pytest-pylint
+, pytestCheckHook
 , responses
 }:
 
 buildPythonPackage rec {
-  pname   = "tldextract";
+  pname = "tldextract";
   version = "2.2.3";
 
   src = fetchPypi {
@@ -12,8 +20,21 @@ buildPythonPackage rec {
     sha256 = "ab0e38977a129c72729476d5f8c85a8e1f8e49e9202e1db8dca76e95da7be9a8";
   };
 
-  propagatedBuildInputs = [ requests requests-file idna ];
-  checkInputs = [ pytest responses ];
+  nativeBuildInputs = [ setuptools_scm ];
+
+  propagatedBuildInputs = [ idna requests requests-file ];
+
+  checkInputs = [ pytestCheckHook pytest-pylint pytest-mock responses ];
+
+  # Disable test that require network access.
+  disabledTests = [
+    "test_log_snapshot_diff"
+  ];
+
+  # Avoid ImportMismatchError.
+  preCheck = ''
+    cd tests
+  '';
 
   meta = {
     homepage = "https://github.com/john-kurkowski/tldextract";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Saw that the build of this derivation was broken.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).