### PR TITLE
netbeans: 12.0 -> 12.1

### DIFF
--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "12.0";
+  version = "12.1";
   desktopItem = makeDesktopItem {
     name = "netbeans";
     exec = "netbeans";
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   inherit version;
   src = fetchurl {
     url = "mirror://apache/netbeans/netbeans/${version}/netbeans-${version}-bin.zip";
-    sha512 = "91030c9628a08acd85f1a58a7f71eec2e57dc85841c1c475cc6311335b5d8cdc10c1198274b9668b7f61a28d04b07661247dc1c3e36b8e29214aec3748e499e4";
+    sha512 = "ad4bb5b191c784ed144b0b4831a8b95e0707c362917833c279d3f6fad11d7b3fb1f004f30121a941b694fc2ce323974b15072aa31cb5449111bc5d33d0d77103";
   };
 
   buildCommand = ''


### PR DESCRIPTION
###### Motivation for this change
Updated to latest release.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
 asbachb@nixos  ~/dev/src/nix/nixpkgs/pkgs/applications/editors/netbeans   update-netbeans  nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
these paths will be fetched (0.03 MiB download, 0.13 MiB unpacked):
  /nix/store/hpsr5c2x5fjh1ad1wmlbnnqmdp8qckc4-nixpkgs-review-2.3.1
copying path '/nix/store/hpsr5c2x5fjh1ad1wmlbnnqmdp8qckc4-nixpkgs-review-2.3.1' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 48, done.
remote: Counting objects: 100% (48/48), done.
remote: Compressing objects: 100% (31/31), done.
remote: Total 55 (delta 32), reused 17 (delta 17), pack-reused 7
Unpacking objects: 100% (55/55), 71.37 KiB | 936.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   44d841f758d..fa50d74be3e  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-69027b0c95f1c6573171e96acfee14bd1e9a46e1-dirty/nixpkgs fa50d74be3e86a25a7da9598bd6a65d000cb4f3b
Preparing worktree (detached HEAD fa50d74be3e)
Updating files: 100% (22596/22596), done.
HEAD is now at fa50d74be3e Merge pull request #93802 from r-ryantm/auto-update/libraw
$ nix-env -f /home/asbachb/.cache/nixpkgs-review/rev-69027b0c95f1c6573171e96acfee14bd1e9a46e1-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
