### PR TITLE
stdenv/adapters.nix: add isStatic when static stdenv adapter is used

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -75,7 +75,7 @@ rec {
          # uname -r
          release = null;
       };
-      isStatic = final.isWasm || final.isRedox;
+      hasDynamicLoader = !final.isWasm && !final.isRedox;
 
       # Just a guess, based on `system`
       inherit

--- a/pkgs/applications/misc/gnome-passwordsafe/default.nix
+++ b/pkgs/applications/misc/gnome-passwordsafe/default.nix
@@ -69,7 +69,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   meta = with lib; {
-    broken = stdenv.hostPlatform.isStatic; # libpwquality doesn't provide bindings when static
+    broken = stdenv.isStatic; # libpwquality doesn't provide bindings when static
     description = "Password manager for GNOME which makes use of the KeePass v.4 format";
     homepage = "https://gitlab.gnome.org/World/PasswordSafe";
     license = licenses.gpl3Only;

--- a/pkgs/development/compilers/llvm/10/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/10/libc++/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetch, cmake, python3, libcxxabi, fixDarwinDylibNames, version
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/10/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/10/libc++abi.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, cmake, fetch, libcxx, libunwind, llvm, version
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/10/libunwind.nix
+++ b/pkgs/development/compilers/llvm/10/libunwind.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, version, fetch, cmake, fetchpatch
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/compilers/llvm/11/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/11/libc++/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetch, cmake, python3, libcxxabi, llvm, fixDarwinDylibNames, version
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/11/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/11/libc++abi.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, cmake, fetch, libcxx, libunwind, llvm, version
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/11/libunwind.nix
+++ b/pkgs/development/compilers/llvm/11/libunwind.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, version, fetch, cmake, fetchpatch
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/compilers/llvm/7/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/7/libc++/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetch, cmake, python3, libcxxabi, fixDarwinDylibNames, version
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/7/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/7/libc++abi.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, cmake, fetch, libcxx, llvm, version
 , standalone ? false
   # on musl the shared objects don't build
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/8/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/8/libc++/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetch, cmake, python3, libcxxabi, fixDarwinDylibNames, version
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/8/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/8/libc++abi.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, cmake, fetch, libcxx, libunwind, llvm, version
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/8/libunwind.nix
+++ b/pkgs/development/compilers/llvm/8/libunwind.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, version, fetch, cmake, fetchpatch
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/9/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/9/libc++/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetch, cmake, python3, libcxxabi, fixDarwinDylibNames, version
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/9/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/9/libc++abi.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, cmake, fetch, libcxx, libunwind, llvm, version
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/llvm/9/libunwind.nix
+++ b/pkgs/development/compilers/llvm/9/libunwind.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, version, fetch, cmake, fetchpatch
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -33,7 +33,7 @@ in
 , profilingDetail ? "exported-functions"
 # TODO enable shared libs for cross-compiling
 , enableSharedExecutables ? false
-, enableSharedLibraries ? !stdenv.hostPlatform.isStatic && (ghc.enableShared or false)
+, enableSharedLibraries ? !stdenv.isStatic && (ghc.enableShared or false)
 , enableDeadCodeElimination ? (!stdenv.isDarwin)  # TODO: use -dead_strip for darwin
 , enableStaticLibraries ? !(stdenv.hostPlatform.isWindows or stdenv.hostPlatform.isWasm)
 , enableHsc2hsViaAsm ? stdenv.hostPlatform.isWindows && lib.versionAtLeast ghc.version "8.4"

--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -59,7 +59,7 @@
 
   # don't have "libgcc_s.so.1" on darwin
   LDFLAGS = lib.optionalString
-    (!stdenv.isDarwin && !stdenv.hostPlatform.isStatic) "-lgcc_s";
+    (!stdenv.isDarwin && !stdenv.isStatic) "-lgcc_s";
 
   configureFlags = [ "--with-libreadline-prefix=${readline.dev}" ]
     ++ lib.optionals stdenv.isSunOS [

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -280,7 +280,7 @@ in with passthru; stdenv.mkDerivation {
     # Never even try to use lchmod on linux,
     # don't rely on detecting glibc-isms.
     "ac_cv_func_lchmod=no"
-  ] ++ optional static "LDFLAGS=-static";
+  ] ++ optional (static && !stdenv.hostPlatform.isDarwin) "LDFLAGS=-static";
 
   preConfigure = ''
     for i in /usr /sw /opt /pkg; do	# improve purity

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -35,7 +35,7 @@
 , rebuildBytecode ? true
 , stripBytecode ? false
 , includeSiteCustomize ? true
-, static ? stdenv.hostPlatform.isStatic
+, static ? stdenv.isStatic
 # Not using optimizations on Darwin
 # configure: error: llvm-profdata is required for a --enable-optimizations build but could not be found.
 , enableOptimizations ? (!stdenv.isDarwin)

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, fetchFromGitHub, fetchpatch, fixDarwinDylibNames
 , autoconf, boost, brotli, cmake, flatbuffers, gflags, glog, gtest, lz4
 , perl, python3, rapidjson, snappy, thrift, utf8proc, which, zlib, zstd
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 let

--- a/pkgs/development/libraries/audiofile/default.nix
+++ b/pkgs/development/libraries/audiofile/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   #
   # There might be a more sensible way to do this with autotools, but I am not
   # smart enough to discover it.
-  preBuild = lib.optionalString stdenv.hostPlatform.isStatic ''
+  preBuild = lib.optionalString stdenv.isStatic ''
     make -C libaudiofile $makeFlags
     sed -i "s/dependency_libs=.*/dependency_libs=' -lstdc++'/" libaudiofile/libaudiofile.la
   '';

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -8,7 +8,7 @@
 , enableDebug ? false
 , enableSingleThreaded ? false
 , enableMultiThreaded ? true
-, enableShared ? !(with stdenv.hostPlatform; isStatic || libc == "msvcrt") # problems for now
+, enableShared ? !(stdenv.isStatic || stdenv.hostPlatform.libc == "msvcrt") # problems for now
 , enableStatic ? !enableShared
 , enablePython ? false
 , enableNumpy ? false

--- a/pkgs/development/libraries/cdo/default.nix
+++ b/pkgs/development/libraries/cdo/default.nix
@@ -2,7 +2,7 @@
 , # build, install and link to a CDI library [default=no]
   enable_cdi_lib ? false
 , # build a completely statically linked CDO binary
-  enable_all_static ? stdenv.hostPlatform.isStatic
+  enable_all_static ? stdenv.isStatic
 , # Use CXX as default compiler [default=no]
   enable_cxx ? false
 }:

