### PR TITLE
arc_unpacker: init at b9843a1

### DIFF
--- a/pkgs/tools/archivers/arc_unpacker/default.nix
+++ b/pkgs/tools/archivers/arc_unpacker/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, cmake, makeWrapper, boost, libpng, libjpeg, zlib
+, openssl, libwebp, catch }:
+
+stdenv.mkDerivation rec {
+  pname = "arc_unpacker-unstable";
+  version = "2019-01-28";
+
+  src = fetchFromGitHub {
+    owner = "vn-tools";
+    repo = "arc_unpacker";
+    # Since the latest release (0.11) doesn't build, we've opened an upstream
+    # issue in https://github.com/vn-tools/arc_unpacker/issues/187 to ask if a
+    # a new release is upcoming
+    rev = "b9843a13e2b67a618020fc12918aa8d7697ddfd5";
+    sha256 = "0wpl30569cip3im40p3n22s11x0172a3axnzwmax62aqlf8kdy14";
+  };
+
+  nativeBuildInputs = [ cmake makeWrapper catch ];
+  buildInputs = [ boost libpng libjpeg zlib openssl libwebp ];
+
+  postPatch = ''
+    cp ${catch}/include/catch/catch.hpp tests/test_support/catch.h
+  '';
+
+  checkPhase = ''
+    pushd ..
+    ./build/run_tests
+    popd
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/doc/arc_unpacker $out/libexec/arc_unpacker
+    cp arc_unpacker $out/libexec/arc_unpacker/arc_unpacker
+    cp ../GAMELIST.{htm,js} $out/share/doc/arc_unpacker
+    cp -r ../etc $out/libexec/arc_unpacker
+    makeWrapper $out/libexec/arc_unpacker/arc_unpacker $out/bin/arc_unpacker
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "A tool to extract files from visual novel archives";
+    homepage = "https://github.com/vn-tools/arc_unpacker";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ midchildan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -603,6 +603,8 @@ in
 
   adlplug = callPackage ../applications/audio/adlplug { };
 
+  arc_unpacker = callPackage ../tools/archivers/arc_unpacker { };
+
   tuijam = callPackage ../applications/audio/tuijam { inherit (python3Packages) buildPythonApplication; };
 
   opnplug = callPackage ../applications/audio/adlplug {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
arc_unpacker is a tool to extract files from visual novel archives.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
