### PR TITLE
gitkraken: 7.2.0 -> 7.3.0

### DIFF
--- a/pkgs/applications/version-management/gitkraken/default.nix
+++ b/pkgs/applications/version-management/gitkraken/default.nix
@@ -3,7 +3,7 @@
 , libX11, libXi, libxcb, libXext, libXcursor, glib, libXScrnSaver, libxkbfile, libXtst
 , nss, nspr, cups, fetchzip, expat, gdk-pixbuf, libXdamage, libXrandr, dbus
 , makeDesktopItem, openssl, wrapGAppsHook, at-spi2-atk, at-spi2-core, libuuid
-, e2fsprogs, krb5
+, e2fsprogs, krb5, libdrm, mesa
 }:
 
 with stdenv.lib;
@@ -13,11 +13,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "gitkraken";
-  version = "7.2.0";
+  version = "7.3.0";
 
   src = fetchzip {
     url = "https://release.axocdn.com/linux/GitKraken-v${version}.tar.gz";
-    sha256 = "0nrrcwikx6dx1j1s0b80gh1s932zvxmijpddqp6a1vh3ddc5v1mp";
+    sha256 = "0q9imaka79p3krmcrxvnxzb2gprczybnw8d4y9p4icbmdbyb6h70";
   };
 
   dontBuild = true;
@@ -61,6 +61,8 @@ stdenv.mkDerivation rec {
     libuuid
     e2fsprogs
     krb5
+    libdrm
+    mesa
   ];
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
###### Motivation for this change
GitKraken version [7.3.0](https://support.gitkraken.com/release-notes/current/#version-730) has been released.

___

GitKraken now depends on `libdrm` and `libgbm`

- Add `libdrm` to `libPath`
- Add `mesa` (`libgbm`) to `libPath`