### PR TITLE
duplicity: 0.8.13 -> 0.8.15

### DIFF
--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -19,11 +19,11 @@ let
 in
 pythonPackages.buildPythonApplication rec {
   pname = "duplicity";
-  version = "0.8.13";
+  version = "0.8.15";
 
   src = fetchurl {
     url = "https://code.launchpad.net/duplicity/${majorMinor version}-series/${majorMinorPatch version}/+download/duplicity-${version}.tar.gz";
-    sha256 = "0lflg1ay4q4w9qzpmh6y2hza4fc3ig12q44qkd80ks17hj21bxa6";
+    sha256 = "1kg467mxg5a97v1rlv4shk32krgv8ys4nczq4b11av4bp1lgysdc";
   };
 
   patches = [

--- a/pkgs/tools/backup/duplicity/use-installed-scripts-in-test.patch
+++ b/pkgs/tools/backup/duplicity/use-installed-scripts-in-test.patch
@@ -38,12 +38,12 @@
          # """ERROR 2
 --- a/testing/functional/test_rdiffdir.py
 +++ b/testing/functional/test_rdiffdir.py
-@@ -38,7 +38,7 @@ class RdiffdirTest(FunctionalTestCase):
- 
-     def run_rdiffdir(self, argstring):
-         u"""Run rdiffdir with given arguments"""
--        self.run_cmd(u"../bin/rdiffdir " + argstring)
-+        self.run_cmd(u"rdiffdir " + argstring)
- 
-     def run_cycle(self, dirname_list):
-         u"""Run diff/patch cycle on directories in dirname_list"""
+@@ -42,7 +42,7 @@ class RdiffdirTest(FunctionalTestCase):
+         basepython = os.environ.get(u'TOXPYTHON', None)
+         if basepython is not None:
+             cmd_list.extend([basepython])
+-        cmd_list.extend([u"../bin/rdiffdir"])
++        cmd_list.extend([u"rdiffdir"])
+         cmd_list.extend(argstring.split())
+         cmdline = u" ".join([u'"%s"' % x for x in cmd_list])
+         self.run_cmd(cmdline)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Updates [duplicity](http://duplicity.nongnu.org/) to current stable 0.8 release 0.8.15, released July 27, 2020.

cc @peti 

Note that the patch change corresponds to https://gitlab.com/duplicity/duplicity/-/commit/6b7a2b06694725fa5d780701413878366de14546

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
