### PR TITLE
svls: init at 0.1.17

### DIFF
--- a/pkgs/development/tools/misc/svls/default.nix
+++ b/pkgs/development/tools/misc/svls/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "svls";
+  version = "0.1.17";
+
+  src = fetchFromGitHub {
+    owner = "dalance";
+    repo = "svls";
+    rev = "v${version}";
+    sha256 = "0qcd9pkshk94c6skzld8cyzppl05hk4vcmmaya8r9l6kdi1f4b5m";
+  };
+
+  cargoSha256 = "0dqa7iw0sffzh07qysznh7ma3d3vl5fhd0i2qmz7a3dvw8mvyvsm";
+
+  meta = with lib; {
+    description = "SystemVerilog language server";
+    homepage = "https://github.com/dalance/svls";
+    license = licenses.mit;
+    maintainers = with maintainers; [ trepetti ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11507,6 +11507,8 @@ in
 
   svlint = callPackage ../development/tools/analysis/svlint { };
 
+  svls = callPackage ../development/tools/misc/svls { };
+
   swarm = callPackage ../development/tools/analysis/swarm { };
 
   swiftformat = callPackage ../development/tools/swiftformat { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add a SystemVerilog language server protocol implementation to Nix for IDE/editor support of RTL design.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
