### PR TITLE
plujain-ramp: init at v1.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3607,6 +3607,12 @@
     email = "t@larkery.com";
     name = "Tom Hinton";
   };
+  hirenashah = {
+    email = "hiren@hiren.io";
+    github = "hirenashah";
+    githubId = 19825977;
+    name = "Hiren Shah";
+  };
   hjones2199 = {
     email = "hjones2199@gmail.com";
     github = "hjones2199";

--- a/pkgs/applications/audio/plujain-ramp/default.nix
+++ b/pkgs/applications/audio/plujain-ramp/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, lv2  }:
+
+stdenv.mkDerivation rec {
+  version = "v1.1.3";
+  pname = "plujain-ramp";
+
+  src = fetchFromGitHub {
+    owner = "Houston4444";
+    repo = "plujain-ramp";
+    rev = "1bc1fed211e140c7330d6035122234afe78e5257";
+    sha256 = "1k7qpr8c15d623c4zqxwdklp98amildh03cqsnqq5ia9ba8z3016";
+  };
+
+  buildInputs = [
+    lv2
+  ];
+
+  installFlags = [ "INSTALL_PATH=$(out)/lib/lv2" ];
+
+  meta = with stdenv.lib; {
+    description = "A mono rhythmic tremolo LV2 Audio Plugin";
+    homepage = "https://github.com/Houston4444/plujain-ramp";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.hirenashah ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6650,6 +6650,8 @@ in
 
   playbar2 = libsForQt5.callPackage ../applications/audio/playbar2 { };
 
+  plujain-ramp = callPackage ../applications/audio/plujain-ramp { };
+
   plex = callPackage ../servers/plex { };
   plexRaw = callPackage ../servers/plex/raw.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Add plujain-ramp LV2 plugin at v1.1.3 version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
