### PR TITLE
nixosTests.systemd-networkd: fix test flakiness

### DIFF
--- a/nixos/tests/systemd-networkd.nix
+++ b/nixos/tests/systemd-networkd.nix
@@ -7,16 +7,17 @@ let generateNodeConf = { lib, pkgs, config, privk, pubk, peerId, nodeId, ...}: {
       virtualisation.vlans = [ 1 ];
       environment.systemPackages = with pkgs; [ wireguard-tools ];
       boot.extraModulePackages = [ config.boot.kernelPackages.wireguard ];
-      systemd.tmpfiles.rules = [
-        "f /run/wg_priv 0640 root systemd-network - ${privk}"
-      ];
       systemd.network = {
         enable = true;
         netdevs = {
           "90-wg0" = {
             netdevConfig = { Kind = "wireguard"; Name = "wg0"; };
             wireguardConfig = {
-              PrivateKeyFile = "/run/wg_priv";
+              # NOTE: we're storing the wireguard private key in the
+              #       store for this test. Do not do this in the real
+              #       world. Keep in mind the nix store is
+              #       world-readable.
+              PrivateKeyFile = pkgs.writeText "wg0-priv" privk;
               ListenPort = 51820;
               FirewallMark = 42;
             };


### PR DESCRIPTION
###### Motivation for this change

Fixes #96642

###### Things done

```
The original idea for this test was, on top of providing a networkd
test, to provide newcomers with a sample configuration they could use
to get started with networkd.

That's precisely why we were doing this systemd tmpfile dance in the
first place. It was a convenient way to create a runtime file with a
specific mode and owner.

Sadly, this tmpfile rule made the test flaky. There's a race condition
between the wireguard interface configured by systemd-networkd and
systemd-tmpfiles-setup.

Sometimes, networkd is going to try loading the wireguard private key
file *before* the said file gets created by systemd-tmpfiles.

A perfect solution here would be to create a "After" dependency
between wg0.netdev and systemd-tmpfiles-setup.service. Sadly, it is
currently impossible to create such a dependency between a
networkd-specific unit and a service.

We're removing this tmp file in favor of pointing networkd directly to
the Nix store. This is clearly something that shouldn't be done in the
real world for a private file: the store is world-readable. However,
this is the only way I found to fix this test flakiness for now.
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@GrahamcOfBorg test systemd-networkd

CC @JJJollyjim @Ma27 
