### PR TITLE
gitAndTools.gita: 0.10.9 -> 0.10.10

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gita/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gita/default.nix
@@ -9,11 +9,11 @@
 }:
 
 buildPythonApplication rec {
-  version = "0.10.9";
+  version = "0.10.10";
   pname = "gita";
 
   src = fetchFromGitHub {
-    sha256 = "0wilyf4nnn2jyxrfqs8krya3zvhj6x36szsp9xhb6h08g1ihzp5i";
+    sha256 = "0k7hicncbrqvhmpq1w3v1309bqij6izw31xs8xcb8is85dvi754h";
     rev = "v${version}";
     repo = "gita";
     owner = "nosarthur";
@@ -45,6 +45,7 @@ buildPythonApplication rec {
 
   postInstall = ''
     installShellCompletion --bash --name gita ${src}/.gita-completion.bash
+    installShellCompletion --zsh --name gita ${src}/.gita-completion.zsh
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Update to latest release [https://github.com/nosarthur/gita/releases/tag/v0.10.10](https://github.com/nosarthur/gita/releases/tag/v0.10.10).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
