### PR TITLE
linux_5_8: 5.8.6 -> 5.8.7

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-5.8.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.8.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "5.8.6";
+  version = "5.8.7";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "180bka8a0f2ykaifgb323pzgh0n909mlrsk08l08zmifggnh19cc";
+    sha256 = "1zhpzlhl2ykna2nc70m72wlgyv1pkvkpfssb4k8p5pwlkh1ga2vv";
   };
 } // (args.argsOverride or {}))


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>105 packages failed to build:</summary>
<br>- linuxPackages_5_8.amdgpu-pro
<br>- linuxPackages_5_8.anbox
<br>- linuxPackages_5_8.ati_drivers_x11
<br>- linuxPackages_5_8.batman_adv
<br>- linuxPackages_5_8.can-isotp
<br>- linuxPackages_5_8.chipsec
<br>- linuxPackages_5_8.cryptodev
<br>- linuxPackages_5_8.ena
<br>- linuxPackages_5_8.exfat-nofuse
<br>- linuxPackages_5_8.ixgbevf
<br>- linuxPackages_5_8.lttng-modules
<br>- linuxPackages_5_8.mwprocapture
<br>- linuxPackages_5_8.mxu11x0
<br>- linuxPackages_5_8.ndiswrapper
<br>- linuxPackages_5_8.netatop
<br>- linuxPackages_5_8.nvidia_x11_legacy304
<br>- linuxPackages_5_8.nvidia_x11_legacy340
<br>- linuxPackages_5_8.nvidia_x11_legacy390
<br>- linuxPackages_5_8.nvidiabl
<br>- linuxPackages_5_8.openafs
<br>- linuxPackages_5_8.openafs_1_8
<br>- linuxPackages_5_8.phc-intel
<br>- linuxPackages_5_8.r8168
<br>- linuxPackages_5_8.rtl8723bs
<br>- linuxPackages_5_8.rtl8812au
<br>- linuxPackages_5_8.rtl8814au
<br>- linuxPackages_5_8.rtl8821au
<br>- linuxPackages_5_8.rtl8821cu
<br>- linuxPackages_5_8.rtl88x2bu
<br>- linuxPackages_5_8.rtl88xxau-aircrack
<br>- linuxPackages_5_8.rtlwifi_new
<br>- linuxPackages_5_8.sch_cake
<br>- linuxPackages_5_8.tbs
<br>- linuxPackages_5_8.virtualbox
<br>- linuxPackages_5_8.virtualboxGuestAdditions
<br>- linuxPackages_latest-libre.amdgpu-pro
<br>- linuxPackages_latest-libre.anbox
<br>- linuxPackages_latest-libre.ati_drivers_x11
<br>- linuxPackages_latest-libre.batman_adv
<br>- linuxPackages_latest-libre.can-isotp
<br>- linuxPackages_latest-libre.chipsec
<br>- linuxPackages_latest-libre.cryptodev
<br>- linuxPackages_latest-libre.ena
<br>- linuxPackages_latest-libre.exfat-nofuse
<br>- linuxPackages_latest-libre.ixgbevf
<br>- linuxPackages_latest-libre.lttng-modules
<br>- linuxPackages_latest-libre.mwprocapture
<br>- linuxPackages_latest-libre.mxu11x0
<br>- linuxPackages_latest-libre.ndiswrapper
<br>- linuxPackages_latest-libre.netatop
<br>- linuxPackages_latest-libre.nvidia_x11_legacy304
<br>- linuxPackages_latest-libre.nvidia_x11_legacy340
<br>- linuxPackages_latest-libre.nvidia_x11_legacy390
<br>- linuxPackages_latest-libre.nvidiabl
<br>- linuxPackages_latest-libre.openafs
<br>- linuxPackages_latest-libre.openafs_1_8
<br>- linuxPackages_latest-libre.phc-intel
<br>- linuxPackages_latest-libre.r8168
<br>- linuxPackages_latest-libre.rtl8723bs
<br>- linuxPackages_latest-libre.rtl8812au
<br>- linuxPackages_latest-libre.rtl8814au
<br>- linuxPackages_latest-libre.rtl8821au
<br>- linuxPackages_latest-libre.rtl8821cu
<br>- linuxPackages_latest-libre.rtl88x2bu
<br>- linuxPackages_latest-libre.rtl88xxau-aircrack
<br>- linuxPackages_latest-libre.rtlwifi_new
<br>- linuxPackages_latest-libre.sch_cake
<br>- linuxPackages_latest-libre.tbs
<br>- linuxPackages_latest-libre.virtualbox
<br>- linuxPackages_latest-libre.virtualboxGuestAdditions
<br>- linuxPackages_latest_xen_dom0.amdgpu-pro
<br>- linuxPackages_latest_xen_dom0.anbox
<br>- linuxPackages_latest_xen_dom0.ati_drivers_x11
<br>- linuxPackages_latest_xen_dom0.batman_adv
<br>- linuxPackages_latest_xen_dom0.can-isotp
<br>- linuxPackages_latest_xen_dom0.chipsec
<br>- linuxPackages_latest_xen_dom0.cryptodev
<br>- linuxPackages_latest_xen_dom0.ena
<br>- linuxPackages_latest_xen_dom0.exfat-nofuse
<br>- linuxPackages_latest_xen_dom0.ixgbevf
<br>- linuxPackages_latest_xen_dom0.lttng-modules
<br>- linuxPackages_latest_xen_dom0.mwprocapture
<br>- linuxPackages_latest_xen_dom0.mxu11x0
<br>- linuxPackages_latest_xen_dom0.ndiswrapper
<br>- linuxPackages_latest_xen_dom0.netatop
<br>- linuxPackages_latest_xen_dom0.nvidia_x11_legacy304
<br>- linuxPackages_latest_xen_dom0.nvidia_x11_legacy340
<br>- linuxPackages_latest_xen_dom0.nvidia_x11_legacy390
<br>- linuxPackages_latest_xen_dom0.nvidiabl
<br>- linuxPackages_latest_xen_dom0.openafs
<br>- linuxPackages_latest_xen_dom0.openafs_1_8
<br>- linuxPackages_latest_xen_dom0.phc-intel
<br>- linuxPackages_latest_xen_dom0.r8168
<br>- linuxPackages_latest_xen_dom0.rtl8723bs
<br>- linuxPackages_latest_xen_dom0.rtl8812au
<br>- linuxPackages_latest_xen_dom0.rtl8814au
<br>- linuxPackages_latest_xen_dom0.rtl8821au
<br>- linuxPackages_latest_xen_dom0.rtl8821cu
<br>- linuxPackages_latest_xen_dom0.rtl88x2bu
<br>- linuxPackages_latest_xen_dom0.rtl88xxau-aircrack
<br>- linuxPackages_latest_xen_dom0.rtlwifi_new
<br>- linuxPackages_latest_xen_dom0.sch_cake
<br>- linuxPackages_latest_xen_dom0.tbs
<br>- linuxPackages_latest_xen_dom0.virtualbox
<br>- linuxPackages_latest_xen_dom0.virtualboxGuestAdditions
</details>
<details>
  <summary>118 packages built:</summary>
