### PR TITLE
pythonPackages.(datasette, mergedeep, asgi-csrf, starlette, httpx, httpcore): upgrades & new additions

### DIFF
--- a/pkgs/development/python-modules/asgi-csrf/default.nix
+++ b/pkgs/development/python-modules/asgi-csrf/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, isPy27, fetchFromGitHub, itsdangerous, python-multipart
+, pytest, starlette, httpx, pytest-asyncio }:
+
+buildPythonPackage rec {
+  version = "0.7";
+  pname = "asgi-csrf";
+  disabled = isPy27;
+
+  # PyPI tarball doesn't include tests directory
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = pname;
+    rev = version;
+    sha256 = "1vf4lh007790836cp3hd6wf8wsgj045dcg0w1cm335p08zz6j4k7";
+  };
+
+  propagatedBuildInputs = [ itsdangerous python-multipart ];
+
+  checkInputs = [ pytest starlette httpx pytest-asyncio ];
+  checkPhase = ''
+    pytest test_asgi_csrf.py
+  '';
+  pythonImportsCheck = [ "asgi_csrf" ];
+
+  meta = with stdenv.lib; {
+    description = "ASGI middleware for protecting against CSRF attacks";
+    license = licenses.asl20;
+    homepage = "https://github.com/simonw/asgi-csrf";
+    maintainers = [ maintainers.ris ];
+  };
+}

--- a/pkgs/development/python-modules/datasette/default.nix
+++ b/pkgs/development/python-modules/datasette/default.nix
@@ -2,19 +2,22 @@
 , buildPythonPackage
 , fetchFromGitHub
 , aiofiles
+, asgi-csrf
 , click
 , click-default-group
 , janus
 , jinja2
 , hupper
+, mergedeep
 , pint
 , pluggy
+, python-baseconv
+, pyyaml
 , uvicorn
 # Check Inputs
 , pytestCheckHook
 , pytestrunner
 , pytest-asyncio
-, black
 , aiohttp
 , beautifulsoup4
 , asgiref
@@ -23,26 +26,30 @@
 
 buildPythonPackage rec {
   pname = "datasette";
-  version = "0.39";
+  version = "0.46";
 
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "datasette";
     rev = version;
-    sha256 = "07d46512bc9sdan9lv39sf1bwlf7vf1bfhcsm825vk7sv7g9kczd";
+    sha256 = "0g4dfq5ykifa9628cb4i7gvx98p8hvb99gzfxk3bkvq1v9p4kcqq";
   };
 
   nativeBuildInputs = [ pytestrunner ];
 
   propagatedBuildInputs = [
     aiofiles
+    asgi-csrf
     click
     click-default-group
     janus
     jinja2
     hupper
+    mergedeep
     pint
     pluggy
+    python-baseconv
+    pyyaml
     uvicorn
     setuptools
   ];
@@ -52,7 +59,6 @@ buildPythonPackage rec {
     pytest-asyncio
     aiohttp
     beautifulsoup4
-    black
     asgiref
   ];
 
@@ -60,22 +66,17 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace "click~=7.1.1" "click" \
       --replace "click-default-group~=1.2.2" "click-default-group" \
-      --replace "Jinja2~=2.10.3" "Jinja2" \
       --replace "hupper~=1.9" "hupper" \
       --replace "pint~=0.9" "pint" \
-      --replace "pluggy~=0.13.0" "pint" \
+      --replace "pluggy~=0.13.0" "pluggy" \
       --replace "uvicorn~=0.11" "uvicorn" \
-      --replace "aiofiles~=0.4.0" "aiofiles" \
-      --replace "janus~=0.4.0" "janus" \
       --replace "PyYAML~=5.3" "PyYAML"
   '';
 
-  # many tests require network access
+  # test_html is very slow
   # test_black fails on darwin
   dontUseSetuptoolsCheck = true;
   pytestFlagsArray = [
-    "--ignore=tests/test_api.py"
-    "--ignore=tests/test_csv.py"
     "--ignore=tests/test_html.py"
     "--ignore=tests/test_docs.py"
     "--ignore=tests/test_black.py"
@@ -84,6 +85,7 @@ buildPythonPackage rec {
     "facet"
     "_invalid_database" # checks error message when connecting to invalid database
   ];
+  pythonImportsCheck = [ "datasette" ];
 
   meta = with lib; {
     description = "An instant JSON API for your SQLite databases";

--- a/pkgs/development/python-modules/httpcore/default.nix
+++ b/pkgs/development/python-modules/httpcore/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, h11
+, sniffio
+}:
+
+buildPythonPackage rec {
+  pname = "httpcore";
+  version = "0.10.2";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "encode";
+    repo = pname;
+    rev = version;
+    sha256 = "00gn8nfv814rg6fj7xv97mrra3fvx6fzjcgx9y051ihm6hxljdsi";
+  };
+
+  propagatedBuildInputs = [ h11 sniffio ];
+
+  # tests require pythonic access to mitmproxy, which isn't (yet?) packaged as
+  # a pythonPackage.
+  doCheck = false;
+  pythonImportsCheck = [ "httpcore" ];
+
+  meta = with stdenv.lib; {
+    description = "A minimal HTTP client";
+    homepage = "https://github.com/encode/httpcore";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.ris ];
+  };
+}

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -2,64 +2,60 @@
 , buildPythonPackage
 , fetchFromGitHub
 , certifi
