### PR TITLE
gocryptfs: 1.7.1 -> 1.8.0

### DIFF
--- a/pkgs/tools/filesystems/gocryptfs/default.nix
+++ b/pkgs/tools/filesystems/gocryptfs/default.nix
@@ -8,7 +8,7 @@ let
 in
 buildGoPackage rec {
   pname = "gocryptfs";
-  version = "1.7.1";
+  version = "1.8.0";
 
   goPackagePath = "github.com/rfjakob/gocryptfs";
 
@@ -19,7 +19,7 @@ buildGoPackage rec {
     owner = "rfjakob";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1zhzhvjhvi6xzib985bsnj9yzp4zsnm91m1679nbab6vm3kanq06";
+    sha256 = "1acalwrr5xqhpqca3gypj0s68w6vpckxmg5z5gfgh8wx6nqx4aw9";
   };
 
   postPatch = "rm -r tests";


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
