### PR TITLE
snooze: init at 0.4

### DIFF
--- a/pkgs/tools/system/snooze/default.nix
+++ b/pkgs/tools/system/snooze/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  pname = "snooze";
+  version = "0.4";
+  src = fetchFromGitHub {
+    owner = "leahneukirchen";
+    repo = "snooze";
+    rev = "v${version}";
+    sha256 = "0a114brvvjf6vl7grviv0gd6gmikr447m8kq1wilp4yj51sfyxa9";
+  };
+  makeFlags = [ "DESTDIR=$(out)" "PREFIX=/" ];
+
+  meta = with stdenv.lib; {
+    description =
+      "Tool for waiting until a particular time and then running a command.";
+    maintainers = with maintainers; [ kaction ];
+    license = licenses.cc0;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2899,6 +2899,8 @@ in
 
   cron = callPackage ../tools/system/cron { };
 
+  snooze = callPackage ../tools/system/snooze { };
+
   cudaPackages = recurseIntoAttrs (callPackage ../development/compilers/cudatoolkit {});
   inherit (cudaPackages)
     cudatoolkit_6


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


````
$ nix-build . -A snooze
$ nix path-info -S ./result
/nix/store/sg3lv6j0bmbfdya48qbbgy80mw43dy6v-snooze-0.4    32991032
````