### PR TITLE
fontdir: Consider scalable fonts in index fonts.dir

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -63,6 +63,14 @@
         <literal>systemd-journal2gelf</literal> no longer parses json and expects the receiving system to handle it. How to achieve this with Graylog is described in this <link xlink:href="https://github.com/parse-nl/SystemdJournal2Gelf/issues/10">GitHub issue</link>.
       </para>
    </listitem>
+   <listitem>
+    <para>
+      The option <option>fonts.enableFontDir</option> has been renamed to
+      <xref linkend="opt-fonts.fontDir.enable"/>. The path of font directory
+      has also been changed to <literal>/run/current-system/sw/share/X11/fonts</literal>,
+      for consistency with other X11 resources.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/config/fonts/fontdir.nix
+++ b/nixos/modules/config/fonts/fontdir.nix
@@ -5,13 +5,10 @@ with lib;
 let
 
   x11Fonts = pkgs.runCommand "X11-fonts" { preferLocalBuild = true; } ''
-    font_formats=('ttf' 'otf' 'pcf' 'pfa' 'pfb' 'bdf')
     mkdir -p "$out/share/X11-fonts"
-    for fmt in "''${font_formats[@]}"; do
-      find ${toString config.fonts.fonts} \
-        \( -name '*.'$fmt -o -name '*.'$fmt'.gz' \) \
-        -exec ln -sf -t "$out/share/X11-fonts" '{}' \;
-    done
+    font_regexp='.*\.\(ttf\|otf\|pcf\|pfa\|pfb\|bdf\)\(\.gz\)?'
+    find ${toString config.fonts.fonts} -regex "$font_regexp" \
+      -exec ln -sf -t "$out/share/X11-fonts" '{}' \;
     cd "$out/share/X11-fonts"
     ${pkgs.xorg.mkfontscale}/bin/mkfontscale
     ${pkgs.xorg.mkfontdir}/bin/mkfontdir

--- a/nixos/modules/config/fonts/fontdir.nix
+++ b/nixos/modules/config/fonts/fontdir.nix
@@ -10,6 +10,9 @@ let
     find ${toString config.fonts.fonts} -regex "$font_regexp" \
       -exec ln -sf -t "$out/share/X11/fonts" '{}' \;
     cd "$out/share/X11/fonts"
+    ${optionalString config.fonts.fontDir.decompressFonts ''
+      ${pkgs.gzip}/bin/gunzip -f *.gz
+    ''}
     ${pkgs.xorg.mkfontscale}/bin/mkfontscale
     ${pkgs.xorg.mkfontdir}/bin/mkfontdir
     cat $(find ${pkgs.xorg.fontalias}/ -name fonts.alias) >fonts.alias
@@ -31,6 +34,14 @@ in
         '';
       };
 
+      decompressFonts = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to decompress fonts in
+          <filename>/run/current-system/sw/share/X11/fonts</filename>.
+        '';
+      };
 
     };
   };

--- a/nixos/modules/config/fonts/fontdir.nix
+++ b/nixos/modules/config/fonts/fontdir.nix
@@ -5,14 +5,16 @@ with lib;
 let
 
   x11Fonts = pkgs.runCommand "X11-fonts" { preferLocalBuild = true; } ''
+    font_formats=('ttf' 'otf' 'pcf' 'pfa' 'pfb' 'bdf')
     mkdir -p "$out/share/X11-fonts"
-    find ${toString config.fonts.fonts} \
-      \( -name fonts.dir -o -name '*.ttf' -o -name '*.otf' \) \
-      -exec ln -sf -t "$out/share/X11-fonts" '{}' \;
+    for fmt in "''${font_formats[@]}"; do
+      find ${toString config.fonts.fonts} \
+        \( -name '*.'$fmt -o -name '*.'$fmt'.gz' \) \
+        -exec ln -sf -t "$out/share/X11-fonts" '{}' \;
+    done
     cd "$out/share/X11-fonts"
-    rm -f fonts.dir fonts.scale fonts.alias
-    ${pkgs.xorg.mkfontdir}/bin/mkfontdir
     ${pkgs.xorg.mkfontscale}/bin/mkfontscale
+    ${pkgs.xorg.mkfontdir}/bin/mkfontdir
     cat $(find ${pkgs.xorg.fontalias}/ -name fonts.alias) >fonts.alias
   '';
 

