### PR TITLE
buildSupport.rust: fix typo in verifyCargoDeps message

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -155,7 +155,7 @@ stdenv.mkDerivation (args // {
       echo
       echo "To fix the issue:"
       echo '1. Use "0000000000000000000000000000000000000000000000000000" as the cargoSha256 value'
-      echo "2. Build the derivation and wait it to fail with a hash mismatch"
+      echo "2. Build the derivation and wait for it to fail with a hash mismatch"
       echo "3. Copy the 'got: sha256:' value back into the cargoSha256 field"
       echo
 


### PR DESCRIPTION
Fix a minor typo within the `verifyCargoDeps` message:

"Build the derivation and wait **_for_** it to fail with a hash mismatch"