### PR TITLE
black-macchiato: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4098,6 +4098,12 @@
     githubId = 1918771;
     name = "Joe Doyle";
   };
+  jperras = {
+    email = "joel@nerderati.com";
+    github = "jperras";
+    githubId = 20675;
+    name = "Joël Perras";
+  };
   jpierre03 = {
     email = "nix@prunetwork.fr";
     github = "jpierre03";

--- a/pkgs/development/python-modules/black-macchiato/default.nix
+++ b/pkgs/development/python-modules/black-macchiato/default.nix
@@ -1,0 +1,35 @@
+{ stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  pytestCheckHook,
+  black
+}:
+
+buildPythonPackage rec {
+  pname = "black-macchiato";
+  version = "1.3.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner  = "wbolster";
+    repo   = pname;
+    rev    = version;
+    sha256 = "0lc9w50nlbmlzj44krk7kxcia202fhybbnwfh77xixlc7vb4rayl";
+  };
+
+  propagatedBuildInputs = [ black ];
+
+  checkInputs = [ pytestCheckHook black ];
+
+  pythonImportsCheck = [ "black" ];
+
+  meta = with stdenv.lib; {
+    description = "This is a small utility built on top of the black Python code formatter to enable formatting of partial files";
+    homepage    = "https://github.com/wbolster/black-macchiato";
+    license     = licenses.bsd3;
+    maintainers = with maintainers; [ jperras ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10552,6 +10552,8 @@ in
 
   black = with python3Packages; toPythonApplication black;
 
+  black-macchiato = with python3Packages; toPythonApplication black-macchiato;
+
   blackmagic = callPackage ../development/tools/misc/blackmagic { };
 
   bloaty = callPackage ../development/tools/bloaty { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -840,6 +840,8 @@ in {
 
   black = callPackage ../development/python-modules/black { };
 
+  black-macchiato = callPackage ../development/python-modules/black-macchiato { };
+
   bleach = callPackage ../development/python-modules/bleach { };
 
   bleak = callPackage ../development/python-modules/bleak { };


### PR DESCRIPTION
###### Motivation for this change

Adds the Python package `black-macchiato`, which allows the usage of Python's `black` formatter for subsets of an entire file.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
