### PR TITLE
beets: fix build with mutagen 1.45

### DIFF
--- a/pkgs/tools/audio/beets/mutagen-1.43.patch
+++ b/pkgs/tools/audio/beets/mutagen-1.43.patch
@@ -1,23 +1,35 @@
 Backport https://github.com/beetbox/mediafile/commit/b3343c4ee08d1251ae5e2344401a2f5892b4e868
 to Beets 1.4.9.
 
-diff --git i/setup.py w/setup.py
-index 79278f8..b8d6068 100755
---- i/setup.py
-+++ w/setup.py
+Also fixes WavpackTest failure: https://github.com/beetbox/mediafile/issues/34
+
+
+diff --git a/setup.py b/setup.py
+index 79278f8b..4b8103fa 100755
+--- a/setup.py
++++ b/setup.py
 @@ -87,7 +87,7 @@ setup(
  
      install_requires=[
          'six>=1.9',
 -        'mutagen>=1.33',
-+        'mutagen>=1.43',
++        'mutagen>=1.45',
          'unidecode',
          'musicbrainzngs>=0.4',
          'pyyaml',
-diff --git i/test/test_mediafile.py w/test/test_mediafile.py
-index 36a2c53..54ef9dd 100644
---- i/test/test_mediafile.py
-+++ w/test/test_mediafile.py
+diff --git a/test/test_mediafile.py b/test/test_mediafile.py
+index 36a2c53a..0ddde44e 100644
+--- a/test/test_mediafile.py
++++ b/test/test_mediafile.py
+@@ -888,7 +888,7 @@ class WavpackTest(ReadWriteTestBase, unittest.TestCase):
+         'bitrate': 109312,
+         'format': u'WavPack',
+         'samplerate': 44100,
+-        'bitdepth': 0,
++        'bitdepth': 16,
+         'channels': 1,
+     }
+ 
 @@ -912,7 +912,7 @@ class AIFFTest(ReadWriteTestBase, unittest.TestCase):
          'bitrate': 705600,
          'format': u'AIFF',


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Build was broken:
```
FAIL: test_read_audio_properties (test.test_mediafile.WavpackTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/source/test/test_mediafile.py", line 440, in test_read_audio_properties
    self.assertEqual(getattr(mediafile, key), value)
AssertionError: 16 != 0
```

See also https://github.com/beetbox/mediafile/issues/34

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
