### PR TITLE
gonic: init at 0.11.0

### DIFF
--- a/pkgs/servers/gonic/default.nix
+++ b/pkgs/servers/gonic/default.nix
@@ -1,0 +1,59 @@
+{ lib, buildGoPackage, fetchFromGitHub
+, pkg-config, taglib, alsaLib
+
+# Disable on-the-fly transcoding,
+# removing the dependency on ffmpeg.
+# The server will (as of 0.11.0) gracefully fall back
+# to the original file, but if transcoding is configured
+# that takes a while. So best to disable all transcoding
+# in the configuration if you disable transcodingSupport.
+, transcodingSupport ? true, ffmpeg
+
+# udpater
+, writers, vgo2nix }:
+
+assert transcodingSupport -> ffmpeg != null;
+
+let
+  # update these, then run `updateScript` to update dependencies
+  version = "0.11.0";
+  rev = "056fb54a703ef5b5194ce112cbbdd8fb53dbb1ea";
+  sha256 = "0hd794wrz29nh89lfnq67w1rc23sg085rqf1agwlgpqycns2djl9";
+
+  src = fetchFromGitHub {
+    owner = "sentriz";
+    repo = "gonic";
+    inherit rev sha256;
+  };
+
+in
+buildGoPackage {
+  pname = "gonic-${version}";
+  inherit version src;
+  goPackagePath = "go.senan.xyz/gonic";
+  goDeps = ./deps.nix;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ taglib alsaLib ];
+
+  postPatch = lib.optionalString transcodingSupport ''
+    substituteInPlace \
+       server/encode/encode.go \
+      --replace \
+        'ffmpegPath = "/usr/bin/ffmpeg"' \
+        'ffmpegPath = "${ffmpeg}/bin/ffmpeg"' \
+  '';
+
+  passthru.updateScript = writers.writeDash "update-gonic" ''
+    ${vgo2nix}/bin/vgo2nix \
+      -dir ${src} \
+      -outfile ${lib.escapeShellArg (toString ./deps.nix)}
+  '';
+
+  meta = {
+    homepage = "https://github.com/sentriz/gonic";
+    description = "Music streaming server / subsonic server API implementation";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ Profpatsch ];
+  };
+}

