### PR TITLE
xorg: convert type1 fonts and mark packages as unfree

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -50,10 +50,6 @@ self: super:
     hardeningDisable = [ "format" ];
   });
 
-  fontbhttf = super.fontbhttf.overrideAttrs (attrs: {
-    meta = attrs.meta // { license = lib.licenses.unfreeRedistributable; };
-  });
-
   fontmiscmisc = super.fontmiscmisc.overrideAttrs (attrs: {
     postInstall =
       ''
@@ -870,3 +866,41 @@ self: super:
   });
 
 }
+
+# mark some packages as unfree
+// (
+  let
+    # unfree but redistributable
+    redist = [
+      "fontadobeutopiatype1"
+      "fontadobeutopia100dpi"
+      "fontadobeutopia75dpi"
+      "fontbhtype1"
+      "fontibmtype1"
+      "fontbhttf"
+      "fontbh100dpi"
+      "fontbh75dpi"
+    ];
+
+    # unfree, possibly not redistributable
+    unfree = [
+      # no license, just a copyright notice
+      "fontbhlucidatypewriter100dpi"
+      "fontbhlucidatypewriter75dpi"
+      "fontdaewoomisc"
+
+      # unclear license, "permission to use"?
+      "fontjismisc"
+    ];
+
+    setLicense = license: name:
+      super.${name}.overrideAttrs (attrs: {
+        meta = attrs.meta // { inherit license; };
+      });
+    mapNamesToAttrs = f: names: with lib;
+      listToAttrs (zipListsWith nameValuePair names (map f names));
+
+  in
+    mapNamesToAttrs (setLicense lib.licenses.unfreeRedistributable) redist //
+    mapNamesToAttrs (setLicense lib.licenses.unfree) unfree
+)


### PR DESCRIPTION
###### Motivation for this change
See this [comment](https://github.com/NixOS/nixpkgs/issues/75160#issuecomment-683400304)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
