### PR TITLE
libzra: init at unstable-2020-08-10

### DIFF
--- a/pkgs/development/libraries/libzra/default.nix
+++ b/pkgs/development/libraries/libzra/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libzra";
+  version = "unstable-2020-08-10";
+
+  src = fetchFromGitHub {
+    owner = "zraorg";
+    repo = "zra";
+    rev = "e678980ae7e79efd716b4a6610fe9f148425fd6b";
+    sha256 = "132xyzhadahm01nas8gycjza5hs839fnpsh73im2a7wwfdw76z4h";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/zraorg/ZRA";
+    description = "Library for ZStandard random access";
+    platforms = platforms.all;
+    maintainers = [ maintainers.ivar ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15876,6 +15876,8 @@ in
 
   zmqpp = callPackage ../development/libraries/zmqpp { };
 
+  libzra = callPackage ../development/libraries/libzra { };
+
   zig = callPackage ../development/compilers/zig {
     llvmPackages = llvmPackages_10;
   };


### PR DESCRIPTION
###### Motivation for this change
Wanted to check out [this library](https://github.com/zraorg/ZRA) implementing ZSTD Random Access. 

Unfortunately upstream does not support pkg-config (needs `zstd` and `crcpp`), so I've enabled submodule fetching.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
