### PR TITLE
nixos/manual: luks entries are auto-detected

### DIFF
--- a/nixos/doc/manual/configuration/luks-file-systems.xml
+++ b/nixos/doc/manual/configuration/luks-file-systems.xml
@@ -26,7 +26,11 @@ Enter passphrase for /dev/disk/by-uuid/3f6b0024-3a44-4fde-a43a-767b872abe5d: ***
 
 # mkfs.ext4 /dev/mapper/crypted
 </screen>
-  To ensure that this file system is automatically mounted at boot time as
+  The LUKS volume should be automatically picked up by
+  <command>nixos-generate-config</command>, but you might want to verify that your
+  <filename>hardware-configuration.nix</filename> looks correct.
+
+  To manually ensure that the system is automatically mounted at boot time as
   <filename>/</filename>, add the following to
   <filename>configuration.nix</filename>:
 <programlisting>


### PR DESCRIPTION
Mention that the the LUKS entries do not need to be added when using
nixos-generate-config. Keep the instructions for people that want to
do it manually.

###### Motivation for this change

The documentation was confusing for a newbie.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
