### PR TITLE
elixir-ls: init at 0.5.0

### DIFF
--- a/pkgs/development/tools/elixir-ls/default.nix
+++ b/pkgs/development/tools/elixir-ls/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, unzip, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "elixir-ls";
+  version = "0.5.0";
+
+  targetPath = "$out/bin";
+
+  src = fetchurl {
+    url = "https://github.com/elixir-lsp/elixir-ls/releases/download/v${version}/elixir-ls.zip";
+    sha256 = "009g6pg13ngdik9yd5s141v5x8w4yzi7288zyzfszshwqpai8sfz";
+  };
+
+  nativeBuildInputs = [
+    unzip
+  ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p ${targetPath}
+    ${unzip}/bin/unzip ${src} -d ${targetPath}
+    rm ${targetPath}/*.bat
+    mv ${targetPath}/debugger.sh ${targetPath}/elixir_ls_debugger.sh
+    mv ${targetPath}/language_server.sh ${targetPath}/elixir_ls_server.sh
+    mv ${targetPath}/launch.sh ${targetPath}/elixir_ls_launch.sh
+  '';
+
+  postFixup = ''
+    ls ${targetPath}
+    substituteInPlace ${targetPath}/elixir_ls_server.sh \
+      --replace 'exec "''${dir}/launch.sh"' 'exec "''${dir}/elixir_ls_launch.sh"'
+
+    substituteInPlace ${targetPath}/elixir_ls_debugger.sh \
+      --replace 'exec "''${dir}/launch.sh"' 'exec "''${dir}/elixir_ls_launch.sh"'
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/elixir-lsp/elixir-ls";
+    description = "A frontend-independent IDE \"smartness\" server for Elixir. Implements the \"Language Server Protocol\" standard and provides debugger support via the \"Debug Adapter Protocol\"";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ parasrah ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -196,6 +196,8 @@ in
 
   eclipse-mat = callPackage ../development/tools/eclipse-mat { };
 
+  elixir-ls = callPackage ../development/tools/elixir-ls { };
+
   glade = callPackage ../development/tools/glade { };
 
   hobbes = callPackage ../development/tools/hobbes { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

close #73231, provide the elixir language server development tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notes

Didn't attempt to build from source given the current state of elixir support in `nixpkgs` (no reliable way to fetch elixir dependencies). I renamed the executable scripts to prevent naming conflicts, removed the scripts targeting windows and tested the language server using `kak-lsp` to ensure it functions properly.