### PR TITLE
audit: add patch to allow 0555 permissions

### DIFF
--- a/pkgs/os-specific/linux/audit/allowed-permissions.patch
+++ b/pkgs/os-specific/linux/audit/allowed-permissions.patch
@@ -1,0 +1,35 @@
+diff --git a/src/auditd-config.c b/src/auditd-config.c
+index 309063b..ac87857 100644
+--- a/src/auditd-config.c
++++ b/src/auditd-config.c
+@@ -771,8 +771,12 @@ static int dispatch_parser(struct nv_pair *nv, int line,
+ 	if ((buf.st_mode & (S_IRWXU|S_IRWXG|S_IRWXO)) !=
+ 			   (S_IRWXU|S_IRGRP|S_IXGRP) && 
+ 	    (buf.st_mode & (S_IRWXU|S_IRWXG|S_IRWXO)) !=
+-			   (S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH)) {
+-		audit_msg(LOG_ERR, "%s permissions should be 0750 or 0755",
++			   (S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH) &&
++	    (buf.st_mode & (S_IRWXU|S_IRWXG|S_IRWXO)) !=
++			   (S_IRUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH) &&
++	    (buf.st_mode & (S_IRWXU|S_IRWXG|S_IRWXO)) !=
++			   (S_IRUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH)) {
++		audit_msg(LOG_ERR, "%s permissions should be 0750, 0755, 0555 or 0550",
+ 				nv->value);
+ 		return 1;
+ 	}
+@@ -1051,9 +1055,13 @@ static int check_exe_name(const char *val, int line)
+ 	if ((buf.st_mode & (S_IRWXU|S_IRWXG|S_IRWXO)) !=
+ 			   (S_IRWXU|S_IRGRP|S_IXGRP) &&
+ 	    (buf.st_mode & (S_IRWXU|S_IRWXG|S_IRWXO)) !=
+-			   (S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH)) {
++			   (S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH) &&
++	    (buf.st_mode & (S_IRWXU|S_IRWXG|S_IRWXO)) !=
++			   (S_IRUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH) &&
++	    (buf.st_mode & (S_IRWXU|S_IRWXG|S_IRWXO)) !=
++			   (S_IRUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH)) {
+ 		audit_msg(LOG_ERR,
+-			"%s permissions should be 0750 or 0755 - line %d",
++			"%s permissions should be 0750, 0755, 0555 or 0550 - line %d",
+ 			val, line);
+ 		return -1;
+ 	}


### PR DESCRIPTION

###### Motivation for this change
When configuring the dispatcher like this in /etc/audit/auditd.conf:
```
dispatcher = ${audit}/bin/audispd
```
Then it would complain that the permissions are not valid for the binary. This is now fixed with the added patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
