### PR TITLE
libxsmm: 1.15 -> 1.16.1, improve derivation

### DIFF
--- a/pkgs/development/libraries/libxsmm/default.nix
+++ b/pkgs/development/libraries/libxsmm/default.nix
@@ -1,9 +1,11 @@
-{ stdenv, fetchFromGitHub, coreutils, gfortran7, gnused
-, python27, utillinux, which, bash
+{ stdenv, fetchFromGitHub, coreutils, gfortran, gnused
+, python3, utillinux, which
+
+, enableStatic ? false
 }:
 
 let
-  version = "1.15";
+  version = "1.16.1";
 in stdenv.mkDerivation {
   pname = "libxsmm";
   inherit version;
@@ -11,24 +13,34 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "hfp";
     repo = "libxsmm";
-    rev = "refs/tags/${version}";
-    sha256 = "1406qk7k2k4qfqy4psqk55iihsrx91w8kjgsa82jxj50nl9nw5nj";
+    rev = version;
+    sha256 = "1c1qj6hcdfx11bvilnly92vgk1niisd2bjw1s8vfyi2f7ws1wnp0";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     coreutils
-    gfortran7
+    gfortran
     gnused
-    python27
+    python3
     utillinux
     which
+  ];
+
+  enableParallelBuilding = true;
+
+  dontConfigure = true;
+
+  makeFlags = let
+    static = if enableStatic then "1" else "0";
+  in [
+    "OMP=1"
+    "PREFIX=$(out)"
+    "STATIC=${static}"
   ];
 
   prePatch = ''
     patchShebangs .
   '';
-
-  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "Library targeting Intel Architecture for specialized dense and sparse matrix operations, and deep learning primitives";
@@ -36,6 +48,5 @@ in stdenv.mkDerivation {
     homepage = "https://github.com/hfp/libxsmm";
     platforms = platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ chessai ];
-    inherit version;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The following changes are made to the derivation besides the version
bump:

- Move all buildInputs to nativeBuildInputs.
- Switch from Python 2 to Python 3.
- Build a dynamic library by default.
- Use gfortran version corresponding to gcc version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
