### PR TITLE
htop: disable use glyphs for checkmarks

### DIFF
--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -1,5 +1,7 @@
-{ lib, fetchFromGitHub, stdenv, autoreconfHook, ncurses,
-IOKit, python3 }:
+{ lib, fetchFromGitHub, stdenv, autoreconfHook
+, ncurses, IOKit, python3
+, fetchpatch
+}:
 
 stdenv.mkDerivation rec {
   pname = "htop";
@@ -12,10 +14,19 @@ stdenv.mkDerivation rec {
     sha256 = "096gdnpaszs5rfp7qj8npi2jkvdqpp8mznn89f97ykrg6pgagwq4";
   };
 
+  patches = [
+    # Never use glyphs for checkmarks. Issue - https://github.com/htop-dev/htop/issues/29
+    # Remove with the next release.
+    (fetchpatch {
+      url = "https://github.com/htop-dev/htop/commit/96074058278829facb86f6f4de099d56a00a0c0e.patch";
+      sha256 = "1rnfvjfsvfgr1s7kzr1hk6nwik6shcq4mg6dlbgdq0f2fz0cnazk";
+    })
+  ];
+
   nativeBuildInputs = [ autoreconfHook python3 ];
-  buildInputs =
-    [ ncurses ] ++
-    lib.optionals stdenv.isDarwin [ IOKit ];
+
+  buildInputs = [ ncurses
+  ] ++ lib.optionals stdenv.isDarwin [ IOKit ];
 
   meta = with stdenv.lib; {
     description = "An interactive process viewer for Linux";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Never use glyphs for checkmarks.
https://github.com/htop-dev/htop/issues/29


cc @xfix @FRidh @Ma27
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
