### PR TITLE
calibre: build with py3 by default

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -16,7 +16,7 @@
 , hyphen
 , unrarSupport ? false
 , chmlib
-, python2Packages
+, pythonPackages
 , libusb1
 , libmtp
 , xdg_utils
@@ -24,10 +24,6 @@
 , removeReferencesTo
 }:
 
-let
-  pypkgs = python2Packages;
-
-in
 mkDerivation rec {
   pname = "calibre";
   version = "4.22.0";
@@ -47,7 +43,7 @@ mkDerivation rec {
   ] ++ lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;
 
   prePatch = ''
-    sed -i "/pyqt_sip_dir/ s:=.*:= '${pypkgs.pyqt5}/share/sip/PyQt5':"  \
+    sed -i "/pyqt_sip_dir/ s:=.*:= '${pythonPackages.pyqt5}/share/sip/PyQt5':"  \
       setup/build_environment.py
 
     # Remove unneeded files and libs
@@ -61,51 +57,48 @@ mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig qmake removeReferencesTo ];
 
-  CALIBRE_PY3_PORT = builtins.toString pypkgs.isPy3k;
+  CALIBRE_PY3_PORT = builtins.toString pythonPackages.isPy3k;
 
   buildInputs = [
-    poppler_utils
-    libpng
-    imagemagick
-    libjpeg
-    fontconfig
-    podofo
-    qtbase
     chmlib
-    icu
+    fontconfig
     hunspell
     hyphen
-    sqlite
-    libusb1
+    icu
+    imagemagick
+    libjpeg
     libmtp
+    libpng
+    libusb1
+    podofo
+    poppler_utils
+    qtbase
+    sqlite
     xdg_utils
   ] ++ (
-    with pypkgs; [
+    with pythonPackages; [
       apsw
-      cssselect
+      beautifulsoup4
       css-parser
+      cssselect
       dateutil
       dnspython
       feedparser
+      html2text
       html5-parser
       lxml
       markdown
+      mechanize
+      msgpack
       netifaces
       pillow
-      python
       pyqt5
-      sip
-      regex
-      msgpack
-      beautifulsoup4
-      html2text
       pyqtwebengine
+      python
+      regex
+      sip
       # the following are distributed with calibre, but we use upstream instead
       odfpy
-    ]
-  ) ++ lib.optionals (!pypkgs.isPy3k) (
-    with pypkgs; [
-      mechanize
     ]
   );
 
@@ -121,17 +114,16 @@ mkDerivation rec {
     export FC_LIB_DIR=${fontconfig.lib}/lib
     export PODOFO_INC_DIR=${podofo.dev}/include/podofo
     export PODOFO_LIB_DIR=${podofo.lib}/lib
-    export SIP_BIN=${pypkgs.sip}/bin/sip
+    export SIP_BIN=${pythonPackages.sip}/bin/sip
     export XDG_DATA_HOME=$out/share
     export XDG_UTILS_INSTALL_MODE="user"
 
-    ${pypkgs.python.interpreter} setup.py install --root=$out \
+    ${pythonPackages.python.interpreter} setup.py install --root=$out \
       --prefix=$out \
       --libdir=$out/lib \
       --staging-root=$out \
       --staging-libdir=$out/lib \
       --staging-sharedir=$out/share
-
 
     PYFILES="$out/bin/* $out/lib/calibre/calibre/web/feeds/*.py
       $out/lib/calibre/calibre/ebooks/metadata/*.py
@@ -154,7 +146,8 @@ mkDerivation rec {
   # 2018-11-06) was a single string like the following:
   #   /nix/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-podofo-0.9.6-dev/include/podofo/base/PdfVariant.h
   preFixup = ''
-    remove-references-to -t ${podofo.dev} $out/lib/calibre/calibre/plugins/podofo.so
+    remove-references-to -t ${podofo.dev} \
+      $out/lib/calibre/calibre/plugins${lib.optionalString pythonPackages.isPy3k "/3"}/podofo.so
 
     for program in $out/bin/*; do
       wrapProgram $program \

--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -26,11 +26,11 @@
 
 mkDerivation rec {
   pname = "calibre";
-  version = "4.22.0";
+  version = "4.23.0";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${pname}-${version}.tar.xz";
-    sha256 = "0d0wmd3ijk8px1d662igal4lfmpyzynfzs6ms1bb9nf42mq2pxai";
+    sha256 = "sha256-Ft5RRzzw4zb5RqVyUaHk9Pu6H4V/F9j8FKoTLn61lRg=";
   };
 
   patches = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19691,7 +19691,11 @@ in
 
   calculix = callPackage ../applications/science/math/calculix {};
 
-  calibre = libsForQt5.callPackage ../applications/misc/calibre { };
+  calibre-py2 = libsForQt5.callPackage ../applications/misc/calibre { pythonPackages = python2Packages; };
+
+  calibre-py3 = libsForQt5.callPackage ../applications/misc/calibre { pythonPackages = python3Packages; };
+
+  calibre = self.calibre-py3;
 
   calligra = libsForQt5.callPackage ../applications/office/calligra {
     inherit (kdeApplications) akonadi-calendar akonadi-contacts;


### PR DESCRIPTION
###### Motivation for this change

python 2 is dead and calibre has been supporting py3 for a while now.

In case people still need py2 due to external plugins not supporting py3
yet, we have calibre-py2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).