### PR TITLE
ec2-metadata-fetcher: use IMDSv2, fetch public-ipv4 as well

### DIFF
--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -13,6 +13,7 @@ let
   metadataFetcher = import ./ec2-metadata-fetcher.nix {
     targetRoot = "$targetRoot/";
     wgetExtraOptions = "-q";
+    useImdsToken = true;
   };
 in
 

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.nix
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.nix
@@ -1,14 +1,27 @@
-{ targetRoot, wgetExtraOptions }:
+# Note: This fetcher is used by both ./amazon-image.nix and
+# ./openstack-config.nix, so we need to be compatible with both.
+#
+# More info about OpenStack's IMDS, including version compatibility:
+# https://docs.openstack.org/nova/latest/user/metadata.html#metadata-ec2-format
+{ targetRoot, wgetExtraOptions, useImdsToken ? false }:
+let
+  # Snippet to fetch the IMDS token, used by IMDSv2:
+  # https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/
+  # We construct the PUT request by hand, because wget is busybox wget and can't.
+  fetchImdsToken = ''
+    TOKEN=$(echo -ne 'PUT /latest/api/token HTTP/1.1\r\nHost: 169.254.169.254\r\nX-aws-ec2-metadata-token-ttl-seconds: 60\r\n\r\n' | nc 169.254.169.254 80 | tail -n 1)
+    wgetCmd="wget ${wgetExtraOptions} --header 'X-aws-ec2-metadata-token: $TOKEN'"
+  '';
+in
 ''
-  imds=http://169.254.169.254/2019-10-01
+  imds=http://169.254.169.254/2009-04-04
   metaDir=${targetRoot}etc/ec2-metadata
+  wgetCmd="wget ${wgetExtraOptions}"
   mkdir -m 0755 -p "$metaDir"
 
   echo "getting EC2 instance metadata..."
 
-  # Construct the PUT request by hand, because wget is busybox wget and can't.
-  TOKEN=$(echo -ne 'PUT /latest/api/token HTTP/1.1\r\nHost: 169.254.169.254\r\nX-aws-ec2-metadata-token-ttl-seconds: 60\r\n\r\n' | nc 169.254.169.254 80 | tail -n 1)
-  wgetCmd="wget ${wgetExtraOptions} --header 'X-aws-ec2-metadata-token: $TOKEN'"
+  ${if useImdsToken then fetchImdsToken else ""}
 
   if ! [ -e "$metaDir/ami-manifest-path" ]; then
     $wgetCmd -O "$metaDir/ami-manifest-path" $imds/meta-data/ami-manifest-path

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.nix
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.nix
@@ -23,23 +23,9 @@ in
 
   ${if useImdsToken then fetchImdsToken else ""}
 
-  if ! [ -e "$metaDir/ami-manifest-path" ]; then
-    $wgetCmd -O "$metaDir/ami-manifest-path" $imds/meta-data/ami-manifest-path
-  fi
-
-  if ! [ -e "$metaDir/user-data" ]; then
-    $wgetCmd -O "$metaDir/user-data" $imds/user-data && chmod 600 "$metaDir/user-data"
-  fi
-
-  if ! [ -e "$metaDir/hostname" ]; then
-    $wgetCmd -O "$metaDir/hostname" $imds/meta-data/hostname
-  fi
-
-  if ! [ -e "$metaDir/public-ipv4" ]; then
-    $wgetCmd -O "$metaDir/public-ipv4" $imds/meta-data/public-ipv4
-  fi
-
-  if ! [ -e "$metaDir/public-keys-0-openssh-key" ]; then
-    $wgetCmd -O "$metaDir/public-keys-0-openssh-key" $imds/meta-data/public-keys/0/openssh-key
-  fi
+  $wgetCmd -O "$metaDir/ami-manifest-path" $imds/meta-data/ami-manifest-path
+  $wgetCmd -O "$metaDir/user-data" $imds/user-data && chmod 600 "$metaDir/user-data"
+  $wgetCmd -O "$metaDir/hostname" $imds/meta-data/hostname
+  $wgetCmd -O "$metaDir/public-ipv4" $imds/meta-data/public-ipv4
+  $wgetCmd -O "$metaDir/public-keys-0-openssh-key" $imds/meta-data/public-keys/0/openssh-key
 ''

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.nix
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.nix
@@ -1,23 +1,32 @@
 { targetRoot, wgetExtraOptions }:
 ''
+  imds=http://169.254.169.254/2019-10-01
   metaDir=${targetRoot}etc/ec2-metadata
   mkdir -m 0755 -p "$metaDir"
 
   echo "getting EC2 instance metadata..."
 
+  # Construct the PUT request by hand, because wget is busybox wget and can't.
+  TOKEN=$(echo -ne 'PUT /latest/api/token HTTP/1.1\r\nHost: 169.254.169.254\r\nX-aws-ec2-metadata-token-ttl-seconds: 60\r\n\r\n' | nc 169.254.169.254 80 | tail -n 1)
+  wgetCmd="wget ${wgetExtraOptions} --header 'X-aws-ec2-metadata-token: $TOKEN'"
+
   if ! [ -e "$metaDir/ami-manifest-path" ]; then
-    wget ${wgetExtraOptions} -O "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
+    $wgetCmd -O "$metaDir/ami-manifest-path" $imds/meta-data/ami-manifest-path
   fi
 
   if ! [ -e "$metaDir/user-data" ]; then
-    wget ${wgetExtraOptions} -O "$metaDir/user-data" http://169.254.169.254/1.0/user-data && chmod 600 "$metaDir/user-data"
+    $wgetCmd -O "$metaDir/user-data" $imds/user-data && chmod 600 "$metaDir/user-data"
   fi
 
   if ! [ -e "$metaDir/hostname" ]; then
-    wget ${wgetExtraOptions} -O "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
+    $wgetCmd -O "$metaDir/hostname" $imds/meta-data/hostname
+  fi
+
+  if ! [ -e "$metaDir/public-ipv4" ]; then
+    $wgetCmd -O "$metaDir/public-ipv4" $imds/meta-data/public-ipv4
   fi
 
   if ! [ -e "$metaDir/public-keys-0-openssh-key" ]; then
-    wget ${wgetExtraOptions} -O "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
+    $wgetCmd -O "$metaDir/public-keys-0-openssh-key" $imds/meta-data/public-keys/0/openssh-key
   fi
 ''


### PR DESCRIPTION
I'd love to have this change make it to the 20.09 NixOS AMIs.

##### Motivation for this change

* Version 2 of the Instance MetaData Service (IMDS) is the new recommended way of fetching instance metadata on AWS: https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/ and means NixOS AMIs can work in environments that are migrating away from permitting IMDSv1.
* I have a server in a private config that wants to know its external IPv4 address, otherwise it doesn't work properly. I intend to use a `readFile /etc/ec2-metadata/public-ipv4` in the configuration I push as instance userdata, so that I can launch EC2 instances running this server.
* Instances can change user data, public IPv4 address &c. over time, so it's correct to repopulate /etc/ec2-metadata on each boot.

###### Things done

* Tested that the changes produce a working image, by:
  - building the image using `nix-build ./nixos/release.nix -A amazonImage --arg supportedSystems '["x86_64-linux"]'` in the nixpkgs root;
  - importing that image using AWS VM import/export: https://docs.aws.amazon.com/vm-import/latest/userguide/what-is-vmimport.html
  - Booting the image on EC2, and ensuring that it's possible to log in, and metadata files exist.
