### PR TITLE
exiv2: clean up

### DIFF
--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
   pname = "exiv2";
   version = "0.27.3";
 
+  outputs = [ "out" "dev" "doc" "man" ];
+
   src = fetchFromGitHub {
     owner = "exiv2";
     repo  = "exiv2";
@@ -31,20 +33,15 @@ stdenv.mkDerivation rec {
       url = "https://github.com/Exiv2/exiv2/commit/bbe0b70840cf28b7dd8c0b7e9bb1b741aeda2efd.patch";
       sha256 = "13zw1mn0ag0jrz73hqjhdsh1img7jvj5yddip2k2sb5phy04rzfx";
     })
-  ];
 
-  cmakeFlags = [
-    "-DEXIV2_BUILD_PO=ON"
-    "-DEXIV2_BUILD_DOC=ON"
-    # the cmake package does not handle absolute CMAKE_INSTALL_INCLUDEDIR correctly
-    # (setting it to an absolute path causes include files to go to $out/$out/include,
-    #  because the absolute path is interpreted with root at $out).
-    # Can probably be removed once https://github.com/Exiv2/exiv2/pull/1263 is merged.
-    "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    "-DCMAKE_INSTALL_LIBDIR=lib"
+    # Use correct paths with multiple outputs
+    # https://github.com/Exiv2/exiv2/pull/1275
+    (fetchpatch {
+      name = "cmake-fix-aarch64.patch";
+      url = "https://github.com/Exiv2/exiv2/commit/48f2c9dbbacc0ef84c8ebf4cb1a603327f0b8750.patch";
+      sha256 = "vjB3+Ld4c/2LT7nq6uatYwfHTh+HeU5QFPFXuNLpIPA=";
+    })
   ];
-
-  outputs = [ "out" "dev" "doc" "man" ];
 
   nativeBuildInputs = [
     cmake
@@ -65,7 +62,13 @@ stdenv.mkDerivation rec {
     which
   ];
 
+  cmakeFlags = [
+    "-DEXIV2_ENABLE_NLS=ON"
+    "-DEXIV2_BUILD_DOC=ON"
+  ];
+
   buildFlags = [
+    "all"
     "doc"
   ];
 
@@ -102,20 +105,11 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  # Fix CMake export paths. Can be removed once https://github.com/Exiv2/exiv2/pull/1263 is merged.
-  postFixup = ''
-    sed -i "$dev/lib/cmake/exiv2/exiv2Config.cmake" \
-        -e "/INTERFACE_INCLUDE_DIRECTORIES/ s@\''${_IMPORT_PREFIX}@$dev@" \
-        -e "/Compute the installation prefix/ a set(_IMPORT_PREFIX \"$out\")" \
-        -e "/^get_filename_component(_IMPORT_PREFIX/ d"
-  '';
-
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "https://www.exiv2.org/";
     description = "A library and command-line utility to manage image metadata";
     platforms = platforms.all;
     license = licenses.gpl2Plus;
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
- EXIV2_BUILD_PO has been replaced by EXIV2_ENABLE_NLS
  https://github.com/Exiv2/exiv2/commit/076585d1476283bc7cffcf08e9006fc64ffbfa10
  Confusingly, the former still appears in the flag summary.
- Remove enableParallelBuilding since it is on by default with CMake
- Reorder the expression
- Apply upstream GNUInstallDirs patch (https://github.com/Exiv2/exiv2/pull/1275)
- Build stuff in build phase, not in install phase
- Add maintainers field (empty at the moment)

cc @paperdigits

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