-, hstspreload
 , chardet
 , h11
 , h2
+, httpcore
 , idna
 , rfc3986
 , sniffio
 , isPy27
 , pytest
+, pytest-asyncio
+, pytest-trio
 , pytestcov
 , trustme
 , uvicorn
-, trio
 , brotli
-, urllib3
 }:
 
 buildPythonPackage rec {
   pname = "httpx";
-  version = "0.12.1";
+  version = "0.14.2";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "1nrp4h1ppb5vll81fzxmks82p0hxcil9f3mja3dgya511kc703h6";
+    sha256 = "08b6k5g8car3bic90aw4ysb2zvsa5nm8qk3hk4dgamllnnxzl5br";
   };
 
   propagatedBuildInputs = [
     certifi
-    hstspreload
     chardet
     h11
     h2
+    httpcore
     idna
     rfc3986
     sniffio
-    urllib3
   ];
 
   checkInputs = [
     pytest
+    pytest-asyncio
+    pytest-trio
     pytestcov
     trustme
     uvicorn
-    trio
     brotli
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-          --replace "h11==0.8.*" "h11"
-  '';
-
   checkPhase = ''
-    PYTHONPATH=.:$PYTHONPATH pytest
+    PYTHONPATH=.:$PYTHONPATH pytest -k 'not (test_connect_timeout or test_elapsed_timer)'
   '';
+  pythonImportsCheck = [ "httpx" ];
 
   meta = with lib; {
     description = "The next generation HTTP client";

--- a/pkgs/development/python-modules/mergedeep/default.nix
+++ b/pkgs/development/python-modules/mergedeep/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, isPy27, fetchFromGitHub, pytest }:
+
+buildPythonPackage rec {
+  pname = "mergedeep";
+  version = "1.3.0";
+  disabled = isPy27;
+
+  # PyPI tarball doesn't include tests directory
+  src = fetchFromGitHub {
+    owner = "clarketm";
+    repo = "mergedeep";
+    rev = "v${version}";
+    sha256 = "1a0y26a04limiggjwqyyqpryxiylbqya74nq1bij75zhz42sa02b";
+  };
+
+  checkInputs = [ pytest ];
+  checkPhase = "pytest";
+  pythonImportsCheck = [ "mergedeep" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/clarketm/mergedeep";
+    description = "A deep merge function for python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -21,19 +21,14 @@
 buildPythonPackage rec {
   pname = "starlette";
 
-  # This is not the latest version of Starlette, however, later
-  # versions of Starlette break FastAPI due to
-  # https://github.com/tiangolo/fastapi/issues/683. Please update when
-  # possible. FastAPI is currently Starlette's only dependent.
-
-  version = "0.13.6";
+  version = "0.13.8";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "08d1d4qdwhi1xxag4am5ijingdyn0mbyqajs9ql5shxnybyjv321";
+    sha256 = "11i0yd8cqwscixajl734g11vf8pghki11c81chzfh8ifmj6mf9jk";
   };
 
   propagatedBuildInputs = [
@@ -57,6 +52,7 @@ buildPythonPackage rec {
   checkPhase = ''
     pytest --ignore=tests/test_graphql.py
   '';
+  pythonImportsCheck = [ "starlette" ];
 
   meta = with lib; {
     homepage = "https://www.starlette.io/";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3589,6 +3589,8 @@ in {
 
   mercurial = disabledIf (!isPy3k) (toPythonModule (pkgs.mercurial.override { python3Packages = self; }));
 
+  mergedeep = callPackage ../development/python-modules/mergedeep { };
+
   merkletools = callPackage ../development/python-modules/merkletools { };
 
   mesa = callPackage ../development/python-modules/mesa { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -377,6 +377,8 @@ in {
   else
     callPackage ../development/python-modules/ase { };
 
+  asgi-csrf = callPackage ../development/python-modules/asgi-csrf { };
+
   asgiref = callPackage ../development/python-modules/asgiref { };
 
   asn1ate = callPackage ../development/python-modules/asn1ate { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2681,6 +2681,8 @@ in {
 
   httpbin = callPackage ../development/python-modules/httpbin { };
 
+  httpcore = callPackage ../development/python-modules/httpcore { };
+
   http-ece = callPackage ../development/python-modules/http-ece { };
 
   httplib2 = callPackage ../development/python-modules/httplib2 { };


### PR DESCRIPTION
###### Motivation for this change
This started with me upgrading `datasette` from 0.39 -> 0.46, in an attempt to mitigate https://github.com/simonw/datasette/security/advisories/GHSA-q6j3-c4wc-63vw.

This required the addition of `mergedeep` and `asgi-csrf`.

The addition of `asgi-csrf` required a bump of `starlette` and `httpx` to get the tests to pass.

The bump of `httpx` required the addition of `httpcore`.

It's been a fun few evenings.

In the bumped packages I also performed a few cleanups, looking for no-longer-necessary dependencies, removing outdated comments etc.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
