### PR TITLE
hspell: fix cross-platform build issues

### DIFF
--- a/pkgs/development/libraries/hspell/default.nix
+++ b/pkgs/development/libraries/hspell/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, zlib }:
+{ stdenv, fetchurl, perl, zlib, buildPackages }:
 
 stdenv.mkDerivation rec {
   name = "${passthru.pname}-${passthru.version}";
@@ -16,7 +16,18 @@ stdenv.mkDerivation rec {
   };
 
   patchPhase = ''patchShebangs .'';
-  buildInputs = [ perl zlib ];
+  preBuild = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    make CC=${buildPackages.stdenv.cc}/bin/cc find_sizes
+    mv find_sizes find_sizes_build
+    make clean
+
+    substituteInPlace Makefile --replace "./find_sizes" "./find_sizes_build"
+    substituteInPlace Makefile --replace "ar cr" "${stdenv.lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar cr"
+    substituteInPlace Makefile --replace "ranlib" "${stdenv.lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib"
+    substituteInPlace Makefile --replace "STRIP=strip" "STRIP=${stdenv.lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}strip"
+  '';
+  nativeBuildInputs = [ perl zlib ];
+#  buildInputs = [ zlib ];
 
   meta = with stdenv.lib; {
     description = "Hebrew spell checker";


### PR DESCRIPTION
###### Motivation for this change

hspell uses a couple of binaries it generates during it's own build.
These will cause the build to fail later in cross-platform builds as
these binaries have the wrong executable format.
Using a hspell to bootstrap it's own build natively resolves this issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
