### PR TITLE
pythonPackages.pint: add missing dependencies

### DIFF
--- a/pkgs/development/python-modules/pint/default.nix
+++ b/pkgs/development/python-modules/pint/default.nix
@@ -1,10 +1,10 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy27
 , pythonOlder
-, funcsigs
 , setuptools_scm
+, importlib-metadata
+, packaging
 # Check Inputs
 , pytestCheckHook
 , numpy
@@ -24,9 +24,10 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.6";
 
-  propagatedBuildInputs = [
-    setuptools_scm
-  ] ++ lib.optional isPy27 funcsigs;
+  nativeBuildInputs = [ setuptools_scm ];
+  
+  propagatedBuildInputs = [ packaging ]
+    ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   # Test suite explicitly requires pytest
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change
`importlib-metadata` and `packaging` appear to have been falsely satisfied by the inclusion of `pytestCheckHook` in `checkInputs`. This can be demonstrated by attempting to build this package with `doCheck = false` and watching it fail.

Also removed the `isPy27` clause as package no longer seems to support <3.6 anyway now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
