### PR TITLE
kde applications: 20.08.0 -> 20.08.1

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=(http://download.kde.org/stable/release-service/20.08.0/src)
+WGET_ARGS=(http://download.kde.org/stable/release-service/20.08.1/src)

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -4,1731 +4,1731 @@
 
 {
   akonadi = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/akonadi-20.08.0.tar.xz";
-      sha256 = "a18ce2d8c9e9fc7f195a7546ee5b7c2541e37ceb7afa0aa25e9ade4f54de2813";
-      name = "akonadi-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/akonadi-20.08.1.tar.xz";
+      sha256 = "f930de5fae376f138e87c6d67357ab799a3397d865b55c50f771b4427d85f495";
+      name = "akonadi-20.08.1.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/akonadi-calendar-20.08.0.tar.xz";
-      sha256 = "4664e2dc6bc0762d999662188c64410fa70be2cef1be221569ec3b9270f80fd8";
-      name = "akonadi-calendar-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/akonadi-calendar-20.08.1.tar.xz";
+      sha256 = "896ec2523203022bf70e23897d59b64c8bfffad4ead5b6756555ab34a4047ef5";
+      name = "akonadi-calendar-20.08.1.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/akonadi-calendar-tools-20.08.0.tar.xz";
-      sha256 = "f994db29d374b0fbfd3328fc618df44680b0dfaec1cf9f842a7a9c6ecbb841fa";
-      name = "akonadi-calendar-tools-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/akonadi-calendar-tools-20.08.1.tar.xz";
+      sha256 = "21ccc2e1090eeda1eba0c29ab51c3bae1e8f57aedead569c4ed7995f5ad6cffc";
+      name = "akonadi-calendar-tools-20.08.1.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/akonadiconsole-20.08.0.tar.xz";
-      sha256 = "a43c6b756a69301f7756464deea58c72aaefaa1b47f1136959588e8f41b7b91b";
-      name = "akonadiconsole-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/akonadiconsole-20.08.1.tar.xz";
+      sha256 = "077ee646babbc4ca4075505d3dd830f4f5b8b1253617228e96f565fe23bcaad9";
+      name = "akonadiconsole-20.08.1.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/akonadi-contacts-20.08.0.tar.xz";
-      sha256 = "206f0704768a789201ead784e78d7138aba6b50b8f3880369df8799730fca8b4";
-      name = "akonadi-contacts-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/akonadi-contacts-20.08.1.tar.xz";
+      sha256 = "eee775960345ec0ca13b0550bb56fb6875867921fa7b9412a2c4b0dfb8ab4366";
+      name = "akonadi-contacts-20.08.1.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/akonadi-import-wizard-20.08.0.tar.xz";
-      sha256 = "d742ced3b498f39edff33f7fc73db1e882bf4b1e17b35d5f734f8732cb1e7bde";
-      name = "akonadi-import-wizard-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/akonadi-import-wizard-20.08.1.tar.xz";
+      sha256 = "d895c866a05f0a55ca8f2d852ed0ae3fdc13aa160cbcbaf9f1017443458d9526";
+      name = "akonadi-import-wizard-20.08.1.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/akonadi-mime-20.08.0.tar.xz";
-      sha256 = "c0a709e25fef86f778ef21adbf78c6beab203f4f4a8d9f5e17a4d3175fe01d33";
-      name = "akonadi-mime-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/akonadi-mime-20.08.1.tar.xz";
+      sha256 = "3c7a57f798a7db1e1aebc3162c20f58a0fb9ed9e703078344ef1de215c73ff0b";
+      name = "akonadi-mime-20.08.1.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/akonadi-notes-20.08.0.tar.xz";
-      sha256 = "aeb348d6af30e8775d60cab0894634c6e5ac95a3baf97f69407602dea5944525";
-      name = "akonadi-notes-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/akonadi-notes-20.08.1.tar.xz";
+      sha256 = "afc0cdba349f0b2edece44221a7c3c532d07251ec51f05994e83a1d79c4f50fc";
+      name = "akonadi-notes-20.08.1.tar.xz";
     };
   };
   akonadi-search = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/akonadi-search-20.08.0.tar.xz";
-      sha256 = "06974398ddd6cbd42d0cb9dc3cac4b6ad6bdc8062d1f94523a973ed702b40e2f";
-      name = "akonadi-search-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/akonadi-search-20.08.1.tar.xz";
+      sha256 = "db305bfc55535d8812d84a119e4dcf04e7b87c345e7ac3a884469cbf55abca83";
+      name = "akonadi-search-20.08.1.tar.xz";
     };
   };
   akregator = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/akregator-20.08.0.tar.xz";
-      sha256 = "e8dbef1b8e8c165e824f108a33f9d2a6a0ea8668299f808fcc2ce2b4d398dcf5";
-      name = "akregator-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/akregator-20.08.1.tar.xz";
+      sha256 = "21751a5a14b188649caeeb19cbcef877dd00548a29c073f8694e227d951c7a00";
+      name = "akregator-20.08.1.tar.xz";
     };
   };
   analitza = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/analitza-20.08.0.tar.xz";
-      sha256 = "51bc5ecd31e557fcf5660e57458aa866ee44e386550bb2c37c22fae252405aa1";
-      name = "analitza-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/analitza-20.08.1.tar.xz";
+      sha256 = "91c691df8be52255db9387549c6392ad2c5358c12e805f3a96520e2aa0c147de";
+      name = "analitza-20.08.1.tar.xz";
     };
   };
   ark = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ark-20.08.0.tar.xz";
-      sha256 = "7627ffa17466d31dfdedabaa07b491ce14b46041d04f8b20316a0fa731fab098";
-      name = "ark-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ark-20.08.1.tar.xz";
+      sha256 = "32e8546b186b88efc9d4688e02def0b6225d921f9b92cfcd328417f09ec0f725";
+      name = "ark-20.08.1.tar.xz";
     };
   };
   artikulate = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/artikulate-20.08.0.tar.xz";
-      sha256 = "30ef4eedabebccfb600eec1ba7bc691e8ad4e0de8d7fdcf56a630714d6b9848b";
-      name = "artikulate-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/artikulate-20.08.1.tar.xz";
+      sha256 = "b626a6a38f6eb50d64607032d5b100351c4242e40a4a13cdce4769e188ee361a";
+      name = "artikulate-20.08.1.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/audiocd-kio-20.08.0.tar.xz";
-      sha256 = "7a01d5b89f5271ee1eba203e15c46b146879e4651643ec6348e1033c0ffdc8c7";
-      name = "audiocd-kio-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/audiocd-kio-20.08.1.tar.xz";
+      sha256 = "7662849929c96d1745ce4ac7ddc931be2eff5e3cc755f2cd959b4d3f4b20b9b0";
+      name = "audiocd-kio-20.08.1.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/baloo-widgets-20.08.0.tar.xz";
-      sha256 = "37800c3cde7e2a9cfbab2e11f21dd1ae76b2a31b687802bc45027966a8734985";
-      name = "baloo-widgets-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/baloo-widgets-20.08.1.tar.xz";
+      sha256 = "9f48cb2f1b45e46828b1656abaeb60e836650015c07277ec52bea053d0058958";
+      name = "baloo-widgets-20.08.1.tar.xz";
     };
   };
   blinken = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/blinken-20.08.0.tar.xz";
-      sha256 = "0a08f5fc8e0c100956bb99910265d9630191e462f8f812842e79b64e76055c1c";
-      name = "blinken-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/blinken-20.08.1.tar.xz";
+      sha256 = "53b30435ea0d83f713ecb53219173aa55c0d11194830972734a4acc9a5a28c5a";
+      name = "blinken-20.08.1.tar.xz";
     };
   };
   bomber = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/bomber-20.08.0.tar.xz";
-      sha256 = "91b4ff0e0615cd42e36c6755d30ee62b74d6c5ae309512b9f8f347c34786ec47";
-      name = "bomber-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/bomber-20.08.1.tar.xz";
+      sha256 = "a4b2f5dcce7e125da30bef6bcc9746b67f8451d2040696714686dd618d80a96c";
+      name = "bomber-20.08.1.tar.xz";
     };
   };
   bovo = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/bovo-20.08.0.tar.xz";
-      sha256 = "f66997324d596095b30442b2446a3c581834ad60d1a27fd7f7f394549f2418a8";
-      name = "bovo-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/bovo-20.08.1.tar.xz";
+      sha256 = "5d5ee817a73de0deef6b7c35a798bda02c6d15e9dd0e7379a13c23c0832fe0d1";
+      name = "bovo-20.08.1.tar.xz";
     };
   };
   calendarsupport = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/calendarsupport-20.08.0.tar.xz";
-      sha256 = "1c1682d46f248b092062a461cdefec9da3733cb0ee1a590b7c48c4977028e977";
-      name = "calendarsupport-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/calendarsupport-20.08.1.tar.xz";
+      sha256 = "38d6e695725c8484e1492d431144a0ecd1b66535bc07ac77e1f0eb1499d8fc32";
+      name = "calendarsupport-20.08.1.tar.xz";
     };
   };
   cantor = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/cantor-20.08.0.tar.xz";
-      sha256 = "1d4babf783f53929f0ea42380dacdb7ab989b66383dd3c37ab22787a26715082";
-      name = "cantor-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/cantor-20.08.1.tar.xz";
+      sha256 = "c44b96ac861302589923d144bf7b5d529b6eb2f91cea2d014944a0516de31a05";
+      name = "cantor-20.08.1.tar.xz";
     };
   };
   cervisia = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/cervisia-20.08.0.tar.xz";
-      sha256 = "6e10acc196661b7d1873e370eb67486386e25e4d6b7946ade8479b70fba34d66";
-      name = "cervisia-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/cervisia-20.08.1.tar.xz";
+      sha256 = "eedd3b3f00b97d513437fdbd2eeaa28cd6db29512983b82196bdededd8b701f2";
+      name = "cervisia-20.08.1.tar.xz";
     };
   };
   dolphin = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/dolphin-20.08.0.tar.xz";
-      sha256 = "fe5a68d9afd0771ba9ffc2d5d79e7bc43da85fd3ee3c2493a9a2d5c359c3cd6f";
-      name = "dolphin-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/dolphin-20.08.1.tar.xz";
+      sha256 = "7d6ef04b866366a0ff3b199aac082ade41b3748b225ef7675ea42ccf48cbdc24";
+      name = "dolphin-20.08.1.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/dolphin-plugins-20.08.0.tar.xz";
-      sha256 = "a8a0c35f75eb8e63ee90f44ce930babceff86676b8bba213c82b7ffb29e526bb";
-      name = "dolphin-plugins-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/dolphin-plugins-20.08.1.tar.xz";
+      sha256 = "a00cab6b30c9b5a4c0164704c9eab2cbb661928e775f83acb3691af77bf17427";
+      name = "dolphin-plugins-20.08.1.tar.xz";
     };
   };
   dragon = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/dragon-20.08.0.tar.xz";
-      sha256 = "0e3a540b3f93118a9a17f2c6f675d0f007b123266c6e71a27b5ddb6b9a7e14a8";
-      name = "dragon-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/dragon-20.08.1.tar.xz";
+      sha256 = "691bc338ca25e70e9a43cbcdf50f2e0aa92643bdad0329bdc3e09373ac287040";
+      name = "dragon-20.08.1.tar.xz";
     };
   };
   elisa = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/elisa-20.08.0.tar.xz";
-      sha256 = "acbff9f3c3d26c2a2c249974ccd8ff0bdeb22148a8a5b72e1199f1ec2f9d712e";
-      name = "elisa-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/elisa-20.08.1.tar.xz";
+      sha256 = "1a0234a074a70bfcd4b2ccc14664b2cc7f88d2ccfd33c1716d35c27a31e258c0";
+      name = "elisa-20.08.1.tar.xz";
     };
   };
   eventviews = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/eventviews-20.08.0.tar.xz";
-      sha256 = "205607d89d739f1efa4472303206647d04fba4e9d80610800a4a229676ede732";
-      name = "eventviews-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/eventviews-20.08.1.tar.xz";
+      sha256 = "b46e6ad32a503ce1dc1e5ade71e79f44011362fe569836ca1f2cd11c560a5a73";
+      name = "eventviews-20.08.1.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ffmpegthumbs-20.08.0.tar.xz";
-      sha256 = "84c3a8f064423d7e51a57b9ed32a9f4fdbca73f7fa7e47a6289d9b516f1ba9ff";
-      name = "ffmpegthumbs-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ffmpegthumbs-20.08.1.tar.xz";
+      sha256 = "8b7cd6bd27b29977d0406b08c2cf33988c651a2f59392be47f076e49eea5673b";
+      name = "ffmpegthumbs-20.08.1.tar.xz";
     };
   };
   filelight = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/filelight-20.08.0.tar.xz";
