### PR TITLE
tiledb: 1.7.7 -> 2.0.7, pythonPackages.tiledb: 0.5.6 -> 0.6.6, enable for darwin along with libpqxx

### DIFF
--- a/pkgs/development/libraries/libpqxx/default.nix
+++ b/pkgs/development/libraries/libpqxx/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "A C++ library to access PostgreSQL databases";
     homepage = "http://pqxx.org/development/libpqxx/";
     license = lib.licenses.bsd3;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.eelco ];
   };
 }

--- a/pkgs/development/libraries/tiledb/default.nix
+++ b/pkgs/development/libraries/tiledb/default.nix
@@ -16,6 +16,7 @@
 , python
 , gtest
 , doxygen
+, fixDarwinDylibNames
 }:
 
 stdenv.mkDerivation rec {
@@ -28,6 +29,12 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "00g8ibsbnl4wjfx3qg4qy6s7z6dsj898j0yqfhw1gjr1pb5dsapb";
   };
+
+  # (bundled) blosc headers have a warning on some archs that it will be using
+  # unaccelerated routines.
+  cmakeFlags = [
+    "-DTILEDB_WERROR=0"
+  ];
 
   nativeBuildInputs = [
     clang-tools
@@ -53,7 +60,7 @@ stdenv.mkDerivation rec {
     openssl
     boost
     libpqxx
-  ];
+  ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   # emulate the process of pulling catch down
   postPatch = ''
@@ -65,11 +72,15 @@ stdenv.mkDerivation rec {
 
   installTargets = [ "install-tiledb" "doc" ];
 
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -add_rpath ${tbb}/lib $out/lib/libtiledb.dylib
+  '';
+
   meta = with lib; {
     description = "TileDB allows you to manage the massive dense and sparse multi-dimensional array data";
     homepage = "https://github.com/TileDB-Inc/TileDB";
     license = licenses.mit;
-    platforms = [ "x86_64-linux"];
+    platforms = platforms.unix;
     maintainers = with maintainers; [ rakesh4g ];
   };
 

--- a/pkgs/development/libraries/tiledb/default.nix
+++ b/pkgs/development/libraries/tiledb/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tiledb";
-  version = "1.7.7";
+  version = "2.0.7";
 
   src = fetchFromGitHub {
     owner = "TileDB-Inc";
     repo = "TileDB";
     rev = version;
-    sha256 = "0vpbyxi8k29c7sjpk86y5w3yyp5fn62q5xvbw061wgp7vrprf8bm";
+    sha256 = "00g8ibsbnl4wjfx3qg4qy6s7z6dsj898j0yqfhw1gjr1pb5dsapb";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/tiledb/default.nix
+++ b/pkgs/development/python-modules/tiledb/default.nix
@@ -63,7 +63,8 @@ buildPythonPackage rec {
     # these tests don't always fail
     substituteInPlace tiledb/tests/test_libtiledb.py --replace \
       "test_varlen_write_int_subarray" "dont_test_varlen_write_int_subarray" \
-      --replace "test_memory_cleanup" "dont_test_memory_cleanup"
+      --replace "test_memory_cleanup" "dont_test_memory_cleanup" \
+      --replace "test_ctx_thread_cleanup" "dont_test_ctx_thread_cleanup"
     substituteInPlace tiledb/tests/test_metadata.py --replace \
       "test_metadata_consecutive" "dont_test_metadata_consecutive"
   '';

--- a/pkgs/development/python-modules/tiledb/default.nix
+++ b/pkgs/development/python-modules/tiledb/default.nix
@@ -3,28 +3,31 @@
 , buildPythonPackage
 , fetchFromGitHub
 , cython
+, pybind11
 , tiledb
 , numpy
 , wheel
 , isPy3k
 , setuptools_scm
 , psutil
+, pandas
 }:
 
 buildPythonPackage rec {
   pname = "tiledb";
-  version = "0.5.6";
+  version = "0.6.6";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "TileDB-Inc";
     repo = "TileDB-Py";
     rev = version;
-    sha256 = "0cgm4dhyqay26xmrzlv21ha8qh55m4q3yr338lrv81ngz77zxsvw";
+    sha256 = "0b2kn1xyf7d994kz29dpqiaf8yzvx0axw4yqi854c54pl22ddgzl";
   };
 
   nativeBuildInputs = [
     cython
+    pybind11
     setuptools_scm
   ];
 
@@ -39,6 +42,8 @@ buildPythonPackage rec {
 
   checkInputs = [
     psutil
+    # optional
+    pandas
   ];
 
   TILEDB_PATH = tiledb;
@@ -57,16 +62,18 @@ buildPythonPackage rec {
       "test_docs" "dont_test_docs"
     # these tests don't always fail
     substituteInPlace tiledb/tests/test_libtiledb.py --replace \
-      "test_varlen_write_int_subarray" "dont_test_varlen_write_int_subarray"
+      "test_varlen_write_int_subarray" "dont_test_varlen_write_int_subarray" \
+      --replace "test_memory_cleanup" "dont_test_memory_cleanup"
     substituteInPlace tiledb/tests/test_metadata.py --replace \
       "test_metadata_consecutive" "dont_test_metadata_consecutive"
   '';
 
   checkPhase = ''
-    pushd "$out"
+    pushd "$TMPDIR"
     ${python.interpreter} -m unittest tiledb.tests.all.suite_test
     popd
   '';
+  pythonImportsCheck = [ "tiledb" ];
 
   meta = with lib; {
     description = "Python interface to the TileDB storage manager";


### PR DESCRIPTION
###### Motivation for this change
This supersedes #94330. The `tiledb` bump also requires a corresponding bump to the python package.

At the same time I fixed/enabled it for non-x86 linux and darwin (tested macos 10.14). The latter first required enabling `libpqxx` for darwin, which turns out to work just fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
