### PR TITLE
gemrb: 0.8.6 -> 0.8.7

### DIFF
--- a/pkgs/games/gemrb/default.nix
+++ b/pkgs/games/gemrb/default.nix
@@ -4,24 +4,27 @@
 
 stdenv.mkDerivation rec {
   pname = "gemrb";
-  version = "0.8.6";
+  version = "0.8.7";
 
   src = fetchFromGitHub {
-    owner  = "gemrb";
-    repo   = "gemrb";
-    rev    = "v${version}";
-    sha256 = "0vsr3fsqmv9b7s5l0cwhpq2pf7ah2wvgmcn9y8asj6w8hprp17d4";
+    owner = "gemrb";
+    repo = "gemrb";
+    rev = "v${version}";
+    sha256 = "14j9mhrbi4gnrbv25nlsvcxzkylijzrnwbqqnrg7pr452lb3srpb";
   };
 
-  # TODO: make libpng, libvorbis, sdl_mixer, freetype, vlc, glew (and other gl reqs) optional
+  # TODO: make libpng, libvorbis, sdl_mixer, freetype, vlc, glew (and other gl
+  # reqs) optional
   buildInputs = [ freetype python openal SDL2 SDL2_mixer zlib libpng libvorbis libiconv ];
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
+  # TODO: add proper OpenGL support. We are currently (0.8.7) getting a shader
+  # error on execution when enabled.
   cmakeFlags = [
     "-DLAYOUT=opt"
+    # "-DOPENGL_BACKEND=GLES"
+    # "-DOpenGL_GL_PREFERENCE=GLVND"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Works with pst and bg1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).