### PR TITLE
emacs: Add missing patches to the Emacs derivations

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -42,7 +42,7 @@ assert withXwidgets -> withGTK3 && webkitgtk != null;
 let
 
 in stdenv.mkDerivation {
-  inherit pname version;
+  inherit pname version patches;
 
   src = fetchurl {
     url = "mirror://gnu/emacs/${name}.tar.xz";


### PR DESCRIPTION



###### Motivation for this change

A recent change (967259e6b495c19aa367d598e8d20d73475d2cfc) to how Emacs derivations are written introduced a bug: patches are not taken into consideration during the builds anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
