### PR TITLE
python3Packages.rq: 1.5.0 -> 1.5.1

### DIFF
--- a/pkgs/development/python-modules/rq/default.nix
+++ b/pkgs/development/python-modules/rq/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, fetchPypi, buildPythonPackage, isPy27, click, redis }:
+{ stdenv, fetchFromGitHub, buildPythonPackage, isPy27, click, redis }:
 
 buildPythonPackage rec {
   pname = "rq";
-  version = "1.5.0";
+  version = "1.5.1";
   disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "370fc800903c226b898a10174e069a23077b74b22297b4b20e925ca82fcd9471";
+  src = fetchFromGitHub {
+    owner = "rq";
+    repo = "rq";
+    rev = "v${version}";
+    sha256 = "0i7yyw828wdvl7ap4gb7jhm4p94502is3xxrgrdgwwp0l1rac004";
   };
 
   # test require a running redis rerver, which is something we can't do yet


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Build is broken at the moment because the pypi package doesn't build.  Therefore I've changed it to the github release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