-      sha256 = "29ea650f7b0f1863ea6caeca39362eff652edee755963967eb4653665a2499b4";
-      name = "filelight-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/filelight-20.08.1.tar.xz";
+      sha256 = "9677038781a1d66238da0e54f967c9c97cb44d593dbe164b8e26f38d0ac75330";
+      name = "filelight-20.08.1.tar.xz";
     };
   };
   granatier = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/granatier-20.08.0.tar.xz";
-      sha256 = "9fd034875c2ac80a089145c47f36b3b97ed69eaa1693aa83bc5bd76561096efd";
-      name = "granatier-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/granatier-20.08.1.tar.xz";
+      sha256 = "7b0d53fd50fdb56270f8fd53d45478c0f1be10bb67b901db08b0f413c4baeb3e";
+      name = "granatier-20.08.1.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/grantlee-editor-20.08.0.tar.xz";
-      sha256 = "08aeac1c6bacabdeb4e4273efc5c5f4995454c45bd51069b3ef6105237b84afa";
-      name = "grantlee-editor-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/grantlee-editor-20.08.1.tar.xz";
+      sha256 = "edeb994eab7001bcf8462834a61ae1a045e9122ae104d31bdeed2ac7497b6306";
+      name = "grantlee-editor-20.08.1.tar.xz";
     };
   };
   grantleetheme = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/grantleetheme-20.08.0.tar.xz";
-      sha256 = "7e86d2f9f5a725f988211f676da2c4191ed6df55418135f3a54da5d687d63e8e";
-      name = "grantleetheme-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/grantleetheme-20.08.1.tar.xz";
+      sha256 = "9a8f91ce63a3b143d47d8e3fbd1378732639cd3daf5b5789989164d8225fe54f";
+      name = "grantleetheme-20.08.1.tar.xz";
     };
   };
   gwenview = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/gwenview-20.08.0.tar.xz";
-      sha256 = "e7a6d96801bfc41156292faac915691b929d4da641cf04839c74a68debc95c44";
-      name = "gwenview-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/gwenview-20.08.1.tar.xz";
+      sha256 = "df1c45317aff9aece8b023cd87aab62c9cd222520795922564e89fdc9df48995";
+      name = "gwenview-20.08.1.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/incidenceeditor-20.08.0.tar.xz";
-      sha256 = "5f23343959cd672570a4a3439be0e8b27c413b9747a17bd04138359c43dac678";
-      name = "incidenceeditor-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/incidenceeditor-20.08.1.tar.xz";
+      sha256 = "eecc51eb405c473eb20449842dcdb3dac96712bbcf7aeedaa06614e1da3e0bbe";
+      name = "incidenceeditor-20.08.1.tar.xz";
     };
   };
   juk = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/juk-20.08.0.tar.xz";
-      sha256 = "ec00ef054768efc64b5b0da69fba90104689b314a064f52989d1c6dbd73dad1b";
-      name = "juk-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/juk-20.08.1.tar.xz";
+      sha256 = "aa9a93a0befacf401cf41d8358b4987d8b370b4c153f3b66e05e922472e004a8";
+      name = "juk-20.08.1.tar.xz";
     };
   };
   k3b = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/k3b-20.08.0.tar.xz";
-      sha256 = "d10ac6bfa89744ec857ce7c65d5d7eae5f26ce151341d6f393b9a141cc05540a";
-      name = "k3b-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/k3b-20.08.1.tar.xz";
+      sha256 = "66fad59f4e35c24dc8868c46ff45ffa66048501e0a6ac0c23a8b9e957033e50f";
+      name = "k3b-20.08.1.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kaccounts-integration-20.08.0.tar.xz";
-      sha256 = "b1d0912ec7771be6c04f4cf635d9196acee1c63f47fe1814a5da2002196125a0";
-      name = "kaccounts-integration-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kaccounts-integration-20.08.1.tar.xz";
+      sha256 = "b65ec11be0c2b612222de382d24345f19be0cd264243f0d954da8a81b80034bc";
+      name = "kaccounts-integration-20.08.1.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kaccounts-providers-20.08.0.tar.xz";
-      sha256 = "5a2293e124839dec3ca5cbe72548ff01ce3c0f7edc5c6dd78ca4d8a27054f574";
-      name = "kaccounts-providers-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kaccounts-providers-20.08.1.tar.xz";
+      sha256 = "481a2e2708773197b63937233ade6380c0b64e13a1610f27aa2751b6ee3624a4";
+      name = "kaccounts-providers-20.08.1.tar.xz";
     };
   };
   kaddressbook = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kaddressbook-20.08.0.tar.xz";
-      sha256 = "e34b4515a5721b9dd1d9d391acb81905bc2b6a0d219347c7dac87ebbb5b7b921";
-      name = "kaddressbook-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kaddressbook-20.08.1.tar.xz";
+      sha256 = "f7fb72cbff43ae6dfb222e5b1c49947602086412b97634484eb3cc86ab773aa2";
+      name = "kaddressbook-20.08.1.tar.xz";
     };
   };
   kajongg = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kajongg-20.08.0.tar.xz";
-      sha256 = "1813ff2d960f96d63c5680b4a7e7dca6249146876c7a6d203eb0f9768eca244b";
-      name = "kajongg-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kajongg-20.08.1.tar.xz";
+      sha256 = "801c0cc63767809ea4909ceb66dbbbb3e8ad400db7a24c80dc6ae8f3f5c9a6b9";
+      name = "kajongg-20.08.1.tar.xz";
     };
   };
   kalarm = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kalarm-20.08.0.tar.xz";
-      sha256 = "02c1a62f603cc6917d0f95eff4aaa23cf808395bed9b1dad21817f6c32256748";
-      name = "kalarm-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kalarm-20.08.1.tar.xz";
+      sha256 = "22fea5be32c8db6b0903f216307f20dafc2ac69c620d9b4512e1034c0294c207";
+      name = "kalarm-20.08.1.tar.xz";
     };
   };
   kalarmcal = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kalarmcal-20.08.0.tar.xz";
-      sha256 = "bd4f048a976829ee5768b9d26aebe4efbbfa0a2991486c8f57f250fe4198532c";
-      name = "kalarmcal-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kalarmcal-20.08.1.tar.xz";
+      sha256 = "745515662c23154480e73f4a8d6e9ec760d01770383c1dd7f31d3f1463be7602";
+      name = "kalarmcal-20.08.1.tar.xz";
     };
   };
   kalgebra = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kalgebra-20.08.0.tar.xz";
-      sha256 = "658fd3eae218b6b73dbf3ff2edb59c511bfb11d549b7e41a5224c62b4bfedc2c";
-      name = "kalgebra-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kalgebra-20.08.1.tar.xz";
+      sha256 = "a5ab916eba3bfd7535408768e6530e993bc1097ef1a2a0af5aa804aa1f713caf";
+      name = "kalgebra-20.08.1.tar.xz";
     };
   };
   kalzium = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kalzium-20.08.0.tar.xz";
-      sha256 = "e9b402ea91ac87a19cef6e686bfb8507f6afac0d19c5dc7de777475d5db1b06f";
-      name = "kalzium-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kalzium-20.08.1.tar.xz";
+      sha256 = "c2c4a823525ab5927c39f29e2150f34fc03947fb852aea1bdb73390c5a709188";
+      name = "kalzium-20.08.1.tar.xz";
     };
   };
   kamera = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kamera-20.08.0.tar.xz";
-      sha256 = "ca4194b99703a1908d4991538419c49fc28f5df8cb32f7c07a20454f4918f12a";
-      name = "kamera-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kamera-20.08.1.tar.xz";
+      sha256 = "f5b04ca46313de1bb0a57253650d1d1578f45796035888b759ad224b5866ee96";
+      name = "kamera-20.08.1.tar.xz";
     };
   };
   kamoso = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kamoso-20.08.0.tar.xz";
-      sha256 = "c27ea592a70d7634740973e860acdf8cda49c0880a13f623c315fbc02cc3d592";
-      name = "kamoso-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kamoso-20.08.1.tar.xz";
+      sha256 = "ed8fa6a6127a8bea5294534aa2552526af101f981de58512fbb9f7dfd78e8984";
+      name = "kamoso-20.08.1.tar.xz";
     };
   };
   kanagram = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kanagram-20.08.0.tar.xz";
-      sha256 = "d7fc300883bb5420ce1f9bc2ec52324a74b775a8ecea12b904afedc0a6af6ca3";
-      name = "kanagram-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kanagram-20.08.1.tar.xz";
+      sha256 = "c810db58884e80d95baef149b8ced8fff7c5e48d6057478e81a5c8895ae67b42";
+      name = "kanagram-20.08.1.tar.xz";
     };
   };
   kapman = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kapman-20.08.0.tar.xz";
-      sha256 = "24ad6ae146c0770fe4498983604b25ced25eab98b4a94898311553f7e4a97475";
-      name = "kapman-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kapman-20.08.1.tar.xz";
+      sha256 = "934da85c5d9c99a0ed658fe4d99df258246716e04e13ceb3e18b11cc035c4f4c";
+      name = "kapman-20.08.1.tar.xz";
     };
   };
   kapptemplate = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kapptemplate-20.08.0.tar.xz";
-      sha256 = "ef92d56a155f1218d28a63167e67f4fc7bbdf9ba63344bef9512b2e1435f322d";
-      name = "kapptemplate-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kapptemplate-20.08.1.tar.xz";
+      sha256 = "7b350467e14bc310a695ffa3481afa7857de2f6ec714915ee2d8a25a6511909b";
+      name = "kapptemplate-20.08.1.tar.xz";
     };
   };
   kate = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kate-20.08.0.tar.xz";
-      sha256 = "aa0695f40cf9d491a08338f1c9b4331dfbb63cb311cf815ed0499b38940fa0db";
-      name = "kate-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kate-20.08.1.tar.xz";
+      sha256 = "44607f6a1d5ca8bb7173bedbeabef65bb98dde0fd009987bd8139fbb53959146";
+      name = "kate-20.08.1.tar.xz";
     };
   };
   katomic = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/katomic-20.08.0.tar.xz";
-      sha256 = "006c55f3f688f70b51cf89589843037f09d30e826cf1a30ec441e84724ad27ab";
-      name = "katomic-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/katomic-20.08.1.tar.xz";
+      sha256 = "1aa655857bb1708880b6fbf4e54acdfe1cb7f47a9494249978251d870b86f13a";
+      name = "katomic-20.08.1.tar.xz";
     };
   };
   kbackup = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kbackup-20.08.0.tar.xz";
-      sha256 = "5d5882df3dfa6a078940ea6e292fd1c1aba7c016426e36d87f0d7f8c149bcd59";
-      name = "kbackup-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kbackup-20.08.1.tar.xz";
+      sha256 = "08b0c43fca2dba65e1173841343daf8e6e37e11101be7315011e8345ba9b1e72";
+      name = "kbackup-20.08.1.tar.xz";
     };
   };
   kblackbox = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kblackbox-20.08.0.tar.xz";
-      sha256 = "0f6d0341e5bbc16d2d0ec9dc14027ebc91fdda2b9eb2ac6061055a60541db358";
-      name = "kblackbox-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kblackbox-20.08.1.tar.xz";
+      sha256 = "3f09d483fa3a3013e685df9efd9cee8d9d1b9f0e017cc97d92636bae89fc469c";
+      name = "kblackbox-20.08.1.tar.xz";
     };
   };
   kblocks = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kblocks-20.08.0.tar.xz";
-      sha256 = "041904451ce1aec7da113ed4fb442abd92083b8d7522b1c91e05933d574fba8e";
-      name = "kblocks-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kblocks-20.08.1.tar.xz";
+      sha256 = "e2b6e5b0727ca45d6b0f0e8b9f0aa029a0acb9bdebeac5bfd849455e560977ed";
+      name = "kblocks-20.08.1.tar.xz";
     };
   };
   kbounce = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kbounce-20.08.0.tar.xz";
-      sha256 = "7949b9ea43ca93b13378c018d8a532c200233f5f3d2acaba3c74d90f3ed79ccb";
-      name = "kbounce-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kbounce-20.08.1.tar.xz";
+      sha256 = "99af3bd297fcbecb9eaa4222bbb5122144beff9cb999420bf45339d61375f2a4";
+      name = "kbounce-20.08.1.tar.xz";
     };
   };
   kbreakout = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kbreakout-20.08.0.tar.xz";
