### PR TITLE
ocrmypdf: 10.3.0 -> 11.0.1; pdfminer_six: 20200720 -> 20200726

### DIFF
--- a/pkgs/development/python-modules/pdfminer_six/default.nix
+++ b/pkgs/development/python-modules/pdfminer_six/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "pdfminer_six";
-  version = "20200720";
+  version = "20200726";
 
   disabled = !isPy3k;
 
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     owner = "pdfminer";
     repo = "pdfminer.six";
     rev = version;
-    sha256 = "19cnl1b6mrk9i18a1k4vdl5k85ww8yhfq89w3fxh6rb0fla5d71i";
+    sha256 = "1hlaz7ax1czb028x3nhk3l2jy07f26q5hbhmdirljaaga24vd96z";
   };
 
   propagatedBuildInputs = [ chardet cryptography sortedcontainers ];

--- a/pkgs/tools/text/ocrmypdf/default.nix
+++ b/pkgs/tools/text/ocrmypdf/default.nix
@@ -29,14 +29,14 @@ let
 in
 buildPythonApplication rec {
   pname = "ocrmypdf";
-  version = "10.3.0";
+  version = "11.0.1";
   disabled = ! python3Packages.isPy3k;
 
   src = fetchFromGitHub {
     owner = "jbarlow83";
     repo = "OCRmyPDF";
     rev = "v${version}";
-    sha256 = "0c6v7846lmkmbyfla07s35mpba4h09h0fx6pxqf0yvdjxmj46q8c";
+    sha256 = "194ds9i1zd80ynzwgv7kprax0crh7bbchayawdcvg2lyr64a82xn";
   };
 
   nativeBuildInputs = with python3Packages; [
@@ -76,8 +76,6 @@ buildPythonApplication rec {
       src = ./liblept.patch;
       liblept = "${stdenv.lib.getLib leptonica}/lib/liblept${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
-    # https://github.com/jbarlow83/OCRmyPDF/pull/596
-    ./0001-Make-compatible-with-pdfminer.six-version-20200720.patch
   ];
 
   makeWrapperArgs = [ "--prefix PATH : ${stdenv.lib.makeBinPath [ ghostscript jbig2enc pngquant qpdf tesseract4 unpaper ]}" ];


### PR DESCRIPTION
###### Motivation for this change

This fixes the ocrmypdf build on master, which currently fails with:

```
ERROR: Could not find a version that satisfies the requirement img2pdf<0.4,>=0.3.0 (from ocrmypdf==10.3.0) (from versions: none)
ERROR: No matching distribution found for img2pdf<0.4,>=0.3.0 (from ocrmypdf==10.3.0)
builder for '/nix/store/1ggj5wwl92xickc7w5hfl3zrjfscxnf1-ocrmypdf-10.3.0.drv' failed with exit code 1
error: build of '/nix/store/1ggj5wwl92xickc7w5hfl3zrjfscxnf1-ocrmypdf-10.3.0.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested the build and `ocrmypdf` seems to run fine on NixOS.

Note that the ocrmypdf tests require a lot of memory.

cc ocrmypdf maintainer @Kiwi and pdfminer_six maintainers @PsyanticY @marsam