### PR TITLE
stdenv: unset SDKROOT on Darwin

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -34,7 +34,7 @@ in rec {
     export NIX_ENFORCE_NO_NATIVE=''${NIX_ENFORCE_NO_NATIVE-1}
     export NIX_ENFORCE_PURITY=''${NIX_ENFORCE_PURITY-1}
     export NIX_IGNORE_LD_THROUGH_GCC=1
-    export SDKROOT=
+    unset SDKROOT
 
     export MACOSX_DEPLOYMENT_TARGET=${macosVersionMin}
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

File this one under *I have little idea what I am doing*. I got a bug report that `broot` builds are failing on Darwin with the helpful :p message:

```
error occurred: No such file or directory (os error 2)
```

With a little DTrace, I found that the `cc` crate, which is used by other crates to compile C/C++ code now runs `xcrun` when SDKROOT is defined:

https://github.com/alexcrichton/cc-rs/commit/a970b0ab0beecec1d9c589d2e6aa5f3ad1bd3f9b

Consequently, building crates that use newer versions of the `cc`
crate fail, because xcrun is not available in pure build environments.

This change unsets SDKROOT.

Questions:

* I am not sure what the ramifications are of not setting `SDKROOT`. Can't test, because my MacBook is not fast enough to do large rebuilds.
* Is it even useful to `unset SDKROOT` (as opposed to just removing the `export SDKROOT=` line? I guess it would help with impure environments, when the user has set `SDKROOT` for some reason?
* Maybe we should just add `xcbuild` as a dependency on Darwin for Rust programs that transitively depend on `cc`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
