### PR TITLE
python3Packages.sqlalchemy-citext: fix tests

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy-citext/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-citext/default.nix
@@ -18,9 +18,10 @@ buildPythonPackage rec {
     sqlalchemy
   ];
 
-  checkPhase = ''
-    ${python.interpreter} tests/test_citext.py
-  '';
+  # tests are not packaged in pypi tarball
+  doCheck = false;
+
+  pythonImportsCheck = [ "citext" ];
 
   meta = with lib; {
     description = "A sqlalchemy plugin that allows postgres use of CITEXT";


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken #97079

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/97132
8 packages built:
apache-airflow buku python27Packages.flask-admin python27Packages.sqlalchemy-citext python37Packages.flask-admin python37Packages.sqlalchemy-citext python38Packages.flask-admin python38Packages.sqlalchemy-citext
```