### PR TITLE
hydra-unstable: 2020-08-04 -> 2020-09-02

### DIFF
--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -24,12 +24,12 @@
   # so when having an older version, `pkgs.hydra-migration` should be deployed first.
 
   hydra-unstable = callPackage ./common.nix {
-    version = "2020-08-04";
+    version = "2020-09-02";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "hydra";
-      rev = "77c33c1d71a8c303f53ccad577eb0a3799e87bda";
-      sha256 = "10pwiww96dbbszzvnj7abn851h89n30ziahjj2zm3liyzyvbylyf";
+      rev = "e707990e2d6afab203c7ef1d769d49c564eff151";
+      sha256 = "0iilf953f6s58szzyd1hzc9b2b2yw8lhbsb8xrb08szpfz7ifwqa";
     };
     nix = nixFlakes;
 


### PR DESCRIPTION

###### Motivation for this change

Needed to fix Hydra with latest `nixUnstable`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
