### PR TITLE
spicetify-cli: init at 1.1.0

### DIFF
--- a/pkgs/applications/misc/spicetify-cli/default.nix
+++ b/pkgs/applications/misc/spicetify-cli/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "spicetify-cli";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "khanhas";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "08rnwj7ggh114n3mhhm8hb8fm1njgb4j6vba3hynp8x1c2ngidff";
+  };
+
+  vendorSha256 = "0k06c3jw5z8rw8nk4qf794kyfipylmz6x6l126a2snvwi0lmc601";
+
+  # used at runtime, but not installed by default
+  postInstall = ''
+    cp -r ${src}/jsHelper $out/bin/jsHelper
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/spicetify-cli --help > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "Command-line tool to customize Spotify client";
+    homepage = "https://github.com/khanhas/spicetify-cli/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15484,6 +15484,8 @@ in
 
   spice-up = callPackage ../applications/office/spice-up { };
 
+  spicetify-cli = callPackage ../applications/misc/spicetify-cli { };
+
   spirv-cross = callPackage ../tools/graphics/spirv-cross { };
 
   sratom = callPackage ../development/libraries/audio/sratom { };


### PR DESCRIPTION
###### Motivation for this change
was testing my `nix-template` tool, decided to try and package a go package

closes: #96419


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
