### PR TITLE
Show sub options of freeform types

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -542,4 +542,30 @@ runTests {
     name = "";
     expected = "unknown";
   };
+
+  testFreeformOptions = {
+    expr =
+      let
+        submodule = { lib, ... }: {
+          freeformType = lib.types.attrsOf (lib.types.submodule {
+            options.bar = lib.mkOption {};
+          });
+          options.bar = lib.mkOption {};
+        };
+
+        module = { lib, ... }: {
+          options.foo = lib.mkOption {
+            type = lib.types.submodule submodule;
+          };
+        };
+
+        options = (evalModules {
+          modules = [ module ];
+        }).options;
+
+        locs = filter (o: ! o.internal) (optionAttrSetToDocList options);
+      in map (o: o.loc) locs;
+    expected = [ [ "foo" ] [ "foo" "<name>" "bar" ] [ "foo" "bar" ] ];
+  };
+
 }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -522,7 +522,12 @@ rec {
             # would be used, and use of `<` and `>` would break the XML document.
             # It shouldn't cause an issue since this is cosmetic for the manual.
             args.name = "‹name›";
-          }).options;
+          }).options // optionalAttrs (freeformType != null) {
+            # Expose the sub options of the freeform type. Note that the option
+            # discovery doesn't care about the attribute name used here, so this
+            # is just to avoid conflicts with potential options from the submodule
+            _freeformOptions = freeformType.getSubOptions prefix;
+          };
         getSubModules = modules;
         substSubModules = m: submoduleWith (attrs // {
           modules = m;


### PR DESCRIPTION
###### Motivation for this change
Previously if you set the freeform type (as introduced in https://github.com/NixOS/nixpkgs/pull/82743) to e.g. `attrsOf (submodule ..)`, those submodule options wouldn't be shown in the manual.

Originally this problem was brought to my attention by @alexarice

With an option declaration like
```nix
{ lib, ... }: {
  options.foofoofoo = lib.mkOption {
    type = lib.types.submodule {
      freeformType = lib.types.attrsOf (lib.types.submodule {
        options.bar = lib.mkOption {
          description = "Freeform bar";
        };
      });
      options.qux.bar = lib.mkOption {
        description = "Qux bar";
      };
      options.bar = lib.mkOption {
        description = "Submodule bar";
      };
    };
  };
}
```

The manual now correctly shows

![2020-09-03_21-17](https://user-images.githubusercontent.com/20525370/92157813-3f3a2100-ee2b-11ea-9680-41311d8022a7.png)

Ping @roberth 

###### Things done

- [x] Checked that the manual still builds
- [x] Checked that even more complex cases like `freeformType = attrsOf (attrsOf (submodule { freeformType = attrsOf ...` work
- [x] Added a test for checking that submodule options are present