### PR TITLE
bacnet-stack: init at 1.0.0

### DIFF
--- a/pkgs/tools/networking/bacnet-stack/default.nix
+++ b/pkgs/tools/networking/bacnet-stack/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "bacnet-stack";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "bacnet-stack";
+    repo = "bacnet-stack";
+    rev = "bacnet-stack-${version}";
+    sha256 = "078p7qsy9v6fl7pzwgcr72pgjqxfxmfxyqajih2zqlb5g5sf88vh";
+  };
+
+  hardeningDisable = [ "all" ];
+
+  buildPhase = ''
+    make BUILD=debug BACNET_PORT=linux BACDL_DEFINE=-DBACDL_BIP=1 BACNET_DEFINES=" -DPRINT_ENABLED=1 -DBACFILE -DBACAPP_ALL -DBACNET_PROPERTY_LISTS"
+  '';
+
+  installPhase = ''
+    mkdir $out
+    cp -r bin $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "BACnet open source protocol stack for embedded systems, Linux, and Windows";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ WhittlesJr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -144,6 +144,8 @@ in
 
   avro-tools = callPackage ../development/tools/avro-tools { };
 
+  bacnet-stack = callPackage ../tools/networking/bacnet-stack {};
+
   # Zip file format only allows times after year 1980, which makes e.g. Python wheel building fail with:
   # ValueError: ZIP does not support timestamps before 1980
   ensureNewerSourcesForZipFilesHook = ensureNewerSourcesHook { year = "1980"; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I use BACnet MS/TP for my employment, and this is the only tool that I'm aware of that allows you to capture BACnet MS/TP traffic running on a serial port on Linux. It works great with Wireshark.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I use this for the "mstpcap" executable which, I have confirmed, works. There are a number of tools that I don't use, and I have not tested them. 