### PR TITLE
Literate: 2019-01-08 -> 2020-09-02

### DIFF
--- a/pkgs/development/tools/literate-programming/Literate/default.nix
+++ b/pkgs/development/tools/literate-programming/Literate/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchgit, dmd, dub }:
 
 stdenv.mkDerivation {
-  name = "Literate-2019-01-08";
+  name = "Literate-2020-09-02";
 
   src = fetchgit {
     url = "https://github.com/zyedidia/Literate.git";
-    rev = "e20c5c86713701d4d17fd2881779d758a27a3e5a";
-    sha256 = "1pr7iipcnp6jxi13341p5b3szdrvs7aixpfbwifj6lgbb45vg9sm";
+    rev = "533991cca6ec7a608a778396d32d51b35182d944";
+    sha256 = "09h1as01z0fw0bj0kf1g9nlhvinya7sqq2x8qb6zmhvqqm6v4n49";
   };
 
   buildInputs = [ dmd dub ];


### PR DESCRIPTION
###### Motivation for this change

Fix compilation of Literate with the current version of `dmd` in Nixpkgs.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
