### PR TITLE
python3Packages.wxPython_4_0: build on darwin

### DIFF
--- a/pkgs/applications/science/robotics/mavproxy/default.nix
+++ b/pkgs/applications/science/robotics/mavproxy/default.nix
@@ -1,5 +1,5 @@
-{ lib, buildPythonApplication, fetchPypi, matplotlib, numpy, pymavlink, pyserial
-, setuptools, wxPython_4_0 }:
+{ stdenv, lib, buildPythonApplication, fetchPypi, matplotlib, numpy, pymavlink, pyserial
+, setuptools, wxPython_4_0, billiard, gnureadline }:
 
 buildPythonApplication rec {
   pname = "MAVProxy";
@@ -10,6 +10,11 @@ buildPythonApplication rec {
     sha256 = "fe046481b793b592334749249620fce8a463f4c46b394ff744645975465d677b";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "opencv-python" ""
+  '';
+
   propagatedBuildInputs = [
     matplotlib
     numpy
@@ -17,7 +22,7 @@ buildPythonApplication rec {
     pyserial
     setuptools
     wxPython_4_0
-  ];
+  ] ++ lib.optionals stdenv.isDarwin [ billiard gnureadline ];
 
   # No tests
   doCheck = false;

--- a/pkgs/development/libraries/wxwidgets/3.0/mac.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/mac.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchzip, expat, libiconv, libjpeg, libpng, libtiff, zlib
 # darwin only attributes
 , derez, rez, setfile
-, AGL, Cocoa, Kernel
+, AGL, Cocoa, Kernel, WebKit
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.0.4";
+  version = "3.0.5.1";
   pname = "wxmac";
 
   src = fetchzip {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     expat libiconv libjpeg libpng libtiff zlib
     derez rez setfile
-    AGL Cocoa Kernel
+    AGL Cocoa Kernel WebKit
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/wxPython/4.0.nix
+++ b/pkgs/development/python-modules/wxPython/4.0.nix
@@ -9,10 +9,18 @@
 , python
 , doxygen
 , ncurses
-, wxGTK
+, libintl
 , numpy
 , pillow
 , six
+, wxGTK
+, wxmac
+, IOKit
+, Carbon
+, Cocoa
+, AudioToolbox
+, OpenGL
+, CoreFoundation
 }:
 
 buildPythonPackage rec {
@@ -26,8 +34,16 @@ buildPythonPackage rec {
 
   doCheck = false;
 
-  nativeBuildInputs = [ pkgconfig which doxygen wxGTK ];
-  buildInputs = [ ncurses wxGTK.gtk ];
+  nativeBuildInputs = [ pkgconfig which doxygen ]
+  ++ (if stdenv.isDarwin then [ wxmac ] else [ wxGTK ]);
+
+  buildInputs = [ ncurses libintl ]
+  ++ (if stdenv.isDarwin
+  then
+    [ AudioToolbox Carbon Cocoa CoreFoundation IOKit OpenGL ]
+  else
+    [ wxGTK.gtk ]
+  );
 
   DOXYGEN = "${doxygen}/bin/doxygen";
 
@@ -50,7 +66,7 @@ buildPythonPackage rec {
     ${python.interpreter} setup.py install --skip-build --prefix=$out
   '';
 
-  passthru = { inherit wxGTK; };
+  passthru = { wxWidgets = if stdenv.isDarwin then wxmac else wxGTK; };
 
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16883,7 +16883,7 @@ in
   };
 
   wxmac = callPackage ../development/libraries/wxwidgets/3.0/mac.nix {
-    inherit (darwin.apple_sdk.frameworks) AGL Cocoa Kernel;
+    inherit (darwin.apple_sdk.frameworks) AGL Cocoa Kernel WebKit;
     inherit (darwin.stubs) setfile rez derez;
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8121,6 +8121,7 @@ in {
 
   wxPython_4_0 = callPackage ../development/python-modules/wxPython/4.0.nix {
     inherit (pkgs) pkgconfig;
+    inherit (pkgs.darwin.apple_sdk.frameworks) AudioToolbox Carbon Cocoa CoreFoundation IOKit OpenGL;
     wxGTK = pkgs.wxGTK30.override {
       withGtk2 = false;
       withWebKit = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #86040

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Building in sandbox cannot be checked, because `clang` fails, as described in #41099 and #41099:

```log
configure:16875: checking whether the C compiler works
configure:16897: clang    conftest.c  >&5
ld: warning: directory not found for option '-F/System/Library/PrivateFrameworks'
ld: file not found: /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
```

Building reverse dependencies fails for the same reason. Essentially I have no idea if I broke something for Darwin users and no reasonable way to check it.

```log
error: build of '/nix/store/fzcx83xcq7ni2wrmjm8j6h894zn1b3cd-env.drv' failed
21 package marked as broken and skipped:
ell errbot mergerfs mergerfs-tools meritous torcs torque torrential w_scan wipe wxGTK29 wxGTK30 wxGTK30-gtk3 wxGTK31 wxGTK31-gtk3 wxSVG wxmaxima wxmupen64plus wxsqlite3 wxsqliteplus wyrd

30 package failed to build:
asls diff-pdf elixir elixir_1_6 elixir_1_7 elixir_1_8 elixir_1_9 erlang erlangR20 erlangR21 erlangR23 erlang_javac erlang_odbc erlang_odbc_javac lfe mavproxy mercury plover.stable python27Packages.wxPython python27Packages.wxPython_4_0 python37Packages.wxPython_4_0 python38Packages.wxPython_4_0 rabbitmq-server rebar rebar3 relxExe torchat tsung winpdb wxmac
```

@LnL7 is there any progress with (or even desire to) fixing sandboxing on Darwin? 