### PR TITLE
mpdscheduler: init at 1.0.0, nixos/mpdscheduler: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -110,6 +110,12 @@
     githubId = 1174810;
     name = "Nikolay Amiantov";
   };
+  aberDerBart = {
+    email = "aber@der-b.art";
+    github = "AberDerBart";
+    githubId = 8435083;
+    name = "Jonas Grosse-Holz";
+  };
   abhi18av = {
     email = "abhi18av@gmail.com";
     github = "abhi18av";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -223,6 +223,7 @@
   ./services/audio/squeezelite.nix
   ./services/audio/spotifyd.nix
   ./services/audio/ympd.nix
+  ./services/audio/mpdscheduler.nix
   ./services/backup/automysqlbackup.nix
   ./services/backup/bacula.nix
   ./services/backup/borgbackup.nix

--- a/nixos/modules/services/audio/mpdscheduler.nix
+++ b/nixos/modules/services/audio/mpdscheduler.nix
@@ -1,0 +1,58 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.mpdscheduler;
+in {
+  options.services.mpdscheduler = {
+    enable = mkEnableOption "mpdscheduler service";
+    host = mkOption {
+      type = types.str;
+      description = "The mpd host to connect to.";
+      default = "localhost";
+      example = "mpdHost.local";
+    };
+    port = mkOption {
+      type = types.port;
+      description = "The mpd tcp port to connect to.";
+      default = 6600;
+    };
+    additionalChannels = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether the 'alarm', 'sleep' and 'cancel' channels shall be used in addition to the 'scheduler' channel.";
+    };
+    fadeTime = mkOption {
+      type = types.ints.unsigned;
+      default = 30;
+      description = "Alarm/sleep fade time in seconds.";
+      example = 15;
+    };
+    maxVolume = mkOption {
+      type = types.ints.between 0 100;
+      default = 100;
+      description = "The volume to wake at in percent.";
+      example = 50;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.mpdscheduler = {
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        MPD_HOST = cfg.host;
+        MPD_PORT = "${toString cfg.port}";
+        MPDSCHEDULER_FADE_TIME = "${toString cfg.fadeTime}";
+        MPDSCHEDULER_MAX_VOLUME = "${toString cfg.maxVolume}";
+        MPDSCHEDULER_ADDITIONAL_CHANNELS = if cfg.additionalChannels then "1" else "0";
+      };
+      after = [
+        "network.target"
+        (mkIf (cfg.host == "localhost") "mpd.service")
+      ];
+      serviceConfig.ExecStart = "${pkgs.mpdscheduler}/bin/mpdscheduler";
+    };
+  };
+
+  meta.maintainers = [ maintainers.aberDerBart ];
+}
+

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -211,6 +211,7 @@ in
   morty = handleTest ./morty.nix {};
   mosquitto = handleTest ./mosquitto.nix {};
   mpd = handleTest ./mpd.nix {};
+  mpdscheduler = handleTest ./mpdscheduler.nix {};
   mumble = handleTest ./mumble.nix {};
   munin = handleTest ./munin.nix {};
   mutableUsers = handleTest ./mutable-users.nix {};

