### PR TITLE
zoom-us: 5.1 -> 5.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -15,11 +15,11 @@ assert pulseaudioSupport -> libpulseaudio != null;
 let
   inherit (stdenv.lib) concatStringsSep makeBinPath optional;
 
-  version = "5.2.454870.0831";
+  version = "5.2.458699.0906";
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${version}/zoom_x86_64.tar.xz";
-      sha256 = "198p7a6kd5bakywj314lwizsy03g3j7w5zd7j3xghmpcfjz5drbn";
+      sha256 = "0cwai5v2m99cvw1dnysl88fi97dwm6rq7xv3y0ydgg3499n8cjpf";
     };
   };
 

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -15,11 +15,11 @@ assert pulseaudioSupport -> libpulseaudio != null;
 let
   inherit (stdenv.lib) concatStringsSep makeBinPath optional;
 
-  version = "5.2.446620.0816";
+  version = "5.2.454870.0831";
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${version}/zoom_x86_64.tar.xz";
-      sha256 = "0d7x4ji5l0rpanh0md75lywa8l9v6pd8bba5dba2xbfp7x9c3c4q";
+      sha256 = "198p7a6kd5bakywj314lwizsy03g3j7w5zd7j3xghmpcfjz5drbn";
     };
   };
 

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -15,11 +15,11 @@ assert pulseaudioSupport -> libpulseaudio != null;
 let
   inherit (stdenv.lib) concatStringsSep makeBinPath optional;
 
-  version = "5.1.422789.0705";
+  version = "5.2.446620.0816";
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${version}/zoom_x86_64.tar.xz";
-      sha256 = "1sc454xadxsbxxyb68qi7ac20yq0vymzzw1i07z19c9idfpjy75f";
+      sha256 = "0d7x4ji5l0rpanh0md75lywa8l9v6pd8bba5dba2xbfp7x9c3c4q";
     };
   };
 

--- a/pkgs/applications/networking/instant-messengers/zoom-us/update.sh
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/update.sh
@@ -1,17 +1,8 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl pcre common-updater-scripts
+#!nix-shell -i bash -p curl pup common-updater-scripts
 
 set -eu -o pipefail
 
-oldVersion=$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion zoom-us" | tr -d '"')
-version="$(curl -sI https://zoom.us/client/latest/zoom_x86_64.tar.xz | grep -Fi 'Location:' | pcregrep -o1 '/(([0-9]\.?)+)/')"
+version="$(curl -Ls https://zoom.us/download\?os\=linux | pup '.linux-ver-text text{}' | cut -d' ' -f2)"
 
-if [ ! "${oldVersion}" = "${version}" ]; then
-  update-source-version zoom-us "$version"
-  nixpkgs="$(git rev-parse --show-toplevel)"
-  default_nix="$nixpkgs/pkgs/applications/networking/instant-messengers/zoom-us/default.nix"
-  git add "${default_nix}"
-  git commit -m "zoom-us: ${oldVersion} -> ${version}"
-else
-  echo "zoom-us is already up-to-date"
-fi
+update-source-version zoom-us "$version"


### PR DESCRIPTION
###### Motivation for this change

New release of Zoom for Linux ([August 17th](https://support.zoom.us/hc/en-us/articles/205759689)) , just on time for the fall semester.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
