### PR TITLE
ocamlPackages.webbrowser: init at 0.6.1

### DIFF
--- a/pkgs/development/ocaml-modules/webbrowser/default.nix
+++ b/pkgs/development/ocaml-modules/webbrowser/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg
+, astring, bos, cmdliner, rresult
+}:
+
+stdenv.mkDerivation rec {
+	name = "ocaml${ocaml.version}-webbrowser-${version}";
+	version = "0.6.1";
+	src = fetchurl {
+		url = "https://erratique.ch/software/webbrowser/releases/webbrowser-${version}.tbz";
+		sha256 = "137a948bx7b71zfv4za3hhznrn5lzbbrgzjy0das83zms508isx3";
+	};
+
+	nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+	buildInputs = [];
+	propagatedBuildInputs = [ astring bos cmdliner rresult ];
+
+	inherit (topkg) buildPhase installPhase;
+
+	meta = {
+		description = "Open and reload URIs in browsers from OCaml";
+		homepage = "https://erratique.ch/software/webbrowser";
+		license = stdenv.lib.licenses.isc;
+		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		inherit (ocaml.meta) platforms;
+	};
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -955,6 +955,8 @@ let
 
     wasm = callPackage ../development/ocaml-modules/wasm { };
 
+    webbrowser = callPackage ../development/ocaml-modules/webbrowser { };
+
     webmachine = callPackage ../development/ocaml-modules/webmachine { };
 
     wtf8 = callPackage ../development/ocaml-modules/wtf8 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add dbuenzli's webbrowser package, a library for opening and reloading URIs in web browsers from OCaml.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
