### PR TITLE
Improut

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9344,6 +9344,12 @@
     githubId = 1069303;
     name = "Kim Simmons";
   };
+  zopieux = {
+    email = "zopieux@gmail.com";
+    github = "zopieux";
+    githubId = 81353;
+    name = "Alexandre Macabies";
+  };
   zowoq = {
     email = "59103226+zowoq@users.noreply.github.com";
     github = "zowoq";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -853,6 +853,7 @@
   ./services/web-apps/icingaweb2/icingaweb2.nix
   ./services/web-apps/icingaweb2/module-monitoring.nix
   ./services/web-apps/ihatemoney
+  ./services/web-apps/improut.nix
   ./services/web-apps/jirafeau.nix
   ./services/web-apps/jitsi-meet.nix
   ./services/web-apps/limesurvey.nix

--- a/nixos/modules/services/web-apps/improut.nix
+++ b/nixos/modules/services/web-apps/improut.nix
@@ -1,0 +1,119 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.services.improut;
+  defaultGroup = "improut";
+
+in {
+  options.services.improut = {
+    enable = lib.mkEnableOption "improut image hosting";
+
+    storageDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/improut";
+      example = "/var/lib/improut";
+      description = ''
+        Directory to store uploaded images.
+      '';
+    };
+
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "localhost";
+      example = "localhost";
+      description = ''
+        Hostname to listen on.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8985;
+      example = 8985;
+      description = ''
+        Port to listen on.
+      '';
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "improut";
+      example = "improut";
+      description = ''
+        Group owning the uploaded files.
+      '';
+    };
+
+    maxSize = lib.mkOption {
+      type = lib.types.int;
+      default = 10485760;  # 10 MiB
+      example = 10485760;
+      description = ''
+        Maximum upload body size to accept, in bytes. Actual maximum file size will be a few bytes smaller.
+      '';
+    };
+
+    maxLifetime = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      example = 30;
+      description = ''
+        Maximum lifetime in days this improut server supports. <literal>0</literal> for unlimited.
+      '';
+    };
+
+    defaultLifetime = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      example = 7;
+      description = ''
+        Default lifetime in days. Users can set a different value as long as it's below <literal>maxLifetime</literal>.
+        <literal>0</literal> for unlimited default lifetime.
+      '';
+    };
+
+    expireCheckInterval = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      example = 24;
+      description = ''
+        Interval in hours to scan for and delete expired images.
+      '';
+    };
+
+    xAccel = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/storage";
+      description = ''
+        If non-null, enables X-Accel-Redirect mechanism with this prefix instead of serving images from improut.
+        This will set the header <literal>X-Accel-Redirect: {xAccel}/{image-name}</literal>
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.groups."${cfg.group}" = {};
+    systemd.tmpfiles.rules = [ "d '${cfg.storageDir}' 0770 root ${cfg.group} -" ];
+    systemd.services.improut = {
+      description = "improut image hosting server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        SupplementaryGroups = cfg.group;
+        Restart = "on-failure";
+        ExecStart = ''
+          ${pkgs.improut}/bin/improut \
+            -listen ${cfg.listenAddress}:${toString cfg.port} \
+            -root ${cfg.storageDir} \
+            -max-size ${toString cfg.maxSize} \
+            ${lib.optionalString (cfg.maxLifetime != null) "-max-lifetime ${toString cfg.maxLifetime}"} \
+            ${lib.optionalString (cfg.defaultLifetime != null) "-default-lifetime ${toString cfg.defaultLifetime}"} \
+            ${lib.optionalString (cfg.expireCheckInterval != null) "-expire-interval ${toString cfg.expireCheckInterval}"} \
+            ${lib.optionalString (cfg.xAccel != null) "-xaccel ${cfg.xAccel}"}
+        '';
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -152,6 +152,7 @@ in
   icingaweb2 = handleTest ./icingaweb2.nix {};
   iftop = handleTest ./iftop.nix {};
   ihatemoney = handleTest ./ihatemoney.nix {};
+  improut = handleTest ./improut.nix {};
   incron = handleTest ./incron.nix {};
   influxdb = handleTest ./influxdb.nix {};
   initrd-network-ssh = handleTest ./initrd-network-ssh {};

--- a/nixos/tests/improut.nix
+++ b/nixos/tests/improut.nix
@@ -1,0 +1,22 @@
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "improut";
+  meta.maintainers = with lib.maintainers; [ zopieux ];
+
+  machine = { pkgs, lib, ... }: {
+    services.improut = {
+      enable = true;
+      maxSize = 1234;
+      defaultLifetime = 42;
+      maxLifetime = 1337;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("improut.service")
+    machine.wait_for_open_port(8985)
+
+    machine.succeed("curl -sSf localhost:8985/infos | grep -q 'max_file_size\":1234'")
+    machine.succeed("curl -sSf localhost:8985/infos | grep -q 'max_delay\":1337'")
+    machine.succeed("curl -sSf localhost:8985/infos | grep -q 'default_delay\":42'")
+  '';
+})

--- a/pkgs/servers/improut/default.nix
+++ b/pkgs/servers/improut/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub, pkgs }:
+
+buildGoModule rec {
+  pname = "improut";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "zopieux";
+    repo = pname;
+    sha256 = "06wk397fa27fx20s6vvg0q85f2zq500bqqr565fl19j4wgxv8yhm";
+    rev = "v${version}";
+  };
+
+  vendorSha256 = "0xxcv6nx54g1wpzkrk92i2lpgkxvyddyv160q0gq14mvmn10af4j";
+
+  # Tests rely on a fs with xattr support, which we don't have during build.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Dead simple image hosting";
+    homepage = "https://github.com/zopieux/improut";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zopieux ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16339,6 +16339,8 @@ in
 
   imgproxy = callPackage ../servers/imgproxy { };
 
+  improut = callPackage ../servers/improut { };
+
   ircdHybrid = callPackage ../servers/irc/ircd-hybrid { };
 
   jboss = callPackage ../servers/http/jboss { };


### PR DESCRIPTION
###### Motivation for this change

[improut](https://github.com/zopieux/improut) is a lightweight image upload service. This adds the package and corresponding module with sane defaults.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
