### PR TITLE
icon-lang: 9.5.1 -> 9.5.20i

### DIFF
--- a/pkgs/development/interpreters/icon-lang/default.nix
+++ b/pkgs/development/interpreters/icon-lang/default.nix
@@ -1,45 +1,37 @@
-{ stdenv, fetchFromGitHub, fetchpatch, libX11, libXt, withGraphics ? true }:
+{ stdenv, fetchFromGitHub
+, libX11, libXt
+, withGraphics ? true
+}:
 
 stdenv.mkDerivation rec {
   pname = "icon-lang";
-  version = "9.5.1";
+  version = "9.5.20i";
+
   src = fetchFromGitHub {
     owner = "gtownsend";
     repo = "icon";
-    rev = "rel${builtins.replaceStrings ["."] [""] version}";
-    sha256 = "1gkvj678ldlr1m5kjhx6zpmq11nls8kxa7pyy64whgakfzrypynw";
+    rev = "v${version}";
+    sha256 = "0072b3jk8mc94w818z8bklhjdf9rf0d9a7lkvw40pz3niy7zv84s";
   };
 
   buildInputs = stdenv.lib.optionals withGraphics [ libX11 libXt ];
 
-  patches = [
-    # Patch on git master, likely won't be necessary in future release
-    (fetchpatch {
-      url = "https://github.com/gtownsend/icon/commit/bfc4a6004d0d3984c8066289b8d8e563640c4ddd.patch";
-      sha256 = "1pqapjghk10rb73a1mfflki2wipjy4kvnravhmrilkqzb9hd6v8m";
-      excludes = [
-        "doc/relnotes.htm"
-        "src/h/version.h"
-      ];
-    })
-  ];
+  configurePhase = let
+    target = if withGraphics then "X-Configure" else "Configure";
+    platform = if stdenv.isLinux  then "linux"
+          else if stdenv.isDarwin then "macintosh"
+          else if stdenv.isBSD    then "bsd"
+          else if stdenv.isCygwin then "cygwin"
+          else if stdenv.isSunOS  then "solaris"
+          else throw "unsupported system";
+  in "make ${target} name=${platform}";
 
-  configurePhase =
-    let
-      _name = if stdenv.isDarwin then "macintosh" else "linux";
-    in
-    ''
-      make ${stdenv.lib.optionalString withGraphics "X-"}Configure name=${_name}
-    '';
-
-  installPhase = ''
-    make Install dest=$out
-  '';
+  installPhase = "make Install dest=$out";
 
   meta = with stdenv.lib; {
     description = ''A very high level general-purpose programming language'';
     maintainers = with maintainers; [ vrthra yurrriq ];
-    platforms = with platforms; linux ++ darwin;
+    platforms = with platforms; linux ++ darwin ++ freebsd ++ netbsd ++ openbsd ++ cygwin ++ illumos;
     license = licenses.publicDomain;
     homepage = "https://www.cs.arizona.edu/icon/";
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This updates icon-lang to version 9.5.20i. It also adds support for platforms listed [here](https://github.com/gtownsend/icon/tree/master/config), although I have not verified it works for these.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
