### PR TITLE
rs-git-fsmonitor: init at 0.1.3

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -211,6 +211,8 @@ let
 
   qgit = qt5.callPackage ./qgit { };
 
+  rs-git-fsmonitor = callPackage ./rs-git-fsmonitor { };
+
   scmpuff = callPackage ./scmpuff { };
 
   stgit = callPackage ./stgit { };

--- a/pkgs/applications/version-management/git-and-tools/rs-git-fsmonitor/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/rs-git-fsmonitor/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, makeWrapper
+, watchman
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rs-git-fsmonitor";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "jgavris";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "021vdk5i7yyrnh4apn0gnsh6ycnx15wm3g2jrfsg7fycnq8167wc";
+  };
+
+  cargoSha256 = "0kfj09xq1g866507k3gcbm30pyi1xzfr7gca6dab7sjlvf83h9xs";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  fixupPhase = ''
+    wrapProgram $out/bin/rs-git-fsmonitor --prefix PATH ":" "${lib.makeBinPath [ watchman ]}" ;
+  '';
+
+  meta = with lib; {
+    description = "A fast git core.fsmonitor hook written in Rust";
+    homepage = "https://github.com/jgavris/rs-git-fsmonitor";
+    license = licenses.mit;
+    maintainers = [ maintainers.SuperSandro2000 ];
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I personally use rs-git-fsmonitor and want to make it available for all.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
