### PR TITLE
p3x-onenote: init at 2020.10.111

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8409,6 +8409,12 @@
     githubId = 1391883;
     name = "Tom Hall";
   };
+  tiagolobocastro = {
+    email = "tiagolobocastro@gmail.com";
+    github = "tiagolobocastro";
+    githubId = 1618946;
+    name = "Tiago Castro";
+  };
   tilpner = {
     email = "till@hoeppner.ws";
     github = "tilpner";

--- a/pkgs/applications/office/p3x-onenote/default.nix
+++ b/pkgs/applications/office/p3x-onenote/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, appimageTools, desktop-file-utils, fetchurl }:
+
+let
+  version = "2020.10.111";
+  name = "p3x-onenote-${version}";
+
+  plat = {
+    aarch64-linux = "-arm64";
+    armv7l-linux = "-armv7l";
+    i386-linux = "-i386";
+    i686-linux = "-i386";
+    x86_64-linux = "";
+  }.${stdenv.hostPlatform.system};
+
+  sha256 = {
+    aarch64-linux = "0a3c0w1312l6k2jvn7cn8priibnh8wg0184zjcli29f9ds1afl5s";
+    armv7l-linux = "172m2d94zzm8q61pvnjy01cl5fg11ad9hfh1han0gycnv3difniy";
+    i386-linux = "12m0i5sb15sbysp5fvhbj4k36950m7kpjr12n88r5fpkyh13ihsp";
+    i686-linux = "12m0i5sb15sbysp5fvhbj4k36950m7kpjr12n88r5fpkyh13ihsp";
+    x86_64-linux = "0bn48r55l5dh8zcf8ijh3z6hlyp3s6fvfyqc1csvnslm63dfkzcq";
+  }.${stdenv.hostPlatform.system};
+
+  src = fetchurl {
+    url = "https://github.com/patrikx3/onenote/releases/download/v${version}/P3X-OneNote-${version}${plat}.AppImage";
+    inherit sha256;
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+in
+appimageTools.wrapType2 rec {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/pixmaps $out/share/licenses/p3x-onenote
+    cp ${appimageContents}/p3x-onenote.png $out/share/pixmaps/
+    cp ${appimageContents}/p3x-onenote.desktop $out
+    cp ${appimageContents}/LICENSE.electron.txt $out/share/licenses/p3x-onenote/LICENSE
+    mv $out/bin/${name} $out/bin/p3x-onenote
+
+    ${desktop-file-utils}/bin/desktop-file-install --dir $out/share/applications \
+      --set-key Exec --set-value $out/bin/p3x-onenote \
+      --set-key Comment --set-value "P3X OneNote Linux" \
+      --delete-original $out/p3x-onenote.desktop
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/patrikx3/onenote";
+    description = "Linux Electron Onenote - A Linux compatible version of OneNote";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tiagolobocastro ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6056,6 +6056,8 @@ in
 
   p2pvc = callPackage ../applications/video/p2pvc {};
 
+  p3x-onenote = callPackage ../applications/office/p3x-onenote { };
+
   p7zip = callPackage ../tools/archivers/p7zip { };
 
   packagekit = callPackage ../tools/package-management/packagekit { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add package for p3x-onenote - A Linux compatible version of OneNote

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
