### PR TITLE
python3Packages.cirq: unbreak

### DIFF
--- a/pkgs/development/python-modules/cirq/default.nix
+++ b/pkgs/development/python-modules/cirq/default.nix
@@ -48,6 +48,15 @@ buildPythonPackage rec {
     })
   ];
 
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "freezegun~=0.3.15" "freezegun" \
+      --replace "matplotlib~=3.0" "matplotlib" \
+      --replace "networkx~=2.4" "networkx" \
+      --replace "numpy~=1.16, < 1.19" "numpy" \
+      --replace "protobuf~=3.12.0" "protobuf"
+  '';
+
   propagatedBuildInputs = [
     freezegun
     google_api_core
@@ -64,7 +73,7 @@ buildPythonPackage rec {
   ];
 
   doCheck = true;
-  # pythonImportsCheck = [ "cirq" "cirq.Ciruit" ];  # cirq's importlib hook doesn't work here
+  # pythonImportsCheck = [ "cirq" "cirq.Circuit" ];  # cirq's importlib hook doesn't work here
   dontUseSetuptoolsCheck = true;
   checkInputs = [
     pytestCheckHook
@@ -78,16 +87,10 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "--ignore=dev_tools"  # Only needed when developing new code, which is out-of-scope
+    "--benchmark-disable" # Don't need to run benchmarks when packaging.
   ];
   disabledTests = [
-    "test_serialize_sympy_constants"  # fails due to small error in pi (~10e-7)
-    "test_convert_to_ion_gates" # fails due to rounding error, 0.75 != 0.750...2
-
-    # Newly disabled tests on cirq 0.8
-    # TODO: test & figure out why failing
-    "engine_job_test"
-    "test_health"
-    "test_run_delegation"
+    "test_convert_to_ion_gates" # fails on some systems due to rounding error, 0.75 != 0.750...2
   ] ++ lib.optionals stdenv.isAarch64 [
     # Seem to fail due to math issues on aarch64?
     "expectation_from_wavefunction"
@@ -97,6 +100,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.";
     homepage = "https://github.com/quantumlib/cirq";
+    changelog = "https://github.com/quantumlib/Cirq/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This is a pre-ZHF PR to unbreak a package before release.

Found out it was broken due to changing dependencies or something.

Remove unneeded test disables.
Add changelog.
Unpin most python dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
