### PR TITLE
utils.bash: revert #93560 for darwin, unblocks channels

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -311,7 +311,7 @@ stdenv.mkDerivation {
 
       substituteAll ${./add-flags.sh} $out/nix-support/add-flags.sh
       substituteAll ${./add-hardening.sh} $out/nix-support/add-hardening.sh
-      substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash
+      substituteAll ${if stdenv.isDarwin then ../wrapper-common/utils.bash.darwin else ../wrapper-common/utils.bash} $out/nix-support/utils.bash
     ''
 
     ##

--- a/pkgs/build-support/wrapper-common/utils.bash.darwin
+++ b/pkgs/build-support/wrapper-common/utils.bash.darwin
@@ -1,0 +1,92 @@
+# Accumulate suffixes for taking in the right input parameters with the `mangle*`
+# functions below. See setup-hook for details.
+accumulateRoles() {
+    declare -ga role_suffixes=()
+    if [ "${NIX_@wrapperName@_TARGET_BUILD_@suffixSalt@:-}" ]; then
+        role_suffixes+=('_FOR_BUILD')
+    fi
+    if [ "${NIX_@wrapperName@_TARGET_HOST_@suffixSalt@:-}" ]; then
+        role_suffixes+=('')
+    fi
+    if [ "${NIX_@wrapperName@_TARGET_TARGET_@suffixSalt@:-}" ]; then
+        role_suffixes+=('_FOR_TARGET')
+    fi
+}
+
+mangleVarList() {
+    local var="$1"
+    shift
+    local -a role_suffixes=("$@")
+
+    local outputVar="${var}_@suffixSalt@"
+    declare -gx ${outputVar}+=''
+    # For each role we serve, we accumulate the input parameters into our own
+    # cc-wrapper-derivation-specific environment variables.
+    for suffix in "${role_suffixes[@]}"; do
+        local inputVar="${var}${suffix}"
+        if [ -v "$inputVar" ]; then
+            export ${outputVar}+="${!outputVar:+ }${!inputVar}"
+        fi
+    done
+}
+
+mangleVarBool() {
+    local var="$1"
+    shift
+    local -a role_suffixes=("$@")
+
+    local outputVar="${var}_@suffixSalt@"
+    declare -gxi ${outputVar}+=0
+    for suffix in "${role_suffixes[@]}"; do
+        local inputVar="${var}${suffix}"
+        if [ -v "$inputVar" ]; then
+            # "1" in the end makes `let` return success error code when
+            # expression itself evaluates to zero.
+            # We don't use `|| true` because that would silence actual
+            # syntax errors from bad variable values.
+            let "${outputVar} |= ${!inputVar:-0}" "1"
+        fi
+    done
+}
+
+skip () {
+    if (( "${NIX_DEBUG:-0}" >= 1 )); then
+        echo "skipping impure path $1" >&2
+    fi
+}
+
+
+# Checks whether a path is impure.  E.g., `/lib/foo.so' is impure, but
+# `/nix/store/.../lib/foo.so' isn't.
+badPath() {
+    local p=$1
+
+    # Relative paths are okay (since they're presumably relative to
+    # the temporary build directory).
+    if [ "${p:0:1}" != / ]; then return 1; fi
+
+    # Otherwise, the path should refer to the store or some temporary
+    # directory (including the build directory).
+    test \
+        "$p" != "/dev/null" -a \
+        "${p:0:${#NIX_STORE}}" != "$NIX_STORE" -a \
+        "${p:0:4}" != "/tmp" -a \
+        "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"
+}
+
+expandResponseParams() {
+    declare -ga params=("$@")
+    local arg
+    for arg in "$@"; do
+        if [[ "$arg" == @* ]]; then
+            # phase separation makes this look useless
+            # shellcheck disable=SC2157
+            if [ -x "@expandResponseParams@" ]; then
+                # params is used by caller
+                #shellcheck disable=SC2034
+                readarray -d '' params < <("@expandResponseParams@" "$@")
+                return 0
+            fi
+        fi
+    done
+}


### PR DESCRIPTION
Temporary fix. We definitely do not want to have two separate
implementations.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
