### PR TITLE
python3Packages.catalogue: fix expression

### DIFF
--- a/pkgs/development/python-modules/catalogue/default.nix
+++ b/pkgs/development/python-modules/catalogue/default.nix
@@ -4,7 +4,6 @@
 , pythonOlder
 , pytestCheckHook
 , importlib-metadata
-, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -18,7 +17,9 @@ buildPythonPackage rec {
     sha256 = "0d01077dbfca7aa53f3ef4adecccce636bce4f82e5b52237703ab2f56478e56e";
   };
 
-  propagatedBuildInputs = [ importlib-metadata ];
+  propagatedBuildInputs = stdenv.lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
 
   checkInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION

###### Motivation for this change
fix a minor boo boo from 377242d5875b871faed3a942161185594b8f32fa

can't do `nixpkgs-review` while staging is like this :(
```
error: while evaluating anonymous function at /home/jon/.cache/nixpkgs-review/pr-97008-2/nixpkgs/lib/meta.nix:46:54, called from undefined position:
while evaluating 'isDerivation' at /home/jon/.cache/nixpkgs-review/pr-97008-2/nixpkgs/lib/attrsets.nix:305:18, called from /home/jon/.cache/nixpkgs-review/pr-97008-2/nixpkgs/lib/meta.nix:46:62:
while evaluating 'callPackageWith' at /home/jon/.cache/nixpkgs-review/pr-97008-2/nixpkgs/lib/customisation.nix:117:35, called from /home/jon/.cache/nixpkgs-review/pr-97008-2/nixpkgs/pkgs/top-level/python-packages.nix:1037:15:
while evaluating 'makeOverridable' at /home/jon/.cache/nixpkgs-review/pr-97008-2/nixpkgs/lib/customisation.nix:67:24, called from /home/jon/.cache/nixpkgs-review/pr-97008-2/nixpkgs/lib/customisation.nix:121:8:
duplicate formal function argument 'pytestCheckHook' at /home/jon/.cache/nixpkgs-review/pr-97008-2/nixpkgs/pkgs/development/python-modules/catalogue/default.nix:5:3
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
