### PR TITLE
sonata: fix gsettings schemas

### DIFF
--- a/pkgs/applications/audio/sonata/default.nix
+++ b/pkgs/applications/audio/sonata/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, gettext, intltool, wrapGAppsHook
+{ stdenv, fetchFromGitHub, wrapGAppsHook, gettext
 , python3Packages, gnome3, gtk3, gsettings-desktop-schemas, gobject-introspection }:
 
 let
@@ -16,12 +16,15 @@ in buildPythonApplication rec {
 
   disabled = !isPy3k;
 
-  nativeBuildInputs = [ pkgconfig gettext ];
+  nativeBuildInputs = [ wrapGAppsHook gettext ];
   buildInputs = [
-    intltool wrapGAppsHook
     gnome3.adwaita-icon-theme
     gsettings-desktop-schemas
   ];
+
+  # Otherwise the setup hook for gsettings-desktop-schemas is not run:
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
 
   postPatch = ''
     # Remove "Local MPD" tab which is not suitable for NixOS.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Otherwise you get the error
```
(sonata:13895): GLib-GIO-ERROR **: 18:57:32.491: No GSettings schemas are installed on the system
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
