### PR TITLE
emulsion: init at 5.0

### DIFF
--- a/pkgs/applications/graphics/emulsion/default.nix
+++ b/pkgs/applications/graphics/emulsion/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, rustPlatform, fetchFromGitHub, libX11, libXcursor, libXrandr, libXi, libGL, patchelf }:
+
+let
+  rpath = [ libX11 libXcursor libXrandr libXi libGL ];
+in
+
+rustPlatform.buildRustPackage rec {
+  pname = "emulsion";
+  version = "v5.0";
+
+  src = fetchFromGitHub {
+    owner = "ArturKovacs";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-AGSki0eMWCUgnG7AK2y6+3uJE1F9nqLGIO4rABr1nxI=";
+  };
+
+  cargoSha256 = "sha256-9f6imRK+UtblayDRFPra23xTh2hLRVE2WlBOkuvjZxk=";
+
+  buildInputs = rpath;
+  nativeBuildInputs = [ patchelf ];
+
+  postFixup = ''
+      patchelf --set-rpath "${stdenv.lib.makeLibraryPath rpath}" $out/bin/emulsion
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A fast and minimalistic image viewer";
+    homepage = "https://github.com/ArturKovacs/emulsion";
+    license = licenses.mit;
+    maintainers = with maintainers; [ TethysSvensson ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20157,6 +20157,8 @@ in
 
   inherit (gnome3) empathy;
 
+  emulsion = callPackage ../applications/graphics/emulsion { };
+
   enhanced-ctorrent = callPackage ../applications/networking/enhanced-ctorrent { };
 
   envelope = callPackage ../applications/office/envelope { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

Add [emulsion](https://github.com/ArturKovacs/emulsion), a fast and  minimalistic image viewer written in rust.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
