### PR TITLE
libseccomp: move gpref from buildInputs to nativeBuildInputs

### DIFF
--- a/pkgs/development/libraries/libseccomp/default.nix
+++ b/pkgs/development/libraries/libseccomp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, getopt, makeWrapper, utillinux, gperf }:
+{ stdenv, fetchurl, getopt, utillinux, gperf }:
 
 stdenv.mkDerivation rec {
   pname = "libseccomp";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" "dev" "man" ];
 
-  buildInputs = [ getopt makeWrapper gperf ];
+  nativeBuildInputs = [ gperf ];
+  buildInputs = [ getopt ];
 
   patchPhase = ''
     patchShebangs .


### PR DESCRIPTION
Fixes a cross-compilation issue due to gperf not being available on the host system

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
