### PR TITLE
mathlibtools: init at 0.0.10

### DIFF
--- a/pkgs/development/python-modules/mathlibtools/default.nix
+++ b/pkgs/development/python-modules/mathlibtools/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, PyGithub, GitPython, toml, click, tqdm,
+  paramiko, networkx, pydot, pyyaml }:
+
+buildPythonPackage rec {
+  pname = "mathlibtools";
+  version = "0.0.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0d708bgsxjhhchqc56afi1h7k87vbfn7v40f4y1zlv7hsjc69s36";
+  };
+
+  propagatedBuildInputs = [
+    PyGithub GitPython toml click tqdm paramiko networkx pydot pyyaml
+  ];
+
+  # requires internet access
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/leanprover-community/mathlib-tools";
+    description = "leanproject is a supporting tool for Lean's mathlib";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ gebner ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25981,6 +25981,7 @@ in
   lean2 = callPackage ../applications/science/logic/lean2 {};
   lean3 = lean;
   elan = callPackage ../applications/science/logic/elan {};
+  mathlibtools = with python3Packages; toPythonApplication mathlibtools;
 
   leo2 = callPackage ../applications/science/logic/leo2 {
      ocaml = ocaml-ng.ocamlPackages_4_01_0.ocaml;};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -992,6 +992,8 @@ in {
 
   matchpy = callPackage ../development/python-modules/matchpy { };
 
+  mathlibtools = callPackage ../development/python-modules/mathlibtools {};
+
   maxminddb = callPackage ../development/python-modules/maxminddb { };
 
   mininet-python = (toPythonModule (pkgs.mininet.override{ inherit python; })).py;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The `mathlibtools` package (from the `mathlib-tools` repository) contains the `leanproject` tool to manage Lean (the proof assistant) projects.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
