### PR TITLE
chromium: Unblock nixos-unstable by using the correct argument to fet…

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -67,7 +67,7 @@ let
   pkgSuffix = if channel == "dev" then "unstable" else channel;
   pkgName = "google-chrome-${pkgSuffix}";
   chromeSrc = fetchurl {
-    url = map (repo: "${repo}/${pkgName}/${pkgName}_${version}-1_amd64.deb") [
+    urls = map (repo: "${repo}/${pkgName}/${pkgName}_${version}-1_amd64.deb") [
       "https://dl.google.com/linux/chrome/deb/pool/main/g"
       "http://95.31.35.30/chrome/pool/main/g"
       "http://mirror.pcbeta.com/google/chrome/deb/pool/main/g"


### PR DESCRIPTION

###### Motivation for this change

nixos-unstable is currently blocked. See https://hydra.nixos.org/build/126501646 for an example of a failing build.

To reproduce the failure, run:

```nix-build pkgs/top-level/release.nix -A unstable --show-trace```

The failing call to `nix-instantiate` can be seen [here](https://github.com/NixOS/nixpkgs/blob/91ad566e18b28cc52bf7ed1ea13390929b2ec103/pkgs/top-level/make-tarball.nix#L93).

This fails, because `find-tarballs.nix` expects the `url` argument to `fetchurl` to be a string, while the `urls` should be used when multiple sources are needed.

This commit fixes a single instance of this problem, and this fix seems to be enough to unblock nixos-unstable. I am also preparing a follow-up PR to fix all additional instances of the problem.

CC: @jonringer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
