### PR TITLE
intltool: fix cross-platform build

### DIFF
--- a/pkgs/development/tools/misc/intltool/default.nix
+++ b/pkgs/development/tools/misc/intltool/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, gettext, perlPackages }:
+{ stdenv, fetchurl, fetchpatch, gettext, perlPackages, buildPackages }:
 
 stdenv.mkDerivation rec {
   pname = "intltool";
@@ -19,8 +19,14 @@ stdenv.mkDerivation rec {
     sha256 = "12q2140867r5d0dysly72khi7b0mm2gd7nlm1k81iyg7fxgnyz45";
   })];
 
-  propagatedBuildInputs = [ gettext ] ++ (with perlPackages; [ perl XMLParser ]);
+  nativeBuildInputs = with perlPackages; [ perl XMLParser ];
+  propagatedBuildInputs = [ gettext ];
 
+  postInstall = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    for f in $out/bin/*; do
+      substituteInPlace $f --replace "${buildPackages.perl}" "${perlPackages.perl}"
+    done
+  '';
   meta = with stdenv.lib; {
     description = "Translation helper tool";
     homepage = "https://launchpad.net/intltool/";


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
