### PR TITLE
htop: 2.2.0 -> 3.0.0

### DIFF
--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -1,23 +1,21 @@
-{ lib, fetchurl, stdenv, ncurses,
+{ lib, fetchFromGitHub, stdenv, autoreconfHook, ncurses,
 IOKit, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "htop";
-  version = "2.2.0";
+  version = "3.0.0";
 
-  src = fetchurl {
-    url = "https://hisham.hm/htop/releases/${version}/${pname}-${version}.tar.gz";
-    sha256 = "0mrwpb3cpn3ai7ar33m31yklj64c3pp576vh1naqff6f21pq5mnr";
+  src = fetchFromGitHub {
+    owner = "htop-dev";
+    repo = pname;
+    rev = version;
+    sha256 = "096gdnpaszs5rfp7qj8npi2jkvdqpp8mznn89f97ykrg6pgagwq4";
   };
 
-  nativeBuildInputs = [ python3 ];
+  nativeBuildInputs = [ autoreconfHook python3 ];
   buildInputs =
     [ ncurses ] ++
     lib.optionals stdenv.isDarwin [ IOKit ];
-
-  prePatch = ''
-    patchShebangs scripts/MakeHeader.py
-  '';
 
   meta = with stdenv.lib; {
     description = "An interactive process viewer for Linux";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

This is strictly speaking a fork of htop (https://htop.dev/) - see https://github.com/hishamhm/htop/issues/992 for more details, however considering Debian, Ubuntu, Arch and Gentoo have replaced their htop package with the forked version of it, this should be fine too for nixpkgs. If it should be a separate package anyway, feel free to tell me.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
