### PR TITLE
gnome-network-displays: init at 0.90.4

### DIFF
--- a/pkgs/applications/networking/gnome-network-displays/default.nix
+++ b/pkgs/applications/networking/gnome-network-displays/default.nix
@@ -1,0 +1,82 @@
+{ stdenv
+, fetchurl
+, fetchpatch
+# native
+, meson
+, ninja
+, pkg-config
+, gettext
+, desktop-file-utils
+, appstream-glib
+, wrapGAppsHook
+, python3
+# Not native
+, gst_all_1
+, gsettings-desktop-schemas
+, gtk3
+, glib
+, networkmanager
+, libpulseaudio
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-network-displays";
+  version = "0.90.4";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "04snnfz5jxxpjkrwa7dchc2h4shszi8mq9g3ihvsvipgzjw3d498";
+  };
+
+  patches = [
+    # Undeclared dependency on gio-unix-2.0, see:
+    # https://github.com/NixOS/nixpkgs/issues/36468 and
+    # https://gitlab.gnome.org/GNOME/gnome-network-displays/-/merge_requests/147
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-network-displays/-/commit/ef3f3ff565acd8238da46de604a1e750d4f02f07.diff";
+      sha256 = "1ljiwgqia6am4lansg70qnwkch9mp1fr6bga98s5fwyiaw6b6f4p";
+    })
+    # Fixes an upstream bug: https://gitlab.gnome.org/GNOME/gnome-network-displays/-/issues/147
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-network-displays/-/commit/23164b58f4d5dd59de988525906d6e5e82c5a63c.patch";
+      sha256 = "0x32dvkzv9m04q41aicscpf4aspghx81a65462kjqnsavi64lga5";
+    })
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gettext
+    desktop-file-utils
+    appstream-glib
+    wrapGAppsHook
+    python3
+  ];
+
+  buildInputs = [
+    gtk3
+    glib
+    gsettings-desktop-schemas
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-rtsp-server
+    networkmanager
+    libpulseaudio
+  ];
+
+  preConfigure = ''
+    patchShebangs ./build-aux/meson/postinstall.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-network-displays";
+    description = "Miracast implementation for GNOME";
+    maintainers = with maintainers; [ doronbehar ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11013,6 +11013,8 @@ in
 
   gnome-latex = callPackage ../applications/editors/gnome-latex/default.nix { };
 
+  gnome-network-displays = callPackage ../applications/networking/gnome-network-displays { };
+
   gnome-multi-writer = callPackage ../applications/misc/gnome-multi-writer {};
 
   gnome-online-accounts = callPackage ../development/libraries/gnome-online-accounts { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://gitlab.gnome.org/GNOME/gnome-network-displays - a Miracast implementation for GNOME.

###### Things done

In order to test, https://github.com/NixOS/nixpkgs/pull/97003 must be merged.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
