### PR TITLE
murmur: support building with grpc

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -6,6 +6,7 @@
 , speechdSupport ? false, speechd ? null
 , pulseSupport ? false, libpulseaudio ? null
 , iceSupport ? false, zeroc-ice ? null
+, grpcSupport ? false, grpc ? null, c-ares ? null, abseil-cpp ? null, which ? null
 , nixosTests
 }:
 
@@ -13,6 +14,7 @@ assert jackSupport -> libjack2 != null;
 assert speechdSupport -> speechd != null;
 assert pulseSupport -> libpulseaudio != null;
 assert iceSupport -> zeroc-ice != null;
+assert grpcSupport -> (grpc != null && c-ares != null && abseil-cpp != null && which != null);
 
 with stdenv.lib;
 let
@@ -117,9 +119,12 @@ let
 
     configureFlags = [
       "CONFIG+=no-client"
-    ] ++ optional (!iceSupport) "CONFIG+=no-ice";
+    ] ++ optional (!iceSupport) "CONFIG+=no-ice"
+      ++ optional grpcSupport "CONFIG+=grpc";
 
-    buildInputs = [ libcap ] ++ optional iceSupport zeroc-ice;
+    buildInputs = [ libcap ]
+      ++ optional iceSupport zeroc-ice
+      ++ optionals grpcSupport [ grpc c-ares abseil-cpp which ];
 
     installPhase = ''
       # bin stuff

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21837,6 +21837,7 @@ in
       avahi = avahi-compat;
       pulseSupport = config.pulseaudio or false;
       iceSupport = config.murmur.iceSupport or true;
+      grpcSupport = config.murmur.grpcSupport or true;
     }).murmur;
 
   mumble = (callPackages ../applications/networking/mumble {


### PR DESCRIPTION
###### Motivation for this change
Murmur supports gRPC since 1.3.0, but the previous versions had some pretty major bugs. With 1.3.2 they all seem to have been ironed out, so let's enable it.

There's a few tools out there already using it, notably [murmur-cli](https://github.com/layeh/murmur-cli).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
