### PR TITLE
nixos/httpd: respect hostName when provisioning certificates

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -647,14 +647,15 @@ in
       wwwrun.gid = config.ids.gids.wwwrun;
     };
 
-    security.acme.certs = mapAttrs (name: hostOpts: {
-      user = cfg.user;
-      group = mkDefault cfg.group;
-      email = if hostOpts.adminAddr != null then hostOpts.adminAddr else cfg.adminAddr;
-      webroot = hostOpts.acmeRoot;
-      extraDomains = genAttrs hostOpts.serverAliases (alias: null);
-      postRun = "systemctl reload httpd.service";
-    }) (filterAttrs (name: hostOpts: hostOpts.enableACME) cfg.virtualHosts);
+    security.acme.certs = mapAttrs' (name: hostOpts: (
+      nameValuePair hostOpts.hostName {
+        user = cfg.user;
+        group = mkDefault cfg.group;
+        email = if hostOpts.adminAddr != null then hostOpts.adminAddr else cfg.adminAddr;
+        webroot = hostOpts.acmeRoot;
+        extraDomains = genAttrs hostOpts.serverAliases (alias: null);
+        postRun = "systemctl reload httpd.service";
+      })) (filterAttrs (name: hostOpts: hostOpts.enableACME) cfg.virtualHosts);
 
     environment.systemPackages = [
       apachectl


### PR DESCRIPTION
##### Motivation for this change
This fixes an inconsistency when the attribute name doesn't match the hostName.
See https://github.com/NixOS/nixpkgs/pull/96910#discussion_r481358226
@aanderse 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
