### PR TITLE
mailpile: 1.0.0rc2 -> 1.0.0rc6

### DIFF
--- a/pkgs/applications/networking/mailreaders/mailpile/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailpile/default.nix
@@ -1,14 +1,21 @@
-{ stdenv, fetchFromGitHub, python2Packages, gnupg1orig, openssl, git }:
+{ stdenv
+, fetchFromGitHub
+, python2Packages
+, gnupg
+, openssl
+, git
+, tor
+}:
 
 python2Packages.buildPythonApplication rec {
   pname = "mailpile";
-  version = "1.0.0rc2";
+  version = "1.0.0rc6";
 
   src = fetchFromGitHub {
     owner = "mailpile";
     repo = "Mailpile";
     rev = version;
-    sha256 = "1z5psh00fjr8gnl4yjcl4m9ywfj24y1ffa2rfb5q8hq4ksjblbdj";
+    sha256 = "13pj494dx5gjf6x4bazh586vqmaqq8ycvw2k65280md1yc79b6l1";
   };
 
   postPatch = ''
@@ -22,17 +29,27 @@ python2Packages.buildPythonApplication rec {
     appdirs
     cryptography
     fasteners
-    gnupg1orig
+    gnupg
     jinja2
     pgpdump
     pillow
-    python2Packages.lxml
+    lxml
     spambayes
+    stem
+    pysocks
+    icalendar
+    imgsize
   ];
+
+  patches = [ ./underscores.patch ];
 
   postInstall = ''
     wrapProgram $out/bin/mailpile \
-      --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnupg1orig openssl ]}" \
+      --set-default MAILPILE_GNUPG "${gnupg}/bin/gpg" \
+      --set-default MAILPILE_GNUPG_GA "${gnupg}/bin/gpg-agent" \
+      --set-default MAILPILE_GNUPG_DM "${gnupg}/bin/dirmngr" \
+      --set-default MAILPILE_OPENSSL "${openssl}/bin/openssl" \
+      --set-default MAILPILE_TOR "${tor}/bin/tor" \
       --set-default MAILPILE_SHARED "$out/share/mailpile"
   '';
 
@@ -45,8 +62,5 @@ python2Packages.buildPythonApplication rec {
     license = [ licenses.asl20 licenses.agpl3 ];
     platforms = platforms.linux;
     maintainers = [ maintainers.domenkozar ];
-    knownVulnerabilities = [
-      "Numerous and uncounted, upstream has requested we not package it. See more: https://github.com/NixOS/nixpkgs/pull/23058#issuecomment-283515104"
-    ];
   };
 }

--- a/pkgs/applications/networking/mailreaders/mailpile/underscores.patch
+++ b/pkgs/applications/networking/mailreaders/mailpile/underscores.patch
@@ -1,0 +1,29 @@
+diff --git a/mailpile/crypto/gpgi.py b/mailpile/crypto/gpgi.py
+index fbe061ef..c5ed12a0 100644
+--- a/mailpile/crypto/gpgi.py
++++ b/mailpile/crypto/gpgi.py
+@@ -640,8 +640,8 @@ class GnuPG:
+ 
+         if version > (2, 1, 11):
+             binaries = mailpile.platforms.DetectBinaries()
+-            for which, setting in (('GnuPG/dm', 'dirmngr-program'),
+-                                   ('GnuPG/ga', 'agent-program')):
++            for which, setting in (('GnuPG_dm', 'dirmngr-program'),
++                                   ('GnuPG_ga', 'agent-program')):
+                 if which in binaries:
+                     args.insert(1, "--%s=%s" % (setting, binaries[which]))
+                 else:
+diff --git a/mailpile/platforms.py b/mailpile/platforms.py
+index b1e73d79..eff87fb1 100644
+--- a/mailpile/platforms.py
++++ b/mailpile/platforms.py
+@@ -17,8 +17,8 @@ BINARIES = {}
+ # they are available/working.
+ BINARIES_WANTED = {
+     'GnuPG':    ['gpg', '--version'],
+-    'GnuPG/dm': ['dirmngr', '--version'],
+-    'GnuPG/ga': ['gpg-agent', '--version'],
++    'GnuPG_dm': ['dirmngr', '--version'],
++    'GnuPG_ga': ['gpg-agent', '--version'],
+     'OpenSSL':  ['openssl', 'version'],
+     'Tor':      ['tor', '--version']}


### PR DESCRIPTION
This PR also removes the `meta.knownVulnerabilities` metadata from the package.  The referenced discussion thread talks about 0.5.x versions of Mailpile; 1.0.0rc* are stated to be ready for packaging.

Atop #97273.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
