### PR TITLE
systemd: build libudev.so "separately"

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -87,9 +87,7 @@ let
   # copy what we need.  Instead of using statically linked binaries,
   # we just copy what we need from Glibc and use patchelf to make it
   # work.
-  extraUtils = let
-    # Use lvm2 without udev support, which is the same lvm2 we already have in the closure anyways
-    lvm2 = pkgs.lvm2.override { udev = null; }; in pkgs.runCommandCC "extra-utils"
+  extraUtils = pkgs.runCommandCC "extra-utils"
     { nativeBuildInputs = [pkgs.buildPackages.nukeReferences];
       allowedReferences = [ "out" ]; # prevent accidents like glibc being included in the initrd
     }
@@ -113,8 +111,8 @@ let
       copy_bin_and_libs ${pkgs.utillinux}/sbin/blkid
 
       # Copy dmsetup and lvm.
-      copy_bin_and_libs ${getBin lvm2}/bin/dmsetup
-      copy_bin_and_libs ${getBin lvm2}/bin/lvm
+      copy_bin_and_libs ${getBin pkgs.lvm2}/bin/dmsetup
+      copy_bin_and_libs ${getBin pkgs.lvm2}/bin/lvm
 
       # Add RAID mdadm tool.
       copy_bin_and_libs ${pkgs.mdadm}/sbin/mdadm

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -633,10 +633,10 @@ in {
           + " mklabel msdos"
           + " mkpart primary ext2 1M 100MB"  # /boot
           + " mkpart extended 100M -1s"
-          + " mkpart logical 102M 2102M"  # md0 (root), first device
-          + " mkpart logical 2103M 4103M"  # md0 (root), second device
-          + " mkpart logical 4104M 4360M"  # md1 (swap), first device
-          + " mkpart logical 4361M 4617M",  # md1 (swap), second device
+          + " mkpart logical 102M 3102M"  # md0 (root), first device
+          + " mkpart logical 3103M 6103M"  # md0 (root), second device
+          + " mkpart logical 6104M 6360M"  # md1 (swap), first device
+          + " mkpart logical 6361M 6617M",  # md1 (swap), second device
           "udevadm settle",
           "ls -l /dev/vda* >&2",
           "cat /proc/partitions >&2",

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -317,7 +317,6 @@ let
             texinfo
             unionfs-fuse
             xorg.lndir
-            (lvm2.override { udev = null; }) # for initrd (extra-utils)
 
             # add curl so that rather than seeing the test attempt to download
             # curl's tarball, we see what it's trying to download

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -48,6 +48,8 @@ stdenv.mkDerivation rec {
   stdenv.lib.optionals (udev != null) [
     "--enable-udev_rules"
     "--enable-udev_sync"
+    # TODO: somehow override the systemd version check?
+    #"--enable-udev-systemd-background-jobs"
   ];
 
   preConfigure = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17234,11 +17234,7 @@ in
 
   criu = callPackage ../os-specific/linux/criu { };
 
-  cryptsetup = callPackage ../os-specific/linux/cryptsetup {
-    # cryptsetup only really needs the devmapper component of cryptsetup
-    # but itself is used as a library in systemd (=udev)
-    lvm2 = lvm2.override { udev = null; };
-  };
+  cryptsetup = callPackage ../os-specific/linux/cryptsetup { };
 
   cramfsprogs = callPackage ../os-specific/linux/cramfsprogs { };
 
@@ -17994,7 +17990,9 @@ in
 
   lsscsi = callPackage ../os-specific/linux/lsscsi { };
 
-  lvm2 = callPackage ../os-specific/linux/lvm2 { };
+  lvm2 = callPackage ../os-specific/linux/lvm2 {
+    udev = systemd.libudev;
+  };
   lvm2_dmeventd = callPackage ../os-specific/linux/lvm2 {
     enableDmeventd = true;
     enableCmdlib = true;


### PR DESCRIPTION
###### Motivation for this change
- breaking a problematic dependency cycle: https://github.com/NixOS/nixpkgs/issues/96479
- perhaps even closure savings


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
