### PR TITLE
databricks-connect: init at 7.1.0

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -439,7 +439,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
   databricks = {
     fullName = "Databricks Proprietary License";
     url = "https://pypi.org/project/databricks-connect";
-
+    free = false;
   };
 
   issl = {

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -436,6 +436,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
   };
 
   # Proprietary binaries; free to redistribute without modification.
+  databricks = {
+    fullName = "Databricks Proprietary License";
+    url = "https://pypi.org/project/databricks-connect";
+
+  };
+
   issl = {
     fullName = "Intel Simplified Software License";
     url = "https://software.intel.com/en-us/license/intel-simplified-software-license";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4310,6 +4310,12 @@
     githubId = 494012;
     name = "Kevin Cox";
   };
+  kfollesdal = {
+    email = "kfollesdal@gmail.com";
+    github = "kfollesdal";
+    githubId = 546087;
+    name = "Kristoffer K. Føllesdal";
+  };
   khumba = {
     email = "bog@khumba.net";
     github = "khumba";

--- a/pkgs/development/python-modules/databricks-connect/default.nix
+++ b/pkgs/development/python-modules/databricks-connect/default.nix
@@ -1,0 +1,32 @@
+{ lib, jdk, buildPythonPackage, fetchPypi, six, py4j }:
+
+buildPythonPackage rec {
+  pname = "databricks-connect";
+  version = "7.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "996a9d0f271f6c7edbd2d85b2efb6ff4e58d15222e80f87ca17fdbf224e17056";
+  };
+
+  sourceRoot = ".";
+
+  propagatedBuildInputs = [ py4j six jdk ];
+
+  # requires network access
+  doCheck = false;
+
+  preFixup = ''
+      substituteInPlace "$out/bin/find-spark-home" \
+      --replace find_spark_home.py .find_spark_home.py-wrapped
+  '';
+
+  pythonImportsCheck = [ "pyspark" "six" "py4j" ];
+
+  meta = with lib; {
+    description = "Client for connecting to remote Databricks clusters";
+    homepage = "https://pypi.org/project/databricks-connect";
+    license = licenses.databricks;
+    maintainers = with maintainers; [ kfollesdal ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1412,6 +1412,8 @@ in {
 
   databricks-cli = callPackage ../development/python-modules/databricks-cli { };
 
+  databricks-connect = callPackage ../development/python-modules/databricks-connect { inherit (pkgs) jdk; };
+
   dataclasses = callPackage ../development/python-modules/dataclasses { };
 
   dataclasses-json = callPackage ../development/python-modules/dataclasses-json { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

Python package [databricks-connect](https://pypi.org/project/databricks-connect/) is missing in nixpkgs. Used this as an opportunity to try make my first nix expression and nixpkgs. 

Very happy for reviews and questions. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Ubuntu
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x]  Tested execution of **relevant** binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
