### PR TITLE
Improve `generators.toPretty`

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -204,7 +204,7 @@ rec {
        will use fn to convert val to a pretty printed representation.
        (This means fn is type Val -> String.) */
     allowPrettyValues ? false
-  }@args: v: with builtins;
+  }@args: let go = v: with builtins;
     let     isPath   = v: typeOf v == "path";
     in if   isInt      v then toString v
     else if isFloat    v then "~${toString v}"
@@ -214,7 +214,7 @@ rec {
     else if null  ==   v then "null"
     else if isPath     v then toString v
     else if isList     v then "[ "
-        + libStr.concatMapStringsSep " " (toPretty args) v
+        + libStr.concatMapStringsSep " " go v
       + " ]"
     else if isAttrs    v then
       # apply pretty values if allowed
@@ -227,7 +227,7 @@ rec {
       else "{ "
           + libStr.concatStringsSep " " (libAttr.mapAttrsToList
               (name: value:
-                "${libStr.escapeNixIdentifier name} = ${toPretty args value};") v)
+                "${libStr.escapeNixIdentifier name} = ${go value};") v)
         + " }"
     else if isFunction v then
       let fna = lib.functionArgs v;
@@ -237,6 +237,7 @@ rec {
       in if fna == {}    then "<λ>"
                          else "<λ:{${showFnas}}>"
     else abort "generators.toPretty: should never happen (v = ${v})";
+  in go;
 
   # PLIST handling
   toPlist = {}: v: let

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -237,10 +237,8 @@ rec {
       # apply pretty values if allowed
       if attrNames v == [ "__pretty" "val" ] && allowPrettyValues
          then v.__pretty v.val
-      # TODO: there is probably a better representation?
       else if v ? type && v.type == "derivation" then
-        "<δ:${v.name}>"
-        # "<δ:${concatStringsSep "," (builtins.attrNames v)}>"
+        "<derivation ${v.drvPath}>"
       else "{" + introSpace
           + libStr.concatStringsSep introSpace (libAttr.mapAttrsToList
               (name: value:
@@ -248,11 +246,11 @@ rec {
         + outroSpace + "}"
     else if isFunction v then
       let fna = lib.functionArgs v;
-          showFnas = concatStringsSep "," (libAttr.mapAttrsToList
-                       (name: hasDefVal: if hasDefVal then "(${name})" else name)
+          showFnas = concatStringsSep ", " (libAttr.mapAttrsToList
+                       (name: hasDefVal: if hasDefVal then name + "?" else name)
                        fna);
-      in if fna == {}    then "<λ>"
-                         else "<λ:{${showFnas}}>"
+      in if fna == {}    then "<function>"
+                         else "<function, args: {${showFnas}}>"
     else abort "generators.toPretty: should never happen (v = ${v})";
   in go "";
 

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -213,7 +213,19 @@ rec {
             outroSpace = if multiline then "\n${indent}" else " ";
     in if   isInt      v then toString v
     else if isFloat    v then "~${toString v}"
-    else if isString   v then ''"${libStr.escape [''"''] v}"''
+    else if isString   v then
+      let
+        # Separate a string into its lines
+        newlineSplits = filter (v: ! isList v) (builtins.split "\n" v);
+        # For a '' string terminated by a \n, which happens when the closing '' is on a new line
+        multilineResult = "''" + introSpace + concatStringsSep introSpace (lib.init newlineSplits) + outroSpace + "''";
+        # For a '' string not terminated by a \n, which happens when the closing '' is not on a new line
+        multilineResult' = "''" + introSpace + concatStringsSep introSpace newlineSplits + "''";
+        # For single lines, replace all newlines with their escaped representation
+        singlelineResult = "\"" + libStr.escape [ "\"" ] (concatStringsSep "\\n" newlineSplits) + "\"";
+      in if multiline && length newlineSplits > 1 then
+        if lib.last newlineSplits == "" then multilineResult else multilineResult'
+      else singlelineResult
     else if true  ==   v then "true"
     else if false ==   v then "false"
     else if null  ==   v then "null"

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -227,7 +227,7 @@ rec {
       else "{ "
           + libStr.concatStringsSep " " (libAttr.mapAttrsToList
               (name: value:
-                "${toPretty args name} = ${toPretty args value};") v)
+                "${libStr.escapeNixIdentifier name} = ${toPretty args value};") v)
         + " }"
     else if isFunction v then
       let fna = lib.functionArgs v;

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -235,6 +235,13 @@ rec {
       else "[" + introSpace
         + libStr.concatMapStringsSep introSpace (go (indent + "  ")) v
         + outroSpace + "]"
+    else if isFunction v then
+      let fna = lib.functionArgs v;
+          showFnas = concatStringsSep ", " (libAttr.mapAttrsToList
+                       (name: hasDefVal: if hasDefVal then name + "?" else name)
+                       fna);
+      in if fna == {}    then "<function>"
+                         else "<function, args: {${showFnas}}>"
     else if isAttrs    v then
       # apply pretty values if allowed
       if attrNames v == [ "__pretty" "val" ] && allowPrettyValues
@@ -247,13 +254,6 @@ rec {
               (name: value:
                 "${libStr.escapeNixIdentifier name} = ${go (indent + "  ") value};") v)
         + outroSpace + "}"
-    else if isFunction v then
-      let fna = lib.functionArgs v;
-          showFnas = concatStringsSep ", " (libAttr.mapAttrsToList
-                       (name: hasDefVal: if hasDefVal then name + "?" else name)
-                       fna);
-      in if fna == {}    then "<function>"
-                         else "<function, args: {${showFnas}}>"
     else abort "generators.toPretty: should never happen (v = ${v})";
   in go "";
 

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -230,13 +230,16 @@ rec {
     else if false ==   v then "false"
     else if null  ==   v then "null"
     else if isPath     v then toString v
-    else if isList     v then "[" + introSpace
+    else if isList     v then
+      if v == [] then "[ ]"
+      else "[" + introSpace
         + libStr.concatMapStringsSep introSpace (go (indent + "  ")) v
-      + outroSpace + "]"
+        + outroSpace + "]"
     else if isAttrs    v then
       # apply pretty values if allowed
       if attrNames v == [ "__pretty" "val" ] && allowPrettyValues
          then v.__pretty v.val
+      else if v == {} then "{ }"
       else if v ? type && v.type == "derivation" then
         "<derivation ${v.drvPath}>"
       else "{" + introSpace

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -461,7 +461,9 @@ runTests {
       function = x: x;
       functionArgs = { arg ? 4, foo }: arg;
       list = [ 3 4 function [ false ] ];
+      emptylist = [];
       attrs = { foo = null; "foo bar" = "baz"; };
+      emptyattrs = {};
       drv = deriv;
     };
     expected = rec {
@@ -476,7 +478,9 @@ runTests {
       function = "<function>";
       functionArgs = "<function, args: {arg?, foo}>";
       list = "[ 3 4 ${function} [ false ] ]";
+      emptylist = "[ ]";
       attrs = "{ foo = null; \"foo bar\" = \"baz\"; }";
+      emptyattrs = "{ }";
       drv = "<derivation ${deriv.drvPath}>";
     };
   };

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -446,7 +446,7 @@ runTests {
   };
 
   testToPretty = {
-    expr = mapAttrs (const (generators.toPretty {})) rec {
+    expr = mapAttrs (const (generators.toPretty { multiline = false; })) rec {
       int = 42;
       float = 0.1337;
       bool = true;
@@ -471,6 +471,30 @@ runTests {
       list = "[ 3 4 ${function} [ false ] ]";
       attrs = "{ foo = null; \"foo bar\" = \"baz\"; }";
       drv = "<δ:test>";
+    };
+  };
+
+  testToPrettyMultiline = {
+    expr = mapAttrs (const (generators.toPretty { })) rec {
+      list = [ 3 4 [ false ] ];
+      attrs = { foo = null; bar.foo = "baz"; };
+    };
+    expected = rec {
+      list = ''
+        [
+          3
+          4
+          [
+            false
+          ]
+        ]'';
+      attrs = ''
+        {
+          bar = {
+            foo = "baz";
+          };
+          foo = null;
+        }'';
     };
   };
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -469,7 +469,7 @@ runTests {
       function = "<λ>";
       functionArgs = "<λ:{(arg),foo}>";
       list = "[ 3 4 ${function} [ false ] ]";
-      attrs = "{ \"foo\" = null; \"foo bar\" = \"baz\"; }";
+      attrs = "{ foo = null; \"foo bar\" = \"baz\"; }";
       drv = "<δ:test>";
     };
   };

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -450,7 +450,9 @@ runTests {
       int = 42;
       float = 0.1337;
       bool = true;
+      emptystring = "";
       string = ''fno"rd'';
+      newlinestring = "\n";
       path = /. + "/foo";
       null_ = null;
       function = x: x;
@@ -463,7 +465,9 @@ runTests {
       int = "42";
       float = "~0.133700";
       bool = "true";
+      emptystring = ''""'';
       string = ''"fno\"rd"'';
+      newlinestring = "\"\\n\"";
       path = "/foo";
       null_ = "null";
       function = "<λ>";
@@ -478,6 +482,16 @@ runTests {
     expr = mapAttrs (const (generators.toPretty { })) rec {
       list = [ 3 4 [ false ] ];
       attrs = { foo = null; bar.foo = "baz"; };
+      newlinestring = "\n";
+      multilinestring = ''
+        hello
+        there
+        test
+      '';
+      multilinestring' = ''
+        hello
+        there
+        test'';
     };
     expected = rec {
       list = ''
@@ -495,6 +509,19 @@ runTests {
           };
           foo = null;
         }'';
+      newlinestring = "''\n  \n''";
+      multilinestring = ''
+        '''
+          hello
+          there
+          test
+        ''''';
+      multilinestring' = ''
+        '''
+          hello
+          there
+          test''''';
+
     };
   };
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -445,7 +445,10 @@ runTests {
       expected = builtins.toJSON val;
   };
 
-  testToPretty = {
+  testToPretty =
+    let
+      deriv = derivation { name = "test"; builder = "/bin/sh"; system = builtins.currentSystem; };
+    in {
     expr = mapAttrs (const (generators.toPretty { multiline = false; })) rec {
       int = 42;
       float = 0.1337;
@@ -459,7 +462,7 @@ runTests {
       functionArgs = { arg ? 4, foo }: arg;
       list = [ 3 4 function [ false ] ];
       attrs = { foo = null; "foo bar" = "baz"; };
-      drv = derivation { name = "test"; system = builtins.currentSystem; };
+      drv = deriv;
     };
     expected = rec {
       int = "42";
@@ -470,11 +473,11 @@ runTests {
       newlinestring = "\"\\n\"";
       path = "/foo";
       null_ = "null";
-      function = "<λ>";
-      functionArgs = "<λ:{(arg),foo}>";
+      function = "<function>";
+      functionArgs = "<function, args: {arg?, foo}>";
       list = "[ 3 4 ${function} [ false ] ]";
       attrs = "{ foo = null; \"foo bar\" = \"baz\"; }";
-      drv = "<δ:test>";
+      drv = "<derivation ${deriv.drvPath}>";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
For big Nix expressions, `toPretty` can be very hard to read, as it doesn't output any newlines. This PR implements the `multiline` option for `toPretty`, enabled by default, which makes it output newlines with proper indentation. Example output:
```nix
{
  foo = {
    bar = 10;
    baz = [
      "baz"
    ];
  };
}
```

In addition, I made some other improvements:
- Don't quote attribute names if they don't need to be quoted by using `escapeNixIdentifier`, introduced in https://github.com/NixOS/nixpkgs/pull/82461/commits/f9eb3d158a47dccb1e4762f3ed91f224fc96dc7e
- Switch away from the δ and λ symbols for derivations and functions respectively
- Multiline strings are printed correctly now

Ping @Profpatsch @rycee 

Best reviewed commit-by-commit. Specifically there's one commit in there that just refactors the function without changing its behavior.

###### Things done

- [x] Added a new test case for all functionality