### PR TITLE
pitivi: fix build

### DIFF
--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -1,8 +1,9 @@
 { stdenv
 , fetchFromGitHub
 , fetchurl
+, fetchpatch
 , pkg-config
-, intltool
+, gettext
 , itstool
 , python3
 , wrapGAppsHook
@@ -20,9 +21,8 @@
 }:
 
 let
-  # gst-transcoder will eventually be merged with gstreamer (according to
-  # gst-transcoder 1.8.0 release notes). For now the only user is pitivi so we
-  # don't bother exposing the package to all of nixpkgs.
+  # gst-transcoder was merged with gst-plugins-bad 1.18.
+  # TODO: switch to that once available.
   gst-transcoder = stdenv.mkDerivation rec {
     version = "1.14.1";
     pname = "gst-transcoder";
@@ -61,13 +61,49 @@ in python3Packages.buildPythonApplication rec {
     # and saves them to the generated binary. This would make the build-time
     # dependencies part of the closure so we remove it.
     ./prevent-closure-contamination.patch
+
+    # Port from intltool to gettext.
+    # Needed for the following patches to apply.
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/pitivi/commit/89b1053f2516c594f414c5c67c835471bce44b67.patch";
+      sha256 = "8yhArzAtZC+WjHftcSDrstBlT8j6WlGHffU9Nj+ny+c=";
+      excludes = [ "po/POTFILES.in" ];
+    })
+
+    # Complete switching to gst-transcoder in gst-plugins-bad.
+    # Otherwise there will likely be conflics.
+    # TODO: Apply this patch once we are using gst-transcoder from gst-plugins-bad.
+    # (fetchpatch {
+    #   url = "https://gitlab.gnome.org/GNOME/pitivi/commit/51ae6533ee26ffd47e453eb5f5ad8cd46f57d15e.patch";
+    #   sha256 = "zxJm+E5o+oZ3lW6wYNY/ERo2g4NmCjoY8oV+uScq8j8=";
+    # })
+
+    # Generate renderer.so on macOS instead of dylib.
+    # Needed for the following patch to apply.
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/pitivi/commit/bcacadcafabf8911efb0fddc8d57329237d08cd1.patch";
+      sha256 = "2BM5acIwOgdr1L9vhtMMN4trrLuqCg/K6v6ZYtD1Fjw=";
+      postFetch = ''
+        sed -i -e "s/1.90.0.1/0.999/g" "$out"
+      '';
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/pitivi/commit/0a3cc054a2c20b59f5aaaaa307de3c9af3c0d270.patch";
+      sha256 = "6DhqRlxFWFFdLwGoFem+vPt8x7v732KMVjMF9fypMK4=";
+      postFetch = ''
+        sed "$out" -i \
+          -e "s/1.90.0.1/0.999/g" \
+          -e "s/\(-python_dep.*\)/\1\n /" \
+          -e "s/-1,9 +1,16/-1,10 +1,17/"
+      '';
+    })
   ];
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
-    intltool
+    gettext
     itstool
     python3
     wrapGAppsHook
@@ -106,6 +142,9 @@ in python3Packages.buildPythonApplication rec {
 
   postPatch = ''
     patchShebangs ./getenvvar.py
+
+    # fetchpatch does not support renamings
+    mv data/org.pitivi.Pitivi-mime.xml data/org.pitivi.Pitivi-mime.xml.in
   '';
 
   passthru = {

--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -1,12 +1,25 @@
-{ stdenv, fetchFromGitHub, fetchurl, pkgconfig, intltool, itstool, python3, wrapGAppsHook
-, python3Packages, gst_all_1, gtk3
-, gobject-introspection, librsvg, gnome3, libnotify, gsound
-, meson, ninja, gsettings-desktop-schemas
+{ stdenv
+, fetchFromGitHub
+, fetchurl
+, pkg-config
+, intltool
+, itstool
+, python3
+, wrapGAppsHook
+, python3Packages
+, gst_all_1
+, gtk3
+, gobject-introspection
+, librsvg
+, gnome3
+, libnotify
+, gsound
+, meson
+, ninja
+, gsettings-desktop-schemas
 }:
 
 let
-  version = "0.999";
-
   # gst-transcoder will eventually be merged with gstreamer (according to
   # gst-transcoder 1.8.0 release notes). For now the only user is pitivi so we
   # don't bother exposing the package to all of nixpkgs.
@@ -19,19 +32,29 @@ let
       rev = version;
       sha256 = "16skiz9akavssii529v9nr8zd54w43livc14khdyzv164djg9q8f";
     };
-    nativeBuildInputs = [ pkgconfig meson ninja gobject-introspection python3 ];
-    buildInputs = with gst_all_1; [ gstreamer gst-plugins-base ];
+    nativeBuildInputs = [
+      pkg-config
+      meson
+      ninja
+      gobject-introspection
+      python3
+    ];
+    buildInputs = with gst_all_1; [
+      gstreamer
+      gst-plugins-base
+    ];
   };
 
 in python3Packages.buildPythonApplication rec {
-  name = "pitivi-${version}";
-
-  src = fetchurl {
-    url = "mirror://gnome/sources/pitivi/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0mxp2p4gg976fp1vj3rb5rmpl5mqfzncm9vw2719irl32f1qlvyb";
-  };
+  pname = "pitivi";
+  version = "0.999";
 
   format = "other";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/pitivi/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0mxp2p4gg976fp1vj3rb5rmpl5mqfzncm9vw2719irl32f1qlvyb";
+  };
 
   patches = [
     # By default, the build picks up environment variables like PYTHONPATH
@@ -40,24 +63,50 @@ in python3Packages.buildPythonApplication rec {
     ./prevent-closure-contamination.patch
   ];
 
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    intltool
+    itstool
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gobject-introspection
+    gtk3
+    librsvg
+    gnome3.gnome-desktop
+    gsound
+    gnome3.adwaita-icon-theme
+    gsettings-desktop-schemas
+    libnotify
+    gst-transcoder
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-editing-services
+    gst-plugins-base
+    (gst-plugins-good.override { gtkSupport = true; })
+    gst-plugins-bad
+    gst-plugins-ugly
+    gst-libav
+    gst-validate
+  ]);
+
+  pythonPath = with python3Packages; [
+    pygobject3
+    gst-python
+    pyxdg
+    numpy
+    pycairo
+    matplotlib
+    dbus-python
+  ];
+
   postPatch = ''
     patchShebangs ./getenvvar.py
   '';
-
-  nativeBuildInputs = [ meson ninja pkgconfig intltool itstool python3 wrapGAppsHook ];
-
-  buildInputs = [
-    gobject-introspection gtk3 librsvg gnome3.gnome-desktop gsound
-    gnome3.adwaita-icon-theme
-    gsettings-desktop-schemas libnotify
-    gst-transcoder
-  ] ++ (with gst_all_1; [
-    gstreamer gst-editing-services
-    gst-plugins-base (gst-plugins-good.override { gtkSupport = true; })
-    gst-plugins-bad gst-plugins-ugly gst-libav gst-validate
-  ]);
-
-  pythonPath = with python3Packages; [ pygobject3 gst-python pyxdg numpy pycairo matplotlib dbus-python ];
 
   passthru = {
     updateScript = gnome3.updateScript {


### PR DESCRIPTION
###### Motivation for this change
The latest version is not compatible with Python 3.8, let's cherry-pick some patches from master.
    
Also pre-prepare for incoming release of GStreamer 1.18 and clean it up a bit.

Fixes: #96914 

cc @davidak 

Did not test it other than by building and starting it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
