### PR TITLE
gamin: Fix cross compiling issues

### DIFF
--- a/pkgs/development/libraries/gamin/abstract-socket-namespace.patch
+++ b/pkgs/development/libraries/gamin/abstract-socket-namespace.patch
@@ -1,0 +1,73 @@
+From 737452159d521aef2041a2767f3ebf9f68f4b6a9 Mon Sep 17 00:00:00 2001
+From: Christian Kampka <christian@kampka.net>
+Date: Tue, 1 Sep 2020 13:54:35 +0200
+Subject: [PATCH] Pin abstract namespace sockets to host_os
+
+Running programs with AC_RUN_IFELSE fails when cross-compiling.
+Since abstract namespace sockets are linux feature, we can easily
+assume it is available for linux and not for darwin.
+---
+ configure.in | 47 ++++++-----------------------------------------
+ 1 file changed, 6 insertions(+), 41 deletions(-)
+
+diff --git a/configure.in b/configure.in
+index eb129db..0ed82ba 100644
+--- a/configure.in
++++ b/configure.in
+@@ -387,47 +387,12 @@ fi
+ 
+ #### Abstract sockets
+ 
+-AC_MSG_CHECKING(abstract socket namespace)
+-AC_LANG_PUSH(C)
+-AC_RUN_IFELSE([AC_LANG_PROGRAM(
+-[[
+-#include <sys/types.h>
+-#include <stdlib.h>
+-#include <string.h>
+-#include <stdio.h>
+-#include <sys/socket.h>
+-#include <sys/un.h>
+-#include <errno.h>
+-]],
+-[[
+-  int listen_fd;
+-  struct sockaddr_un addr;
+-  
+-  listen_fd = socket (PF_UNIX, SOCK_STREAM, 0);
+-  
+-  if (listen_fd < 0)
+-    {
+-      fprintf (stderr, "socket() failed: %s\n", strerror (errno));
+-      exit (1);
+-    }
+-
+-  memset (&addr, '\0', sizeof (addr));
+-  addr.sun_family = AF_UNIX;
+-  strcpy (addr.sun_path, "X/tmp/dbus-fake-socket-path-used-in-configure-test");
+-  addr.sun_path[0] = '\0'; /* this is what makes it abstract */
+-  
+-  if (bind (listen_fd, (struct sockaddr*) &addr, SUN_LEN (&addr)) < 0)
+-    {
+-       fprintf (stderr, "Abstract socket namespace bind() failed: %s\n", 
+-                strerror (errno));
+-       exit (1);
+-    }
+-  else 
+-    exit (0);
+-]])],
+-              [have_abstract_sockets=yes],
+-              [have_abstract_sockets=no])
+-AC_LANG_POP(C)
++AC_MSG_CHECKING([whether target os has abstract socket namespace])
++if test x$target_os = xlinux-gnu ; then
++    have_abstract_sockets=yes
++else
++    have_abstract_sockets=no
++fi	
+ AC_MSG_RESULT($have_abstract_sockets)
+ 
+ if test x$enable_abstract_sockets = xyes; then
+-- 
+2.25.4
+

--- a/pkgs/development/libraries/gamin/default.nix
+++ b/pkgs/development/libraries/gamin/default.nix
@@ -1,6 +1,8 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, glib }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, glib, autoreconfHook }:
 
-stdenv.mkDerivation (rec {
+let
+  cross = stdenv.hostPlatform != stdenv.buildPlatform;
+in stdenv.mkDerivation (rec {
   name = "gamin-0.1.10";
 
   src = fetchurl {
@@ -8,7 +10,7 @@ stdenv.mkDerivation (rec {
     sha256 = "18cr51y5qacvs2fc2p1bqv32rs8bzgs6l67zhasyl45yx055y218";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
 
   buildInputs = [ glib ];
 
@@ -27,7 +29,7 @@ stdenv.mkDerivation (rec {
       name = "fix-pthread-mutex.patch";
       url = "https://git.alpinelinux.org/aports/plain/main/gamin/fix-pthread-mutex.patch?h=3.4-stable&id=a1a836b089573752c1b0da7d144c0948b04e8ea8";
       sha256 = "13igdbqsxb3sz0h417k6ifmq2n4siwqspj6slhc7fdl5wd1fxmdz";
-    });
+    }) ++ stdenv.lib.optional (cross) ./abstract-socket-namespace.patch ;
 
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Gamin fails to build cross-platform because it tries to run
AC_RUN_IFELSE during configure which fails as the test program is built
for the wrong platform and cannot execute. Since the test is only for
the 'abstract socket namespace' feature, we can just pin the results
for out builds, it is 'yes' for Linux and 'no' for Darwin (and other
BSD).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
