### PR TITLE
sd-local: init at 1.0.5

### DIFF
--- a/pkgs/development/tools/sd-local/default.nix
+++ b/pkgs/development/tools/sd-local/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "sd-local";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "screwdriver-cd";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "09j1wcx66sz2b0pps0bgbay5x06lc0d2awxjvd5zi8wqnbsrdq60";
+  };
+
+  vendorSha256 = "1qy51jx181rwim2v53ysgf7rys0nmxsbawvsbh3z1ihh3dlgw5bc";
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "screwdriver.cd local mode";
+    homepage = "https://github.com/screwdriver-cd/sd-local";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ midchildan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11402,6 +11402,8 @@ in
 
   scaff = callPackage ../development/tools/scaff { };
 
+  sd-local = callPackage ../development/tools/sd-local { };
+
   selenium-server-standalone = callPackage ../development/tools/selenium/server { };
 
   selendroid = callPackage ../development/tools/selenium/selendroid { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

sd-local is a command line tool to run screwdriver.cd CI jobs on local development machines.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
