### PR TITLE
bzip2_1_1: init at 2020-08-11

### DIFF
--- a/pkgs/tools/compression/bzip2/1_1.nix
+++ b/pkgs/tools/compression/bzip2/1_1.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, fetchFromGitLab
+, meson
+, python3
+, ninja
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bzip2-unstable";
+  version = "2020-08-11";
+
+  src = fetchFromGitLab {
+    owner = "federicomenaquintero";
+    repo = "bzip2";
+    rev = "15255b553e7c095fb7a26d4dc5819a11352ebba1";
+    sha256 = "sha256-BAyz35D62LWi47B/gNcCSKpdaECHBGSpt21vtnk3fKs=";
+  };
+
+  postPatch = ''
+    patchShebangs install_links.py
+  '';
+
+  nativeBuildInputs = [
+    meson
+    python3
+    ninja
+  ];
+
+  outputs = [ "bin" "dev" "out" "man" ];
+
+  mesonFlags = [
+    "-Ddocs=disabled"
+  ];
+
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "High-quality data compression program";
+    license = licenses.bsdOriginal;
+    platforms = platforms.all;
+    maintainers = [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2573,6 +2573,8 @@ in
 
   bzip2 = callPackage ../tools/compression/bzip2 { };
 
+  bzip2_1_1 = callPackage ../tools/compression/bzip2/1_1.nix { };
+
   cabextract = callPackage ../tools/archivers/cabextract { };
 
   cadaver = callPackage ../tools/networking/cadaver {


### PR DESCRIPTION
bzip2 has been unmaintained for a long time. For a while now, there has
been maintainership, resulting in the release of 1.0.8. At the same
time, there is now a master branch (version 1.1.x) which supports meson
and cmake as build systems.

This commit adds the current HEAD of the master branch (1.1.x). In the
future we may want to use this one instead of the older and patched
1.0.6 we currently have.

Related:
- https://github.com/NixOS/nixpkgs/pull/65029
- https://github.com/NixOS/nixpkgs/pull/94969

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