-      sha256 = "0aa63a16d45ca432065777352f69a7fc0993fd0077f14e05cb89b06a1b69ad69";
-      name = "kbreakout-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kbreakout-20.08.1.tar.xz";
+      sha256 = "0d57c105f2778b68c0b5ff8cb3e02d5c7ea2956b90d48d126ff1118b94d5f2fa";
+      name = "kbreakout-20.08.1.tar.xz";
     };
   };
   kbruch = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kbruch-20.08.0.tar.xz";
-      sha256 = "9e0c51ec0e32a8b46b567c7d275acb3845e09aef446c27324d872fc3a096113e";
-      name = "kbruch-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kbruch-20.08.1.tar.xz";
+      sha256 = "f04bf902a31b68d18c69afff511a591817a35f5ad866de4f84aa1b664b35a41e";
+      name = "kbruch-20.08.1.tar.xz";
     };
   };
   kcachegrind = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kcachegrind-20.08.0.tar.xz";
-      sha256 = "94b3963e9eebc0bf67644de1666cf019649f5eaf924ac01c1af6e48619a11f87";
-      name = "kcachegrind-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kcachegrind-20.08.1.tar.xz";
+      sha256 = "59c43296aaa7d8a5dbf782ba9248ee8bb6308e7bd7bdfc0b99e1c912529337f2";
+      name = "kcachegrind-20.08.1.tar.xz";
     };
   };
   kcalc = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kcalc-20.08.0.tar.xz";
-      sha256 = "3b6dee02e43ddb85ae6748cd8aefb422112be411e778c56372e97de0046bfca2";
-      name = "kcalc-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kcalc-20.08.1.tar.xz";
+      sha256 = "46702fe8eca8b604e15f3f2eb4d1f17b8601b6ad0b03bb9cd0a0dd7ed7a13c49";
+      name = "kcalc-20.08.1.tar.xz";
     };
   };
   kcalutils = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kcalutils-20.08.0.tar.xz";
-      sha256 = "82504223fe3a0f6149204aa5f3b38dc7fb05a25048e4a0159ba6e1923c24c1f8";
-      name = "kcalutils-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kcalutils-20.08.1.tar.xz";
+      sha256 = "ae6a8ca02722f8f593a8d248ab3d043cc68be23d18f820e150af000a902601c2";
+      name = "kcalutils-20.08.1.tar.xz";
     };
   };
   kcharselect = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kcharselect-20.08.0.tar.xz";
-      sha256 = "91b17c42286c3a715dcde764057364bada6d07ae163f9b5cdc7daec338ee3a72";
-      name = "kcharselect-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kcharselect-20.08.1.tar.xz";
+      sha256 = "36575e9fd0a93fb3ddaf6a75a213786351bdd3ab8c167dc1a3e2824a23a6655b";
+      name = "kcharselect-20.08.1.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kcolorchooser-20.08.0.tar.xz";
-      sha256 = "df1bfd346bfcdea7a585f489f62ab2f76993ce07f83c47cb8202be981b8a3829";
-      name = "kcolorchooser-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kcolorchooser-20.08.1.tar.xz";
+      sha256 = "20cae01bd5e8c824f8e7900badd0d66464c363a749a1ce9fe6fe3a1e31c99ade";
+      name = "kcolorchooser-20.08.1.tar.xz";
     };
   };
   kcron = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kcron-20.08.0.tar.xz";
-      sha256 = "e45d06ed0665d8f1cad3d44cc43035d50fc533bf9ab6e10fe53ab23f2ed5e708";
-      name = "kcron-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kcron-20.08.1.tar.xz";
+      sha256 = "24ee9aee48bef951d6ac1fff32271417c4eb2239f0ec1de8388f2bae55ce83f5";
+      name = "kcron-20.08.1.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdebugsettings-20.08.0.tar.xz";
-      sha256 = "21914b67dfc654ed525118afeda74e6a0539af9a0f3be05c490e9edbf13b2328";
-      name = "kdebugsettings-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdebugsettings-20.08.1.tar.xz";
+      sha256 = "cac50d34c8a31805924aa75755475a754109fc643e95fe50188477522d113a55";
+      name = "kdebugsettings-20.08.1.tar.xz";
     };
   };
   kdeconnect-kde = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdeconnect-kde-20.08.0.tar.xz";
-      sha256 = "3de16bf165b68635919e68fa2460a5d14139cd9a63cb27573a7b2b2a5b0044a1";
-      name = "kdeconnect-kde-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdeconnect-kde-20.08.1.tar.xz";
+      sha256 = "8ebfe36b4d08b36881082a3748f63a7c645b51e8f3b094607512817e9f6ce668";
+      name = "kdeconnect-kde-20.08.1.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kde-dev-scripts-20.08.0.tar.xz";
-      sha256 = "2c3120e63ebcd41e30acfd53063bad659e1982f79b81429e0541b0100bc25ad3";
-      name = "kde-dev-scripts-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kde-dev-scripts-20.08.1.tar.xz";
+      sha256 = "f7f99a199fea69019738e6d2147e5f6e4419835aa2c39e6d60f4d2e5d629ba96";
+      name = "kde-dev-scripts-20.08.1.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kde-dev-utils-20.08.0.tar.xz";
-      sha256 = "7998afa4ac1b293eb3ba8f48ea77cd0bc22d2c2eda84e291d8c9cf2a5e719547";
-      name = "kde-dev-utils-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kde-dev-utils-20.08.1.tar.xz";
+      sha256 = "8105a5b911643dca1f0c476c9247282f80e4ea17bae06dcca63ba9638bf5d21d";
+      name = "kde-dev-utils-20.08.1.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdeedu-data-20.08.0.tar.xz";
-      sha256 = "c863f72c8dacb47dc8c82f966f4b70d33f75c2b9f6d63c174e9f3a2c73241943";
-      name = "kdeedu-data-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdeedu-data-20.08.1.tar.xz";
+      sha256 = "d9c10c849f94b8cff7f79747a0594b8050f19d5477799b03f803c4241a9d12b6";
+      name = "kdeedu-data-20.08.1.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdegraphics-mobipocket-20.08.0.tar.xz";
-      sha256 = "2c11b6efe2c5f7725341c861dd9ba8e919ba3734866e808225c13bb2f2d90a2d";
-      name = "kdegraphics-mobipocket-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdegraphics-mobipocket-20.08.1.tar.xz";
+      sha256 = "9974c36d90fc23d9a3a7172cf1526dc3671bf90f01f608effe92f64fce53c372";
+      name = "kdegraphics-mobipocket-20.08.1.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdegraphics-thumbnailers-20.08.0.tar.xz";
-      sha256 = "d466c08b4a5e4ccc36907dd38e82019f9060c2ea1931f336f9fbb2f79036566e";
-      name = "kdegraphics-thumbnailers-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdegraphics-thumbnailers-20.08.1.tar.xz";
+      sha256 = "8303231f2fc44c071b3f6a477ae5335f2657dbfaba52362529aaba20973a5995";
+      name = "kdegraphics-thumbnailers-20.08.1.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdenetwork-filesharing-20.08.0.tar.xz";
-      sha256 = "8fabf6b5eae8c32bf75db911ae76d35aa9fee66355964cf0ad8150f960b83256";
-      name = "kdenetwork-filesharing-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdenetwork-filesharing-20.08.1.tar.xz";
+      sha256 = "e88f4a2f6d7b8a61ebd491eb112f51d50f9949d729022fab01223d6ea36b8a01";
+      name = "kdenetwork-filesharing-20.08.1.tar.xz";
     };
   };
   kdenlive = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdenlive-20.08.0.tar.xz";
-      sha256 = "89914ee37f5bbdd16051b0db4a6cfb6f8c3d748f47c9e28e5349920ca133c0bd";
-      name = "kdenlive-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdenlive-20.08.1.tar.xz";
+      sha256 = "f99e3f22c3d5e41a3ca251299d010ac2bc44933091c25d360104d562a1090873";
+      name = "kdenlive-20.08.1.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdepim-addons-20.08.0.tar.xz";
-      sha256 = "4045f7879cc47829a82a4ada18a35cb3bdf89a489a15cd0bd48441c305b3cb06";
-      name = "kdepim-addons-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdepim-addons-20.08.1.tar.xz";
+      sha256 = "a0bddcbe8f8f6d8c878a6b5634578522a8d485e424cf37d35bc17df9a1ffc7c2";
+      name = "kdepim-addons-20.08.1.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdepim-apps-libs-20.08.0.tar.xz";
-      sha256 = "bf7ac0af294510e4127808f3f2c1e25368c97b78ff0a5405219abb67173598a0";
-      name = "kdepim-apps-libs-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdepim-apps-libs-20.08.1.tar.xz";
+      sha256 = "a0664933b3b5ff20747bf2adec9fbbecf22935129349208430d53e8c9bf5b5bb";
+      name = "kdepim-apps-libs-20.08.1.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdepim-runtime-20.08.0.tar.xz";
-      sha256 = "f6e4ff70b9cb85e8590ab8d7432abe1b6a2daa14d09a2974f8902b882b16409d";
-      name = "kdepim-runtime-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdepim-runtime-20.08.1.tar.xz";
+      sha256 = "27a4c04dcf2eac4108a43acbdd57e3a8aa1da92443a3e7977329d0218da05c24";
+      name = "kdepim-runtime-20.08.1.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdesdk-kioslaves-20.08.0.tar.xz";
-      sha256 = "0ab8188c1746ec5786d94e5988487b766a04a9df1c275b25778ab2948e302776";
-      name = "kdesdk-kioslaves-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdesdk-kioslaves-20.08.1.tar.xz";
+      sha256 = "528cce0ea4c7c9fd53a604591eae4a70d39421ebbe62ed59bcbc80072f95c19f";
+      name = "kdesdk-kioslaves-20.08.1.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdesdk-thumbnailers-20.08.0.tar.xz";
-      sha256 = "8f2adb38ca24b82119eb52ef879f5fd6a5d48b9c012956a518cefefd86fbd6d3";
-      name = "kdesdk-thumbnailers-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdesdk-thumbnailers-20.08.1.tar.xz";
+      sha256 = "5b189182f2a734f82e67e23d3293e694c51f97c0a9acd1ec5498442a3d2a3804";
+      name = "kdesdk-thumbnailers-20.08.1.tar.xz";
     };
   };
   kdf = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdf-20.08.0.tar.xz";
-      sha256 = "2f5fddbaf09d3cfdfb3e18b0a9292ecb6bcf14969e4d031a4215f22fecda0892";
-      name = "kdf-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdf-20.08.1.tar.xz";
+      sha256 = "c100c87e9dbfcf7c12ce78d743f4ce3a2ec2bf3c1b0d969af1285255071195a5";
+      name = "kdf-20.08.1.tar.xz";
     };
   };
   kdialog = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdialog-20.08.0.tar.xz";
-      sha256 = "669da86bebf2cfac4cda7c873bb57417aac8d293cee8c5950968495520954ed5";
-      name = "kdialog-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdialog-20.08.1.tar.xz";
+      sha256 = "089e8a8e85a9021b830e9b8a19ecb1999781915a716c9c2b3c99894a5d1c8dcf";
+      name = "kdialog-20.08.1.tar.xz";
     };
   };
   kdiamond = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kdiamond-20.08.0.tar.xz";
-      sha256 = "56efcb8b2bf81d62324911f404e918f7bcd62f6fa2ee9d4e513df54e37631889";
-      name = "kdiamond-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kdiamond-20.08.1.tar.xz";
+      sha256 = "1629dc6f70873b42081bd75dbf858da56d380c32925ddd49bd2110d458cb4b23";
+      name = "kdiamond-20.08.1.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/keditbookmarks-20.08.0.tar.xz";
-      sha256 = "7fab031ae4d62e3c9d37dce671af4580afe01e6e3411ef199115568e893b7df5";
-      name = "keditbookmarks-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/keditbookmarks-20.08.1.tar.xz";
+      sha256 = "8bfedffae0332dbfb611d25f3178ab7babe374155cce7c44e1aaa841934c3123";
+      name = "keditbookmarks-20.08.1.tar.xz";
     };
   };
   kfind = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kfind-20.08.0.tar.xz";