--- a/nixos/modules/config/fonts/fontdir.nix
+++ b/nixos/modules/config/fonts/fontdir.nix
@@ -5,11 +5,11 @@ with lib;
 let
 
   x11Fonts = pkgs.runCommand "X11-fonts" { preferLocalBuild = true; } ''
-    mkdir -p "$out/share/X11-fonts"
+    mkdir -p "$out/share/X11/fonts"
     font_regexp='.*\.\(ttf\|otf\|pcf\|pfa\|pfb\|bdf\)\(\.gz\)?'
     find ${toString config.fonts.fonts} -regex "$font_regexp" \
-      -exec ln -sf -t "$out/share/X11-fonts" '{}' \;
-    cd "$out/share/X11-fonts"
+      -exec ln -sf -t "$out/share/X11/fonts" '{}' \;
+    cd "$out/share/X11/fonts"
     ${pkgs.xorg.mkfontscale}/bin/mkfontscale
     ${pkgs.xorg.mkfontdir}/bin/mkfontdir
     cat $(find ${pkgs.xorg.fontalias}/ -name fonts.alias) >fonts.alias
@@ -28,7 +28,7 @@ in
         default = false;
         description = ''
           Whether to create a directory with links to all fonts in
-          <filename>/run/current-system/sw/share/X11-fonts</filename>.
+          <filename>/run/current-system/sw/share/X11/fonts</filename>.
         '';
       };
 
@@ -38,9 +38,13 @@ in
 
   config = mkIf config.fonts.enableFontDir {
 
+    # This is enough to make a symlink because the xserver
+    # module already links all /share/X11 paths.
     environment.systemPackages = [ x11Fonts ];
 
-    environment.pathsToLink = [ "/share/X11-fonts" ];
+    services.xserver.filesSection = ''
+      FontPath "${x11Fonts}/share/X11/fonts"
+    '';
 
   };
 

