### PR TITLE
jackline: 2020-04-24 → 2020-09-03

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -1,30 +1,50 @@
-{ stdenv, fetchFromGitHub, ocamlPackages }:
+{ lib, fetchFromGitHub, ocamlPackages }:
 
-assert stdenv.lib.versionAtLeast ocamlPackages.ocaml.version "4.07";
+with ocamlPackages;
 
-stdenv.mkDerivation {
+buildDunePackage rec {
   pname = "jackline";
-  version = "unstable-2020-04-24";
+  version = "unstable-2020-09-03";
+
+  minimumOCamlVersion = "4.08";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner  = "hannesm";
     repo   = "jackline";
-    rev    = "885b97b90d565f5f7c2b5f66f5edf14a82251b87";
-    sha256 = "1mdn413ya2g0a1mrdbh1b65gnygrxb08k99z5lmidhh34kd1llsj";
+    rev    = "dd5f19636c9b99b72c348f0f639452d87b7c017c";
+    sha256 = "076smdgig4nwvqsqxa6gsl0c3daq5agwgzp4n2y8xxm3qiq91y89";
   };
 
-  buildInputs = with ocamlPackages; [
-                  ocaml ocamlbuild findlib topkg ppx_sexp_conv ppx_deriving
-                  erm_xmpp tls mirage-crypto mirage-crypto-pk x509 domain-name
-                  ocaml_lwt otr astring ptime notty sexplib hex uutf
-                  dns-client base64
-                ];
+  nativeBuildInpts = [
+    ppx_sexp_conv
+    ppx_deriving
+  ];
 
-  buildPhase = "${ocamlPackages.topkg.run} build --pinned true";
+  buildInputs = [
+    erm_xmpp
+    tls
+    mirage-crypto-pk
+    x509
+    domain-name
+    ocaml_lwt
+    otr
+    astring
+    ptime
+    notty
+    sexplib
+    hex
+    uutf
+    uchar
+    uuseg
+    uucp
+    dns-client
+    cstruct
+    base64
+  ];
 
-  inherit (ocamlPackages.topkg) installPhase;
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/hannesm/jackline";
     description = "minimalistic secure XMPP client in OCaml";
     license = licenses.bsd2;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

* Build package with dune
* Minor UI fixes
* IPv6 support

I also now use the required packages as inputs instead of the whole `ocamlPackages` set.

@vbgl How do you feel about using `ocamlPackages.callPackage` outside of `ocamlPackages`? If it's a problem, I can easily revert the change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