-      sha256 = "f47f1ee0dc1c75b90d70027eb0ce2b470912aff9db2c18a0380eb65b16e6c842";
-      name = "kfind-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kfind-20.08.1.tar.xz";
+      sha256 = "e49412d0eae6f77369b96ee7fa5902252294d03da1e8782460d4bba5be6bb149";
+      name = "kfind-20.08.1.tar.xz";
     };
   };
   kfloppy = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kfloppy-20.08.0.tar.xz";
-      sha256 = "85732b804ee19c1a1db82845d7ab8c1ba1872d8d40737ee5b6beef8798c457f3";
-      name = "kfloppy-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kfloppy-20.08.1.tar.xz";
+      sha256 = "cfbe396c252acc23a929d05fe1a71099bc19ee3ab55f4f40e47780cf871852c5";
+      name = "kfloppy-20.08.1.tar.xz";
     };
   };
   kfourinline = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kfourinline-20.08.0.tar.xz";
-      sha256 = "9b1d520d61ddd98ce629a50355a190bded41d6abea100d87f3650e15e0c358b6";
-      name = "kfourinline-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kfourinline-20.08.1.tar.xz";
+      sha256 = "2c65dcc685d7e46da73e53ac3ab250ef4d1738bb85aa6f1b09160ff2ece364a2";
+      name = "kfourinline-20.08.1.tar.xz";
     };
   };
   kgeography = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kgeography-20.08.0.tar.xz";
-      sha256 = "7fd2b7449309d6c42e01038c93ce8dda9c7a8acb806b27b9ff58d4556711ff5e";
-      name = "kgeography-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kgeography-20.08.1.tar.xz";
+      sha256 = "f7ce4c6a00f18558aa04f4af0b71e45efc10c67f0b3454c5f0b2527a43133d30";
+      name = "kgeography-20.08.1.tar.xz";
     };
   };
   kget = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kget-20.08.0.tar.xz";
-      sha256 = "de46cbe0a53c7246d1aeb4f15d24b90633eaf37e236d67882e1454b61fea1a09";
-      name = "kget-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kget-20.08.1.tar.xz";
+      sha256 = "efbfc08a5a4ed3974bbdab20c5eae07cdb70f7f42e9de1c75651a57511d7e576";
+      name = "kget-20.08.1.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kgoldrunner-20.08.0.tar.xz";
-      sha256 = "29caf1637daea69013061d170a749411b18f543af7e2f8a0f295f1eb5cb62586";
-      name = "kgoldrunner-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kgoldrunner-20.08.1.tar.xz";
+      sha256 = "40380c0d3b65e06cdb9d9ca3791c10e0d2d300856cc49a7b3da0145b7651274b";
+      name = "kgoldrunner-20.08.1.tar.xz";
     };
   };
   kgpg = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kgpg-20.08.0.tar.xz";
-      sha256 = "102cc0d44b7621ebad1d5914bbb44a598689ebb95093e4a76713679996c2af0c";
-      name = "kgpg-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kgpg-20.08.1.tar.xz";
+      sha256 = "6b926c2adf896c3f68402ec10faf8db1e5f7c7b9fa8c1c26f9021d1fb0c975b0";
+      name = "kgpg-20.08.1.tar.xz";
     };
   };
   khangman = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/khangman-20.08.0.tar.xz";
-      sha256 = "11f442e24f0a428c0338000f66687bc021f4290bcd8cc0acc3fd882ce3cf4b0b";
-      name = "khangman-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/khangman-20.08.1.tar.xz";
+      sha256 = "fe94116ea833295a46c59a7420676925bb1038e7da86f6369d452087add40868";
+      name = "khangman-20.08.1.tar.xz";
     };
   };
   khelpcenter = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/khelpcenter-20.08.0.tar.xz";
-      sha256 = "2c45fb76c5503441dcf9ab1cae386dd2e10a2ad1af08f60090d362e82364e98c";
-      name = "khelpcenter-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/khelpcenter-20.08.1.tar.xz";
+      sha256 = "217b433c1a5da966ad5dab1e89e2e719632f1e035ab92cce094c5f0848bb6e39";
+      name = "khelpcenter-20.08.1.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kidentitymanagement-20.08.0.tar.xz";
-      sha256 = "4c7dca3e27f87203b27af219ebe07701e641a56dd7a8c1d7a3fa7cef2fe1c5af";
-      name = "kidentitymanagement-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kidentitymanagement-20.08.1.tar.xz";
+      sha256 = "3b34e029e99647d6742825633682ab8a5eecbe102e34ea2472cb53afb853840d";
+      name = "kidentitymanagement-20.08.1.tar.xz";
     };
   };
   kig = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kig-20.08.0.tar.xz";
-      sha256 = "fa9754f5a67e35fdfd8b836d423001fc48fe5c41fadbfceece834fb3f5b6cccd";
-      name = "kig-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kig-20.08.1.tar.xz";
+      sha256 = "f318d346cd152e62ae892ade31a784f0b7b823c56fdfd64e05a330072ad95745";
+      name = "kig-20.08.1.tar.xz";
     };
   };
   kigo = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kigo-20.08.0.tar.xz";
-      sha256 = "5e787cad2370b479feeae3be81b0972314429e0e896b9943445653731c9c6040";
-      name = "kigo-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kigo-20.08.1.tar.xz";
+      sha256 = "58fa166a487c855d300c8a33758928131fc4db80cbda19a08e3de918335d2bdb";
+      name = "kigo-20.08.1.tar.xz";
     };
   };
   killbots = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/killbots-20.08.0.tar.xz";
-      sha256 = "3b647fd8af007619acdfc7c72d572a3184a8e8c5ecbeb472559c5e40e9d53257";
-      name = "killbots-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/killbots-20.08.1.tar.xz";
+      sha256 = "252636f4df2af0e087f4d604f76c5d8702c38392d821281a0f6283be4e429af9";
+      name = "killbots-20.08.1.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kimagemapeditor-20.08.0.tar.xz";
-      sha256 = "17d3ccfc35aecd802729da6c78a78cb358cf68bd5079bcae6d83af0874e86a00";
-      name = "kimagemapeditor-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kimagemapeditor-20.08.1.tar.xz";
+      sha256 = "bf391d0812e0f2dce6a11481972cf9d04f14d0bf92cad7210fa35a1fa0edf230";
+      name = "kimagemapeditor-20.08.1.tar.xz";
     };
   };
   kimap = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kimap-20.08.0.tar.xz";
-      sha256 = "4ebb75312aac29274d8faa68f885c78a77c1173fc0200c08825670ac263cbec6";
-      name = "kimap-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kimap-20.08.1.tar.xz";
+      sha256 = "eae645ae2535c2612556e8938011cc478054c032126bb55683b95127d1b94741";
+      name = "kimap-20.08.1.tar.xz";
     };
   };
   kio-extras = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kio-extras-20.08.0.tar.xz";
-      sha256 = "6bfbb92dd56755ec0b2dee0cd889d6081ae00df339c05b4cb7a173a463275e2d";
-      name = "kio-extras-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kio-extras-20.08.1.tar.xz";
+      sha256 = "1122635926052f34fd35d8aeef9c3c1d892690d8372f2b7d902e6449cdab988a";
+      name = "kio-extras-20.08.1.tar.xz";
     };
   };
   kio-gdrive = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kio-gdrive-20.08.0.tar.xz";
-      sha256 = "c08f809d575a24887aacd1a046b01cf2c3df7b77813fecf89cb6cdbec13ab299";
-      name = "kio-gdrive-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kio-gdrive-20.08.1.tar.xz";
+      sha256 = "5104136948ee60cd527109bb9e8830e6a12f6062a29f34bc995b2625b0280825";
+      name = "kio-gdrive-20.08.1.tar.xz";
     };
   };
   kipi-plugins = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kipi-plugins-20.08.0.tar.xz";
-      sha256 = "f8f03a9797b4855839693ffca93245460e78fd2f6eeb763d16dd159711f40683";
-      name = "kipi-plugins-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kipi-plugins-20.08.1.tar.xz";
+      sha256 = "b7d8f1aa087006a48d9bd7ec036ab4779e898e3b02692c91342439747cad6c5c";
+      name = "kipi-plugins-20.08.1.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kirigami-gallery-20.08.0.tar.xz";
-      sha256 = "8cabcee747152b41b558c0a9eb1fd0d55fb155b3b807a57d2176023806a59f2b";
-      name = "kirigami-gallery-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kirigami-gallery-20.08.1.tar.xz";
+      sha256 = "497886cc5a8483f068a642ce19df19f69fd105a4fb583f1a9898c885659c9df5";
+      name = "kirigami-gallery-20.08.1.tar.xz";
     };
   };
   kiriki = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kiriki-20.08.0.tar.xz";
-      sha256 = "56db705674a43c249f2374eb1ce2c20e4b3e22223348959b3f5db67c0f52db4f";
-      name = "kiriki-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kiriki-20.08.1.tar.xz";
+      sha256 = "51e77cbbf6a0c60487d72b03b28c08409d0b6134c983d9e420fbc4d7f73223e8";
+      name = "kiriki-20.08.1.tar.xz";
     };
   };
   kiten = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kiten-20.08.0.tar.xz";
-      sha256 = "17cb8344d679040b5c7be99049f73b88517cf127e3d045d469cdae9602945263";
-      name = "kiten-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kiten-20.08.1.tar.xz";
+      sha256 = "f3764d090db8027746e83c326e833680fd669dca66dd6af095ba120e66de2901";
+      name = "kiten-20.08.1.tar.xz";
     };
   };
   kitinerary = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kitinerary-20.08.0.tar.xz";
-      sha256 = "a87ce5dd8e978dad8bcac7d92d89c4a5eeaa847e8819c2aa84ebce51dfe95f50";
-      name = "kitinerary-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kitinerary-20.08.1.tar.xz";
+      sha256 = "d3e0b6130b5c603bc1494404fa91ed1995e9142d66e4c3ddd5d2c79fdea856e4";
+      name = "kitinerary-20.08.1.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kjumpingcube-20.08.0.tar.xz";
-      sha256 = "5ea4187326a0ff0a77c0aef774d9ba9c3c20b438def85abe9e4b0822a8350a70";
-      name = "kjumpingcube-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kjumpingcube-20.08.1.tar.xz";
+      sha256 = "226424cd21f75c499eedd15460a466988b179312467ed16437df87be494d9fbc";
+      name = "kjumpingcube-20.08.1.tar.xz";
     };
   };
   kldap = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kldap-20.08.0.tar.xz";
-      sha256 = "db358a6ec50f5d3988583096ccc5fe1389999b4dd3a3c787d7797f6e0b32ee53";
-      name = "kldap-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kldap-20.08.1.tar.xz";
+      sha256 = "098fb07b280ef25dcf04b18f627223014257f6c0874b2959f2a8e68cacdb74a7";
+      name = "kldap-20.08.1.tar.xz";
     };
   };
   kleopatra = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kleopatra-20.08.0.tar.xz";
-      sha256 = "776fbb8d06edc83834745a8af05b23297aeba89b8dce3410a2d48f37a91b5a87";
-      name = "kleopatra-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kleopatra-20.08.1.tar.xz";
+      sha256 = "e7bc3ce03ad5431e4289360ba6b701e38d53b60de58fd1ed358480cec48657a6";
+      name = "kleopatra-20.08.1.tar.xz";
     };
   };
   klettres = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/klettres-20.08.0.tar.xz";
-      sha256 = "55748999e29ecec5fb3ce206c74bc44f7e83f4f239edd61c161e4df4e597bca2";
-      name = "klettres-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/klettres-20.08.1.tar.xz";
+      sha256 = "f29d6df1de3562731f246a892caaa493b9bccc9d1317a948e03ad12cb8c80c06";
+      name = "klettres-20.08.1.tar.xz";
     };
   };
   klickety = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/klickety-20.08.0.tar.xz";
-      sha256 = "0b6d71d54a5521ae8cc66eca1d397289a35733af2fc686b82bc01dd6777fa926";
-      name = "klickety-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/klickety-20.08.1.tar.xz";
+      sha256 = "a9b63b3e944faba25498e981c06981dc354f9acd34b77f46fe2bebef388bf2cb";
+      name = "klickety-20.08.1.tar.xz";
     };
   };
   klines = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/klines-20.08.0.tar.xz";
-      sha256 = "778928fc55fe551eb836beba3f74b0f20602a0fae7366c71fa84a95ad6ca803a";
-      name = "klines-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/klines-20.08.1.tar.xz";
+      sha256 = "d16650d7d44f48f47700dcb8fe97519dd28fe7213052636363d281c24f46a2b9";
+      name = "klines-20.08.1.tar.xz";
     };
   };
   kmag = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kmag-20.08.0.tar.xz";
