### PR TITLE
pythonPackages.blis: add missing dependency numpy

### DIFF
--- a/pkgs/development/python-modules/blis/default.nix
+++ b/pkgs/development/python-modules/blis/default.nix
@@ -20,11 +20,13 @@ buildPythonPackage rec {
     cython
   ];
 
+  propagatedBuildInputs = [
+    numpy
+  ];
+
 
   checkInputs = [
-    cython
     hypothesis
-    numpy
     pytest
   ];
 


### PR DESCRIPTION
###### Motivation for this change
`blis`' `numpy` dependency seems to have been falsely satisfied by its inclusion in `checkInputs`, whereas this seems to actually be an install dependency. This can be demonstrated by attempting to build this package with `doCheck = false` and watching it fail.

Also removed `cython` from `checkInputs` as it's already in `nativeBuildInputs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
