### PR TITLE
suitesparse: rename fixDarwinDylibNames override

### DIFF
--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -57,29 +57,6 @@ stdenv.mkDerivation rec {
     "library"
   ];
 
-  # Likely fixed after 5.7.2
-  # https://github.com/DrTimothyAldenDavis/SuiteSparse/commit/f6daae26ee391e475e2295e77c839aa7c1a8b784
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
-    # The fixDarwinDylibNames in nixpkgs can't seem to fix all the libraries.
-    # We manually fix them up here.
-    fixDarwinDylibNames() {
-        local flags=()
-        local old_id
-
-        for fn in "$@"; do
-            flags+=(-change "$PWD/lib/$(basename "$fn")" "$fn")
-        done
-
-        for fn in "$@"; do
-            if [ -L "$fn" ]; then continue; fi
-            echo "$fn: fixing dylib"
-            install_name_tool -id "$fn" "''${flags[@]}" "$fn"
-        done
-    }
-
-    fixDarwinDylibNames $(find "$out" -name "*.dylib")
-  '';
-
   meta = with stdenv.lib; {
     homepage = "http://faculty.cse.tamu.edu/davis/suitesparse.html";
     description = "A suite of sparse matrix algorithms";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This seems to prevent shadowing the regular fixDarwinDylibNames function, which is a nativeBuildInput.  Without this change some dylibs still had relative paths embedded.  It's possible something deeper is happening, but this change fixed the issue for me.  See #96981 for details.

Fixes #96981

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
