### PR TITLE
`nixos-rebuild edit` improvements

### DIFF
--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -288,6 +288,9 @@ fi
 if [ "$action" = edit ]; then
     if [[ -z $flake ]]; then
         NIXOS_CONFIG=${NIXOS_CONFIG:-$(nix-instantiate --find-file nixos-config)}
+        if [[ -d $NIXOS_CONFIG ]]; then
+            NIXOS_CONFIG=$NIXOS_CONFIG/default.nix
+        fi
         exec "${EDITOR:-nano}" "$NIXOS_CONFIG"
     else
         exec nix edit "${lockFlags[@]}" -- "$flake#$flakeAttr"

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -291,7 +291,7 @@ if [ "$action" = edit ]; then
         if [[ -d $NIXOS_CONFIG ]]; then
             NIXOS_CONFIG=$NIXOS_CONFIG/default.nix
         fi
-        exec "${EDITOR:-nano}" "$NIXOS_CONFIG"
+        exec ${EDITOR:-nano} "$NIXOS_CONFIG"
     else
         exec nix edit "${lockFlags[@]}" -- "$flake#$flakeAttr"
     fi


### PR DESCRIPTION
Currently, having `$NIXOS_CONFIG` or `<nixos-config>` point to a directory will make `nixos-rebuild edit` try to open your `$EDITOR` on that directory, instead of on the `default.nix` within that it should. It also quotes `$EDITOR`, which is wrong, since that can contain important flags. This PR fixes both of the above.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
