### PR TITLE
pythonPackages.pdoc3: init at 0.9.1

### DIFF
--- a/pkgs/development/python-modules/pdoc3/default.nix
+++ b/pkgs/development/python-modules/pdoc3/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchPypi
+, pythonOlder
+, Mako
+, markdown
+, setuptools-git
+, setuptools_scm
+}:
+
+buildPythonPackage rec {
+  pname = "pdoc3";
+  version = "0.9.1";
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15482rvpg5r70gippj3nbl58x9plgmgvp0rg4xi4dpdqhma8v171";
+  };
+
+  nativeBuildInputs = [ setuptools-git setuptools_scm ];
+  propagatedBuildInputs = [ Mako markdown ];
+
+  meta = with lib; {
+    description = "Auto-generate API documentation for Python projects.";
+    homepage = "https://pdoc3.github.io/pdoc/";
+    license = with licenses; [ agpl3Plus ];
+    maintainers = with maintainers; [ catern ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4392,6 +4392,8 @@ in {
 
   pdfx = callPackage ../development/python-modules/pdfx { };
 
+  pdoc3 = callPackage ../development/python-modules/pdoc3 { };
+
   pecan = callPackage ../development/python-modules/pecan { };
 
   peewee = callPackage ../development/python-modules/peewee { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
pdoc3 is nicer than Sphinx.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