--- a/pkgs/servers/gonic/deps.nix
+++ b/pkgs/servers/gonic/deps.nix
@@ -1,0 +1,795 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/google-cloud-go";
+      rev = "v0.33.1";
+      sha256 = "1xs487sqajpvnhlwp130sfaajyinhxxq2yvmv2533mwf0zhcpz6v";
+    };
+  }
+  {
+    goPackagePath = "dmitri.shuralyov.com/gpu/mtl";
+    fetch = {
+      type = "git";
+      url = "https://dmitri.shuralyov.com/gpu/mtl";
+      rev = "666a987793e9";
+      sha256 = "1isd03hgiwcf2ld1rlp0plrnfz7r4i7c5q4kb6hkcd22axnmrv0z";
+    };
+  }
+  {
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "v0.3.1";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
+    };
+  }
+  {
+    goPackagePath = "github.com/BurntSushi/xgb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/xgb";
+      rev = "27f122750802";
+      sha256 = "18lp2x8f5bljvlz0r7xn744f0c9rywjsb9ifiszqqdcpwhsa0kvj";
+    };
+  }
+  {
+    goPackagePath = "github.com/Masterminds/goutils";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Masterminds/goutils";
+      rev = "v1.1.0";
+      sha256 = "180px47gj936qyk5bkv5mbbgiil9abdjq6kwkf7sq70vyi9mcfiq";
+    };
+  }
+  {
+    goPackagePath = "github.com/Masterminds/semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Masterminds/semver";
+      rev = "v1.5.0";
+      sha256 = "1i169xscsxsh8lsw8bz2apnsqixld37xdnfh36i30xy5wnf0iwfx";
+    };
+  }
+  {
+    goPackagePath = "github.com/Masterminds/sprig";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Masterminds/sprig";
+      rev = "v2.22.0";
+      sha256 = "09dzwhj4zh3p6f1jhyic16n4qdnvpamz7hyk9fycpm4b1jfq63gd";
+    };
+  }
+  {
+    goPackagePath = "github.com/OneOfOne/xxhash";
+    fetch = {
+      type = "git";
+      url = "https://github.com/OneOfOne/xxhash";
+      rev = "v1.2.2";
+      sha256 = "1mjfhrwhvxa48rycjnqpqzm521i38h1hdyz6pdwmhd7xb8j6gwi6";
+    };
+  }
+  {
+    goPackagePath = "github.com/cespare/xxhash";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cespare/xxhash";
+      rev = "v1.1.0";
+      sha256 = "1qyzlcdcayavfazvi03izx83fvip8h36kis44zr2sg7xf6sx6l4x";
+    };
+  }
+  {
+    goPackagePath = "github.com/d4l3k/messagediff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/d4l3k/messagediff";
+      rev = "7e0a312ae40b";
+      sha256 = "1ab2gm7ys33rs84fjzqcb7b4jy2rr1a0w5a9kakfaf80wd0rjrah";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath = "github.com/denisenkom/go-mssqldb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/denisenkom/go-mssqldb";
+      rev = "732737034ffd";
+      sha256 = "0k1inn33lbfj97d5ir3k5gffjcpb39kairq91jfrz6pnbq0w3zlf";
+    };
+  }
+  {
+    goPackagePath = "github.com/disintegration/imaging";
+    fetch = {
+      type = "git";
+      url = "https://github.com/disintegration/imaging";
+      rev = "v1.6.2";
+      sha256 = "1sl201nmk601h0aii4234sycn4v2b0rjxf8yhrnik4yjzd68q9x5";
+    };
+  }
+  {
+    goPackagePath = "github.com/dustin/go-humanize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dustin/go-humanize";
+      rev = "v1.0.0";
+      sha256 = "1kqf1kavdyvjk7f8kx62pnm7fbypn9z1vbf8v2qdh3y7z7a0cbl3";
+    };
+  }
+  {
+    goPackagePath = "github.com/erikstmartin/go-testdb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/erikstmartin/go-testdb";
+      rev = "8d10e4a1bae5";
+      sha256 = "1fhrqcpv8x74qwxx9gpnhgqbz5wkp2bnsq92w418l1fnrgh4ppmq";
+    };
+  }
+  {
+    goPackagePath = "github.com/faiface/beep";
+    fetch = {
+      type = "git";
+      url = "https://github.com/faiface/beep";
+      rev = "v1.0.2";
+      sha256 = "07j0k0ynw1q8f7fzsan4kvfmdlda11583sck66hxfsk9zbp8vpxv";
+    };
+  }
+  {
+    goPackagePath = "github.com/gdamore/encoding";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gdamore/encoding";
+      rev = "v1.0.0";
+      sha256 = "1vmm5zll92i2fm4ajqx0gyx0p9j36496x5nabi3y0x7h0inv0pk9";
+    };
+  }
+  {
+    goPackagePath = "github.com/gdamore/tcell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gdamore/tcell";
+      rev = "v1.1.1";
+      sha256 = "0il2nnxp2cqiy73m49215dnf9in3vd25ji8qxbmq87c5qy7i1q9d";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-audio/audio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-audio/audio";
+      rev = "v1.0.0";
+      sha256 = "05ai13yc8wwk2zlk9br62lh4z9hs1q685l7ij618bknf449vjsf3";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-audio/riff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-audio/riff";
+      rev = "v1.0.0";
+      sha256 = "0wg3p3gsad1rql7bzx7pwwsyd00a5gdb8f1h7zfr7hlqja5skwb4";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-audio/wav";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-audio/wav";
+      rev = "v1.0.0";
+      sha256 = "058mgc5ahjibnsqayk3k75l04gg9mv27bpmj79jyrya3kaczpamk";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-gl/glfw";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-gl/glfw";
+      rev = "6f7a984d4dc4";
+      sha256 = "1nyv7h08qf4dp8w9pmcnrc6vv9bkwj8fil6pz0mkbss5hf4i8xcq";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-sql-driver/mysql";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-sql-driver/mysql";
+      rev = "v1.5.0";
+      sha256 = "11x0m9yf3kdnf6981182r824psgxwfaqhn3x3in4yiidp0w0hk3v";
+    };
+  }
+  {
+    goPackagePath = "github.com/gofrs/uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gofrs/uuid";
+      rev = "v3.2.0";
+      sha256 = "1q63mp7bznhfgyw133c0wc0hpcj1cq9bcf7w1f8r6inkcrils1fz";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang-sql/civil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang-sql/civil";
+      rev = "cb61b32ac6fe";
+      sha256 = "0yadfbvi0w06lg3sxw0daji02jxd3vv2in26yfmwpl4vd4vm9zay";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.2.0";
+      sha256 = "0kf4b59rcbb1cchfny2dm9jyznp8ri2hsb14n8iak1q8986xa0ab";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev = "v0.2.0";
+      sha256 = "1fbv0x27k9sn8svafc0hjwsnckk864lv4yi7bvzrxvmd3d5hskds";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/uuid";
+      rev = "v1.1.1";
+      sha256 = "0hfxcf9frkb57k6q0rdkrmnfs78ms21r1qfk9fhlqga2yh5xg8zb";
+    };
+  }
+  {
+    goPackagePath = "github.com/gopherjs/gopherjs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gopherjs/gopherjs";
+      rev = "0210a2f0f73c";
+      sha256 = "1n80xjfc1dkxs8h8mkpw83n89wi5n7hzc3rxhwjs76rkxpq3rc9j";
+    };
+  }
+  {
+    goPackagePath = "github.com/gopherjs/gopherwasm";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gopherjs/gopherwasm";
+      rev = "v1.0.0";
+      sha256 = "0q20il68gqnrc0s8jndc8mw1ynln60a4xy1lrqakzmp8whyilwri";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/context";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/context";
+      rev = "v1.1.1";
+      sha256 = "03p4hn87vcmfih0p9w663qbx9lpsf7i7j3lc7yl7n84la3yz63m4";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/mux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/mux";
+      rev = "v1.7.4";
+      sha256 = "1d0sy1paa055ic84sp3766s9pa24q008hf77dc842vrgvn8p3wmh";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/securecookie";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/securecookie";
+      rev = "v1.1.1";
+      sha256 = "16bqimpxs9vj5n59vm04y04v665l7jh0sddxn787pfafyxcmh410";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/sessions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/sessions";
+      rev = "v1.2.0";
+      sha256 = "1kz6ydgp7vamhl2ak02hvzp2yv1dbfbwzsdxn6271lyzzdvz4pp1";
+    };
+  }
+  {
+    goPackagePath = "github.com/hajimehoshi/go-mp3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hajimehoshi/go-mp3";
+      rev = "v0.2.1";
+      sha256 = "0dxqpyj4xbq570if25g5wqbbp6frhq733h2ny3b2z3z8hw4q7vgg";
+    };
+  }
+  {
+    goPackagePath = "github.com/hajimehoshi/oto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hajimehoshi/oto";
+      rev = "v0.6.1";
+      sha256 = "1k3c0y8gdxn2c8fqc8rbjrn7nbbbhii3krma267jg01qq2zpsm8h";
+    };
+  }
+  {
+    goPackagePath = "github.com/huandu/xstrings";
+    fetch = {
+      type = "git";
+      url = "https://github.com/huandu/xstrings";
+      rev = "v1.3.1";
+      sha256 = "0j5vsyjxclk7g7vfr3mfybbimywf3khr8yx07dsdcm1zjwb092iy";
+    };
+  }
+  {
+    goPackagePath = "github.com/icza/bitio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/icza/bitio";
+      rev = "v1.0.0";
+      sha256 = "1c4ps4a9khx2bqp6v0p7b7l0s0gly3vj8rkh816vznj4mdlgk76w";
+    };
+  }
+  {
+    goPackagePath = "github.com/icza/mighty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/icza/mighty";
+      rev = "cfd07d671de6";
+      sha256 = "09prb460wqg72s753g3a9rm0ph60hp83najj0lx9ifp1lixnfb3d";
+    };
+  }
+  {
+    goPackagePath = "github.com/imdario/mergo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/imdario/mergo";
+      rev = "v0.3.9";
+      sha256 = "042v7bzx575isa4pr868hrlv085qxpg8qi4m04jnkh5vbq4hvs90";
+    };
+  }
+  {
+    goPackagePath = "github.com/jfreymuth/oggvorbis";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jfreymuth/oggvorbis";
+      rev = "v1.0.0";
+      sha256 = "0c0r63sp4q8bl8vvgayr98m0fsscl1f65cd2h7i4cr1awg6r6l6a";
+    };
+  }
+  {
+    goPackagePath = "github.com/jfreymuth/vorbis";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jfreymuth/vorbis";
+      rev = "v1.0.0";
+      sha256 = "16gl1lwagiqw6ib48zsl4zpv1dmykz7fzhxc65vpcdipx2byhi7a";
+    };
+  }
+  {
+    goPackagePath = "github.com/jinzhu/gorm";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jinzhu/gorm";
+      rev = "v1.9.12";
+      sha256 = "06d25jvrqvp1bd4k7mh9gsk414d2vhpr049qvj46yx21hyv9d6v3";
+    };
+  }
+  {
+    goPackagePath = "github.com/jinzhu/inflection";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jinzhu/inflection";
+      rev = "v1.0.0";
+      sha256 = "165i20d11s03771gi43skl66salxj36212r25fbs0cgr4qgfj7fy";
+    };
+  }
+  {
+    goPackagePath = "github.com/jinzhu/now";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jinzhu/now";
+      rev = "v1.0.1";
+      sha256 = "1b4gyw01b3rq3js43n0wqb1k2iymb2mnpdv7vapjs0lsbm4g5q1p";
+    };
+  }
+  {
+    goPackagePath = "github.com/joho/godotenv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/joho/godotenv";
+      rev = "v1.3.0";
+      sha256 = "0ri8if0pc3x6jg4c3i8wr58xyfpxkwmcjk3rp8gb398a1aa3gpjm";
+    };
+  }
+  {
+    goPackagePath = "github.com/josephburnett/jd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/josephburnett/jd";
+      rev = "aa1a7c66b42f";
+      sha256 = "0yjdnifwxhdgzcw4jkal3f69sgcjrdiscd5wg45d83zfrsqbb34c";
+    };
+  }
+  {
+    goPackagePath = "github.com/karrick/godirwalk";
+    fetch = {
+      type = "git";
+      url = "https://github.com/karrick/godirwalk";
+      rev = "v1.15.6";
+      sha256 = "0i8202kcihz2hvqp7zzbla5p9x2ljpbjg5zy5dy3x0capz0ina3c";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pretty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pretty";
+      rev = "v0.1.0";
+      sha256 = "18m4pwg2abd0j9cn5v3k2ksk9ig4vlwxmlw9rrglanziv9l967qp";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pty";
+      rev = "v1.1.1";
+      sha256 = "0383f0mb9kqjvncqrfpidsf8y6ns5zlrc91c6a74xpyxjwvzl2y6";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/text";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/text";
+      rev = "v0.1.0";
+      sha256 = "1gm5bsl01apvc84bw06hasawyqm4q84vx1pm32wr9jnd7a8vjgj1";
+    };
+  }
+  {
+    goPackagePath = "github.com/lib/pq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lib/pq";
+      rev = "v1.3.0";
+      sha256 = "0bfravwqyj7z6v4lhsibbmgp7lajdydy4ij6c81g8hv0067x2mqw";
+    };
+  }
+  {
+    goPackagePath = "github.com/lucasb-eyer/go-colorful";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lucasb-eyer/go-colorful";
+      rev = "12d3b2882a08";
+      sha256 = "1w95axfn1a6rz31xrks77ingr9mdkqyr7mh0glv664kz1wg2h0gw";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev = "v0.0.4";
+      sha256 = "00b3ssm7wiqln3k54z2wcnxr3k3c7m1ybyhb9h8ixzbzspld0qzs";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-sqlite3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-sqlite3";
+      rev = "v2.0.3";
+      sha256 = "0gn4dgvwmbf8gmhn5nzpwixc39g8mkp3n8lhyjgvhvsl72llcdzv";
+    };
+  }
+  {
+    goPackagePath = "github.com/mewkiz/flac";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mewkiz/flac";
+      rev = "v1.0.6";
+      sha256 = "19083pfc6wxkb45s61di9a542jslcgkzif5z3qjymy085w4aizzx";
+    };
+  }
+  {
+    goPackagePath = "github.com/mewkiz/pkg";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mewkiz/pkg";
+      rev = "f6b5e26764c3";
+      sha256 = "0djxw953sp2cwqybjxsfrsfma5yjn8n1l19g8yrd629cb6r1ghq2";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/copystructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/copystructure";
+      rev = "v1.0.0";
+      sha256 = "05njg92w1088v4yl0js0zdrpfq6k37i9j14mxkr3p90p5yd9rrrr";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-wordwrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-wordwrap";
+      rev = "v1.0.0";
+      sha256 = "1jffbwcr3nnq6c12c5856bwzv2nxjzqk3jwgvxkwi1xhpd2by0bf";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/reflectwalk";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/reflectwalk";
+      rev = "v1.0.1";
+      sha256 = "0pa6a3nhzwv5s5yqcmsmsfhdp5ggxsg2wa86f3akawxrhrkjarnx";
+    };
+  }
+  {
+    goPackagePath = "github.com/nicksellen/audiotags";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nicksellen/audiotags";
+      rev = "94015fa599bd";
+      sha256 = "1817vw2j1lnk4y3925cszmkvwzsdcmgccrcdqyq39jqpwawl2c0j";
+    };
+  }
+  {
+    goPackagePath = "github.com/oklog/run";
+    fetch = {
+      type = "git";
+      url = "https://github.com/oklog/run";
+      rev = "v1.1.0";
+      sha256 = "0r55p3kgdkgw55i33lqvvvl60mjp92mhd1170m980sw98z9150jk";
+    };
+  }
+  {
+    goPackagePath = "github.com/oxtoacart/bpool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/oxtoacart/bpool";
+      rev = "03653db5a59c";
+      sha256 = "1crdgm5w6kvcnvdglrrnrfkh5h60ldafwvrv00q97lz3790kgb15";
+    };
+  }
+  {
+    goPackagePath = "github.com/pelletier/go-toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-toml";
+      rev = "v1.6.0";
+      sha256 = "0l2830pi64fg0bdsyd5afkbw0p7879pppzdqqk3c7vjrjfmi5xbq";
+    };
+  }
+  {
+    goPackagePath = "github.com/peterbourgon/ff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/peterbourgon/ff";
+      rev = "v1.7.0";
+      sha256 = "17msscfi4pfdih1w3sq0wsw6246a30fckga9kvjpzwva6jni0466";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "v0.9.1";
+      sha256 = "1761pybhc2kqr6v5fm8faj08x9bql8427yqg6vnfv6nhrasx1mwq";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/rainycape/unidecode";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rainycape/unidecode";
+      rev = "cb7f23ec59be";
+      sha256 = "1wvzdijd640blwkgmw6h09frkfa04kcpdq87n2zh2ymj1dzla5v5";
+    };
+  }
+  {
+    goPackagePath = "github.com/spaolacci/murmur3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spaolacci/murmur3";
+      rev = "f09979ecbc72";
+      sha256 = "1lv3zyz3jy2d76bhvvs8svygx66606iygdvwy5cwc0p5z8yghq25";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.1.0";
+      sha256 = "19ynspzjdynbi85xw06mh8ad5j0qa1vryvxjgvbnyrr8rbm4vd8w";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.3.0";
+      sha256 = "0wjchp2c8xbgcbbq32w3kvblk6q6yn533g78nxl6iskq6y95lxsy";
+    };
+  }
+  {
+    goPackagePath = "github.com/wader/gormstore";
+    fetch = {
+      type = "git";
+      url = "https://github.com/wader/gormstore";
+      rev = "65a111a20c23";
+      sha256 = "0dnylv4gdqsizll7b07nivv6chanqm0014yhqg6gcjccns6bl9bm";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "06a226fb4e37";
+      sha256 = "0fdig6jx81g7a44dnxggibl909wchsj4nakmmhhz7db36sl0d7m5";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/exp";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/exp";
+      rev = "00229845015e";
+      sha256 = "0b0f05vbxzbgaaawxqns2m9qbvkfam1ylq8c8yhv7h6jnk2afaff";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/image";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/image";
+      rev = "33d19683fad8";
+      sha256 = "16qw6s9qlv84x98s9dib90y97x8bli3msaqw8kz498dbnbyx59zk";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/mobile";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/mobile";
+      rev = "4c31acba0007";
+      sha256 = "0k42pn6fq886k9hn85wbgg4h4y1myj7niw0746sn50zfbrmy3s2c";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/mod";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/mod";
+      rev = "331c550502dd";
+      sha256 = "0942gzs6mlsjal4drjmm8gr54pj1cdhsl9mnj3ygm200mf3fj6pi";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "3b0461eec859";
+      sha256 = "0l00c8l0a8xnv6qdpwfzxxsr58jggacgzdrwiprrfx2xqm37b6d5";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "112230192c58";
+      sha256 = "05i2k43j2d0llq768hg5pf3hb2yhfzp9la1w5wp0rsnnzblr0lfn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "fe76b779f299";
+      sha256 = "0g6j3n9fdv1a2lp2i8wbaaya85yrbfx3ns6iq1s7l2ayhxxmgh6b";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "b753a1ba74fa";
+      sha256 = "1xyzswbz9cx0bns2n75fw9pbm82dk9dj2il9iknmryyxvci9n5zv";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/xerrors";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/xerrors";
+      rev = "1b5146add898";
+      sha256 = "0w2akj91krxjag0xdhsg78470888nicc5ismc2ap9jqpss6v1zih";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev = "v1.4.0";
+      sha256 = "06zl7w4sxgdq2pl94wy9ncii6h0z3szl4xpqds0sv3b3wbdlhbnn";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/DATA-DOG/go-sqlmock.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/DATA-DOG/go-sqlmock.v1";
+      rev = "v1.3.0";
+      sha256 = "1684d6ima6638xwvr743kd7j5mpqq0vspcw9ai67bnb7m722qqqv";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "788fd7840127";
+      sha256 = "0v3bim0j375z81zrpr5qv42knqs0y2qv2vkjiqi5axvb78slki1a";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/gormigrate.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/gormigrate.v1";
+      rev = "v1.6.0";
+      sha256 = "03304vh58i5gxchrxy2v91bjdfgp7849jarmlanz3gaa2r574fmf";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.4";
+      sha256 = "11bwj757wi8kdrcnlgfqb8vv2d2xdhlghmyagd19i62khrkchsg2";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20718,6 +20718,8 @@ in
 
   gollum = callPackage ../applications/misc/gollum { };
 
+  gonic = callPackage ../servers/gonic { };
+
   googleearth = callPackage ../applications/misc/googleearth { };
 
   google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; };


### PR DESCRIPTION
Gonic is an implementation of the subsonic server and protocol.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
