### PR TITLE
numworks: init udev rules and module

### DIFF
--- a/pkgs/os-specific/linux/numworks-udev-rules/50-numworks-calculator.rules
+++ b/pkgs/os-specific/linux/numworks-udev-rules/50-numworks-calculator.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="a291", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="df11", TAG+="uaccess"

--- a/pkgs/os-specific/linux/numworks-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/numworks-udev-rules/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "numworks-udev-rules";
+  version = "unstable-2020-08-31";
+
+  udevRules = ./50-numworks-calculator.rules;
+  dontUnpack = true;
+
+  installPhase = ''
+    install -Dm 644 "${udevRules}" "$out/lib/udev/rules.d/50-numworks-calculator.rules"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Udev rules for Numworks calculators";
+    homepage = "https://numworks.com";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/numworks-udev-rules/update.sh
+++ b/pkgs/os-specific/linux/numworks-udev-rules/update.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+wget -O 50-numworks-calculator.rules "https://workshop.numworks.com/files/drivers/linux/50-numworks-calculator.rules"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2151,6 +2151,8 @@ in
 
   numatop = callPackage ../os-specific/linux/numatop { };
 
+  numworks-udev-rules = callPackage ../os-specific/linux/numworks-udev-rules { };
+
   iio-sensor-proxy = callPackage ../os-specific/linux/iio-sensor-proxy { };
 
   ipvsadm = callPackage ../os-specific/linux/ipvsadm { };


### PR DESCRIPTION
###### Motivation for this change
Just bought a numworks calculator and needed to upgrade the firmware (will also hack a bit with it as all the software is opensource).

###### Things done
Packaged the linux udev rule for numworks calculators and created the corresponding module. 

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
