### PR TITLE
kdesu: update patch to use qCWarning

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kdesu/kdesu-search-for-wrapped-daemon-first.patch
+++ b/pkgs/development/libraries/kde-frameworks/kdesu/kdesu-search-for-wrapped-daemon-first.patch
@@ -21,14 +21,14 @@ index 44fbacd..6b5abf5 100644
 -    if (!QFile::exists(daemon)) { // if not in libexec, find it in PATH
 -        daemon = QStandardPaths::findExecutable(QStringLiteral("kdesud"));
 -        if (daemon.isEmpty()) {
--            qWarning() << "kdesud daemon not found.";
+-            qCWarning(KSU_LOG) << "kdesud daemon not found.";
 +    QString daemon = QFile::decodeName("/run/wrappers/bin/kdesud");
 +    if (!QFile::exists(daemon)) { // if not in wrappers
 +        daemon = QFile::decodeName(CMAKE_INSTALL_FULL_LIBEXECDIR_KF5 "/kdesud");
 +        if (!QFile::exists(daemon)) { // if not in libexec, find it in PATH
 +            daemon = QStandardPaths::findExecutable(QStringLiteral("kdesud"));
 +            if (daemon.isEmpty()) {
-+                qWarning() << "kdesud daemon not found.";
++                qCWarning(KSU_LOG) << "kdesud daemon not found.";
 +            }
          }
      }


### PR DESCRIPTION
###### Motivation for this change
Resolves #96667

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
