### PR TITLE
cordless: init at 2020-08-30

### DIFF
--- a/pkgs/applications/networking/instant-messengers/cordless/default.nix
+++ b/pkgs/applications/networking/instant-messengers/cordless/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "cordless";
+  version = "2020-08-30";
+
+  src = fetchFromGitHub {
+    owner = "Bios-Marcel";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-CwOI7Ah4+sxD9We+Va5a6jYat5mjOeBk2EsOfwskz6k=";
+  };
+
+  subPackages = [ "." ];
+
+  vendorSha256 = "sha256-01I7GrZkaskuz20kVK2YwqvP7ViPMlQ3BFaoLHwgvOE=";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Bios-Marcel/cordless";
+    description = "Discord terminal client";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ colemickens ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19812,6 +19812,8 @@ in
 
   convchain = callPackage ../tools/graphics/convchain {};
 
+  cordless = callPackage ../applications/networking/instant-messengers/cordless { };
+
   coursera-dl = callPackage ../applications/misc/coursera-dl {};
 
   coyim = callPackage ../applications/networking/instant-messengers/coyim {};


### PR DESCRIPTION
###### Motivation for this change
Fixes #96938 by packaging "cordless" at version 2020-08-30.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
