### PR TITLE
fwupd: Add upstream patch to fix build with systemd 246

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -167,6 +167,11 @@ let
         # Needs a different set of modules than po/make-images.
         inherit installedTestsPython;
       })
+
+      (fetchpatch {
+        url = "https://github.com/fwupd/fwupd/commit/3e82beeddac31292c50229e59e2404865edee5ad.patch";
+        sha256 = "17p9r8qddqkrnhy9bvp9207afh5fcl1whn79nqcp57b4q4c17zgk";
+      })
     ];
 
     postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes build failure with systemd 246 (#96663).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
