### PR TITLE
Fix paperless and other Python pkgs

### DIFF
--- a/pkgs/applications/office/paperless/default.nix
+++ b/pkgs/applications/office/paperless/default.nix
@@ -106,25 +106,25 @@ let
   };
 
   python = python3.override {
-    packageOverrides = self: super: {
-      # Paperless only supports Django 2.0
-      django = django_2_0 super;
+    packageOverrides = self: super: let
+      customPkgs = import ./python-modules super fetchFromGitHub; in
+    {
       pyocr = pyocrWithUserTesseract super;
+
+      # Paperless only supports Django 2.0
+      django = customPkgs.django_2_0;
+
+      # Paperless is incompatible with factory_boy >= 3
+      factory_boy = customPkgs.factory_boy_2_12_0;
+
+      # The current version of django_extensions is incompatible with django 2.0
+      django_extensions = customPkgs.django_extensions_2_2_8;
+
       # These are pre-release versions, hence they are private to this pkg
       django-filter = self.callPackage ./python-modules/django-filter.nix {};
       django-crispy-forms = self.callPackage ./python-modules/django-crispy-forms.nix {};
     };
   };
-
-  django_2_0 = pyPkgs: pyPkgs.django_2_2.overrideDerivation (_: rec {
-    pname = "Django";
-    version = "2.0.12";
-    name = "${pname}-${version}";
-    src = pyPkgs.fetchPypi {
-      inherit pname version;
-      sha256 = "15s8z54k0gf9brnz06521bikm60ddw5pn6v3nbvnl47j1jjsvwz2";
-    };
-  });
 
   runtimePackages = with python.pkgs; [
     dateparser

--- a/pkgs/applications/office/paperless/python-modules/default.nix
+++ b/pkgs/applications/office/paperless/python-modules/default.nix
@@ -1,0 +1,30 @@
+pyPkgs: fetchFromGitHub:
+{
+  django_2_0 = pyPkgs.django_2_2.overridePythonAttrs (old: rec {
+    version = "2.0.12";
+    src = pyPkgs.fetchPypi {
+      inherit (old) pname;
+      inherit version;
+      sha256 = "15s8z54k0gf9brnz06521bikm60ddw5pn6v3nbvnl47j1jjsvwz2";
+    };
+  });
+
+  django_extensions_2_2_8 = pyPkgs.django_extensions.overridePythonAttrs (old: rec {
+    version = "2.2.8";
+    src = fetchFromGitHub {
+      owner = old.pname;
+      repo = old.pname;
+      rev = version;
+      sha256 = "1gd3nykwzh3azq1p9cvgkc3l5dwrv7y86sfjxd9llbyj8ky71iaj";
+    };
+  });
+
+  factory_boy_2_12_0 = pyPkgs.factory_boy.overridePythonAttrs (old: rec {
+    version = "2.12.0";
+    src = pyPkgs.fetchPypi {
+      inherit (old) pname;
+      inherit version;
+      sha256 = "0w53hjgag6ad5i2vmrys8ysk54agsqvgbjy9lg8g0d8pi9h8vx7s";
+    };
+  });
+}

--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -18,13 +18,13 @@
 
 buildPythonPackage rec {
   pname = "django-extensions";
-  version = "2.2.8";
+  version = "3.0.8";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "1gd3nykwzh3azq1p9cvgkc3l5dwrv7y86sfjxd9llbyj8ky71iaj";
+    sha256 = "1z2si9wpc8irqhi5i2wp4wr05dqxyw4mn2vj3amp0rvsvydws92c";
   };
 
   LC_ALL = "en_US.UTF-8";

--- a/pkgs/development/python-modules/django-picklefield/default.nix
+++ b/pkgs/development/python-modules/django-picklefield/default.nix
@@ -1,15 +1,26 @@
-{ lib, buildPythonPackage, fetchPypi, django }:
+{ lib, buildPythonPackage, fetchFromGitHub, django, pytest, pytest-django }:
 
 buildPythonPackage rec {
   pname = "django-picklefield";
   version = "3.0.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "15ccba592ca953b9edf9532e64640329cd47b136b7f8f10f2939caa5f9ce4287";
+  # The PyPi source doesn't contain tests
+  src = fetchFromGitHub {
+    owner = "gintas";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ni7bc86k0ra4pc8zv451pzlpkhs1nyil1sq9jdb4m2mib87b5fk";
   };
 
   propagatedBuildInputs = [ django ];
+
+  checkInputs = [ pytest pytest-django ];
+
+  checkPhase = ''
+    PYTHONPATH="$(pwd):$PYTHONPATH" \
+    DJANGO_SETTINGS_MODULE=tests.settings \
+      pytest tests/tests.py
+  '';
 
   meta = {
     description = "A pickled object field for Django";


### PR DESCRIPTION
This fixes:
- django_extensions. The old version was incompatible with the newly updated version of `factory_boy`,
- django-picklefield: The source was missing test files.
- paperless: The pkg needed older versions of `factory_boy` and `django_extensions`.
  This also fixes the corresponding NixOS test.

This is the complete closure of dependents/referrers of all changed pkgs:

```
django_extensions -----------------\
                                    |---> hyperkitty
django-picklefield --> django-q  --/

paperless --> (none, leaf node)

```
All pkgs in this graph are now building again. This PR is strictly fixing pkgs and introduces no new breakage.