### PR TITLE
nixos/packetbeat: Add packetbeat module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -381,6 +381,7 @@
   ./services/logging/fluentd.nix
   ./services/logging/graylog.nix
   ./services/logging/heartbeat.nix
+  ./services/logging/packetbeat.nix
   ./services/logging/journalbeat.nix
   ./services/logging/journaldriver.nix
   ./services/logging/journalwatch.nix

--- a/nixos/modules/services/logging/packetbeat.nix
+++ b/nixos/modules/services/logging/packetbeat.nix
@@ -68,7 +68,7 @@ in
               };
 
               protocols = mkOption {
-                type = format.type;
+                type = types.listOf format.type;
                 description = ''
                   Configuration of what protocols packetbeat should gather info about.
                   See <link xlink:href='https://www.elastic.co/guide/en/beats/packetbeat/current/configuration-protocols.html'/>
@@ -157,51 +157,64 @@ in
           timeout = mkDefault "30s";
           period = mkDefault "10s";
         };
-        protocols = mapAttrs (name: mkDefault) {
-          icmp = {
+        protocols = mkBefore [
+          {
+            "type" = "icmp";
             enabled = true;
-          };
-          amqp = {
+          }
+          {
+            "type" = "amqp";
             ports = [ 5672 ];
-          };
-          cassandra = {
+          }
+          {
+            "type" = "cassandra";
             ports = [ 9042 ];
-          };
-          dhcpv4 = {
+          }
+          {
+            "type" = "dhcpv4";
             ports = [ 67 68 ];
-          };
-          dns = {
+          }
+          {
+            "type" = "dns";
             ports = [ 53 ];
-          };
-          http = {
+          }
+          {
+            "type" = "http";
             ports = [ 80 8080 8000 5000 8002 ];
-          };
-          memcache = {
+          }
+          {
+            "type" = "memcache";
             ports = [ 11211 ];
-          };
-          mysql = {
+          }
+          {
+            "type" = "mysql";
             ports = [ 3306 3307 ];
-          };
-          pgsql = {
+          }
+          {
+            "type" = "pgsql";
             ports = [ 5432 ];
-          };
-          redis = {
+          }
+          {
+            "type" = "redis";
             ports = [ 6379 ];
-          };
-          thrift = {
+          }
+          {
+            "type" = "thrift";
             ports = [ 9090 ];
-          };
-          mongodb = {
+          }
+          {
+            "type" = "mongodb";
             ports = [ 27017 ];
-          };
-          nfs = {
+          }
+          {
+            "type" = "nfs";
             ports = [ 2049 ];
-          };
-          tls = {
+          }
+          {
+            "type" = "tls";
             ports = [ 443 993 995 5223 8443 8883 9243 ];
-          };
-        };
-
+          }
+        ];
       };
       output = {
         elasticsearch = {

--- a/nixos/modules/services/logging/packetbeat.nix
+++ b/nixos/modules/services/logging/packetbeat.nix
@@ -115,6 +115,8 @@ in
         default = {};
         description = ''
           Any other configuration options you want to add.
+          See <link xlink:href='https://www.elastic.co/guide/en/beats/packetbeat/current/configuring-howto-packetbeat.html'/>
+          for all the configuration options available for packetbeat.
         '';
         example = ''
           output = {
@@ -251,6 +253,11 @@ in
 
       serviceConfig = mkMerge [
         {
+          DynamicUser = "yes";
+          AmbientCapabilities = [
+            "CAP_NET_RAW"
+            "CAP_NET_ADMIN"
+          ];
           ExecStart = ''
             ${cfg.package}/bin/packetbeat \
               -c ${format.generate "packetbeat.yml" cfg.settings} \

--- a/nixos/modules/services/logging/packetbeat.nix
+++ b/nixos/modules/services/logging/packetbeat.nix
@@ -234,16 +234,29 @@ in
         };
       };
       processors = mkDefault [
-        ''
-          if.contains.tags: forwarded
-          then:
-            - drop_fields:
-              fields: [host]
-          else:
-            - add_host_metadata: ~
-        ''
-        "add_cloud_metadata: ~"
-        "add_docker_metadata: ~"
+        {
+          "if.contains.tags" = "forwarded";
+          "then" = [
+            {
+              drop_fields = {
+                fields = [
+                  "host"
+                ];
+              };
+            }
+          ];
+          "else" = [
+            {
+              add_host_metadata = null;
+            }
+          ];
+        }
+        {
+          add_cloud_metadata = null;
+        }
+        {
+          add_docker_metadata = null;
+        }
       ];
     };
 

--- a/nixos/modules/services/logging/packetbeat.nix
+++ b/nixos/modules/services/logging/packetbeat.nix
@@ -1,0 +1,256 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.packetbeat;
+  format = pkgs.formats.yaml {};
+in
+{
+  options = {
+
+    services.packetbeat = {
+      enable = mkEnableOption "packetbeat";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.packetbeat;
+        defaultText = "pkgs.packetbeat";
+        example = literalExample "pkgs.packetbeat7";
+        description = ''
+          The packetbeat package to use
+        '';
+      };
+
+      stateDir = mkOption {
+        type = types.path;
+        default = "/var/lib/packetbeat";
+        description = ''
+          Directory to store packetbeat's data. If left as the default value
+          this directory will automatically be created before packetbeat starts, otherwise
+          the sysadmin is responsible for ensuring the directory exists with appropriate ownership
+          and permissions.
+        '';
+      };
+
+      settings = mkOption {
+        type = types.submodule {
+          freeformType = format.type;
+          options = {
+            name = mkOption {
+              type = types.str;
+              default = "packetbeat";
+              description = "Name of the beat";
+            };
+
+            tags = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              description = "Tags to place on the shipped log messages";
+            };
+
+            packetbeat = {
+              interfaces = mkOption {
+                type = with types; attrsOf (oneOf [ bool str ]);
+                description = ''
+                  Configuration of what interfaces packetbeat should monitor and how. See
+                  <link xlink:href='https://www.elastic.co/guide/en/beats/packetbeat/current/configuration-interfaces.html'/>
+                  for all available configuration options.
+                '';
+              };
+              flows = mkOption {
+                type = with types; attrsOf (oneOf [ bool str ]);
+                description = ''
+                  Configuration of how packetbeat should handle flows. See
+                  <link xlink:href='https://www.elastic.co/guide/en/beats/packetbeat/current/configuration-flows.html'/>
+                  for all available configuration options.
+                '';
+              };
+
+              protocols = mkOption {
+                type = with types; attrsOf (oneOf [ bool (listOf port) (listOf str) ]);
+                description = ''
+                  Configuration of what protocols packetbeat should gather info about.
+                  See <link xlink:href='https://www.elastic.co/guide/en/beats/packetbeat/current/configuration-protocols.html'/>
+                  for the configuration options available.
+                '';
+              };
+            };
+            output = mkOption {
+              type = with types; attrsOf (oneOf [ bool str (attrsOf str) (listOf str) ]);
+              description = ''
+                Configuration of where packetbeat should send the information its gathered.
+                See <link xlink:href='https://www.elastic.co/guide/en/beats/packetbeat/current/configuring-output.html'/>
+                for the configuration options available.
+              '';
+            };
+
+            setup = mkOption {
+              type = with types; attrsOf (oneOf [ bool str (attrsOf str) ]);
+              description = ''
+                Configures where the kibana endpoint is for setting up dashboards and
+                whether packetbeat should setup ILM and index templates in elasticsearch.
+              '';
+            };
+
+            fields = mkOption {
+              type = with types; attrsOf str;
+              description = ''
+                Extra fields that packetbeat should add to the top-level of the objects it
+                sends to its output.
+              '';
+            };
+
+            processors = mkOption {
+              type = with types; listOf (oneOf [ str (listOf str) (attrsOf str) ]);
+              description = ''
+                Configuration of what enrichment and/or filtering processors packetbeat
+                should gather information from before sending it to the output.
+                See <link xlink:href='https://www.elastic.co/guide/en/beats/packetbeat/current/filtering-and-enhancing-data.html'/>
+                for the configuration options available.
+              '';
+            };
+          };
+        };
+        default = {};
+        description = ''
+          Any other configuration options you want to add.
+        '';
+        example = ''
+          output = {
+            elasticsearch = {
+              hosts = [ "localhost:9200" ];
+            };
+          };
+          setup = {
+            template = {
+              settings = {
+                index.number_of_shards =  1;
+              };
+            };
+            kibana = {
+              host =  "localhost:5601";
+            };
+          };
+          processors =  [
+            '''
+              if.contains.tags: forwarded
+              then:
+                - drop_fields:
+                  fields: [host]
+              else:
+                - add_host_metadata: ~
+            '''
+            "add_cloud_metadata: ~"
+            "add_docker_metadata: ~"
+          ];
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.packetbeat.settings = {
+      packetbeat = {
+        interfaces.device = mkDefault "any";
+        flows = {
+          timeout = mkDefault "30s";
+          period = mkDefault "10s";
+        };
+        protocols = mapAttrs (name: mkDefault) {
+          icmp = {
+            enabled = true;
+          };
+          amqp = {
+            ports = [ 5672 ];
+          };
+          cassandra = {
+            ports = [ 9042 ];
+          };
+          dhcpv4 = {
+            ports = [ 67 68 ];
+          };
+          dns = {
+            ports = [ 53 ];
+          };
+          http = {
+            ports = [ 80 8080 8000 5000 8002 ];
+          };
+          memcache = {
+            ports = [ 11211 ];
+          };
+          mysql = {
+            ports = [ 3306 3307 ];
+          };
+          pgsql = {
+            ports = [ 5432 ];
+          };
+          redis = {
+            ports = [ 6379 ];
+          };
+          thrift = {
+            ports = [ 9090 ];
+          };
+          mongodb = {
+            ports = [ 27017 ];
+          };
+          nfs = {
+            ports = [ 2049 ];
+          };
+          tls = {
+            ports = [ 443 993 995 5223 8443 8883 9243 ];
+          };
+        };
+
+      };
+      output = {
+        elasticsearch = {
+          hosts = mkDefault [ "localhost:9200" ];
+        };
+      };
+      setup = {
+        template = {
+          settings = {
+            index.number_of_shards = mkDefault 1;
+          };
+        };
+        kibana = {
+          host = mkDefault "localhost:5601";
+        };
+      };
+      processors = mkDefault [
+        ''
+          if.contains.tags: forwarded
+          then:
+            - drop_fields:
+              fields: [host]
+          else:
+            - add_host_metadata: ~
+        ''
+        "add_cloud_metadata: ~"
+        "add_docker_metadata: ~"
+      ];
+    };
+
+    systemd.services.packetbeat = {
+      description = "Packetbeat log shipper";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = mkMerge [
+        {
+          ExecStart = ''
+            ${cfg.package}/bin/packetbeat \
+              -c ${format.generate "packetbeat.yml" cfg.settings} \
+              -path.data ${cfg.stateDir} \
+              -e
+          '';
+          Restart = "always";
+          LogsDirectory = "packetbeat";
+        }
+        (mkIf (cfg.stateDir == "/var/lib/packetbeat") {
+          StateDirectory = "packetbeat";
+        })
+      ];
+    };
+  };
+}

--- a/nixos/modules/services/logging/packetbeat.nix
+++ b/nixos/modules/services/logging/packetbeat.nix
@@ -51,7 +51,7 @@ in
 
             packetbeat = {
               interfaces = mkOption {
-                type = with types; attrsOf (oneOf [ bool str ]);
+                type = format.type;
                 description = ''
                   Configuration of what interfaces packetbeat should monitor and how. See
                   <link xlink:href='https://www.elastic.co/guide/en/beats/packetbeat/current/configuration-interfaces.html'/>
@@ -59,7 +59,7 @@ in
                 '';
               };
               flows = mkOption {
-                type = with types; attrsOf (oneOf [ bool str ]);
+                type = format.type;
                 description = ''
                   Configuration of how packetbeat should handle flows. See
                   <link xlink:href='https://www.elastic.co/guide/en/beats/packetbeat/current/configuration-flows.html'/>
@@ -68,7 +68,7 @@ in
               };
 
               protocols = mkOption {
-                type = with types; attrsOf (oneOf [ bool (listOf port) (listOf str) ]);
+                type = format.type;
                 description = ''
                   Configuration of what protocols packetbeat should gather info about.
                   See <link xlink:href='https://www.elastic.co/guide/en/beats/packetbeat/current/configuration-protocols.html'/>
@@ -77,7 +77,7 @@ in
               };
             };
             output = mkOption {
-              type = with types; attrsOf (oneOf [ bool str (attrsOf str) (listOf str) ]);
+              type = format.type;
               description = ''
                 Configuration of where packetbeat should send the information its gathered.
                 See <link xlink:href='https://www.elastic.co/guide/en/beats/packetbeat/current/configuring-output.html'/>
@@ -86,7 +86,7 @@ in
             };
 
             setup = mkOption {
-              type = with types; attrsOf (oneOf [ bool str (attrsOf str) ]);
+              type = format.type;
               description = ''
                 Configures where the kibana endpoint is for setting up dashboards and
                 whether packetbeat should setup ILM and index templates in elasticsearch.
@@ -94,7 +94,7 @@ in
             };
 
             fields = mkOption {
-              type = with types; attrsOf str;
+              type = format.type;
               description = ''
                 Extra fields that packetbeat should add to the top-level of the objects it
                 sends to its output.
@@ -102,7 +102,7 @@ in
             };
 
             processors = mkOption {
-              type = with types; listOf (oneOf [ str (listOf str) (attrsOf str) ]);
+              type = format.type;
               description = ''
                 Configuration of what enrichment and/or filtering processors packetbeat
                 should gather information from before sending it to the output.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adds a packetbeat module so that it can be configured with
freeform settings. Made with big help from @aanderse and
@infinisil.

We have the packetbeat package in nixpkgs for some time, but no module, so I decided to make one. It uses the freeform module concept.

Remade PR after screwing up the prior PR with a botched rebase.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
