### PR TITLE
texi2html: Fix cross-platform build

### DIFF
--- a/pkgs/development/tools/misc/texi2html/default.nix
+++ b/pkgs/development/tools/misc/texi2html/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, gettext }:
+{ stdenv, fetchurl, perl, gettext, buildPackages }:
 
 stdenv.mkDerivation rec {
   pname = "texi2html";
@@ -9,12 +9,19 @@ stdenv.mkDerivation rec {
     sha256 = "1yprv64vrlcbksqv25asplnjg07mbq38lfclp1m5lj8cw878pag8";
   };
 
-  nativeBuildInputs = [ gettext ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ gettext perl ];
   buildInputs = [ perl ];
 
-  preBuild = ''
-    substituteInPlace separated_to_hash.pl \
-      --replace "/usr/bin/perl" "${perl}/bin/perl"
+  postPatch = ''
+    patchShebangs separated_to_hash.pl
+  '';
+
+  postInstall = stdenv.lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    for f in $out/bin/*; do
+      substituteInPlace $f --replace "${buildPackages.perl}" "${perl}"
+    done
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
