### PR TITLE
svlint: init at 0.4.7

### DIFF
--- a/pkgs/development/tools/analysis/svlint/default.nix
+++ b/pkgs/development/tools/analysis/svlint/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "svlint";
+  version = "0.4.7";
+
+  src = fetchFromGitHub {
+    owner = "dalance";
+    repo = "svlint";
+    rev = "v${version}";
+    sha256 = "0gn68achvhyxljvhw5rwraxjcgdwrl1bwbsn596ka15nrk4lwb34";
+  };
+
+  cargoSha256 = "0v94zsh4jhzjnqbkgwn8rjbs72i5cw2nmkwn7xhdbbwxh17a88x4";
+
+  meta = with lib; {
+    description = "SystemVerilog linter";
+    homepage = "https://github.com/dalance/svlint";
+    license = licenses.mit;
+    maintainers = with maintainers; [ trepetti ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11501,6 +11501,8 @@ in
 
   summon = callPackage ../development/tools/summon { };
 
+  svlint = callPackage ../development/tools/analysis/svlint { };
+
   swarm = callPackage ../development/tools/analysis/swarm { };
 
   swiftformat = callPackage ../development/tools/swiftformat { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add a SystemVerilog linter to Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
