### PR TITLE
fpc: 3.0.4 -> 3.2.0, add support for aarch64-linux

### DIFF
--- a/pkgs/development/compilers/fpc/binary.nix
+++ b/pkgs/development/compilers/fpc/binary.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
         url = "mirror://sourceforge/project/freepascal/Linux/${version}/fpc-${version}-x86_64-linux.tar";
         sha256 = "0gfbwjvjqlx0562ayyl08khagslrws758al2yhbi4bz5rzk554ni";
       }
+    else if stdenv.hostPlatform.system == "aarch64-linux" then
+      fetchurl {
+        url = "mirror://sourceforge/project/freepascal/Linux/${version}/fpc-${version}.aarch64-linux.tar";
+        sha256 = "1h481ngg3m8nlsg9mw7rr1bn2c4sj4wzqny9bxyq3xvcral12r71";
+      }
     else throw "Not supported on ${stdenv.hostPlatform.system}.";
 
   builder = ./binary-builder.sh;

--- a/pkgs/development/compilers/fpc/binary.nix
+++ b/pkgs/development/compilers/fpc/binary.nix
@@ -1,18 +1,19 @@
 { stdenv, fetchurl }:
 
-stdenv.mkDerivation {
-  name = "fpc-3.0.0-binary";
+stdenv.mkDerivation rec {
+  pname = "fpc-binary";
+  version = "3.2.0";
 
   src =
     if stdenv.hostPlatform.system == "i686-linux" then
       fetchurl {
-        url = "mirror://sourceforge/project/freepascal/Linux/3.0.0/fpc-3.0.0.i386-linux.tar";
-        sha256 = "0h3f1dgs1zsx7vvk9kg67anjvgw5sslfbmjblif7ishbcp3k3g5k";
+        url = "mirror://sourceforge/project/freepascal/Linux/${version}/fpc-${version}.i386-linux.tar";
+        sha256 = "0y0510b2fbxbqz28967xx8b023k6q9fv5yclfrc1yc9mg8fyn411";
       }
     else if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
-        url = "mirror://sourceforge/project/freepascal/Linux/3.0.0/fpc-3.0.0.x86_64-linux.tar";
-        sha256 = "1m2xx3nda45cb3zidbjgdr8kddd19zk0khvp7xxdlclszkqscln9";
+        url = "mirror://sourceforge/project/freepascal/Linux/${version}/fpc-${version}-x86_64-linux.tar";
+        sha256 = "0gfbwjvjqlx0562ayyl08khagslrws758al2yhbi4bz5rzk554ni";
       }
     else throw "Not supported on ${stdenv.hostPlatform.system}.";
 
@@ -21,4 +22,4 @@ stdenv.mkDerivation {
   meta = {
     description = "Free Pascal Compiler from a binary distribution";
   };
-} 
+}

--- a/pkgs/development/compilers/fpc/mark-paths.patch
+++ b/pkgs/development/compilers/fpc/mark-paths.patch
@@ -1,5 +1,5 @@
 diff --git a/fpcsrc/compiler/systems/t_linux.pas b/fpcsrc/compiler/systems/t_linux.pas
-index a7398fb9..a1e41ecb 100644
+index a7398fb9..8e46fec0 100644
 --- a/fpcsrc/compiler/systems/t_linux.pas
 +++ b/fpcsrc/compiler/systems/t_linux.pas
 @@ -135,13 +135,13 @@ begin
@@ -19,6 +19,15 @@ index a7398fb9..a1e41ecb 100644
  {$else powerpc64}
        LibrarySearchPath.AddLibraryPath(sysrootpath,'=/lib;=/usr/lib;=/usr/X11R6/lib',true);
  {$endif powerpc64}
+@@ -164,7 +164,7 @@ begin
+       LibrarySearchPath.AddLibraryPath(sysrootpath,'=/usr/lib/i386-linux-gnu',true);
+ {$endif i386}
+ {$ifdef aarch64}
+-      LibrarySearchPath.AddLibraryPath(sysrootpath,'=/usr/lib/aarch64-linux-gnu',true);
++      LibrarySearchPath.AddLibraryPath(sysrootpath,'=@syslibpath@',true);
+ {$endif aarch64}
+ {$ifdef powerpc}
+       LibrarySearchPath.AddLibraryPath(sysrootpath,'=/usr/lib/powerpc-linux-gnu',true);
 @@ -185,53 +185,53 @@ begin
  end;
  

