### PR TITLE
octoprint.python.pkgs.octoprint-dashboard: init at 1.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3623,6 +3623,12 @@
     githubId = 26877687;
     name = "Yurii Izorkin";
   };
+  j0hax = {
+    name = "Johannes Arnold";
+    email = "johannes.arnold@stud.uni-hannover.de";
+    github = "j0hax";
+    githubId = 3802620;
+  };
   jacg = {
     name = "Jacek Generowicz";
     email = "jacg@my-post-office.net";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -271,4 +271,23 @@ in {
       maintainers = with maintainers; [ j0hax ];
     };
   };
+
+  octoprint-dashboard = buildPlugin rec {
+    pname = "OctoPrint-Dashboard";
+    version = "1.13.0";
+
+    src = fetchFromGitHub {
+      owner = "StefanCohen";
+      repo = pname;
+      rev = version;
+      sha256 = "1879l05gkkryvhxkmhr3xvd10d4m7i0cr3jk1gdcv47xwyr6q9pf";
+    };
+
+    meta = with stdenv.lib; {
+      description = "A dashboard for Octoprint";
+      homepage = "https://github.com/StefanCohen/OctoPrint-Dashboard";
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ j0hax ];
+    };
+  };
 }

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -252,4 +252,23 @@ in {
       maintainers = with maintainers; [ WhittlesJr ];
     };
   };
+
+  displaylayerprogress = buildPlugin rec {
+    pname = "OctoPrint-DisplayLayerProgress";
+    version = "1.23.2";
+
+    src = fetchFromGitHub {
+      owner = "OllisGit";
+      repo = pname;
+      rev = version;
+      sha256 = "0yv8gy5dq0rl7zxkvqa98az391aiixl8wbzkyvbmpjar9r6whdzm";
+    };
+
+    meta = with stdenv.lib; {
+      description = "OctoPrint-Plugin that sends the current progress of a print via M117 command";
+      homepage = "https://github.com/OllisGit/OctoPrint-DisplayLayerProgress";
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ j0hax ];
+    };
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Added the plugin `Octoprint-Dashboard` and its optional dependency `Octoprint-DisplayLayerProgress`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
