### PR TITLE
dep2nix, leaps: regenerate deps.nix

### DIFF
--- a/pkgs/development/tools/dep2nix/deps.nix
+++ b/pkgs/development/tools/dep2nix/deps.nix
@@ -1,145 +1,129 @@
-
-  # file automatically generated from Gopkg.lock with https://github.com/nixcloud/dep2nix (golang dep)
-  [
-  
-    {
-      goPackagePath  = "github.com/Masterminds/semver";
-      fetch = {
-        type = "git";
-        url = "https://github.com/Masterminds/semver";
-        rev =  "a93e51b5a57ef416dac8bb02d11407b6f55d8929";
-        sha256 = "1rd3p135r7iw0lvaa6vk7afxna87chq61a7a0wqnxd3xgpnpa9ik";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/Masterminds/vcs";
-      fetch = {
-        type = "git";
-        url = "https://github.com/Masterminds/vcs";
-        rev =  "6f1c6d150500e452704e9863f68c2559f58616bf";
-        sha256 = "02bpyzccazw9lwqchcz349al4vlxnz4m5gzwigk02zg2qpa1j53j";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/armon/go-radix";
-      fetch = {
-        type = "git";
-        url = "https://github.com/armon/go-radix";
-        rev =  "1fca145dffbcaa8fe914309b1ec0cfc67500fe61";
-        sha256 = "19jws9ngncpbhghzcy7biyb4r8jh14mzknyk67cvq6ln7kh1qyic";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/boltdb/bolt";
-      fetch = {
-        type = "git";
-        url = "https://github.com/boltdb/bolt";
-        rev =  "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8";
-        sha256 = "0z7j06lijfi4y30ggf2znak2zf2srv2m6c68ar712wd2ys44qb3r";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/golang/dep";
-      fetch = {
-        type = "git";
-        url = "https://github.com/CrushedPixel/dep";
-        rev =  "fa9f32339c8855ebe7e7bc66e549036a7e06d37a";
-        sha256 = "1knaxs1ji1b0b68393f24r8qzvahxz9x7rqwc8jsjlshvpz0hlm6";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/golang/protobuf";
-      fetch = {
-        type = "git";
-        url = "https://github.com/golang/protobuf";
-        rev =  "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175";
-        sha256 = "1pyli3dcagi7jzpiazph4fhkz7a3z4bhd25nwbb7g0iy69b8z1g4";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/jmank88/nuts";
-      fetch = {
-        type = "git";
-        url = "https://github.com/jmank88/nuts";
-        rev =  "8b28145dffc87104e66d074f62ea8080edfad7c8";
-        sha256 = "1d0xj1dj1lfalq3pg15h0c645n84lf122xx3zkm7hawq9zri6n5k";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/nightlyone/lockfile";
-      fetch = {
-        type = "git";
-        url = "https://github.com/nightlyone/lockfile";
-        rev =  "6a197d5ea61168f2ac821de2b7f011b250904900";
-        sha256 = "03znnf6rzyyi4h4qj81py1xpfs3pnfm39j4bfc9qzakz5j9y1gdl";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/pelletier/go-toml";
-      fetch = {
-        type = "git";
-        url = "https://github.com/pelletier/go-toml";
-        rev =  "acdc4509485b587f5e675510c4f2c63e90ff68a8";
-        sha256 = "1y5m9pngxhsfzcnxh8ma5nsllx74wn0jr47p2n6i3inrjqxr12xh";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/pkg/errors";
-      fetch = {
-        type = "git";
-        url = "https://github.com/pkg/errors";
-        rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
-        sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/sdboyer/constext";
-      fetch = {
-        type = "git";
-        url = "https://github.com/sdboyer/constext";
-        rev =  "836a144573533ea4da4e6929c235fd348aed1c80";
-        sha256 = "0055yw73di4spa1wwpa2pyb708wmh9r3xd8dcv8pn81dba94if1w";
-      };
-    }
-    
-    {
-      goPackagePath  = "golang.org/x/net";
-      fetch = {
-        type = "git";
-        url = "https://go.googlesource.com/net";
-        rev =  "dc948dff8834a7fe1ca525f8d04e261c2b56e70d";
-        sha256 = "0gkw1am63agb1rgpxr2qhns9npr99mzwrxg7px88qq8h93zzd4kg";
-      };
-    }
-    
-    {
-      goPackagePath  = "golang.org/x/sync";
-      fetch = {
-        type = "git";
-        url = "https://go.googlesource.com/sync";
-        rev =  "fd80eb99c8f653c847d294a001bdf2a3a6f768f5";
-        sha256 = "12lzldlj1cqc1babp1hkkn76fglzn5abkqvmbpr4f2j95mf9x836";
-      };
-    }
-    
-    {
-      goPackagePath  = "golang.org/x/sys";
-      fetch = {
-        type = "git";
-        url = "https://go.googlesource.com/sys";
-        rev =  "37707fdb30a5b38865cfb95e5aab41707daec7fd";
-        sha256 = "1abrr2507a737hdqv4q7pw7hv6ls9pdiq9crhdi52r3gcz6hvizg";
-      };
-    }
-    
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/Masterminds/semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/carolynvs/semver.git";
+      rev =  "a93e51b5a57ef416dac8bb02d11407b6f55d8929";
+      sha256 = "1rd3p135r7iw0lvaa6vk7afxna87chq61a7a0wqnxd3xgpnpa9ik";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Masterminds/vcs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Masterminds/vcs";
+      rev =  "6f1c6d150500e452704e9863f68c2559f58616bf";
+      sha256 = "02bpyzccazw9lwqchcz349al4vlxnz4m5gzwigk02zg2qpa1j53j";
+    };
+  }
+  {
+    goPackagePath  = "github.com/armon/go-radix";
+    fetch = {
+      type = "git";
+      url = "https://github.com/armon/go-radix";
+      rev =  "1fca145dffbcaa8fe914309b1ec0cfc67500fe61";
+      sha256 = "19jws9ngncpbhghzcy7biyb4r8jh14mzknyk67cvq6ln7kh1qyic";
+    };
+  }
+  {
+    goPackagePath  = "github.com/boltdb/bolt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/boltdb/bolt";
+      rev =  "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8";
+      sha256 = "0z7j06lijfi4y30ggf2znak2zf2srv2m6c68ar712wd2ys44qb3r";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/dep";
+    fetch = {
+      type = "git";
+      url = "https://github.com/CrushedPixel/dep";
+      rev =  "fa9f32339c8855ebe7e7bc66e549036a7e06d37a";
+      sha256 = "1knaxs1ji1b0b68393f24r8qzvahxz9x7rqwc8jsjlshvpz0hlm6";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175";
+      sha256 = "1pyli3dcagi7jzpiazph4fhkz7a3z4bhd25nwbb7g0iy69b8z1g4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jmank88/nuts";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jmank88/nuts";
+      rev =  "8b28145dffc87104e66d074f62ea8080edfad7c8";
+      sha256 = "1d0xj1dj1lfalq3pg15h0c645n84lf122xx3zkm7hawq9zri6n5k";
+    };
+  }
+  {
+    goPackagePath  = "github.com/nightlyone/lockfile";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nightlyone/lockfile";
+      rev =  "6a197d5ea61168f2ac821de2b7f011b250904900";
+      sha256 = "03znnf6rzyyi4h4qj81py1xpfs3pnfm39j4bfc9qzakz5j9y1gdl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pelletier/go-toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-toml";
+      rev =  "acdc4509485b587f5e675510c4f2c63e90ff68a8";
+      sha256 = "1y5m9pngxhsfzcnxh8ma5nsllx74wn0jr47p2n6i3inrjqxr12xh";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/sdboyer/constext";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sdboyer/constext";
+      rev =  "836a144573533ea4da4e6929c235fd348aed1c80";
+      sha256 = "0055yw73di4spa1wwpa2pyb708wmh9r3xd8dcv8pn81dba94if1w";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "dc948dff8834a7fe1ca525f8d04e261c2b56e70d";
+      sha256 = "0gkw1am63agb1rgpxr2qhns9npr99mzwrxg7px88qq8h93zzd4kg";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev =  "fd80eb99c8f653c847d294a001bdf2a3a6f768f5";
+      sha256 = "12lzldlj1cqc1babp1hkkn76fglzn5abkqvmbpr4f2j95mf9x836";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "37707fdb30a5b38865cfb95e5aab41707daec7fd";
+      sha256 = "1abrr2507a737hdqv4q7pw7hv6ls9pdiq9crhdi52r3gcz6hvizg";
+    };
+  }
 ]

--- a/pkgs/development/tools/leaps/deps.nix
+++ b/pkgs/development/tools/leaps/deps.nix
@@ -1,185 +1,165 @@
-
-  # file automatically generated from Gopkg.lock with https://github.com/nixcloud/dep2nix (golang dep)
-  [
-  
-    {
-      goPackagePath  = "github.com/Azure/go-autorest";
-      fetch = {
-        type = "git";
-        url = "https://github.com/Azure/go-autorest";
-        rev =  "fc3b03a2d2d1f43fad3007038bd16f044f870722";
-        sha256 = "1j6aqbizlpiqcywdsj4dy4i76g8fbqc7d61c22ppc9knw0968h4r";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/Jeffail/gabs";
-      fetch = {
-        type = "git";
-        url = "https://github.com/Jeffail/gabs";
-        rev =  "2a3aa15961d5fee6047b8151b67ac2f08ba2c48c";
-        sha256 = "1fx6fyl5x037viwlj319f3gsq749an17q5l6n2zvf3ny5wq0iqxr";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/amir/raidman";
-      fetch = {
-        type = "git";
-        url = "https://github.com/amir/raidman";
-        rev =  "1ccc43bfb9c93cb401a4025e49c64ba71e5e668b";
-        sha256 = "074ckbyslrwn23q4x01hn3j7c3xngagn36lbli2g51n9j3x14jxr";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/azure/azure-sdk-for-go";
-      fetch = {
-        type = "git";
-        url = "https://github.com/azure/azure-sdk-for-go";
-        rev =  "21b68149ccf7c16b3f028bb4c7fd0ab458fe308f";
-        sha256 = "0zlhrh3n9mc5w7r0sdaqmpqfm2d290b50an0k1bvrr892m4cnxaq";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/cenkalti/backoff";
-      fetch = {
-        type = "git";
-        url = "https://github.com/cenkalti/backoff";
-        rev =  "61153c768f31ee5f130071d08fc82b85208528de";
-        sha256 = "08x77mgb9zsj047n74rx6c16jjx985lmy4s6fl58mdgxgxjv54y5";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/dgrijalva/jwt-go";
-      fetch = {
-        type = "git";
-        url = "https://github.com/dgrijalva/jwt-go";
-        rev =  "dbeaa9332f19a944acb5736b4456cfcc02140e29";
-        sha256 = "0zk6l6kzsjdijfn7c4h0aywdjx5j2hjwi67vy1k6wr46hc8ks2hs";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/elazarl/go-bindata-assetfs";
-      fetch = {
-        type = "git";
-        url = "https://github.com/elazarl/go-bindata-assetfs";
-        rev =  "30f82fa23fd844bd5bb1e5f216db87fd77b5eb43";
-        sha256 = "1swfb37g6sga3awvcmxf49ngbpvjv7ih5an9f8ixjqcfcwnb7nzp";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/garyburd/redigo";
-      fetch = {
-        type = "git";
-        url = "https://github.com/garyburd/redigo";
-        rev =  "d1ed5c67e5794de818ea85e6b522fda02623a484";
-        sha256 = "0gw18k9kg93hvdks93hckrdqppg1bav82sp2c98q6z36dkvaih24";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/go-sql-driver/mysql";
-      fetch = {
-        type = "git";
-        url = "https://github.com/go-sql-driver/mysql";
-        rev =  "a0583e0143b1624142adab07e0e97fe106d99561";
-        sha256 = "1rw1m91dpm23s6nn6jc4zi6rq2mgl7zx07gyadrdn0sh7cj8c89d";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/golang/protobuf";
-      fetch = {
-        type = "git";
-        url = "https://github.com/golang/protobuf";
-        rev =  "925541529c1fa6821df4e44ce2723319eb2be768";
-        sha256 = "1d3zjvhl115l23xakj0014qpjchivlg098h10v5nfirkk1i9f9sa";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/gorilla/websocket";
-      fetch = {
-        type = "git";
-        url = "https://github.com/gorilla/websocket";
-        rev =  "ea4d1f681babbce9545c9c5f3d5194a789c89f5b";
-        sha256 = "1bhgs2542qs49p1dafybqxfs2qc072xv41w5nswyrknwyjxxs2a1";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/kardianos/osext";
-      fetch = {
-        type = "git";
-        url = "https://github.com/kardianos/osext";
-        rev =  "ae77be60afb1dcacde03767a8c37337fad28ac14";
-        sha256 = "056dkgxrqjj5r18bnc3knlpgdz5p3yvp12y4y978hnsfhwaqvbjz";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/lib/pq";
-      fetch = {
-        type = "git";
-        url = "https://github.com/lib/pq";
-        rev =  "88edab0803230a3898347e77b474f8c1820a1f20";
-        sha256 = "02y7c8xy33x5q4167x2drzrys41nfi7wxxp9hy4vpazfws88al9p";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/marstr/guid";
-      fetch = {
-        type = "git";
-        url = "https://github.com/marstr/guid";
-        rev =  "8bdf7d1a087ccc975cf37dd6507da50698fd19ca";
-        sha256 = "1mxcigzfc1bbh5b616hm89bp06allhwcsas9v9lks235h0acgn4x";
-      };
-    }
-    
-    {
-      goPackagePath  = "github.com/satori/go.uuid";
-      fetch = {
-        type = "git";
-        url = "https://github.com/satori/go.uuid";
-        rev =  "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3";
-        sha256 = "1j4s5pfg2ldm35y8ls8jah4dya2grfnx2drb4jcbjsyrp4cm5yfb";
-      };
-    }
-    
-    {
-      goPackagePath  = "golang.org/x/net";
-      fetch = {
-        type = "git";
-        url = "https://go.googlesource.com/net";
-        rev =  "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb";
-        sha256 = "1hmpqkxh97ayyy0xcdvf1bwirwja4wyin3sh0fzjlh93aqmqgylf";
-      };
-    }
-    
-    {
-      goPackagePath  = "gopkg.in/alexcesaro/statsd.v2";
-      fetch = {
-        type = "git";
-        url = "https://gopkg.in/alexcesaro/statsd.v2";
-        rev =  "7fea3f0d2fab1ad973e641e51dba45443a311a90";
-        sha256 = "02jdx68vicwsgabrnwgg1rvc45rinyh8ikinqgbqc56c5hkx3brj";
-      };
-    }
-    
-    {
-      goPackagePath  = "gopkg.in/yaml.v2";
-      fetch = {
-        type = "git";
-        url = "https://gopkg.in/yaml.v2";
-        rev =  "d670f9405373e636a5a2765eea47fac0c9bc91a4";
-        sha256 = "1w1xid51n8v1mydn2m3vgggw8qgpd5a5sr62snsc77d99fpjsrs0";
-      };
-    }
-    
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/Azure/go-autorest";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Azure/go-autorest";
+      rev =  "fc3b03a2d2d1f43fad3007038bd16f044f870722";
+      sha256 = "1j6aqbizlpiqcywdsj4dy4i76g8fbqc7d61c22ppc9knw0968h4r";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Jeffail/gabs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Jeffail/gabs";
+      rev =  "2a3aa15961d5fee6047b8151b67ac2f08ba2c48c";
+      sha256 = "1fx6fyl5x037viwlj319f3gsq749an17q5l6n2zvf3ny5wq0iqxr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/amir/raidman";
+    fetch = {
+      type = "git";
+      url = "https://github.com/amir/raidman";
+      rev =  "1ccc43bfb9c93cb401a4025e49c64ba71e5e668b";
+      sha256 = "074ckbyslrwn23q4x01hn3j7c3xngagn36lbli2g51n9j3x14jxr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/azure/azure-sdk-for-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/azure/azure-sdk-for-go";
+      rev =  "21b68149ccf7c16b3f028bb4c7fd0ab458fe308f";
+      sha256 = "0zlhrh3n9mc5w7r0sdaqmpqfm2d290b50an0k1bvrr892m4cnxaq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cenkalti/backoff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cenkalti/backoff";
+      rev =  "61153c768f31ee5f130071d08fc82b85208528de";
+      sha256 = "08x77mgb9zsj047n74rx6c16jjx985lmy4s6fl58mdgxgxjv54y5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dgrijalva/jwt-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgrijalva/jwt-go";
+      rev =  "dbeaa9332f19a944acb5736b4456cfcc02140e29";
+      sha256 = "0zk6l6kzsjdijfn7c4h0aywdjx5j2hjwi67vy1k6wr46hc8ks2hs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/elazarl/go-bindata-assetfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/elazarl/go-bindata-assetfs";
+      rev =  "30f82fa23fd844bd5bb1e5f216db87fd77b5eb43";
+      sha256 = "1swfb37g6sga3awvcmxf49ngbpvjv7ih5an9f8ixjqcfcwnb7nzp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/garyburd/redigo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/garyburd/redigo";
+      rev =  "d1ed5c67e5794de818ea85e6b522fda02623a484";
+      sha256 = "0gw18k9kg93hvdks93hckrdqppg1bav82sp2c98q6z36dkvaih24";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-sql-driver/mysql";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-sql-driver/mysql";
+      rev =  "a0583e0143b1624142adab07e0e97fe106d99561";
+      sha256 = "1rw1m91dpm23s6nn6jc4zi6rq2mgl7zx07gyadrdn0sh7cj8c89d";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "925541529c1fa6821df4e44ce2723319eb2be768";
+      sha256 = "1d3zjvhl115l23xakj0014qpjchivlg098h10v5nfirkk1i9f9sa";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gorilla/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/websocket";
+      rev =  "ea4d1f681babbce9545c9c5f3d5194a789c89f5b";
+      sha256 = "1bhgs2542qs49p1dafybqxfs2qc072xv41w5nswyrknwyjxxs2a1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/kardianos/osext";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kardianos/osext";
+      rev =  "ae77be60afb1dcacde03767a8c37337fad28ac14";
+      sha256 = "056dkgxrqjj5r18bnc3knlpgdz5p3yvp12y4y978hnsfhwaqvbjz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/lib/pq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lib/pq";
+      rev =  "88edab0803230a3898347e77b474f8c1820a1f20";
+      sha256 = "02y7c8xy33x5q4167x2drzrys41nfi7wxxp9hy4vpazfws88al9p";
+    };
+  }
+  {
+    goPackagePath  = "github.com/marstr/guid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/marstr/guid";
+      rev =  "8bdf7d1a087ccc975cf37dd6507da50698fd19ca";
+      sha256 = "1mxcigzfc1bbh5b616hm89bp06allhwcsas9v9lks235h0acgn4x";
+    };
+  }
+  {
+    goPackagePath  = "github.com/satori/go.uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/satori/go.uuid";
+      rev =  "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3";
+      sha256 = "1j4s5pfg2ldm35y8ls8jah4dya2grfnx2drb4jcbjsyrp4cm5yfb";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb";
+      sha256 = "1hmpqkxh97ayyy0xcdvf1bwirwja4wyin3sh0fzjlh93aqmqgylf";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/alexcesaro/statsd.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alexcesaro/statsd";
+      rev =  "7fea3f0d2fab1ad973e641e51dba45443a311a90";
+      sha256 = "02jdx68vicwsgabrnwgg1rvc45rinyh8ikinqgbqc56c5hkx3brj";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "d670f9405373e636a5a2765eea47fac0c9bc91a4";
+      sha256 = "1w1xid51n8v1mydn2m3vgggw8qgpd5a5sr62snsc77d99fpjsrs0";
+    };
+  }
 ]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Both of these file were oddly formatted with trailing whitespaces compared to the others  generated by dep2nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
