### PR TITLE
cryptsetup: Build with an lvm2 that’s built with udev

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17237,7 +17237,7 @@ in
   cryptsetup = callPackage ../os-specific/linux/cryptsetup {
     # cryptsetup only really needs the devmapper component of cryptsetup
     # but itself is used as a library in systemd (=udev)
-    lvm2 = lvm2.override { udev = null; };
+    lvm2 = lvm2.override { udev = udev.override { cryptsetup = null; }; };
   };
 
   cramfsprogs = callPackage ../os-specific/linux/cramfsprogs { };


### PR DESCRIPTION
###### Motivation for this change

Apparently, taking one more step along the systemd → cryptsetup → lvm2 → udev=systemd dependency cycle before breaking the chain allows the installer.luksroot test to pass.

This is a bit ridiculous because we end up with this even stupider chain in the runtime closure of lvm2:

lvm2 → systemd → cryptsetup → different lvm2 → different systemd

But it’s better than leaving nixos-unstable blocked forever while we look for a better solution.  Fixes #96479.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
