### PR TITLE
linux-rt(,_latest): init at 5.4.61-rt37 and 5.6.19-rt12

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rt-5.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.4.nix
@@ -1,0 +1,41 @@
+{ lib, buildLinux, fetchurl
+, kernelPatches ? [ ]
+, structuredExtraConfig ? {}
+, extraMeta ? {}
+, argsOverride ? {}
+, ... } @ args:
+
+let
+  version = "5.4.61-rt37"; # updated by ./update-rt.sh
+  branch = lib.versions.majorMinor version;
+  kversion = builtins.elemAt (lib.splitString "-" version) 0;
+in buildLinux (args // {
+  inherit version;
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
+    sha256 = "197y2yb60m1k8i7mig4pa9wsrklfxq81ba3zfahwb2b31w2kvwc6";
+  };
+
+  kernelPatches = let rt-patch = {
+    name = "rt";
+    patch = fetchurl {
+      url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
+      sha256 = "1qgd55x62pczgmxcxbigkg6f622ma5a6mz4gi55a8mlbxzh2pddj";
+    };
+  }; in [ rt-patch ] ++ lib.remove rt-patch kernelPatches;
+
+  structuredExtraConfig = with lib.kernel; {
+    PREEMPT_RT = yes;
+    # Fix error: unused option: PREEMPT_RT.
+    EXPERT = yes; # PREEMPT_RT depends on it (in kernel/Kconfig.preempt)
+    # Fix error: option not set correctly: PREEMPT_VOLUNTARY (wanted 'y', got 'n').
+    PREEMPT_VOLUNTARY = lib.mkForce no; # PREEMPT_RT deselects it.
+    # Fix error: unused option: RT_GROUP_SCHED.
+    RT_GROUP_SCHED = lib.mkForce (option no); # Removed by sched-disable-rt-group-sched-on-rt.patch.
+  } // structuredExtraConfig;
+
+  extraMeta = extraMeta // {
+    inherit branch;
+  };
+} // argsOverride)

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.6.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.6.nix
@@ -1,0 +1,41 @@
+{ lib, buildLinux, fetchurl
+, kernelPatches ? [ ]
+, structuredExtraConfig ? {}
+, extraMeta ? {}
+, argsOverride ? {}
+, ... } @ args:
+
+let
+  version = "5.6.19-rt12"; # updated by ./update-rt.sh
+  branch = lib.versions.majorMinor version;
+  kversion = builtins.elemAt (lib.splitString "-" version) 0;
+in buildLinux (args // {
+  inherit version;
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
+    sha256 = "1s0yc1138sglbm4vyizl4r7hnc1l7nykdjp4063ad67yayr2ylv2";
+  };
+
+  kernelPatches = let rt-patch = {
+    name = "rt";
+    patch = fetchurl {
+      url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
+      sha256 = "0ia8rx0615x0z2s4ppw1244crg7c5ak07c9n3wbnz7y8bk8hyxws";
+    };
+  }; in [ rt-patch ] ++ lib.remove rt-patch kernelPatches;
+
+  structuredExtraConfig = with lib.kernel; {
+    PREEMPT_RT = yes;
+    # Fix error: unused option: PREEMPT_RT.
+    EXPERT = yes; # PREEMPT_RT depends on it (in kernel/Kconfig.preempt)
+    # Fix error: option not set correctly: PREEMPT_VOLUNTARY (wanted 'y', got 'n').
+    PREEMPT_VOLUNTARY = lib.mkForce no; # PREEMPT_RT deselects it.
+    # Fix error: unused option: RT_GROUP_SCHED.
+    RT_GROUP_SCHED = lib.mkForce (option no); # Removed by sched-disable-rt-group-sched-on-rt.patch.
+  } // structuredExtraConfig;
+
+  extraMeta = extraMeta // {
+    inherit branch;
+  };
+} // argsOverride)