--- a/pkgs/development/libraries/crc32c/default.nix
+++ b/pkgs/development/libraries/crc32c/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, cmake, gflags
-, staticOnly ? stdenv.hostPlatform.isStatic
+, staticOnly ? stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/crypto++/default.nix
+++ b/pkgs/development/libraries/crypto++/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, nasm, which
-, enableStatic ? stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
 , enableShared ? !enableStatic
 }:
 

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, cmake
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 let

--- a/pkgs/development/libraries/gflags/default.nix
+++ b/pkgs/development/libraries/gflags/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, m4
 , cxx ? true
-, withStatic ? stdenv.hostPlatform.isStatic
+, withStatic ? stdenv.isStatic
 }:
 
 let inherit (lib) optional; in

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, m4
 , cxx ? !stdenv.hostPlatform.useAndroidPrebuilt && !stdenv.hostPlatform.isWasm
 , buildPackages
-, withStatic ? stdenv.hostPlatform.isStatic
+, withStatic ? stdenv.isStatic
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus

--- a/pkgs/development/libraries/gsm/default.nix
+++ b/pkgs/development/libraries/gsm/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl
 , # Compile statically (support for packages that look for the static object)
-  staticSupport ? stdenv.hostPlatform.isStatic
+  staticSupport ? stdenv.isStatic
 }:
 
 let

--- a/pkgs/development/libraries/libbacktrace/default.nix
+++ b/pkgs/development/libraries/libbacktrace/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, callPackage, fetchFromGitHub
-, enableStatic ? stdenv.hostPlatform.isStatic
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 let
   yesno = b: if b then "yes" else "no";

--- a/pkgs/development/libraries/libev/default.nix
+++ b/pkgs/development/libraries/libev/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl
 , # Note: -static hasn’t work on darwin
-  static ? with stdenv.hostPlatform; isStatic && !isDarwin
+  static ? stdenv.isStatic && !stdenv.hostPlatform.isDarwin
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus

