### PR TITLE
dnspython: reintroduce version 1.16.0, fix electrum build

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -67,7 +67,7 @@ python3Packages.buildPythonApplication {
     aiorpcx
     attrs
     bitstring
-    dnspython
+    dnspython1
     ecdsa
     jsonrpclib-pelix
     matplotlib

--- a/pkgs/development/python-modules/dnspython/1.nix
+++ b/pkgs/development/python-modules/dnspython/1.nix
@@ -1,14 +1,13 @@
-{ buildPythonPackage, fetchPypi, lib, pythonOlder }:
+{ buildPythonPackage, fetchPypi, lib }:
 
 buildPythonPackage rec {
   pname = "dnspython";
-  version = "2.0.0";
-  disabled = pythonOlder "3.6";
+  version = "1.16.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "044af09374469c3a39eeea1a146e8cac27daec951f1f1f157b1962fc7cb9d1b7";
+    sha256 = "36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01";
   };
 
   # needs networking for some tests

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2922,8 +2922,9 @@ in {
 
   dnslib = callPackage ../development/python-modules/dnslib { };
 
+  dnspython1 = callPackage ../development/python-modules/dnspython/1.nix { };
   dnspython = callPackage ../development/python-modules/dnspython { };
-  dns = self.dnspython; # Alias for compatibility, 2017-12-10
+  dns = self.dnspython1; # Alias for compatibility, 2017-12-10
 
   docker = callPackage ../development/python-modules/docker {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/96477

Reintroduced dnspython 1.x, added to dependency of `electrum`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