--- a/nixos/modules/config/fonts/fontdir.nix
+++ b/nixos/modules/config/fonts/fontdir.nix
@@ -20,10 +20,9 @@ in
 {
 
   options = {
+    fonts.fontDir = {
 
-    fonts = {
-
-      enableFontDir = mkOption {
+      enable = mkOption {
         type = types.bool;
         default = false;
         description = ''
@@ -32,11 +31,11 @@ in
         '';
       };
 
-    };
 
+    };
   };
 
-  config = mkIf config.fonts.enableFontDir {
+  config = mkIf config.fonts.fontDir.enable {
 
     # This is enough to make a symlink because the xserver
     # module already links all /share/X11 paths.
@@ -47,5 +46,9 @@ in
     '';
 
   };
+
+  imports = [
+    (mkRenamedOptionModule [ "fonts" "enableFontDir" ] [ "fonts" "fontDir" "enable" ])
+  ];
 
 }

--- a/nixos/modules/config/fonts/fontdir.nix
+++ b/nixos/modules/config/fonts/fontdir.nix
@@ -4,13 +4,15 @@ with lib;
 
 let
 
+  cfg = config.fonts.fontDir;
+
   x11Fonts = pkgs.runCommand "X11-fonts" { preferLocalBuild = true; } ''
     mkdir -p "$out/share/X11/fonts"
     font_regexp='.*\.\(ttf\|otf\|pcf\|pfa\|pfb\|bdf\)\(\.gz\)?'
     find ${toString config.fonts.fonts} -regex "$font_regexp" \
       -exec ln -sf -t "$out/share/X11/fonts" '{}' \;
     cd "$out/share/X11/fonts"
-    ${optionalString config.fonts.fontDir.decompressFonts ''
+    ${optionalString cfg.decompressFonts ''
       ${pkgs.gzip}/bin/gunzip -f *.gz
     ''}
     ${pkgs.xorg.mkfontscale}/bin/mkfontscale
@@ -36,7 +38,7 @@ in
 
       decompressFonts = mkOption {
         type = types.bool;
-        default = false;
+        default = config.programs.xwayland.enable;
         description = ''
           Whether to decompress fonts in
           <filename>/run/current-system/sw/share/X11/fonts</filename>.
@@ -46,7 +48,7 @@ in
     };
   };
 
-  config = mkIf config.fonts.fontDir.enable {
+  config = mkIf cfg.enable {
 
     # This is enough to make a symlink because the xserver
     # module already links all /share/X11 paths.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -175,6 +175,7 @@
   ./programs/xfs_quota.nix
   ./programs/xonsh.nix
   ./programs/xss-lock.nix
+  ./programs/xwayland.nix
   ./programs/yabar.nix
   ./programs/zmap.nix
   ./programs/zsh/oh-my-zsh.nix

--- a/nixos/modules/programs/sway.nix
+++ b/nixos/modules/programs/sway.nix
@@ -86,8 +86,7 @@ in {
     extraPackages = mkOption {
       type = with types; listOf package;
       default = with pkgs; [
-        swaylock swayidle
-        xwayland alacritty dmenu
+        swaylock swayidle alacritty dmenu
         rxvt-unicode # For backward compatibility (old default terminal)
       ];
       defaultText = literalExample ''
@@ -104,6 +103,7 @@ in {
         Extra packages to be installed system wide.
       '';
     };
+
   };
 
   config = mkIf cfg.enable {
@@ -130,6 +130,7 @@ in {
     programs.dconf.enable = mkDefault true;
     # To make a Sway session available if a display manager like SDDM is enabled:
     services.xserver.displayManager.sessionPackages = [ swayPackage ];
+    programs.xwayland.enable = mkDefault true;
   };
 
   meta.maintainers = with lib.maintainers; [ gnidorah primeos colemickens ];

--- a/nixos/modules/programs/xwayland.nix
+++ b/nixos/modules/programs/xwayland.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.xwayland;
+
+in
+
+{
+  options.programs.xwayland = {
+
+    enable = mkEnableOption ''
+      Xwayland X server allows running X programs on a Wayland compositor.
+    '';
+
+    defaultFontPath = mkOption {
+      type = types.str;
+      default = optionalString config.fonts.fontDir.enable
+        "/run/current-system/sw/share/X11/fonts";
+      description = ''
+        Default font path. Setting this option causes Xwayland to be rebuilt.
+      '';
+    };
+
+    package = mkOption {
+      type = types.path;
+      description = "The Xwayland package";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    # Needed by some applications for fonts and default settings
+    environment.pathsToLink = [ "/share/X11" ];
+
+    environment.systemPackages = [ cfg.package ];
+
+    programs.xwayland.package = pkgs.xwayland.override (oldArgs: {
+      inherit (cfg) defaultFontPath;
+    });
+
+  };
+}

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -371,7 +371,7 @@ in
         type = types.lines;
         default = "";
         example = ''FontPath "/path/to/my/fonts"'';
-        description = "Contents of the first Files section of the X server configuration file.";
+        description = "Contents of the first <literal>Files</literal> section of the X server configuration file.";
       };
 
       deviceSection = mkOption {

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -136,6 +136,7 @@ let
           fi
         done
 
+        echo '${cfg.filesSection}' >> $out
         echo 'EndSection' >> $out
 
         echo "$config" >> $out
@@ -364,6 +365,13 @@ in
           The contents of the configuration file of the X server
           (<filename>xorg.conf</filename>).
         '';
+      };
+
+      filesSection = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''FontPath "/path/to/my/fonts"'';
+        description = "Contents of the first Files section of the X server configuration file.";
       };
 
       deviceSection = mkOption {

--- a/pkgs/servers/x11/xorg/xwayland.nix
+++ b/pkgs/servers/x11/xorg/xwayland.nix
@@ -1,4 +1,6 @@
-{ stdenv, wayland, wayland-protocols, xorgserver, xkbcomp, xkeyboard_config, epoxy, libxslt, libunwind, makeWrapper, egl-wayland }:
+{ stdenv, wayland, wayland-protocols, xorgserver, xkbcomp, xkeyboard_config
+, epoxy, libxslt, libunwind, makeWrapper, egl-wayland
+, defaultFontPath ? "" }:
 
 with stdenv.lib;
 
@@ -19,7 +21,7 @@ xorgserver.overrideAttrs (oldAttrs: {
     "--disable-xquartz"
     "--disable-xwin"
     "--enable-glamor"
-    "--with-default-font-path="
+    "--with-default-font-path=${defaultFontPath}"
     "--with-xkb-bin-directory=${xkbcomp}/bin"
     "--with-xkb-path=${xkeyboard_config}/etc/X11/xkb"
     "--with-xkb-output=$(out)/share/X11/xkb/compiled"


### PR DESCRIPTION
mkfontdir requires the file fonts.scale to consider scalable fonts, thus, mkfontscale should be run before.

This change affects to everyone using the option enableFontDir

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
- The need to use scalable fonts in an old application (using the X11 core font API instead of font-config)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
