### PR TITLE
google-chrome: add libxkbcommon+wayland for ozone/wayland

### DIFF
--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -6,6 +6,7 @@
 , alsaLib, libXdamage, libXtst, libXrandr, expat, cups
 , dbus, gtk2, gtk3, gdk-pixbuf, gcc-unwrapped, at-spi2-atk, at-spi2-core
 , kerberos, libdrm, mesa
+, libxkbcommon, wayland # ozone/wayland
 
 # Command line programs
 , coreutils
@@ -62,6 +63,7 @@ let
     flac harfbuzz icu libpng opusWithCustomModes snappy speechd
     bzip2 libcap at-spi2-atk at-spi2-core
     kerberos libdrm mesa coreutils
+    libxkbcommon wayland
   ] ++ optional pulseSupport libpulseaudio
     ++ [ gtk ];
 


### PR DESCRIPTION
###### Motivation for this change
As of [cc45a53ce5908f1d9bd4c98694a97eea3adae4cd](https://github.com/AeonGames/build/commit/0c1b85ff492b7d05cb42aeee577c19b453cacf1e) in chromium, it seems to have stuck this time and some Dev builds are out with ozone support.

Thus, when chromium's upstream-info.nix is next updated, the `-dev` builds of `chromium` and `google-chrome` will support `--ozone-platform=wayland` to boot a native Wayland instance.

This change is needed to the wrapper for this to work. (I have tested it after updating chromium's versions locally)

I don't really remember the conventions for updating chromium and it triggers a huge rebuild so I figured I'd leave it out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
