### PR TITLE
sparkleshare: init at 3.28

### DIFF
--- a/pkgs/applications/version-management/sparkleshare/default.nix
+++ b/pkgs/applications/version-management/sparkleshare/default.nix
@@ -1,0 +1,87 @@
+{
+  appindicator-sharp,
+  coreutils,
+  fetchFromGitHub,
+  git,
+  glib,
+  gtk-sharp-3_0,
+  lib,
+  makeWrapper,
+  meson,
+  mono,
+  ninja,
+  notify-sharp,
+  openssh,
+  openssl,
+  pkg-config,
+  stdenv,
+  symlinkJoin,
+  webkit2-sharp,
+  xdg_utils,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sparkleshare";
+  version = "3.28";
+
+  src = fetchFromGitHub {
+    owner = "hbons";
+    repo = "SparkleShare";
+    rev = version;
+    sha256 = "sha256:1x5nv2f3mrsr4a336bz5kc2lzkzilfh43bxy2yqhhjp2dgb20497";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    meson
+    mono
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    appindicator-sharp
+    gtk-sharp-3_0
+    notify-sharp
+    webkit2-sharp
+  ];
+
+  patchPhase = ''
+    # Nix will manage the icon cache.
+    echo '#!/bin/sh' >scripts/post-install.sh
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/sparkleshare \
+        --set PATH ${symlinkJoin {
+          name = "mono-path";
+          paths = [
+            coreutils
+            git
+            glib
+            mono
+            openssh
+            openssl
+            xdg_utils
+          ];
+        }}/bin \
+        --set MONO_GAC_PREFIX ${lib.concatStringsSep ":" [
+          appindicator-sharp
+          gtk-sharp-3_0
+          webkit2-sharp
+        ]} \
+        --set LD_LIBRARY_PATH ${lib.makeLibraryPath [
+          appindicator-sharp
+          gtk-sharp-3_0.gtk3
+          webkit2-sharp
+          webkit2-sharp.webkitgtk
+        ]}
+  '';
+
+  meta = {
+    description = "Share and collaborate by syncing with any Git repository instantly. Linux, macOS, and Windows.";
+    homepage = "https://sparkleshare.org";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ kevincox ];
+  };
+}

--- a/pkgs/desktops/gnome-2/platform/libgnomeui/default.nix
+++ b/pkgs/desktops/gnome-2/platform/libgnomeui/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       name = "0001-gnome-scores.h-Convert-to-UTF-8.patch";
-      url = "https://github.com/GNOME/libgnomeui/commit/30334c28794ef85d8973f4ed0779b5ceed6594f2.diff";
+      url = "https://gitlab.gnome.org/Archive/libgnomeui/-/commit/30334c28794ef85d8973f4ed0779b5ceed6594f2.diff";
       sha256 = "1sn8j8dkam14wfkpw8nga3gk63wniff243mzv3jp0fvv52q8sqhk";
     })
   ];

--- a/pkgs/development/libraries/appindicator-sharp/default.nix
+++ b/pkgs/development/libraries/appindicator-sharp/default.nix
@@ -1,0 +1,43 @@
+{
+  autoreconfHook,
+  fetchFromGitHub,
+  lib,
+  libappindicator,
+  mono,
+  gtk-sharp-3_0,
+  pkg-config,
+  stdenv,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "appindicator-sharp";
+  version = "5a79cde93da6d68a4b1373f1ce5796c3c5fe1b37";
+
+  src = fetchFromGitHub {
+    owner = "stsundermann";
+    repo = "appindicator-sharp";
+    rev = version;
+    sha256 = "sha256:1i0vqbp05l29f5v9ygp7flm4s05pcnn5ivl578mxmhb51s7ncw6l";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    mono
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk-sharp-3_0
+    libappindicator
+  ];
+
+  ac_cv_path_MDOC = "no";
+  installFlagsArray = ["GAPIXMLDIR=/tmp/gapixml"];
+
+  meta = {
+    description = "Bindings for appindicator using gobject-introspection";
+    homepage = "https://github.com/stsundermann/appindicator-sharp";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ kevincox ];
+  };
+}

