### PR TITLE
zathura: symlinkJoin all of plugins

### DIFF
--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -1,21 +1,16 @@
 { symlinkJoin, lib, makeWrapper, zathura_core, file, plugins ? [] }:
-
-let
-  pluginsPath = lib.makeSearchPath "lib/zathura" plugins;
-
-in symlinkJoin {
+symlinkJoin {
   name = "zathura-with-plugins-${zathura_core.version}";
 
-  paths = with zathura_core; [ man dev out ];
+  paths = with zathura_core; [ man dev out ] ++ plugins;
 
-  inherit plugins;
 
   buildInputs = [ makeWrapper ];
 
   postBuild = ''
     makeWrapper ${zathura_core.bin}/bin/zathura $out/bin/zathura \
       --prefix PATH ":" "${lib.makeBinPath [ file ]}" \
-      --add-flags --plugins-dir=${pluginsPath}
+      --add-flags --plugins-dir="$out/lib/zathura"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -24,6 +24,6 @@ symlinkJoin {
     '';
     license = licenses.zlib;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ smironov globin ];
+    maintainers = with maintainers; [ smironov globin TethysSvensson ];
   };
 }


### PR DESCRIPTION
This is a rebase of #49141, which can be closed if this goes through. I have also added myself as a maintainer.

###### Motivation for this change

The motivation is the same as for the original PR:

> Zathura is not registered as a pdf reader, for instance nautilus doesn't propose it as a pdf reader.
It's because the default .desktop file doesn't contain any MimeType, these are provided by the plugins see https://git.pwmt.org/pwmt/zathura/issues/45#note_416.
> 
> Instead of copying the .desktop entries, I relied on the already present symlinkJoin.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
