### PR TITLE
crcpp: init at 1.0.1.0

### DIFF
--- a/pkgs/development/libraries/crcpp/default.nix
+++ b/pkgs/development/libraries/crcpp/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "crcpp";
+  version = "1.0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "d-bahr";
+    repo = "CRCpp";
+    rev = "release-${version}";
+    sha256 = "138w97kfxnv8rcnvggba6fcxgbgq8amikkmy3jhqfn6xzy6zaimh";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/include
+    cp inc/CRC.h $out/include
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/d-bahr/CRCpp";
+    description = "Easy to use and fast C++ CRC library";
+    platforms = platforms.all;
+    maintainers = [ maintainers.ivar ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -962,6 +962,8 @@ in
 
   crc32c = callPackage ../development/libraries/crc32c { };
 
+  crcpp = callPackage ../development/libraries/crcpp { };
+
   cudd = callPackage ../development/libraries/cudd { };
 
   cue = callPackage ../development/tools/cue { };


### PR DESCRIPTION
###### Motivation for this change
Noticed this wasn't in nixpkgs. Note that this is a header only library, so I've just copied those over to `$out/include`.

https://github.com/d-bahr/CRCpp

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
