### PR TITLE
openocd: 0.10.0 -> 2020-09-02

### DIFF
--- a/pkgs/development/tools/misc/openocd/default.nix
+++ b/pkgs/development/tools/misc/openocd/default.nix
@@ -1,24 +1,17 @@
-{ stdenv, lib, fetchurl, fetchpatch, libftdi1, libusb1, pkgconfig, hidapi }:
+{ stdenv, lib, fetchgit, libftdi1, libusb1, pkgconfig, hidapi, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "openocd";
-  version = "0.10.0";
+  version = "2020-09-02";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/openocd/openocd-${version}.tar.bz2";
-    sha256 = "1bhn2c85rdz4gf23358kg050xlzh7yxbbwmqp24c0akmh3bff4kk";
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/openocd/code";
+    rev = "d46f28c2ea2611f5fbbc679a5eed253d3dcd2fe3";
+    sha256 = "1256qqhn3pxmijfk1x0y5b5kc5ar88ivykkvx0h1m7pdwqfs6zm9";
+    fetchSubmodules = true;
   };
 
-  patches = [
-    # Fix FTDI channel configuration for SheevaPlug
-    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=837989
-    (fetchpatch {
-      url = "https://salsa.debian.org/electronics-team/openocd/raw/9a94335daa332a37a51920f87afbad4d36fad2d5/debian/patches/fix-sheeva.patch";
-      sha256 = "01x021fagwvgxdpzk7psap7ryqiya4m4mi4nqr27asbmb3q46g5r";
-    })
-  ];
-
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [ libftdi1 libusb1 hidapi ];
 
   configureFlags = [
@@ -34,14 +27,9 @@ stdenv.mkDerivation rec {
     "--enable-remote-bitbang"
   ];
 
-  NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.cc.isGNU [
-    "-Wno-implicit-fallthrough"
-    "-Wno-format-truncation"
-    "-Wno-format-overflow"
-    "-Wno-error=tautological-compare"
-    "-Wno-error=array-bounds"
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [
     "-Wno-error=cpp"
-  ]);
+  ];
 
   postInstall = lib.optionalString stdenv.isLinux ''
     mkdir -p "$out/etc/udev/rules.d"
@@ -64,7 +52,7 @@ stdenv.mkDerivation rec {
       "remote target" for source-level debugging of embedded systems using the
       GNU GDB program.
     '';
-    homepage = "http://openocd.sourceforge.net/";
+    homepage = "https://openocd.sourceforge.net/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ bjornfor ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change
latest release is 3.5 years old but the project is still active

###### Things done

- bump the commit to the latest revision
- verified the patch has been upstreamed

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `243157280` -> `243982256`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
