### PR TITLE
texinfo: Depend on gettext on Darwin

### DIFF
--- a/pkgs/development/tools/misc/texinfo/6.5.nix
+++ b/pkgs/development/tools/misc/texinfo/6.5.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "6.5";
-  sha256 = "0qjzvbvnv9003xdrcpi3jp7y68j4hq2ciw9frh2hghh698zlnxvp";
-}

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -1,6 +1,6 @@
 { version, sha256 }:
 
-{ stdenv, buildPackages, fetchurl, perl, xz
+{ stdenv, buildPackages, fetchurl, perl, xz, gettext
 
 # we are a dependency of gcc, this simplifies bootstraping
 , interactive ? false, ncurses, procps
@@ -39,6 +39,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ xz.bin ]
     ++ optionals stdenv.isSunOS [ libiconv gawk ]
+    ++ optionals stdenv.isDarwin [ gettext ]
     ++ optional interactive ncurses;
 
   configureFlags = [ "PERL=${buildPackages.perl}/bin/perl" ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11555,10 +11555,8 @@ in
   texinfo413 = callPackage ../development/tools/misc/texinfo/4.13a.nix { };
   texinfo4 = texinfo413;
   texinfo5 = callPackage ../development/tools/misc/texinfo/5.2.nix { };
-  texinfo6_5 = callPackage ../development/tools/misc/texinfo/6.5.nix { };
   texinfo6 = callPackage ../development/tools/misc/texinfo/6.7.nix { };
-  # Temporarily use older version on Darwin until it works.
-  texinfo = if stdenv.isDarwin then texinfo6_5 else texinfo6;
+  texinfo = texinfo6;
   texinfoInteractive = appendToName "interactive" (
     texinfo.override { interactive = true; }
   );


### PR DESCRIPTION
texinfo version 6.7 requires libintl.h which on Linux is provided
by the libc. On Darwin, this lib should be provided by [gettext](https://git.savannah.gnu.org/gitweb/?p=gettext.git;a=blob;f=gettext-runtime/intl/Makefile.am;hb=e645b7d56385200610d9ca0babc5006d1d5f552b#l254) instead.

@NixOS/darwin-maintainers I cannot test this myself, can one of you please verify this PR? Thanks! 

If this tests well we should be able to revert b23940e