### PR TITLE
lyrebird: init at 1.1.0

### DIFF
--- a/pkgs/applications/audio/lyrebird/default.nix
+++ b/pkgs/applications/audio/lyrebird/default.nix
@@ -1,0 +1,63 @@
+{ python3Packages
+, lib
+, fetchFromGitHub
+, makeDesktopItem
+, wrapGAppsHook
+, gtk3
+, gobject-introspection
+, sox
+, pulseaudio
+}:
+let
+  desktopItem = makeDesktopItem {
+    name = "lyrebird";
+    exec = "lyrebird";
+    icon = "${placeholder "out"}/share/lyrebird/icon.png";
+    desktopName = "Lyrebird";
+    genericName = "Voice Changer";
+    categories = "AudioVideo;Audio;";
+  };
+in
+python3Packages.buildPythonApplication rec {
+  pname = "lyrebird";
+  version = "1.1.0";
+
+  format = "other";
+  doCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "chxrlt";
+    repo = "lyrebird";
+    rev = "v${version}";
+    sha256 = "0wmnww2wi8bb9m8jgc18n04gjia8pf9klmvij0w98xz11l6kxb13";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ toml pygobject3 ];
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  buildInputs = [ gtk3 gobject-introspection sox ];
+
+  dontWrapGApps = true;
+  makeWrapperArgs = [
+    "--prefix 'PATH' ':' '${lib.makeBinPath [ sox pulseaudio ]}'"
+    "--prefix 'PYTHONPATH' ':' '${placeholder "out"}/share/lyrebird'"
+    "--run 'cd ${placeholder "out"}/share/lyrebird'"
+    ''"''${gappsWrapperArgs[@]}"''
+  ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/{applications,lyrebird}}
+    cp -at $out/share/lyrebird/ app icon.png
+    cp -at $out/share/applications/ ${desktopItem}
+    install -Dm755 app.py $out/bin/lyrebird
+  '';
+
+  meta = with lib; {
+    description = "Simple and powerful voice changer for Linux, written in GTK 3";
+    homepage = "https://github.com/chxrlt/lyrebird";
+    license = licenses.mit;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21572,6 +21572,8 @@ in
 
   lynx = callPackage ../applications/networking/browsers/lynx { };
 
+  lyrebird = callPackage ../applications/audio/lyrebird { };
+
   lyx = libsForQt5.callPackage ../applications/misc/lyx { };
 
   mac = callPackage ../development/libraries/mac { };


### PR DESCRIPTION
First time I'm packaging something Python-y, please go easy on me if there are any problems with this. :stuck_out_tongue: 

###### Motivation for this change
New package "lyrebird" - an easy-to-use, GTK3-based voice changer application for Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
