### PR TITLE
nixos/manual: add pkg to the lexical scope of opengl.extraPackages

### DIFF
--- a/nixos/doc/manual/configuration/gpu-accel.xml
+++ b/nixos/doc/manual/configuration/gpu-accel.xml
@@ -100,8 +100,8 @@ Platform Vendor      Advanced Micro Devices, Inc.</screen>
        support. For example, for Gen8 and later GPUs, the following
        configuration can be used:
 
-	      <programlisting><xref linkend="opt-hardware.opengl.extraPackages"/> = with pkgs; [
-  intel-compute-runtime
+	      <programlisting><xref linkend="opt-hardware.opengl.extraPackages"/> = [
+  pkgs.intel-compute-runtime
 ];</programlisting>
 
       </para>

--- a/nixos/doc/manual/configuration/gpu-accel.xml
+++ b/nixos/doc/manual/configuration/gpu-accel.xml
@@ -100,7 +100,7 @@ Platform Vendor      Advanced Micro Devices, Inc.</screen>
        support. For example, for Gen8 and later GPUs, the following
        configuration can be used:
 
-	      <programlisting><xref linkend="opt-hardware.opengl.extraPackages"/> = [
+	      <programlisting><xref linkend="opt-hardware.opengl.extraPackages"/> = with pkgs; [
   intel-compute-runtime
 ];</programlisting>
 


### PR DESCRIPTION
###### Motivation for this change
Code snippet does not work when just adding to a configuration without a supporting `with pkgs;`

###### Things done

Small documentation change