### PR TITLE
mympd: init at 6.8.1

### DIFF
--- a/pkgs/applications/audio/mympd/default.nix
+++ b/pkgs/applications/audio/mympd/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, mpd_clientlib
+, openssl
+, lua5_3
+, libid3tag
+, flac
+, mongoose
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mympd";
+  version = "6.8.1";
+
+  src = fetchFromGitHub {
+    owner = "jcorporation";
+    repo = "myMPD";
+    rev = "v${version}";
+    sha256 = "dIGg2mLxN6XBDH3GFXtF7nB9a/zf/qMlPCvIulFRXn8=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
+  buildInputs = [
+    mpd_clientlib
+    openssl
+    lua5_3
+    libid3tag
+    flac
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_LUA=ON"
+    # Otherwise, it tries to parse $out/etc/mympd.conf on startup.
+    "-DCMAKE_INSTALL_SYSCONFDIR=/etc"
+    # similarly here
+    "-DCMAKE_INSTALL_LOCALSTATEDIR=/var/lib/mympd"
+  ];
+  # See https://github.com/jcorporation/myMPD/issues/315
+  hardeningDisable = [ "strictoverflow" ];
+
+  meta = {
+    homepage = "https://jcorporation.github.io/mympd";
+    description = "A standalone and mobile friendly web mpd client with a tiny footprint and advanced features";
+    maintainers = [ stdenv.lib.maintainers.doronbehar ];
+    platforms = stdenv.lib.platforms.linux;
+    license = stdenv.lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22556,6 +22556,9 @@ in
 
   ympd = callPackage ../applications/audio/ympd { };
 
+  # a somewhat more maintained fork of ympd
+  mympd = callPackage ../applications/audio/mympd { };
+
   nload = callPackage ../applications/networking/nload { };
 
   normalize = callPackage ../applications/audio/normalize { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add a maintained fork of ympd.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