-      sha256 = "b1a8fe75a03dbeac8f2080808f580bea588bf39c97534ddfa0cbf7d0de20efb7";
-      name = "kmag-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kmag-20.08.1.tar.xz";
+      sha256 = "0aaaf19af2c943ae460dbcc1984bae167b79be287802e8a6faa6aaaed11718f3";
+      name = "kmag-20.08.1.tar.xz";
     };
   };
   kmahjongg = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kmahjongg-20.08.0.tar.xz";
-      sha256 = "05538c97613d6e3547161136b9d7aec9bb2918c9f4033a084e1576041b83d4e6";
-      name = "kmahjongg-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kmahjongg-20.08.1.tar.xz";
+      sha256 = "842b3d2e9c60b6a8e6bb6d09f26db49d988889ec3962ac40aea0e79434c2eb43";
+      name = "kmahjongg-20.08.1.tar.xz";
     };
   };
   kmail = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kmail-20.08.0.tar.xz";
-      sha256 = "0432ec1fd68868e9385dd3f6b9e2429feb5b5057317ef3940eb0e67a63e0c0f0";
-      name = "kmail-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kmail-20.08.1.tar.xz";
+      sha256 = "7ba5854e36e2ed752baa3a1ac15d1a6227699da6f5bdca3c250f22226b4d902b";
+      name = "kmail-20.08.1.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kmail-account-wizard-20.08.0.tar.xz";
-      sha256 = "9f4eac46049acbc7452bbbf84569031d91f86c2577beecacb3a6200deefcc253";
-      name = "kmail-account-wizard-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kmail-account-wizard-20.08.1.tar.xz";
+      sha256 = "7a1dc9ad542c0e54b80e955a162888c7d4b6bababcf02681d54af4480c03bd8d";
+      name = "kmail-account-wizard-20.08.1.tar.xz";
     };
   };
   kmailtransport = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kmailtransport-20.08.0.tar.xz";
-      sha256 = "af337017b884519065fea520fd66a8fc2e553d84ca3d8afc35739c18e67b4d73";
-      name = "kmailtransport-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kmailtransport-20.08.1.tar.xz";
+      sha256 = "4cabad74e141891546b0f47f44030eeb59fb63257a5c0d1c12124815ebf710c1";
+      name = "kmailtransport-20.08.1.tar.xz";
     };
   };
   kmbox = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kmbox-20.08.0.tar.xz";
-      sha256 = "58a2ecc7222a8ee5697102ca2bc871e7e30c823dcd906ac4160323fd1ba14d85";
-      name = "kmbox-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kmbox-20.08.1.tar.xz";
+      sha256 = "df77b2bf448d1ce21ff4a816f1164297519b48cd60200cea0edae6e72a81a19b";
+      name = "kmbox-20.08.1.tar.xz";
     };
   };
   kmime = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kmime-20.08.0.tar.xz";
-      sha256 = "55f2160fa78202cf45a4b08b9bb2fec1bc54a3700f6c9aceeec8d7fc3a64a317";
-      name = "kmime-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kmime-20.08.1.tar.xz";
+      sha256 = "cd0beaa46040d571b505d07853be76f099289e22d99ce4884695d4d645dfbe8c";
+      name = "kmime-20.08.1.tar.xz";
     };
   };
   kmines = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kmines-20.08.0.tar.xz";
-      sha256 = "d8d0f1a82fe279ed208a9005e8ffbe1277e25b33e9e0a1301013820e559ba750";
-      name = "kmines-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kmines-20.08.1.tar.xz";
+      sha256 = "eeb58941c94330f3ffdca60c0ca84d8ebcc9c6c355737217b521c54e50c650cd";
+      name = "kmines-20.08.1.tar.xz";
     };
   };
   kmix = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kmix-20.08.0.tar.xz";
-      sha256 = "4553362d4d14fdaf019b1fc55b98aac16c2db56542996a3c2f87603c41bc2859";
-      name = "kmix-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kmix-20.08.1.tar.xz";
+      sha256 = "012d14adbb200a7e66ddbc9ebc8e18c4e5082ae24dea6ab22284b6c730a1b472";
+      name = "kmix-20.08.1.tar.xz";
     };
   };
   kmousetool = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kmousetool-20.08.0.tar.xz";
-      sha256 = "285d947548ee863de6274888b097e19aff39ed2bb8cdd33e37707c39c8417863";
-      name = "kmousetool-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kmousetool-20.08.1.tar.xz";
+      sha256 = "c1d769efdd318eb1e29905122c579c72a41da74b45a076b79cf177b1800e1464";
+      name = "kmousetool-20.08.1.tar.xz";
     };
   };
   kmouth = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kmouth-20.08.0.tar.xz";
-      sha256 = "a783e73e8087d090cf4eba89fabcb9aee8c6b0858a6dea8a137323c1bbc110b1";
-      name = "kmouth-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kmouth-20.08.1.tar.xz";
+      sha256 = "d87fb47fa00c54f13cdaef33d15cc74f31d7009d4a8d988902b62c698d1e2c2c";
+      name = "kmouth-20.08.1.tar.xz";
     };
   };
   kmplot = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kmplot-20.08.0.tar.xz";
-      sha256 = "f2d31d8c9091c74c6d0e65a0cba77bac23eb6f78913b31d049a0e2c9ca4ec8c0";
-      name = "kmplot-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kmplot-20.08.1.tar.xz";
+      sha256 = "6d294a89f9e0fc42262ada6d71ba5abaeb756beb194e71f1852e18ae2b85456e";
+      name = "kmplot-20.08.1.tar.xz";
     };
   };
   knavalbattle = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/knavalbattle-20.08.0.tar.xz";
-      sha256 = "887d2f4e24d522ab66c2a4e183b9d5359213d67382fa2350f2edff6478666aa8";
-      name = "knavalbattle-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/knavalbattle-20.08.1.tar.xz";
+      sha256 = "e0cbffc5643aac302c53cfd957eefa7f89486fdd0d9c55b74f39d733a0ac3b65";
+      name = "knavalbattle-20.08.1.tar.xz";
     };
   };
   knetwalk = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/knetwalk-20.08.0.tar.xz";
-      sha256 = "83fdf150c1c14f7c1807b73ce1d4bacfd10469f565541a379daa828755ddf5c6";
-      name = "knetwalk-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/knetwalk-20.08.1.tar.xz";
+      sha256 = "30cbf7bdf5f875ce172a382ef7da8e74803015017c6cd525cb6c288defac020d";
+      name = "knetwalk-20.08.1.tar.xz";
     };
   };
   knights = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/knights-20.08.0.tar.xz";
-      sha256 = "b754af5da0ee922834644c578f2133695cc446dfb8ac327fae357e7a6c027bf7";
-      name = "knights-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/knights-20.08.1.tar.xz";
+      sha256 = "58518d8ecce5744fdf68c18e0803f48cb912fa29c5ea93ed6ccd2d4d320f722d";
+      name = "knights-20.08.1.tar.xz";
     };
   };
   knotes = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/knotes-20.08.0.tar.xz";
-      sha256 = "35454e609c6ea2f805c8976d2897d2b2b9137a61ad8d396be2b510881bbd7cf3";
-      name = "knotes-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/knotes-20.08.1.tar.xz";
+      sha256 = "7d066a34d46684f258481466875d18f99a9000d66dec36f7dcab92790f6c57bb";
+      name = "knotes-20.08.1.tar.xz";
     };
   };
   kolf = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kolf-20.08.0.tar.xz";
-      sha256 = "dbc0d129e1d1fc8c597979c5ec96d612014aa56b0b0825be653b410995987305";
-      name = "kolf-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kolf-20.08.1.tar.xz";
+      sha256 = "04d117895a6504d6138d1e3cd3157dd3318ba93eefd749182556344650f6a2f8";
+      name = "kolf-20.08.1.tar.xz";
     };
   };
   kollision = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kollision-20.08.0.tar.xz";
-      sha256 = "a7d59d6f4132a669ce4fe74b3b58168ce6f2036a27d37cc6362b471b58a70fe4";
-      name = "kollision-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kollision-20.08.1.tar.xz";
+      sha256 = "858d69131951734181b449ce48498b3b843634eb8c069c932042b3c0f862f98c";
+      name = "kollision-20.08.1.tar.xz";
     };
   };
   kolourpaint = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kolourpaint-20.08.0.tar.xz";
-      sha256 = "f2b5dee4e8c2b8245b2fd652c5ead015f637f62bc4b799735af255e2c5831629";
-      name = "kolourpaint-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kolourpaint-20.08.1.tar.xz";
+      sha256 = "7de98e081f13fb9f8a73932d5e8ce6f1cfd73e345fa28d03f515cad69f1b8bae";
+      name = "kolourpaint-20.08.1.tar.xz";
     };
   };
   kompare = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kompare-20.08.0.tar.xz";
-      sha256 = "712d248edc6eae8dd94d41efccde94ccbc5753ecd01eb69cb3d80757a63805a3";
-      name = "kompare-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kompare-20.08.1.tar.xz";
+      sha256 = "6e9109f1b24b3d79dec3d70c75357a67d16ab35081bcf7e4b842981b84796aa2";
+      name = "kompare-20.08.1.tar.xz";
     };
   };
   konqueror = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/konqueror-20.08.0.tar.xz";
-      sha256 = "4db172cff4bd3fd06ee1905dcf87013059e02902808e77acfc4bf2734d6ff73f";
-      name = "konqueror-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/konqueror-20.08.1.tar.xz";
+      sha256 = "e3aac062d9e431e63a861ecf5a1d577b11a154faaed5bd95ef6b69b4fc8a34e9";
+      name = "konqueror-20.08.1.tar.xz";
     };
   };
   konquest = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/konquest-20.08.0.tar.xz";
-      sha256 = "e6938230c2fdd94903d13ed34f8d1e8db8221c9ceb571c5737f429291d4cca04";
-      name = "konquest-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/konquest-20.08.1.tar.xz";
+      sha256 = "cad87dd698bd1ebc0279216614f7fa7c3d3f36d545683a69f1ceafe9e279bbfe";
+      name = "konquest-20.08.1.tar.xz";
     };
   };
   konsole = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/konsole-20.08.0.tar.xz";
-      sha256 = "b641bc2f66195887a25ec588b638a78a0d00e6d2d41c126bca9a45f30f70aee9";
-      name = "konsole-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/konsole-20.08.1.tar.xz";
+      sha256 = "bdd82f9104b2f76c53bdbdef613391719b70719a132d24f12e5f620e1c9313d1";
+      name = "konsole-20.08.1.tar.xz";
     };
   };
   kontact = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kontact-20.08.0.tar.xz";
-      sha256 = "d759b475938079f87d5042d4fc6608c0263800cfc2156e83c874faa77c488646";
-      name = "kontact-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kontact-20.08.1.tar.xz";
+      sha256 = "36c33eb5685c22f94257e86ff760d1aa225ae6e2d69402a2b653c54627c7cbde";
+      name = "kontact-20.08.1.tar.xz";
     };
   };
   kontactinterface = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kontactinterface-20.08.0.tar.xz";
-      sha256 = "6b20e160642063b966f359ecf2e1946db161728d42f4e6b15a77f6a19f151048";
-      name = "kontactinterface-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kontactinterface-20.08.1.tar.xz";
+      sha256 = "8272d0c17423a15e56e9e6d3979ee3017fd02ed996b8b6902c47312276ffeb51";
+      name = "kontactinterface-20.08.1.tar.xz";
     };
   };
   kopete = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kopete-20.08.0.tar.xz";
-      sha256 = "44805238ed04620101d3921e3eab0bb89d329c4d216b9cb49589459a3e4ea7e6";
-      name = "kopete-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kopete-20.08.1.tar.xz";
+      sha256 = "9846baae28d723963927d231716e2a8bc19795bac920958b688b48394ef5bc05";
+      name = "kopete-20.08.1.tar.xz";
     };
   };
   korganizer = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/korganizer-20.08.0.tar.xz";
-      sha256 = "c99470c92327e9e6c91276b4141bb36b08e3a9726e40edba6656d1014ee46b82";
-      name = "korganizer-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/korganizer-20.08.1.tar.xz";
+      sha256 = "e693d895b36575f2a73c36ceaafadf81465bbf9b03c74da27f5273a2e7e3670e";
+      name = "korganizer-20.08.1.tar.xz";
     };
   };
   kpat = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kpat-20.08.0.tar.xz";
