### PR TITLE
filebot: init at 4.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2805,6 +2805,16 @@
     githubId = 541748;
     name = "Felipe Espinoza";
   };
+  felschr = {
+    email = "dev@felschr.com";
+    github = "felschr";
+    githubId = 3314323;
+    name = "Felix Tenley";
+    keys = [{
+      longkeyid = "ed25519/0x910ACB9F6BD26F58";
+      fingerprint = "6AB3 7A28 5420 9A41 82D9  0068 910A CB9F 6BD2 6F58";
+    }];
+  };
   ffinkdevs = {
     email = "fink@h0st.space";
     github = "ffinkdevs";

--- a/pkgs/applications/video/filebot/default.nix
+++ b/pkgs/applications/video/filebot/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchurl, openjdk11, makeWrapper, autoPatchelfHook
+, zlib, libzen, libmediainfo, curl, libmms, glib
+}:
+
+let
+  # FileBot requires libcurl-gnutls.so to build
+  curlWithGnuTls = curl.override { gnutlsSupport = true; sslSupport = false; };
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "filebot";
+  version = "4.9.1";
+
+  src = fetchurl {
+    url = "https://get.filebot.net/filebot/FileBot_${version}/FileBot_${version}-portable.tar.xz";
+    sha256 = "0l496cz703mjymjhgmyrkqbfld1bz53pdsbkx00h9a267j22fkms";
+  };
+
+  unpackPhase = "tar xvf $src";
+
+  nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
+
+  buildInputs = [ zlib libzen libmediainfo curlWithGnuTls libmms glib ];
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/opt $out/bin
+    # Since FileBot has dependencies on relative paths between files, all required files are copied to the same location as is.
+    cp -r filebot.sh lib/ jar/ $out/opt/
+    # Filebot writes to $APP_DATA, which fails due to read-only filesystem. Using current user .local directory instead.
+    substituteInPlace $out/opt/filebot.sh \
+      --replace 'APP_DATA="$FILEBOT_HOME/data/$USER"' 'APP_DATA=''${XDG_DATA_HOME:-$HOME/.local/share}/filebot/data' \
+      --replace '$FILEBOT_HOME/data/.license' '$APP_DATA/.license'
+    wrapProgram $out/opt/filebot.sh \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ openjdk11 ]}
+    # Expose the binary in bin to make runnable.
+    ln -s $out/opt/filebot.sh $out/bin/filebot
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The ultimate TV and Movie Renamer";
+    longDescription = ''
+      FileBot is the ultimate tool for organizing and renaming your Movies, TV
+      Shows and Anime as well as fetching subtitles and artwork. It's smart and
+      just works.
+    '';
+    homepage = "https://filebot.net";
+    changelog = "https://www.filebot.net/forums/viewforum.php?f=7";
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ gleber felschr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1945,6 +1945,8 @@ in
 
   filebench = callPackage ../tools/misc/filebench { };
 
+  filebot = callPackage ../applications/video/filebot { };
+
   fileshare = callPackage ../servers/fileshare {};
 
   fileshelter = callPackage ../servers/web-apps/fileshelter { };


### PR DESCRIPTION
###### Motivation for this change
This continues the work from https://github.com/NixOS/nixpkgs/pull/67849, implementing some of the suggested changes and updating to the most recent version.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