--- a/nixos/tests/mpdscheduler.nix
+++ b/nixos/tests/mpdscheduler.nix
@@ -1,0 +1,130 @@
+import ./make-test-python.nix ({ pkgs, ... } :
+let
+  track = pkgs.fetchurl {
+    # Sourced from http://freemusicarchive.org/music/Blue_Wave_Theory/Surf_Music_Month_Challenge/Skyhawk_Beach_fade_in
+    # License: http://creativecommons.org/licenses/by-sa/4.0/
+
+    name = "Blue_Wave_Theory-Skyhawk_Beach.mp3";
+    url = "https://files.freemusicarchive.org/storage-freemusicarchive-org/music/ccCommunity/Blue_Wave_Theory/Surf_Music_Month_Challenge/Blue_Wave_Theory_-_04_-_Skyhawk_Beach.mp3";
+    sha256 = "0xw417bxkx4gqqy139bb21yldi37xx8xjfxrwaqa0gyw19dl6mgp";
+  };
+in {
+  name = "mpdscheduler";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ aberDerBart ];
+  };
+
+  nodes = {
+    mpdWithSchedulerHost = { config, pkgs, ... }: {
+      boot.kernelModules = [ "snd-dummy" ];
+      sound.enable = true;
+      services.mpd = {
+        enable = true;
+        extraConfig = ''
+          audio_output {
+            type "alsa"
+            name "alsa"
+            mixer_type "null"
+          }
+          follow_outside_symlinks "yes"
+
+          log_level "verbose"
+        '';
+      };
+      # systemd.services.musicService = musicService {};
+      systemd.tmpfiles.rules = [ "L /var/lib/mpd/music/skyhawk_beach.mp3 - - - - ${track}" ];
+      services.mpdscheduler = {
+        enable = true;
+        fadeTime = 0;
+      };
+
+      environment.systemPackages = with pkgs; [
+        mpc_cli
+      ];
+
+      networking.firewall.allowedTCPPorts = [ 6600 ];
+    };
+
+    mpdOnlyHost = { config, pkgs, ... }: {
+      boot.kernelModules = [ "snd-dummy" ];
+      sound.enable = true;
+      services.mpd = {
+        enable = true;
+        network.listenAddress = "any";
+      };
+
+      environment.systemPackages = with pkgs; [
+        mpc_cli
+      ];
+
+      networking.firewall.allowedTCPPorts = [ 6600 ];
+    };
+
+    mpdschedulerHost = { config, pkgs, ... }: {
+      services.mpdscheduler = {
+        enable = true;
+        host = "mpdOnlyHost";
+        additionalChannels = false;
+      };
+    };
+  };
+
+  testScript = ''
+    mpc = "${pkgs.mpc_cli}/bin/mpc --wait"
+
+    with subtest("Mpdscheduler running on the same machine, additionalChannels=true"):
+        h = mpdWithSchedulerHost
+
+        h.wait_for_unit("mpdscheduler.service")
+        h.wait_for_unit("systemd-tmpfiles-setup.service")
+
+        h.succeed(f"{mpc} update")
+
+        # add a song to the playlist so mpd can play
+        h.succeed(f"{mpc} listall | mpc add")
+
+        # Check we succeeded adding audio tracks to the playlist
+        _, added_tracks = h.execute(f"{mpc} playlist")
+        # assert len(added_tracks.splitlines()) == 0
+
+        # test alarm
+        h.succeed(f"{mpc} sendmessage scheduler 'alarm +0'")
+        # wait for mpdscheduler to do its work
+        time.sleep(0.1)
+        _, output = h.execute(f"{mpc} status")
+        # Assure audio track is playing
+        assert "playing" in output
+
+        # test sleep
+        h.succeed(f"{mpc} sendmessage scheduler 'sleep +0'")
+        # wait for mpdscheduler to do its work
+        time.sleep(0.1)
+        _, output = h.execute(f"{mpc} status")
+        # Assure audio track is paused
+        assert "paused" in output
+
+        # test additional channels
+        h.succeed(f"{mpc} sendmessage alarm +1")
+        h.succeed(f"{mpc} sendmessage sleep +1")
+        h.succeed(f"{mpc} sendmessage cancel 1")
+        h.succeed(f"{mpc} sendmessage cancel 0")
+
+    with subtest("Mpdscheduler on different machine, additionalChannels=false"):
+        h = mpdOnlyHost
+
+        h.wait_for_unit("mpd.service")
+        mpdschedulerHost.wait_for_unit("mpdscheduler.service")
+
+        # test scheduler channel to be available
+        h.succeed(f"{mpc} sendmessage scheduler 'alarm +1'")
+
+        # test additional channels not to be available
+        h.fail(f"{mpc} sendmessage alarm +1")
+        h.fail(f"{mpc} sendmessage sleep +1")
+        h.fail(f"{mpc} sendmessage cancel 0")
+
+        # cancel pending alarm
+        h.succeed(f"{mpc} sendmessage scheduler 'cancel 0'")
+  '';
+})
+

--- a/pkgs/applications/audio/mpdscheduler/default.nix
+++ b/pkgs/applications/audio/mpdscheduler/default.nix
@@ -1,0 +1,27 @@
+{ fetchFromGitHub, stdenv, buildGoModule }:
+
+buildGoModule rec {
+  pname = "mpdscheduler";
+  version = "1.0.0";
+
+  rev = "v${version}";
+  name = "${pname}-${rev}";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "AberDerBart";
+    repo = "mpdscheduler";
+    sha256 = "1fxc416h1hisf3rdnk3h488hbapkmdpxhladbc0v6spgp6ck9y6s";
+  };
+
+  vendorSha256 = "19kxvgxx2cdgwpnqjkkfb0xw73hrf5h1486zfgyhpzm1r3rnwv0v";
+
+  goPackagePath = "github.com/AberDerBart/mpdscheduler";
+
+  meta = with stdenv.lib; {
+    description = "Adds alarm and sleep timer functionality to mpd";
+    maintainers = [ maintainers.aberDerBart ];
+    platforms = platforms.unix;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21718,6 +21718,8 @@ in
 
   ympd = callPackage ../applications/audio/ympd { };
 
+  mpdscheduler = callPackage ../applications/audio/mpdscheduler { };
+
   nload = callPackage ../applications/networking/nload { };
 
   normalize = callPackage ../applications/audio/normalize { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Introduces the tool mpdscheduler which allows setting alarms and sleep timers for [mpd](https://musicpd.org).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
