### PR TITLE
nixos/tests/sssd-ldap: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -325,6 +325,7 @@ in
   sonarr = handleTest ./sonarr.nix {};
   sslh = handleTest ./sslh.nix {};
   sssd = handleTestOn ["x86_64-linux"] ./sssd.nix {};
+  sssd-ldap = handleTestOn ["x86_64-linux"] ./sssd-ldap.nix {};
   strongswan-swanctl = handleTest ./strongswan-swanctl.nix {};
   sudo = handleTest ./sudo.nix {};
   switchTest = handleTest ./switch-test.nix {};

--- a/nixos/tests/sssd-ldap.nix
+++ b/nixos/tests/sssd-ldap.nix
@@ -1,0 +1,78 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+  let
+    dbDomain = "example.org";
+    dbSuffix = "dc=example,dc=org";
+
+    ldapRootUser = "admin";
+    ldapRootPassword = "foobar";
+
+    testUser = "alice";
+  in
+  {
+    name = "sssd-ldap";
+
+    meta = with pkgs.stdenv.lib.maintainers; {
+      maintainers = [ bbigras ];
+    };
+
+    machine = { pkgs, ... }: {
+      services.openldap = {
+        enable = true;
+        rootdn = "cn=${ldapRootUser},${dbSuffix}";
+        rootpw = ldapRootPassword;
+        suffix = dbSuffix;
+        declarativeContents = ''
+          dn: ${dbSuffix}
+          objectClass: top
+          objectClass: dcObject
+          objectClass: organization
+          o: ${dbDomain}
+
+          dn: ou=posix,${dbSuffix}
+          objectClass: top
+          objectClass: organizationalUnit
+
+          dn: ou=accounts,ou=posix,${dbSuffix}
+          objectClass: top
+          objectClass: organizationalUnit
+
+          dn: uid=${testUser},ou=accounts,ou=posix,${dbSuffix}
+          objectClass: person
+          objectClass: posixAccount
+          # userPassword: somePasswordHash
+          homeDirectory: /home/${testUser}
+          uidNumber: 1234
+          gidNumber: 1234
+          cn: ""
+          sn: ""
+        '';
+      };
+
+      services.sssd = {
+        enable = true;
+        config = ''
+          [sssd]
+          config_file_version = 2
+          services = nss, pam, sudo
+          domains = ${dbDomain}
+
+          [domain/${dbDomain}]
+          auth_provider = ldap
+          id_provider = ldap
+          ldap_uri = ldap://127.0.0.1:389
+          ldap_search_base = ${dbSuffix}
+          ldap_default_bind_dn = cn=${ldapRootUser},${dbSuffix}
+          ldap_default_authtok_type = password
+          ldap_default_authtok = ${ldapRootPassword}
+        '';
+      };
+    };
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("openldap.service")
+      machine.wait_for_unit("sssd.service")
+      machine.succeed("getent passwd ${testUser}")
+    '';
+  }
+)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

He's a very basic sssd test with ldap. It doesn't test auth but it does test `getent passwd <username>`.

This could maybe be used as a base for more advanced tests like for gdm, sddm, ssh...

I hope this test doesn't share any of the problem that the [removed test](https://github.com/NixOS/nixpkgs/pull/87004) had.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
