### PR TITLE
airscan: 0.99.8 -> 0.99.16

### DIFF
--- a/pkgs/applications/graphics/sane/backends/airscan/default.nix
+++ b/pkgs/applications/graphics/sane/backends/airscan/default.nix
@@ -1,17 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, avahi, libsoup, libjpeg, libpng
+{ lib, stdenv, fetchFromGitHub, pkg-config, avahi, libsoup, libjpeg, libpng, gnutls
 , sane-backends, meson, ninja }:
 stdenv.mkDerivation rec {
   pname = "sane-airscan";
-  version = "0.99.8";
+  version = "0.99.16";
 
   nativeBuildInputs = [ meson ninja pkg-config ];
-  buildInputs = [ avahi libsoup libjpeg libpng sane-backends ];
+  buildInputs = [ avahi libsoup libjpeg libpng gnutls sane-backends ];
 
   src = fetchFromGitHub {
     owner = "alexpevzner";
     repo = pname;
     rev = version;
-    sha256 = "0sdlnbzhnfn4i5mkqhc8zmjywbbjqkbnsiz2gpqhy6fypshryahz";
+    sha256 = "00lgcdbpns0shwlpkvrpfm4z05s7v5q3al4kcw6ii7xnkzmv1721";
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Update airscan, got support of couple additional scanners. My is WorkCentre 3025 and works now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