--- a/pkgs/development/compilers/fpc/mark-paths.patch
+++ b/pkgs/development/compilers/fpc/mark-paths.patch
@@ -1,0 +1,100 @@
+diff --git a/fpcsrc/compiler/systems/t_linux.pas b/fpcsrc/compiler/systems/t_linux.pas
+index a7398fb9..a1e41ecb 100644
+--- a/fpcsrc/compiler/systems/t_linux.pas
++++ b/fpcsrc/compiler/systems/t_linux.pas
+@@ -135,13 +135,13 @@ begin
+       LibrarySearchPath.AddLibraryPath(sysrootpath,'=/usr/lib64',true);
+       { /lib64 should be the really first, so add it before everything else }
+       LibrarySearchPath.AddLibraryPath(sysrootpath,'=/lib',true);
+-      LibrarySearchPath.AddLibraryPath(sysrootpath,'=/lib64',true);
++      LibrarySearchPath.AddLibraryPath(sysrootpath,'=@syslibpath@',true);
+ {$else}
+ {$ifdef powerpc64}
+       if target_info.abi<>abi_powerpc_elfv2 then
+-        LibrarySearchPath.AddLibraryPath(sysrootpath,'=/lib64;=/usr/lib64;=/usr/X11R6/lib64',true)
++        LibrarySearchPath.AddLibraryPath(sysrootpath,'=/@syslibpath@;=/usr/lib64;=/usr/X11R6/lib64',true)
+       else
+-        LibrarySearchPath.AddLibraryPath(sysrootpath,'=/lib64;=/usr/lib/powerpc64le-linux-gnu;=/usr/X11R6/powerpc64le-linux-gnu',true);
++        LibrarySearchPath.AddLibraryPath(sysrootpath,'=/@syslibpath@;=/usr/lib/powerpc64le-linux-gnu;=/usr/X11R6/powerpc64le-linux-gnu',true);
+ {$else powerpc64}
+       LibrarySearchPath.AddLibraryPath(sysrootpath,'=/lib;=/usr/lib;=/usr/X11R6/lib',true);
+ {$endif powerpc64}
+@@ -185,53 +185,53 @@ begin
+ end;
+ 
+ {$ifdef m68k}
+-  const defdynlinker='/lib/ld.so.1';
++  const defdynlinker='@dynlinker-prefix@/lib/ld.so.1';
+ {$endif m68k}
+ 
+ {$ifdef i386}
+-  const defdynlinker='/lib/ld-linux.so.2';
++  const defdynlinker='@dynlinker-prefix@/lib/ld-linux.so.2';
+ {$endif}
+ 
+ {$ifdef x86_64}
+-  const defdynlinker='/lib64/ld-linux-x86-64.so.2';
++  const defdynlinker='@dynlinker-prefix@/lib64/ld-linux-x86-64.so.2';
+ {$endif x86_64}
+ 
+ {$ifdef sparc}
+-  const defdynlinker='/lib/ld-linux.so.2';
++  const defdynlinker='@dynlinker-prefix@/lib/ld-linux.so.2';
+ {$endif sparc}
+ 
+ {$ifdef powerpc}
+-  const defdynlinker='/lib/ld.so.1';
++  const defdynlinker='@dynlinker-prefix@/lib/ld.so.1';
+ {$endif powerpc}
+ 
+ {$ifdef powerpc64}
+-  const defdynlinkerv1='/lib64/ld64.so.1';
+-  const defdynlinkerv2='/lib64/ld64.so.2';
++  const defdynlinkerv1='@dynlinker-prefix@/lib64/ld64.so.1';
++  const defdynlinkerv2='@dynlinker-prefix@/lib64/ld64.so.2';
+   var defdynlinker: string;
+ {$endif powerpc64}
+ 
+ {$ifdef arm}
+ {$ifdef FPC_ARMHF}
+-  const defdynlinker='/lib/ld-linux-armhf.so.3';
++  const defdynlinker='@dynlinker-prefix@/lib/ld-linux-armhf.so.3';
+ {$else FPC_ARMHF}
+ {$ifdef FPC_ARMEL}
+-  const defdynlinker='/lib/ld-linux.so.3';
++  const defdynlinker='@dynlinker-prefix@/lib/ld-linux.so.3';
+ {$else FPC_ARMEL}
+-  const defdynlinker='/lib/ld-linux.so.2';
++  const defdynlinker='@dynlinker-prefix@/lib/ld-linux.so.2';
+ {$endif FPC_ARMEL}
+ {$endif FPC_ARMHF}
+ {$endif arm}
+ 
+ {$ifdef aarch64}
+-const defdynlinker='/lib/ld-linux-aarch64.so.1';
++const defdynlinker='@dynlinker-prefix@/lib/ld-linux-aarch64.so.1';
+ {$endif aarch64}
+ 
+ {$ifdef mips}
+-  const defdynlinker='/lib/ld.so.1';
++  const defdynlinker='@dynlinker-prefix@/lib/ld.so.1';
+ {$endif mips}
+ 
+ {$ifdef sparc64}
+-  const defdynlinker='/lib64/ld-linux.so.2';
++  const defdynlinker='@dynlinker-prefix@/lib64/ld-linux.so.2';
+ {$endif sparc64}
+ 
+ 
+@@ -266,9 +266,9 @@ begin
+       libctype:=uclibc;
+     end
+ {$ifdef i386}
+-  else if FileExists(sysrootpath+'/lib/ld-linux.so.1',false) then
++  else if FileExists(sysrootpath+'@dynlinker-prefix@/lib/ld-linux.so.1',false) then
+     begin
+-      DynamicLinker:='/lib/ld-linux.so.1';
++      DynamicLinker:='@dynlinker-prefix@/lib/ld-linux.so.1';
+       libctype:=glibc2;
+     end
+ {$endif i386}

