### PR TITLE
gtg: Run tests

### DIFF
--- a/pkgs/applications/office/gtg/default.nix
+++ b/pkgs/applications/office/gtg/default.nix
@@ -50,8 +50,15 @@ python3Packages.buildPythonApplication rec {
     liblarch
   ];
 
+  checkInputs = with python3Packages; [
+    nose
+    mock
+  ];
+
   format = "other";
   strictDeps = false; # gobject-introspection does not run with strictDeps (https://github.com/NixOS/nixpkgs/issues/56943)
+
+  checkPhase = "python3 ../run-tests";
 
   meta = with stdenv.lib; {
     description = " A personal tasks and TODO-list items organizer.";


### PR DESCRIPTION
###### Motivation for this change
This package comes with tests.  Run them.

* Running tests helps identify causes when things break in the public tree.
* Running tests helps me more quickly detect problems in my local patched builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    No change: 993270144 → 993270144
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


This adds

    Running install tests
    ....................................................................................................
    ----------------------------------------------------------------------
    Ran 100 tests in 0.125s

    OK
to the build output.