### PR TITLE
pythonPackages.howdoi: 2.0.3 -> 2.0.4, fix build, init pythonPackages.keep @ 2.9

### DIFF
--- a/pkgs/development/python-modules/howdoi/default.nix
+++ b/pkgs/development/python-modules/howdoi/default.nix
@@ -2,27 +2,37 @@
 , buildPythonPackage
 , fetchPypi
 , six
-, requests-cache
 , pygments
 , pyquery
 , cachelib
 , appdirs
+, keep
 }:
 
 buildPythonPackage rec {
   pname = "howdoi";
-  version = "2.0.3";
+  version = "2.0.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ed8acb75779f598a831224f33fa991c51764872574a128e9b2f11b83fcace010";
+    sha256 = "0hq5biy0mpycbji2mikfbflw4r39prylr47iqhlz234kvwdy0jsg";
   };
 
-  propagatedBuildInputs = [ six requests-cache pygments pyquery cachelib appdirs ];
+  postPatch = ''
+    substituteInPlace setup.py --replace 'cachelib==0.1' 'cachelib'
+  '';
 
+  propagatedBuildInputs = [ six pygments pyquery cachelib appdirs keep ];
+
+  # author hasn't included page_cache directory (which allows tests to run without
+  # external requests) in pypi tarball. github repo doesn't have release revisions
+  # clearly tagged. re-enable tests when either is sorted.
+  doCheck = false;
   preCheck = ''
+    mv howdoi _howdoi
     export HOME=$(mktemp -d)
   '';
+  pythonImportsCheck = [ "howdoi" ];
 
   meta = with lib; {
     description = "Instant coding answers via the command line";

--- a/pkgs/development/python-modules/keep/default.nix
+++ b/pkgs/development/python-modules/keep/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, PyGithub
+, terminaltables
+, click
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "keep";
+  version = "2.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0902kcvhbmy5q5n0ai1df29ybf87qaljz306c5ssl8j9xdjipcq2";
+  };
+
+  propagatedBuildInputs = [
+    click
+    requests
+    terminaltables
+    PyGithub
+  ];
+
+  # no tests
+  pythonImportsCheck = [ "keep" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/orkohunter/keep";
+    description = "A Meta CLI toolkit: Personal shell command keeper and snippets manager";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3104,6 +3104,8 @@ in {
 
   kconfiglib = callPackage ../development/python-modules/kconfiglib { };
 
+  keep = callPackage ../development/python-modules/keep { };
+
   keepalive = callPackage ../development/python-modules/keepalive { };
 
   keepkey_agent = callPackage ../development/python-modules/keepkey_agent { };


### PR DESCRIPTION
###### Motivation for this change
Multiple things were stopping `howdoi` building following its recent bump. It had a new missing dependency `keep`, and its tests were broken.

So I've added `keep`, and tweaked some overly-strict requirements, but eventually had to disable `howdoi`'s tests as it looks like the author has not included the useful `page_cache` directory in the release tarball. The contents of this directory allow the tests to run without external network access. And the github repo isn't clearly tagged with release versions, so I didn't want to go that route. I did turn on `pythonImportsCheck` though, which is better than nothing.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
