### PR TITLE
pytorch-bin: init at 1.6.0

### DIFF
--- a/pkgs/development/python-modules/pytorch/bin.nix
+++ b/pkgs/development/python-modules/pytorch/bin.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, buildPythonPackage
+, fetchurl
+, isPy37
+, isPy38
+, python
+, nvidia_x11
+, addOpenGLRunpath
+, future
+, numpy
+, patchelf
+, pyyaml
+, requests
+}:
+
+let
+  pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
+  platform = if stdenv.isDarwin then "darwin" else "linux";
+  srcs = import ./binary-hashes.nix;
+  unsupported = throw "Unsupported system";
+in buildPythonPackage {
+  pname = "pytorch";
+  # Don't forget to update pytorch to the same version.
+  version = "1.6.0";
+
+  format = "wheel";
+
+  disabled = !(isPy37 || isPy38);
+
+  src = fetchurl srcs."${stdenv.system}-${pyVerNoDot}" or unsupported;
+
+  nativeBuildInputs = [
+    addOpenGLRunpath
+    patchelf
+  ];
+
+  propagatedBuildInputs = [
+    future
+    numpy
+    pyyaml
+    requests
+  ];
+
+  postInstall = ''
+    # ONNX conversion
+    rm -rf $out/bin
+  '';
+
+  postFixup = let
+    rpath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib nvidia_x11 ];
+  in ''
+    find $out/${python.sitePackages}/torch/lib -type f \( -name '*.so' -or -name '*.so.*' \) | while read lib; do
+      echo "setting rpath for $lib..."
+      patchelf --set-rpath "${rpath}:$out/${python.sitePackages}/torch/lib" "$lib"
+      addOpenGLRunpath "$lib"
+    done
+  '';
+
+  pythonImportsCheck = [ "torch" ];
+
+  meta = with stdenv.lib; {
+    description = "Open source, prototype-to-production deep learning platform";
+    homepage = "https://pytorch.org/";
+    license = licenses.unfree; # Includes CUDA and Intel MKL.
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/development/python-modules/pytorch/binary-hashes.nix
+++ b/pkgs/development/python-modules/pytorch/binary-hashes.nix
@@ -1,0 +1,10 @@
+{
+  x86_64-linux-37 = {
+    url = "https://download.pytorch.org/whl/cu102/torch-1.6.0-cp37-cp37m-linux_x86_64.whl";
+    sha256 = "0xhwv68j8gvahfzcp43bqp2x71iwv6zjhkw2f1hb82xps40mrml7";
+  };
+  x86_64-linux-38 = {
+    url = "https://download.pytorch.org/whl/cu102/torch-1.6.0-cp38-cp38-linux_x86_64.whl";
+    sha256 = "05m2l04wqzw5xvjam6zwvlmc3979cksl3hrdqc2aikrv4hz8fmsk";
+  };
+}

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -104,8 +104,10 @@ let
     "LD_LIBRARY_PATH=${cudaStub}\${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH ";
 
 in buildPythonPackage rec {
-  version = "1.6.0";
   pname = "pytorch";
+  # Don't forget to update pytorch-bin to the same version.
+  version = "1.6.0";
+
   disabled = !isPy3k;
 
   outputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4088,6 +4088,10 @@ in {
     cudaSupport = pkgs.config.cudaSupport or false;
   };
 
+  pytorch-bin = callPackage ../development/python-modules/pytorch/bin.nix {
+    inherit (pkgs.linuxPackages) nvidia_x11;
+  };
+
   pyro-ppl = callPackage ../development/python-modules/pyro-ppl {};
 
   opt-einsum = if isPy27 then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

PyTorch from the binary wheel. This is especially handy for users that need PyTorch with CUDA support or compiled against MKL, but do not have the resources to do a full PyTorch build when there are some changes in PyTorch or its transitive dependencies.

Tested with CPU and CUDA.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
