### PR TITLE
trojita: enable localization

### DIFF
--- a/pkgs/applications/networking/mailreaders/trojita/default.nix
+++ b/pkgs/applications/networking/mailreaders/trojita/default.nix
@@ -1,6 +1,7 @@
 { akonadi-contacts
 , cmake
 , fetchgit
+, fetchsvn
 , gnupg
 , gpgme
 , kcontacts
@@ -15,17 +16,32 @@
 , qtkeychain
 , qttools
 , qtwebkit
+, qttranslations
+, substituteAll
+, withI18n ? true
 }:
 
 mkDerivation rec {
   pname = "trojita";
-  version = "0.7.20200706";
+  version = "unstable-2020-07-06";
 
   src = fetchgit {
     url = "https://anongit.kde.org/trojita.git";
     rev = "e973a5169f18ca862ceb8ad749c93cd621d86e14";
     sha256 = "0r8nmlqwgsqkk0k8xh32fkwvv6iylj35xq2h8b7l3g03yc342kbn";
   };
+
+  l10n = fetchsvn {
+    url = "svn://anonsvn.kde.org/home/kde/trunk/l10n-kf5";
+    rev = "1566642";
+    sha256 = "0y45fjib153za085la3hqpryycx33dkj3cz8kwzn2w31kvldfl1q";
+  };
+
+  patches = (substituteAll {
+    # See https://github.com/NixOS/nixpkgs/issues/86054
+    src = ./fix-qttranslations-path.patch;
+    inherit qttranslations;
+  });
 
   buildInputs = [
     akonadi-contacts
@@ -47,6 +63,14 @@ mkDerivation rec {
     qttools
     gnupg
   ];
+
+  postPatch = "echo ${version} > src/trojita-version"
+    + lib.optionalString withI18n ''
+    mkdir -p po
+    for f in `find ${l10n} -name "trojita_common.po"`; do
+      cp $f po/trojita_common_$(echo $f | cut -d/ -f5).po
+    done
+  '';
 
   meta = with lib; {
     description = "A Qt IMAP e-mail client";

--- a/pkgs/applications/networking/mailreaders/trojita/fix-qttranslations-path.patch
+++ b/pkgs/applications/networking/mailreaders/trojita/fix-qttranslations-path.patch
@@ -1,0 +1,13 @@
+diff --git i/src/Gui/main.cpp w/src/Gui/main.cpp
+index 851db4f1..e997f46e 100644
+--- i/src/Gui/main.cpp
++++ w/src/Gui/main.cpp
+@@ -52,7 +52,7 @@ int main(int argc, char **argv)
+ 
+     QTranslator qtTranslator;
+     qtTranslator.load(QLatin1String("qt_") + QLocale::system().name(),
+-                      QLibraryInfo::location(QLibraryInfo::TranslationsPath));
++                      QLatin1String("@qttranslations@/translations"));
+     app.installTranslator(&qtTranslator);
+ 
+     QLatin1String localeSuffix("/locale");


### PR DESCRIPTION
###### Motivation for this change
* Fetch translation from the l10n-kf5 repo (see [l10n-fetch-po-files.py](https://invent.kde.org/pim/trojita/-/blob/master/l10n-fetch-po-files.py) for more details)
* Fix qt translations path (https://github.com/NixOS/nixpkgs/issues/86054)
* Fix version (`0.7.20200706` -> `unstable-2020-07-06`), see [Package naming](https://nixos.org/manual/nixpkgs/stable/#sec-package-naming)
* Fix displayed version in "About Trojita" dialog (`0.7-git` -> `unstable-2020-07-06`)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
