### PR TITLE
mdcat: 0.20.0 -> 0.21.1

### DIFF
--- a/pkgs/tools/text/mdcat/default.nix
+++ b/pkgs/tools/text/mdcat/default.nix
@@ -2,19 +2,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mdcat";
-  version = "0.20.0";
+  version = "0.21.1";
 
   src = fetchFromGitHub {
     owner = "lunaryorn";
     repo = pname;
     rev = "mdcat-${version}";
-    hash = "sha256-1qxz6p7VaJ9eMcLQaTW/M4+Xo0WLihzyEAycbkjjPyA=";
+    hash = "sha256-O7LlbSkxcyHQiTHYB/QBJVlShzTSzud3VJDIQ1ScvM4=";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ] ++ stdenv.lib.optional stdenv.isDarwin Security;
 
-  cargoSha256 = "sha256-/mAwlxed1MOFUA1jDSrgPzJuURbKzwucBWORVVHlrt8=";
+  cargoSha256 = "sha256-pvhYKyFraMI4w5nq6L8qs/ONSNDTHElhZnZmD5mmAZs=";
 
   checkInputs = [ ansi2html ];
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Update to most recent version of mdcat.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
