### PR TITLE
Revert "systemd: build with cryptsetup and cryptsetup-generators"

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -25,7 +25,7 @@ let
       "nss-lookup.target"
       "nss-user-lookup.target"
       "time-sync.target"
-      "cryptsetup.target"
+      #"cryptsetup.target"
       "sigpwr.target"
       "timers.target"
       "paths.target"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -9,7 +9,6 @@
 , patchelf
 , substituteAll
 , getent
-, cryptsetup, lvm2
 , buildPackages
 , perl
 , withSelinux ? false, libselinux
@@ -31,7 +30,6 @@ let gnupg-minimal = gnupg.override {
   zlib = null;
   bzip2 = null;
 };
-
 in stdenv.mkDerivation {
   version = "245.7";
   pname = "systemd";
@@ -91,7 +89,7 @@ in stdenv.mkDerivation {
     ];
   buildInputs =
     [ linuxHeaders libcap curl.dev kmod xz pam acl
-      cryptsetup libuuid glib libgcrypt libgpgerror libidn2
+      /* cryptsetup */ libuuid glib libgcrypt libgpgerror libidn2
       pcre2 ] ++
       stdenv.lib.optional withKexectools kexectools ++
       stdenv.lib.optional withLibseccomp libseccomp ++

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17222,11 +17222,7 @@ in
 
   criu = callPackage ../os-specific/linux/criu { };
 
-  cryptsetup = callPackage ../os-specific/linux/cryptsetup {
-    # cryptsetup only really needs the devmapper component of cryptsetup
-    # but itself is used as a library in systemd (=udev)
-    lvm2 = lvm2.override { udev = null; };
-  };
+  cryptsetup = callPackage ../os-specific/linux/cryptsetup { };
 
   cramfsprogs = callPackage ../os-specific/linux/cramfsprogs { };
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/96479 (hopefully)

This reverts commit 72c8ed038946850d345db13f30e259a368d7c3c5.

###### Motivation for this change

`unstable` is blocked by https://github.com/NixOS/nixpkgs/issues/96479

This is a quick hacky fix only -- there is clearly some strange interaction between `systemd-udevd` and `cryptsetup` caused by 72c8ed038946850d345db13f30e259a368d7c3c5.

###### Things done

I'm currently running
```
$ nix-build -I "nixpkgs=$(pwd)" nixos/tests/installer.nix -A 'luksroot'
```

However, my machine is taking a while with it as it is rebuilding systemd. I'll update this PR once it completes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
