### PR TITLE
nixos/test-driver: Use guest time when using sleep

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -773,7 +773,8 @@ class Machine:
         retry(window_is_visible)
 
     def sleep(self, secs: int) -> None:
-        time.sleep(secs)
+        # We want to sleep in *guest* time, not *host* time.
+        self.succeed(f"sleep {secs}")
 
     def forward_port(self, host_port: int = 8080, guest_port: int = 80) -> None:
         """Forward a TCP port on the host to a TCP port on the guest.


### PR DESCRIPTION
With the Perl driver, `machine.sleep(N)` was doing a sleep on the guest machine instead of the host machine. The new Python test driver however uses `time.sleep()`, which instead sleeps on the host.

While this shouldn't make a difference most of the time, it *does* however make a huge difference if the test machine is loaded and you're sleeping for a minimum duration of eg. an animation.

I stumbled on this while porting most of all my tests to the new Python test driver and particularly my video game tests failed on a fairly loaded machine, whereas they don't with the Perl test driver.

Switching the `sleep()` method to sleep on the guest instead of the host fixes this.