### PR TITLE
ocamlPackages.piqi-ocaml: 0.7.5 → 0.7.7

### DIFF
--- a/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
@@ -1,20 +1,18 @@
-{ stdenv, fetchurl, fetchpatch, ocaml, findlib, piqi, camlp4 }:
+{ stdenv, fetchFromGitHub, fetchpatch, ocaml, findlib, piqi, stdlib-shims }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.5";
+  version = "0.7.7";
   pname = "piqi-ocaml";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/alavrik/piqi-ocaml/archive/v${version}.tar.gz";
-    sha256 = "0ngz6y8i98i5v2ma8nk6mc83pdsmf2z0ks7m3xi6clfg3zqbddrv";
+  src = fetchFromGitHub {
+    owner = "alavrik";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1913jpsb8mvqi8609j4g4sm5jhg50dq0xqxgy8nmvknfryyc89nm";
   };
 
-  patches = [ (fetchpatch {
-    url = "https://github.com/alavrik/piqi-ocaml/commit/336e8fdb84e77f4105e9bbb5ab545b8729101308.patch";
-    sha256 = "071s4xjyr6xx95v6az2lbl2igc87n7z5jqnnbhfq2pidrxakd0la";
-  })];
-
-  buildInputs = [ ocaml findlib piqi camlp4 ];
+  buildInputs = [ ocaml findlib piqi stdlib-shims ];
 
   createFindlibDestdir = true;
 


### PR DESCRIPTION
###### Motivation for this change

Drop the dependency on camlp4

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
