### PR TITLE
rainloop: allow multiple instances to use the same package

### DIFF
--- a/pkgs/servers/rainloop/default.nix
+++ b/pkgs/servers/rainloop/default.nix
@@ -24,7 +24,8 @@
          */
         function __get_custom_data_full_path()
         {
-          return '${dataPath}'; // custom data folder path
+          $v = getenv('RAINLOOP_DATA_DIR', TRUE);
+          return $v === FALSE ? '${dataPath}' : $v;
         }
       '';
 
@@ -33,6 +34,8 @@
         cp -r rainloop/* $out
         rm -rf $out/data
         cp ${includeScript} $out/include.php
+        mkdir $out/data
+        chmod 700 $out/data
       '';
 
       meta = with stdenv.lib; {
@@ -44,13 +47,13 @@
         maintainers = with maintainers; [ das_j ];
       };
     });
-  in {
-    rainloop-community = common {
-      edition = "community";
-      sha256 = "0a8qafm4khwj8cnaiaxvjb9073w6fr63vk1b89nks4hmfv10jn6y";
-    };
-    rainloop-standard = common {
-      edition = "";
-      sha256 = "0961g4mci080f7y98zx9r4qw620l4z3na1ivvlyhhr1v4dywqvch";
-    };
-  }
+in {
+  rainloop-community = common {
+    edition = "community";
+    sha256 = "0a8qafm4khwj8cnaiaxvjb9073w6fr63vk1b89nks4hmfv10jn6y";
+  };
+  rainloop-standard = common {
+    edition = "";
+    sha256 = "0961g4mci080f7y98zx9r4qw620l4z3na1ivvlyhhr1v4dywqvch";
+  };
+}


### PR DESCRIPTION
This pull request allows the `rainloop` data directory to be overridden with an environment variable at runtime, thereby allowing the package to be used to serve multiple instances without having to override the data directory and build a new package.  If the `RAINLOOP_DATA_DIR` environment variable is not set, the package behaves as it previously did.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
