### PR TITLE
mbuffer: Use objdump from environment when cross-building

### DIFF
--- a/pkgs/tools/misc/mbuffer/default.nix
+++ b/pkgs/tools/misc/mbuffer/default.nix
@@ -12,6 +12,14 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ openssl ];
+
+  # The mbuffer configure scripts fails to recognize the correct
+  # objdump binary during cross-building for foreign platforms.
+  # The correct objdump is exposed via the environment variable
+  # $OBJDUMP, which should be used in such cases.
+  preConfigure = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    substituteInPlace configure --replace "OBJDUMP=$ac_cv_path_OBJDUMP" 'OBJDUMP=''${OBJDUMP}'
+  '';
   doCheck = true;
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
The mbuffer configure scripts fails to recognize the correct
objdump binary during cross-building for foreign platforms.
The correct objdump is exposed via the environment variable
$OBJDUMP, which should be used in such cases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
