### PR TITLE
nix-template: init at 0.1.0

### DIFF
--- a/pkgs/tools/package-management/nix-template/default.nix
+++ b/pkgs/tools/package-management/nix-template/default.nix
@@ -1,0 +1,23 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nix-template";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jonringer";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1h6xdvhzg7nb0s82b3r5bsh8bfdb1l5sm7fa24lfwd396xp9yyig";
+  };
+
+  cargoSha256 = "13y3b60xnry71999kygvkr29gkyjss3ga3rzb43ajah4qp90rsqs";
+
+  meta = with lib; {
+    description = "Make creating nix expressions easy";
+    homepage = "https://github.com/jonringer/nix-template/";
+    changelog = "https://github.com/jonringer/nix-template/releases/tag/v${version}";
+    license = licenses.cc0;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2241,6 +2241,8 @@ in
 
   nix-direnv = callPackage ../tools/misc/nix-direnv { };
 
+  nix-template = callPackage ../tools/package-management/nix-template { };
+
   nixpkgs-pytools = with python3.pkgs; toPythonApplication nixpkgs-pytools;
 
   noteshrink = callPackage ../tools/misc/noteshrink { };


### PR DESCRIPTION
###### Motivation for this change
I've been cooking up a small CLI program to help with having to generate largely boilerplate nix expressions

Felt like it was "good" enough for a beta "0.1.0" release

Also using it as an excuse to learn Rust.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
