### PR TITLE
intltool: add perl to propagatedBuildInputs

### DIFF
--- a/pkgs/development/tools/misc/intltool/default.nix
+++ b/pkgs/development/tools/misc/intltool/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   })];
 
   nativeBuildInputs = with perlPackages; [ perl XMLParser ];
-  propagatedBuildInputs = [ gettext ];
+  propagatedBuildInputs = [ gettext ] ++ (with perlPackages; [ perl XMLParser ]);
 
   postInstall = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     for f in $out/bin/*; do


### PR DESCRIPTION
###### Motivation for this change

Fixes regression introduced in #96959 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
