### PR TITLE
pythonPackages.django-user-agents: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8663,6 +8663,12 @@
     githubId = 33242106;
     name = "Uri Baghin";
   };
+  urlordjames = {
+    email = "urlordjames@gmail.com";
+    github = "urlordjames";
+    githubId = 32751441;
+    name = "urlordjames";
+  };
   uskudnik = {
     email = "urban.skudnik@gmail.com";
     github = "uskudnik";

--- a/pkgs/development/python-modules/django-user-agents/default.nix
+++ b/pkgs/development/python-modules/django-user-agents/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, django
+, user-agents
+}:
+
+buildPythonPackage rec {
+  pname = "django-user_agents";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "051m98z8n6lh159sn9fpj51hnmycdvsl6yd0cxl0xqyf8qhsxa6d";
+  };
+
+  doCheck = false;
+
+  buildInputs = [ django user-agents ];
+
+  meta = with stdenv.lib; {
+    description = "A django package that allows easy identification of visitors' browser, operating system and device information";
+    homepage = "https://github.com/selwin/django-user_agents";
+    license = licenses.mit;
+    maintainers = with maintainers; [ urlordjames ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -563,6 +563,8 @@ in {
 
   django-sesame = callPackage ../development/python-modules/django-sesame { };
 
+  django-user-agents = callPackage ../development/python-modules/django-user-agents { };
+
   bravado-core = callPackage ../development/python-modules/bravado-core { };
 
   breathe = callPackage ../development/python-modules/breathe { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add django-user-agents.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
