### PR TITLE
rustscan: init at 1.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7995,6 +7995,12 @@
     githubId = 65870;
     name = "Сухарик";
   };
+  SuperSandro2000 = {
+    email = "sandro.jaeckel@gmail.com";
+    github = "SuperSandro2000";
+    githubId = 7258858;
+    name = "Sandro Jäckel";
+  };
   SuprDewd = {
     email = "suprdewd@gmail.com";
     github = "SuprDewd";

--- a/pkgs/tools/security/rustscan/default.nix
+++ b/pkgs/tools/security/rustscan/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, nmap
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rustscan";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "RustScan";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "0rkqsh4i58cf18ad97yr4f68s5jg6z0ybz4bw8607lz7cjkfvjay";
+  };
+
+  cargoSha256 = "0mj214f2md7kjknmcayc5dcfmlk2b8mqkn7kxzdis8qv9a5xcbk8";
+
+  postPatch = ''
+    substituteInPlace src/main.rs \
+      --replace 'Command::new("nmap")' 'Command::new("${nmap}/bin/nmap")'
+  '';
+
+  checkFlags = [
+    "--skip=infer_ulimit_lowering_no_panic"
+    "--skip=google_dns_runs"
+    "--skip=parse_correct_ips_or_hosts"
+  ];
+
+  meta = with lib; {
+    description = "Faster Nmap Scanning with Rust";
+    homepage = "https://github.com/RustScan/RustScan";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6712,6 +6712,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  rustscan = callPackage ../tools/security/rustscan { };
+
   rw = callPackage ../tools/misc/rw { };
 
   rxp = callPackage ../tools/text/xml/rxp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Get rustscan into nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
