### PR TITLE
noto-fonts: use poetry2nix for python build dependencies

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -12,6 +12,7 @@
 , which
 , imagemagick
 , zopfli
+, poetry2nix
 }:
 
 let
@@ -112,8 +113,9 @@ in
 
   noto-fonts-emoji = let
     version = "unstable-2020-08-20";
-    emojiPythonEnv =
-      python3.withPackages (p: with p; [ fonttools nototools ]);
+    emojiPythonEnv = poetry2nix.mkPoetryEnv {
+      projectDir = ./.;
+    };
   in stdenv.mkDerivation {
     pname = "noto-fonts-emoji";
     inherit version;

--- a/pkgs/data/fonts/noto-fonts/poetry.lock
+++ b/pkgs/data/fonts/noto-fonts/poetry.lock
@@ -1,0 +1,48 @@
+[[package]]
+category = "main"
+description = "Tools to manipulate font files"
+name = "fonttools"
+optional = false
+python-versions = ">=3.6"
+version = "4.14.0"
+
+[package.extras]
+all = ["fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "zopfli (>=0.1.4)", "lz4 (>=1.7.4.2)", "matplotlib", "sympy", "brotli (>=1.0.1)", "scipy", "brotlipy (>=0.7.0)", "munkres", "unicodedata2 (>=13.0.0)", "xattr"]
+graphite = ["lz4 (>=1.7.4.2)"]
+interpolatable = ["scipy", "munkres"]
+lxml = ["lxml (>=4.0,<5)"]
+plot = ["matplotlib"]
+symfont = ["sympy"]
+type1 = ["xattr"]
+ufo = ["fs (>=2.2.0,<3)"]
+unicode = ["unicodedata2 (>=13.0.0)"]
+woff = ["zopfli (>=0.1.4)", "brotli (>=1.0.1)", "brotlipy (>=0.7.0)"]
+
+[[package]]
+category = "main"
+description = "Noto font tools"
+name = "notofonttools"
+optional = false
+python-versions = ">=3.7"
+version = "0.2.11"
+
+[package.dependencies]
+fontTools = "*"
+
+[package.extras]
+shapediff = ["booleanoperations", "defcon", "pillow"]
+
+[metadata]
+content-hash = "2773d30b50571394428d2f7c11e873b5e69ec16ad934ebf1b68cdddefd5bcdaf"
+lock-version = "1.0"
+python-versions = "^3.8"
+
+[metadata.files]
+fonttools = [
+    {file = "fonttools-4.14.0-py3-none-any.whl", hash = "sha256:78a061adbc58ea2e7a6428866aca5f47e119920848fda3cc195e6e843263d390"},
+    {file = "fonttools-4.14.0.zip", hash = "sha256:65744b52eee9da4e6ece77e0f8be1f79ab75f30d0b161ce667e9e2e2ed00b0d1"},
+]
+notofonttools = [
+    {file = "notofonttools-0.2.11-py3-none-any.whl", hash = "sha256:a05ffb34df8600eb02f0df8a013429f4ca02393d138ca256fec78515d7e32d75"},
+    {file = "notofonttools-0.2.11.tar.gz", hash = "sha256:d6cf474d6a2859353901a1600165ed59e188667d4178e746bf37107b138955ac"},
+]

--- a/pkgs/data/fonts/noto-fonts/pyproject.toml
+++ b/pkgs/data/fonts/noto-fonts/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.poetry]
+name = "noto-emoji"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+notofonttools = ">=0.2.4"
+fonttools = "^4.14.0"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
The python dependencies are only used during the build of the font
artifacts, so instead of having to manually package the transitive
dependency graph for every single update, let’s just use a poetry lock
file that can be bumped semi-automatically.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
