### PR TITLE
lsd2dsl: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/applications/misc/lsd2dsl/default.nix
+++ b/pkgs/applications/misc/lsd2dsl/default.nix
@@ -3,13 +3,13 @@
 
 mkDerivation rec {
   pname = "lsd2dsl";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "nongeneric";
     repo = pname;
     rev = "v${version}";
-    sha256 = "100qd9i0x6r0nkw1ic2p0xjr16jlhinxkn1x7i98s4xmw4wyb8n8";
+    sha256 = "0s0la6zkg584is93p4nj1ha3pbnvadq84zgsv8nym3r35n7k8czi";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -19,8 +19,7 @@ mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-Wno-error=unused-result -Wno-error=missing-braces";
 
   installPhase = ''
-    install -Dm755 console/lsd2dsl $out/bin/lsd2dsl
-    install -m755 gui/lsd2dsl-qtgui $out/bin/lsd2dsl-qtgui
+    install -Dm755 console/lsd2dsl gui/lsd2dsl-qtgui -t $out/bin
   '' + lib.optionalString stdenv.isDarwin ''
     wrapQtApp $out/bin/lsd2dsl
     wrapQtApp $out/bin/lsd2dsl-qtgui

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21898,7 +21898,7 @@ in
 
   loxodo = callPackage ../applications/misc/loxodo { };
 
-  lsd2dsl = libsForQt514.callPackage ../applications/misc/lsd2dsl { };
+  lsd2dsl = libsForQt5.callPackage ../applications/misc/lsd2dsl { };
 
   lrzsz = callPackage ../tools/misc/lrzsz { };
 


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/nongeneric/lsd2dsl/releases/tag/v0.5.2)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
