### PR TITLE
firefox-bin: 80.0 -> 80.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "80.0";
+  version = "80.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ach/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ach/firefox-80.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "4679b0ce4913b2c240f873fe5898234362d0b2cd6777e73ce272f37950edfd02";
+      sha256 = "d3297316b481d6fa10cf71e7d1331f407e6167fbd1b6a854fc39fe2aca466250";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/af/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/af/firefox-80.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "ae2f6e7d46344f56599ef1e7ba3f3321636ee378e8e1a4c0b8e652c5e71b932b";
+      sha256 = "464726f6cf660a8f5d6059ee85fdd0b87cd97c51abf578fdb851a181c94b110a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/an/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/an/firefox-80.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "8ae2ea7f6184f5f0cd5bc937924cfc5d813bb8bb0ea3e4e0770352b15291c043";
+      sha256 = "3fcc891f53ed5986554c5f595fa75631402ae35eb484ae22c15cdcf3d1885311";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ar/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ar/firefox-80.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "54926c7b61e4d99f1d49f709fad198604c5e5af165d60a96c6f5cb1a94f73884";
+      sha256 = "d30299d7e707c7528a87d3094612bff6013bf135f4ca5e2cc2105bcd434baddf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ast/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ast/firefox-80.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "589262534a8665387cbbb3c13f5003738bca4c5673884bda831a4858aa73de54";
+      sha256 = "c766b9c3fc2b63e0e61e113678afa783efabb96620d1715fb72bd17f4a93188d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/az/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/az/firefox-80.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "60bfac6b93deff04f63c67dc9944d3df8efb314054ed6ee8f93d3b09db8608b6";
+      sha256 = "49264b6f35bc0cc5198782fd2fa62a0388e04141b1580a44f71c48e6b44853df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/be/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/be/firefox-80.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "48cdbcb785f190dce708db6ca1fc711d5d2411da0f544b3a5d03aba6665efa1b";
+      sha256 = "391f9423e7211790509e03822a4186117320da8f660a1e3b44ff44712235762e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/bg/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/bg/firefox-80.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "a48fbe5f88ec729c1becbf7c63957ee48cd7692d153dcf709dd038ce1a218317";
+      sha256 = "45e04e624329abe7704242581599a11e177ff3418adc49cd5bd59f45b2f0d517";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/bn/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/bn/firefox-80.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "38245ddeeaa699941f54ba3d3d0fc3e804b57d4e8a6a0d1c58cf25d7c271a23c";
+      sha256 = "36c1ce02ae8b4ed1dd78ade3dadfb24042c6fe7d942c9e3be6b9c94dd7fa96df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/br/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/br/firefox-80.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "6766542a98977e6f2329b76345ab8f59d545479f1564261a47c0cb7b7db1e3d8";
+      sha256 = "83c0b3ec0fcf7d26a45c7e59a7c467c64fbc7d9fcce5358451e51828aa57acde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/bs/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/bs/firefox-80.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "9bcd21931680502a9a5459f82a6d103d8b367b09cfa9048f54d87ca654e39e34";
+      sha256 = "d1c1dbb0060ab256ca932f1ae2a8df8e8b130242c8a1d9014a047eae79d95687";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ca-valencia/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ca-valencia/firefox-80.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "a666b19726a6d10863cf351059dc45f610cd0356e2220a8d9e2a5bf2df0fde3a";
+      sha256 = "8b4b1b7bb92287b4049712335c6da52f7bd825490996a48e4b376a3811700790";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ca/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ca/firefox-80.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "458e791ac8025a56a7a9444aeb8aa1138f5108c5a5cd1d87a31bbe71c6ed51ca";
+      sha256 = "34a48e1d85e7557b318590faccf621fd4c32e51060dc5d06f40ec933599ac4b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/cak/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/cak/firefox-80.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "890f462890cdc825e138d174e396b78e10f74111d01da47514a8e449ee470676";
+      sha256 = "8db14d21c578d8e238b3a0882bcce70bb48d66fe60fc74053acf5bcf212fd243";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/cs/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/cs/firefox-80.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "98e1bec6f176bc83da232b76b33e6dfe09db91c4be1424cf0c7b4e18e26b8d5e";
+      sha256 = "361414fede99694a9b8f31076b1a9d7c871d857870cfe0ef01cb3e02a5be0b3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/cy/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/cy/firefox-80.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "06b649bc87eea5c81fa37873582a963d972cbc3d0a65fa9fcc12c67c107ccfbc";
+      sha256 = "bde481d7acfca3e0c33c63d7dffd9772adbd11c252dc4e92367476c5fc347cd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/da/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/da/firefox-80.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "98328f0f7ec2b807717fd4ae6aaeb7daaae8a962eb929b760598f225f6d9e784";
+      sha256 = "bca4e7d4690cb950d9fa87623da30b93f54d0efd005e440b1af9acb06833baf2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/de/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/de/firefox-80.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "401877f41fd2bda02d0cbb7737f029f648e1d2b3c9642b093ef8bd4342f13712";
+      sha256 = "e4deb64c304ec7b5c06c0f8ec8299d6c513def1e0524cb93dba2fb3e22fca8e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/dsb/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/dsb/firefox-80.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "408ae85999139ba5c027bbf9ca20157b991e741349aae77176c012b862a7b4ff";
+      sha256 = "809080cde0646ed2e4a64e2e70beb25aa3dcc47f7f749f2722c898f8efd9271b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/el/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/el/firefox-80.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "430c1062e9edc9bc4a0a47268782cb7928214df074aec17e2e3a283b7bfa69d0";
+      sha256 = "7f5abfb89c70187b9b8e954c21b566da9b28781f1de80634da6c47d149363cff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/en-CA/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/en-CA/firefox-80.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "7f8d97a5643c959eb09119264c8829c7b7227c01f8e035b17f3c21eee3d1e0c9";
+      sha256 = "61d6a1cf59a89d2e690423f38779dc7c776757ed39a1fd66b9bfa6b5e63e68b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/en-GB/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/en-GB/firefox-80.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "d2361c90c46dc43eae25ff53440157322351645d6a20ed077e2496fbc3b955bf";
+      sha256 = "75b1808a6d5ea0b70df3bbb7d9b8890418069c5fa9bd8a5dce6b0f18f5e3b2de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/en-US/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/en-US/firefox-80.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "84191f06dd927cd16b8c0900e6c330f68cc8012bc48e9277891282a2d6f7bce7";
+      sha256 = "3ac0c9c4454647ce986bbe6f3567b0e1de5c0719ed6b6627344292c581a2afd3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/eo/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/eo/firefox-80.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "8a9f5359cbb0d8a0d173d3302181ab41f463d8cf6b17f9c06e33432a95d79b0f";
+      sha256 = "5c61e9348fe69bbd32d9501730b9cc12c14b55746b5b670379ab0c463f2d71c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/es-AR/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/es-AR/firefox-80.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "0f5e7d4a23daab7c96cf706fe1c5a62d9a244d39bf6be97325cfcc1d699936c3";
+      sha256 = "0203caa38c1526c8c3df9c315e205770b43594f222364f9bebb3e89485a1803d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/es-CL/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/es-CL/firefox-80.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "fd914b5892f2aa297054e79c6d6d863f1b4d88ab1a2bfae3d40192848c9efd64";
+      sha256 = "c2b7e09dce573ef945379a7a5f7691d877efa14e226bcd20ad48a3dedba1d1d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/es-ES/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/es-ES/firefox-80.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "b87aa07e99d0c8d3a17c76bc7e281f8309cda97565bbfa4dff653326fb2bbcb5";
+      sha256 = "0653d855ff0e04b6f6a6e44de558de69fac582996c7b944dec043810c8faa704";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/es-MX/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/es-MX/firefox-80.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "ffb619b95658d5001a036e0906689f12520cc25d541c4b5b154e44e4b176da33";
+      sha256 = "9c6f7b6208b390a73dfe778ac0a798b4999abe93840b4224a5852143f3588f2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/et/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/et/firefox-80.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "2558280c2fa85aa3a2fdfc59994de6a593ccbb6a7141e76c21e5318152b6e992";
+      sha256 = "786495f0ef9af4475755378d9ae3095041c4f329e9cbca197eaff0199d6bdf02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/eu/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/eu/firefox-80.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "0ad66a2dd10d1e5b0d44e6db28982d82430acb7cef6e465ad0c88fd7958606ef";
+      sha256 = "91c9baea255e46ebc3ef8702eb8e233b395cd39c9c092c0812adcdcb60f5f3ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/fa/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/fa/firefox-80.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "39b1bc086dd14ced01668961dac12a5408f5cc261188b2c32b6114dc70c67e4d";
+      sha256 = "1baf78177598c3e0fa6714ed85a305b6a811baa26b1d0c6d7d6d05c8bb8b8595";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ff/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ff/firefox-80.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "1511c50bd3ced8f570fe409ef609a6c9dc626d061156e5091e667b9314a5c4a0";
+      sha256 = "20e44b613633e84c8808c76ccd61a78bb8dce1a09bdaa1d6aa95dae1eacaafc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/fi/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/fi/firefox-80.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "4d9e7fe4eaa94e4a2195589cdaf9f58c4b55339751001e87bd42a6326ee26787";
+      sha256 = "d6f634e7aa109d368bb2b7e8b3c3682117d350ad7630d6283006f8d22f98201c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/fr/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/fr/firefox-80.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "99f293639744dd8e2615bc4d6290d2f5baeb9d646bc796d3bfac5de8a1c001f8";
+      sha256 = "a0c7326670acb7b097c17905b23410819429b2357534eade971a9c3b22b268ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/fy-NL/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/fy-NL/firefox-80.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "a8628d16e51d7355198415f086186c9874f37f9250e64512457aa725c8ba9f04";
+      sha256 = "f28ae560003555ded4590f0640a89090cbe0e732449973aa2b42d530e3829b73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ga-IE/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ga-IE/firefox-80.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "df63d7991979e8fdf8f6911f8df2122d9995c50c089596bc0f7c0e7179326051";
+      sha256 = "04b260885b755f9c7fe93a82ad10855abfbd14706ec81f0fe38c96c2355c833d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/gd/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/gd/firefox-80.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "616906a45df46004e081cba3cdadd2782c3d402619193f5d19142977b7ff0fcb";
+      sha256 = "b8f4529a7970906654a6df2f91a5687d49dccf8f1438ed86bcc4d9608a2f26fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/gl/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/gl/firefox-80.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "bbff8f63ba3c029c97e5d40d3ecb41d757b5fccd59018dc81d7484f12c830686";
+      sha256 = "234c4f3ddb6e5a59f8eaae2b58d8a1dc302f66a5e7edc6337d9b1e6e1e1dab24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/gn/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/gn/firefox-80.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "62d7fbf8afb95d221df768fc190381a859e142a253b8df6b63ee276c4111077e";
+      sha256 = "0c7688233efc95bcbefa8b2faaced313d69c0fb246a91564b3629ec24026843b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/gu-IN/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/gu-IN/firefox-80.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "3e451729a93e315c9ae767d21c5fe25c505e327ab435c5a9c4f606e04ca61051";
+      sha256 = "12c45963b4b7e4976f656b60e9c4964ad871f96cefeb5e898c3a830c85d92d78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/he/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/he/firefox-80.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "a48159e9c2798308ca4765f02ac90a0a2b05029ae0505ad59688d281fc06344f";
+      sha256 = "8e0c8c06f5e9665a7bc9733e3afe514620c2b6071451c9ca05f0a1fa9b953c58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/hi-IN/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/hi-IN/firefox-80.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "39341543e9e8e2d5a377ead92287413df77d2f1c00a7362eb42d8e640b8f75ab";
+      sha256 = "008d5f194b9572ecee09ea67481ed1fa91f6a7987105d90c53924fd9d8e7ec7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/hr/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/hr/firefox-80.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "0067b77ff388004e0c60855868f1a45a282282b8c7360847b65ad2b53a558010";
+      sha256 = "2ce4d27f389f2f4137d8f8487c4f4d32bf6833870592755e13694f48ab6966f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/hsb/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/hsb/firefox-80.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "5c3a47a28a8e67f6a5be72540d9ae85474e093b1a67254949794918a8294ded6";
+      sha256 = "2c540fc55a0bebe2886123e3edcaaedf793e022eb0244c2eead9e1fba337d129";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/hu/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/hu/firefox-80.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "2c6e390d9348d2d9c1f2adc30b73c451aa6fdd281dfc040fa79dc7365a5414f4";
+      sha256 = "8f2c14860f0a97c2aea13b262a7f4ba62efbf643eb285f2282ba3467d7aa59c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/hy-AM/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/hy-AM/firefox-80.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "ba3d7371aae296aa6417e3c5d2b4647c0d0d0cb4f20441be525f2dd2ad594125";
+      sha256 = "c003e6572b150a9c0f33f1fe0d2d2e537e1d5bd901b937663cbdb8c50a0b2639";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ia/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ia/firefox-80.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "799ba99b5e5c9568d94c7ee7a3bc482eb6d827830ecdc8aef9a2e4d9b157634a";
+      sha256 = "b8da547a7236c08b681d33d405f6ddf3f17a5342f8354a3565c6dfc39d3cabd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/id/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/id/firefox-80.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "97f9f9194178918d8af8453b165aaede0a236e75b973a8ab0374a36ea4a8f8cc";
+      sha256 = "7c3adc7ec426b3f8a2da36fba744d07774037fa8dbadbf727eae3fdbb19a3bf7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/is/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/is/firefox-80.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "f63efcd86ece79d4a996c23e22a1876e3db25bfc09e5132e1832c309711d9012";
+      sha256 = "57bbfd97596d9d2c557186d729ea74f233bc50833d8a1d768402cf6d25cb8dd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/it/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/it/firefox-80.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "c1d5fcbe8a3fba613e5da888f5252043663b7a1fb801da5cf54934af11ea5782";
+      sha256 = "0de8a984c4a328020d351edfefe717325d4c50403f126b8c211b2798062c854c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ja/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ja/firefox-80.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "75c5d37fdf2a488b0dbfb09c6bd020db90d699713350ca3c091d5e8096d41d18";
+      sha256 = "5a718d304fd3dd30abb9b9b5f6a54aca5c9a6cd1c9ccc3bd5859773112432f8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ka/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ka/firefox-80.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "364b16782a4948e986268aca5e07dd92367120e97aa1d3bcfd5b78e58f58025c";
+      sha256 = "2422236d92428e2a0f921433f6bbcb87505aac7110cacc6ca61173a28555ba35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/kab/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/kab/firefox-80.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "20a5bfaf08f75040d1c627f79ff8cb133d0574c83cb13f8902367e88a3742bfc";
+      sha256 = "ab81137395002af2626e534e5133b455d4b50f441cf71f9a11b8f92444221535";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/kk/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/kk/firefox-80.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "f61bce593069f598b8b8fc035b09607f423d5600df7cb620360fb1aaf4cce68a";
+      sha256 = "daba81c27dc36bcd267a0c77255b8333b8ab0f3e0e338a74eb17a36cd83af7db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/km/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/km/firefox-80.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "7056f40cc5fc9d59145f4e08a4b19aad8e2b473beb4d8a7b09d636559bcd8457";
+      sha256 = "021f7787bfe87ccc8bc33ed6668196f4a7d528672ba14eff1ca4fa4efe0c2768";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/kn/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/kn/firefox-80.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "c18b07bc5ee941f001e3ba9336d677f51b60dc08c2bf516b68882f647475b5b9";
+      sha256 = "973259c5b54672b0f5aedbb5c2126716cc7b8792f3b2c6f9d6d745eb9e6d9529";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ko/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ko/firefox-80.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "7b58b30aa461119ef842ee886d06676fb5b00d05547e959bbaae4ab597cdcda6";
+      sha256 = "3bda308c8bce3b00250827d7b505c9cbe9574cd7809dd866ffe7a230dbdbb7bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/lij/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/lij/firefox-80.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "8107773361daf1257a1a77d853ae5baa1e9ff393d16118fb1987723f2a7af33b";
+      sha256 = "c57dccdb4f9281b31c1b359bd2a07b3376a693f3f37c513223029fa854b61644";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/lt/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/lt/firefox-80.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "356a337cdb3ea658e6723897da2f8d99179ebfac01d071f641c661eea1da52c3";
+      sha256 = "ce04853033bb00b760c4814b436a67e151f54842ab736b440f118c44945e53d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/lv/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/lv/firefox-80.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "10a9272101d4b37ac5949f2606317da5f41d205cfdc0967cacd9c72aba550cbb";
+      sha256 = "79b71529569df018e86925e8df25dae43cc54629eee50035fe515c9299d2664f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/mk/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/mk/firefox-80.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "45618096f39f0c6e28a900e2a5985fc1ce5c9fbcd6abeeb2d21fb4b5bc095876";
+      sha256 = "3a015b82f1f966e1ecc49af369ff80bd922dd1dd4d93a642c9b7bb8f9ea078bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/mr/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/mr/firefox-80.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "63d774fdd4f825780c7f667365a560b72dd1f31449d408553f8c51dfb6583dc4";
+      sha256 = "4fbf77e82ac6739eb4f557ef9fbf2d86574c50260d2661964ee01b99d496a10b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ms/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ms/firefox-80.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "fa67faa072b03b64132320a19691eadc719f8598167aa39f21d097b1e8fe42ce";
+      sha256 = "c6e07a8f1eff5239ee19eec7d4828ca175535656fd130fcb72552e4585e1d9e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/my/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/my/firefox-80.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "e40c7c534108dc7e9f978d3e6ea025e41b0e6120b9dd701a7935f90a7c4b834a";
+      sha256 = "a98a72b72665fda08f2b834af3a7c060d07cd638a69cad4f165f9af4730b642e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/nb-NO/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/nb-NO/firefox-80.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "99b52d2ecd2ce0154378630f80f3bb9371d0cb7c59d780e8abcbd47f7008a7c2";
+      sha256 = "948454e67ed57e47f3879c866c9ef72245b552066689d1e5d7e95431c06c72ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ne-NP/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ne-NP/firefox-80.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "49e9e67f879ecc519001ba500d136285c89a0fef3f7b8b1a693e8efd2af152cc";
+      sha256 = "280857446256df49b901eae8d64f4255fb279dae7f67ff83beefd59d227ea466";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/nl/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/nl/firefox-80.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "ada875468cd865efa4023bfecc0cde06469fa3bf655944a2dfb945603d3ad483";
+      sha256 = "6e50983c69ac40ddb403c1e2a5b6ac1fb713bd1d169d8dd402516f827907d457";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/nn-NO/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/nn-NO/firefox-80.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "b04996dccdb1a34ae41066a58090eb1be8fef2d458cf1aeb0297650123ffbce8";
+      sha256 = "27178fe7b5bf19c4b9fdc42c90651f4c53379996ba67b743485decce0fd9e18d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/oc/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/oc/firefox-80.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "c6db46006f3bdaacd7a4ede17166e2bbcb4ef672d432363e86a819858327d867";
+      sha256 = "aa517e0e68aff16ccd693a7a282ee8aef1df8486b68b546af166bf39ef67baba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/pa-IN/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/pa-IN/firefox-80.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "a52fde04d6f25f6ff0641ade83dbb88f4d15aff689a041cad36352705fcb43ae";
+      sha256 = "cb5ea9559d416f44c0830cb1bc85fffd3ee02a63697ffed7c0d5ec9bee8bf1e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/pl/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/pl/firefox-80.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "6918dd7bbde254eef27b740147d64550a1b4203979fedec6f9064006300e4638";
+      sha256 = "36d0b84933e689b36701b50c1145b6f64e8f09af4ab8a7aafa53e1d33d8148f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/pt-BR/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/pt-BR/firefox-80.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "21bd4c8b68c7154889f4d06cec9eb3696dde94e2ec2b946f25a627ade2b16a7b";
+      sha256 = "24093debf351c29812350c5feb68f741fd0d05cadad962ec5acb5ea0d9450bec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/pt-PT/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/pt-PT/firefox-80.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "b30ab69cacd27d7a60a0387caea18712cfd4f4e2dd45f7bb51e3074e46dc3f05";
+      sha256 = "bac0a7f9f902ec3a1006a45a330b52520377b43c61aba4b6fb3a45eb126379ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/rm/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/rm/firefox-80.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "9fdba8959e1276684bdd53c2c3d02e80768f3e9a289bccacf5a719f5ce51efbb";
+      sha256 = "e86c79a49f0c980ff4ad60f151e9350e66df0ecf8b9bfcd08586cbae9abad957";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ro/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ro/firefox-80.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "e31d0a914b107736fb83e686c5c011b912b7a5b04fb394b7e769c40ab249b504";
+      sha256 = "32d089bfa4ebed3c6938abea0e16a9527cf303f6b9c5fd68e3adb2cd967ac3b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ru/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ru/firefox-80.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "3b26ecd7fd38e224625def5087fe5e6ff1aa408e3a04a06e160e688402026113";
+      sha256 = "75a470c503f19282b3b1730cfc1bfef450634f1166d094b4e4f30a8f872da1ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/si/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/si/firefox-80.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "bb37483590bfe23951063e15626724a665cb03de6ce2916992ebad88759f2691";
+      sha256 = "f919ae9b3f2b6e1df1d073e3e7556091bc3586584c39a8dcbe91b8c29a4396d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/sk/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/sk/firefox-80.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "60be0fae9156d425708360e233a39e8b1d2be45216d8a155d06f020fb5808cd9";
+      sha256 = "de6b476f015fad31e80a504c29c05d60c95c0dce18309765a3108ab27c926900";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/sl/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/sl/firefox-80.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "d1261f9dc8091df947df5e64b5123d8d4b39bf15ba6dbe5fc4844bce9f3be220";
+      sha256 = "9cba9b423bfda5788a76692e78310d961db70cc870e0797bcfc4020dc63e2019";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/son/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/son/firefox-80.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "76ae5c6f4890d5c29ee33ffd81923696f755e6fe0fa8081c75e72ed1599e5070";
+      sha256 = "4423551873bfee1d1d4c7acdeaed8a133df3d467e711d4b2ffdcfe4dcecf434f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/sq/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/sq/firefox-80.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "5aa679e980bd0808b0c924e4ad11bb6b3256afd031cb04f16f862eb9bfd4644d";
+      sha256 = "739918066fae4e5b20093540a2ea6e527878991ffab59ecbbd264aba5a13eabf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/sr/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/sr/firefox-80.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "a4941d40721de72abf22b97846cc16de49670d7f096829aa0d1775089734d36e";
+      sha256 = "5fe944b1fcb260fdbd747b9009ce05708d6ac82ae9f501d6a7efefc87d95fbfe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/sv-SE/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/sv-SE/firefox-80.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "c50a2d0bb15cc95982e3d2997719a65eba6e0099ffb13b066e66e5aa951375fc";
+      sha256 = "3f0ba11adce493f8ab6a771a362ada50abe442f60a2d910a36339ee19889b152";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ta/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ta/firefox-80.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "53651d5b0ea3d36c6600c57f02c27202f2f5b938aef34de4164f325ef46d8666";
+      sha256 = "7fdcfb26091269bbda4f81991d3dff20fcbfba534be9e9ae315459306aef0d17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/te/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/te/firefox-80.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "5225d57d4a5c83843ecc83735be2fbb4004d4411da5ea72340cd6306078fc426";
+      sha256 = "54fbdcd804f4d2dec3096a041927e65ed999126f21a748a7f0b36091c4c4c7b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/th/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/th/firefox-80.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "b38092aef16253b180dfe0d297ee1bb8417dbb4851466625b80858a18b2d3801";
+      sha256 = "ebccb1cfdc0394889e7c67a5ef9be54dd87818c8f326e89ac6a97fcd9865c721";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/tl/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/tl/firefox-80.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "5ac9aa87ad90d60a852f7cbfc611c05eeef09b2aba46da80a2ddb093ce5f1730";
+      sha256 = "7585a169f7975bbaa752caacf1863a2bd3ac9eeb17a031492a7cea5dd1b24efe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/tr/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/tr/firefox-80.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "b2a6aa22523f9d3396675c60ca7590e9c379a15c445727f01c3ada090a0557fa";
+      sha256 = "a475825fb5f0125f16edc895921d3839393fa806a12b3bf2f296321853cb66ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/trs/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/trs/firefox-80.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "0e3e21f8c76bba90e730959e3f176c5b4406196a4b9f00aa4d85088495eeb337";
+      sha256 = "4dedb4d60db089358b9371a828165f6fa7e329af5deb1177d090730c22323b9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/uk/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/uk/firefox-80.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "626f9af6252a003cf869067de439197d8b0dd0b73e654310f439579959036f5b";
+      sha256 = "5a2a6f9234db28e79c8472206d40f1d403af05de2f9f4e1b6253bf3e912386e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/ur/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/ur/firefox-80.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "67e1108697c033ba3c6bcce7e36e5ab269f66a75674795e931aeeefadd7e949f";
+      sha256 = "30f3516680ef54d1e3636e858b8000aac4ac462e3fe6e20db16fbb0d037c2394";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/uz/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/uz/firefox-80.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "90e6d82c75ee24925cc6fdb48674e7ace3e58fd2cf27441d8ba9b24002b03a03";
+      sha256 = "84a6ed8eed48ebf993ebf779c623472ea3d2bee84457fdc4e1968c013c8b8383";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/vi/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/vi/firefox-80.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "dff1e18e968d514b91d4f3c419da0570478e1667485761be703349b5c6019124";
+      sha256 = "eb58bad9266d0e46b55d4815212083609197acc4c8a7cd3a1ee9901adca7dae2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/xh/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/xh/firefox-80.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "1d524f5c5e6003c4cb1e00676ab5c369752c80c763684d7550224c7bdc66ca68";
+      sha256 = "d478b199b9096b264f92f793f713b3e1cb42fb7c5f017ac0f1b82eea33434cbf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/zh-CN/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/zh-CN/firefox-80.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "8893528da90e46d8eb287ab857ee6e18d89355d7901e221c7820d7f1bdfc155f";
+      sha256 = "b91d7637a20ebd8dc3200d222f98ac2d065a3633988ef0d17591cc8e72efac03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-x86_64/zh-TW/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-x86_64/zh-TW/firefox-80.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "8b01036a6c807e22f66ccd93fa335e3fe71476e7a9993965172b85d2eada27ea";
+      sha256 = "42bbf8d38c417fbf0d6de21e4fb4f3090096e0bcc2820504b8ea69f057d50a91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ach/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ach/firefox-80.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "1bb95b52770a8cad2b339874ac4576e190790935dfbfccf22cfa8be41e3b7e5a";
+      sha256 = "1d39224b647c9a18c6a5021366775c05bf704bf316d6329f170cc4eb59c05a10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/af/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/af/firefox-80.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "919522f2c9d8f0b3c7f7c7d4311735e68eee173883c80f4d168625b690d0f29c";
+      sha256 = "a4b998c95454270fa98c59cb94dcad6e5db2da8a92f9cd75e8d0e30041eccc5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/an/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/an/firefox-80.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "878eba95507de8dc1788e01facd9710e39cb62d75229d6204601c58ea0df4cf5";
+      sha256 = "ff786a29ef12215fdc8bc057f596ef9ab1ef207fbe84910504a314e27fa54c79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ar/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ar/firefox-80.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "4bfc935eb7a94eb6cb957b118c4811cbc0d1265a9fbcd4b4ecd3aea593658af1";
+      sha256 = "498ecc3042b4ccfbb155e632531df9ab75f7e3225820f0fe6929f80a91a91660";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ast/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ast/firefox-80.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "c64157e1ef1c361cf1dff89ed443f9b7fceab088c3bdac4058e262a1c068c97d";
+      sha256 = "1174347fac624e8c4573bf80ce0867ec8e94694bb0cd623de86949fab0780044";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/az/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/az/firefox-80.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "6045ef88f6cda1ac9b87854c7ac0dbfe789f9a4b4f7d35f9612beff57d832b60";
+      sha256 = "ddd0856d036f9f3eb87874440bcd6e85106f7391f03e76cd1f1d5428a69b8374";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/be/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/be/firefox-80.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "6c0e25a6610a0da75f086a829a142f1b7f419e1357d7c97efaba4f1a9c95b5d2";
+      sha256 = "23a8c4cb1c4d9e0e0b5a5924119670a4224ded0595d8326ae500a7bbafdd49a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/bg/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/bg/firefox-80.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "1c8579439940499262e8e2096f16bd6767441b72a00774a35d76db9463fdaf34";
+      sha256 = "a0fdc2f520e251f624ae19a169ee7f1349017a8af87b9c149ea731e32054ef4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/bn/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/bn/firefox-80.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "06eaec1ac31a6c2dc21eaa871aa2dd4f45a299458d5cc950c2d52454366ba1b3";
+      sha256 = "553e9a0704e4984e091716d41fb040f3b93bb192fa292cd7453ede137b170b74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/br/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/br/firefox-80.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "3f8a1a9204ba24d2367f6ad995343eccdb48c981d726ed72e6f96b3579bb504f";
+      sha256 = "dd82f29c768befcbcc691a1665a5fe2e519f94558c331ed29c368c005e764d25";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/bs/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/bs/firefox-80.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "61da2d6bb7dc90615949b10ab45ac56d38ccd4007ab6f0ff730454994d303f6c";
+      sha256 = "59fca5c16258a5f5e3f8725ae1da886381fc78963fc6174762c9b74e6a83b01f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ca-valencia/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ca-valencia/firefox-80.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "15ea7d6e7eee13f2100111b8c9fd10cba728acdc27575ad0160b5baa5c5ba0f1";
+      sha256 = "d75878b8d573a96a65fe320cd00208733f46984b88f44a3ab571bbbec17f2fb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ca/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ca/firefox-80.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "140c3b74f0edd7ad47c07dfd5cff6fd224048560ccc691467a00d3c67cc1505e";
+      sha256 = "f89d8655184f74f3218510d8e44b8bf4fe9840fc3555d4a4ca59dab8b77f8a46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/cak/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/cak/firefox-80.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "614876abaaddbca2dd2c56eae7b865828fa446c07bc5401f7bfca7637edb2728";
+      sha256 = "31008fdaf9a7ff5a3051b936dbd4253da76770da2e59fd97707378b4c9cae4c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/cs/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/cs/firefox-80.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "2dafa0635a3192a9049d7804f97beaccf6e62a8613e96ba241dff1728aef840f";
+      sha256 = "7e8ed50ec696cf3fa98aa2ec0d2755e0064dd285c43f17fc4f58adfb427cbb3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/cy/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/cy/firefox-80.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "1993cd996e6027b4dbc0e306ab8c09772e0013bdbdd2dc9c774a702555b2f21e";
+      sha256 = "64b5cda8d4a0febaa96c778a3b45c380903835b7eb27ff375cb24c7ab3c56813";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/da/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/da/firefox-80.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "8fb1663ba5f646cf65593fe6eb57a63f750b555f6c75fad7f4a9d3592bb46421";
+      sha256 = "b7ba473e03fb0bd3efc7f00882270e65e2f74d12e4a150221519e9fefed6f470";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/de/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/de/firefox-80.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "9536de23132d6267f3535e08194679ec16afbcf1c3cf6beaec64cff7de38d701";
+      sha256 = "4ff6aa86a82b4466c5809fb192021fcacefe3309f73cbcbb8d4f952c066e4307";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/dsb/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/dsb/firefox-80.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "277cd59ab97d33a89e621ca3819fea2cc58042cc373891fd4599cdbddbf483ef";
+      sha256 = "8ff130011dd318c45d7c85f26137a73f2abdd90eeb21ff4e29f45eb786e24541";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/el/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/el/firefox-80.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "609c2e25ab34f793a85e60ff9fec4d4281bdd228026ef698fda1b25e956142ed";
+      sha256 = "c2c7f0d40a3c32896678cffce276a8d71613b09eda6fa715d10f156c13a1f6e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/en-CA/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/en-CA/firefox-80.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "ca54e8fd35633530605149ca7aba49099098f96e880dd0629885e6c867c3d632";
+      sha256 = "b06db042a7429c1743f4b0488e403a5051acfa1be556e07769880345b72f5cf1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/en-GB/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/en-GB/firefox-80.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "6a6e6b1b34fbaa578a035e430d10fd2911bf64e1917b170cd47ab565ddf9bdbd";
+      sha256 = "435e24ff0665065a2eef6efbd8ea86e5c7e2752f44c420e94a7b0fdd503ea5b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/en-US/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/en-US/firefox-80.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "d87d71827f0161f7d3230217fc4f7c7bdca804ccc5f49b4d107151fbcdd7622b";
+      sha256 = "fc1d7b798644f41a0da9e2dccc1e8fda86cd12e2f2dd3808ccbc247084221648";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/eo/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/eo/firefox-80.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "50f158c96b8de9b789dbc138004646ae583b900fb067b59108ee4ad97e0cd2e1";
+      sha256 = "e5504a7bf75e2eba860f61fc3fdd979b2a766a4299b3652bf62d5a46526e50eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/es-AR/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/es-AR/firefox-80.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "e5589a3a92ce6ee1b5756beb4cd6903e1526d74d457bf3fffd8b9072ded3c5a0";
+      sha256 = "b53c9605b8798c6ecea9f1f47b0a1590a788c12f2fa9c09293a05ffbf4b22d53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/es-CL/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/es-CL/firefox-80.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "3188fad7ee67a0c98b370ac32a50136c41f69154f99fda13804d16356679a87f";
+      sha256 = "a2fd6bfce565cebfae759dcbb7b3cc3f504f0bee5324849a63a39fc65c36724c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/es-ES/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/es-ES/firefox-80.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "c9f37fa0ab8e4d3c16cbc20ae9ce0f0a568a9cc2c48fbcfa114b1ab2b9b462a7";
+      sha256 = "c15751d3f0dc389d2a2e9cd40e8da88f1710a6f64999d106bee1dcab09daed5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/es-MX/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/es-MX/firefox-80.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "f07ee3d9317157e5205187bffddb0339fb810ff06aeb192d12e367acdfe89592";
+      sha256 = "070a68c0893d63c5663252e52664cbeabbbf0d31542499575507644e003664ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/et/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/et/firefox-80.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "01aa2da0ec5504f601e774fb9a35e0b8bcaf59fee1cf8fe33a5d29c05fa75d68";
+      sha256 = "2eecd4ff182a25ba4e1a1edb78a8a9b1881321cea2740207795351700af1f4a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/eu/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/eu/firefox-80.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "6d3f10b801660064e8f51fa45bc17bf1fec641cbb526e1da925b8eb71b863112";
+      sha256 = "5fa2531712b5dff1d9931a369e774dfe15d2fc74078ed65ced0196b80faf2c8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/fa/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/fa/firefox-80.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "0f519bd6d2e8d1e01ef3f6af13937a84fe4c551b56a6c438d01f2b7818c0c440";
+      sha256 = "c22c673516a9837fe3d454bdecf0a59efd3b18f1e7cec51a6e742a343367aaed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ff/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ff/firefox-80.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "f72bf80190d3bf1a4b81aa06f6f0a7ea25267302747ead42a505461d4cd63e35";
+      sha256 = "64de30cf7241daa09cbf7b027017c6411fbe01aa84c8bcb62d4cfac0eb86b540";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/fi/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/fi/firefox-80.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "44aef7c10ed8815634d62bb60b7d5412901dd016ef7439b28a84219546b702b6";
+      sha256 = "549743b069385b594c78f8732f28cdae1a73324d3662f671e9721b566629ea01";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/fr/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/fr/firefox-80.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "a347e36231516c410e756e55fa8e03c660635a70c8315ec14e9b2c68deae9db8";
+      sha256 = "abfb9e7c89fed1a4553bdd7cdbaab84f7f5221d31df404af0143bed0e6b817c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/fy-NL/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/fy-NL/firefox-80.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "d53d4fad373b633e287db03675f89279e44b80c28ab50c238a05b286abb916b6";
+      sha256 = "97accf68261aa9b04cbbcf424afeb7a3aea92853c70a4f0a52d10fc408d5e83d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ga-IE/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ga-IE/firefox-80.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "279f93b6e57dbaa443df2221217e4ef60be015c0a4e6fad8806e97f46f074f9e";
+      sha256 = "61f830ff111c0de73a229d12705ef6b3cc1b597abe668488c8f8ba3bf5dde217";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/gd/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/gd/firefox-80.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "b3c89bb8b8e4f9bae3686e601de8ad7c065940f8852d63a8e503095b0674e931";
+      sha256 = "cd4904d29ba8f649f3a960953e99a5a8ea12375d2cbe651d1bf09210a08e6400";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/gl/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/gl/firefox-80.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "cc9687f4d35a62ba0be5c362bf0d55ed1acdc4d1b4e0284cc4db04553c36786b";
+      sha256 = "0589a2465fff938d88a248f4175d9c3c0ccd4602b317f403ed3b7966b1d1cdc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/gn/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/gn/firefox-80.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "c3d4cec222d099bd2a9f66c543c97d1c18c0abfa087c19fac3da08579c60d103";
+      sha256 = "64f4f44b7b6b07970fe0c2f73b9e8afc5df75125a8c84f4c56b839c47899ee5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/gu-IN/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/gu-IN/firefox-80.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "7af5a56a90bd0eadf93ffeb2b61f08232996b560588fa52d55ffe3023e08b3e8";
+      sha256 = "46ac00838fe4775ad83a4cf6a510c7a80a6106896060bc3d6c2a94ae91004202";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/he/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/he/firefox-80.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "65222595c4df12375837f0994f9fe23a3a8f96fde8ec0d7be980ab16ea19bc71";
+      sha256 = "563abdb4e26b3bf628f14bd5ef0cb3fe326b3e0a0bd65aba67fece4460b434aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/hi-IN/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/hi-IN/firefox-80.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "ee52e1eaca1e61c5ee1cfd5e86fc0afed242f9162f36027f57052162b88b2500";
+      sha256 = "828c6e01a4f2db95d36e1f8826fde98c8d762ea0e0aaff0abd50a9ade5638b8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/hr/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/hr/firefox-80.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "ae9936bd5b55e92250d73859b1d78505fcc3d3312d0772591720012ea820c367";
+      sha256 = "6cffbcc579f3c489e6d3e8da4bff44189851565cbe196b6f8f3e1a864ebf15d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/hsb/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/hsb/firefox-80.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "55e837eb12417899dbcab8d15f3c8e3604f7a071339b1f2ee608801ad7fe7912";
+      sha256 = "c2a744f2115d1e67d430dbbfc7388043a740840dbbdbc40bb34b6d7c8feda525";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/hu/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/hu/firefox-80.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "710a5e73c34cdc1b7a77e8465724b0e99c4084effb015c3dd71e3fc2f678149c";
+      sha256 = "cb382f9253652ed6109f8ab1b90eddcb3f7a5bb56aa3b4d99faa755b09dd197a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/hy-AM/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/hy-AM/firefox-80.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "7e40874e151c69145db6a812d7050de5ea65b8939a394cbc468c3492abd189fe";
+      sha256 = "f298f1a9a427ba647d99f082a40e39be2e80dfa2388b731ed7e27a6da4efbd8c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ia/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ia/firefox-80.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "5c6083dd765489f378b6855713e601d50ff84acf95674b8d3b873b29981dda99";
+      sha256 = "d823238dd340f45f776d73710c0cd77edca6be241aab189618f6def9d46f60e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/id/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/id/firefox-80.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "b8cf9a69b6b52f816e355399e2bf6c1742f56d7d631dbee78a687a1cde9312dc";
+      sha256 = "667ec59c3743f707d4b3084a19ba09aac625794d2c7a240a04f9d932ffba9046";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/is/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/is/firefox-80.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "532793a2e2d761ba36a3bdaa0a257e8828b5516193c4cf1f1ec1735efa510e6f";
+      sha256 = "bfa3be98edd904965d65c1094a9b83807633867c802b605bb93dda031e979a22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/it/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/it/firefox-80.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "a5309e5f3c387990ba1aa255684ec73f2e38dca0aa873f998effb7dd7b13e0a0";
+      sha256 = "198aef68d51404fd37ad602e1f450afa8dd439d4ebcacffe1e920d4629593da9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ja/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ja/firefox-80.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "f9dc927612114a5c8d9a4e0ee311356a0e5e819729f4ebd08ee5f03dcda52afd";
+      sha256 = "4a443e7b2d8169871b789ad90ca23ef8a01e7578fcf6b1af6ceccd4af93fdadf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ka/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ka/firefox-80.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "37b82df19bd4897bc2c29eb3f5f94d107b6b97eeb5a1b3ff5ddcaf641dd0fb19";
+      sha256 = "8884da1d0c2cd6fa7aace95a8be04c8fd691b24428207eb62ffd3e7509494eb6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/kab/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/kab/firefox-80.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "1ef2b402c518da26838c2c3e0d5c47fa8f3c5d74cb2f9a95999814476d3bc629";
+      sha256 = "328ca68297bf281c573e6059f3cedb872396f0a7474e92caf78906d4d4089531";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/kk/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/kk/firefox-80.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "d152f45918a163fccc9eec97f5543d8c206a3e9ac130de58260943e6aebb19a8";
+      sha256 = "f632d1f23c5936bd498b695de562935a968e592013ffdfaf878516b94db9f149";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/km/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/km/firefox-80.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "2d9639684b0115f9db6eb73379e1d7b24670db83afd2e7d2bed2a7c62188f54c";
+      sha256 = "8f7a5370f6108b6b7ac28c35a845378ae67929accafba911cca34c2e67dd6da8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/kn/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/kn/firefox-80.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "224e41e1c33e60f1de88fe8243742675e0813b7041f1bac3a9a29528c618df3b";
+      sha256 = "395311e396a7267baa31f74dd30cb2e2721784de4ebdaba72c44bb384e4a6aa7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ko/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ko/firefox-80.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "16372732d44159e017875ee9d3bdbc5443bfb1eb577d62e8b28a05560caa2650";
+      sha256 = "40e0ca4c3380213a902ed08e0f7cb7feab7d45f9ac035467ac0a50cc99af771c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/lij/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/lij/firefox-80.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "a796e32ed17c08499fc2e459a1bf753c7578f5555e0a7eb62757b4c5d4f6b735";
+      sha256 = "35ed355715f7d6263ba90a563f573a3cd6ac186727b6e982692458720dfaedb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/lt/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/lt/firefox-80.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "6687e81d9be17a992e34fbbc9f44edb86be75e1329292122e7978211d4c0b43a";
+      sha256 = "0d0df39e1552a6e310d279f53384a8f8f8298df2f590fdb2683012499e599152";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/lv/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/lv/firefox-80.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "7c4beca6385caaf9e05eb6f6cf508f51d559094cff3eb60e28d562ec7404d804";
+      sha256 = "41905b366ba007d226c07064c90b104eba01be85397541e50ec7858e72c444df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/mk/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/mk/firefox-80.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "d8da49d2b43467ef4b29f55a15f71125ceb8388a55ded93ccd90e7d484d84feb";
+      sha256 = "3461c717fb3c1560ee383c044423874244c5fba95edbd2b8ab0ffd6223c03b10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/mr/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/mr/firefox-80.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "304c8f8caf6ebdd5d928135f7fb94d490658e0fb6b7b73e2f1618b7b07234de2";
+      sha256 = "3453bbf846392782d902217a331e1b74aaa93475131a866661e233ecdb4e108f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ms/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ms/firefox-80.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "a4cea6625395d522ab3d4000f6774ba5898a1f740c9b70b23f71f52e1231404d";
+      sha256 = "7e3f92a4429eea8f3d79dd105164461b6e218842c3131e8a186cda71504ca3d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/my/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/my/firefox-80.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "1bbb703f65bc5d41174800ec789066d99ca10430605dfb2975b6d788b41c1220";
+      sha256 = "bb4ef9a5ea013aed6a85aad02211f744b8cbce62ae94ac815b6880b986503b9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/nb-NO/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/nb-NO/firefox-80.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "95592600fbb71a6346fa42f8647460fed047af96f38754a3322eef9bec7a22aa";
+      sha256 = "e0e6524cfc56b09bb37501acf0ba2074c8fd2d1b3e9130e8c223b0156a02ee2d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ne-NP/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ne-NP/firefox-80.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "f902008b0c6390265e11209e573555b0854b0d0c879eb5c2637f18ce981223fc";
+      sha256 = "ed13d6e6826b14efe1e7d322e7c93243c413277cc360c2f2f6389975e8a234a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/nl/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/nl/firefox-80.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "9ef3bbe6b6975b50013a951559f6beaa34ddd5b183ccb33500c585e3c094fc05";
+      sha256 = "08e06314f3633a93363c79a4470fd78ae7fadb1421140da81ddf82f2cd8a1a87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/nn-NO/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/nn-NO/firefox-80.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "783427d27ef6be2bac3a219f72d61a6cc8b6105ec01c94476b06187d83fada90";
+      sha256 = "ca2cc7cd99ae698e48bc75274811ca2e0cf92e34fead87fa4b3450d5cfeac522";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/oc/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/oc/firefox-80.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "f5a6af6e4d2bee9ea6c8e27edfe593640f0410766eec4a029c7b6641731cca58";
+      sha256 = "2136473ae8be4213aa16f542014a3c2671d538792ed87d06ab205be9d3ef2bf0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/pa-IN/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/pa-IN/firefox-80.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "8d45fd730fcbf898062231356d11892eda44a2dc124444fc0623de363a807a73";
+      sha256 = "8bcb5f76cab4a7c9635eb456ea05697c32e2eb22a4f81ff91142e0a92c9f358f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/pl/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/pl/firefox-80.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "9c89d3be668a295ef53d1dba84d1b9db230956d5700de6a86a6c8b0dffce5781";
+      sha256 = "445021b7e78eb046bafe176abd466679c296ddf2795deefb2c1e325388db0876";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/pt-BR/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/pt-BR/firefox-80.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "8c591df0daa36ce3fd8380d34609cd1e1d26c8116db5bbe22828820c1f7f84aa";
+      sha256 = "65212c864d33f04ad6e5250fdf674c274c696ee8d7c13a0c91f38d204b9dacda";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/pt-PT/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/pt-PT/firefox-80.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "e3ea46565734355a779e5b4b083c14e2f13d14f78f7347c36306fce57f4beb16";
+      sha256 = "9e1664031ca29e5f0f9cab5bd0cddfe3a053a0737d5fae82ce42d8c4a89c3044";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/rm/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/rm/firefox-80.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "c2355ccb07cd804aae65b31270e51d2d0a1ea438db44ab75c22aa57cb1bec71a";
+      sha256 = "7ee02dc6ae964991e4aed47bd47fdea644cf6ab98a541f59c7f72eb175a04c57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ro/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ro/firefox-80.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "e7b729a18283dabd9f295a436e97c3bd42eb6666e77c42ef1b967598d6e0ae37";
+      sha256 = "932a7723262b8c3c1ee54e9e06f4301b8996eb590c6c52030b42804d18f1cbdc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ru/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ru/firefox-80.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "d9b2a3449ca0ed738db8bbd3f316a4973fa318c4abdb63aced9832419b579229";
+      sha256 = "36727824ef047330a2448ea1c8a436dc074de60d64eec981d4cc52c3f3f6a4d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/si/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/si/firefox-80.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "8a43a0b25befbb5f0a9477086ae85d58b1d4c448e06630d1c0ece950d24bb6a5";
+      sha256 = "8bbda31d0e2a7cc46740b2c0545c725c881f482c300efd9baa6fb4e2e7103d0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/sk/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/sk/firefox-80.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "40a4e4b307ebea63a13e8073536c1d039ee400b4eff109a4ed086c5f073c12bf";
+      sha256 = "2ac41667c392735f11b21c149b7a1f29122c4528eed7863180c5f9a3528bc6b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/sl/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/sl/firefox-80.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "19b163d77a8480099cc356f84c00d51c62cf97095ed2a3f2a16a654abcc0d413";
+      sha256 = "4f60048b39306e9da94a5205a89dcaed1a30927fe1865ce6934a1ef0b0050a71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/son/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/son/firefox-80.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "0c9b0546846cde59fc550f2a94abb8e909f1955ff5790aacd3bfdf63a668a1d8";
+      sha256 = "3c83ccf6b9a037af11f9431423afada70c979cdd8d12117f0256576e56600b1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/sq/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/sq/firefox-80.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "b153afd0d8efcb4563bf46df1f8d20408e179ecd94a4e294683eb5caa0141228";
+      sha256 = "d87237e6ecdb3797c787f35f9ced339cc32380c23c3a0663cc3d46d3312aa8ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/sr/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/sr/firefox-80.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "36a3dbe8a9fec700ab91134344db6d70dfe96d53bfcf366ac83b29ba7f405a35";
+      sha256 = "4e2a7a21e3f94b0344fa5bb471dafb11d4589ae3966799b7b4e82d8503f5e7a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/sv-SE/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/sv-SE/firefox-80.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "708b43a83fc88ddec15a87a0f753690048dcb7500aee2a52c59c28912de5f401";
+      sha256 = "4b91c958b998f7f3cd59b26a27bc848aea98d5319a169684b82dfc3750ab0fc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ta/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ta/firefox-80.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "e552b1ff45f4b904a7b76af41f44e9e349cf08f20981f44b95d7e89f727d3c12";
+      sha256 = "9772ccd592e51ce71ea86b241c9bfdd78793a90b8f0156c049f1b603f1d9a8ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/te/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/te/firefox-80.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "5ea5d027d0b6aacec730a865d8c70e8929c858b26a3ca0f798bb3a405e438aa6";
+      sha256 = "b7906bbb4993e1fc231e02f390af62fcd40d7e6fb0cdc5031447d97c8e29eca9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/th/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/th/firefox-80.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "32e0e810308c3fdb52b247d086193f0dbf1184ee2f6ac42c2a25766f158ed79c";
+      sha256 = "dc978d91b6de96590cfd95514a9563510d4f4725a80402e2eb6b2289de1f49a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/tl/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/tl/firefox-80.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "d64ff747faf81f626ff91c18f72f786669f48ca84f55df58a25ffeadc1683325";
+      sha256 = "98d617fb0ca75a977b127633a8050e119a047fc881161d97a852431231ecdc67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/tr/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/tr/firefox-80.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "22cfc8b33829476e0a058900f5a606020b249225e15c3a78a5baa314ea39a5eb";
+      sha256 = "1228b0ba249cb2b9367db532647fdd0d58057e11d1b182a0982ac12e2c8f686f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/trs/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/trs/firefox-80.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "a7db4c7fc442156414d658b04cb531fe5b4f4ac7b46e3a62229bb7528b40a43d";
+      sha256 = "e32783dc73b6e8d5aa2f0fc1e44fb361e07aecdacfa8a5f3dbcf0aadfa871762";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/uk/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/uk/firefox-80.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "072b4d82b5a8c14764f3664ea5fd436aa616984e044e078002ef6c4ab3f5a804";
+      sha256 = "aea971a56865756e9e6cd25638051e3e8048c2110e72aad2961bad40025fec05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/ur/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/ur/firefox-80.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "c52f5cb761b5d8f7c6c3646c3fc2a5c4580d5dcaa0d8757f3f37b990a1b61191";
+      sha256 = "aa9ba0b3709ae1afc610b873877ec4b46a5ef3a801d04157c104ee985db4d9c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/uz/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/uz/firefox-80.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "4bc2ca5751a9d0cd69661799ab5ca6725bdc12055d07c975a6a7f90f44d93182";
+      sha256 = "a3f0e1c314825ee0d8c6dfe6d5d5dabada792088342565d65cdc336fc74a8e98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/vi/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/vi/firefox-80.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "1ce68d3b630754f961264558c424c0c9771d77f01858570ef0d15ed2098e99c8";
+      sha256 = "92f17fffcdbea8ca77dfc0da435ed936bd2011bb8b3bff7b565433ff281a9dc5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/xh/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/xh/firefox-80.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "b7e4d8f55c8ff78491cf2e65510397f09b3b5995f7f7fd506c7e20027d330ee5";
+      sha256 = "05a56d5d5abb3d0090b2bcae93a7d1ea45050da6ecbdef013916dd3b26228c16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/zh-CN/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/zh-CN/firefox-80.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "3ab8f24ea6809b9a2b1cbecef55caa39dbf4ecd33b287b8ef77e5a76bb617337";
+      sha256 = "39231fb7720d7e35f81eb4aaf188eeda2414cc700d8e9658c776ff3bb535e418";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0/linux-i686/zh-TW/firefox-80.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/80.0.1/linux-i686/zh-TW/firefox-80.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "4c306d3227ca8dc322780c0eeb8532a62db101c6cde8317acfa824bdddea4d12";
+      sha256 = "09d04e81464057e0ecb222b28009a255a51023ff70aab58ba4411c8457d331fc";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change

https://www.mozilla.org/en-US/firefox/80.0.1/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