--- a/pkgs/development/libraries/notify-sharp/default.nix
+++ b/pkgs/development/libraries/notify-sharp/default.nix
@@ -1,12 +1,13 @@
-{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook
+{ stdenv, fetchFromGitLab, pkgconfig, autoreconfHook
 , mono, gtk-sharp-3_0, dbus-sharp-1_0, dbus-sharp-glib-1_0 }:
 
 stdenv.mkDerivation rec {
   pname = "notify-sharp";
   version = "3.0.3";
 
-  src = fetchFromGitHub {
-    owner = "GNOME";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "Archive";
     repo = "notify-sharp";
 
     rev = version;

--- a/pkgs/development/libraries/webkit2-sharp/default.nix
+++ b/pkgs/development/libraries/webkit2-sharp/default.nix
@@ -1,0 +1,49 @@
+{
+  stdenv,
+  autoreconfHook,
+  fetchFromGitHub,
+  gtk-sharp-3_0,
+  lib,
+  libxslt,
+  mono,
+  pkg-config,
+  webkitgtk,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "webkit2-sharp";
+  version = "a59fd76dd730432c76b12ee6347ea66567107ab9";
+
+  src = fetchFromGitHub {
+    owner = "hbons";
+    repo = "webkit2-sharp";
+    rev = version;
+    sha256 = "sha256:0a7vx81zvzn2wq4q2mqrxvlps1mqk28lm1gpfndqryxm4iiw28vc";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    libxslt
+    mono
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk-sharp-3_0
+    webkitgtk
+  ];
+
+  ac_cv_path_MONODOCER = "no";
+  installFlagsArray = ["GAPIXMLDIR=/tmp/gapixml"];
+
+  passthru = {
+    inherit webkitgtk;
+  };
+
+  meta = {
+    description = "C# bindings for WebKit 2 with GTK+ 3";
+    homepage = "https://github.com/hbons/webkit2-sharp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kevincox ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4576,7 +4576,7 @@ in
 
   isync = callPackage ../tools/networking/isync { };
 
-  itm-tools = callPackage ../development/tools/misc/itm-tools { };  
+  itm-tools = callPackage ../development/tools/misc/itm-tools { };
 
   ix = callPackage ../tools/misc/ix { };
 
@@ -10191,6 +10191,8 @@ in
   self = pkgsi686Linux.callPackage ../development/interpreters/self { };
 
   spark = callPackage ../applications/networking/cluster/spark { };
+
+  sparkleshare = callPackage ../applications/version-management/sparkleshare { };
 
   spidermonkey_1_8_5 = callPackage ../development/interpreters/spidermonkey/1.8.5.nix { };
   spidermonkey_38 = callPackage ../development/interpreters/spidermonkey/38.nix ({
@@ -27502,7 +27504,7 @@ in
   sequeler = callPackage ../applications/misc/sequeler { };
 
   sequelpro = callPackage ../applications/misc/sequelpro {};
-  
+
   snowsql = callPackage ../applications/misc/snowsql {};
 
   sidequest = callPackage ../applications/misc/sidequest {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27275,6 +27275,8 @@ in
 
   webfs = callPackage ../servers/http/webfs { };
 
+  webkit2-sharp = callPackage ../development/libraries/webkit2-sharp {  };
+
   websocketd = callPackage ../applications/networking/websocketd { };
 
   wikicurses = callPackage ../applications/misc/wikicurses {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -123,6 +123,8 @@ in
 
   appimageTools = callPackage ../build-support/appimage { };
 
+  appindicator-sharp = callPackage ../development/libraries/appindicator-sharp { };
+
   ensureNewerSourcesHook = { year }: makeSetupHook {}
     (writeScript "ensure-newer-sources-hook.sh" ''
       postUnpackHooks+=(_ensureNewerSources)


### PR DESCRIPTION
Note: This change includes adding and fixing some dependencies in separate commits. If preferred I can submit them as separate PRs.

###### Motivation for this change

Make sparkleshare available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
