### PR TITLE
cudatext: init at 1.111.0

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -1,0 +1,113 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, lazarus
+, fpc
+, libX11
+
+# GTK2/3
+, pango
+, cairo
+, glib
+, atk
+, gtk2
+, gtk3
+, gdk-pixbuf
+, python3
+
+# Qt5
+, libqt5pas
+, qt5
+
+, widgetset ? "qt5"
+# See https://github.com/Alexey-T/CudaText-lexers
+, additionalLexers ? [ "Nix" ]
+}:
+
+assert builtins.elem widgetset [ "gtk2" "gtk3" "qt5" ];
+
+let
+  deps = lib.mapAttrs
+    (name: spec:
+      fetchFromGitHub {
+        owner = "Alexey-T";
+        repo = name;
+        inherit (spec) rev sha256;
+      }
+    )
+    (builtins.fromJSON (builtins.readFile ./deps.json));
+in
+stdenv.mkDerivation rec {
+  pname = "cudatext";
+  version = "1.111.0";
+
+  src = fetchFromGitHub {
+    owner = "Alexey-T";
+    repo = "CudaText";
+    rev = version;
+    sha256 = "1ai0g8fmw4m237dqh5dkr8w9qqricyvp49ijz2ivvmg9dsdfzjfp";
+  };
+
+  patches = [
+    # Don't check for update
+    ./dont-check-update.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace app/proc_globdata.pas \
+      --replace "/usr/share/cudatext" "$out/share/cudatext" \
+      --replace "libpython3.so" "${python3}/lib/libpython3.so"
+  '';
+
+  nativeBuildInputs = [ lazarus fpc ]
+    ++ lib.optional (widgetset == "qt5") qt5.wrapQtAppsHook;
+
+  buildInputs = [ libX11 ]
+    ++ lib.optionals (lib.hasPrefix "gtk" widgetset) [ pango cairo glib atk gdk-pixbuf ]
+    ++ lib.optional (widgetset == "gtk2") gtk2
+    ++ lib.optional (widgetset == "gtk3") gtk3
+    ++ lib.optional (widgetset == "qt5") libqt5pas;
+
+  NIX_LDFLAGS = "--as-needed -rpath ${lib.makeLibraryPath buildInputs}";
+
+  buildPhase = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: dep: ''
+    cp -r --no-preserve=mode ${dep} ${name}
+  '') deps) + ''
+    lazbuild --lazarusdir=${lazarus}/share/lazarus --pcp=./lazarus --ws=${widgetset} \
+      EncConv/encconv/encconv_package.lpk \
+      ATBinHex-Lazarus/atbinhex/atbinhex_package.lpk \
+      ATFlatControls/atflatcontrols/atflatcontrols_package.lpk \
+      ATSynEdit/atsynedit/atsynedit_package.lpk \
+      ATSynEdit_Cmp/atsynedit_cmp/atsynedit_cmp_package.lpk \
+      EControl/econtrol/econtrol_package.lpk \
+      ATSynEdit_Ex/atsynedit_ex/atsynedit_ex_package.lpk \
+      Python-for-Lazarus/python4lazarus/python4lazarus_package.lpk \
+      Emmet-Pascal/emmet/emmet_package.lpk \
+      app/cudatext.lpi
+  '';
+
+  installPhase = ''
+    install -Dm755 app/cudatext $out/bin/cudatext
+
+    install -dm755 $out/share/cudatext
+    cp -r app/{data,py,settings_default} $out/share/cudatext
+
+    install -Dm644 setup/debfiles/cudatext-512.png -t $out/share/pixmaps
+    install -Dm644 setup/debfiles/cudatext.desktop -t $out/share/applications
+  '' + lib.concatMapStringsSep "\n" (lexer: ''
+    install -Dm644 CudaText-lexers/${lexer}/*.{cuda-lexmap,lcf} $out/share/cudatext/data/lexlib
+  '') additionalLexers;
+
+  meta = with lib; {
+    description = "Cross-platform code editor";
+    longDescription = ''
+      Text/code editor with lite UI. Syntax highlighting for 200+ languages.
+      Config system in JSON files. Multi-carets and multi-selections.
+      Search and replace with RegEx. Extendable by Python plugins and themes.
+    '';
+    homepage = "http://www.uvviewsoft.com/cudatext/";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/editors/cudatext/deps.json
+++ b/pkgs/applications/editors/cudatext/deps.json
@@ -1,0 +1,42 @@
+{
+  "EncConv": {
+    "rev": "2020.06.15",
+    "sha256": "07dpvq3ppfq3b70i1smkf7vwdlzq8qnxs3fk94hi9h1z36bz2rw3"
+  },
+  "ATBinHex-Lazarus": {
+    "rev": "2020.09.05",
+    "sha256": "022yx5vic4hnc9lz53wvr4h7hf0h71801dzlilj55x5mf8p59072"
+  },
+  "ATFlatControls": {
+    "rev": "2020.08.23",
+    "sha256": "1axzwiz5h62v11ncynxcg431dfbky9pwyha7cd6kpizjdjagfklw"
+  },
+  "ATSynEdit": {
+    "rev": "2020.09.05",
+    "sha256": "0qn0fp7rbi48f3nrysb0knkd7a3a6pl5w72yf95g5iibal4zrib2"
+  },
+  "ATSynEdit_Cmp": {
+    "rev": "2020.09.05",
+    "sha256": "1bd25zc97001b7lg0bvi8va9mazkr6jih6d2ddkabcxcnsj0dxnq"
+  },
+  "EControl": {
+    "rev": "2020.09.05",
+    "sha256": "1n7s1zkhrr216gqdqvq6wq0n3jq7s78mwpi5s5j8054p0fak1ywi"
+  },
+  "ATSynEdit_Ex": {
+    "rev": "2020.09.05",
+    "sha256": "17y2cx5syj3jvrszjgdyf1p6vilp2qgaggz4y8yqnz99cvd0shs7"
+  },
+  "Python-for-Lazarus": {
+    "rev": "2020.07.31",
+    "sha256": "0qbs51h6gw8qd3h06kwy1j7db35shbg7r2rayrhvvw0vzr9n330j"
+  },
+  "Emmet-Pascal": {
+    "rev": "2020.09.05",
+    "sha256": "0qfiirxnk5g3whx8y8hp54ch3h6gkkd01yf79m95bwar5qvdfybg"
+  },
+  "CudaText-lexers": {
+    "rev": "2020.08.10",
+    "sha256": "1gzs2psyfhb9si1qyacxzfjb3dz2v255hv7y4jlkbxdxv0kckqr6"
+  }
+}

--- a/pkgs/applications/editors/cudatext/dont-check-update.patch
+++ b/pkgs/applications/editors/cudatext/dont-check-update.patch
@@ -1,0 +1,12 @@
+diff --git i/app/formmain.pas w/app/formmain.pas
+index 8c1131680..6c6c0043f 100644
+--- i/app/formmain.pas
++++ w/app/formmain.pas
+@@ -2135,6 +2135,7 @@ begin
+     false
+     {$endif};
+     *)
++  mnuHelpCheckUpd.Enabled:=false;
+ 
+   with AppPanels[cPaneSide] do
+   begin

--- a/pkgs/development/compilers/fpc/libqt5pas.nix
+++ b/pkgs/development/compilers/fpc/libqt5pas.nix
@@ -1,0 +1,24 @@
+{ stdenv, lazarus, qt5 }:
+
+stdenv.mkDerivation {
+  pname = "libqt5pas";
+  inherit (lazarus) version src;
+
+  sourceRoot = "lazarus/lcl/interfaces/qt5/cbindings";
+
+  postPatch = ''
+    substituteInPlace Qt5Pas.pro \
+      --replace "target.path = \$\$[QT_INSTALL_LIBS]" "target.path = $out/lib"
+  '';
+
+  nativeBuildInputs = with qt5; [ qmake ];
+
+  buildInputs = with qt5; [ qtbase qtx11extras ];
+
+  meta = with stdenv.lib; {
+    description = "Free Pascal Qt5 binding library";
+    homepage = "https://wiki.freepascal.org/Qt5_Interface#libqt5pas";
+    maintainers = with maintainers; [ sikmir ];
+    inherit (lazarus.meta) license platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13932,6 +13932,8 @@ in
 
   libqalculate = callPackage ../development/libraries/libqalculate { };
 
+  libqt5pas = callPackage ../development/compilers/fpc/libqt5pas.nix { };
+
   libroxml = callPackage ../development/libraries/libroxml { };
 
   librsvg = callPackage ../development/libraries/librsvg { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19844,6 +19844,10 @@ in
   codeblocks = callPackage ../applications/editors/codeblocks { };
   codeblocksFull = codeblocks.override { contribPlugins = true; };
 
+  cudatext-qt = callPackage ../applications/editors/cudatext { widgetset = "qt5"; };
+  cudatext-gtk = callPackage ../applications/editors/cudatext { widgetset = "gtk2"; };
+  cudatext = cudatext-qt;
+
   convos = callPackage ../applications/networking/irc/convos { };
 
   comical = callPackage ../applications/graphics/comical { };


### PR DESCRIPTION
###### Motivation for this change
**[CudaText](http://uvviewsoft.com/cudatext)** is a cross-platform text editor, written in Lazarus.
Resolves #56339.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
