### PR TITLE
postman: 7.30.1 -> 7.31.1

### DIFF
--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "postman";
-  version = "7.30.1";
+  version = "7.31.1";
 
   src = fetchurl {
     url = "https://dl.pstmn.io/download/version/${version}/linux64";
-    sha256 = "18bphn5m42z9x0igafd259q7i88qn7wcxvvhdjv9ldnvmhf1k935";
+    sha256 = "14df24gj0mljblzc78pggyajr7004mg35gary5cz2c26vcklx4pw";
     name = "${pname}.tar.gz";
   };
 


### PR DESCRIPTION
###### Motivation for this change
Postman version [7.31.1](https://www.postman.com/downloads/release-notes/#changelog-linux-app-7.31.1) has been released.