### PR TITLE
nixos/cri-o: unset hooks dir to avoid dir creation on startup

### DIFF
--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -101,6 +101,7 @@ in
       log_level = "${cfg.logLevel}"
       manage_ns_lifecycle = true
       pinns_path = "${cfg.package}/bin/pinns"
+      hooks_dir = []
 
       ${optionalString (cfg.runtime != null) ''
       default_runtime = "${cfg.runtime}"


### PR DESCRIPTION

###### Motivation for this change
The hooks directory is created on startup of CRI-O and NixOS does not provide any hooks per default. I think it is save to disable it.

cc @NixOS/podman 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