--- a/pkgs/os-specific/linux/kernel/update-rt.sh
+++ b/pkgs/os-specific/linux/kernel/update-rt.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# To update all rt kernels run: ./update-rt.sh
+
+# To update just one ./linux-rt-5.X.nix run: ./update-rt.sh ./linux-rt-5.X.nix
+
+# To add a new kernel branch 5.Y run: ./update-rt.sh ./linux-rt-5.Y.nix
+# (with nonexistent .nix file) and update all-packages.nix.
+
+# To commit run with: env COMMIT=1
+
+mirror=https://kernel.org/pub/linux/kernel
+
+main() {
+    if [ $# -ge 1 ]; then
+        update-if-needed "$1"
+    else
+        update-all-if-needed
+    fi
+}
+
+update-all-if-needed() {
+    for f in "$(dirname "$0")"/linux-rt-*.nix; do
+        update-if-needed "$f"
+    done
+}
+
+file-version() {
+    file="$1" # e.g. ./linux-rt-5.4.nix
+    if [ -e "$file" ]; then
+        grep ' version = ' "$file" | grep -o '[0-9].[^"]*'
+    fi
+}
+
+latest-rt-version() {
+    branch="$1" # e.g. 5.4
+    curl -sL "$mirror/projects/rt/$branch/sha256sums.asc" |
+        sed -ne '/.patch.xz/ { s/.*patch-\(.*\).patch.xz/\1/; p; q }'
+}
+
+update-if-needed() {
+    file="$1" # e.g. ./linux-rt-5.4.nix (created if does not exist)
+    branch=$(basename "$file" .nix) # e.g. linux-rt-5.4
+    branch=${branch#linux-rt-} # e.g. 5.4
+    cur=$(file-version "$file") # e.g. 5.4.59-rt36 or empty
+    new=$(latest-rt-version "$branch") # e.g. 5.4.61-rt37
+    kversion=${new%-*} # e.g. 5.4.61
+    major=${branch%.*} # e.g 5
+    nixattr="linux-rt_${branch/./_}"
+    if [ "$new" = "$cur" ]; then
+        echo "$nixattr: $cur (up-to-date)"
+        return
+    fi
+    khash=$(nix-prefetch-url "$mirror/v${major}.x/linux-${kversion}.tar.xz")
+    phash=$(nix-prefetch-url "$mirror/projects/rt/${branch}/older/patch-${new}.patch.xz")
+    if [ "$cur" ]; then
+        msg="$nixattr: $cur -> $new"
+    else
+        msg="$nixattr: init at $new"
+        prev=$(ls "$(dirname "$0")"/linux-rt-*.nix | tail -1)
+        cp "$prev" "$file"
+        cur=$(file-version "$file")
+    fi
+    echo "$msg"
+    sed -i "$file" \
+        -e "s/$cur/$new/" \
+        -e "s|kernel/v[0-9]*|kernel/v$major|" \
+        -e "1,/.patch.xz/ s/sha256 = .*/sha256 = \"$khash\";/" \
+        -e "1,/.patch.xz/! s/sha256 = .*/sha256 = \"$phash\";/"
+    if [ "${COMMIT:-}" ]; then
+        git add "$file"
+        git commit -m "$msg"
+    fi
+}
+
+return 2>/dev/null || main "$@"

--- a/pkgs/os-specific/linux/kernel/update.sh
+++ b/pkgs/os-specific/linux/kernel/update.sh
@@ -58,6 +58,9 @@ ls $NIXPKGS/pkgs/os-specific/linux/kernel | while read FILE; do
   echo "Updated $OLDVER -> $V"
 done
 
+# Update linux-rt
+COMMIT=1 $NIXPKGS/pkgs/os-specific/linux/kernel/update-rt.sh
+
 # Update linux-libre
 COMMIT=1 $NIXPKGS/pkgs/os-specific/linux/kernel/update-libre.sh
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17590,6 +17590,14 @@ in
     ];
   };
 
+  linux-rt_5_6 = callPackage ../os-specific/linux/kernel/linux-rt-5.6.nix {
+    kernelPatches = [
+      kernelPatches.bridge_stp_helper
+      kernelPatches.request_key_helper
+      kernelPatches.export_kernel_fpu_functions."5.3"
+    ];
+  };
+
   linux_5_7 = callPackage ../os-specific/linux/kernel/linux-5.7.nix {
     kernelPatches = [
       kernelPatches.bridge_stp_helper
@@ -17836,6 +17844,10 @@ in
   linuxPackages-rt_5_4 = linuxPackagesFor pkgs.linux-rt_5_4;
   linuxPackages-rt = linuxPackages-rt_5_4;
   linux-rt = linuxPackages-rt.kernel;
+  linuxPackages-rt_5_6 = linuxPackagesFor pkgs.linux-rt_5_6;
+  linuxPackages-rt_latest = linuxPackages-rt_5_6;
+  linux-rt_latest = linuxPackages-rt_latest.kernel;
+
   linuxPackages_mptcp = linuxPackagesFor pkgs.linux_mptcp;
   linuxPackages_rpi1 = linuxPackagesFor pkgs.linux_rpi1;
   linuxPackages_rpi2 = linuxPackagesFor pkgs.linux_rpi2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17582,6 +17582,14 @@ in
     ];
   };
 
+  linux-rt_5_4 = callPackage ../os-specific/linux/kernel/linux-rt-5.4.nix {
+    kernelPatches = [
+      kernelPatches.bridge_stp_helper
+      kernelPatches.request_key_helper
+      kernelPatches.export_kernel_fpu_functions."5.3"
+    ];
+  };
+
   linux_5_7 = callPackage ../os-specific/linux/kernel/linux-5.7.nix {
     kernelPatches = [
       kernelPatches.bridge_stp_helper
@@ -17824,12 +17832,16 @@ in
   linuxPackages_latest = linuxPackages_5_8;
   linux_latest = linuxPackages_latest.kernel;
 
-  # Build the kernel modules for the some of the kernels.
+  # Realtime kernel packages.
+  linuxPackages-rt_5_4 = linuxPackagesFor pkgs.linux-rt_5_4;
+  linuxPackages-rt = linuxPackages-rt_5_4;
+  linux-rt = linuxPackages-rt.kernel;
   linuxPackages_mptcp = linuxPackagesFor pkgs.linux_mptcp;
   linuxPackages_rpi1 = linuxPackagesFor pkgs.linux_rpi1;
   linuxPackages_rpi2 = linuxPackagesFor pkgs.linux_rpi2;
   linuxPackages_rpi3 = linuxPackagesFor pkgs.linux_rpi3;
   linuxPackages_rpi4 = linuxPackagesFor pkgs.linux_rpi4;
+  # Build kernel modules for some of the kernels.
   linuxPackages_4_4 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_4);
   linuxPackages_4_9 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_9);
   linuxPackages_4_14 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_14);
@@ -17838,7 +17850,7 @@ in
   linuxPackages_5_7 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_5_7);
   linuxPackages_5_8 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_5_8);
 
-  # When adding to this list:
+  # When adding to the list above:
   # - Update linuxPackages_latest to the latest version
   # - Update the rev in ../os-specific/linux/kernel/linux-libre.nix to the latest one.
 


### PR DESCRIPTION
###### Motivation for this change

Closes #59268

Usage: set `boot.kernelPackages = pkgs.linuxPackages-rt;` (or linuxPackages-rt_latest) in configuration.nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