--- a/pkgs/development/libraries/libexecinfo/default.nix
+++ b/pkgs/development/libraries/libexecinfo/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch
 , enableStatic ? true
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/libiberty/default.nix
+++ b/pkgs/development/libraries/libiberty/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, buildPackages
-, staticBuild ? stdenv.hostPlatform.isStatic
+, staticBuild ? stdenv.isStatic
 }:
 
 let inherit (buildPackages.buildPackages) gcc; in

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, lib
-, enableStatic ? stdenv.hostPlatform.isStatic
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 # assert !stdenv.hostPlatform.isLinux || stdenv.hostPlatform != stdenv.buildPlatform; # TODO: improve on cross

--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, nasm
-, enableStatic ? stdenv.hostPlatform.isStatic
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/libpfm/default.nix
+++ b/pkgs/development/libraries/libpfm/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation (rec {

--- a/pkgs/development/libraries/libpwquality/default.nix
+++ b/pkgs/development/libraries/libpwquality/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook perl python3 ];
   buildInputs = [ cracklib ];
 
-  patches = lib.optional stdenv.hostPlatform.isStatic [
+  patches = lib.optional stdenv.isStatic [
     (fetchpatch {
       name = "static-build.patch";
       url = "https://github.com/libpwquality/libpwquality/pull/40.patch";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  configureFlags = lib.optional stdenv.hostPlatform.isStatic [
+  configureFlags = lib.optional stdenv.isStatic [
     # Python binding generates a shared library which are unavailable with musl build
     "--disable-python-bindings"
   ];

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, lib, cmake, cacert, fetchpatch
-, buildShared ? !stdenv.hostPlatform.isStatic
+, buildShared ? !stdenv.isStatic
 }:
 
 let

--- a/pkgs/development/libraries/libxsmm/default.nix
+++ b/pkgs/development/libraries/libxsmm/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, coreutils, gfortran, gnused
 , python3, util-linux, which
 
-, enableStatic ? stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
 }:
 
 let

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -3,7 +3,7 @@
 , abiVersion ? "6"
 , mouseSupport ? false
 , unicode ? true
-, enableStatic ? stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
 , enableShared ? !enableStatic
 , withCxx ? !stdenv.hostPlatform.useAndroidPrebuilt
 

--- a/pkgs/development/libraries/neon/default.nix
+++ b/pkgs/development/libraries/neon/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchurl, libxml2, pkg-config, perl
 , compressionSupport ? true, zlib ? null
 , sslSupport ? true, openssl ? null
-, static ? stdenv.hostPlatform.isStatic
-, shared ? !stdenv.hostPlatform.isStatic
+, static ? stdenv.isStatic
+, shared ? !stdenv.isStatic
 }:
 
 assert compressionSupport -> zlib != null;

--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -8,7 +8,7 @@
 , enableAsioLib ? false, boost ? null
 , enableGetAssets ? false, libxml2 ? null
 , enableJemalloc ? false, jemalloc ? null
-, enableApp ? with stdenv.hostPlatform; !isWindows && !isStatic
+, enableApp ? !stdenv.hostPlatform.isWindows && !stdenv.isStatic
 , enablePython ? false, python ? null, cython ? null, ncurses ? null, setuptools ? null
 }:
 

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -2,7 +2,7 @@
 , withCryptodev ? false, cryptodev
 , enableSSL2 ? false
 , enableSSL3 ? false
-, static ? stdenv.hostPlatform.isStatic
+, static ? stdenv.isStatic
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus

--- a/pkgs/development/libraries/re2/default.nix
+++ b/pkgs/development/libraries/re2/default.nix
@@ -17,13 +17,13 @@ stdenv.mkDerivation {
     substituteInPlace Makefile  --replace "SED_INPLACE=sed -i '''" "SED_INPLACE=sed -i"
   '';
 
-  buildFlags = lib.optionals stdenv.hostPlatform.isStatic [ "static" ];
+  buildFlags = lib.optionals stdenv.isStatic [ "static" ];
 
   preCheck = "patchShebangs runtests";
   doCheck = true;
   checkTarget = "test";
 
-  installTargets = lib.optionals stdenv.hostPlatform.isStatic [ "static-install" ];
+  installTargets = lib.optionals stdenv.isStatic [ "static-install" ];
 
   doInstallCheck = true;
   installCheckTarget = "testinstall";

--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -10,7 +10,7 @@
 , zstd
 , enableJemalloc ? false, jemalloc
 , enableLite ? false
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -6,7 +6,7 @@
 , undmg
 , darwin
 , validatePkgConfig
-, enableStatic ? stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
 }:
 
 /*

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -15,8 +15,8 @@
 # Select a specific optimization target (other than the default)
 # See https://github.com/xianyi/OpenBLAS/blob/develop/TargetList.txt
 , target ? null
-, enableStatic ? stdenv.hostPlatform.isStatic
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 with lib;

--- a/pkgs/development/libraries/simdjson/default.nix
+++ b/pkgs/development/libraries/simdjson/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DSIMDJSON_JUST_LIBRARY=ON"
-  ] ++ lib.optional stdenv.hostPlatform.isStatic "-DSIMDJSON_BUILD_STATIC=ON";
+  ] ++ lib.optional stdenv.isStatic "-DSIMDJSON_BUILD_STATIC=ON";
 
   meta = with lib; {
     homepage = "https://simdjson.org/";

--- a/pkgs/development/libraries/snappy/default.nix
+++ b/pkgs/development/libraries/snappy/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake
-, static ? stdenv.hostPlatform.isStatic
+, static ? stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -17,8 +17,8 @@ let
       buildInputs = [ fmt ];
 
       cmakeFlags = [
-        "-DSPDLOG_BUILD_SHARED=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
-        "-DSPDLOG_BUILD_STATIC=${if stdenv.hostPlatform.isStatic then "ON" else "OFF"}"
+        "-DSPDLOG_BUILD_SHARED=${if stdenv.isStatic then "OFF" else "ON"}"
+        "-DSPDLOG_BUILD_STATIC=${if stdenv.isStatic then "ON" else "OFF"}"
         "-DSPDLOG_BUILD_EXAMPLE=OFF"
         "-DSPDLOG_BUILD_BENCH=OFF"
         "-DSPDLOG_BUILD_TESTS=ON"

--- a/pkgs/development/libraries/thrift/default.nix
+++ b/pkgs/development/libraries/thrift/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch, boost, zlib, libevent, openssl, python, cmake, pkg-config
 , bison, flex, twisted
-, static ? stdenv.hostPlatform.isStatic
+, static ? stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/tinycdb/default.nix
+++ b/pkgs/development/libraries/tinycdb/default.nix
@@ -2,7 +2,7 @@
 let
   isCross = stdenv.buildPlatform != stdenv.hostPlatform;
   cross = "${stdenv.hostPlatform.config}";
-  static = stdenv.hostPlatform.isStatic;
+  static = stdenv.isStatic;
 
   cc = if !isCross then "cc" else "${cross}-cc";
   ar = if !isCross then "ar" else "${cross}-ar";

--- a/pkgs/development/libraries/xxHash/default.nix
+++ b/pkgs/development/libraries/xxHash/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   # Upstream Makefile does not anticipate that user may not want to
   # build .so library.
-  postPatch = lib.optionalString stdenv.hostPlatform.isStatic ''
+  postPatch = lib.optionalString stdenv.isStatic ''
     sed -i 's/lib: libxxhash.a libxxhash/lib: libxxhash.a/' Makefile
     sed -i '/LIBXXH) $(DESTDIR/ d' Makefile
   '';

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv
 , fetchurl
-, shared ? !stdenv.hostPlatform.isStatic
+, shared ? !stdenv.isStatic
 , static ? true
 # If true, a separate .static ouput is created and the .a is moved there.
 # In this case `pkg-config` auto detection does not currently work if the

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub, fetchurl, zlib, autoreconfHook, gettext
 # Enabling all targets increases output size to a multiple.
 , withAllTargets ? false, libbfd, libopcodes
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 , noSysDirs
 , gold ? true
 , bison ? null

--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -5,8 +5,8 @@
 , Security
 , callPackage
 
-, enableShared ? !stdenv.hostPlatform.isStatic
-, enableStatic ? stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
+, enableStatic ? stdenv.isStatic
 , webUISupport ? false
 }:
 

--- a/pkgs/development/web/woff2/default.nix
+++ b/pkgs/development/web/woff2/default.nix
@@ -1,5 +1,5 @@
 { brotli, cmake, pkg-config, fetchFromGitHub, lib, stdenv
-, static ? stdenv.hostPlatform.isStatic
+, static ? stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix
@@ -1,6 +1,6 @@
 { stdenv, appleDerivation, lib
-, enableStatic ? stdenv.hostPlatform.isStatic
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 appleDerivation {

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, buildPackages, fetchurl, fetchFromGitLab
-, enableStatic ? stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
 , enableMinimal ? false
 # Allow forcing musl without switching stdenv itself, e.g. for our bootstrapping:
 # nix build -f pkgs/top-level/release.nix stdenvBootstrapTools.x86_64-linux.dist

--- a/pkgs/os-specific/linux/keyutils/default.nix
+++ b/pkgs/os-specific/linux/keyutils/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     ./conf-symlink.patch
   ];
 
-  makeFlags = lib.optionals stdenv.hostPlatform.isStatic "NO_SOLIB=1";
+  makeFlags = lib.optionals stdenv.isStatic "NO_SOLIB=1";
 
   BUILDDATE = "1970-01-01";
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, autoreconfHook, pkg-config
 , libxslt, xz, elf-header
-, withStatic ? stdenv.hostPlatform.isStatic
+, withStatic ? stdenv.isStatic
 }:
 
 let

--- a/pkgs/os-specific/linux/libcap/default.nix
+++ b/pkgs/os-specific/linux/libcap/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, buildPackages, fetchurl, attr, perl
 , usePam ? !isStatic, pam ? null
-, isStatic ? stdenv.hostPlatform.isStatic
+, isStatic ? stdenv.isStatic
 }:
 
 assert usePam -> pam != null;

--- a/pkgs/servers/gobetween/default.nix
+++ b/pkgs/servers/gobetween/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildGoModule, fetchFromGitHub, lib
-, enableStatic ? stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
 }:
 
 buildGoModule rec {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -70,7 +70,7 @@ self: super:
 
   libxcb = super.libxcb.overrideAttrs (attrs: {
     configureFlags = [ "--enable-xkb" "--enable-xinput" ]
-      ++ lib.optional stdenv.hostPlatform.isStatic "--disable-shared";
+      ++ lib.optional stdenv.isStatic "--disable-shared";
     outputs = [ "out" "dev" "man" "doc" ];
   });
 
@@ -80,7 +80,7 @@ self: super:
       ++ malloc0ReturnsNullCrossFlag;
     depsBuildBuild = [
       buildPackages.stdenv.cc
-    ] ++ lib.optionals stdenv.hostPlatform.isStatic [
+    ] ++ lib.optionals stdenv.isStatic [
       (self.buildPackages.stdenv.cc.libc.static or null)
     ];
     preConfigure = ''
@@ -139,7 +139,7 @@ self: super:
       ++ malloc0ReturnsNullCrossFlag;
     preConfigure = attrs.preConfigure or ""
     # missing transitive dependencies
-    + lib.optionalString stdenv.hostPlatform.isStatic ''
+    + lib.optionalString stdenv.isStatic ''
       export NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK -lXau -lXdmcp"
     '';
   });
@@ -229,7 +229,7 @@ self: super:
     propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ self.libXfixes ];
     configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       "xorg_cv_malloc0_returns_null=no"
-    ] ++ lib.optional stdenv.hostPlatform.isStatic "--disable-shared";
+    ] ++ lib.optional stdenv.isStatic "--disable-shared";
   });
 
   libXinerama = super.libXinerama.overrideAttrs (attrs: {
@@ -752,7 +752,7 @@ self: super:
     doCheck = false; # fails
     preConfigure = attrs.preConfigure or ""
     # missing transitive dependencies
-    + lib.optionalString stdenv.hostPlatform.isStatic ''
+    + lib.optionalString stdenv.isStatic ''
       export NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK -lxcb -lXau -lXdmcp"
     '';
   });

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -54,7 +54,8 @@ rec {
   # Return a modified stdenv that builds static libraries instead of
   # shared libraries.
   makeStaticLibraries = stdenv: stdenv //
-    { mkDerivation = args: stdenv.mkDerivation (args // {
+    { isStatic = true;
+      mkDerivation = args: stdenv.mkDerivation (args // {
         dontDisableStatic = true;
         configureFlags = (args.configureFlags or []) ++ [
           "--enable-static"

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -38,7 +38,7 @@ in lib.init bootStages ++ [
   (buildPackages: {
     inherit config;
     overlays = overlays ++ crossOverlays
-      ++ (if (with crossSystem; isWasm || isRedox) then [(import ../../top-level/static.nix)] else []);
+      ++ (if (!crossSystem.hasDynamicLoader) then [(import ../../top-level/static.nix)] else []);
     selfBuild = false;
     stdenv = buildPackages.stdenv.override (old: rec {
       buildPlatform = localSystem;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -161,6 +161,8 @@ let
       inherit overrides;
 
       inherit cc hasCC;
+
+      isStatic = false;
     }
 
     # Propagate any extra attributes.  For instance, we use this to

--- a/pkgs/tools/compression/brotli/default.nix
+++ b/pkgs/tools/compression/brotli/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, fetchpatch
-, staticOnly ? stdenv.hostPlatform.isStatic
+, staticOnly ? stdenv.isStatic
 }:
 
 # ?TODO: there's also python lib in there

--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl
-, linkStatic ? with stdenv.hostPlatform; isStatic || isCygwin
+, linkStatic ? stdenv.isStatic || stdenv.hostPlatform.isCygwin
 , autoreconfHook
 }:
 

--- a/pkgs/tools/compression/lz4/default.nix
+++ b/pkgs/tools/compression/lz4/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, valgrind, fetchpatch
-, enableStatic ? stdenv.hostPlatform.isStatic
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl
-, enableStatic ? stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus

--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -2,7 +2,7 @@
 , fixDarwinDylibNames
 , file
 , legacySupport ? false
-, static ? stdenv.hostPlatform.isStatic
+, static ? stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, buildPackages, fetchurl, fetchpatch, pkg-config, libuuid, gettext, texinfo
-, shared ? !stdenv.hostPlatform.isStatic
+, shared ? !stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/filesystems/nixpart/0.4/parted.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/parted.nix
@@ -1,6 +1,6 @@
 { lib,stdenv, fetchurl, fetchpatch, lvm2, libuuid, gettext, readline
 , util-linux, check
-, enableStatic ? stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/graphics/gifsicle/default.nix
+++ b/pkgs/tools/graphics/gifsicle/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, xorgproto, libXt, libX11
 , gifview ? false
-, static ? stdenv.hostPlatform.isStatic
+, static ? stdenv.isStatic
 }:
 
 with lib;

--- a/pkgs/tools/graphics/optipng/default.nix
+++ b/pkgs/tools/graphics/optipng/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, libpng
-, static ? stdenv.hostPlatform.isStatic
+, static ? stdenv.isStatic
 }:
 
 # This package comes with its own copy of zlib, libpng and pngxtern

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -7,7 +7,7 @@
 , szip ? null
 , mpiSupport ? false
 , mpi
-, enableShared ? !stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.isStatic
 }:
 
 # cpp and mpi options are mutually exclusive

--- a/pkgs/tools/misc/parted/default.nix
+++ b/pkgs/tools/misc/parted/default.nix
@@ -11,7 +11,7 @@
 , python3
 , util-linux
 , check
-, enableStatic ? stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/misc/toybox/default.nix
+++ b/pkgs/tools/misc/toybox/default.nix
@@ -1,7 +1,7 @@
 {
   stdenv, lib, fetchFromGitHub, which,
   buildPackages,
-  enableStatic ? stdenv.hostPlatform.isStatic,
+  enableStatic ? stdenv.isStatic,
   enableMinimal ? false,
   extraConfig ? ""
 }:

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -8,7 +8,7 @@
 , wolfsslSupport ? false, wolfssl ? null
 , scpSupport ? zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin, libssh2 ? null
 , # a very sad story re static: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=439039
-  gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic, libkrb5 ? null
+  gssSupport ? !stdenv.hostPlatform.isWindows && !stdenv.isStatic, libkrb5 ? null
 , c-aresSupport ? false, c-ares ? null
 , brotliSupport ? false, brotli ? null
 }:

--- a/pkgs/tools/networking/dropbear/default.nix
+++ b/pkgs/tools/networking/dropbear/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, glibc, zlib
-, enableStatic ? stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.isStatic
 , sftpPath ? "/run/current-system/sw/libexec/sftp-server"
 }:
 

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
   # code in openssh's configure.ac. Neither of them support static
   # build, but patching code for krb5-config is simpler, so to get it
   # into PATH, kerberos.dev is added into buildInputs.
-  + optionalString stdenv.hostPlatform.isStatic ''
+  + optionalString stdenv.isStatic ''
     sed -i "s,PKGCONFIG --libs,PKGCONFIG --libs --static,g" configure
     sed -i 's#KRB5CONF --libs`#KRB5CONF --libs` -lkrb5support -lkeyutils#g' configure
     sed -i 's#KRB5CONF --libs gssapi`#KRB5CONF --libs gssapi` -lkrb5support -lkeyutils#g' configure

--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     "--with-rootkey-file=${dns-root-data}/root.key"
     "--enable-pie"
     "--enable-relro-now"
-  ] ++ lib.optional stdenv.hostPlatform.isStatic [
+  ] ++ lib.optional stdenv.isStatic [
     "--disable-flto"
   ] ++ lib.optionals withSystemd [
     "--enable-systemd"

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -23,7 +23,7 @@ common =
   , confDir
   , withLibseccomp ? lib.any (lib.meta.platformMatch stdenv.hostPlatform) libseccomp.meta.platforms, libseccomp
   , withAWS ? !enableStatic && (stdenv.isLinux || stdenv.isDarwin), aws-sdk-cpp
-  , enableStatic ? stdenv.hostPlatform.isStatic
+  , enableStatic ? stdenv.isStatic
   , name, suffix ? "", src
   , patches ? [ ]
   }:

--- a/pkgs/tools/system/ipmitool/default.nix
+++ b/pkgs/tools/system/ipmitool/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, openssl, fetchpatch, static ? stdenv.hostPlatform.isStatic }:
+{ stdenv, lib, fetchurl, openssl, fetchpatch, static ? stdenv.isStatic }:
 
 let
   pkgname = "ipmitool";

--- a/pkgs/tools/system/pciutils/default.nix
+++ b/pkgs/tools/system/pciutils/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, zlib, kmod, which
-, static ? stdenv.hostPlatform.isStatic
+, static ? stdenv.isStatic
 , darwin ? null
 }:
 

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     mv $lib/lib/liblowdown.{so,dylib}
   '';
 
-  patches = lib.optional (!stdenv.hostPlatform.isStatic) ./shared.patch;
+  patches = lib.optional (!stdenv.isStatic) ./shared.patch;
 
   meta = with lib; {
     homepage = "https://kristaps.bsd.lv/lowdown/";
@@ -36,4 +36,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
   };
 }
-

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -218,7 +218,6 @@ let
       crossOverlays = [ (import ./static.nix) ];
     } // lib.optionalAttrs stdenv.hostPlatform.isLinux {
       crossSystem = {
-        isStatic = true;
         parsed = stdenv.hostPlatform.parsed // {
           abi = {
             gnu = lib.systems.parse.abis.musl;


### PR DESCRIPTION
This corrects an issue from
https://github.com/NixOS/nixpkgs/pull/96223, where darwin/macOS static
compilation is broken. The issue is that stdenv.hostPlatform.isStatic
is only set on Linux:

https://github.com/NixOS/nixpkgs/blob/916815204eac9e4a41f263dd9855e51380135674/pkgs/top-level/stage.nix#L221

and not macOS or other platforms. This means that we can’t static
compile on platforms platforms that can’t cross-compile to themselves.
To fix this, move isStatic from stdenv.hostPlatform to stdenv. This
avoids the need to have stdenv.hostPlatform != stdenv.buildPlatform.

We still can have something similar to isStatic in
stdenv.hostPlatform, but instead of being a configurable value, it is
now called ‘hasDynamicLoader’. This should be true for everything but
a few specific platforms we support.

This also makes some weird cases less confusing. For instance, `import nixpkgs { crossSystem = { system = builtins.currentSystem; isStatic = true; }` would be expected to provide static stdenv, but it actually doesn't.

/cc @vcunat @ericson2314 @KAction 
