### PR TITLE
kwin-dynamic-workspaces: init at 1.0.1

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/scripts/dynamic-workspaces.nix
+++ b/pkgs/desktops/plasma-5/kwin/scripts/dynamic-workspaces.nix
@@ -1,0 +1,39 @@
+{ lib, mkDerivation, fetchFromGitHub
+, kcoreaddons, kwindowsystem, plasma-framework, systemsettings }:
+
+mkDerivation rec {
+  pname = "dynamic_workspaces";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "d86leader";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1mnwh489i6l8z9s5a1zl7zybkw76pp9fdmmis41mym7r4wz4iznm";
+  };
+
+  buildInputs = [
+    kcoreaddons kwindowsystem plasma-framework systemsettings
+  ];
+
+  dontBuild = true;
+
+  # 1. --global still installs to $HOME/.local/share so we use --packageroot
+  # 2. plasmapkg2 doesn't copy metadata.desktop into place, so we do that manually
+  installPhase = ''
+    runHook preInstall
+
+    plasmapkg2 --type kwinscript --install ${src} --packageroot $out/share/kwin/scripts
+    install -Dm644 ${src}/metadata.desktop $out/share/kservices5/dynamic_workspaces.desktop
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "KWin script that automatically adds/removes virtual desktops";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ samuelgrf ];
+    inherit (src.meta) homepage;
+    inherit (kwindowsystem.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25472,6 +25472,8 @@ in
 
   plasma-applet-caffeine-plus = libsForQt5.callPackage ../desktops/plasma-5/addons/caffeine-plus.nix { };
 
+  kwin-dynamic-workspaces = libsForQt5.callPackage ../desktops/plasma-5/kwin/scripts/dynamic-workspaces.nix { };
+
   kwin-tiling = libsForQt5.callPackage ../desktops/plasma-5/kwin/scripts/tiling.nix { };
 
   krohnkite = libsForQt5.callPackage ../desktops/plasma-5/kwin/scripts/krohnkite.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add dynamic_workspaces, a KWin script that automatically adds/removes virtual desktops.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
