### PR TITLE
concourse-bin: init at 6.5.1

### DIFF
--- a/pkgs/development/tools/continuous-integration/concourse-bin/default.nix
+++ b/pkgs/development/tools/continuous-integration/concourse-bin/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib
+, fetchurl, autoPatchelfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "concourse-bin";
+  version = "6.5.1";
+
+  src = fetchurl {
+    url = "https://github.com/concourse/concourse/releases/download/v${version}/concourse-${version}-linux-amd64.tgz";
+    sha256 = "ec0ed4a68a7221edea8ded0f569655298419ef4de8f9193b59dcd5098a4a360c";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  installPhase = ''
+    install -m755 -D bin/concourse $out/bin/concourse
+  '';
+
+  meta = with lib; {
+    description = "Concourse is a pipeline-based continuous thing-doer.";
+    homepage = "https://concourse-ci.org/docs.html";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ fooker ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10725,6 +10725,8 @@ in
 
   cli11 = callPackage ../development/tools/misc/cli11 { };
 
+  concourse-bin = callPackage ../development/tools/continuous-integration/concourse-bin { };
+
   dcadec = callPackage ../development/tools/dcadec { };
 
   dejagnu = callPackage ../development/tools/misc/dejagnu { };


### PR DESCRIPTION
###### Motivation for this change

https://concourse-ci.org/

The package is hard to build on nix (See https://github.com/concourse/concourse/issues/5613). Therefore this is a binary package using the GitHub releases.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