<br>- bpftool
<br>- linuxPackages_5_8.acpi_call
<br>- linuxPackages_5_8.asus-wmi-sensors
<br>- linuxPackages_5_8.bbswitch
<br>- linuxPackages_5_8.bcc
<br>- linuxPackages_5_8.bpftrace
<br>- linuxPackages_5_8.broadcom_sta
<br>- linuxPackages_5_8.cpupower (linuxPackages_latest_xen_dom0.cpupower)
<br>- linuxPackages_5_8.ddcci-driver
<br>- linuxPackages_5_8.digimend
<br>- linuxPackages_5_8.dpdk
<br>- linuxPackages_5_8.evdi
<br>- linuxPackages_5_8.facetimehd
<br>- linuxPackages_5_8.fwts-efi-runtime
<br>- linuxPackages_5_8.hyperv-daemons (linuxPackages_latest_xen_dom0.hyperv-daemons)
<br>- linuxPackages_5_8.intel-speed-select (linuxPackages_latest_xen_dom0.intel-speed-select)
<br>- linuxPackages_5_8.it87
<br>- linuxPackages_5_8.jool
<br>- linuxPackages_5_8.kernel
<br>- linuxPackages_5_8.mba6x_bl
<br>- linuxPackages_5_8.nvidia_x11
<br>- linuxPackages_5_8.oci-seccomp-bpf-hook
<br>- linuxPackages_5_8.openrazer
<br>- linuxPackages_5_8.perf (linuxPackages_latest_xen_dom0.perf)
<br>- linuxPackages_5_8.ply (linuxPackages_latest_xen_dom0.ply)
<br>- linuxPackages_5_8.r8125
<br>- linuxPackages_5_8.rtl8192eu
<br>- linuxPackages_5_8.rtl8821ce
<br>- linuxPackages_5_8.sysdig
<br>- linuxPackages_5_8.systemtap
<br>- linuxPackages_5_8.tmon (linuxPackages_latest_xen_dom0.tmon)
<br>- linuxPackages_5_8.tp_smapi
<br>- linuxPackages_5_8.turbostat (linuxPackages_latest_xen_dom0.turbostat)
<br>- linuxPackages_5_8.tuxedo-keyboard
<br>- linuxPackages_5_8.usbip (linuxPackages_latest_xen_dom0.usbip)
<br>- linuxPackages_5_8.v4l2loopback
<br>- linuxPackages_5_8.v86d
<br>- linuxPackages_5_8.vhba
<br>- linuxPackages_5_8.x86_energy_perf_policy (linuxPackages_latest_xen_dom0.x86_energy_perf_policy)
<br>- linuxPackages_5_8.xpadneo
<br>- linuxPackages_5_8.zenpower
<br>- linuxPackages_5_8.zfs
<br>- linuxPackages_5_8.zfsUnstable
<br>- linuxPackages_latest-libre.acpi_call
<br>- linuxPackages_latest-libre.asus-wmi-sensors
<br>- linuxPackages_latest-libre.bbswitch
<br>- linuxPackages_latest-libre.bcc
<br>- linuxPackages_latest-libre.bpftrace
<br>- linuxPackages_latest-libre.broadcom_sta
<br>- linuxPackages_latest-libre.cpupower
<br>- linuxPackages_latest-libre.ddcci-driver
<br>- linuxPackages_latest-libre.digimend
<br>- linuxPackages_latest-libre.dpdk
<br>- linuxPackages_latest-libre.evdi
<br>- linuxPackages_latest-libre.facetimehd
<br>- linuxPackages_latest-libre.fwts-efi-runtime
<br>- linuxPackages_latest-libre.hyperv-daemons
<br>- linuxPackages_latest-libre.intel-speed-select
<br>- linuxPackages_latest-libre.it87
<br>- linuxPackages_latest-libre.jool
<br>- linuxPackages_latest-libre.kernel
<br>- linuxPackages_latest-libre.mba6x_bl
<br>- linuxPackages_latest-libre.nvidia_x11
<br>- linuxPackages_latest-libre.oci-seccomp-bpf-hook
<br>- linuxPackages_latest-libre.openrazer
<br>- linuxPackages_latest-libre.perf
<br>- linuxPackages_latest-libre.ply
<br>- linuxPackages_latest-libre.r8125
<br>- linuxPackages_latest-libre.rtl8192eu
<br>- linuxPackages_latest-libre.rtl8821ce
<br>- linuxPackages_latest-libre.sysdig
<br>- linuxPackages_latest-libre.systemtap
<br>- linuxPackages_latest-libre.tmon
<br>- linuxPackages_latest-libre.tp_smapi
<br>- linuxPackages_latest-libre.turbostat
<br>- linuxPackages_latest-libre.tuxedo-keyboard
<br>- linuxPackages_latest-libre.usbip
<br>- linuxPackages_latest-libre.v4l2loopback
<br>- linuxPackages_latest-libre.v86d
<br>- linuxPackages_latest-libre.vhba
<br>- linuxPackages_latest-libre.x86_energy_perf_policy
<br>- linuxPackages_latest-libre.xpadneo
<br>- linuxPackages_latest-libre.zenpower
<br>- linuxPackages_latest-libre.zfs
<br>- linuxPackages_latest-libre.zfsUnstable
<br>- linuxPackages_latest_xen_dom0.acpi_call
<br>- linuxPackages_latest_xen_dom0.asus-wmi-sensors
<br>- linuxPackages_latest_xen_dom0.bbswitch
<br>- linuxPackages_latest_xen_dom0.bcc
<br>- linuxPackages_latest_xen_dom0.bpftrace
<br>- linuxPackages_latest_xen_dom0.broadcom_sta
<br>- linuxPackages_latest_xen_dom0.ddcci-driver
<br>- linuxPackages_latest_xen_dom0.digimend
<br>- linuxPackages_latest_xen_dom0.dpdk
<br>- linuxPackages_latest_xen_dom0.evdi
<br>- linuxPackages_latest_xen_dom0.facetimehd
<br>- linuxPackages_latest_xen_dom0.fwts-efi-runtime
<br>- linuxPackages_latest_xen_dom0.it87
<br>- linuxPackages_latest_xen_dom0.jool
<br>- linuxPackages_latest_xen_dom0.kernel
<br>- linuxPackages_latest_xen_dom0.mba6x_bl
<br>- linuxPackages_latest_xen_dom0.nvidia_x11
<br>- linuxPackages_latest_xen_dom0.oci-seccomp-bpf-hook
<br>- linuxPackages_latest_xen_dom0.openrazer
<br>- linuxPackages_latest_xen_dom0.r8125
<br>- linuxPackages_latest_xen_dom0.rtl8192eu
<br>- linuxPackages_latest_xen_dom0.rtl8821ce
<br>- linuxPackages_latest_xen_dom0.sysdig
<br>- linuxPackages_latest_xen_dom0.systemtap
<br>- linuxPackages_latest_xen_dom0.tp_smapi
<br>- linuxPackages_latest_xen_dom0.tuxedo-keyboard
<br>- linuxPackages_latest_xen_dom0.v4l2loopback
<br>- linuxPackages_latest_xen_dom0.v86d
<br>- linuxPackages_latest_xen_dom0.vhba
<br>- linuxPackages_latest_xen_dom0.xpadneo
<br>- linuxPackages_latest_xen_dom0.zenpower
<br>- linuxPackages_latest_xen_dom0.zfs
<br>- linuxPackages_latest_xen_dom0.zfsUnstable
</details>
