### PR TITLE
hp2p: init at 3.3

### DIFF
--- a/pkgs/tools/networking/hp2p/default.nix
+++ b/pkgs/tools/networking/hp2p/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub, mpi, python3Packages, autoconf, automake } :
+
+stdenv.mkDerivation rec {
+  pname = "hp2p";
+  version = "3.3";
+
+  src = fetchFromGitHub {
+    owner = "cea-hpc";
+    repo = "hp2p";
+    rev = version;
+    sha256 = "0zvlwb941rlp3vrf9yzv7njgpj3mh4671ch7qvxfa4hq2ivd52br";
+  };
+
+  patches = [ ./python3.patch ];
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ autoconf automake python3Packages.wrapPython ];
+  buildInputs = [ mpi ] ++ (with python3Packages; [ python numpy matplotlib plotly mpldatacursor ]) ;
+  pythonPath = (with python3Packages; [ numpy matplotlib plotly mpldatacursor ]) ;
+
+  preConfigure = ''
+    patchShebangs autogen.sh
+    ./autogen.sh
+    export CC=mpicc
+    export CXX=mpic++
+  '';
+
+  postInstall = ''
+    wrapPythonPrograms
+  '';
+
+  meta = with lib; {
+    description = "A MPI based benchmark for network diagnostics";
+    homepage = "https://github.com/cea-hpc/hp2p";
+    platforms = platforms.unix;
+    license = licenses.cecill-c;
+    maintainers = [ maintainers.bzizou ];
+  };
+}

