### PR TITLE
blis: init at 0.7.0

### DIFF
--- a/doc/using/overlays.xml
+++ b/doc/using/overlays.xml
@@ -187,14 +187,28 @@ self: super:
        <listitem>
          <para>
            <link
-           xlink:href="https://developer.amd.com/amd-aocl/blas-library/">AMD
-           BLIS/LIBFLAME</link> (optimized for modern AMD x86_64 CPUs)
+           xlink:href="https://github.com/flame/blis">BLIS</link>
          </para>
          <para>
-          The AMD BLIS library, with attribute <literal>amd-blis</literal>,
-          provides a BLAS implementation. The complementary AMD LIBFLAME
-          library, with attribute <literal>amd-libflame</literal>, provides
-          a LAPACK implementation.
+          BLIS, available through the attribute
+          <literal>blis</literal>, is a framework for linear algebra kernels. In
+          addition, it implements the BLAS interface.
+         </para>
+       </listitem>
+       <listitem>
+         <para>
+          <link
+           xlink:href="https://developer.amd.com/amd-aocl/blas-library/">AMD
+          BLIS/LIBFLAME</link> (optimized for modern AMD x86_64 CPUs)
+         </para>
+         <para>
+          The AMD fork of the BLIS library, with attribute
+          <literal>amd-blis</literal>, extends BLIS with optimizations for
+          modern AMD CPUs. The changes are usually submitted to
+          the upstream BLIS project after some time. However, AMD BLIS
+          typically provides some performance improvements on AMD Zen CPUs.
+          The complementary AMD LIBFLAME library, with attribute
+          <literal>amd-libflame</literal>, provides a LAPACK implementation.
          </para>
        </listitem>
      </itemizedlist>

--- a/pkgs/development/libraries/science/math/blis/default.nix
+++ b/pkgs/development/libraries/science/math/blis/default.nix
@@ -1,0 +1,64 @@
+{ stdenv
+, fetchFromGitHub
+, perl
+, python3
+
+# Enable BLAS interface with 64-bit integer width.
+, blas64 ? false
+
+# Target architecture. x86_64 builds Intel and AMD kernels.
+, withArchitecture ? "x86_64"
+
+# Enable OpenMP-based threading.
+, withOpenMP ? true
+}:
+
+let
+  blasIntSize = if blas64 then "64" else "32";
+in stdenv.mkDerivation rec {
+  pname = "blis";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "flame";
+    repo = "blis";
+    rev = version;
+    sha256 = "13g9kg7x8j9icg4frdq3wpl2cmp0jnh93mw48daa7ym399w17423";
+  };
+
+  inherit blas64;
+
+  nativeBuildInputs = [
+    perl
+    python3
+  ];
+
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--enable-cblas"
+    "--blas-int-size=${blasIntSize}"
+  ] ++ stdenv.lib.optionals withOpenMP [ "--enable-threading=openmp" ]
+    ++ [ withArchitecture ];
+
+  postPatch = ''
+    patchShebangs configure build/flatten-headers.py
+  '';
+
+  postInstall = ''
+    ln -s $out/lib/libblis.so.3 $out/lib/libblas.so.3
+    ln -s $out/lib/libblis.so.3 $out/lib/libcblas.so.3
+    ln -s $out/lib/libblas.so.3 $out/lib/libblas.so
+    ln -s $out/lib/libcblas.so.3 $out/lib/libcblas.so
+  '';
+
+  meta = with stdenv.lib; {
+    description = "BLAS-compatible linear algebra library";
+    homepage = "https://github.com/flame/blis";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.danieldk ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1385,6 +1385,8 @@ in
 
   blink1-tool = callPackage ../tools/misc/blink1-tool { };
 
+  blis = callPackage ../development/libraries/science/math/blis { };
+
   bliss = callPackage ../applications/science/math/bliss { };
 
   blobfuse = callPackage ../tools/filesystems/blobfuse { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add the BLIS linear algebra library, which also implements the (C)BLAS interface. This is an alternative to the `amd-blis` derivation and also has (working) kernels for Intel CPUs.

Tested by building PyTorch with BLIS. Performance of a large transformer network is on-par with Intel MKL.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
