### PR TITLE
liberation_ttf: Fix cross-compiling

### DIFF
--- a/pkgs/data/fonts/liberation-fonts/default.nix
+++ b/pkgs/data/fonts/liberation-fonts/default.nix
@@ -2,6 +2,7 @@
 let
   inherit (python3.pkgs) fonttools;
 
+  commonNativeBuildInputs = [ fontforge python3 ];
   common =
     { version, repo, sha256, nativeBuildInputs, postPatch ? null }:
       stdenv.mkDerivation rec {
@@ -50,13 +51,13 @@ in
   liberation_ttf_v1 = common {
     repo = "liberation-1.7-fonts";
     version = "1.07.5";
-    nativeBuildInputs = [ fontforge ];
+    nativeBuildInputs = commonNativeBuildInputs ;
     sha256 = "1ffl10mf78hx598sy9qr5m6q2b8n3mpnsj73bwixnd4985gsz56v";
   };
   liberation_ttf_v2 = common {
     repo = "liberation-fonts";
     version = "2.1.0";
-    nativeBuildInputs = [ fontforge fonttools ];
+    nativeBuildInputs = commonNativeBuildInputs ++ [ fonttools ];
     postPatch = ''
       substituteInPlace scripts/setisFixedPitch-fonttools.py --replace \
         'font = ttLib.TTFont(fontfile)' \


### PR DESCRIPTION
###### Motivation for this change

liberation_ttf runs python3 during build, hence it needs to be in nativeBuildInputs when cross-building.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
