### PR TITLE
python3Packages.tensorboardx: fix build after upgrade to PyTorch 1.6

### DIFF
--- a/pkgs/development/python-modules/tensorboardx/default.nix
+++ b/pkgs/development/python-modules/tensorboardx/default.nix
@@ -19,6 +19,12 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ numpy protobuf six ];
 
+  # apparently torch API changed a bit at 1.6
+  postPatch = ''
+    substituteInPlace tensorboardX/pytorch_graph.py --replace "torch.onnx.set_training(model, False)" "torch.onnx.select_model_mode_for_export(model, torch.onnx.TrainingMode.EVAL)"
+  '';
+
+
   disabledTests = [ "test_TorchVis"  "test_onnx_graph" ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Torch ONNX api changed a bit in 1.6 version. TensorboardX build fails now.

###### Things done
Tweaked code a bit so test works again.


- Built on platform(s)
   - [X ] NixOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
