### PR TITLE
Better type deprecation messages

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -457,7 +457,11 @@ rec {
       # yield a value computed from the definitions
       value = if opt ? apply then opt.apply res.mergedValue else res.mergedValue;
 
-    in opt //
+      warnDeprecation =
+        if opt.type.deprecationMessage == null then id
+        else warn "The type `types.${opt.type.name}' of option `${showOption loc}' defined in ${showFiles opt.declarations} is deprecated. ${opt.type.deprecationMessage}";
+
+    in warnDeprecation opt //
       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
         inherit (res.defsFinal') highestPrio;
         definitions = map (def: def.value) res.defsFinal;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -225,8 +225,10 @@ rec {
 
     # Deprecated; should not be used because it quietly concatenates
     # strings, which is usually not what you want.
-    string = warn "types.string is deprecated because it quietly concatenates strings"
-      (separatedString "");
+    string = separatedString "" // {
+      name = "string";
+      deprecationMessage = "See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.";
+    };
 
     attrs = mkOptionType {
       name = "attrs";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -529,8 +529,9 @@ rec {
     # declarations from the ‘options’ attribute of containing option
     # declaration.
     optionSet = mkOptionType {
-      name = builtins.trace "types.optionSet is deprecated; use types.submodule instead" "optionSet";
+      name = "optionSet";
       description = "option set";
+      deprecationMessage = "Use `types.submodule' instead";
     };
     # Augment the given type with an additional type check function.
     addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -329,14 +329,12 @@ rec {
     };
 
     # TODO: drop this in the future:
-    loaOf =
-      let msg =
-        ''
-          `types.loaOf` has been removed and mixing lists with attribute values
-          is no longer possible; please use `types.attrsOf` instead.
-          See https://github.com/NixOS/nixpkgs/issues/1800 for the motivation.
-        '';
-      in builtins.trace msg types.attrsOf;
+    loaOf = elemType: types.attrsOf elemType // {
+      name = "loaOf";
+      deprecationMessage = "Mixing lists with attribute values is no longer"
+        + " possible; please use `types.attrsOf` instead. See"
+        + " https://github.com/NixOS/nixpkgs/issues/1800 for the motivation.";
+    };
 
     # Value of given type but with no merging (i.e. `uniq list`s are not concatenated).
     uniq = elemType: mkOptionType rec {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -255,9 +255,6 @@ rec {
       merge = mergeEqualOption;
     };
 
-    # TODO: drop this in the future:
-    list = builtins.trace "`types.list` has been removed; please use `types.listOf` instead" types.listOf;
-
     listOf = elemType: mkOptionType rec {
       name = "listOf";
       description = "list of ${elemType.description}s";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -91,9 +91,12 @@ rec {
       #            combinable with the binOp binary operation.
       #   binOp: binary operation that merge two payloads of the same type.
       functor ? defaultFunctor name
+    , # The deprecation message to display when this type is used by an option
+      # If null, the type isn't deprecated
+      deprecationMessage ? null
     }:
     { _type = "option-type";
-      inherit name check merge emptyValue getSubOptions getSubModules substSubModules typeMerge functor;
+      inherit name check merge emptyValue getSubOptions getSubModules substSubModules typeMerge functor deprecationMessage;
       description = if description == null then name else description;
     };
 


### PR DESCRIPTION
###### Motivation for this change
We want to deprecate option types over time, but how it's currently done, it's very hard to figure out which options actually use these deprecated types. This PR improves on this by allowing types to set a `deprecationMessage`, which when set, is displayed along the option that uses the type.

So with an option using `types.loaOf`, you now get
```
trace: warning: The type `types.loaOf' of option `foo.bar' defined in
  `/home/infinisil/src/nixpkgs/config.nix' is deprecated. Mixing lists with
  attribute values is no longer possible; please use `types.attrsOf` instead. See
  https://github.com/NixOS/nixpkgs/issues/1800 for the motivation.
```

Similar for `types.string` and `types.optionSet`. I also removed `types.list` completely because it's been deprecated for 7 years.

Previous PR's/commits that deprecated option types: https://github.com/NixOS/nixpkgs/commit/fd803fce606a007403ba6d05f09ed2e6a3371830, https://github.com/NixOS/nixpkgs/pull/54637, https://github.com/NixOS/nixpkgs/pull/66346 (https://github.com/NixOS/nixpkgs/issues/16750), https://github.com/NixOS/nixpkgs/pull/96042 (https://github.com/NixOS/nixpkgs/issues/1800, https://github.com/NixOS/nixpkgs/pull/63103, https://github.com/NixOS/nixpkgs/issues/77189)

I also plan to deprecate more types in the future.

Ping @roberth @rycee @Profpatsch @danbst @rnhmjoj @worldofpeace @cole-h 

###### Things done
- [x] Checked that all the deprecated types are usable and display the deprecation message