### PR TITLE
treewide: use URN for fontconfig DTD

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -35,7 +35,7 @@ let
     in
     pkgs.writeText "fc-00-nixos-cache.conf" ''
       <?xml version='1.0'?>
-      <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+      <!DOCTYPE fontconfig SYSTEM 'urn:fontconfig:fonts.dtd'>
       <fontconfig>
         <!-- Font directories -->
         ${concatStringsSep "\n" (map (font: "<dir>${font}</dir>") config.fonts.fonts)}
@@ -53,7 +53,7 @@ let
   # priority 10
   renderConf = pkgs.writeText "fc-10-nixos-rendering.conf" ''
     <?xml version='1.0'?>
-    <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+    <!DOCTYPE fontconfig SYSTEM 'urn:fontconfig:fonts.dtd'>
     <fontconfig>
 
       <!-- Default rendering settings -->
@@ -110,7 +110,7 @@ let
     in
     pkgs.writeText "fc-52-nixos-default-fonts.conf" ''
     <?xml version='1.0'?>
-    <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+    <!DOCTYPE fontconfig SYSTEM 'urn:fontconfig:fonts.dtd'>
     <fontconfig>
 
       <!-- Default fonts -->
@@ -129,7 +129,7 @@ let
   # priority 53
   rejectBitmaps = pkgs.writeText "fc-53-no-bitmaps.conf" ''
     <?xml version="1.0"?>
-    <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+    <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
     <fontconfig>
 
     ${optionalString (!cfg.allowBitmaps) ''
@@ -157,7 +157,7 @@ let
   # priority 53
   rejectType1 = pkgs.writeText "fc-53-nixos-reject-type1.conf" ''
     <?xml version="1.0"?>
-    <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+    <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
     <fontconfig>
 
     <!-- Reject Type 1 fonts -->

--- a/pkgs/applications/video/lightworks/default.nix
+++ b/pkgs/applications/video/lightworks/default.nix
@@ -47,7 +47,7 @@ let
       # This adds it to lightworks' search path while keeping the default
       # using the FONTCONFIG_FILE env variable
       echo "<?xml version='1.0'?>
-      <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+      <!DOCTYPE fontconfig SYSTEM 'urn:fontconfig:fonts.dtd'>
       <fontconfig>
           <dir>/usr/share/fonts/truetype</dir>
           <include>/etc/fonts/fonts.conf</include>

--- a/pkgs/data/fonts/caladea/cambria-alias.conf
+++ b/pkgs/data/fonts/caladea/cambria-alias.conf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
 <fontconfig>
   <!-- Configure Caladea as a metric-compatible alias for the
        Microsoft Cambria font family. -->

--- a/pkgs/data/fonts/carlito/calibri-alias.conf
+++ b/pkgs/data/fonts/carlito/calibri-alias.conf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
 <fontconfig>
   <!-- Configure Carlito as a metric-compatible alias for the
        Microsoft Calibri font family. -->

--- a/pkgs/data/fonts/comic-relief/comic-sans-ms-alias.conf
+++ b/pkgs/data/fonts/comic-relief/comic-sans-ms-alias.conf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
 <fontconfig>
   <!-- Configure Comic Relief as a metric-compatible alias for the
        Microsoft Comic Sans font family. -->

--- a/pkgs/data/fonts/corefonts/no-op.conf
+++ b/pkgs/data/fonts/corefonts/no-op.conf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
 <fontconfig>
   <!-- This configuation is intentionally left empty in order to
        override any other font package that may wish to set up an

--- a/pkgs/data/fonts/vista-fonts-chs/no-op.conf
+++ b/pkgs/data/fonts/vista-fonts-chs/no-op.conf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
 <fontconfig>
   <!-- This configuation is intentionally left empty in order to
        override any other font package that may wish to set up an

--- a/pkgs/data/fonts/vista-fonts/no-op.conf
+++ b/pkgs/data/fonts/vista-fonts/no-op.conf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
 <fontconfig>
   <!-- This configuation is intentionally left empty in order to
        override any other font package that may wish to set up an

--- a/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
@@ -16,7 +16,7 @@ runCommand "fc-cache"
 
     cat > fonts.conf << EOF
     <?xml version='1.0'?>
-    <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+    <!DOCTYPE fontconfig SYSTEM 'urn:fontconfig:fonts.dtd'>
     <fontconfig>
       <include>${fontconfig.out}/etc/fonts/fonts.conf</include>
       <cachedir>$out</cachedir>

--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
@@ -12,7 +12,7 @@
                 extension-element-prefixes="str"
                 >
 
-  <xsl:output method='xml' encoding="UTF-8" doctype-system="fonts.dtd" />
+  <xsl:output method='xml' encoding="UTF-8" doctype-system="urn:fontconfig:fonts.dtd" />
 
   <xsl:param name="fontDirectories" />
   <xsl:param name="fontconfig" />


### PR DESCRIPTION
###### Motivation for this change
To match upstream change:

https://gitlab.freedesktop.org/fontconfig/fontconfig/commit/9c46ef4aac87c42d013d0e7380b6aeb03e1a9949


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