--- a/pkgs/games/hedgewars/default.nix
+++ b/pkgs/games/hedgewars/default.nix
@@ -34,6 +34,10 @@ mkDerivation rec {
   postPatch = ''
     substituteInPlace gameServer/CMakeLists.txt \
       --replace mask evaluate
+
+    # compile with fpc >= 3.2.0
+    # https://github.com/archlinux/svntogit-community/blob/75a1b3900fb3dd553d5114bbc8474d85fd6abb02/trunk/PKGBUILD#L26
+    sed -i 's/procedure ShiftWorld(Dir: LongInt); inline;/procedure ShiftWorld(Dir: LongInt);/' hedgewars/uWorld.pas
   '';
 
   cmakeFlags = [
@@ -42,7 +46,7 @@ mkDerivation rec {
   ];
 
 
-  # hslogger brings network-3 and network-bsd which conflict with 
+  # hslogger brings network-3 and network-bsd which conflict with
   # network-2.6.3.1
   preConfigure = ''
     substituteInPlace gameServer/CMakeLists.txt \

--- a/pkgs/games/ultrastardx/default.nix
+++ b/pkgs/games/ultrastardx/default.nix
@@ -1,7 +1,26 @@
-{ stdenv, autoreconfHook, fetchFromGitHub, pkgconfig
-, lua, fpc, pcre, portaudio, freetype, libpng
-, SDL2, SDL2_image, SDL2_gfx, SDL2_mixer, SDL2_net, SDL2_ttf
-, ffmpeg, sqlite, zlib, libX11, libGLU, libGL }:
+{ stdenv
+, autoreconfHook
+, fetchFromGitHub
+, fetchpatch
+, pkgconfig
+, lua
+, fpc
+, pcre
+, portaudio
+, freetype
+, libpng
+, SDL2
+, SDL2_image
+, SDL2_gfx
+, SDL2_mixer
+, SDL2_net, SDL2_ttf
+, ffmpeg
+, sqlite
+, zlib
+, libX11
+, libGLU
+, libGL
+}:
 
 let
   sharedLibs = [
@@ -22,6 +41,14 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [ fpc libpng ] ++ sharedLibs;
+
+  patches = [
+    (fetchpatch {
+      name = "fpc-3.2-support.patch";
+      url = "https://github.com/UltraStar-Deluxe/USDX/commit/1b8e8714c1523ef49c2fd689a1545d097a3d76d7.patch";
+      sha256 = "02zmjymj9w1mkpf7armdpf067byvml6lprs1ca4lhpkv45abddp4";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace src/config.inc.in \

--- a/pkgs/games/ultrastardx/default.nix
+++ b/pkgs/games/ultrastardx/default.nix
@@ -12,12 +12,12 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "ultrastardx";
-  version = "unstable-2019-01-07";
+  version = "2020.4.0";
   src = fetchFromGitHub {
     owner = "UltraStar-Deluxe";
     repo = "USDX";
-    rev = "3df142590f29db1505cc58746af9f8cf7cb4a6a5";
-    sha256 = "0853rg7vppkmw37wm9xm0m0wab3r09ws6w04xs2wgwj1mwl0d70j";
+    rev = "v${version}";
+    sha256 = "0vmfv8zpyf8ymx3rjydpd7iqis080lni94vb316vfxkgvjmqbhym";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];

--- a/pkgs/tools/system/ddrescueview/default.nix
+++ b/pkgs/tools/system/ddrescueview/default.nix
@@ -1,19 +1,23 @@
 { stdenv, lib, fetchurl, fpc, lazarus, atk, cairo, gdk-pixbuf, glib, gtk2, libX11, pango }:
 
-stdenv.mkDerivation rec {
-  name = "ddrescueview-0.4alpha3";
+let
+  versionBase = "0.4";
+  versionSuffix = "alpha4";
+in stdenv.mkDerivation rec {
+  pname = "ddrescueview";
+  version = "${versionBase}${versionSuffix}";
+  name = "ddrescueview-0.4alpha4";
 
   src = fetchurl {
-    name = "${name}.tar.xz";
-    url = "mirror://sourceforge/ddrescueview/ddrescueview-source-0.4%7Ealpha3.tar.xz";
-    sha256 = "0603jisxkswfyh93s3i20f8ns4yf83dmgmy0lg5001rvaw9mkw9j";
+    name = "ddrescueview-${versionBase}${versionSuffix}.tar.xz";
+    url = "mirror://sourceforge/ddrescueview/ddrescueview-source-${versionBase}~${versionSuffix}.tar.xz";
+    sha256 = "0v159nlc0lrqznbbwi7zda619is5h2rjk55gz6cl807j0kd19ycc";
   };
+  sourceRoot = "ddrescueview-source-${versionBase}~${versionSuffix}/source";
 
   nativeBuildInputs = [ fpc lazarus ];
 
   buildInputs = [ atk cairo gdk-pixbuf glib gtk2 libX11 pango ];
-
-  sourceRoot = "source";
 
   NIX_LDFLAGS = "--as-needed -rpath ${lib.makeLibraryPath buildInputs}";
 
@@ -24,9 +28,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -Dt $out/bin ddrescueview
     cd ../resources/linux
-    install -Dt $out/share/applications ddrescueview.desktop
-    install -Dt $out/share/icons/hicolor/32x32/apps ddrescueview.xpm
-    install -Dt $out/share/man/man1 ddrescueview.1
+    mkdir -p "$out/share"
+    cp -ar applications icons man $out/share
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

I want to play hedgewars on my raspberry pi. For that I need fpc on aarch64, which required an fpc update.

There was no 3.1 for some reason. The old sed-based path patching was
broken and resulted in syntax errors since it was a bit over-eager.
Instead of fixing it, I decided to replace it with a patch file which is
easier to inspect and will fail in a more obvious way next time.

The patch is now applied unconditionally, since it actually applies to
all linux platforms. The changes are localized to linux-specific code,
so it does not hurt to apply it on non-linux platforms as well.

CC @7c6f434c

Also updates `ddrescueview` and `ultrastardx` since those were broken by the `fpc` update.

Unfortunately `hedgewars` still doesn't quite build on aarch64, but that is an unrelated issue.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