-      sha256 = "feaca3a018a8b2a94a183915b29ff671474911b1da3a149bf3ba70fdcd0a6f53";
-      name = "kpat-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kpat-20.08.1.tar.xz";
+      sha256 = "2c23ee028c03c5c210b110a2ad253aa7d91c5a0abcb101eb2b3f4c640092463c";
+      name = "kpat-20.08.1.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kpimtextedit-20.08.0.tar.xz";
-      sha256 = "3ae3b9f8a980d10e366351efaf2b186fd911402da5b5ee634f4687d43586ce34";
-      name = "kpimtextedit-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kpimtextedit-20.08.1.tar.xz";
+      sha256 = "2664e6cbe520fa345e18db071dd5b8a5b4cf9b0fc7317eb04849005228666189";
+      name = "kpimtextedit-20.08.1.tar.xz";
     };
   };
   kpkpass = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kpkpass-20.08.0.tar.xz";
-      sha256 = "553b841cf3fdf4809251941997f7dee8e09360a5b7df386e3540c73d176ba055";
-      name = "kpkpass-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kpkpass-20.08.1.tar.xz";
+      sha256 = "76012e5bdd4cc434313a0f311acec8f7c798542008cd8efa71fcdf04fb77e55b";
+      name = "kpkpass-20.08.1.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kqtquickcharts-20.08.0.tar.xz";
-      sha256 = "f17807dfa20de202615c56779ef6e4d355a275b576d6e0969357fdb359b1b235";
-      name = "kqtquickcharts-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kqtquickcharts-20.08.1.tar.xz";
+      sha256 = "ea931bfefcc04bee03bff2498b92ca1a390967bbc5366c739d1a7cde6bb75820";
+      name = "kqtquickcharts-20.08.1.tar.xz";
     };
   };
   krdc = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/krdc-20.08.0.tar.xz";
-      sha256 = "96f4411dc80e746142796745c3b7fca4663aa37878391a00d1e70f2ba3be652c";
-      name = "krdc-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/krdc-20.08.1.tar.xz";
+      sha256 = "7b1fa57be31a3534099e7f203ef9afde23c86c4bbed1072a9d1164a3cf5e1e20";
+      name = "krdc-20.08.1.tar.xz";
     };
   };
   kreversi = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kreversi-20.08.0.tar.xz";
-      sha256 = "341603d23ffaf94af6c246540bbe7ba86aca3e5afe3135a0511aca22cd6a4d7f";
-      name = "kreversi-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kreversi-20.08.1.tar.xz";
+      sha256 = "5da68ddd37f5dbd4e1c94d1641c69f0e9b4e99eff3cdafcdcbac1139ca517315";
+      name = "kreversi-20.08.1.tar.xz";
     };
   };
   krfb = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/krfb-20.08.0.tar.xz";
-      sha256 = "f7ca46cc216ecd3790d045a36a642c834a9af4024409075e7a5bf8b498c67e4b";
-      name = "krfb-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/krfb-20.08.1.tar.xz";
+      sha256 = "a80b9bab47f2a7299e33b0e2a10b117605ec1cc572ca72e914c7f01dde383eda";
+      name = "krfb-20.08.1.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kross-interpreters-20.08.0.tar.xz";
-      sha256 = "7a27547b150d686524578fc256e1282f64554513d2724994020caf89e7a60b10";
-      name = "kross-interpreters-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kross-interpreters-20.08.1.tar.xz";
+      sha256 = "1fb7d75d83e63d1a7147468dd25eeb6aeb06b4679f126c658a8b40ef257f9a4e";
+      name = "kross-interpreters-20.08.1.tar.xz";
     };
   };
   kruler = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kruler-20.08.0.tar.xz";
-      sha256 = "71ca2308b8cee2fdd01faac526d20c813cab3664443b78e751f9d7d024e4e2c0";
-      name = "kruler-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kruler-20.08.1.tar.xz";
+      sha256 = "a9a1f3bd7b02416a393826f7bb810211ef2e14a3628706de735cb88e791d72d1";
+      name = "kruler-20.08.1.tar.xz";
     };
   };
   kshisen = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kshisen-20.08.0.tar.xz";
-      sha256 = "5b3cc83d3cd427dcbaa98e2536f58deb36ee4eefe0a35e6d5c9613a64abad0d8";
-      name = "kshisen-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kshisen-20.08.1.tar.xz";
+      sha256 = "d53af415ed2f4d202f5a6f965408e39062e39f43acf83b9550b6cf2ecc1f7641";
+      name = "kshisen-20.08.1.tar.xz";
     };
   };
   ksirk = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ksirk-20.08.0.tar.xz";
-      sha256 = "7e4acd8586a2c8619c3ca08138ca22cee46b4c46d5972a571665b09c6468cd06";
-      name = "ksirk-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ksirk-20.08.1.tar.xz";
+      sha256 = "763d3a8f518365391d2a04943f6efa9c73c388b7701deff300e9e42e4efe848f";
+      name = "ksirk-20.08.1.tar.xz";
     };
   };
   ksmtp = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ksmtp-20.08.0.tar.xz";
-      sha256 = "3fe08534bdb7037a8fd9a8c1a37456abe80252994232cfe31c368dcdc3c328c2";
-      name = "ksmtp-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ksmtp-20.08.1.tar.xz";
+      sha256 = "608d395cd1a046810ebd00f990d6f7c63d66677e7293ef06948ab9d336d2f08f";
+      name = "ksmtp-20.08.1.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ksnakeduel-20.08.0.tar.xz";
-      sha256 = "ebc5353ea2e5d16f2d966859b0ea081c81ed7d10c1975054e441545b79f60e5e";
-      name = "ksnakeduel-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ksnakeduel-20.08.1.tar.xz";
+      sha256 = "25bb5cfe2ed480b8ee31d9fe2e62272d77e7b8667748eb4f2c855901f718784f";
+      name = "ksnakeduel-20.08.1.tar.xz";
     };
   };
   kspaceduel = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kspaceduel-20.08.0.tar.xz";
-      sha256 = "6cd633521091ac8a1eed28b234657ba2db287c3b29ee2d071005f3438bbb1b07";
-      name = "kspaceduel-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kspaceduel-20.08.1.tar.xz";
+      sha256 = "382def18d1ce6a4333fb47bcd87aed6837382a2b0da2cb8b835d0b34eaed9e38";
+      name = "kspaceduel-20.08.1.tar.xz";
     };
   };
   ksquares = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ksquares-20.08.0.tar.xz";
-      sha256 = "84b459e6c1058f637b4894a4f97dfd95b0c9bb70954059d24538f80918b45ed3";
-      name = "ksquares-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ksquares-20.08.1.tar.xz";
+      sha256 = "163c5c070643e31594ada4e812433eb5f615ef425dddafd515e6c445d821f319";
+      name = "ksquares-20.08.1.tar.xz";
     };
   };
   ksudoku = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ksudoku-20.08.0.tar.xz";
-      sha256 = "0dbe6e03ca8b7203a307f97dad4a8035c20f3172d3e005b047557c2334c04a92";
-      name = "ksudoku-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ksudoku-20.08.1.tar.xz";
+      sha256 = "e53b694b340f812cd3bdf5126a32a1e71efe0785897c5d15f9e28c68fd794840";
+      name = "ksudoku-20.08.1.tar.xz";
     };
   };
   ksystemlog = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ksystemlog-20.08.0.tar.xz";
-      sha256 = "359eaa1cc34fa06b2ef3788c249c2b3355d6d39cddbf809df07179c10630e9a4";
-      name = "ksystemlog-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ksystemlog-20.08.1.tar.xz";
+      sha256 = "e0e8bc1cf8ee229206c8a65e30979ba8b72426c8dc2f737f6fecb0dfb36ed21a";
+      name = "ksystemlog-20.08.1.tar.xz";
     };
   };
   kteatime = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kteatime-20.08.0.tar.xz";
-      sha256 = "c7142cd0329cf23fdb79d3c2d508cb00cb70c517db1f832d2a39ba7c4e103fd3";
-      name = "kteatime-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kteatime-20.08.1.tar.xz";
+      sha256 = "23cc14f587e4ae4e3b56f1fb7a2093301df740328e35b25d7fca55d35f012ce5";
+      name = "kteatime-20.08.1.tar.xz";
     };
   };
   ktimer = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktimer-20.08.0.tar.xz";
-      sha256 = "4a3722945f26df087158a5af69cc81ba10054a778f04fecd32ff816732dff0dd";
-      name = "ktimer-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktimer-20.08.1.tar.xz";
+      sha256 = "9c7062f9ee64ff49a7c7773fe41cee0899e30f1f47368af73da067e51db6714b";
+      name = "ktimer-20.08.1.tar.xz";
     };
   };
   ktnef = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktnef-20.08.0.tar.xz";
-      sha256 = "69d18a052cc522161821f98fb4103d38e1ff566622915b7138866e7737ffa62f";
-      name = "ktnef-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktnef-20.08.1.tar.xz";
+      sha256 = "433b232a0c835e7f27c06e6d19856e4f8690c3e3b5c5d63f85172897b2448c81";
+      name = "ktnef-20.08.1.tar.xz";
     };
   };
   ktouch = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktouch-20.08.0.tar.xz";
-      sha256 = "c4b218f672c0cb86930cdadf622d758a42b54732319e8ea86405b7f9b3281802";
-      name = "ktouch-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktouch-20.08.1.tar.xz";
+      sha256 = "e098ebbccca743f678103a9adf54fc388fa4379cc6f667e48259d0b50f56b5fb";
+      name = "ktouch-20.08.1.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktp-accounts-kcm-20.08.0.tar.xz";
-      sha256 = "912552aa0df62298323c5eaaf36975b71ef50be56a5b69ceddcd5f00d4acb4f9";
-      name = "ktp-accounts-kcm-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktp-accounts-kcm-20.08.1.tar.xz";
+      sha256 = "b71f2f654c3cf48e4b4b037a0ae8f6fef5bac9c3483458c0eadf7b3253577504";
+      name = "ktp-accounts-kcm-20.08.1.tar.xz";
     };
   };
   ktp-approver = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktp-approver-20.08.0.tar.xz";
