### PR TITLE
source-highlight: Skip building docs when cross-compiling

### DIFF
--- a/pkgs/tools/text/source-highlight/default.nix
+++ b/pkgs/tools/text/source-highlight/default.nix
@@ -12,6 +12,14 @@ stdenv.mkDerivation {
     sha256 = "148w47k3zswbxvhg83z38ifi85f9dqcpg7icvvw1cm6bg21x4zrs";
   };
 
+  # source-highlight uses it's own binary to generate documentation.
+  # During cross-compilation, that binary was built for the target
+  # platform architecture, so it can't run on the build host.
+  patchPhase = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    substituteInPlace Makefile.in --replace "src doc tests" "src tests"
+  '';
+
+  strictDeps = true;
   buildInputs = [ boost ];
 
   configureFlags = [ "--with-boost=${boost.out}" ];


### PR DESCRIPTION
###### Motivation for this change

source-highlight uses it's own binary to generate documentation.
During cross-compilation, that binary was built for the target
platform architecture, so it can't run on the build host.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