--- a/pkgs/tools/networking/hp2p/python3.patch
+++ b/pkgs/tools/networking/hp2p/python3.patch
@@ -1,0 +1,120 @@
+diff -u -r source.orig/src/vizhp2p source/src/vizhp2p
+--- source.orig/src/vizhp2p	1970-01-01 01:00:01.000000000 +0100
++++ source/src/vizhp2p	2021-08-24 10:41:42.926881770 +0200
+@@ -94,25 +94,25 @@
+             with open(hostfile) as fd:
+                 for line in fd:
+                     if line.startswith(motif_rank):
+-                        print line
++                        print(line)
+                         c,v = line[len(motif_rank)+1:-1].split(separator)
+                         nodes[c] = v
+                         
+         # display k worst nodes indices
+-        print "\nTop %d bad mean:" % k
++        print("\nTop %d bad mean:" % k)
+         mean_order = np.argsort(a_mean)
+-        print [nodes[str(c)] for c in mean_order[:k]]
++        print([nodes[str(c)] for c in mean_order[:k]])
+         mean_st = "Top nodes with bad mean:\n"
+         for i in range(0, k, hostname_per_line):
+             mean_st += repr([nodes[str(c)] for c 
+                              in mean_order[i:i + hostname_per_line]]) + "\n"
+ 
+-        print "Top %d bad std:" % k
+-        print [nodes[str(c)] for c in np.argsort(a_std)[-k:][::-1]]
++        print("Top %d bad std:" % k)
++        print([nodes[str(c)] for c in np.argsort(a_std)[-k:][::-1]])
+ 
+-        print "Top %d bad mean/std:" % k
++        print("Top %d bad mean/std:" % k)
+         pen_order = np.argsort(a_mean / a_std)
+-        print [nodes[str(c)] for c in pen_order[:k]]
++        print([nodes[str(c)] for c in pen_order[:k]])
+         pen_st = "Top nodes with bad mean/std:\n"
+         for i in range(0, k, hostname_per_line):
+             pen_st += repr([nodes[str(c)] for c 
+@@ -293,9 +293,9 @@
+ # and 'p' (snapshot) 
+ def onrefresh(event):
+     if event.key == 'r':
+-        print "refreshing...",
++        print("refreshing...", end=' ')
+         loop()
+-        print "ok"
++        print("ok")
+     elif event.key == 'q':
+         exit()
+     elif event.key == 'p':
+@@ -303,9 +303,9 @@
+         fig1.savefig(snapfile)
+         snapfile = outputname + "_snapshot_time.png"
+         fig2.savefig(snapfile)
+-        print 'snapshot saved (%s)' % snapfile
++        print('snapshot saved (%s)' % snapfile)
+     else:
+-        print "The answer to %s is 42." % event.key
++        print("The answer to %s is 42." % event.key)
+ 
+ 
+ if __name__ == "__main__":
+@@ -356,11 +356,11 @@
+         countfile = outputname + ".count.bin"
+ 
+     print("visu_hp2p configuration:")
+-    print("   DATAFILE            : %s"%resfile)
+-    print("   BIN_TIMER_FILE      : %s"%resfile_time)
+-    print("   HOSTFILE            : %s"%hostfile)
+-    print("   Bad nodes to display: %d"%k)
+-    print("   GUI resolution      : %s"%resolution)
++    print(("   DATAFILE            : %s"%resfile))
++    print(("   BIN_TIMER_FILE      : %s"%resfile_time))
++    print(("   HOSTFILE            : %s"%hostfile))
++    print(("   Bad nodes to display: %d"%k))
++    print(("   GUI resolution      : %s"%resolution))
+ 
+     hostname_per_line = 4 # for GUI layout
+     refresh_in_sec = 60
+@@ -377,7 +377,7 @@
+     # wait for resfile
+     while not os.path.exists(resfile) :
+         time.sleep(5)
+-        print "Waiting for input files..."
++        print("Waiting for input files...")
+ 
+     # add callback on key press event
+     cid1 = fig1.canvas.mpl_connect('key_press_event', onrefresh)
+Only in source/src: vizhp2p.bak
+diff -u -r source.orig/src/vizhp2p_html source/src/vizhp2p_html
+--- source.orig/src/vizhp2p_html	1970-01-01 01:00:01.000000000 +0100
++++ source/src/vizhp2p_html	2021-08-24 10:41:54.799946303 +0200
+@@ -118,7 +118,7 @@
+     hostfile = args.hostfile
+     clustername = args.clustername
+     if len(args.OutputName) == 0:
+-        print "No DATAFILE given! Please provide Hp2p output files name !"
++        print("No DATAFILE given! Please provide Hp2p output files name !")
+         exit(0)
+     else:
+         outputname = args.OutputName.split('.')[0]
+@@ -134,13 +134,13 @@
+         else:
+             outfile = args.outfile
+ 
+-    print "%s configuration:"%commandname
+-    print "   DATAFILE            : %s"%resfile
+-    print "   HOSTFILE            : %s"%hostfile
+-    print "   CLUSTER             : %s"%clustername
+-    print "   OUTPUTFILE          : %s"%outfile
++    print("%s configuration:"%commandname)
++    print("   DATAFILE            : %s"%resfile)
++    print("   HOSTFILE            : %s"%hostfile)
++    print("   CLUSTER             : %s"%clustername)
++    print("   OUTPUTFILE          : %s"%outfile)
+     if not os.path.exists(resfile):
+-        print "%s doesn't exist...Exiting"%resfile
++        print("%s doesn't exist...Exiting"%resfile)
+         exit(0)
+ 
+ # Data management
+Only in source/src: vizhp2p_html.bak

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1648,6 +1648,8 @@ with pkgs;
 
   hostctl = callPackage ../tools/system/hostctl { };
 
+  hp2p = callPackage ../tools/networking/hp2p { };
+
   hpe-ltfs = callPackage ../tools/backup/hpe-ltfs { };
 
   http2tcp = callPackage ../tools/networking/http2tcp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
A simple and powerful tool for benchmarking our low latency hpc networks
This package has been successfully used in production as a NUR package (https://github.com/nix-community/nur-combined/tree/master/repos/gricad/pkgs/hp2p) on an Omnipath interconnected cluster running Debian.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
