### PR TITLE
haskellPackages.haskell-language-server: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1473,10 +1473,11 @@ self: super: {
   # INSERT NEW OVERRIDES ABOVE THIS LINE
 
 } // (let
+  inherit (self) hls-ghcide;
   hlsScopeOverride = self: super: {
     # haskell-language-server uses its own fork of ghcide
     # Test disabled: it seems to freeze (is it just that it takes a long time ?)
-    ghcide = dontCheck super.hls-ghcide;
+    ghcide = hls-ghcide;
     # we are faster than stack here
     hie-bios = dontCheck super.hie-bios_0_7_1;
     lsp-test = dontCheck super.lsp-test_0_11_0_4;
@@ -1488,7 +1489,13 @@ self: super: {
   in {
     # jailbreaking for hie-bios 0.7.0 (upstream PR: https://github.com/haskell/haskell-language-server/pull/357)
     haskell-language-server = dontCheck (doJailbreak (super.haskell-language-server.overrideScope hlsScopeOverride));
-    hls-ghcide = dontCheck (super.hls-ghcide.overrideScope hlsScopeOverride);
+    hls-ghcide = appendPatch (dontCheck (super.hls-ghcide.overrideScope hlsScopeOverride))
+      (pkgs.fetchpatch {
+        # This patch loosens the hie-bios upper bound.
+        # It is already merged into upstream and won‘t be needed for ghcide 0.4.0
+        url = "https://github.com/haskell/ghcide/commit/3e1b3620948870a4da8808ca0c0897fbd3ecad16.patch";
+        sha256 = "1jwn7jgi740x6wwv1k0mz9d4z0b9p3mzs54pdg4nfq0h2v7zxchz";
+      });
     fourmolu = super.fourmolu.overrideScope hlsScopeOverride;
   }
 )  // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/tools/haskell/haskell-language-server/default.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/default.nix
@@ -11,11 +11,11 @@
 }:
 mkDerivation {
   pname = "haskell-language-server";
-  version = "0.3.0.0";
+  version = "0.4.0.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "0gh3sgy6a08d8d3q6r2qn5r817ilzka2qkp0g0y6wsx7rjwag0yx";
-    rev = "23dda97f583e8ff39993b89c01bbd1ac24187605";
+    sha256 = "157bsq6i824bl6krw7znp0byd8ibaqsq7mfwnkl741dmrflsxpa9";
+    rev = "cb861b878ae01911b066182ff0d8080050c3b2d6";
     fetchSubmodules = true;
   };
   isLibrary = true;

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-ghcide.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-ghcide.nix
@@ -17,9 +17,9 @@ mkDerivation {
   pname = "ghcide";
   version = "0.2.0";
   src = fetchgit {
-    url = "https://github.com/wz1000/ghcide";
-    sha256 = "112bsk2660750n94gnsgrvd30rk0ccxb8dbhka606a11pcqv5cgx";
-    rev = "3f6cd4553279ec47d1599b502720791a4f4613cd";
+    url = "https://github.com/haskell/ghcide";
+    sha256 = "1zq7ngaak8il91a309rl51dghzasnk4m2sm3av6d93cyqyra1hfc";
+    rev = "078e3d3c0d319f83841ccbcdc60ff5f0e243f6be";
     fetchSubmodules = true;
   };
   isLibrary = true;

--- a/pkgs/development/tools/haskell/haskell-language-server/update.sh
+++ b/pkgs/development/tools/haskell/haskell-language-server/update.sh
@@ -29,7 +29,7 @@ ghcide_new_version=$(curl --silent "https://api.github.com/repos/haskell/haskell
 echo "Updating haskell-language-server's ghcide from old version $ghcide_old_version to new version $ghcide_new_version."
 echo "Running cabal2nix and outputting to ${ghcide_derivation_file}..."
 
-cabal2nix --revision "$ghcide_new_version" "https://github.com/wz1000/ghcide" > "$ghcide_derivation_file"
+cabal2nix --revision "$ghcide_new_version" "https://github.com/haskell/ghcide" > "$ghcide_derivation_file"
 
 
 # ===========================


### PR DESCRIPTION
I am sorry for the override scope shenanigans I am doing there. But 

a) this is the best way I could think of to prevent code duplication.
b) haskell-language-server will soon be in hackage and probably even in stack. Then everything will become easier.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
