### PR TITLE
puddletag: 1.2.0 -> 2.0.1

### DIFF
--- a/pkgs/applications/audio/puddletag/default.nix
+++ b/pkgs/applications/audio/puddletag/default.nix
@@ -1,37 +1,34 @@
-{ stdenv, fetchFromGitHub, python2Packages, chromaprint }:
+{ stdenv, fetchFromGitHub, python3Packages, chromaprint }:
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "puddletag";
-  version = "1.2.0";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
-    owner  = "keithgg";
-    repo   = "puddletag";
-    rev    = "v${version}";
-    sha256 = "1g6wa91awy17z5b704yi9kfynnvfm9lkrvpfvwccscr1h8s3qmiz";
+    owner = "keithgg";
+    repo = "puddletag";
+    rev = version;
+    sha256 = "sha256-9l8Pc77MX5zFkOqU00HFS8//3Bzd2OMnVV1brmWsNAQ=";
   };
 
-  setSourceRoot = ''
-    sourceRoot=$(echo */source)
-  '';
+  sourceRoot = "source/source";
 
-  disabled = python2Packages.isPy3k; # work to support python 3 has not begun
-
-  propagatedBuildInputs = [ chromaprint ] ++ (with python2Packages; [
+  propagatedBuildInputs = [ chromaprint ] ++ (with python3Packages; [
     configobj
     mutagen
     pyparsing
-    pyqt4
+    pyqt5
   ]);
 
   doCheck = false;   # there are no tests
+
   dontStrip = true;  # we are not generating any binaries
 
   meta = with stdenv.lib; {
     description = "An audio tag editor similar to the Windows program, Mp3tag";
-    homepage    = "https://docs.puddletag.net";
-    license     = licenses.gpl3;
+    homepage = "https://docs.puddletag.net";
+    license = licenses.gpl3;
     maintainers = with maintainers; [ peterhoeg ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Double whammy - py2 -> py3 *AND* qt4 -> qt5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).