### PR TITLE
cudnn: skip libcudnn_cnn_infer.so, instead of removing

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -32,19 +32,20 @@ stdenv.mkDerivation {
     mkdir -p $out
     cp -a include $out/include
     cp -a lib64 $out/lib64
-
-    ${lib.optionalString (lib.versionAtLeast version "8") ''
-      # patchelf fails on libcudnn_cnn_infer due to it being too big.
-      # I'm hoping it's not needed for most programs.
-      # (https://github.com/NixOS/patchelf/issues/222)
-      rm -f $out/lib64/libcudnn_cnn_infer*
-    ''}
   '';
 
   # Set RUNPATH so that libcuda in /run/opengl-driver(-32)/lib can be found.
   # See the explanation in addOpenGLRunpath.
   postFixup = ''
-    addOpenGLRunpath $out/lib/lib*.so
+    for lib in $out/lib/lib*.so; do
+      # patchelf fails on libcudnn_cnn_infer due to it being too big.
+      # Most programs will still get the RPATH since they link to
+      # other things.
+      # (https://github.com/NixOS/patchelf/issues/222)
+      if [ "$(basename $lib)" != libcudnn_cnn_infer.so ]; then
+        addOpenGLRunpath $lib
+      fi
+    done
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
This is needed to build the CUDNN samples, so we should make sure it
winds up in $out/lib. The library is too big to support patchelf, so
we need to skip it. Most programs will still get the opengl path
because it also links to other libraries.
