### PR TITLE
hedgewars: enable build on hydra

### DIFF
--- a/pkgs/games/hedgewars/default.nix
+++ b/pkgs/games/hedgewars/default.nix
@@ -103,6 +103,5 @@ mkDerivation rec {
        all movement on the battlefield has ceased).'';
     maintainers = with maintainers; [ kragniz fpletz ];
     inherit (ghc.meta) platforms;
-    hydraPlatforms = [];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Was disabled when the package was marked as broken in
c33386195407e13d588ed4e13925c78d524ba86f. It has since been un-broken,
but the hydraPlatforms exception was left presumably by mistake.

CC @peti who marked it as broken in the first place.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
