### PR TITLE
rainloop service: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -410,6 +410,7 @@
   ./services/mail/postsrsd.nix
   ./services/mail/postgrey.nix
   ./services/mail/spamassassin.nix
+  ./services/mail/rainloop.nix
   ./services/mail/rspamd.nix
   ./services/mail/rss2email.nix
   ./services/mail/roundcube.nix

--- a/nixos/modules/services/mail/rainloop.nix
+++ b/nixos/modules/services/mail/rainloop.nix
@@ -1,0 +1,136 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.rainloop;
+  instance = name: { package, php-package, user, group, vhost, location, ... }: let
+    user-name = if user == null then "rainloop-${name}" else user;
+    location' = if lib.hasPrefix "/" location then location else "/${location}";
+    location'' = if lib.hasSuffix "/" location' then location' else "${location'}/";
+
+  in {
+    users = {
+      ${if user != null then null else user-name} = {
+        isSystemUser = true;
+        description = "Rainloop user for ${name}";
+        createHome = true;
+        home = "/var/lib/rainloop/${name}";
+      };
+    };
+
+    pools."rainloop-${name}" = {
+      user = user-name;
+      group = group;
+      settings = {
+        "env[RAINLOOP_DATA_DIR]" = config.users.users.${user-name}.home;
+        "listen.owner" = user-name;
+        "listen.group" = group;
+        "pm" = "dynamic";
+        "pm.max_children" = 32;
+        "pm.max_requests" = 500;
+        "pm.start_servers" = 2;
+        "pm.min_spare_servers" = 2;
+        "pm.max_spare_servers" = 5;
+        "php_admin_value[error_log]" = "stderr";
+        "php_admin_flag[log_errors]" = true;
+        "catch_workers_output" = true;
+      };
+      phpEnv."PATH" = lib.makeBinPath [ php-package ];
+      phpOptions = ''
+        upload_max_filesize = 40m
+        post_max_size = 49M
+      '';
+    };
+
+    vhosts.${vhost} = {
+      extraConfig = "client_max_body_size 50m;";
+      locations.${location''} = {
+        alias = "${package}/";
+        index = "index.php";
+        extraConfig = ''
+          location ~ \.php$ {
+            include       ${pkgs.nginx}/conf/fastcgi.conf;
+            fastcgi_param SCRIPT_FILENAME $request_filename;
+            fastcgi_param SCRIPT_NAME /$1;
+            fastcgi_param DOCUMENT_URI /$1;
+            fastcgi_pass  unix:${config.services.phpfpm.pools."rainloop-${name}".socket};
+          }
+        '';
+      };
+    };
+  };
+in
+{
+  options.services.rainloop = mkOption {
+    default = { };
+    description = ''
+      Named instances of the Rainloop webmail client to run.
+    '';
+    type = types.attrsOf (types.submodule {
+      options = {
+        package = mkOption {
+          default = pkgs.rainloop-community;
+          defaultText = "pkgs.rainloop-community";
+          type = types.package;
+          description = ''
+            Rainloop package to use.
+          '';
+        };
+
+        php-package = mkOption {
+          default = pkgs.php;
+          defaultText = "pkgs.php";
+          type = types.package;
+          description = ''
+            PHP package to use.
+          '';
+        };
+
+        user = mkOption {
+          default = null;
+          type = types.nullOr types.str;
+          description = ''
+            Name of the user to run as.  Pass `null` to create a new
+            dedicated user named `rainloop-<instance name>` with home
+            under `/var/lib/rainloop`.
+          '';
+        };
+
+        group = mkOption {
+          default = "nginx";
+          type = types.str;
+          description = ''
+            Name of the group to run as.
+          '';
+        };
+
+        vhost = mkOption {
+          default = null;
+          type = types.nullOr types.str;
+          description = ''
+            Name of the nginx virtual host on which to expose Rainloop.
+            Pass `null` to disable nginx integration.
+          '';
+        };
+
+        location = mkOption {
+          default = "/";
+          type = types.str;
+          description = ''
+            HTTP location at which Rainloop will be exposed.
+          '';
+        };
+      };
+    });
+  };
+
+  config = let
+    c = mapAttrsToList instance cfg;
+    vhosts = catAttrs "vhosts" c;
+  in mkIf (cfg != { }) {
+    systemd.tmpfiles.rules = [ "d /var/lib/rainloop 0755 root root - -" ];
+    users.users = mkMerge (catAttrs "users" c);
+    services.phpfpm.pools = mkMerge (catAttrs "pools" c);
+    services.nginx.enable = builtins.length vhosts > 0;
+    services.nginx.virtualHosts = mkMerge vhosts;
+  };
+}

--- a/pkgs/servers/rainloop/default.nix
+++ b/pkgs/servers/rainloop/default.nix
@@ -24,7 +24,8 @@
          */
         function __get_custom_data_full_path()
         {
-          return '${dataPath}'; // custom data folder path
+          $v = getenv('RAINLOOP_DATA_DIR', TRUE);
+          return $v === FALSE ? '${dataPath}' : $v;
         }
       '';
 
@@ -33,6 +34,8 @@
         cp -r rainloop/* $out
         rm -rf $out/data
         cp ${includeScript} $out/include.php
+        mkdir $out/data
+        chmod 700 $out/data
       '';
 
       meta = with stdenv.lib; {
@@ -44,13 +47,13 @@
         maintainers = with maintainers; [ das_j ];
       };
     });
-  in {
-    rainloop-community = common {
-      edition = "community";
-      sha256 = "0a8qafm4khwj8cnaiaxvjb9073w6fr63vk1b89nks4hmfv10jn6y";
-    };
-    rainloop-standard = common {
-      edition = "";
-      sha256 = "0961g4mci080f7y98zx9r4qw620l4z3na1ivvlyhhr1v4dywqvch";
-    };
-  }
+in {
+  rainloop-community = common {
+    edition = "community";
+    sha256 = "0a8qafm4khwj8cnaiaxvjb9073w6fr63vk1b89nks4hmfv10jn6y";
+  };
+  rainloop-standard = common {
+    edition = "";
+    sha256 = "0961g4mci080f7y98zx9r4qw620l4z3na1ivvlyhhr1v4dywqvch";
+  };
+}


### PR DESCRIPTION
This pull request introduces a service for running (multiple instances of) the `rainloop` webmail client.

It sits atop #97271.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
