### PR TITLE
mpvScripts.youtube-quality: init at unstable-2020-02-11

### DIFF
--- a/pkgs/applications/video/mpv/scripts/youtube-quality.nix
+++ b/pkgs/applications/video/mpv/scripts/youtube-quality.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, mpv-unwrapped }:
+
+# Usage: `pkgs.mpv.override { scripts = [ pkgs.mpvScripts.youtube-quality ]; }`
+stdenv.mkDerivation rec {
+  pname = "mpv-youtube-quality";
+  version = "unstable-2020-02-11";
+
+  src = fetchFromGitHub {
+    owner = "jgreco";
+    repo = pname;
+    rev = "1f8c31457459ffc28cd1c3f3c2235a53efad7148";
+    sha256 = "09z6dkypg0ajvlx02270p3zmax58c0pkqkh6kh8gy2mhs3r4z0xy";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D youtube-quality.lua $out/share/mpv/scripts/youtube-quality.lua
+    runHook postInstall
+  '';
+
+  passthru.scriptName = "youtube-quality.lua";
+
+  meta = with stdenv.lib; {
+    description = "mpv script for changing YouTube video quality (ytdl-format) on the fly";
+    inherit (src.meta) homepage;
+    inherit (mpv-unwrapped.meta) platforms;
+    maintainers = with maintainers; [ samuelgrf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21884,6 +21884,7 @@ in
     mpris = callPackage ../applications/video/mpv/scripts/mpris.nix {};
     simple-mpv-webui = callPackage ../applications/video/mpv/scripts/simple-mpv-webui.nix {};
     sponsorblock = callPackage ../applications/video/mpv/scripts/sponsorblock.nix {};
+    youtube-quality = callPackage ../applications/video/mpv/scripts/youtube-quality.nix {};
   };
 
   mrpeach = callPackage ../applications/audio/pd-plugins/mrpeach { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
mpv-youtube-quality is an mpv script for changing YouTube video quality (ytdl-format) on the fly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
