### PR TITLE
tor: Add option to tor service for package

### DIFF
--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -34,8 +34,8 @@ let
     User tor
     DataDirectory ${torDirectory}
     ${optionalString cfg.enableGeoIP ''
-      GeoIPFile ${pkgs.tor.geoip}/share/tor/geoip
-      GeoIPv6File ${pkgs.tor.geoip}/share/tor/geoip6
+      GeoIPFile ${cfg.package.geoip}/share/tor/geoip
+      GeoIPv6File ${cfg.package.geoip}/share/tor/geoip6
     ''}
 
     ${optint "ControlPort" cfg.controlPort}
@@ -120,6 +120,16 @@ in
         description = ''
           Enable the Tor daemon. By default, the daemon is run without
           relay, exit, bridge or client connectivity.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.tor;
+        defaultText = "pkgs.tor";
+        example = literalExample "pkgs.tor";
+        description = ''
+          Tor package to use
         '';
       };
 
@@ -749,8 +759,8 @@ in
         serviceConfig =
           { Type         = "simple";
             # Translated from the upstream contrib/dist/tor.service.in
-            ExecStartPre = "${pkgs.tor}/bin/tor -f ${torRcFile} --verify-config";
-            ExecStart    = "${pkgs.tor}/bin/tor -f ${torRcFile}";
+            ExecStartPre = "${cfg.package}/bin/tor -f ${torRcFile} --verify-config";
+            ExecStart    = "${cfg.package}/bin/tor -f ${torRcFile}";
             ExecReload   = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
             KillSignal   = "SIGINT";
             TimeoutSec   = 30;
@@ -773,7 +783,7 @@ in
           };
       };
 
-    environment.systemPackages = [ pkgs.tor ];
+    environment.systemPackages = [ cfg.package ];
 
     services.privoxy = mkIf (cfg.client.enable && cfg.client.privoxy.enable) {
       enable = true;


### PR DESCRIPTION
###### Motivation for this change

Currently the nixos module for running tor uses pkgs.tor to run the service. As a user I would like to be able to run the latest version of tor for my relay. I was able to accomplish this by overriding tor in nixpkgs like so:

```
  nixpkgs.config = {
    packageOverrides = pkgs: let self = pkgs; in with self; rec {
      tor = unstable.pkgs.tor;
    };
  };
```

But I would like to be able to not overwrite tor in this way and simply tell the service which package I want it to use. This is something many other modules allow. I could then replace the above with:

```
   services.tor = {
     enable = true;
     package = unstable.pkgs.tor;
   };
```
###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
