### PR TITLE
oauth2_proxy: 6.0.0 -> 6.1.1

### DIFF
--- a/pkgs/servers/oauth2_proxy/default.nix
+++ b/pkgs/servers/oauth2_proxy/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "oauth2-proxy";
-  version = "6.0.0";
+  version = "6.1.1";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "oauth2-proxy";
-    sha256 = "0mbjg0d0w173xpq69frjdvgyx5k74pkrfx3phc3lq8snvhnf1c2n";
+    sha256 = "10vvib4089yywd10kigjszsfxkzv8xzj7dy3wr5df8h80rcfa74n";
     rev = "v${version}";
   };
 
-  vendorSha256 = "1hrk3h729kcc77fq44kiywmyzk5a78v7bm5d2yl76lfxxdcdric7";
+  vendorSha256 = "0z8ibmpil899xvjaw7siswy22shjhx17a6lnjpr62paqdxy1sfwc";
 
   # Taken from https://github.com/oauth2-proxy/oauth2-proxy/blob/master/Makefile
   buildFlagsArray = ("-ldflags=-X main.VERSION=${version}");


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/h1d50v23fbivd3bxipslps5w2dlcwzsh-oauth2-proxy-6.0.0    50.2M
/nix/store/7cy0d0bw49dgg22kwlk714rjpm9i9ahr-oauth2-proxy-6.1.1    51.9M