### PR TITLE
Xtreme-Download-Manager: init at 7.2.11

### DIFF
--- a/pkgs/applications/networking/xtreme-download-manager/default.nix
+++ b/pkgs/applications/networking/xtreme-download-manager/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+, buildMavenRepositoryFromLockFile
+, jdk11
+, makeWrapper
+, maven
+}:
+
+let
+  mavenRepository =
+   buildMavenRepositoryFromLockFile { file = ./mvn2nix-lock.json; };
+in stdenv.mkDerivation rec {
+  pname = "xtreme-download-manager";
+  version = "7.2.11";
+
+  src = fetchFromGitHub {
+    owner = "subhra74";
+    repo = "xdm";
+    rev = version;
+    sha256 = "1p2mzaaig7fxk3gsk7r5shl1hijfz6bjlhmkqxgipywr1q1f67fb";
+    name = "xdm";
+  };
+
+  sourceRoot = "xdm/app";
+
+  buildInputs = [ jdk11 maven makeWrapper ];
+  buildPhase = ''
+    echo "Building with maven repository ${mavenRepository}"
+    mvn package --offline -Dmaven.repo.local=${mavenRepository}
+    runHook postBuild
+  '';
+
+  postBuild = ''
+    mv target/xdman.jar target/${pname}-${version}.jar
+  '';
+
+  installPhase = ''
+    # create the bin directory
+    mkdir -p $out/bin
+
+    # create a symbolic link for the lib directory
+    ln -s ${mavenRepository} $out/lib
+
+    # copy out the JAR
+    # Maven already setup the classpath to use m2 repository layout
+    # with the prefix of lib/
+    cp target/${pname}-${version}.jar $out/
+
+    # create a wrapper that will automatically set the classpath
+    # this should be the paths from the dependency derivation
+    makeWrapper ${jdk11}/bin/java $out/bin/${pname} \
+          --add-flags "-jar $out/${pname}-${version}.jar"
+  '';
+
+  meta = with lib; {
+    description = "Powerful download accelerator and video downloader";
+    license = licenses.gpl2Plus;
+    homepage = "http://subhra74.github.io/xdm";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/xtreme-download-manager/mvn2nix-lock.json
+++ b/pkgs/applications/networking/xtreme-download-manager/mvn2nix-lock.json
@@ -1,0 +1,2114 @@
+{
+  "dependencies": {
+    "org.codehaus.plexus:plexus-components:pom:1.1.19": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.19/plexus-components-1.1.19.pom",
+      "sha256": "d3e7f3adf5d002c01f362760ad1c2dce98e6354009a7c07c0a105c3eccb17159",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.19/plexus-components-1.1.19.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.18": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.18/plexus-components-1.1.18.pom",
+      "sha256": "ef5dbc7fa918b6dbba71d27e5b3d7a00df624bcfa2549a7297f36fe275f634d7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.18/plexus-components-1.1.18.pom"
+    },
+    "org.sonatype.sisu:sisu-inject-bean:pom:1.4.2": {
+      "layout": "org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.pom",
+      "sha256": "06d75dd6f2a0dc9ea6bf73a67491ba4790f92251c654bf4925511e5e4f48f1df",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.pom"
+    },
+    "org.sonatype.sisu:sisu-guice:pom:2.1.7": {
+      "layout": "org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7.pom",
+      "sha256": "2b3f02f2d0ec3e95884f9ab415596ce627492469c2d8fd75e3fb00fb69532c44",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.15": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.15/plexus-components-1.1.15.pom",
+      "sha256": "7940cd305323b8409fdb7e78398f6efd8ff8a642c7dd8f353e519abe91ab0da3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.15/plexus-components-1.1.15.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.14": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.14/plexus-components-1.1.14.pom",
+      "sha256": "381d72c526be217b770f9f8c3f749a86d3b1548ac5c1fcb48d267530ec60d43f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.14/plexus-components-1.1.14.pom"
+    },
+    "org.apache.maven:maven-artifact-manager:pom:2.0": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0/maven-artifact-manager-2.0.pom",
+      "sha256": "fbe4dae4a41127b78f75a40543d2aad51130252d904f5bdab34aeb1f08dbedd6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0/maven-artifact-manager-2.0.pom"
+    },
+    "org.apache.maven.shared:maven-shared-io:jar:1.1": {
+      "layout": "org/apache/maven/shared/maven-shared-io/1.1/maven-shared-io-1.1.jar",
+      "sha256": "10c0b971d692d2e3026aec6c49cbb12ddee4214e2a727603d1d309779ca2a62b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-io/1.1/maven-shared-io-1.1.jar"
+    },
+    "org.codehaus.plexus:plexus-io:jar:2.0.2": {
+      "layout": "org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.jar",
+      "sha256": "e2f88c8813463aabfb1b689f0be551c24c58e8e5508fd5a44f8d20a327b1517f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.jar"
+    },
+    "org.apache.maven:maven-project:pom:2.0.4": {
+      "layout": "org/apache/maven/maven-project/2.0.4/maven-project-2.0.4.pom",
+      "sha256": "8dfa987422e1eeaa2f8da8d2696f9bc00c127647830e56254ffe6ae5709faeaf",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.4/maven-project-2.0.4.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:2.0.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/2.0.1/plexus-utils-2.0.1.pom",
+      "sha256": "5e436f4f8a223f6e41f103abad1bc4be3a48402cfb8dc6532f5a03e7bdb1c723",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.1/plexus-utils-2.0.1.pom"
+    },
+    "org.apache.maven:maven:pom:2.0": {
+      "layout": "org/apache/maven/maven/2.0/maven-2.0.pom",
+      "sha256": "26f4354dd76180a0a397e7733cdcb5f7ff8744fd327390f989d8e3ecb4ddf2bb",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0/maven-2.0.pom"
+    },
+    "org.apache.maven:maven-project:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.pom",
+      "sha256": "7dd6468c154d99c39a94c7a8c734aa96366864334b6b2ea10778459860cbe3e5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.pom"
+    },
+    "org.apache.maven:maven-project:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.pom",
+      "sha256": "fa8043afdbe232e7541b965386dc582be336783ac220aadc9bde401b02295a90",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.pom"
+    },
+    "org.apache.maven:maven-plugin-api:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.pom",
+      "sha256": "0ef1a886c795b5ca48d08245b13d1128ecbc6fd0f05e6556749547df9978680b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.pom"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.7.1": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.7.1/plexus-containers-1.7.1.pom",
+      "sha256": "5566a0bb51dc994c0350206608c7b4cdcc9b66881497bab56a32c42edca53e79",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.7.1/plexus-containers-1.7.1.pom"
+    },
+    "org.apache.maven:maven:pom:2.0.4": {
+      "layout": "org/apache/maven/maven/2.0.4/maven-2.0.4.pom",
+      "sha256": "39ed32405d60da7d1e194b3a13e53ead998558668db87d21bef7fe69d9cbd287",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.4/maven-2.0.4.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:jar:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.jar",
+      "sha256": "69197486cd80beb54b4e0fcabaa325ec2d4e2636e9b245c472435c87a10931cf",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.jar"
+    },
+    "org.apache.maven:maven:pom:2.0.2": {
+      "layout": "org/apache/maven/maven/2.0.2/maven-2.0.2.pom",
+      "sha256": "1eb80693b5d9c6d8c0124766606cca4e8199f7a07724d09fdf4e9c000ee8c304",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.2/maven-2.0.2.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:2.0.4": {
+      "layout": "org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.pom",
+      "sha256": "2896dbf57e8c82121481400e8be4df6110edd37e346a6c144b3156f24bf98f72",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.pom"
+    },
+    "org.apache.maven:maven:pom:2.0.9": {
+      "layout": "org/apache/maven/maven/2.0.9/maven-2.0.9.pom",
+      "sha256": "6db25755b962d443bd7698b87654f336de43fd5319cbcc000e2e72c08c3619b4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.9/maven-2.0.9.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:2.0.5": {
+      "layout": "org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom",
+      "sha256": "35bc7d1213616236571072b2c56da18f7a57658de8b4a4100645b7054a2b273b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom"
+    },
+    "org.apache.maven:maven:pom:2.0.8": {
+      "layout": "org/apache/maven/maven/2.0.8/maven-2.0.8.pom",
+      "sha256": "33f59eb5269d810f999ce018f974e23ce4e8a144daf72943bd50265b6b7f4f0d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.8/maven-2.0.8.pom"
+    },
+    "org.apache.maven:maven:pom:2.0.6": {
+      "layout": "org/apache/maven/maven/2.0.6/maven-2.0.6.pom",
+      "sha256": "f5755c01058f048c61c3baf11e03c605b9c0ec1021ab40a3dcb76fb5bf51ff34",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.6/maven-2.0.6.pom"
+    },
+    "org.sonatype.plexus:plexus-cipher:pom:1.4": {
+      "layout": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom",
+      "sha256": "a63a2e23988cca7fac6c93886d6f0506fd26d88d7e8cc0cb89b9c6e0d6c994ad",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.15": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.pom",
+      "sha256": "12a3c9a32b82fdc95223cab1f9d344e14ef3e396da14c4d0013451646f3280e7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.pom"
+    },
+    "backport-util-concurrent:backport-util-concurrent:pom:3.1": {
+      "layout": "backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.pom",
+      "sha256": "770471090ca40a17b9e436ee2ec00819be42042da6f4085ece1d37916dc08ff9",
+      "url": "https://repo.maven.apache.org/maven2/backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.pom"
+    },
+    "commons-logging:commons-logging-api:jar:1.1": {
+      "layout": "commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.jar",
+      "sha256": "33a4dd47bb4764e4eb3692d86386d17a0d9827f4f4bb0f70121efab6bc03ba35",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.jar"
+    },
+    "org.apache.maven:maven-profile:pom:2.0.4": {
+      "layout": "org/apache/maven/maven-profile/2.0.4/maven-profile-2.0.4.pom",
+      "sha256": "3dfe0725e12871248ac59c36abe1316fcfeab2051bd203ba53edfdd0e658ca33",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.4/maven-profile-2.0.4.pom"
+    },
+    "org.apache.maven.shared:maven-filtering:jar:1.1": {
+      "layout": "org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.jar",
+      "sha256": "05fa641c31894ce930c6eb76ec1aa53a9de4cd9baa837fe492e9e0407099d226",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.jar"
+    },
+    "org.apache.maven.plugins:maven-compiler-plugin:pom:3.1": {
+      "layout": "org/apache/maven/plugins/maven-compiler-plugin/3.1/maven-compiler-plugin-3.1.pom",
+      "sha256": "45940a032f78466dd1686acb5769eca3ecc9baf7ca9a3517c138887d8cbe8b1c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.1/maven-compiler-plugin-3.1.pom"
+    },
+    "org.apache.maven:maven-core:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.pom",
+      "sha256": "1ae908507b9781902c425f261af8aa1bf5cf77632a69534aee479887787ee059",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.pom"
+    },
+    "org.apache.maven:maven-profile:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.pom",
+      "sha256": "3be51b8a7e080ae0a765e870fa8c3acaab2a916ec24cbf0bb468d5d8abcbc104",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.pom"
+    },
+    "org.apache.maven:maven-core:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom",
+      "sha256": "1ab7fdd1b82382690c081d3ea3f53bad2902e1d62a11a8096488711e7a5f607e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom"
+    },
+    "org.apache.maven:maven-profile:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.pom",
+      "sha256": "09455abf6ab86671fab0ae5bba8293c17382c8a9c53fafc3befb3e0720f2b707",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.pom"
+    },
+    "org.apache.commons:commons-parent:pom:42": {
+      "layout": "org/apache/commons/commons-parent/42/commons-parent-42.pom",
+      "sha256": "cd313494c670b483ec256972af1698b330e598f807002354eb765479f604b09c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/42/commons-parent-42.pom"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.0": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0/maven-plugin-parameter-documenter-2.0.pom",
+      "sha256": "dd73b6a91523cf25ada769922b368e1f4a0f1bcd41ca9aefe9d98509f4d213bc",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0/maven-plugin-parameter-documenter-2.0.pom"
+    },
+    "org.apache.maven.surefire:surefire-booter:pom:3.0.0-M3": {
+      "layout": "org/apache/maven/surefire/surefire-booter/3.0.0-M3/surefire-booter-3.0.0-M3.pom",
+      "sha256": "6321afbd7879b8945aef21b3b5fbab2caf4d7e94448b8b6062f678d8e36853b8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.0.0-M3/surefire-booter-3.0.0-M3.pom"
+    },
+    "org.apache.maven.wagon:wagon-provider-api:pom:1.0-alpha-6": {
+      "layout": "org/apache/maven/wagon/wagon-provider-api/1.0-alpha-6/wagon-provider-api-1.0-alpha-6.pom",
+      "sha256": "0a752e52297e91d0d1266655e3058fda197fb3f0d9d37f01ac49053b223ccbc5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/1.0-alpha-6/wagon-provider-api-1.0-alpha-6.pom"
+    },
+    "org.apache.maven:maven-parent:pom:9": {
+      "layout": "org/apache/maven/maven-parent/9/maven-parent-9.pom",
+      "sha256": "8e7054879496abff4f6960b946dbf67ab33671bf8c9b98bc154b7e0fb8bad5ae",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/9/maven-parent-9.pom"
+    },
+    "org.apache.maven:maven-parent:pom:8": {
+      "layout": "org/apache/maven/maven-parent/8/maven-parent-8.pom",
+      "sha256": "3cb6712f827c80dc6b0b0b967776dba451c023a92b7741bba45d23ab7a83281a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/8/maven-parent-8.pom"
+    },
+    "org.apache.maven:maven-parent:pom:7": {
+      "layout": "org/apache/maven/maven-parent/7/maven-parent-7.pom",
+      "sha256": "54adf65728e30283650f9a9fac0d2d33f60f2c99fbcdea27671e6f6b076f6df3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/7/maven-parent-7.pom"
+    },
+    "org.apache.maven:maven-parent:pom:6": {
+      "layout": "org/apache/maven/maven-parent/6/maven-parent-6.pom",
+      "sha256": "df8f5fc5e956249833fe9e9bd6df891ca7224ceff1cb729dd84848376545afda",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/6/maven-parent-6.pom"
+    },
+    "org.apache.maven:maven-parent:pom:5": {
+      "layout": "org/apache/maven/maven-parent/5/maven-parent-5.pom",
+      "sha256": "5d7c2a229173155823c45380332f221bf0d27e52c9db76e9217940306765bd50",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/5/maven-parent-5.pom"
+    },
+    "org.apache.maven:maven-parent:pom:4": {
+      "layout": "org/apache/maven/maven-parent/4/maven-parent-4.pom",
+      "sha256": "2b4fe0b8d8b098514fae7bc73891864abc1da4a530613f836f298fa9640d7b63",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/4/maven-parent-4.pom"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:pom:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.pom",
+      "sha256": "815f3ec316b8c5fa701385fdf4009bfb51e07d780e8f6a6e2afe720c52d7e292",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.pom"
+    },
+    "org.apache.maven:maven-toolchain:pom:3.0-alpha-2": {
+      "layout": "org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.pom",
+      "sha256": "764a6ebbc61180bdfd5ab35cb9d8460eadcbc05ceea1fbfbcd355f34f8f19c19",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.pom"
+    },
+    "org.apache.maven:maven:pom:3.0": {
+      "layout": "org/apache/maven/maven/3.0/maven-3.0.pom",
+      "sha256": "28fc63720c4a5ff92bf0e358ed55a6f24626f35bccc13cc3e194231e158848f6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/3.0/maven-3.0.pom"
+    },
+    "org.sonatype.forge:forge-parent:pom:3": {
+      "layout": "org/sonatype/forge/forge-parent/3/forge-parent-3.pom",
+      "sha256": "03263b68791fb11e7464ffcc2c3de7eaeae235de8c94827ce6407e0454d2aae9",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/3/forge-parent-3.pom"
+    },
+    "org.sonatype.forge:forge-parent:pom:5": {
+      "layout": "org/sonatype/forge/forge-parent/5/forge-parent-5.pom",
+      "sha256": "e56188aa8ce51278006aa90bc7e0f304a81e2f1219f462e7d21f262535cd2795",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/5/forge-parent-5.pom"
+    },
+    "org.sonatype.forge:forge-parent:pom:4": {
+      "layout": "org/sonatype/forge/forge-parent/4/forge-parent-4.pom",
+      "sha256": "1838d132479005b4b7459b798e9d9915515090c288082fdcd86db0b10983a24c",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom"
+    },
+    "org.sonatype.forge:forge-parent:pom:6": {
+      "layout": "org/sonatype/forge/forge-parent/6/forge-parent-6.pom",
+      "sha256": "9c5f7cd5226ac8c3798cb1f800c031f7dedc1606dc50dc29567877c8224459a7",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/6/forge-parent-6.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom",
+      "sha256": "f658a628efd6e0efe416b977638ba144af660fe6413f3637a4d03feb6a1ce806",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom"
+    },
+    "org.apache.maven.surefire:surefire:pom:3.0.0-M3": {
+      "layout": "org/apache/maven/surefire/surefire/3.0.0-M3/surefire-3.0.0-M3.pom",
+      "sha256": "ac196bf297309a375ca732d0967260a9bddbc86b533140d63128441f0075257c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/3.0.0-M3/surefire-3.0.0-M3.pom"
+    },
+    "org.apache.maven:maven-error-diagnostics:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar",
+      "sha256": "59c637b910c0de53d28aeeb6444ee5fe1a8fa8f3da32dbbc4485250c166d3fee",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar"
+    },
+    "org.apache.maven:maven-artifact-manager:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.jar",
+      "sha256": "2cc0e74f4f8fe9f9733cd207101809273026464c64d3f1fb2af06b9d2a3c323e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.jar"
+    },
+    "org.apache.maven:maven-artifact-manager:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.jar",
+      "sha256": "d913865e03e719ac5733260019e98090a12b50683134e65f78c36e8d67f11ff1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.jar"
+    },
+    "org.apache:apache:pom:13": {
+      "layout": "org/apache/apache/13/apache-13.pom",
+      "sha256": "ff513db0361fd41237bef4784968bc15aae478d4ec0a9496f811072ccaf3841d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/13/apache-13.pom"
+    },
+    "org.apache.maven:maven-compat:pom:3.0": {
+      "layout": "org/apache/maven/maven-compat/3.0/maven-compat-3.0.pom",
+      "sha256": "612a1751377f324c1a6167c6d70a26800cbe3f1b2a37d03a9377ef4f80e7b526",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0/maven-compat-3.0.pom"
+    },
+    "org.apache.maven:maven-error-diagnostics:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.jar",
+      "sha256": "c16be9fd50777338fa36d09c5c037b2d9ef9b68f00c67e9aa54b2d2b19fbf8f2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.jar"
+    },
+    "org.apache.maven:maven-artifact-manager:jar:2.0.2": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.2/maven-artifact-manager-2.0.2.jar",
+      "sha256": "3ceec8c66c1d206d6e51e43659bccd26b53db32ace638b5f77f99c43f9a51e3d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.2/maven-artifact-manager-2.0.2.jar"
+    },
+    "org.apache:apache:pom:18": {
+      "layout": "org/apache/apache/18/apache-18.pom",
+      "sha256": "7831307285fd475bbc36b20ae38e7882f11c3153b1d5930f852d44eda8f33c17",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/18/apache-18.pom"
+    },
+    "org.codehaus.plexus:plexus-java:jar:1.0.1": {
+      "layout": "org/codehaus/plexus/plexus-java/1.0.1/plexus-java-1.0.1.jar",
+      "sha256": "c52be20104a347003c254365476bf25b271232cee95baa01fd8f93e42502353d",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.0.1/plexus-java-1.0.1.jar"
+    },
+    "org.codehaus.plexus:plexus-interactivity-api:pom:1.0-alpha-4": {
+      "layout": "org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.pom",
+      "sha256": "42aada809ec125bbfe4d38f9d196bbeb59f298b389df96e610269e369b8eb2c9",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.pom"
+    },
+    "net.java.dev.jna:jna-platform:jar:5.5.0": {
+      "layout": "net/java/dev/jna/jna-platform/5.5.0/jna-platform-5.5.0.jar",
+      "sha256": "24d81621f82ac29fcdd9a74116031f5907a2343158e616f4573bbfa2434ae0d5",
+      "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna-platform/5.5.0/jna-platform-5.5.0.jar"
+    },
+    "org.apache:apache:pom:11": {
+      "layout": "org/apache/apache/11/apache-11.pom",
+      "sha256": "9a4fb5addb41d8116b6441e9e3c48764d9cc562243d5608652bea6db0509297b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/11/apache-11.pom"
+    },
+    "org.apache:apache:pom:10": {
+      "layout": "org/apache/apache/10/apache-10.pom",
+      "sha256": "802feece72852dafcbd0a425a60367c72c5cb9b6ea5aae59481128569189daf9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/10/apache-10.pom"
+    },
+    "org.apache.maven.doxia:doxia-sink-api:pom:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.pom",
+      "sha256": "3b0fa210dcbf0c92545ac31740fc2dd8af61dc72fd452cfca3d68aeabb642003",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.pom"
+    },
+    "org.codehaus.plexus:plexus-io:pom:1.0-alpha-4": {
+      "layout": "org/codehaus/plexus/plexus-io/1.0-alpha-4/plexus-io-1.0-alpha-4.pom",
+      "sha256": "96a4c8bf4446c22e9560009a4f3670425e83eec979b9ebdc15565b4fb6615de5",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/1.0-alpha-4/plexus-io-1.0-alpha-4.pom"
+    },
+    "org.codehaus.plexus:plexus-io:pom:1.0-alpha-3": {
+      "layout": "org/codehaus/plexus/plexus-io/1.0-alpha-3/plexus-io-1.0-alpha-3.pom",
+      "sha256": "6bc7fceccaabde91557f6a32a671d6c5a2e980bd817f2abbc07e8033db4788b3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/1.0-alpha-3/plexus-io-1.0-alpha-3.pom"
+    },
+    "org.apache.maven.plugins:maven-jar-plugin:pom:2.4": {
+      "layout": "org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.pom",
+      "sha256": "a98f60925af4a1729529a1e9c5aba78ffdd024c67a8f825ed974a0ab006d315a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.pom"
+    },
+    "commons-net:commons-net:pom:3.6": {
+      "layout": "commons-net/commons-net/3.6/commons-net-3.6.pom",
+      "sha256": "1bbf48fc513118d7662cc678bade5603e5cacfebe4e186883ca7328d141072c6",
+      "url": "https://repo.maven.apache.org/maven2/commons-net/commons-net/3.6/commons-net-3.6.pom"
+    },
+    "org.tukaani:xz:jar:1.8": {
+      "layout": "org/tukaani/xz/1.8/xz-1.8.jar",
+      "sha256": "8c7964b36fe3f0cbe644b04fcbff84e491ce81917db2f5bfa0cba8e9548aff5d",
+      "url": "https://repo.maven.apache.org/maven2/org/tukaani/xz/1.8/xz-1.8.jar"
+    },
+    "org.apache.maven.shared:maven-common-artifact-filters:pom:1.0-alpha-1": {
+      "layout": "org/apache/maven/shared/maven-common-artifact-filters/1.0-alpha-1/maven-common-artifact-filters-1.0-alpha-1.pom",
+      "sha256": "96edee15f85d167e596a1b251de23b6359116da73aab500851c20d8bbfb738bc",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/1.0-alpha-1/maven-common-artifact-filters-1.0-alpha-1.pom"
+    },
+    "org.apache.maven:maven-parent:pom:33": {
+      "layout": "org/apache/maven/maven-parent/33/maven-parent-33.pom",
+      "sha256": "3856e3fcd169502d5f12fe2452604ebf6c7c025f15656bfa558ea99ed29d73ea",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/33/maven-parent-33.pom"
+    },
+    "org.apache.maven.shared:maven-filtering:pom:1.0-beta-2": {
+      "layout": "org/apache/maven/shared/maven-filtering/1.0-beta-2/maven-filtering-1.0-beta-2.pom",
+      "sha256": "6e0b7374c960c957deca066619b5cb0987f65f6a27ad88c32f50f7244939c12b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.0-beta-2/maven-filtering-1.0-beta-2.pom"
+    },
+    "net.java.dev.jna:jna:jar:5.5.0": {
+      "layout": "net/java/dev/jna/jna/5.5.0/jna-5.5.0.jar",
+      "sha256": "b308faebfe4ed409de8410e0a632d164b2126b035f6eacff968d3908cafb4d9e",
+      "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna/5.5.0/jna-5.5.0.jar"
+    },
+    "org.apache.maven:maven-plugin-descriptor:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.pom",
+      "sha256": "aa38ab11a2c97f9b61dec56074d59e98f2ea63c0cd7b3b2f61acff6549d064e6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.pom"
+    },
+    "org.sonatype.aether:aether-util:jar:1.7": {
+      "layout": "org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar",
+      "sha256": "ff690ffc550b7ada3a4b79ef4ca89bf002b24f43a13a35d10195c3bba63d7654",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar"
+    },
+    "org.apache:apache:pom:21": {
+      "layout": "org/apache/apache/21/apache-21.pom",
+      "sha256": "af10c108da014f17cafac7b52b2b4b5a3a1c18265fa2af97a325d9143537b380",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/21/apache-21.pom"
+    },
+    "org.apache.maven:maven-plugin-descriptor:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom",
+      "sha256": "77ca407ccc76079a2b60f4d3e652c19552890303fa00748623e372eac09039a1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom"
+    },
+    "org.sonatype.sisu.inject:guice-bean:pom:1.4.2": {
+      "layout": "org/sonatype/sisu/inject/guice-bean/1.4.2/guice-bean-1.4.2.pom",
+      "sha256": "d2ee7efbcdc82206c69559548aef86a99add95378f03cc58b4d9696b3969c8bb",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-bean/1.4.2/guice-bean-1.4.2.pom"
+    },
+    "org.sonatype.plexus:plexus-build-api:jar:0.0.4": {
+      "layout": "org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar",
+      "sha256": "d2d415ba26078a84e97816fd444361def86dec65a23b4278d95cfb1c285f2649",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar"
+    },
+    "org.apache.maven.surefire:surefire-api:pom:3.0.0-M3": {
+      "layout": "org/apache/maven/surefire/surefire-api/3.0.0-M3/surefire-api-3.0.0-M3.pom",
+      "sha256": "e2ab0335a6bdd34fbca1a28ffbbe1556a7e7ee314c961587ac7de3fbdebea4a0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.0.0-M3/surefire-api-3.0.0-M3.pom"
+    },
+    "org.codehaus.plexus:plexus-archiver:pom:2.1": {
+      "layout": "org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.pom",
+      "sha256": "d2e14a5c6bed6ac4fc27d57f6ba227bb64a96742f71ee3fbafd2c019fa9d4449",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.pom"
+    },
+    "org.apache.maven:maven-monitor:pom:2.0": {
+      "layout": "org/apache/maven/maven-monitor/2.0/maven-monitor-2.0.pom",
+      "sha256": "bfa63866f2312b1fe99689520d4098824833fd18c548a315901be3b31d5c6122",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0/maven-monitor-2.0.pom"
+    },
+    "org.apache.maven:maven-parent:pom:22": {
+      "layout": "org/apache/maven/maven-parent/22/maven-parent-22.pom",
+      "sha256": "165a409718070698b4eb18fdfee4325bc3361cbb8e96a35f4669982cd2adb79a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/22/maven-parent-22.pom"
+    },
+    "org.apache.maven:maven-parent:pom:21": {
+      "layout": "org/apache/maven/maven-parent/21/maven-parent-21.pom",
+      "sha256": "fc45af8911ea307d1b57564eef1f78b69801e9c11a5619e7eb58d5d00ae9db8e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/21/maven-parent-21.pom"
+    },
+    "org.apache.maven:maven-parent:pom:23": {
+      "layout": "org/apache/maven/maven-parent/23/maven-parent-23.pom",
+      "sha256": "5425501edd9e0bd7b01eca53cc92e06836d24851151304f9c6759e1713541685",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/23/maven-parent-23.pom"
+    },
+    "org.sonatype.aether:aether-impl:jar:1.7": {
+      "layout": "org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.jar",
+      "sha256": "288149850d8d131763df4151f7e443fd2739e48510a6e4cfe49ca082c76130fa",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.jar"
+    },
+    "org.apache.maven:maven-profile:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom",
+      "sha256": "d125b3ade9f694ae60ef835f5ae000b6ba35fba8c34bafd8b40a1961375e63fa",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom"
+    },
+    "org.apache.maven:maven-model:jar:3.0": {
+      "layout": "org/apache/maven/maven-model/3.0/maven-model-3.0.jar",
+      "sha256": "27e426d73f8662b47f60df0e43439b3dec2909c42b89175a6e4431dfed3edafd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.jar"
+    },
+    "org.apache.maven:maven-artifact:pom:3.0": {
+      "layout": "org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.pom",
+      "sha256": "c56a0dbd90cea691f83e58fa9a6388fb3ac6bc3c14b8c04d2e112544651fa528",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.0.4": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.0.4/plexus-utils-1.0.4.pom",
+      "sha256": "36623a9539061d87f078af61ca62c3eacf422eb374641cf8903cdeb759671eb3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.0.4/plexus-utils-1.0.4.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting:pom:2.0": {
+      "layout": "org/apache/maven/reporting/maven-reporting/2.0/maven-reporting-2.0.pom",
+      "sha256": "cacd1da4ae4eb15bc4ddb581ceda9d097b275506d7731d03458edbcf737024d2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.0/maven-reporting-2.0.pom"
+    },
+    "org.apache.maven:maven-plugin-api:pom:2.0.4": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.4/maven-plugin-api-2.0.4.pom",
+      "sha256": "86eee056eb9e468bc78febc4dd2f6b69584e18f4670f7615f4b67e094dac662a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.4/maven-plugin-api-2.0.4.pom"
+    },
+    "org.apache.maven:maven-plugin-api:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.pom",
+      "sha256": "e5886cbf7478ed0a89d4502cb4b6b4d25095a53b74e07439ec0ab3f793405822",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.pom"
+    },
+    "org.codehaus.plexus:plexus-compiler-api:jar:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler-api/2.2/plexus-compiler-api-2.2.jar",
+      "sha256": "b8c7f9f4ea32cee0263d6589bdeb617325edbf6c2930b3d5d1fb5c1442e545d3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.2/plexus-compiler-api-2.2.jar"
+    },
+    "org.apache.maven:maven-archiver:jar:2.5": {
+      "layout": "org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar",
+      "sha256": "9fd34ed18dc5a49011380e620be86314f9f734193b8fcf85fb11e7b3a3929d6e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar"
+    },
+    "org.codehaus.plexus:plexus-compiler-manager:jar:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.jar",
+      "sha256": "e5e201f06eca14b5268ec58003926552aea36b27492da20134c1a00ded6759bb",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.jar"
+    },
+    "org.apache.maven:maven-archiver:jar:2.4": {
+      "layout": "org/apache/maven/maven-archiver/2.4/maven-archiver-2.4.jar",
+      "sha256": "a2d61a09bc82d13dc333e2e4c9795918364d0f959d40616dadeaf1add2575751",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.4/maven-archiver-2.4.jar"
+    },
+    "org.apache.maven:maven-parent:pom:11": {
+      "layout": "org/apache/maven/maven-parent/11/maven-parent-11.pom",
+      "sha256": "7450c3330cf06c254db9f0dc5ef49eac15502311cf19e0208ba473076ee043d6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/11/maven-parent-11.pom"
+    },
+    "org.apache.maven:maven-error-diagnostics:pom:2.0": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.0/maven-error-diagnostics-2.0.pom",
+      "sha256": "e4af173db164e0d7cfc5f1d38dfb9d8323d2339d25246fd87816da93168af81d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0/maven-error-diagnostics-2.0.pom"
+    },
+    "org.apache.maven:maven-parent:pom:10": {
+      "layout": "org/apache/maven/maven-parent/10/maven-parent-10.pom",
+      "sha256": "81fe14cb9779d36e0c610e1049e5b32a6b9974957f257921acf628b31c5486c8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/10/maven-parent-10.pom"
+    },
+    "org.apache.xbean:xbean-reflect:pom:3.4": {
+      "layout": "org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.pom",
+      "sha256": "01c97d4286dd3b5e5441faac3abb589f1fe123cea138bb4ae0995ffae14938df",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting:pom:2.0.6": {
+      "layout": "org/apache/maven/reporting/maven-reporting/2.0.6/maven-reporting-2.0.6.pom",
+      "sha256": "ab803be997ac806ee7f2e179ad3cda640345ed8fc911082b1f80202c7fc463a4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.0.6/maven-reporting-2.0.6.pom"
+    },
+    "commons-lang:commons-lang:jar:2.1": {
+      "layout": "commons-lang/commons-lang/2.1/commons-lang-2.1.jar",
+      "sha256": "2ded7343dc8e57decd5e6302337139be020fdd885a2935925e8d575975e480b9",
+      "url": "https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.1/commons-lang-2.1.jar"
+    },
+    "classworlds:classworlds:pom:1.1-alpha-2": {
+      "layout": "classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.pom",
+      "sha256": "0cc647963b74ad1d7a37c9868e9e5a8f474e49297e1863582253a08a4c719cb1",
+      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.pom"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:pom:1.7.1": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.pom",
+      "sha256": "a909a0cbe292e54122b6b785f6924ab2f09b1630b7889c800e099e2627f91a78",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.pom"
+    },
+    "org.apache.maven:maven-artifact:jar:3.0": {
+      "layout": "org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.jar",
+      "sha256": "759079b9cf0cddae5ba06c96fd72347d82d0bc1d903c95d398c96522b139e470",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.jar"
+    },
+    "org.apache.maven:maven-parent:pom:15": {
+      "layout": "org/apache/maven/maven-parent/15/maven-parent-15.pom",
+      "sha256": "e25770d5d46dcdfdbb9e38ca04f272c5bdf476d88392ab4044ba90678e616d54",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/15/maven-parent-15.pom"
+    },
+    "org.hamcrest:hamcrest-core:pom:1.1": {
+      "layout": "org/hamcrest/hamcrest-core/1.1/hamcrest-core-1.1.pom",
+      "sha256": "397387f406c68ccb403f477ccbec1c818cfc6b8ff4fada5a33e26183a8417c83",
+      "url": "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.1/hamcrest-core-1.1.pom"
+    },
+    "org.apache.maven.wagon:wagon-provider-api:jar:1.0-alpha-6": {
+      "layout": "org/apache/maven/wagon/wagon-provider-api/1.0-alpha-6/wagon-provider-api-1.0-alpha-6.jar",
+      "sha256": "a1e299e44d17d6eb67aacc4b5476bba4cbd4df7d1a16ef46ba9624e79d300c68",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/1.0-alpha-6/wagon-provider-api-1.0-alpha-6.jar"
+    },
+    "org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3": {
+      "layout": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
+      "sha256": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar"
+    },
+    "org.apache.maven:maven-plugin-registry:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar",
+      "sha256": "5e6cc5d0501c8d9b9abf9605283e95733b9428c9033a079502cd4d97cd0c490e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar"
+    },
+    "org.apache.maven:maven-plugin-registry:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom",
+      "sha256": "3db15325cd620c0e54c3d88b6b7ec1bac43db376e18c9bf56bd0c05402ee6be8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom"
+    },
+    "org.sonatype.spice:spice-parent:pom:16": {
+      "layout": "org/sonatype/spice/spice-parent/16/spice-parent-16.pom",
+      "sha256": "258f43b5e805687302a5bb400856b972a573ec42a44f949641354a84b9243758",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/16/spice-parent-16.pom"
+    },
+    "org.sonatype.spice:spice-parent:pom:17": {
+      "layout": "org/sonatype/spice/spice-parent/17/spice-parent-17.pom",
+      "sha256": "9151f9a5b33ec36ee8778842fc56144fb0242d39cbcc42061b053b8909969bdf",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/17/spice-parent-17.pom"
+    },
+    "org.codehaus.plexus:plexus-java:pom:1.0.1": {
+      "layout": "org/codehaus/plexus/plexus-java/1.0.1/plexus-java-1.0.1.pom",
+      "sha256": "343996e51c4ac29a8a94470af1776f97f6682ebf70f3447c2d9d6407c77f2db7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.0.1/plexus-java-1.0.1.pom"
+    },
+    "org.apache:apache:pom:3": {
+      "layout": "org/apache/apache/3/apache-3.pom",
+      "sha256": "393c50afb4b7aa6eb57e5377a55a1a0610b19f75b52ece01308db04a1187a20e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/3/apache-3.pom"
+    },
+    "org.apache.maven:maven-plugin-registry:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.jar",
+      "sha256": "98d6f3fbd17a67736d65e9c4ee484c5d6bc54589042e7cd3db65f87d91070f2a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.jar"
+    },
+    "org.apache:apache:pom:4": {
+      "layout": "org/apache/apache/4/apache-4.pom",
+      "sha256": "9e9323a26ba8eb2394efef0c96d31b70df570808630dc147cab1e73541cc5194",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/4/apache-4.pom"
+    },
+    "org.apache:apache:pom:5": {
+      "layout": "org/apache/apache/5/apache-5.pom",
+      "sha256": "1933a6037439b389bda2feaccfc0113880fd8d88f7d240d2052b91108dd5ae89",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/5/apache-5.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:7": {
+      "layout": "org/apache/maven/shared/maven-shared-components/7/maven-shared-components-7.pom",
+      "sha256": "4f0a6ebf2c0fa535e9861a95d6c6fe0a2d1090876021278b494d0aab9bd130db",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/7/maven-shared-components-7.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:6": {
+      "layout": "org/apache/maven/shared/maven-shared-components/6/maven-shared-components-6.pom",
+      "sha256": "82d8e8844a07dc0ff0211a1bb6f90b2e717c73c846a239b7203964168f3add03",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/6/maven-shared-components-6.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:8": {
+      "layout": "org/apache/maven/shared/maven-shared-components/8/maven-shared-components-8.pom",
+      "sha256": "a8d03f96ac58a1d00bad2ed7d251e3eda857c592a09e58d6bdb79d5e8626a316",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/8/maven-shared-components-8.pom"
+    },
+    "net.java.dev.jna:jna-platform:pom:5.5.0": {
+      "layout": "net/java/dev/jna/jna-platform/5.5.0/jna-platform-5.5.0.pom",
+      "sha256": "10569e3622e974d3e66255ba85923c125d84fa257ef2543d8ac1c658d9ebcd10",
+      "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna-platform/5.5.0/jna-platform-5.5.0.pom"
+    },
+    "org.sonatype.spice:spice-parent:pom:10": {
+      "layout": "org/sonatype/spice/spice-parent/10/spice-parent-10.pom",
+      "sha256": "683c012c6bf5e1e31b232b3755c027ccd829692a09c8216652b414b09d4ae623",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/10/spice-parent-10.pom"
+    },
+    "org.sonatype.spice:spice-parent:pom:12": {
+      "layout": "org/sonatype/spice/spice-parent/12/spice-parent-12.pom",
+      "sha256": "21a19b26dbe5c38ddb5114cf4eadbf5ccb411bc6b128fdd5949b1ccb12f3683e",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom"
+    },
+    "org.apache.maven.shared:maven-shared-incremental:jar:1.1": {
+      "layout": "org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar",
+      "sha256": "61988e54486a5dc38f06c70fdae5b108556c63bd433697b9f4305fcdb30fa40e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:4": {
+      "layout": "org/apache/maven/shared/maven-shared-components/4/maven-shared-components-4.pom",
+      "sha256": "89ba78a4eef91456b28df9b0ed874e889d6ede135e6269d218964f5b2749d45e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/4/maven-shared-components-4.pom"
+    },
+    "org.codehaus.plexus:plexus-compiler-api:pom:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler-api/2.2/plexus-compiler-api-2.2.pom",
+      "sha256": "c50bb4169e2ae41d184b6507839100033bf6e86f54828829038aa0f7c8e89aa3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.2/plexus-compiler-api-2.2.pom"
+    },
+    "org.apache.maven.wagon:wagon-provider-api:pom:1.0-beta-6": {
+      "layout": "org/apache/maven/wagon/wagon-provider-api/1.0-beta-6/wagon-provider-api-1.0-beta-6.pom",
+      "sha256": "85c3c8840bb21554faf159998146f7ca9ef1b951defb29ec4e8252ec463728fd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/1.0-beta-6/wagon-provider-api-1.0-beta-6.pom"
+    },
+    "classworlds:classworlds:jar:1.1": {
+      "layout": "classworlds/classworlds/1.1/classworlds-1.1.jar",
+      "sha256": "4e3e0ad158ec60917e0de544c550f31cd65d5a97c3af1c1968bf427e4a9df2e4",
+      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1/classworlds-1.1.jar"
+    },
+    "org.sonatype.aether:aether-api:jar:1.7": {
+      "layout": "org/sonatype/aether/aether-api/1.7/aether-api-1.7.jar",
+      "sha256": "1c5c5ac5e8f29aefc8faa051ffa14eccd85b9e20f4bb35dc82fba7d5da50d326",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.7/aether-api-1.7.jar"
+    },
+    "org.apache.maven.plugins:maven-resources-plugin:jar:2.6": {
+      "layout": "org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.jar",
+      "sha256": "07bd1b98b5b029af91fabcf99a9b3463b9dc09b993f28c2ee0ccc98265888ca6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.jar"
+    },
+    "org.codehaus.plexus:plexus-active-collections:pom:1.0-beta-2": {
+      "layout": "org/codehaus/plexus/plexus-active-collections/1.0-beta-2/plexus-active-collections-1.0-beta-2.pom",
+      "sha256": "51fd6215404edb9e390dde8b302fe17b59b6ba69331c65b1ed3260ff30c51a37",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-active-collections/1.0-beta-2/plexus-active-collections-1.0-beta-2.pom"
+    },
+    "org.apache.maven:maven-aether-provider:pom:3.0": {
+      "layout": "org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.pom",
+      "sha256": "755c07a1ae47cff80f633265b224341d6d8cc26f02d37eb407bc45ff5db9a71d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.pom"
+    },
+    "org.ow2:ow2:pom:1.5": {
+      "layout": "org/ow2/ow2/1.5/ow2-1.5.pom",
+      "sha256": "0f8a1b116e760b8fe6389c51b84e4b07a70fc11082d4f936e453b583dd50b43b",
+      "url": "https://repo.maven.apache.org/maven2/org/ow2/ow2/1.5/ow2-1.5.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-22": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-22/plexus-container-default-1.0-alpha-22.pom",
+      "sha256": "05c646a3006f96aa1fe2e7d78dcf6bbb81252aee40eb9d83430da0bb423e98a5",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-22/plexus-container-default-1.0-alpha-22.pom"
+    },
+    "org.apache.maven:maven-plugin-api:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom",
+      "sha256": "c10d0460c2d5c5076304598965991d6257d1bf31bdef921a17ce3d059bce654e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom"
+    },
+    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7": {
+      "layout": "org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar",
+      "sha256": "240113a2f22fd1f0b182b32baecf0e7876b3a8e41f3c4da3335eeb9ffb24b9f4",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar"
+    },
+    "org.apache.maven.plugins:maven-surefire-plugin:jar:3.0.0-M3": {
+      "layout": "org/apache/maven/plugins/maven-surefire-plugin/3.0.0-M3/maven-surefire-plugin-3.0.0-M3.jar",
+      "sha256": "f78b27e4bda669163d5e350fa18c833686abb47b437771fc1bbae9a5e64f0f4a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.0.0-M3/maven-surefire-plugin-3.0.0-M3.jar"
+    },
+    "org.codehaus.plexus:plexus-classworlds:pom:2.2.2": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.pom",
+      "sha256": "6aad43eb7fee989d50f1ecaf4a8030c708f9c9ea3eb72ee023d76746ff89570a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.pom"
+    },
+    "com.google:google:pom:1": {
+      "layout": "com/google/google/1/google-1.pom",
+      "sha256": "cd6db17a11a31ede794ccbd1df0e4d9750f640234731f21cff885a9997277e81",
+      "url": "https://repo.maven.apache.org/maven2/com/google/google/1/google-1.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:pom:2.2.3": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.pom",
+      "sha256": "a2d14b6752e30a100a6cb03c040d0160b71b61928daf8ea97cabfb4a3335b213",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.pom"
+    },
+    "org.apache.maven:maven-plugin-descriptor:pom:2.0": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.0/maven-plugin-descriptor-2.0.pom",
+      "sha256": "c5122a68fe16b32009f55e1d3434941393cb7787a1d39e55caa481f6a9fd80ff",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0/maven-plugin-descriptor-2.0.pom"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom",
+      "sha256": "902b0160f7b81ec76452468f8ae087fc1cfefc08367c84d9197512dfb01d845d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-8": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-8/plexus-container-default-1.0-alpha-8.pom",
+      "sha256": "b6617c2c7169b8d6c2440972e0d36e1265a80ed1d0def0263f1b400f4f3494a3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-8/plexus-container-default-1.0-alpha-8.pom"
+    },
+    "org.apache.xbean:xbean:pom:3.4": {
+      "layout": "org/apache/xbean/xbean/3.4/xbean-3.4.pom",
+      "sha256": "56ab9c6c2d022a9b7079006ba500a996cd2c21411d53cac524933af20c5a4b99",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean/3.4/xbean-3.4.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-9": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.pom",
+      "sha256": "8864b08e353614d0c4111f455f8b3907179f8b0be6c0845bc7f31ef6daf206ec",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.pom"
+    },
+    "com.google.collections:google-collections:pom:1.0": {
+      "layout": "com/google/collections/google-collections/1.0/google-collections-1.0.pom",
+      "sha256": "893d56afcea1b22f83220fd7e49a6668c5b8901e39bd59dc57b42f55673721ce",
+      "url": "https://repo.maven.apache.org/maven2/com/google/collections/google-collections/1.0/google-collections-1.0.pom"
+    },
+    "org.apache.maven.surefire:surefire-logger-api:pom:3.0.0-M3": {
+      "layout": "org/apache/maven/surefire/surefire-logger-api/3.0.0-M3/surefire-logger-api-3.0.0-M3.pom",
+      "sha256": "447246bbc5b59953d17a26f4d233283fb4adbe8e9a42bb5a80960131909d1fb0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.0.0-M3/surefire-logger-api-3.0.0-M3.pom"
+    },
+    "org.apache.maven.plugins:maven-resources-plugin:pom:2.6": {
+      "layout": "org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.pom",
+      "sha256": "a7842d002fbc7d2a84217106be909bc85ea35aa47031e410ab8afbb3b3364e2d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.3": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.3/plexus-utils-1.3.pom",
+      "sha256": "29fd54ef49c7b404b091e87bb8726de50447d728b46c592fab0806ac9f6b113b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.3/plexus-utils-1.3.pom"
+    },
+    "org.sonatype.oss:oss-parent:pom:9": {
+      "layout": "org/sonatype/oss/oss-parent/9/oss-parent-9.pom",
+      "sha256": "fb40265f982548212ff82e362e59732b2187ec6f0d80182885c14ef1f982827a",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.pom",
+      "sha256": "e1772a8a6be92088ae069a3dd4f7c9dcbc0888434341028735da0f22481bcd47",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.2": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.2/plexus-utils-1.2.pom",
+      "sha256": "71b8f080225e4a18aaeb18f43aab9a98bc76a6052d864e89eff79070b2b498c6",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.2/plexus-utils-1.2.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.11": {
+      "layout": "org/codehaus/plexus/plexus/1.0.11/plexus-1.0.11.pom",
+      "sha256": "5197630dcd2336f5b4ab8e6d26e5b8675f5ebd83bd8c91d6aba431b09627d626",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.11/plexus-1.0.11.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.10": {
+      "layout": "org/codehaus/plexus/plexus/1.0.10/plexus-1.0.10.pom",
+      "sha256": "09b999a969e73525a6cc3ad2868ea744766e1d93b25c6c656d61a5ff9c881da9",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.10/plexus-1.0.10.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-15": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-15/plexus-container-default-1.0-alpha-15.pom",
+      "sha256": "734a7a72d14604611991e1342cc3677eab4f974bf8f7fe73b54cf77f44169832",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-15/plexus-container-default-1.0-alpha-15.pom"
+    },
+    "log4j:log4j:jar:1.2.12": {
+      "layout": "log4j/log4j/1.2.12/log4j-1.2.12.jar",
+      "sha256": "dc67378cf428c06408e7959e83bdc1518dd22ccd313e7c28a986612d65c276c7",
+      "url": "https://repo.maven.apache.org/maven2/log4j/log4j/1.2.12/log4j-1.2.12.jar"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.12": {
+      "layout": "org/codehaus/plexus/plexus/1.0.12/plexus-1.0.12.pom",
+      "sha256": "e3feb169478a21ea8e3af27f90b2d8551309ee771f24176e37ad48bbd7bdad04",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.12/plexus-1.0.12.pom"
+    },
+    "org.hamcrest:hamcrest-parent:pom:1.1": {
+      "layout": "org/hamcrest/hamcrest-parent/1.1/hamcrest-parent-1.1.pom",
+      "sha256": "14e6950a1a6298cbcb83cf9429cac415ff273167f6f15876859413b0d6c07e3a",
+      "url": "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-parent/1.1/hamcrest-parent-1.1.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:jar:2.0.6": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar",
+      "sha256": "ba372ac9e52b481671bb3ea913063cd66747780de340d0c3b1f18c49ec998786",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.6": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.6/plexus-utils-1.5.6.pom",
+      "sha256": "0d473f85e79ae843569b9302f634fc3f70bdf135200ab2a486770f57deddbf39",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.6/plexus-utils-1.5.6.pom"
+    },
+    "org.apache.maven.surefire:surefire-api:jar:3.0.0-M3": {
+      "layout": "org/apache/maven/surefire/surefire-api/3.0.0-M3/surefire-api-3.0.0-M3.jar",
+      "sha256": "d585ca4abbdcff01708ed0b3f8ee531767edb6063f7dce845046544158b5ebb4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.0.0-M3/surefire-api-3.0.0-M3.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.8": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.pom",
+      "sha256": "1ff4fb95c218af4a46f71d625212c70f377ccf97ad2e26cb8d4c10709265bf62",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.pom",
+      "sha256": "e237bba8d1c65c171b5fe8774a2ff817525df6315b929a2085cf70cff15b1b58",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.pom"
+    },
+    "org.apache.maven:maven-settings:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar",
+      "sha256": "1e5c98ebc4b9ae1f2c8d843c1dd9701a1c25b9afaff143c3e1fa4d90c22850fe",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom",
+      "sha256": "f860675cad10e561bfa175d5717e2d8617d40c62321086ca4a85c006a0fa30d1",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom"
+    },
+    "org.apache.maven:maven-settings:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar",
+      "sha256": "bb7af11f28a37d21bf20e11705c78aa4adce3aaff1b9b981c031c6be1aa0ec97",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar"
+    },
+    "commons-cli:commons-cli:jar:1.0": {
+      "layout": "commons-cli/commons-cli/1.0/commons-cli-1.0.jar",
+      "sha256": "43f24850b7b7b7d79c5fa652418518fbdf427e602b1edabe6f11b85fb93eb013",
+      "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0.jar"
+    },
+    "org.codehaus.plexus:plexus-compiler-javac:pom:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.pom",
+      "sha256": "18a41342ece8d3016b4b5ec3e84b52331420413a17ce298574c1f61e26733955",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.pom"
+    },
+    "org.apache.maven.shared:maven-shared-incremental:pom:1.1": {
+      "layout": "org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom",
+      "sha256": "f21d19eb49b4a66cd85354a9ee7335439ea92a368173760a202766008cc19924",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom"
+    },
+    "org.codehaus.plexus:plexus-interactivity-api:jar:1.0-alpha-4": {
+      "layout": "org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar",
+      "sha256": "4f60eb379f93d8b616bc3b4d299f466bc54fcced959f7ad082dae78b89d6a3f0",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.0": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0/maven-repository-metadata-2.0.pom",
+      "sha256": "28af1b6839e3f6709d47f5f17b3574c571d48e6f69d3fa385bd5d9bc0e721ff1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0/maven-repository-metadata-2.0.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:jar:2.0.2": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.2/maven-repository-metadata-2.0.2.jar",
+      "sha256": "d033d8cb402ded41b2716b67fad71ed22b2fa6fa4a35fc709e6fb079752eb2e9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.2/maven-repository-metadata-2.0.2.jar"
+    },
+    "com.google.code.findbugs:jsr305:pom:2.0.1": {
+      "layout": "com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom",
+      "sha256": "02c12c3c2ae12dd475219ff691c82a4d9ea21f44bc594a181295bf6d43dcfbb0",
+      "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.0.8": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.pom",
+      "sha256": "0f0794dc7bdd60775d1b1e9bf70c55f2e4051bcd3d5e263a56c678080db3bbc1",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.pom"
+    },
+    "org.apache.maven.wagon:wagon:pom:1.0-beta-6": {
+      "layout": "org/apache/maven/wagon/wagon/1.0-beta-6/wagon-1.0-beta-6.pom",
+      "sha256": "025caec7c56a0cb4d86c45bc18ac3e23dba291e22ebceb76302a9a9b9b7183cc",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon/1.0-beta-6/wagon-1.0-beta-6.pom"
+    },
+    "org.apache.maven.doxia:doxia:pom:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia/1.0-alpha-7/doxia-1.0-alpha-7.pom",
+      "sha256": "172106a7ac51408883a074a1b847768e71c40fbbd969c8d645d2570026b811be",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia/1.0-alpha-7/doxia-1.0-alpha-7.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:jar:3.0": {
+      "layout": "org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.jar",
+      "sha256": "c938e4d8cdf0674496749a87e6d3b29aa41b1b35a39898a1ade2bc9eae214c17",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.jar"
+    },
+    "org.apache.maven:maven-repository-metadata:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar",
+      "sha256": "dce817d7c4229d5e666247c05853ef8ad7ac1b72d27953501c4a1ea739f67b25",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.5.5/plexus-containers-1.5.5.pom",
+      "sha256": "1bc264824ec876b0ca6f4f5838175c541c638cbc43326a268b9aee7d4778b5ef",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.5.5/plexus-containers-1.5.5.pom"
+    },
+    "org.apache.maven:maven:pom:2.2.1": {
+      "layout": "org/apache/maven/maven/2.2.1/maven-2.2.1.pom",
+      "sha256": "d135cff96dcbbc8a5fab30180e557cae620373cf26941d4c738a88896a2d98ed",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.2.1/maven-2.2.1.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar",
+      "sha256": "2c302f060de887716be438e0eb0c3d89d7ece213631882446ee0b19880c00dbd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar"
+    },
+    "org.sonatype.aether:aether-api:pom:1.7": {
+      "layout": "org/sonatype/aether/aether-api/1.7/aether-api-1.7.pom",
+      "sha256": "e855b04820e58822bda1ab448f7b29e2fccf363f1b2ca95c8c05f2d625b28928",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.7/aether-api-1.7.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.4.9": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.4.9/plexus-utils-1.4.9.pom",
+      "sha256": "06bb5b2a9138416ec6617cdd2afbfe7949be261f69bc6149c7de23e69b54a10c",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.9/plexus-utils-1.4.9.pom"
+    },
+    "org.apache.maven.plugins:maven-assembly-plugin:pom:2.2-beta-5": {
+      "layout": "org/apache/maven/plugins/maven-assembly-plugin/2.2-beta-5/maven-assembly-plugin-2.2-beta-5.pom",
+      "sha256": "d1e70b2862b18af99e026eb383675cf0b4ade5b2d8b337c2bca0b2abb7e95b94",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/2.2-beta-5/maven-assembly-plugin-2.2-beta-5.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:3.0": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.jar",
+      "sha256": "e67fc0b78b5cbabe6748677ebec9844db5014ac397ab1537558bcd614b5c41e1",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.jar"
+    },
+    "org.apache.maven.plugins:maven-plugins:pom:16": {
+      "layout": "org/apache/maven/plugins/maven-plugins/16/maven-plugins-16.pom",
+      "sha256": "fcc5d05bda9c1ed30e48a3a86409f46ad1c727a8a00361485c609f99bf95db47",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/16/maven-plugins-16.pom"
+    },
+    "org.apache.maven:maven-plugin-api:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar",
+      "sha256": "f1e4b0af3079cc0db361eab9429a3cda7b118cd032211c7e61b3805a62bfde1f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.4.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.4.1/plexus-utils-1.4.1.pom",
+      "sha256": "894261f5b21a2a18519537086181426450300385518e53d2555f5b4a6c1260e7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.1/plexus-utils-1.4.1.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.9": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.9/plexus-components-1.1.9.pom",
+      "sha256": "f8c18b1a70bb21e3e62a750ebeec2ff4304049c390b33b0675dbd10b84bbe373",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.9/plexus-components-1.1.9.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.4.2": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.4.2/plexus-utils-1.4.2.pom",
+      "sha256": "93d6675b2cf585c9c1148f1964156306c2573adfc1181c7219bd42a54a133771",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.2/plexus-utils-1.4.2.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.7": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.7/plexus-interpolation-1.7.jar",
+      "sha256": "87520a457bee0e86085860e8d5baba9797dfe60057f6b5b5e5dbd15be0b6dd63",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.7/plexus-interpolation-1.7.jar"
+    },
+    "org.apache.maven:maven-plugin-api:jar:2.0.4": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.4/maven-plugin-api-2.0.4.jar",
+      "sha256": "9ceee514d1ea380f2ebd146a55c6b504025b91411d53e0248391cbc84397da5a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.4/maven-plugin-api-2.0.4.jar"
+    },
+    "commons-cli:commons-cli:pom:1.0": {
+      "layout": "commons-cli/commons-cli/1.0/commons-cli-1.0.pom",
+      "sha256": "97ee40f4e80ca5ecc20162f4e97ee1adfeac1b45ba88b923d5a521e487c9c407",
+      "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0.pom"
+    },
+    "org.ow2.asm:asm:pom:7.0-beta": {
+      "layout": "org/ow2/asm/asm/7.0-beta/asm-7.0-beta.pom",
+      "sha256": "2d85484e0c0dd935e38edec52a33267ea1d50eb06d4c2ffb90d444c089571f86",
+      "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.0-beta/asm-7.0-beta.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.4.5": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.4.5/plexus-utils-1.4.5.pom",
+      "sha256": "687d05a9521ecb8e319e6beb46abcf53e0e61be647f1c7642a86e22f46814336",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.5/plexus-utils-1.4.5.pom"
+    },
+    "org.apache.maven:maven-plugin-api:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar",
+      "sha256": "a1b54bbe38d25ccd3179c5563156b3b0c0ecd014647c3ebaeba8e92b2e2e5053",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.4.6": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.4.6/plexus-utils-1.4.6.pom",
+      "sha256": "6c68126854b084eed9b25ebc7dd08e965a3b0e73d7538fc750b4a56e44e7b920",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.6/plexus-utils-1.4.6.pom"
+    },
+    "org.apache.maven:maven-core:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom",
+      "sha256": "5cc81603cab47bf20dbfd5e28e311da1fd26f2e3617b50547da5cd0b4f59edf3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom"
+    },
+    "org.sonatype.sisu:sisu-inject:pom:1.4.2": {
+      "layout": "org/sonatype/sisu/sisu-inject/1.4.2/sisu-inject-1.4.2.pom",
+      "sha256": "a5991ead85259ba9f8c985d194aace3b069e14bcd8cde68fce928223714d3968",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject/1.4.2/sisu-inject-1.4.2.pom"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom",
+      "sha256": "b5b53025b13fa0013ae2caede21f9af4215c25279db4ee0a1f943aaa8815c174",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar",
+      "sha256": "7c758612888782ccfe376823aee7cdcc7e0cdafb097f7ef50295a0b0c3a16edf",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar"
+    },
+    "org.apache.maven:maven-monitor:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar",
+      "sha256": "47289bc307849383d41eddbe3800f1945b2204ab319b0d38e391f6780c37b4e3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar"
+    },
+    "org.apache.maven:maven:pom:3.0-alpha-2": {
+      "layout": "org/apache/maven/maven/3.0-alpha-2/maven-3.0-alpha-2.pom",
+      "sha256": "4c2f8341518aeb9d488844e334c02fa66dd4bb091bfdeb965c8a848ac6ea5aa2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/3.0-alpha-2/maven-3.0-alpha-2.pom"
+    },
+    "org.apache.maven.plugins:maven-plugins:pom:24": {
+      "layout": "org/apache/maven/plugins/maven-plugins/24/maven-plugins-24.pom",
+      "sha256": "bfba38bd72d1a898f6f88e17cea240c67426be64d00c166b29c461d9bc149e56",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/24/maven-plugins-24.pom"
+    },
+    "org.apache.maven.plugins:maven-plugins:pom:23": {
+      "layout": "org/apache/maven/plugins/maven-plugins/23/maven-plugins-23.pom",
+      "sha256": "e07710c7d516a873c8fcafe85840d8a1a78f460c9a364d1c57b1d9e4554639ce",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/23/maven-plugins-23.pom"
+    },
+    "org.apache.maven.plugins:maven-plugins:pom:22": {
+      "layout": "org/apache/maven/plugins/maven-plugins/22/maven-plugins-22.pom",
+      "sha256": "34d303bbdd31d34f5a1570549b0e134b72afb18db53d8fcfdad222d51e941630",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/22/maven-plugins-22.pom"
+    },
+    "org.apache.maven:maven-monitor:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.jar",
+      "sha256": "69f5fbf13f7e54885b53b5c2c00adb24178e43a6e997c6350a45a7dc287ebd2f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.jar"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.pom",
+      "sha256": "3d356e97c1ab8c5673e8908b07e1e50d842dab8cbea8a2082f87016b891f91a6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.pom"
+    },
+    "com.thoughtworks.qdox:qdox:pom:2.0-M9": {
+      "layout": "com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.pom",
+      "sha256": "8fb39a1e86ee1dca54680df79512ff2939eba17660f62e142b2b9df699b3b6a3",
+      "url": "https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:3.0": {
+      "layout": "org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.pom",
+      "sha256": "8d9ce34e4bc02c4df761578c5f48ac3da5af51f259f5e3e4ea9047ec345ed1b7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.7": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.7/plexus-interpolation-1.7.pom",
+      "sha256": "0fdd7d8954e33d94814f7c0419c8070179638ab31aedcb5667da4d0302812c06",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.7/plexus-interpolation-1.7.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.6": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.6/plexus-interpolation-1.6.pom",
+      "sha256": "4db9d2a93730f2d48ad492219d58c4e7620f9ac4687e6ee3bd54d7b91aa3d3de",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.6/plexus-interpolation-1.6.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-9-stable-1": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.pom",
+      "sha256": "ef71d45a49edfe76be0f520312a76bc2aae73ec0743a5ffffe10d30122c6e2b2",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.pom"
+    },
+    "org.apache.maven.surefire:surefire-booter:jar:3.0.0-M3": {
+      "layout": "org/apache/maven/surefire/surefire-booter/3.0.0-M3/surefire-booter-3.0.0-M3.jar",
+      "sha256": "329e3a8c2f3b51c7c4d8674ef5500d5fb55ad1096711afca15681427ce72026e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.0.0-M3/surefire-booter-3.0.0-M3.jar"
+    },
+    "org.codehaus.plexus:plexus-compiler-javac:jar:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.jar",
+      "sha256": "03344d155153620b4de75d322d1b422701ac827dd0c631def1c7f46abf81386d",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.0": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.pom",
+      "sha256": "f479d0dc224974b50cfefae14344a4cd8b692b8dbf58df2d8c5c2f13db01d642",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.pom"
+    },
+    "org.slf4j:slf4j-parent:pom:1.5.6": {
+      "layout": "org/slf4j/slf4j-parent/1.5.6/slf4j-parent-1.5.6.pom",
+      "sha256": "b9d17d6f915b389c7dd77f170d6fcc77f1c7d6c7362fefb146043d8412defddd",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.5.6/slf4j-parent-1.5.6.pom"
+    },
+    "org.apache.maven.shared:maven-plugin-testing-harness:pom:1.1": {
+      "layout": "org/apache/maven/shared/maven-plugin-testing-harness/1.1/maven-plugin-testing-harness-1.1.pom",
+      "sha256": "3e82bced7eb460d4bab67700d32955feb27f400e2827b6b908dccc607205e88c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-plugin-testing-harness/1.1/maven-plugin-testing-harness-1.1.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.6": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.6/plexus-components-1.1.6.pom",
+      "sha256": "18468cef09449bc187a6d7c502cfbfad347a235129861ad138faeb87c2cda153",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.6/plexus-components-1.1.6.pom"
+    },
+    "org.apache:apache:pom:6": {
+      "layout": "org/apache/apache/6/apache-6.pom",
+      "sha256": "12edb5096e13f40c362d0bd40902589fa9586505123fa26799ce50b116fa5bb3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/6/apache-6.pom"
+    },
+    "classworlds:classworlds:pom:1.1": {
+      "layout": "classworlds/classworlds/1.1/classworlds-1.1.pom",
+      "sha256": "25a1efc00bcd1f029fd20c44df843b8b12d1fa17485235470764f011d2f5cb29",
+      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1/classworlds-1.1.pom"
+    },
+    "org.apache.maven.shared:maven-filtering:pom:1.1": {
+      "layout": "org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.pom",
+      "sha256": "9f4bf710d0de3c4dde45182aae3d604784b4e2f91696e27f3411286ef96d181c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.pom"
+    },
+    "org.apache.maven.wagon:wagon:pom:1.0-alpha-6": {
+      "layout": "org/apache/maven/wagon/wagon/1.0-alpha-6/wagon-1.0-alpha-6.pom",
+      "sha256": "36632b9cd41cc3010ac8f5c8cc2a015956f2256a4045c63d968898c1567b0eaf",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon/1.0-alpha-6/wagon-1.0-alpha-6.pom"
+    },
+    "junit:junit:pom:3.8.1": {
+      "layout": "junit/junit/3.8.1/junit-3.8.1.pom",
+      "sha256": "e68f33343d832398f3c8aa78afcd808d56b7c1020de4d3ad8ce47909095ee904",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.1/junit-3.8.1.pom"
+    },
+    "junit:junit:pom:3.8.2": {
+      "layout": "junit/junit/3.8.2/junit-3.8.2.pom",
+      "sha256": "aede67999f02ac851c2a2ae8cec58f9d801f826ba20994df23a1d9fbecc47f0f",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.pom"
+    },
+    "org.sonatype.forge:forge-parent:pom:10": {
+      "layout": "org/sonatype/forge/forge-parent/10/forge-parent-10.pom",
+      "sha256": "c14fb9c32b59cc03251f609416db7c0cff01f811edcccb4f6a865d6e7046bd0b",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/10/forge-parent-10.pom"
+    },
+    "org.codehaus.plexus:plexus-compiler:pom:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler/2.2/plexus-compiler-2.2.pom",
+      "sha256": "1d94e9a3f048c9eaaba0016ea188a4e7029c6849b8708ff6dc900a34fe03c28c",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler/2.2/plexus-compiler-2.2.pom"
+    },
+    "org.sonatype.aether:aether-impl:pom:1.7": {
+      "layout": "org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.pom",
+      "sha256": "0cf0bc1966c54645ed9702538158cc4a363861905470991616f4dabd4030e851",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.11": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.pom",
+      "sha256": "b84d281f59b9da528139e0752a0e1cab0bd98d52c58442b00e45c9748e1d9eee",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.12": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.12/plexus-interpolation-1.12.pom",
+      "sha256": "9e1d13d08550026de20cf8120b7e62e0ee842fc9df94140974c082b067fa5b72",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.12/plexus-interpolation-1.12.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.15": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.pom",
+      "sha256": "4a9f28e95f82a80fbd0632e6305b3c676f4d5e946f93028226d5365f53492bc7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.13": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.pom",
+      "sha256": "e37731ea5ed19d276f33b77c93399fb5df026e1191133b15fbeab73342c6363b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.pom"
+    },
+    "org.apache.maven:maven-error-diagnostics:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.pom",
+      "sha256": "581cf29ef72ebbaeff78a8054482ea8a4cd43e6d905f4adb7a16edf1636a619b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.14": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.pom",
+      "sha256": "d08155c497df37b2c3d9b5b0dfdb02ec0525b2070b5be3739fffde942fcac9af",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.pom"
+    },
+    "org.apache.maven:maven-error-diagnostics:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom",
+      "sha256": "cb80662bd8274131bb09e140a4075bff660bdab5be56bf0f926efee0389f3c4e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom"
+    },
+    "org.apache.maven.surefire:maven-surefire-common:pom:3.0.0-M3": {
+      "layout": "org/apache/maven/surefire/maven-surefire-common/3.0.0-M3/maven-surefire-common-3.0.0-M3.pom",
+      "sha256": "737bdee0cb6ddee0c5b93a9034fcd763d9b55402710f5b1797077a8227e76af5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.0.0-M3/maven-surefire-common-3.0.0-M3.pom"
+    },
+    "net.java.dev.jna:jna:pom:5.5.0": {
+      "layout": "net/java/dev/jna/jna/5.5.0/jna-5.5.0.pom",
+      "sha256": "a51ad94e3f74f85a3cdfad975392829316452669f588203c7b49e5f8179be539",
+      "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna/5.5.0/jna-5.5.0.pom"
+    },
+    "org.apache.maven.shared:maven-plugin-testing-harness:jar:1.1": {
+      "layout": "org/apache/maven/shared/maven-plugin-testing-harness/1.1/maven-plugin-testing-harness-1.1.jar",
+      "sha256": "92e9f4feb7855b825f2eacf210bff51f63c13281d89c1520a7645f1ea94b2b0b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-plugin-testing-harness/1.1/maven-plugin-testing-harness-1.1.jar"
+    },
+    "com.google.code.findbugs:jsr305:jar:2.0.1": {
+      "layout": "com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar",
+      "sha256": "1e7f53fa5b8b5c807e986ba335665da03f18d660802d8bf061823089d1bee468",
+      "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar"
+    },
+    "classworlds:classworlds:jar:1.1-alpha-2": {
+      "layout": "classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar",
+      "sha256": "2bf4e59f3acd106fea6145a9a88fe8956509f8b9c0fdd11eb96fee757269e3f3",
+      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar"
+    },
+    "org.apache.maven:maven-plugin-api:pom:3.0": {
+      "layout": "org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.pom",
+      "sha256": "8a722af2564205ae996f9035cc04670d3e9e4ae592f5a643c58fb7b0f43e1501",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.pom"
+    },
+    "org.codehaus.plexus:plexus-archiver:jar:1.0-alpha-12": {
+      "layout": "org/codehaus/plexus/plexus-archiver/1.0-alpha-12/plexus-archiver-1.0-alpha-12.jar",
+      "sha256": "20770300791d3734f8794a89a41316c238116338bcae0d7fc527349da5fea12a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/1.0-alpha-12/plexus-archiver-1.0-alpha-12.jar"
+    },
+    "org.sonatype.plexus:plexus-sec-dispatcher:pom:1.3": {
+      "layout": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom",
+      "sha256": "d5e650c50ef6958c028ed024b59af04cf3d38e1453a77d542b6b484bc0f4ca0b",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom"
+    },
+    "org.hamcrest:hamcrest-core:jar:1.1": {
+      "layout": "org/hamcrest/hamcrest-core/1.1/hamcrest-core-1.1.jar",
+      "sha256": "0361d1493ff0d94f861359efea91200720635072134792efb7217f6e09d5cffb",
+      "url": "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.1/hamcrest-core-1.1.jar"
+    },
+    "org.apache.maven.surefire:maven-surefire-common:jar:3.0.0-M3": {
+      "layout": "org/apache/maven/surefire/maven-surefire-common/3.0.0-M3/maven-surefire-common-3.0.0-M3.jar",
+      "sha256": "fa9d09c709725bdf1412d722a50a919f5dbcc32bc5c8a7a5f495c03759851557",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.0.0-M3/maven-surefire-common-3.0.0-M3.jar"
+    },
+    "org.apache.maven:maven-compat:jar:3.0": {
+      "layout": "org/apache/maven/maven-compat/3.0/maven-compat-3.0.jar",
+      "sha256": "3b8ad55703b8b60e6978b0efed24103a331c7ffd788374af85e2020f6c9b1f00",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0/maven-compat-3.0.jar"
+    },
+    "org.apache.maven.plugins:maven-compiler-plugin:jar:3.1": {
+      "layout": "org/apache/maven/plugins/maven-compiler-plugin/3.1/maven-compiler-plugin-3.1.jar",
+      "sha256": "62286cd88a4bfa04e31c52415a61c4cc5611b7e814fbc96be6f217d5d3c302c6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.1/maven-compiler-plugin-3.1.jar"
+    },
+    "org.apache.maven:maven-profile:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar",
+      "sha256": "89c07a73ea3b41e6c3c7e126871c898f1741fbfddd35633f9524fda09c25dc01",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.14": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar",
+      "sha256": "7fc63378d3e84663619b9bedace9f9fe78b276c2be3c62ca2245449294c84176",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.15": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.jar",
+      "sha256": "7111a4eb5f137781b68127a5a02d0208c28f26d2626fbd7a81d1172cd56449a8",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.jar"
+    },
+    "org.apache.maven:maven-profile:jar:2.0.4": {
+      "layout": "org/apache/maven/maven-profile/2.0.4/maven-profile-2.0.4.jar",
+      "sha256": "8e75daa4cc3f8a2aa68de0f8a28eaa655fdbb2e04708bad19d63657045ab7f14",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.4/maven-profile-2.0.4.jar"
+    },
+    "com.googlecode.json-simple:json-simple:jar:1.1.1": {
+      "layout": "com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1.jar",
+      "sha256": "4e69696892b88b41c55d49ab2fdcc21eead92bf54acc588c0050596c3b75199c",
+      "url": "https://repo.maven.apache.org/maven2/com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1.jar"
+    },
+    "org.sonatype.aether:aether-spi:pom:1.7": {
+      "layout": "org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.pom",
+      "sha256": "a5a8a19df914af051d29eeb4084189a118c8c301054df41472d9f180ddcc6747",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:3.0.1": {
+      "layout": "org/codehaus/plexus/plexus/3.0.1/plexus-3.0.1.pom",
+      "sha256": "1649f67caab553dd7e6b98002dcc670dab3f624c78f1259c8323e705b0c41e32",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.0.1/plexus-3.0.1.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.13": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.jar",
+      "sha256": "8e149132ff32907f39560398e222f1733ae959cedd099b32ee31c7b9d3bc1d6f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.jar"
+    },
+    "org.apache.maven:maven-profile:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar",
+      "sha256": "88fe952eaf4e28da0533ceef5d8e9b7fc9f09f7f825ab342130bf4b8c3805664",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.0-alpha-22": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.0-alpha-22/plexus-containers-1.0-alpha-22.pom",
+      "sha256": "c9db83cf13b16c2536a04c24187112c909b03e06228ca8be88f37cb1e65a9b22",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0-alpha-22/plexus-containers-1.0-alpha-22.pom"
+    },
+    "org.apache.maven.shared:maven-shared-io:pom:1.0": {
+      "layout": "org/apache/maven/shared/maven-shared-io/1.0/maven-shared-io-1.0.pom",
+      "sha256": "6bfda76b551173eab2d355d5af547a916e2b66d9b393bbc2f7262c5a931d642a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-io/1.0/maven-shared-io-1.0.pom"
+    },
+    "org.apache.maven.shared:maven-shared-io:pom:1.1": {
+      "layout": "org/apache/maven/shared/maven-shared-io/1.1/maven-shared-io-1.1.pom",
+      "sha256": "ce42b015e3c2d6dafeb99763e360d0c0b08dfe054e204e944a23ddcc2463686a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-io/1.1/maven-shared-io-1.1.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.pom",
+      "sha256": "0447b3919bc7d0301b763852aca8dc0e87ccfbe34a4d5257f7f4fae8a4e87998",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.pom",
+      "sha256": "df10657745e39010954fd009276b65b75198bdc40d0adb9916f9697c71fcd986",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.pom"
+    },
+    "org.sonatype.sisu:sisu-inject-plexus:jar:1.4.2": {
+      "layout": "org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar",
+      "sha256": "a65e27aefbe74102d73cd7e3c5c7637021d294a9e7f33132f3c782a76714d0a3",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:2.0.5": {
+      "layout": "org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.jar",
+      "sha256": "b4c51a337078b934ad656ee78a2d3a805a507129dc034692c67db0f94b659d3e",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.jar"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.pom",
+      "sha256": "3f0dc324ff65ccdbd6bb3df39136e2878047a2b0c19799689bcefa4132bdcba4",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.pom"
+    },
+    "org.codehaus.plexus:plexus-archiver:pom:1.0-alpha-11": {
+      "layout": "org/codehaus/plexus/plexus-archiver/1.0-alpha-11/plexus-archiver-1.0-alpha-11.pom",
+      "sha256": "373734855a2ae0128e2ec84e8f9f6e8d6a3fe38dbcca8779e3dc13e035f90ae4",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/1.0-alpha-11/plexus-archiver-1.0-alpha-11.pom"
+    },
+    "org.codehaus.plexus:plexus-archiver:pom:1.0-alpha-12": {
+      "layout": "org/codehaus/plexus/plexus-archiver/1.0-alpha-12/plexus-archiver-1.0-alpha-12.pom",
+      "sha256": "d98edd0806de07079e8c31f7f90c8b96d3ffc6a92c293df215e8281b5abc152c",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/1.0-alpha-12/plexus-archiver-1.0-alpha-12.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.0.4": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.4/maven-repository-metadata-2.0.4.pom",
+      "sha256": "2d5e793791748e714becdbcfe29b73f512f9e9f87715982ff10f4e77eb01837a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.4/maven-repository-metadata-2.0.4.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:pom:1.2-alpha-6": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/1.2-alpha-6/plexus-classworlds-1.2-alpha-6.pom",
+      "sha256": "6ddf6083d4449f11a0c15cc1c0b78ccb4fbcd9c167ec9ad29284d58e9e33a847",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/1.2-alpha-6/plexus-classworlds-1.2-alpha-6.pom"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.0-alpha-16": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.0-alpha-16/plexus-containers-1.0-alpha-16.pom",
+      "sha256": "85a1bef623d7f6158ed0bb34adb768147af5afab04d72239c313aaea91231c78",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0-alpha-16/plexus-containers-1.0-alpha-16.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.0.2": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.2/maven-repository-metadata-2.0.2.pom",
+      "sha256": "4dd5ff83a2089613e828ee6c8bd6888d8732217392e2c442f6302df4a025e629",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.2/maven-repository-metadata-2.0.2.pom"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.0-alpha-15": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.0-alpha-15/plexus-containers-1.0-alpha-15.pom",
+      "sha256": "1bd587c06afffc206cf70fddbd91637241118f81ffaf10d9e2c8bdefcc9781ee",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0-alpha-15/plexus-containers-1.0-alpha-15.pom"
+    },
+    "org.apache.maven:maven-plugin-api:pom:2.0": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0/maven-plugin-api-2.0.pom",
+      "sha256": "701487785d69eeb27ff700a2d7d1af708c5e4b66cd640095193c07fefaff92e7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0/maven-plugin-api-2.0.pom"
+    },
+    "org.sonatype.sisu.inject:guice-plexus:pom:1.4.2": {
+      "layout": "org/sonatype/sisu/inject/guice-plexus/1.4.2/guice-plexus-1.4.2.pom",
+      "sha256": "13a66ca6e6ad1a186076513eea822db2c3c0e460a983a0a31f4d937de336ad98",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-plexus/1.4.2/guice-plexus-1.4.2.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:pom:1.2-alpha-7": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/1.2-alpha-7/plexus-classworlds-1.2-alpha-7.pom",
+      "sha256": "2a0abfc63ed5c6216356255aa7c572723087938879934aca1ce11f17c24ce156",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/1.2-alpha-7/plexus-classworlds-1.2-alpha-7.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.3.1": {
+      "layout": "org/codehaus/plexus/plexus-components/1.3.1/plexus-components-1.3.1.pom",
+      "sha256": "8cbcb2aacd7f4a7759866ce91b2f910310fbe5a586b5fc7b9bdb76af9257e7c4",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.3.1/plexus-components-1.3.1.pom"
+    },
+    "org.apache.maven.shared:maven-repository-builder:pom:1.0-alpha-2": {
+      "layout": "org/apache/maven/shared/maven-repository-builder/1.0-alpha-2/maven-repository-builder-1.0-alpha-2.pom",
+      "sha256": "b8f92c499146980d88186202ec412aea4431f846f3f5634b935a9ac89ec0fdde",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-repository-builder/1.0-alpha-2/maven-repository-builder-1.0-alpha-2.pom"
+    },
+    "org.slf4j:slf4j-api:pom:1.5.6": {
+      "layout": "org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom",
+      "sha256": "91b0a0d016b8c0cba1ddd8a5c59e5bf5c2a9b49b95577e8e38927a7fdff55ce8",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom"
+    },
+    "org.sonatype.plexus:plexus-cipher:jar:1.4": {
+      "layout": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
+      "sha256": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
+    },
+    "org.codehaus.plexus:plexus-archiver:jar:2.1": {
+      "layout": "org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.jar",
+      "sha256": "5a49a4c13e29da41c24bbb35b2f94b82bde259e25d4dd55ee3159e31d20677b8",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.jar"
+    },
+    "org.apache.maven:maven-plugin-registry:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.pom",
+      "sha256": "cf633e8cde33e65580776d845756d332d24f7c6d5bf9ae90fc6c43d73cb5fe23",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:3.3.1": {
+      "layout": "org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom",
+      "sha256": "6ec96f889bc29250f90b167c14e547f1b05aa23565c63f9079595befbde816bb",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom"
+    },
+    "org.apache.maven:maven-plugin-registry:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.pom",
+      "sha256": "7de23d8212885031dc2e6fabc327957ff8324563a8fbeb10b0a85b498b826667",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.pom"
+    },
+    "org.codehaus.plexus:plexus-archiver:pom:1.0-alpha-7": {
+      "layout": "org/codehaus/plexus/plexus-archiver/1.0-alpha-7/plexus-archiver-1.0-alpha-7.pom",
+      "sha256": "9ece2108b5f3694fa2a240cafe232a0ff479120a8718cfcb2505f6110e0d47c9",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/1.0-alpha-7/plexus-archiver-1.0-alpha-7.pom"
+    },
+    "org.apache.maven:maven-archiver:pom:2.4": {
+      "layout": "org/apache/maven/maven-archiver/2.4/maven-archiver-2.4.pom",
+      "sha256": "2740f4988514c8a79e15af77b6dbb3527f3aae4cfe0a454c22a060cc70dee144",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.4/maven-archiver-2.4.pom"
+    },
+    "org.apache.maven:maven-aether-provider:jar:3.0": {
+      "layout": "org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.jar",
+      "sha256": "1205a1f229999170dcadcfb885a278ad0bc2295540a251f4c438f887ead7bbd9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.jar"
+    },
+    "org.apache.maven:maven-model:pom:3.0": {
+      "layout": "org/apache/maven/maven-model/3.0/maven-model-3.0.pom",
+      "sha256": "3d6fdeb72b2967f1fa2784134fb832d08d8d6e879b7ace7712f2c7281994fc1e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.pom"
+    },
+    "org.apache.xbean:xbean-reflect:jar:3.4": {
+      "layout": "org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar",
+      "sha256": "17e0efa187127034623197fb88c50c30d3baa62baa0f07d6ec693047ac92ec3b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar"
+    },
+    "org.apache.maven:maven-archiver:pom:2.5": {
+      "layout": "org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.pom",
+      "sha256": "86214750be31034691143c797a2656bc647f0defeb4988031aa5afaf39f16a31",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.pom"
+    },
+    "org.apache.maven:maven-artifact:jar:2.0.4": {
+      "layout": "org/apache/maven/maven-artifact/2.0.4/maven-artifact-2.0.4.jar",
+      "sha256": "7294778dc3eb8ede4950ccca80dab8debc725304116b19ccb1929023d12534c4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.4/maven-artifact-2.0.4.jar"
+    },
+    "junit:junit:pom:4.10": {
+      "layout": "junit/junit/4.10/junit-4.10.pom",
+      "sha256": "22a1bf0baae8b6106b7ad8026ecf27c59e7e47ddb49d62975036beadb2c62eb5",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/4.10/junit-4.10.pom"
+    },
+    "org.apache.maven:maven-artifact:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar",
+      "sha256": "0b16842a33350f5478c4c717bf664251c27459ec5c0b8d0ca4d0050545aba48b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar"
+    },
+    "org.apache.maven.shared:maven-filtering:jar:1.0-beta-2": {
+      "layout": "org/apache/maven/shared/maven-filtering/1.0-beta-2/maven-filtering-1.0-beta-2.jar",
+      "sha256": "c83a954b12b7f7cd9cb9e8cee507aa30b38512c041c996f690274d7c18fb9ed5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.0-beta-2/maven-filtering-1.0-beta-2.jar"
+    },
+    "org.apache.maven:maven-artifact:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar",
+      "sha256": "f45629a70af0dfec1c1b542e162a2aceb976bb492825b6ee192e6a14fff238b6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar"
+    },
+    "org.codehaus.plexus:plexus-compiler-manager:pom:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.pom",
+      "sha256": "bf2aedb6f801096d0b7f9db201fef9ceb0696b801c446ada188144cae4e91dd2",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.pom"
+    },
+    "org.apache.maven:maven-error-diagnostics:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.pom",
+      "sha256": "228367b7569fb1462a3eb1423bc2778e2fc7fbaee3d3767890c02b8924fa1889",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.pom"
+    },
+    "org.apache.maven:maven-project:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar",
+      "sha256": "c82db125f53716f59008e3214063869717a976bf857879de6d4092c73cdc7e12",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar"
+    },
+    "org.apache.maven:maven-model:jar:2.0.4": {
+      "layout": "org/apache/maven/maven-model/2.0.4/maven-model-2.0.4.jar",
+      "sha256": "025e9ba00b87e33c90ccb9f8befec4c3c6baa42436f158f00a69747007f84351",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.4/maven-model-2.0.4.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:2.0.4": {
+      "layout": "org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.jar",
+      "sha256": "6a17cfbfffe6bb87215ad38bcaac716383e552ec2ba7b204e2673ee66a2afaaa",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.jar"
+    },
+    "org.apache.maven:maven-model:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.jar",
+      "sha256": "b86dbf20852da19fb17301ae7e2a40d87930c7d76fe43f0f93ff86b8a64c6962",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:2.0.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/2.0.1/plexus-utils-2.0.1.jar",
+      "sha256": "1568f133d2611141a04d4d5c71d1f9913c1f2615ca6f2aab4b843357da454e3c",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.1/plexus-utils-2.0.1.jar"
+    },
+    "org.apache.maven:maven-model:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.jar",
+      "sha256": "87083dd97721542f2745eede587fbb6cb1aef2b395f46c2bd578c6d9d7b63521",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.jar"
+    },
+    "org.apache.maven:maven-project:jar:2.0.4": {
+      "layout": "org/apache/maven/maven-project/2.0.4/maven-project-2.0.4.jar",
+      "sha256": "27a6b287359f57c02a263369034b0c16a597c7f7b99df45e8f9b1c57a48c52a6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.4/maven-project-2.0.4.jar"
+    },
+    "org.codehaus.plexus:plexus-io:pom:2.0.2": {
+      "layout": "org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.pom",
+      "sha256": "67a1ce072ad9ff4ce37985a1c32827eaeda4660cabe7f69eff2ca1ebff2d23bd",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.pom"
+    },
+    "org.apache.maven:maven-project:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar",
+      "sha256": "f091ef5587537947a4c6e43cf200c567e1bf44c101443e8f8cf51e2c126e0195",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar"
+    },
+    "org.apache.maven:maven-settings-builder:jar:3.0": {
+      "layout": "org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.jar",
+      "sha256": "e17e706c6f03c453f6000599cab607c2af5f1cc6e3a3b1e6fce27e5ef4999eab",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.jar"
+    },
+    "org.codehaus.plexus:plexus-component-api:pom:1.0-alpha-16": {
+      "layout": "org/codehaus/plexus/plexus-component-api/1.0-alpha-16/plexus-component-api-1.0-alpha-16.pom",
+      "sha256": "c254b481f6d50db6c2e15df5f027612c127a4408898e78904ffacb2c7e507bdc",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-api/1.0-alpha-16/plexus-component-api-1.0-alpha-16.pom"
+    },
+    "org.codehaus.plexus:plexus-component-api:pom:1.0-alpha-15": {
+      "layout": "org/codehaus/plexus/plexus-component-api/1.0-alpha-15/plexus-component-api-1.0-alpha-15.pom",
+      "sha256": "13c08c826418e737c907260e12ab2431ab5c5b833b65610d5adfbee7fcbbf937",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-api/1.0-alpha-15/plexus-component-api-1.0-alpha-15.pom"
+    },
+    "org.apache.maven.doxia:doxia-sink-api:jar:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar",
+      "sha256": "37e66f15f348df957538f81f7e10a3fdcf84e5fbd687b2001ee3d6ab4a25aafe",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar"
+    },
+    "org.apache.maven:maven-settings:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom",
+      "sha256": "0d25a88a1b1e44801f8912206a40ff249cb5702ee87cf3d243d5213f7bcf534f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom"
+    },
+    "org.sonatype.sisu:sisu-inject-bean:jar:1.4.2": {
+      "layout": "org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar",
+      "sha256": "fb3160e1e3a7852b441016dbcc97a34e3cf4eeb8ceb9e82edf2729439858f080",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar"
+    },
+    "org.codehaus.plexus:plexus-io:jar:1.0-alpha-4": {
+      "layout": "org/codehaus/plexus/plexus-io/1.0-alpha-4/plexus-io-1.0-alpha-4.jar",
+      "sha256": "68a108cfe167cbf956ecdb3d6d9f794ff3f87eebb7bef2b8936c3f67e914d93a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/1.0-alpha-4/plexus-io-1.0-alpha-4.jar"
+    },
+    "org.apache.maven.plugins:maven-jar-plugin:jar:2.4": {
+      "layout": "org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.jar",
+      "sha256": "1f22f2e528daddbc5d06518c4dbe4d5f4fa6995c8441c702ee5d7d506bb4b4f3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.jar"
+    },
+    "org.apache.maven:maven-core:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar",
+      "sha256": "710d56c05add33beadea2f86254223955aca570c15a610f81be07c96c919d7b6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar"
+    },
+    "org.apache.maven:maven-core:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.jar",
+      "sha256": "da9bdd720f0b1861fe649a2edf8fc0a65e4e2c4a1a05d8d96adbfaa1319f7285",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.jar"
+    },
+    "commons-logging:commons-logging-api:pom:1.1": {
+      "layout": "commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.pom",
+      "sha256": "69b8be61aa746c7d02acb1b11eb3b57cb22b246780ed71d79764195cbbe3d99d",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.pom"
+    },
+    "org.codehaus.plexus:plexus-active-collections:jar:1.0-beta-2": {
+      "layout": "org/codehaus/plexus/plexus-active-collections/1.0-beta-2/plexus-active-collections-1.0-beta-2.jar",
+      "sha256": "75fa462fdbd5f9ba3b629d3910c460f54dde55aafadc36ead5feef6181e7819e",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-active-collections/1.0-beta-2/plexus-active-collections-1.0-beta-2.jar"
+    },
+    "org.apache.maven:maven-model:pom:2.0": {
+      "layout": "org/apache/maven/maven-model/2.0/maven-model-2.0.pom",
+      "sha256": "2d727af4b8bd10382777d34a16e521e948b8a9684f1094bf06ee9b5b616bd5ed",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0/maven-model-2.0.pom"
+    },
+    "org.apache.maven:maven-project:pom:2.0": {
+      "layout": "org/apache/maven/maven-project/2.0/maven-project-2.0.pom",
+      "sha256": "dd14ed05a563983fc4496224dca9562c683aa68f70a9d279082d6fb5bd8232d8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0/maven-project-2.0.pom"
+    },
+    "com.google.collections:google-collections:jar:1.0": {
+      "layout": "com/google/collections/google-collections/1.0/google-collections-1.0.jar",
+      "sha256": "81b8d638af0083c4b877099d56aa0fee714485cd2ace1b6a09cab867cadb375d",
+      "url": "https://repo.maven.apache.org/maven2/com/google/collections/google-collections/1.0/google-collections-1.0.jar"
+    },
+    "org.slf4j:slf4j-jdk14:pom:1.5.6": {
+      "layout": "org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom",
+      "sha256": "85f97344eeeed2714eda6f800aa712c1aa7405b0d7f98e207499363f82f37eec",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom"
+    },
+    "commons-net:commons-net:jar:3.6": {
+      "layout": "commons-net/commons-net/3.6/commons-net-3.6.jar",
+      "sha256": "d3b3866c61a47ba3bf040ab98e60c3010d027da0e7a99e1755e407dd47bc2702",
+      "url": "https://repo.maven.apache.org/maven2/commons-net/commons-net/3.6/commons-net-3.6.jar"
+    },
+    "org.apache.maven.plugins:maven-surefire-plugin:pom:3.0.0-M3": {
+      "layout": "org/apache/maven/plugins/maven-surefire-plugin/3.0.0-M3/maven-surefire-plugin-3.0.0-M3.pom",
+      "sha256": "e6fe653cabc6b6e2ea472f77140933ce946cf31ed37a965197a480f3e6b8c6ae",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.0.0-M3/maven-surefire-plugin-3.0.0-M3.pom"
+    },
+    "org.apache.maven.shared:maven-repository-builder:jar:1.0-alpha-2": {
+      "layout": "org/apache/maven/shared/maven-repository-builder/1.0-alpha-2/maven-repository-builder-1.0-alpha-2.jar",
+      "sha256": "b98e071e744a51f56a88adad29803fa7aedace672ed252da128e5b64db55fb89",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-repository-builder/1.0-alpha-2/maven-repository-builder-1.0-alpha-2.jar"
+    },
+    "org.apache.maven:maven-toolchain:jar:3.0-alpha-2": {
+      "layout": "org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.jar",
+      "sha256": "e0bb64267e6cd6e51d38cc88ba72e8a8adf616c2dc317782127cd61a8ae2a65c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/3.0-alpha-2/maven-toolchain-3.0-alpha-2.jar"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom",
+      "sha256": "9dad0f56523955b60a9903f4e8342891355d7a59c77f36a3b53cf6ff2e4df625",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom"
+    },
+    "org.tukaani:xz:pom:1.8": {
+      "layout": "org/tukaani/xz/1.8/xz-1.8.pom",
+      "sha256": "f29e75cb88eb4acbf7e5aa5c09ed55eac2cbae601d63a9f375231f45452c1013",
+      "url": "https://repo.maven.apache.org/maven2/org/tukaani/xz/1.8/xz-1.8.pom"
+    },
+    "org.apache.maven.shared:maven-shared-utils:pom:0.1": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom",
+      "sha256": "9ecb36b0e0d7d1d0f0dabd8705368b710df58b943091e9fa9071a29ccdc15a33",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom"
+    },
+    "org.apache.maven.wagon:wagon-provider-api:jar:1.0-beta-6": {
+      "layout": "org/apache/maven/wagon/wagon-provider-api/1.0-beta-6/wagon-provider-api-1.0-beta-6.jar",
+      "sha256": "e116f32edcb77067289a3148143f2c0c97b27cf9a1342f8108ee37dec4868861",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/1.0-beta-6/wagon-provider-api-1.0-beta-6.jar"
+    },
+    "org.apache.maven:maven-monitor:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom",
+      "sha256": "bc962d48dcebb463c1071004015c4609516d616e884ce36eb7390f9a8095a65b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.0.3": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.0.3/plexus-containers-1.0.3.pom",
+      "sha256": "7c75075badcb014443ee94c8c4cad2f4a9905be3ce9430fe7b220afc7fa3a80f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0.3/plexus-containers-1.0.3.pom"
+    },
+    "org.sonatype.aether:aether-util:pom:1.7": {
+      "layout": "org/sonatype/aether/aether-util/1.7/aether-util-1.7.pom",
+      "sha256": "0342bdcbd23208534dde58819ddf937aabbe3d61a47231ffb06632fb47dd2657",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-util/1.7/aether-util-1.7.pom"
+    },
+    "org.apache.maven:maven-profile:pom:2.0": {
+      "layout": "org/apache/maven/maven-profile/2.0/maven-profile-2.0.pom",
+      "sha256": "2a8a1b9046b8f26c2dd5fa4d0c5b18b55156f7d1291f2b64dc31b1261018774a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0/maven-profile-2.0.pom"
+    },
+    "org.apache.maven:maven-artifact-manager:pom:2.0.2": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.2/maven-artifact-manager-2.0.2.pom",
+      "sha256": "94348507ad85d221df9167e9db313dfdb474d59e715d2c0638d3eac341756222",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.2/maven-artifact-manager-2.0.2.pom"
+    },
+    "org.apache.maven:maven-artifact-manager:pom:2.0.4": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.4/maven-artifact-manager-2.0.4.pom",
+      "sha256": "5620e8f30457d1f379bb3dc0f67e759d890177befdf5f2591809f9e0e302b68a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.4/maven-artifact-manager-2.0.4.pom"
+    },
+    "org.apache.maven:maven-artifact-manager:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.pom",
+      "sha256": "a80884dfac999ebdda57904f929a14f28ab08e5411d515bdb1fbdaacf0ed6d6f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.0": {
+      "layout": "org/apache/maven/maven-artifact/2.0/maven-artifact-2.0.pom",
+      "sha256": "ed4c936be78a46d73fb64a24f97f971465eb32e76c4625a9738b6f1a25b2d570",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0/maven-artifact-2.0.pom"
+    },
+    "org.apache.maven:maven-settings:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.pom",
+      "sha256": "eececa44387deebbac73192967eabad80f2f43fe96f70b98f3e21951b1bfaea1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.pom"
+    },
+    "org.apache.maven:maven-settings:pom:2.0": {
+      "layout": "org/apache/maven/maven-settings/2.0/maven-settings-2.0.pom",
+      "sha256": "cbff616828f8a694e59c4d5efe1198d4bd6c9bc1c03496dc5c92083a9419b4ec",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0/maven-settings-2.0.pom"
+    },
+    "org.apache.maven:maven-settings:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.pom",
+      "sha256": "672f22f9b697784518b8b84719324013a8f1bf0337f1d3059b83982d4ca480ca",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:1.5.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar",
+      "sha256": "72582f8ba285601fa753ceeda73ff3cbd94c6e78f52ec611621eaa0186165452",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar"
+    },
+    "org.apache.maven.shared:maven-shared-utils:jar:0.1": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.jar",
+      "sha256": "86cd563b0bb40b0ef4e7183e41768049ad0afaca5b5acbf9680c53c217ca93d7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.jar"
+    },
+    "org.apache.maven.shared:maven-common-artifact-filters:jar:1.1": {
+      "layout": "org/apache/maven/shared/maven-common-artifact-filters/1.1/maven-common-artifact-filters-1.1.jar",
+      "sha256": "f0b2e3f253b80e3d76f3d6ade48a5dcaaba384b6f6ae3dbd32cdffa697538860",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/1.1/maven-common-artifact-filters-1.1.jar"
+    },
+    "org.apache.maven:maven-artifact-manager:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.pom",
+      "sha256": "d573bbb1b78c76523c45aba2859d390883b932dfde67e3c2032fc443c0fa098d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.pom"
+    },
+    "org.apache.maven:maven-plugin-descriptor:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom",
+      "sha256": "d4ef608f90dc9599c0cc325ca2ccc2e1ceb439b3d2ff31ae22e30ac1a63a68f0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:2.0.6": {
+      "layout": "org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom",
+      "sha256": "bea12e747708d25e73410ca1c731ebdfa102e8bdb6ec7d81bd4522583b234bcc",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:2.0.7": {
+      "layout": "org/codehaus/plexus/plexus/2.0.7/plexus-2.0.7.pom",
+      "sha256": "2b59062030ab0a15c5d0977ba22421706368926488739a65f25793e715cc8a74",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.7/plexus-2.0.7.pom"
+    },
+    "org.apache.maven:maven-settings:jar:3.0": {
+      "layout": "org/apache/maven/maven-settings/3.0/maven-settings-3.0.jar",
+      "sha256": "3b1a46b4bc26a0176acaf99312ff2f3a631faf3224b0996af546aa48bd73c647",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.0/maven-settings-3.0.jar"
+    },
+    "org.apache.maven.surefire:surefire-logger-api:jar:3.0.0-M3": {
+      "layout": "org/apache/maven/surefire/surefire-logger-api/3.0.0-M3/surefire-logger-api-3.0.0-M3.jar",
+      "sha256": "d0149177962039d32265e668600316409f34def1ddb217abfce670ab6eaf2448",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.0.0-M3/surefire-logger-api-3.0.0-M3.jar"
+    },
+    "org.codehaus.plexus:plexus:pom:2.0.2": {
+      "layout": "org/codehaus/plexus/plexus/2.0.2/plexus-2.0.2.pom",
+      "sha256": "e246e2a062b5d989fdefc521c9c56431ba5554ff8d2344edee9218a34a546a33",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.2/plexus-2.0.2.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:2.0.3": {
+      "layout": "org/codehaus/plexus/plexus/2.0.3/plexus-2.0.3.pom",
+      "sha256": "fcc5670db8864c50c16bd96972f0da876f6651a8edc99850e68b2d569c5a4776",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.3/plexus-2.0.3.pom"
+    },
+    "com.googlecode.json-simple:json-simple:pom:1.1.1": {
+      "layout": "com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1.pom",
+      "sha256": "665f63590defb63d62add21d3525362cf937cf6a1c05e4b0145bae8da8a57f83",
+      "url": "https://repo.maven.apache.org/maven2/com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1.pom"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:jar:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar",
+      "sha256": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar"
+    },
+    "org.apache.maven:maven-settings:pom:2.0.4": {
+      "layout": "org/apache/maven/maven-settings/2.0.4/maven-settings-2.0.4.pom",
+      "sha256": "9469dbe562fcf278a4a31d6050629790c1158bab3cd39b5ce8f6fb4ccdd13deb",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.4/maven-settings-2.0.4.pom"
+    },
+    "commons-lang:commons-lang:pom:2.1": {
+      "layout": "commons-lang/commons-lang/2.1/commons-lang-2.1.pom",
+      "sha256": "f1a709cd489f23498a0b6b3dfbfc0d21d4f15904791446dec7f8a58a7da5bd6a",
+      "url": "https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.1/commons-lang-2.1.pom"
+    },
+    "org.apache.maven:maven-settings:pom:3.0": {
+      "layout": "org/apache/maven/maven-settings/3.0/maven-settings-3.0.pom",
+      "sha256": "2340855d40ce6125d9a23ab80d94848efa50b2957cf93531e2a7dcf631b4f22b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.0/maven-settings-3.0.pom"
+    },
+    "org.apache.maven.plugins:maven-assembly-plugin:jar:2.2-beta-5": {
+      "layout": "org/apache/maven/plugins/maven-assembly-plugin/2.2-beta-5/maven-assembly-plugin-2.2-beta-5.jar",
+      "sha256": "b5ec1a1556b3cf90e248fd58a6d96b5b0e7250da3c38cde7dca8f050dee976bb",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/2.2-beta-5/maven-assembly-plugin-2.2-beta-5.jar"
+    },
+    "org.apache.maven:maven-model-builder:jar:3.0": {
+      "layout": "org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.jar",
+      "sha256": "1c98a4ec9eb0cb86ecf01710aa75c0346ee3f96edc6edeabcb21ed984120e154",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.jar"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:pom:2.0": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0/maven-reporting-api-2.0.pom",
+      "sha256": "2b013803feb37705908b5af78fbcf584e479f03d792964dc96446dceed0d1756",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0/maven-reporting-api-2.0.pom"
+    },
+    "com.thoughtworks.qdox:qdox:jar:2.0-M9": {
+      "layout": "com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.jar",
+      "sha256": "ee2f7fa60b6ef3151f1bb0a242e0bacb832ff29f3ee8fd3da61d26d8608bc1bc",
+      "url": "https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.jar"
+    },
+    "org.apache.maven.shared:maven-common-artifact-filters:pom:1.1": {
+      "layout": "org/apache/maven/shared/maven-common-artifact-filters/1.1/maven-common-artifact-filters-1.1.pom",
+      "sha256": "471b4a0d14c7f019db66f3862aa40525455533fe10bf06d04aa85eac0ac91918",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/1.1/maven-common-artifact-filters-1.1.pom"
+    },
+    "org.sonatype.plexus:plexus-build-api:pom:0.0.4": {
+      "layout": "org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.pom",
+      "sha256": "9bd824511766b9f512d7badbf24add39ece050c75e07d6cacc954517f49ea465",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.pom"
+    },
+    "org.slf4j:jcl-over-slf4j:pom:1.5.6": {
+      "layout": "org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom",
+      "sha256": "d71d7748e68bb9cb7ad38b95d17c0466e31fc1f4d15bb1e635f3ebad34a38ff3",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom"
+    },
+    "org.apache.maven:maven-model:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.pom",
+      "sha256": "e88566fd64906e8e9a2315e5cb67efb7e0f4947a1c45a45cff399f64a235ac1f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.pom"
+    },
+    "org.apache.maven:maven-model:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.pom",
+      "sha256": "2bfc8ce93b46c1bbe8e809197a2f970c5573d2b0d3412c84d7cdfa5961299087",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.pom"
+    },
+    "org.apache.maven:maven-monitor:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom",
+      "sha256": "2cfd187d6465c5ad99552da8441d31ff0c1ced1808d2f624dbdb49223d3baa89",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom"
+    },
+    "org.ow2.asm:asm:jar:7.0-beta": {
+      "layout": "org/ow2/asm/asm/7.0-beta/asm-7.0-beta.jar",
+      "sha256": "ba84438f0f08ae2c2f85423dc3628361d20197c46a194687defdf63ed1896a3a",
+      "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.0-beta/asm-7.0-beta.jar"
+    },
+    "org.apache.maven:maven-model:pom:2.0.4": {
+      "layout": "org/apache/maven/maven-model/2.0.4/maven-model-2.0.4.pom",
+      "sha256": "a0df5fc56a44d4a716291d8879737a80516db598ca9c823f1dad525149df82b0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.4/maven-model-2.0.4.pom"
+    },
+    "org.apache.maven:maven-settings-builder:pom:3.0": {
+      "layout": "org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.pom",
+      "sha256": "1e707086b2efabe7527e75539f87e5b4544ed20e8b5ae8aa35bcc24d7ba3a2b0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.pom"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar",
+      "sha256": "b5f0dd177264a6e25ce0ed8724f8b6f3bca48b215b9ff4576e1bec7b0773f9e8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar"
+    },
+    "org.apache.maven:maven-monitor:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.pom",
+      "sha256": "4fe978f252f57c1768d917603127db3b82e98820059b4943ae04b79c5ac79419",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.pom"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.jar",
+      "sha256": "3be9db19335747e8a22f768fab3539992a66d280ccff5f8cd487cada733aee98",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.jar"
+    },
+    "junit:junit:jar:3.8.2": {
+      "layout": "junit/junit/3.8.2/junit-3.8.2.jar",
+      "sha256": "ecdcc08183708ea3f7b0ddc96f19678a0db8af1fb397791d484aed63200558b0",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.jar"
+    },
+    "org.apache.maven.shared:file-management:jar:1.1": {
+      "layout": "org/apache/maven/shared/file-management/1.1/file-management-1.1.jar",
+      "sha256": "b7d139b2a04687d399fb296a1d6c1d7925b54a65c2ace87b1cd4ea20e3d422c1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/file-management/1.1/file-management-1.1.jar"
+    },
+    "org.apache.maven:maven-artifact-manager:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom",
+      "sha256": "ecf58351f8fe0c398b8b452216705bece5291b9b327d30202c16b28ac680450c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom"
+    },
+    "junit:junit:jar:3.8.1": {
+      "layout": "junit/junit/3.8.1/junit-3.8.1.jar",
+      "sha256": "b58e459509e190bed737f3592bc1950485322846cf10e78ded1d065153012d70",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.1/junit-3.8.1.jar"
+    },
+    "org.apache.maven:maven-toolchain:pom:1.0": {
+      "layout": "org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.pom",
+      "sha256": "665a0be425b12cc6938a41f7ebde2c4c7c23b02b3826344462001057449d503d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.pom"
+    },
+    "org.apache.maven:maven-core:pom:2.0": {
+      "layout": "org/apache/maven/maven-core/2.0/maven-core-2.0.pom",
+      "sha256": "7736a088c18a6d189741d0c80b4ca73b302781049fe216d6edbc4ccbadc2543d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0/maven-core-2.0.pom"
+    },
+    "org.sonatype.aether:aether-spi:jar:1.7": {
+      "layout": "org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.jar",
+      "sha256": "f54a0a28ce3d62af0e1cfe41dde616f645c28e452e77f77b78bc36e74d5e1a69",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.jar"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:10": {
+      "layout": "org/apache/maven/shared/maven-shared-components/10/maven-shared-components-10.pom",
+      "sha256": "833aa62469a7c812cccc5a572983d662a4a1805dcdc90ad0244ba159426ec00f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/10/maven-shared-components-10.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:18": {
+      "layout": "org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom",
+      "sha256": "a1d54fb81b5a8f197f5b3d0a928f63da2278c79bc8dd06e0be93593403f05775",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:17": {
+      "layout": "org/apache/maven/shared/maven-shared-components/17/maven-shared-components-17.pom",
+      "sha256": "4b96931a6d12491f858b44b2dbea50c1070c960232c041b966189dc905ac2631",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/17/maven-shared-components-17.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:19": {
+      "layout": "org/apache/maven/shared/maven-shared-components/19/maven-shared-components-19.pom",
+      "sha256": "d82408269aada2eb1521ee8ff17f7c67333684f8ed2a09a9e35badd2e7575957",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/19/maven-shared-components-19.pom"
+    },
+    "org.apache.maven:maven-plugin-api:jar:3.0": {
+      "layout": "org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.jar",
+      "sha256": "f5ecc6eaa4a32ee0c115d31525f588f491b2cc75fdeb4ed3c0c662c12ac0c32f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.jar"
+    },
+    "org.sonatype.aether:aether-parent:pom:1.7": {
+      "layout": "org/sonatype/aether/aether-parent/1.7/aether-parent-1.7.pom",
+      "sha256": "29004012161043936443d59574924e0406a2326f53943f02eca7944b33c169df",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-parent/1.7/aether-parent-1.7.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:4.0": {
+      "layout": "org/codehaus/plexus/plexus/4.0/plexus-4.0.pom",
+      "sha256": "0a1b692d7fcc90d6a45dae2e50f4660d48f7a44504f174aa60ef34fbe1327f6a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/4.0/plexus-4.0.pom"
+    },
+    "org.apache.maven:maven-project:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom",
+      "sha256": "34af0baedaef19375b7c1a7da967e9089d5e0754647fdbe9a302590392874b77",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom"
+    },
+    "org.codehaus.plexus:plexus-compilers:pom:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compilers/2.2/plexus-compilers-2.2.pom",
+      "sha256": "f6c8d1ee6e02ecd7376346b3f526e90b9e2c4d6128efa3b33cd463bcef8d480a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compilers/2.2/plexus-compilers-2.2.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.4": {
+      "layout": "org/codehaus/plexus/plexus/1.0.4/plexus-1.0.4.pom",
+      "sha256": "2242fd02d12b1ca73267fb3d89863025517200e7a4ee426cba4667d0172c74c3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.4/plexus-1.0.4.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.5": {
+      "layout": "org/codehaus/plexus/plexus/1.0.5/plexus-1.0.5.pom",
+      "sha256": "9a1df7db80ac85a4559a935404b9e57dc3dabeded5fb497d513dc51a1745e254",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.5/plexus-1.0.5.pom"
+    },
+    "org.apache.maven:maven-plugin-registry:pom:2.0": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0/maven-plugin-registry-2.0.pom",
+      "sha256": "aa0ff0841c724a7abdf25bd39a5d518de4ad7b688496137cadec0f58267e2d85",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0/maven-plugin-registry-2.0.pom"
+    },
+    "org.apache.maven:maven-core:jar:3.0": {
+      "layout": "org/apache/maven/maven-core/3.0/maven-core-3.0.jar",
+      "sha256": "ba03294ee53e7ba31838e4950f280d033c7744c6c7b31253afc75aa351fbd989",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.0/maven-core-3.0.jar"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:jar:1.7.1": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
+      "sha256": "a7fee9435db716bff593e9fb5622bcf9f25e527196485929b0cd4065c43e61df",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.8": {
+      "layout": "org/codehaus/plexus/plexus/1.0.8/plexus-1.0.8.pom",
+      "sha256": "a89a2f99088e244b3e52e35f19f5f7d3aba03dbb3cfaea044e2a694119e88f79",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.8/plexus-1.0.8.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.9": {
+      "layout": "org/codehaus/plexus/plexus/1.0.9/plexus-1.0.9.pom",
+      "sha256": "11a987607957fcac04d6ac182308abf5a7d3707f519863e55c8eb419953f5374",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.9/plexus-1.0.9.pom"
+    },
+    "org.sonatype.sisu:sisu-parent:pom:1.4.2": {
+      "layout": "org/sonatype/sisu/sisu-parent/1.4.2/sisu-parent-1.4.2.pom",
+      "sha256": "abb04084d0885319fd0b372d77655f8feb8aa8bb091699fcd99b45798a9587d5",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-parent/1.4.2/sisu-parent-1.4.2.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:jar:2.2.3": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.jar",
+      "sha256": "7d95ad21733b060bfda2142b62439a196bde7644f9f127c299ae86d92179b518",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.jar"
+    },
+    "org.apache.maven:maven-core:pom:3.0": {
+      "layout": "org/apache/maven/maven-core/3.0/maven-core-3.0.pom",
+      "sha256": "f70e12ebea93f119f4f63766c2b8a3386c34bb48e588df710cb98c8e3822f7c7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.0/maven-core-3.0.pom"
+    },
+    "junit:junit:jar:4.10": {
+      "layout": "junit/junit/4.10/junit-4.10.jar",
+      "sha256": "36a747ca1e0b86f6ea88055b8723bb87030d627766da6288bf077afdeeb0f75a",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/4.10/junit-4.10.jar"
+    },
+    "org.codehaus.plexus:plexus-classworlds:jar:2.2.2": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.jar",
+      "sha256": "13a90763640e445ffa432ce9586e416572645c3ed4db6a860fe0d28256ad40ce",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.jar"
+    },
+    "org.apache.maven:maven-toolchain:jar:1.0": {
+      "layout": "org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.jar",
+      "sha256": "95730d85b872517036b12ef7d474e72f2467f09ae40006169570450e6de6ac95",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.jar"
+    },
+    "org.codehaus.plexus:plexus:pom:3.2": {
+      "layout": "org/codehaus/plexus/plexus/3.2/plexus-3.2.pom",
+      "sha256": "1c7c732fdc37e7705af76835b1589fedd9db2abe1baa76b16bd061bd7291de4f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.2/plexus-3.2.pom"
+    },
+    "org.apache.maven:maven-model-builder:pom:3.0": {
+      "layout": "org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.pom",
+      "sha256": "c1413ace47dafabe7917072f26e0b667f5b3a762156f82893544cd71e6a6c4ba",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.pom"
+    },
+    "org.apache.maven.shared:file-management:pom:1.1": {
+      "layout": "org/apache/maven/shared/file-management/1.1/file-management-1.1.pom",
+      "sha256": "f7f68cb1f1dd99706fd30f2d40daad485dd160528408be6642875851714a1686",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/file-management/1.1/file-management-1.1.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:pom:2.0.6": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.pom",
+      "sha256": "4ac659858bac5929ea8fc183d7ce4b588d7e69363a76277f6a26349393686657",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.pom"
+    },
+    "org.sonatype.sisu:sisu-inject-plexus:pom:1.4.2": {
+      "layout": "org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.pom",
+      "sha256": "e302200cf462cf1af9f3e870738253cdf90d7abc8279b9d3b507a5d0d3b9f289",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.pom"
+    },
+    "org.apache.maven:maven-plugin-descriptor:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.jar",
+      "sha256": "d4b0d72958125b6cedc12c7ed5c50a20624e1e57ee37d622fb67f30dcf0327b3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.jar"
+    },
+    "org.apache.maven:maven-artifact:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.pom",
+      "sha256": "77f614225a71c207a45f270be0190d34bac4dbc14684cda26015717710411aee",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.0.8": {
+      "layout": "org/apache/maven/maven-artifact/2.0.8/maven-artifact-2.0.8.pom",
+      "sha256": "eb7bf61f1215585e1d625781a803d9e7fe4ac21466b150674873ffa4819809c7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.8/maven-artifact-2.0.8.pom"
+    },
+    "org.apache.maven:maven-plugin-descriptor:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar",
+      "sha256": "e6e99e03921e576358e24a797e3034d0587ad08dac8ebf78b3fcf3e1a96a37d9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar"
+    },
+    "doxia:doxia-sink-api:pom:1.0-alpha-4": {
+      "layout": "doxia/doxia-sink-api/1.0-alpha-4/doxia-sink-api-1.0-alpha-4.pom",
+      "sha256": "1ac3583fa5308e7c7823e64f0975478bdf5fdd2031885cdfa6b2a24373224a1a",
+      "url": "https://repo.maven.apache.org/maven2/doxia/doxia-sink-api/1.0-alpha-4/doxia-sink-api-1.0-alpha-4.pom"
+    },
+    "org.codehaus.plexus:plexus-languages:pom:1.0.1": {
+      "layout": "org/codehaus/plexus/plexus-languages/1.0.1/plexus-languages-1.0.1.pom",
+      "sha256": "01d70fb74d60ed98c108fc74494e8078ffa451218af83dc90097a1698fbe8853",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/1.0.1/plexus-languages-1.0.1.pom"
+    },
+    "log4j:log4j:pom:1.2.12": {
+      "layout": "log4j/log4j/1.2.12/log4j-1.2.12.pom",
+      "sha256": "cb54dedc5d8c4510148dfa792701cbac1a84c383a84f48f5a32e6d7e460bbb72",
+      "url": "https://repo.maven.apache.org/maven2/log4j/log4j/1.2.12/log4j-1.2.12.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.pom",
+      "sha256": "7231047667b34a36cfed19d51ef38c9755e97e1acf11595a4b503c5ce7f0c595",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.pom"
+    },
+    "org.apache.maven:maven-model:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom",
+      "sha256": "62dd8e35a2c4432bb22f8250bbfe08639635599b4064d5d747bd24cf3c02fac5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.0.4": {
+      "layout": "org/apache/maven/maven-artifact/2.0.4/maven-artifact-2.0.4.pom",
+      "sha256": "d8e78bc70afb9631d4e7c9db8f52778c4fd8c7c7998143bd7c420c40cf63ded4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.4/maven-artifact-2.0.4.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.0.2": {
+      "layout": "org/apache/maven/maven-artifact/2.0.2/maven-artifact-2.0.2.pom",
+      "sha256": "0123d59dd14fa00b8a50eb299bf59945dbd824b6deec43823e2612151ca38c17",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.2/maven-artifact-2.0.2.pom"
+    }
+  }
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8110,6 +8110,17 @@ in
     boost = boost165;
   };
 
+  xtreme-download-manager = callPackage ../applications/networking/xtreme-download-manager 
+  {
+    buildMavenRepositoryFromLockFile = (import
+      (pkgs.fetchFromGitHub {
+        owner = "fzakaria";
+        repo = "mvn2nix";
+        rev = "bc86f650d80ce9d29c376d6955ed175cba87915e";
+        sha256 = "0lzy1l208sxrs83y6l7dlrbmg1q3y75gw4fxy3wpzjhsxlycv3xj";
+      }) { }).buildMavenRepositoryFromLockFile;
+  };
+
   xurls = callPackage ../tools/text/xurls {};
 
   xxv = callPackage ../tools/misc/xxv {};


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/96557

###### Things done
Packaged xdman at release 7.2.11

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
