### PR TITLE
Wordpress improvements

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -727,6 +727,19 @@
           <literal>linuxPackages_5_10_hardened</literal>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>services.wordpress.$name.database.name</literal>
+          default value has changed from <literal>wordpress</literal> to
+          <literal>wordpress-${name}</literal> on NixOS installations
+          where <literal>system.stateVersion</literal> is
+          <literal>21.11</literal> or higher. This will break existing
+          installations if you don’t manually set
+          <literal>services.wordpress.$name.database.name</literal> back
+          to <literal>wordpress</literal> or rename the database
+          manually to the new name.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -188,6 +188,9 @@ To be able to access the web UI this port needs to be opened in the firewall.
   a hardened kernel, please pin it explicitly with a versioned attribute such as
   `linuxPackages_5_10_hardened`.
 
+- `services.wordpress.$name.database.name` default value has changed from `wordpress` to `wordpress-${name}` on NixOS installations where `system.stateVersion` is `21.11` or higher.
+  This will break existing installations if you don't manually set `services.wordpress.$name.database.name` back to `wordpress` or rename the database manually to the new name.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 - The setting [`services.openssh.logLevel`](options.html#opt-services.openssh.logLevel) `"VERBOSE"` `"INFO"`. This brings NixOS in line with upstream and other Linux distributions, and reduces log spam on servers due to bruteforcing botnets.

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -483,7 +483,7 @@ in
             ''
               ( echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' IDENTIFIED WITH ${if isMariaDB then "unix_socket" else "auth_socket"};"
                 ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
-                  echo "GRANT ${permission} ON ${database} TO '${user.name}'@'localhost';"
+                  echo 'GRANT ${permission} ON ${database} TO `${user.name}`@`localhost`;'
                 '') user.ensurePermissions)}
               ) | ${cfg.package}/bin/mysql -N
             '') cfg.ensureUsers}

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -169,7 +169,7 @@ let
 
           name = mkOption {
             type = types.str;
-            default = "wordpress";
+            default = if lib.versionAtLeast config.system.stateVersion "21.11" then "wordpress-${name}" else "wordpress";
             description = "Database name.";
           };
 
@@ -315,7 +315,7 @@ in
       ensureDatabases = mapAttrsToList (hostName: cfg: cfg.database.name) eachSite;
       ensureUsers = mapAttrsToList (hostName: cfg:
         { name = cfg.database.user;
-          ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
+          ensurePermissions = { "`${cfg.database.name}`.*" = "ALL PRIVILEGES"; };
         }
       ) eachSite;
     };

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -127,7 +127,7 @@ let
           default = [];
           description = ''
             List of path(s) to respective plugin(s) which are copied from the 'plugins' directory.
-            <note><para>These plugins need to be packaged before use, see example.</para></note>
+            <note><para>These plugins need to be packaged before use, see example. Using something like https://git.helsinki.tools/helsinki-systems/wp4nix may be a better option.</para></note>
           '';
           example = ''
             # Wordpress plugin 'embed-pdf-viewer' installation example
@@ -154,7 +154,7 @@ let
           default = [];
           description = ''
             List of path(s) to respective theme(s) which are copied from the 'theme' directory.
-            <note><para>These themes need to be packaged before use, see example.</para></note>
+            <note><para>These themes need to be packaged before use, see example. Using something like https://git.helsinki.tools/helsinki-systems/wp4nix may be a better option.</para></note>
           '';
           example = ''
             # Let's package the responsive theme

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -87,7 +87,8 @@ let
         package = mkOption {
           type = types.package;
           default = pkgs.wordpress;
-          description = "Which WordPress package to use.";
+          example = literalExample "pkgs.wordpress-core";
+          description = "Which WordPress package to use. Use pkgs.wordpress-core for a version without the default plugins and theme.";
         };
 
         uploadsDir = mkOption {

--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
     inherit (nixosTests) wordpress;
   };
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     homepage = "https://wordpress.org";
     description = "WordPress is open source software you can use to create a beautiful website, blog, or app";

--- a/pkgs/servers/web-apps/wordpress/update.sh
+++ b/pkgs/servers/web-apps/wordpress/update.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts jq
+
+set -eu -o pipefail
+
+version=$(curl --globoff "https://api.wordpress.org/core/version-check/1.7/" | jq -r '.offers[0].version')
+update-source-version wordpress $version

--- a/pkgs/servers/web-apps/wordpress/wordpress-core.nix
+++ b/pkgs/servers/web-apps/wordpress/wordpress-core.nix
@@ -1,0 +1,10 @@
+{ wordpress }:
+
+wordpress.overrideAttrs (oldAttrs: {
+  pname = "wordpress-core";
+
+  installPhase = oldAttrs.installPhase + ''
+    rm -r $out/share/wordpress/wp-content/plugins/*
+    rm -r $out/share/wordpress/wp-content/themes/*
+  '';
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32379,6 +32379,8 @@ with pkgs;
 
   wordpress = callPackage ../servers/web-apps/wordpress { };
 
+  wordpress-core = callPackage ../servers/web-apps/wordpress/wordpress-core.nix { };
+
   wprecon = callPackage ../tools/security/wprecon { };
 
   wraith = callPackage ../applications/networking/irc/wraith {


### PR DESCRIPTION
#####  Motivation for this change
Improve the wordpress service:
* Add separate package that removes built-in themes and plugins as these can't be updated independently and also can't be removed otherwise.
* Package auto-update script
* Separate databases to allow multiple wordpress installations on one host by default
* Add option for mutable wp-content

(edit: updated)

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
