### PR TITLE
super-slicer: init at 2.2.53.1

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -1,0 +1,50 @@
+{
+  stdenv, lib, fetchFromGitHub, makeDesktopItem, prusa-slicer
+}:
+let
+  appname = "SuperSlicer";
+  version = "2.2.53.1";
+  pname = "super-slicer";
+  description = "PrusaSlicer fork with more features and faster development cycle";
+  override = super: {
+    inherit version pname;
+
+    src = fetchFromGitHub {
+      owner = "supermerill";
+      repo = "SuperSlicer";
+      sha256 = "sha256-CAhwmQ63N/XJYToTnIV84lNnjDGNbkmYPzNKNL/wVxs=";
+      rev = version;
+    };
+
+    # See https://github.com/supermerill/SuperSlicer/issues/432
+    cmakeFlags = super.cmakeFlags ++ [
+      "-DSLIC3R_BUILD_TESTS=0"
+    ];
+
+    postInstall = ''
+      mkdir -p "$out/share/pixmaps/"
+      # Change slic3r++ to SuperSlicer at the next release!
+      ln -s "$out/share/slic3r++/icons/Slic3r.png" "$out/share/pixmaps/${appname}.png"
+      mkdir -p "$out/share/applications"
+      cp "$desktopItem"/share/applications/* "$out/share/applications/"
+    '';
+
+    desktopItem = makeDesktopItem {
+      name = appname;
+      exec = "superslicer";
+      icon = appname;
+      comment = description;
+      desktopName = appname;
+      genericName = "3D printer tool";
+      categories = "Development;";
+    };
+
+    meta = with stdenv.lib; {
+      inherit description;
+      homepage = "https://github.com/supermerili/SuperSlicer";
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ cab404 moredread ];
+    };
+
+  };
+in prusa-slicer.overrideAttrs override

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22992,6 +22992,8 @@ in
 
   prusa-slicer = callPackage ../applications/misc/prusa-slicer { };
 
+  super-slicer = callPackage ../applications/misc/prusa-slicer/super-slicer.nix { };
+
   robustirc-bridge = callPackage ../servers/irc/robustirc-bridge { };
 
   sddm = libsForQt5.callPackage ../applications/display-managers/sddm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Added SuperSlicer — PrusaSlicer fork with more features and faster development cycle.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
