### PR TITLE
adobe-reader: add gkd-pixbuf-xlib based on issue: #96683

### DIFF
--- a/pkgs/applications/misc/adobe-reader/default.nix
+++ b/pkgs/applications/misc/adobe-reader/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, libX11, cups, zlib, libxml2, pango, atk, gtk2, glib
-, gdk-pixbuf }:
+, gdk-pixbuf, gdk-pixbuf-xlib }:
 
 assert stdenv.hostPlatform.system == "i686-linux";
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   # versions.
 
   libPath = stdenv.lib.makeLibraryPath
-    [ stdenv.cc.cc libX11 zlib libxml2 cups pango atk gtk2 glib gdk-pixbuf ];
+    [ stdenv.cc.cc libX11 zlib libxml2 cups pango atk gtk2 glib gdk-pixbuf gdk-pixbuf-xlib ];
 
   passthru.mozillaPlugin = "/libexec/adobe-reader/Browser/intellinux";
 


### PR DESCRIPTION
##### Motivation for this change
acroreader failed to run, see  #96683

###### Things done
Added gdk-pixbuf-xlib to the lib path

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
