### PR TITLE
lowdown: Split out "bin" and "man" outputs

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -45,7 +45,7 @@ common =
           [ autoreconfHook
             autoconf-archive
             bison flex
-            lowdown mdbook
+            (lib.getBin lowdown) mdbook
             jq
            ];
 
@@ -55,7 +55,7 @@ common =
         ]
         ++ lib.optionals stdenv.isDarwin [ Security ]
         ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
-        ++ lib.optionals is24 [ libarchive gmock ]
+        ++ lib.optionals is24 [ libarchive gmock lowdown ]
         ++ lib.optional withLibseccomp libseccomp
         ++ lib.optional withAWS
             ((aws-sdk-cpp.override {

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "lowdown";
   version = "0.7.9";
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "lib" "dev" "man" ];
 
   src = fetchurl {
     url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
@@ -16,8 +16,11 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     ./configure PREFIX=''${!outputDev} \
                 BINDIR=''${!outputBin}/bin \
-                MANDIR=''${!outputBin}/share/man
+                LIBDIR=''${!outputLib}/lib \
+                MANDIR=''${!outputMan}/share/man
   '';
+
+  patches = lib.optional (!stdenv.hostPlatform.isStatic) ./shared.patch;
 
   meta = with lib; {
     homepage = "https://kristaps.bsd.lv/lowdown/";

--- a/pkgs/tools/typesetting/lowdown/shared.patch
+++ b/pkgs/tools/typesetting/lowdown/shared.patch
@@ -1,0 +1,41 @@
+diff --git a/Makefile b/Makefile
+index 955f737..2c9532c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -80,7 +80,7 @@ REGRESS_ARGS	+= "--parse-no-autolink"
+ REGRESS_ARGS	+= "--parse-no-cmark"
+ REGRESS_ARGS	+= "--parse-no-deflists"
+ 
+-all: lowdown lowdown-diff lowdown.pc
++all: lowdown lowdown-diff liblowdown.so lowdown.pc
+ 
+ www: $(HTMLS) $(PDFS) $(THUMBS) lowdown.tar.gz lowdown.tar.gz.sha512
+ 
+@@ -101,6 +101,9 @@ lowdown-diff: lowdown
+ liblowdown.a: $(OBJS) $(COMPAT_OBJS)
+ 	$(AR) rs $@ $(OBJS) $(COMPAT_OBJS)
+ 
++liblowdown.so: $(OBJS) $(COMPAT_OBJS)
++	$(CC) -shared -o $@ $(OBJS) $(COMPAT_OBJS) $(LDFLAGS)
++
+ install: all
+ 	mkdir -p $(DESTDIR)$(BINDIR)
+ 	mkdir -p $(DESTDIR)$(LIBDIR)/pkgconfig
+@@ -111,7 +114,7 @@ install: all
+ 	$(INSTALL_DATA) lowdown.pc $(DESTDIR)$(LIBDIR)/pkgconfig
+ 	$(INSTALL_PROGRAM) lowdown $(DESTDIR)$(BINDIR)
+ 	$(INSTALL_PROGRAM) lowdown-diff $(DESTDIR)$(BINDIR)
+-	$(INSTALL_LIB) liblowdown.a $(DESTDIR)$(LIBDIR)
++	$(INSTALL_LIB) liblowdown.so $(DESTDIR)$(LIBDIR)
+ 	$(INSTALL_DATA) lowdown.h $(DESTDIR)$(INCLUDEDIR)
+ 	for f in $(MANS) ; do \
+ 		name=`basename $$f .html` ; \
+@@ -199,7 +202,7 @@ main.o: lowdown.h
+ 
+ clean:
+ 	rm -f $(OBJS) $(COMPAT_OBJS) main.o
+-	rm -f lowdown lowdown-diff liblowdown.a lowdown.pc
++	rm -f lowdown lowdown-diff liblowdown.so lowdown.pc
+ 	rm -f index.xml diff.xml diff.diff.xml README.xml lowdown.tar.gz.sha512 lowdown.tar.gz
+ 	rm -f $(PDFS) $(HTMLS) $(THUMBS)
+ 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
