### PR TITLE
netpbm: 10.89.1 → 10.91.2

### DIFF
--- a/pkgs/development/libraries/jbigkit/default.nix
+++ b/pkgs/development/libraries/jbigkit/default.nix
@@ -8,15 +8,23 @@ stdenv.mkDerivation rec {
     sha256 = "0cnrcdr1dwp7h7m0a56qw09bv08krb37mpf7cml5sjdgpyv0cwfy";
   };
 
+  makeFlags = [
+    "CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
+    "AR=${stdenv.lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar"
+    "RANLIB=${stdenv.lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib"
+  ];
+
   postPatch = ''
     sed -i 's/^\(CFLAGS.*\)$/\1 -fPIC/' Makefile
-  '' + stdenv.lib.optionalString stdenv.cc.isClang ''
+
     for f in Makefile libjbig/Makefile pbmtools/Makefile; do
-        substituteInPlace $f --replace "CC = gcc" "CC = clang"
+        sed -i -E 's/\bar /$(AR) /g;s/\branlib /$(RANLIB) /g' "$f"
     done
   '';
 
   installPhase = ''
+    runHook preInstall
+
     install -D -m644 libjbig/libjbig.a $out/lib/libjbig.a
     install -D -m644 libjbig/libjbig85.a $out/lib/libjbig85.a
     install -D -m644 libjbig/jbig.h $out/include/jbig.h
@@ -30,12 +38,14 @@ stdenv.mkDerivation rec {
     install -D -m755 pbmtools/pbmtojbg $out/bin/pbmtojbg
     install -D -m755 pbmtools/jbgtopbm85 $out/bin/jbgtopbm85
     install -D -m755 pbmtools/pbmtojbg85 $out/bin/pbmtojbg85
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {
     homepage = "http://www.cl.cam.ac.uk/~mgk25/jbigkit/";
     description = "A software implementation of the JBIG1 data compression standard";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -19,14 +19,14 @@
 stdenv.mkDerivation {
   # Determine version and revision from:
   # https://sourceforge.net/p/netpbm/code/HEAD/log/?path=/advanced
-  name = "netpbm-10.91.3";
+  name = "netpbm-10.92.0";
 
   outputs = [ "bin" "out" "dev" ];
 
   src = fetchsvn {
     url = "https://svn.code.sf.net/p/netpbm/code/advanced";
-    rev = "3940";
-    sha256 = "DLpby9vZ1fZd1Cb5GbNcfKWkWh27jwoog5W+p2FM7IM=";
+    rev = "3972";
+    sha256 = "09fpy4n4f867j23pr3b719wpvp8hjrr4drxp0r1csw74p8j6vfy3";
   };
 
   nativeBuildInputs = [
@@ -57,10 +57,6 @@ stdenv.mkDerivation {
     # Install libnetpbm.so symlink to correct destination
     substituteInPlace lib/Makefile \
       --replace '/sharedlink' '/lib'
-
-    # TODO: move to config.mk in 10.91.4
-    substituteInPlace GNUmakefile \
-        --replace 'pkg-config' '${buildPackages.pkgconfig}/bin/${buildPackages.pkgconfig.targetPrefix}pkg-config'
   '';
 
   configurePhase = ''
@@ -76,6 +72,7 @@ stdenv.mkDerivation {
     echo 'CC = ${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc' >> config.mk
     echo 'CC_FOR_BUILD = ${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc' >> config.mk
     echo 'LD_FOR_BUILD = $(CC_FOR_BUILD)' >> config.mk
+    echo 'PKG_CONFIG = ${buildPackages.pkgconfig}/bin/${buildPackages.pkgconfig.targetPrefix}pkg-config' >> config.mk
     echo 'RANLIB = ${stdenv.lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib' >> config.mk
 
     # Use libraries from Nixpkgs

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -17,14 +17,14 @@
 stdenv.mkDerivation {
   # Determine version and revision from:
   # https://sourceforge.net/p/netpbm/code/HEAD/log/?path=/advanced
-  name = "netpbm-10.89.1";
+  name = "netpbm-10.91.3";
 
   outputs = [ "bin" "out" "dev" ];
 
   src = fetchsvn {
     url = "https://svn.code.sf.net/p/netpbm/code/advanced";
-    rev = "3735";
-    sha256 = "1m7ks6k53gsjsdazgf22g16dfgj3pqvqy9mhxzlwszv5808sj5w5";
+    rev = "3940";
+    sha256 = "DLpby9vZ1fZd1Cb5GbNcfKWkWh27jwoog5W+p2FM7IM=";
   };
 
   nativeBuildInputs = [
@@ -70,7 +70,7 @@ stdenv.mkDerivation {
     echo "LDSHLIB=-dynamiclib -install_name $out/lib/libnetpbm.\$(MAJ).dylib" >> config.mk
     echo "NETPBMLIBTYPE = dylib" >> config.mk
     echo "NETPBMLIBSUFFIX = dylib" >> config.mk
-
+  '' + ''
     runHook postConfigure
   '';
 

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -4,6 +4,7 @@
 , pkg-config
 , libjpeg
 , libpng
+, jbigkit
 , flex
 , zlib
 , perl
@@ -40,6 +41,7 @@ stdenv.mkDerivation {
     libjpeg
     libxml2
     libtiff
+    jbigkit
   ] ++ lib.optional enableX11 libX11;
 
   enableParallelBuilding = true;
@@ -63,6 +65,9 @@ stdenv.mkDerivation {
     echo "TIFFLIB_NEEDS_JPEG = N" >> config.mk
     echo "TIFFLIB_NEEDS_Z = N" >> config.mk
     echo "JPEGLIB = libjpeg.so" >> config.mk
+    echo "JBIGLIB = libjbig.a" >> config.mk
+    # Insecure
+    echo "JASPERLIB = NONE" >> config.mk
 
     # Fix path to rgb.txt
     echo "RGB_DB_PATH = $out/share/netpbm/misc/rgb.txt" >> config.mk


### PR DESCRIPTION
###### Motivation for this change
Tried updating if it makes cross compilation better.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
