### PR TITLE
octave: Fix libtool framework link failure on Darwin

### DIFF
--- a/pkgs/development/libraries/qt-5/hooks/fix-qmake-libtool.sh
+++ b/pkgs/development/libraries/qt-5/hooks/fix-qmake-libtool.sh
@@ -5,8 +5,19 @@
 fixQmakeLibtool() {
     if [ -d "$1" ]; then
         find "$1" -name '*.la' | while read la; do
+            set +e
+            framework_libs=$(grep '^dependency_libs' "$la" | grep -Eo -- '-framework +\w+' | tr '\n' ' ')
+            set -e
             sed -i "$la" \
-                -e '/^dependency_libs/ s,\(/[^ ]\+\)/lib\([^/ ]\+\)\.so,-L\1 -l\2,g'
+                -e '/^dependency_libs/ s,\(/[^ ]\+\)/lib\([^/ ]\+\)\.so,-L\1 -l\2,g' \
+                -e '/^dependency_libs/ s,-framework \+\w\+,,g'
+            if [ ! -z "$framework_libs" ]; then
+                if grep '^inherited_linker_flags=' $la >/dev/null; then
+                    sed -i "$la" -e "s/^\(inherited_linker_flags='[^']*\)/\1 $framework_libs/"
+                else
+                    echo "inherited_linker_flags='$framework_libs'" >> "$la"
+                fi
+            fi
         done
     fi
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This fix moves linker flags of the form `-framework foo` from dependency_libs to
inherited_linker_flags, since libtool doesn't understand them.  See #96977 for
details.

There may be a better way to do this, and it's also possible/likely that we could just drop these args from dependency_libs rather than moving them to inherited_linker_flags (which would simplify the implementation considerably).  Using inherited_linker_flags was advised here: https://bugreports.qt.io/browse/QTBUG-48575.

Fixes #96977

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
