### PR TITLE
gst_all_1.gst-rtsp-server: fix pkgconfig includedir and libdir

### DIFF
--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -20,6 +20,15 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
+  patches = [
+    # To use split outputs, we need this so double prefix won't be used in the
+    # pkg-config files. Hopefully, this won't be needed on the next release,
+    # _if_
+    # https://gitlab.freedesktop.org/gstreamer/gst-rtsp-server/merge_requests/1
+    # will be merged. For the current release, this merge request won't apply.
+    ./fix_pkgconfig_includedir.patch
+  ];
+
   nativeBuildInputs = [
     meson
     ninja

--- a/pkgs/development/libraries/gstreamer/rtsp-server/fix_pkgconfig_includedir.patch
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/fix_pkgconfig_includedir.patch
@@ -1,0 +1,15 @@
+diff --git i/pkgconfig/meson.build w/pkgconfig/meson.build
+index 8ed8299..594cbfe 100644
+--- i/pkgconfig/meson.build
++++ w/pkgconfig/meson.build
+@@ -2,8 +2,8 @@ pkgconf = configuration_data()
+ 
+ pkgconf.set('prefix', get_option('prefix'))
+ pkgconf.set('exec_prefix', '${prefix}')
+-pkgconf.set('libdir', '${prefix}/@0@'.format(get_option('libdir')))
+-pkgconf.set('includedir', '${prefix}/@0@'.format(get_option('includedir')))
++pkgconf.set('libdir', join_paths(get_option('prefix'), get_option('libdir')))
++pkgconf.set('includedir', join_paths(get_option('prefix'), get_option('includedir')))
+ pkgconf.set('GST_API_VERSION', api_version)
+ pkgconf.set('VERSION', gst_version)
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #96946 , based on patches applied to other gst plugin packages. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
