### PR TITLE
nixos/installer: enable sshd by default

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -73,7 +73,7 @@
     can use activated SSH daemon. You need to copy your ssh key to either
     <literal>/home/nixos/.ssh/authorized_keys</literal> or
     <literal>/root/.ssh/authorized_keys</literal> (Tip: For installers with a
-    modifyable filesystem such as the sd-card installer image a key can be be manual
+    modifiable filesystem such as the sd-card installer image a key can be be manually
     placed by mounting the image on a different machine). Alternatively you must set
     a password for either <literal>root</literal> or <literal>nixos</literal> with
     <command>passwd</command> to be able to login.

--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -70,9 +70,13 @@
 
    <para>
     If you would like to continue the installation from a different machine you
-    need to activate the SSH daemon via <command>systemctl start
-    sshd</command>. You then must set a password for either <literal>root</literal> or
-    <literal>nixos</literal> with <command>passwd</command> to be able to login.
+    can use activated SSH daemon. You need to copy your ssh key to either
+    <literal>/home/nixos/.ssh/authorized_keys</literal> or
+    <literal>/root/.ssh/authorized_keys</literal> (Tip: For installers with a
+    modifyable filesystem such as the sd-card installer image a key can be be manual
+    placed by mounting the image on a different machine). Alternatively you must set
+    a password for either <literal>root</literal> or <literal>nixos</literal> with
+    <command>passwd</command> to be able to login.
    </para>
   </section>
  </section>

--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -73,7 +73,7 @@
     can use activated SSH daemon. You need to copy your ssh key to either
     <literal>/home/nixos/.ssh/authorized_keys</literal> or
     <literal>/root/.ssh/authorized_keys</literal> (Tip: For installers with a
-    modifiable filesystem such as the sd-card installer image a key can be be manually
+    modifiable filesystem such as the sd-card installer image a key can be manually
     placed by mounting the image on a different machine). Alternatively you must set
     a password for either <literal>root</literal> or <literal>nixos</literal> with
     <command>passwd</command> to be able to login.

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -865,6 +865,10 @@ CREATE ROLE postgres LOGIN SUPERUSER;
    </para>
    </listitem>
    <listitem>
+    The installer now enables sshd by default. This improves installation on headless machines especially ARM single-board-computer.
+    To login through ssh, either a password or an ssh key must be set for the root user or the nixos user.
+   </listitem>
+   <listitem>
     <para>
      The scripted networking system now uses <literal>.link</literal> files in
      <literal>/etc/systemd/network</literal> to configure mac address and link MTU,

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -51,22 +51,23 @@ with lib;
     services.mingetty.helpLine = ''
       The "nixos" and "root" accounts have empty passwords.
 
-      Type `sudo systemctl start sshd` to start the SSH daemon.
-      You then must set a password for either "root" or "nixos"
-      with `passwd` to be able to login.
+      An ssh daemon is running. You then must set a password
+      for either "root" or "nixos" with `passwd` or add an ssh key
+      to /home/nixos/.ssh/authorized_keys be able to login.
     '' + optionalString config.services.xserver.enable ''
       Type `sudo systemctl start display-manager' to
       start the graphical user interface.
     '';
 
-    # Allow sshd to be started manually through "systemctl start sshd".
+    # We run sshd by default. Login via root is only possible after adding a
+    # password via "passwd" or by adding a ssh key to /home/nixos/.ssh/authorized_keys.
+    # The latter one is particular useful if keys are manually added to
+    # installation device for head-less systems i.e. arm boards by manually
+    # mounting the storage in a different system.
     services.openssh = {
       enable = true;
-      # Allow password login to the installation, if the user sets a password via "passwd"
-      # It is safe as root doesn't have a password by default and SSH is disabled by default
       permitRootLogin = "yes";
     };
-    systemd.services.sshd.wantedBy = mkOverride 50 [];
 
     # Enable wpa_supplicant, but don't start it by default.
     networking.wireless.enable = mkDefault true;


### PR DESCRIPTION
Right now the UX for installing NixOS on a headless system is very bad.
To enable sshd without physical steps users have to have either physical
access or need to be very knowledge-able to figure out how to modify the
installation image by hand to put an `sshd.service` symlink in the
right directory in /nix/store. This is in particular a problem on ARM
SBCs (single board computer) but also other hardware where network is
the only meaningful way to access the hardware.

This commit enables sshd by default. This does not give anyone access to
the NixOS installer since by default. There is no user with a non-empty
password or key. It makes it easy however to add ssh keys to the
installation image (usb stick, sd-card on arm boards) by simply mounting
it and adding a keys to `/root/.ssh/authorized_keys`.
Importantly this should not require nix/nixos on the machine that
prepare the installation device and even feasible on non-linux systems
by using ext4 third party drivers.

Potential new threats: Since this enables sshd by default a
potential bug in openssh could lead to remote code execution. Openssh
has a very good track-record over the last 20 years, which makes it
far more likely that Linux itself would have a remote code execution
vulnerability. It is trusted by millions of servers on many operating
systems to be exposed to the internet by default.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

###### Todo

- [x] update installation manual docs

- [x] add changelog entry

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
