### PR TITLE
computecpp: 1.3.0 -> 2.2.1

### DIFF
--- a/pkgs/development/compilers/computecpp/default.nix
+++ b/pkgs/development/compilers/computecpp/default.nix
@@ -3,24 +3,23 @@
 , pkg-config
 , autoPatchelfHook
 , installShellFiles
-, ncurses5
 , ocl-icd
 , zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "computecpp";
-  version = "1.3.0";
+  version = "2.2.1";
 
   src = fetchzip {
-    url = "https://computecpp.codeplay.com/downloads/computecpp-ce/${version}/ubuntu-16.04-64bit.tar.gz";
-    sha256 = "1q6gqjpzz4a260gsd6mm1iv4z8ar3vxaypmgdwl8pb4i7kg6ykaz";
+    url = "https://computecpp.codeplay.com/downloads/computecpp-ce/${version}/x86_64-linux-gnu.tar.gz";
+    hash = "sha256-niXNWbkXjd35col6dS66HdxFurXfJw/Xb2c5njukxcg=";
     stripRoot = true;
   };
 
   dontStrip = true;
 
-  buildInputs = [ stdenv.cc.cc.lib ncurses5 ocl-icd zlib ];
+  buildInputs = [ stdenv.cc.cc.lib ocl-icd zlib ];
   nativeBuildInputs = [ autoPatchelfHook pkg-config installShellFiles ];
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Update to most recent version of ComputeCpp.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
