### PR TITLE
gtkcord3: init at 0.0.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gtkcord3/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gtkcord3/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, buildGoModule, fetchFromGitHub
+, pkg-config, makeDesktopItem
+, gtk3, libhandy
+}:
+
+buildGoModule rec {
+  pname = "gtkcord3";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "diamondburned";
+    repo = pname;
+    rev = "v" + version;
+    sha256 = "sha256-zdku9lpoanV/wDq8H+0bw4yaVaeZxYT2RP1+UDQAJlk=";
+  };
+
+  vendorSha256 = "sha256-Ngq1RUc+w3GbslYJhb8U7OvlkRO6ANn8ICRLhkFH+E8=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ gtk3 libhandy ];
+
+  subPackages = [ "." ];
+
+  postInstall = ''
+    cp -r ${
+      makeDesktopItem {
+        name = "gtkcord3";
+        exec = "@out@/bin/gtkcord3";
+        terminal = "true";
+        desktopName = "Gtkcord3";
+        genericName = "Discord client";
+        categories = "Network;Chat";
+        comment = meta.description;
+      }
+    }/* $out/
+    substituteAllInPlace $out/share/applications/*
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/diamondburned/gtkcord3";
+    description = "A Gtk3 Discord client in Golang";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ colemickens ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20393,6 +20393,8 @@ in
 
   gthumb = callPackage ../applications/graphics/gthumb { };
 
+  gtkcord3 = callPackage ../applications/networking/instant-messengers/gtkcord3 { };
+
   gtimelog = pythonPackages.gtimelog;
 
   inherit (gnome3) gucharmap;


### PR DESCRIPTION
###### Motivation for this change
Fixes #96936 by packaging `gtkcord3` at version `0.0.4`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