-      sha256 = "463a9009599b6e18b2e30793b6bce408e4c9a0edb2de458fb588204eb0aa2f3a";
-      name = "ktp-approver-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktp-approver-20.08.1.tar.xz";
+      sha256 = "51296f4d84585ba63d4c72cdbdee6e2b436a1aff8ce6b475a8c9a81766856b39";
+      name = "ktp-approver-20.08.1.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktp-auth-handler-20.08.0.tar.xz";
-      sha256 = "d2f1dd4c5f4043eebeb178dd20eedc95dea47a4c75f2df13cd1d9cd0288b699a";
-      name = "ktp-auth-handler-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktp-auth-handler-20.08.1.tar.xz";
+      sha256 = "6c1c006a3381caeebdfc37886b91b598153f3778567303d8a031e84599c9d582";
+      name = "ktp-auth-handler-20.08.1.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktp-call-ui-20.08.0.tar.xz";
-      sha256 = "2744e739456fd3aba322eb3c47be84511450dd713838e133be4f1957a3b9a0bf";
-      name = "ktp-call-ui-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktp-call-ui-20.08.1.tar.xz";
+      sha256 = "feb783be10b0792cb0c59456a00607b2d595e8bef90f0b4ec79dd070596d413c";
+      name = "ktp-call-ui-20.08.1.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktp-common-internals-20.08.0.tar.xz";
-      sha256 = "9ee962e2afd5db0fc23da69468f008ff239e97ef77d8930f7e5960d732d8a4b2";
-      name = "ktp-common-internals-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktp-common-internals-20.08.1.tar.xz";
+      sha256 = "5750bde4950fbe26f06a306aa642c9c501d4f0e1b41b57234d9e36b189a91d1b";
+      name = "ktp-common-internals-20.08.1.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktp-contact-list-20.08.0.tar.xz";
-      sha256 = "ec00bf525450c972634e60dfb423f9cd2be7caa4181e84efa7d88fc6f079a995";
-      name = "ktp-contact-list-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktp-contact-list-20.08.1.tar.xz";
+      sha256 = "809db5ff05c1ec632109be408cef987532193b1b0bea69d6a9286c12ccfe19a1";
+      name = "ktp-contact-list-20.08.1.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktp-contact-runner-20.08.0.tar.xz";
-      sha256 = "1123adbdfdbdb8bb524ba39ab175f39964cef2ecf5eed9a0a1d0129d7ae8ecbc";
-      name = "ktp-contact-runner-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktp-contact-runner-20.08.1.tar.xz";
+      sha256 = "a9e761fd35545cfffade088e33f4358e2743416f61e9ba490f21f3b04193158f";
+      name = "ktp-contact-runner-20.08.1.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktp-desktop-applets-20.08.0.tar.xz";
-      sha256 = "6a6eb5090f6273abb9ff1b70777c32bd4ba5fd0d270dfa0490ac370c31d0cab5";
-      name = "ktp-desktop-applets-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktp-desktop-applets-20.08.1.tar.xz";
+      sha256 = "d6ffd4b29c4fb977937cb47d55d023012be1a9b3602dd1f1628eba7d8c9167cd";
+      name = "ktp-desktop-applets-20.08.1.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktp-filetransfer-handler-20.08.0.tar.xz";
-      sha256 = "df16a920a233eaec25c73514e951f5f569a0f0f6d4ba46b60a0c2bc3da4ab6cd";
-      name = "ktp-filetransfer-handler-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktp-filetransfer-handler-20.08.1.tar.xz";
+      sha256 = "35495c1d18a7b65496fcf17cade4a81e4795b1603c380c036dda0a7626f66312";
+      name = "ktp-filetransfer-handler-20.08.1.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktp-kded-module-20.08.0.tar.xz";
-      sha256 = "f321a7db60b0fcd9dd207c38c8097e6cdb3a22aba6730bc03f9ea67bc8d9bb2e";
-      name = "ktp-kded-module-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktp-kded-module-20.08.1.tar.xz";
+      sha256 = "247e4047e3955e21066ec461a5374d1b3d925bb92b42adc46d3711e542ad7e04";
+      name = "ktp-kded-module-20.08.1.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktp-send-file-20.08.0.tar.xz";
-      sha256 = "86d3ca20eb3c3fbfa169a355c0e64d1574433c6985d5188697ef18e521d82104";
-      name = "ktp-send-file-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktp-send-file-20.08.1.tar.xz";
+      sha256 = "b3786c6e6f09ea086c2d94d2a6dd653e45bab8f984c6287c39f5e0134d6ffee1";
+      name = "ktp-send-file-20.08.1.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktp-text-ui-20.08.0.tar.xz";
-      sha256 = "a1f5c4c98761f61abd62b6e788a8ec5c4e2b4020e92f3c0c75770c0f01386676";
-      name = "ktp-text-ui-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktp-text-ui-20.08.1.tar.xz";
+      sha256 = "5cdb88f55b6ca1a1053b8d5b2604eff681c5f3558f0c8037034c264793de8c02";
+      name = "ktp-text-ui-20.08.1.tar.xz";
     };
   };
   ktuberling = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/ktuberling-20.08.0.tar.xz";
-      sha256 = "8d56e4330b68d8597d502db311282a9d59f8ad91f8acfa7f029d354ac399b702";
-      name = "ktuberling-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/ktuberling-20.08.1.tar.xz";
+      sha256 = "62d3d8db7b1db7f9d58df44acf61342ce42fb081038fc48f8f6e45d9167ceaa6";
+      name = "ktuberling-20.08.1.tar.xz";
     };
   };
   kturtle = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kturtle-20.08.0.tar.xz";
-      sha256 = "9c086a0aec74d9d5aa5792f026e6b44b8fdc613cfdeba060fb4694fb3e9b27f9";
-      name = "kturtle-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kturtle-20.08.1.tar.xz";
+      sha256 = "c261fdf44b36aaa278b4b9752a0d989facec3768853606e5c0b8a86d9d01edb3";
+      name = "kturtle-20.08.1.tar.xz";
     };
   };
   kubrick = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kubrick-20.08.0.tar.xz";
-      sha256 = "2cf725a96d52d7be157690fb9ce6fe0dcc2cb853fe6e1f9d56ae6c23c09974cc";
-      name = "kubrick-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kubrick-20.08.1.tar.xz";
+      sha256 = "c0c017f6913f94224e18df7d96ba9ad92f51522a331b77f5722f2d2c953c342c";
+      name = "kubrick-20.08.1.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kwalletmanager-20.08.0.tar.xz";
-      sha256 = "4dea2e1b08cc996d6d4961393d9c8f24051b0a7f6373c4cf575ddf8324804b7a";
-      name = "kwalletmanager-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kwalletmanager-20.08.1.tar.xz";
+      sha256 = "b5a134db6b6bceb802c6c45915636bcd95fea5b6846cfd022917405f48cc92c5";
+      name = "kwalletmanager-20.08.1.tar.xz";
     };
   };
   kwave = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kwave-20.08.0.tar.xz";
-      sha256 = "7291122e5112eea9b8026937682f77d78e43153c4dc38005ac31fd7235a18e69";
-      name = "kwave-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kwave-20.08.1.tar.xz";
+      sha256 = "3791f9401271c23d3ababd14e4c1e6acfe58df2100331e31ba61453feaf9fa32";
+      name = "kwave-20.08.1.tar.xz";
     };
   };
   kwordquiz = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/kwordquiz-20.08.0.tar.xz";
-      sha256 = "c8350fcf5b4ed61a43d3d72aabfef645e7d1908ef753df36c0124601873b4951";
-      name = "kwordquiz-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/kwordquiz-20.08.1.tar.xz";
+      sha256 = "77d2d30abcb37ee6a8e0b121ed1969f2fa61eb32814f49a0186043a4e8f1a71c";
+      name = "kwordquiz-20.08.1.tar.xz";
     };
   };
   libgravatar = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libgravatar-20.08.0.tar.xz";
-      sha256 = "9faf1ab53cebf2f54fb851ec5bcffc65b18a846a50e3d890b66b947ab93d6397";
-      name = "libgravatar-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libgravatar-20.08.1.tar.xz";
+      sha256 = "dfe95055869944b79b1f4120f013b547225b02b69c7e410fd09d52469a892263";
+      name = "libgravatar-20.08.1.tar.xz";
     };
   };
   libkcddb = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkcddb-20.08.0.tar.xz";
-      sha256 = "516723e29ae37c84865eaf86f82481c4275ea8507e172fc8a0279572705fbc6a";
-      name = "libkcddb-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkcddb-20.08.1.tar.xz";
+      sha256 = "1519c9248b46d95d8761a8ed22b0805964a5fef5aa665710b08851c753f70590";
+      name = "libkcddb-20.08.1.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkcompactdisc-20.08.0.tar.xz";
-      sha256 = "043a0ca6dd5d85b4313495d0ae530fe96448da2f472a8af2a633d646be0c065c";
-      name = "libkcompactdisc-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkcompactdisc-20.08.1.tar.xz";
+      sha256 = "f43b8129a0083686dbc939387931867d9d65e14936f2a86be0a7286e01cf1974";
+      name = "libkcompactdisc-20.08.1.tar.xz";
     };
   };
   libkdcraw = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkdcraw-20.08.0.tar.xz";
-      sha256 = "8e2e1577a751eb0c570e5f6ad394d459ef3d127ee8950eee25a4ebf62a2eece7";
-      name = "libkdcraw-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkdcraw-20.08.1.tar.xz";
+      sha256 = "3431810972d886635ba6249ac86a9442a9c3a3333eb0b27533fc459e757e9eb1";
+      name = "libkdcraw-20.08.1.tar.xz";
     };
   };
   libkdegames = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkdegames-20.08.0.tar.xz";
-      sha256 = "d77f5e2d913c68286014fe1438b9909826931aaa944a0ce1753d1a449766d99c";
-      name = "libkdegames-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkdegames-20.08.1.tar.xz";
+      sha256 = "6ab0b143dcba2d935dd0182c9154657ebbfb205c28bc86e2e13875b58e23737d";
+      name = "libkdegames-20.08.1.tar.xz";
     };
   };
   libkdepim = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkdepim-20.08.0.tar.xz";
-      sha256 = "4f5f0688529d13c10c1c3509f64874a069a5d6cae84f81b258b1d081e86771e0";
-      name = "libkdepim-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkdepim-20.08.1.tar.xz";
+      sha256 = "a2fb769239283e7f536d4779089ad8664d1498cf7520f057589bf0285630fb4b";
+      name = "libkdepim-20.08.1.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkeduvocdocument-20.08.0.tar.xz";
-      sha256 = "21ee64628a012478eb8c53ce2374a57d587f6160f32f09231c78e9fac7600d5d";
-      name = "libkeduvocdocument-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkeduvocdocument-20.08.1.tar.xz";
+      sha256 = "ecd158beb7fcc1a5d540d956669c6fdce6172f4b282755170d2791076d75ad84";
+      name = "libkeduvocdocument-20.08.1.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkexiv2-20.08.0.tar.xz";
-      sha256 = "d4e3fcdaf160c70165b1217931484d544d56ca7630d5f2c85484caebb2afe399";
-      name = "libkexiv2-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkexiv2-20.08.1.tar.xz";
+      sha256 = "67310ae90d89f26d2ae98ede8fa973e27ea1ce3d15c389954d391cd058543979";
+      name = "libkexiv2-20.08.1.tar.xz";
     };
   };
   libkgapi = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkgapi-20.08.0.tar.xz";
-      sha256 = "215d21a89887522bbac09774723098dac1602bfc39e4ca23306d08b11d0cd89d";
-      name = "libkgapi-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkgapi-20.08.1.tar.xz";
+      sha256 = "dfa9003556a01ef19eda186973f87356d32ea8f82f8d653803b2cc935f077127";
+      name = "libkgapi-20.08.1.tar.xz";
     };
   };
   libkgeomap = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkgeomap-20.08.0.tar.xz";
-      sha256 = "bf39da71ec7cc40e536bf071abda61569acec4ae027d896738ae1ace74eaddf7";
-      name = "libkgeomap-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkgeomap-20.08.1.tar.xz";
+      sha256 = "a210945b6807efca3390173233269aa31f27a23b5f36670b88f66b3b28df846f";
+      name = "libkgeomap-20.08.1.tar.xz";
     };
   };
   libkipi = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkipi-20.08.0.tar.xz";
-      sha256 = "2a66512b9c840e7e19f943066197a4ef68aea8cd059427732dec9cf5de84294e";
-      name = "libkipi-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkipi-20.08.1.tar.xz";
+      sha256 = "4722ab563c1350042920d1937b84fdd38b5779449a2d9b689328cd82241cb5d2";
+      name = "libkipi-20.08.1.tar.xz";
     };
   };
   libkleo = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkleo-20.08.0.tar.xz";
-      sha256 = "44100f7a001ca7eb8cc4b2b9eeab5e8806a5d4eb2a01a69eeaf1843f4e023f85";
-      name = "libkleo-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkleo-20.08.1.tar.xz";
+      sha256 = "78c1dc2e4d7177aaf37cb1c706d9c21b08fac7d130ac1da3d3f2a6f083117ffb";
+      name = "libkleo-20.08.1.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkmahjongg-20.08.0.tar.xz";
-      sha256 = "1792a04f59fe188a7707c0f77e9ef598e9dfb6444c7aba574a4a46760aeaf63a";
-      name = "libkmahjongg-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkmahjongg-20.08.1.tar.xz";
+      sha256 = "5a8674921e39b38655d1f95340831b1bc746047cbad8501706436f5dacf47fc2";
+      name = "libkmahjongg-20.08.1.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libkomparediff2-20.08.0.tar.xz";
-      sha256 = "0571d016675496341d6e841d88b2ff8682b2958d91a38a69a6130a0766ff6a1b";
-      name = "libkomparediff2-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libkomparediff2-20.08.1.tar.xz";
+      sha256 = "9d109dfea1433602cdabc89ffa5f522147befc9b1d6d9760549aba7db5dbd399";
+      name = "libkomparediff2-20.08.1.tar.xz";
     };
   };
   libksane = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libksane-20.08.0.tar.xz";
-      sha256 = "536e0f914095ddfeee132e227d9d2a840186da512b82d95fc9a7262a3a912ea6";
-      name = "libksane-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libksane-20.08.1.tar.xz";
+      sha256 = "0d8717ad004a2480aea232d9a2317b4d1cc4678d53f0176bdaeb411eedd19dbe";
+      name = "libksane-20.08.1.tar.xz";
     };
   };
   libksieve = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/libksieve-20.08.0.tar.xz";
