### PR TITLE
fcft: 2.2.6 → 2.3.1

### DIFF
--- a/pkgs/development/libraries/fcft/default.nix
+++ b/pkgs/development/libraries/fcft/default.nix
@@ -1,18 +1,19 @@
 { stdenv, lib, fetchgit, pkg-config, meson, ninja, scdoc
-,freetype, fontconfig, pixman, tllist, check }:
+,freetype, fontconfig, pixman, tllist, check, harfbuzz
+}:
 
 stdenv.mkDerivation rec {
   pname = "fcft";
-  version = "2.2.6";
+  version = "2.3.1";
 
   src = fetchgit {
     url = "https://codeberg.org/dnkl/fcft.git";
-    rev = "${version}";
-    sha256 = "06zywvvgrch9k4d07bir2sxddwsli2gzpvlvjfcwbrj3bw5x6j1b";
+    rev = version;
+    sha256 = "1ddzdfq6y9db50zimxfsr955zkpr8y6fk4nrblsl0j0vliywlg8l";
   };
 
   nativeBuildInputs = [ pkg-config meson ninja scdoc ];
-  buildInputs = [ freetype fontconfig pixman tllist ];
+  buildInputs = [ freetype fontconfig pixman tllist harfbuzz ];
   checkInputs = [ check ];
 
   mesonFlags = [ "--buildtype=release" ];
@@ -25,5 +26,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fionera ];
     license = licenses.mit;
     platforms = with platforms; linux;
+    changelog = "https://codeberg.org/dnkl/fcft/releases/tag/${version}";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

* [improved bitmap rendering](https://linuxrocks.online/@dnkl/104785149754346986)
* <https://codeberg.org/dnkl/fcft/releases/tag/2.3.1>
* <https://codeberg.org/dnkl/fcft/releases/tag/2.3.0>
* <https://codeberg.org/dnkl/fcft/releases/tag/2.2.7>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
