### PR TITLE
aribb25: init at 0.2.7

### DIFF
--- a/pkgs/development/libraries/aribb25/default.nix
+++ b/pkgs/development/libraries/aribb25/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, fetchFromGitLab
+, fetchpatch
+, autoreconfHook
+, pkgconfig
+, pcsclite
+, PCSC
+}:
+
+stdenv.mkDerivation rec {
+  pname = "aribb25";
+  version = "0.2.7";
+
+  src = fetchFromGitLab {
+    domain = "code.videolan.org";
+    owner = "videolan";
+    repo = pname;
+    # rev = version; FIXME: uncomment in next release
+    rev = "c14938692b313b5ba953543fd94fd1cad0eeef18"; # 0.2.7 with build fixes
+    sha256 = "1kb9crfqib0npiyjk4zb63zqlzbhqm35nz8nafsvdjd71qbd2amp";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = if stdenv.isDarwin then [ PCSC ] else [ pcsclite ];
+
+  patches = let
+    url = pr: "https://code.videolan.org/videolan/${pname}/-/merge_requests/${pr}.patch";
+  in [
+    (fetchpatch {
+      name = "make-cli-pipes-work.patch";
+      url = url "3";
+      sha256 = "1sx4zb8c3hxbq81ykxijdl11bh1imw206qzx9319z35pyi7qdxjp";
+    })
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://code.videolan.org/videolan/aribb25";
+    description = "Sample implementation of the ARIB STD-B25 standard";
+    platforms = platforms.all;
+    license = licenses.isc;
+    maintainers = with maintainers; [ midchildan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11870,6 +11870,10 @@ in
 
   argp-standalone = callPackage ../development/libraries/argp-standalone {};
 
+  aribb25 = callPackage ../development/libraries/aribb25 {
+    inherit (darwin.apple_sdk.frameworks) PCSC;
+  };
+
   armadillo = callPackage ../development/libraries/armadillo {};
 
   arrayfire = callPackage ../development/libraries/arrayfire {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add aribb25, a sample implementation of the ARIB STD-B25 standard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