-      sha256 = "af6b4a1b787efdf20792a8ded6ae4d8f49d4cef129b4b3fd7048441bb879b586";
-      name = "libksieve-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/libksieve-20.08.1.tar.xz";
+      sha256 = "a1defe888c6c5a3c16ef6fad39d9eb94bc784031079763f004048951820acec0";
+      name = "libksieve-20.08.1.tar.xz";
     };
   };
   lokalize = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/lokalize-20.08.0.tar.xz";
-      sha256 = "dd05509386b816aeb02797769c28e12cf8b3f38d88f722a699a77db94c9ab71e";
-      name = "lokalize-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/lokalize-20.08.1.tar.xz";
+      sha256 = "a4a3e5703d39ae8fe12d2ff832e99b3339ba1c8ec8d2439abeb348e687f1eae9";
+      name = "lokalize-20.08.1.tar.xz";
     };
   };
   lskat = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/lskat-20.08.0.tar.xz";
-      sha256 = "9a6af851f0fb0b7e6f6d1983bf3c7f12a74022977e879a525424d2867762b471";
-      name = "lskat-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/lskat-20.08.1.tar.xz";
+      sha256 = "319d611468b969b3bb62731a0aa04c5672bb689c41adf5545dfa8b9742668775";
+      name = "lskat-20.08.1.tar.xz";
     };
   };
   mailcommon = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/mailcommon-20.08.0.tar.xz";
-      sha256 = "fa110a41d5e4848d203d3c17fe18c584d892bf78f750c36a5e88a80c80dcd04a";
-      name = "mailcommon-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/mailcommon-20.08.1.tar.xz";
+      sha256 = "d4ee996f74a749ad626ca5029821546da82dbfc1c81864ff39b5f51d6dcf1d88";
+      name = "mailcommon-20.08.1.tar.xz";
     };
   };
   mailimporter = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/mailimporter-20.08.0.tar.xz";
-      sha256 = "5263fdc50b772458cb584f799f80da765e0ac3c4f2e0fecee15305db829cd851";
-      name = "mailimporter-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/mailimporter-20.08.1.tar.xz";
+      sha256 = "dcf2b94d4f66be2b339b31dfebef7af373e0cf59f09e4cfb664eb828e1d4f73f";
+      name = "mailimporter-20.08.1.tar.xz";
     };
   };
   marble = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/marble-20.08.0.tar.xz";
-      sha256 = "0f61c29acc3f88a0eeb0e0923f8c5138188712aad6aa4d9445add186d5962381";
-      name = "marble-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/marble-20.08.1.tar.xz";
+      sha256 = "96b019a41ae4e0aaab59950b6be040bd2145f130190b8c0dea436c791e3192ed";
+      name = "marble-20.08.1.tar.xz";
     };
   };
   mbox-importer = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/mbox-importer-20.08.0.tar.xz";
-      sha256 = "075afd543bec9c8c2d056b96704fbfd2fbc4498b289596d4fbb0cd49ff5c720b";
-      name = "mbox-importer-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/mbox-importer-20.08.1.tar.xz";
+      sha256 = "262c8805539b7c766099c6287d1dbf88161afe6d32c1c6821ebe63cff4fe3b71";
+      name = "mbox-importer-20.08.1.tar.xz";
     };
   };
   messagelib = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/messagelib-20.08.0.tar.xz";
-      sha256 = "13aa522b8ff8cf2d7ac7ca6ae4c92e1bd2379d13fc23cabaa36fd6d6bda261cd";
-      name = "messagelib-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/messagelib-20.08.1.tar.xz";
+      sha256 = "fc41124e905456a3c5227ca6154dc3e77620e307458fbb19f5421cbfb04523b3";
+      name = "messagelib-20.08.1.tar.xz";
     };
   };
   minuet = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/minuet-20.08.0.tar.xz";
-      sha256 = "f3e57e225ec6a0515d39bf868cdd934a6823071527f6da9910b839abc96c8fdb";
-      name = "minuet-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/minuet-20.08.1.tar.xz";
+      sha256 = "a640025550337f415f7bfaaad7f6ef7de667dd054131be2c313d894c3f6703ea";
+      name = "minuet-20.08.1.tar.xz";
     };
   };
   okular = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/okular-20.08.0.tar.xz";
-      sha256 = "8d775292cc6b2cb703e5ff716337a49352cd6d3faa90d6d7ac2f4e9d006a4047";
-      name = "okular-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/okular-20.08.1.tar.xz";
+      sha256 = "77b5d8e410a2a008ea63f60a561f99053ec07d92da6ee3afaeefd977aadebd83";
+      name = "okular-20.08.1.tar.xz";
     };
   };
   palapeli = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/palapeli-20.08.0.tar.xz";
-      sha256 = "bbbf4d6c0a2048e2bb5e2483acf1970748d9f109e25f3c5cbf6f04709a61aeab";
-      name = "palapeli-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/palapeli-20.08.1.tar.xz";
+      sha256 = "31b847caa89b998dfa580553d96c656b05f2d85fdd88f0ba71e953762cefac90";
+      name = "palapeli-20.08.1.tar.xz";
     };
   };
   parley = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/parley-20.08.0.tar.xz";
-      sha256 = "b1c8d5f39a563ddcc6a00a7e1008608bd58bdcdfc23c11c822b15625f5a48d60";
-      name = "parley-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/parley-20.08.1.tar.xz";
+      sha256 = "9617a90c2d4f9ab5d928febc6bcd10c9023dcc10e9f1202bfb97b77019948f0c";
+      name = "parley-20.08.1.tar.xz";
     };
   };
   picmi = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/picmi-20.08.0.tar.xz";
-      sha256 = "5003bcf33c08eebe24fb689790aef56eb418990a7c6588e2bd1c94ec6f398a5a";
-      name = "picmi-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/picmi-20.08.1.tar.xz";
+      sha256 = "027e37a2c9dcf828684a0f8ffdcfc6451a2bd62976c10d990e471fa0f5ba97c3";
+      name = "picmi-20.08.1.tar.xz";
     };
   };
   pimcommon = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/pimcommon-20.08.0.tar.xz";
-      sha256 = "4280d7116d392dff4febbadbca6fa20c38b787da7af537ce4e64af28509bd82e";
-      name = "pimcommon-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/pimcommon-20.08.1.tar.xz";
+      sha256 = "58a33349bf932076f6be343ae64e23f146e2a6a96e3af8ce68dbd752f2c80dd9";
+      name = "pimcommon-20.08.1.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/pim-data-exporter-20.08.0.tar.xz";
-      sha256 = "42f070d3aea3871004bea3fa712f01ef307ba12328495ded06d3115e7e8ed894";
-      name = "pim-data-exporter-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/pim-data-exporter-20.08.1.tar.xz";
+      sha256 = "54092763e4b951f4e90a217c876107900e0706da68ca5517184e5da258ae95ec";
+      name = "pim-data-exporter-20.08.1.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/pim-sieve-editor-20.08.0.tar.xz";
-      sha256 = "65167f716ce2cc70a4ccbf7f9a5b2a873f36df54984dcc46af1d5694973e709a";
-      name = "pim-sieve-editor-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/pim-sieve-editor-20.08.1.tar.xz";
+      sha256 = "f788038796f226bfe426835fc6f186e23f2c7f9fda8316dfa6af307d6936d4ad";
+      name = "pim-sieve-editor-20.08.1.tar.xz";
     };
   };
   poxml = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/poxml-20.08.0.tar.xz";
-      sha256 = "07f5e8f0b215d864d48523c9a1b689f7434dfc0a561d5cf253ad69698770e096";
-      name = "poxml-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/poxml-20.08.1.tar.xz";
+      sha256 = "9f4bcafc664532706fe634ce8b0f410619d5e3c285526a7b61969155d75bbad2";
+      name = "poxml-20.08.1.tar.xz";
     };
   };
   print-manager = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/print-manager-20.08.0.tar.xz";
-      sha256 = "6fe74bc4555f92b7d372d01878cbf25b4339f3f0047b52bd0c92571a2b835271";
-      name = "print-manager-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/print-manager-20.08.1.tar.xz";
+      sha256 = "52d41ca3ae69e6e8e1eb4ddf1d516868dc436e81779053efdea5e3819545ca5b";
+      name = "print-manager-20.08.1.tar.xz";
     };
   };
   rocs = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/rocs-20.08.0.tar.xz";
-      sha256 = "447fecd5e87171cae444e70146b5ce99ac94a558db5f7e1ff9053c31953ba48e";
-      name = "rocs-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/rocs-20.08.1.tar.xz";
+      sha256 = "3c5f764f06f6f5b7c68523be4fdd37e75b2249e0b15001bc39e55051d9e271ef";
+      name = "rocs-20.08.1.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/signon-kwallet-extension-20.08.0.tar.xz";
-      sha256 = "ec65a9b05dd014ec541ba87e39b6ae8a7af8bf4017f58c7b566960e452f99493";
-      name = "signon-kwallet-extension-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/signon-kwallet-extension-20.08.1.tar.xz";
+      sha256 = "10a0ea806dc63cbf6c6d4794fe596c68355bccb3e08370d70ce7a8e95af448a5";
+      name = "signon-kwallet-extension-20.08.1.tar.xz";
     };
   };
   spectacle = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/spectacle-20.08.0.tar.xz";
-      sha256 = "8712c8fc19bc2cc39c5e51cf62dedfba423ad53225b629d667d7ffb8d3900692";
-      name = "spectacle-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/spectacle-20.08.1.tar.xz";
+      sha256 = "4a01b5ef41901ff2e83bb517c2e96a978188b98cb62243eb541a317f57a2bd69";
+      name = "spectacle-20.08.1.tar.xz";
     };
   };
   step = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/step-20.08.0.tar.xz";
-      sha256 = "8415f807de351b85bc3c4feb9ac45b01300210b9517987c617cd49ba6d472418";
-      name = "step-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/step-20.08.1.tar.xz";
+      sha256 = "6e04930963676b1bfa55ee095914c7491a61bf3963c45ed4157f868175ee6605";
+      name = "step-20.08.1.tar.xz";
     };
   };
   svgpart = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/svgpart-20.08.0.tar.xz";
-      sha256 = "3ebb9140ac13c7ece171622ead8c7fd1b1128cccde9635cbc912ca7f8da767a7";
-      name = "svgpart-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/svgpart-20.08.1.tar.xz";
+      sha256 = "206c3741464f959ffbaea09bc918fc3e88f32fcf12928cd8c399ab44d4b1f228";
+      name = "svgpart-20.08.1.tar.xz";
     };
   };
   sweeper = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/sweeper-20.08.0.tar.xz";
-      sha256 = "b0d7b983a5bb8ceb2454863181c6a2d55c42114f58f66241f46c3365d90a52ec";
-      name = "sweeper-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/sweeper-20.08.1.tar.xz";
+      sha256 = "722c25de8cc74fe7e8310d47a7e794f32e935331f89d4f5249fd045a83ce0431";
+      name = "sweeper-20.08.1.tar.xz";
     };
   };
   umbrello = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/umbrello-20.08.0.tar.xz";
-      sha256 = "49e9f7e0748b8f103f72bbc3fbe0ab7b3605646b5024512118dd9beafd64a041";
-      name = "umbrello-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/umbrello-20.08.1.tar.xz";
+      sha256 = "d980d67f8a878e01cd3af5499aa843df703f20cdecca8a14b59d87d13c747328";
+      name = "umbrello-20.08.1.tar.xz";
     };
   };
   yakuake = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/yakuake-20.08.0.tar.xz";
-      sha256 = "1c13334e0e4c1a6a3f8e11ed6cd05b2cecdd0eb29201c41bd26ca62e22cc084a";
-      name = "yakuake-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/yakuake-20.08.1.tar.xz";
+      sha256 = "6768a360a3d79080e6e53821460ed27f6c2e47fa11077bbec3213d85385d6fac";
+      name = "yakuake-20.08.1.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "20.08.0";
+    version = "20.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.0/src/zeroconf-ioslave-20.08.0.tar.xz";
-      sha256 = "78bdd0b377132abf30f1ed40c15eae3f0726d7075b311c3b23c71ad59725dc22";
-      name = "zeroconf-ioslave-20.08.0.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.1/src/zeroconf-ioslave-20.08.1.tar.xz";
+      sha256 = "ca1685a22922057ba89510d71a11218bf47db0d0313aec2b55aca21932564866";
+      name = "zeroconf-ioslave-20.08.1.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

nix-review confirms all is good (virt-manager-qt  and kontact-zenshin
were broken before)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).