### PR TITLE
ocamlPackages.fdkaac: init at 0.3.2

### DIFF
--- a/pkgs/development/ocaml-modules/fdkaac/default.nix
+++ b/pkgs/development/ocaml-modules/fdkaac/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub, buildDunePackage, dune-configurator
+, fdk_aac
+}:
+
+buildDunePackage rec {
+  pname = "fdkaac";
+  version = "0.3.2";
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-fdkaac";
+    rev = version;
+    sha256 = "10i6hsjkrpw7zgx99zvvka3sapd7zy53k7z4b6khj9rdrbrgznv8";
+  };
+
+  useDune2 = true;
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ fdk_aac ];
+
+  meta = {
+    description = "OCaml binding for the fdk-aac library";
+    inherit (src.meta) homepage;
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -284,6 +284,8 @@ let
 
     farfadet = callPackage ../development/ocaml-modules/farfadet { };
 
+    fdkaac = callPackage ../development/ocaml-modules/fdkaac { };
+
     fiat-p256 = callPackage ../development/ocaml-modules/fiat-p256 { };
 
     fieldslib_p4 = callPackage ../development/ocaml-modules/fieldslib { };


### PR DESCRIPTION
###### Motivation for this change

Dependency of recent liquidsoap.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
