### PR TITLE
nixos/step-ca: Adding module for step-ca

### DIFF
--- a/nixos/modules/services/security/step-ca.nix
+++ b/nixos/modules/services/security/step-ca.nix
@@ -1,0 +1,76 @@
+{ config, lib, pkgs, ... }:
+
+let cfg = config.services.step-ca;
+
+in {
+  options = {
+    services.step-ca = {
+      enable = lib.mkEnableOption "Step CA PKI Server.";
+      dataDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/lib/step-ca";
+        description = "Directory to store Step CA Service data";
+      };
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "SmallStep CA";
+        description = "Name of your CA.";
+      };
+      hostname = lib.mkOption {
+        type = lib.types.str;
+        default = "localhost";
+        description = "Hostname/FQDN of your CA.";
+
+      };
+      address = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = "Address to listen at, defaults to all interfaces.";
+      };
+      port = lib.mkOption {
+        type = lib.types.int;
+        default = 9075;
+        description = "Port to listen on.";
+      };
+      passwordFile = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description =
+          "Path to file containing password of your first provisioner.";
+      };
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "admin";
+        description = "";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.step-ca = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      path = [ pkgs.coreutils pkgs.step-ca pkgs.step-cli ];
+      environment = { STEPPATH = "${cfg.dataDir}"; };
+      script = ''
+        mkdir -p ${cfg.dataDir}
+        if [ ! -f "${cfg.dataDir}/ca-is-init" ]; then
+          step ca init --ssh --name ${cfg.name} --dns ${cfg.hostname} \
+            --address ${cfg.address}:${
+              toString cfg.port
+            } --provisioner ${cfg.user}\
+               --password-file ${cfg.passwordFile}
+          touch ${cfg.dataDir}/ca-is-init
+        fi
+        step-ca $(step path)/config/ca.json --password-file ${cfg.passwordFile}
+      '';
+      serviceConfig = {
+        Type = "simple";
+        ExecReload = "/run/current-system/sw/bin/kill -HUP $MAINPID";
+        PIDFile = "step-ca.pid";
+        Restart = "on-failure";
+        WorkingDirectory = cfg.dataDir;
+      };
+    };
+  };
+}


### PR DESCRIPTION
nixos: Adding module for step-ca, set up by default to allow for both regular x.509 certs and SSH certs as well.

###### Motivation for this change
There wasn't already a module, and having an easily set up root CA is something I've found to be fairly useful.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
