### PR TITLE
ocamlPackages.srt: init at 0.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/srt/default.nix
+++ b/pkgs/development/ocaml-modules/srt/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildDunePackage, fetchFromGitHub
+, dune-configurator
+, posix-socket
+, srt
+}:
+
+buildDunePackage rec {
+  pname = "srt";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-srt";
+    rev = "v${version}";
+    sha256 = "0xh89w4j7lljvpy2n08x6m9kw88f82snmzf23kp0gw637sjnrj6f";
+  };
+
+  useDune2 = true;
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ posix-socket srt ];
+
+  meta = {
+    description = "OCaml bindings for the libsrt library";
+    license = lib.licenses.gpl2Only;
+    inherit (src.meta) homepage;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -912,6 +912,10 @@ let
 
     sqlite3EZ = callPackage ../development/ocaml-modules/sqlite3EZ { };
 
+    srt = callPackage ../development/ocaml-modules/srt {
+      inherit (pkgs) srt;
+    };
+
     ssl = callPackage ../development/ocaml-modules/ssl { };
 
     stdlib-shims = callPackage ../development/ocaml-modules/stdlib-shims { };


### PR DESCRIPTION
###### Motivation for this change

Dependency of recent liquidsoap.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
