### PR TITLE
python3Packages.transformers: 3.0.2 -> 3.1.0

### DIFF
--- a/pkgs/development/python-modules/transformers/default.nix
+++ b/pkgs/development/python-modules/transformers/default.nix
@@ -16,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "transformers";
-  version = "3.0.2";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0rdlikh2qilwd0s9f3zif51p1q7sp3amxaccqic8p5qm6dqpfpz6";
+    sha256 = "0wg36qrcljmpsyhjaxpqw3s1r6276yg8cq0bjrf52l4zlc5k4xzk";
   };
 
   propagatedBuildInputs = [
@@ -44,16 +44,23 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "tokenizers == 0.8.1.rc1" "tokenizers>=0.8"
+      --replace "tokenizers == 0.8.1.rc2" "tokenizers>=0.8"
   '';
 
   preCheck = ''
     export HOME="$TMPDIR"
     cd tests
+
+    # This test requires the nlp module, which we haven't
+    # packaged yet. However, nlp is optional for transformers
+    # itself
+    rm test_trainer.py
   '';
 
   # Disable tests that require network access.
   disabledTests = [
+    "PegasusTokenizationTest"
+    "T5TokenizationTest"
     "test_all_tokenizers"
     "test_batch_encoding_is_fast"
     "test_batch_encoding_pickle"
@@ -63,6 +70,7 @@ buildPythonPackage rec {
     "test_hf_api"
     "test_outputs_can_be_shorter"
     "test_outputs_not_longer_than_maxlen"
+    "test_padding_accepts_tensors"
     "test_pretokenized_tokenizers"
     "test_tokenizer_equivalence_en_de"
     "test_tokenizer_from_model_type"
@@ -74,6 +82,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     homepage = "https://github.com/huggingface/transformers";
     description = "State-of-the-art Natural Language Processing for TensorFlow 2.0 and PyTorch";
+    changelog = "https://github.com/huggingface/transformers/releases/tag/v${version}";
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [ danieldk pashashocky ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Transformers now has `nlp` as an optional dependency. `nlp` will
require some work to package, since it attempts to download modules
into its Python package path by default. So, the `nlp`-based test
is disable for the time being.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
