### PR TITLE
mkl: 2020.2.254 -> 2020.3.279

### DIFF
--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -19,14 +19,18 @@ let
   # Darwin is pinned to 2019.3 because the DMG does not unpack; see here for details:
   # https://github.com/matthewbauer/undmg/issues/4
   year = if stdenvNoCC.isDarwin then "2019" else "2020";
-  spot = if stdenvNoCC.isDarwin then "3" else "2";
-  rel = if stdenvNoCC.isDarwin then "199" else "254";
+  spot = if stdenvNoCC.isDarwin then "3" else "3";
+  rel = if stdenvNoCC.isDarwin then "199" else "279";
+
+  # Replace `openmpSpot` by `spot` after 2020.3. Release 2020.03
+  # adresses performance regressions and does not update OpenMP.
+  openmpSpot = if stdenvNoCC.isDarwin then spot else "2";
 
   rpm-ver = "${year}.${spot}-${rel}-${year}.${spot}-${rel}";
 
   # Intel openmp uses its own versioning, but shares the spot release patch.
   openmp = if stdenvNoCC.isDarwin then "19.0" else "19.1";
-  openmp-ver = "${openmp}.${spot}-${rel}-${openmp}.${spot}-${rel}";
+  openmp-ver = "${openmp}.${openmpSpot}-${rel}-${openmp}.${openmpSpot}-${rel}";
 
   shlibExt = stdenvNoCC.hostPlatform.extensions.sharedLibrary;
 
@@ -42,8 +46,8 @@ in stdenvNoCC.mkDerivation {
       })
     else
       (fetchurl {
-        url = "https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16849/l_mkl_${version}.tgz";
-        sha256 = "08q2q5rary7fxlrk09kpw0vl7mkk2smmklib44a6qainmxks407d";
+        url = "https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16903/l_mkl_${version}.tgz";
+        sha256 = "013shn3c823bjfssq4jyl3na5lbzj99s09ds608ljqllri7473ib";
       });
 
   nativeBuildInputs = [ validatePkgConfig ] ++ (if stdenvNoCC.isDarwin


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Release notes:

https://software.intel.com/content/www/us/en/develop/articles/intel-math-kernel-library-release-notes-and-new-features.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
