### PR TITLE
elasticmq-server: 0.14.6 -> 1.2.0, add passthru.tests

### DIFF
--- a/pkgs/servers/elasticmq-server-bin/default.nix
+++ b/pkgs/servers/elasticmq-server-bin/default.nix
@@ -1,34 +1,40 @@
-{ lib, stdenv, fetchurl, jdk, jre, makeWrapper }:
+{ lib, stdenv, fetchurl, jdk, jre, makeWrapper, runCommand, python3Packages, writeText }:
 
-stdenv.mkDerivation rec {
-  pname = "elasticmq-server";
-  version = "0.15.7";
+let
+  elasticmq-server = stdenv.mkDerivation rec {
+    pname = "elasticmq-server";
+    version = "0.15.7";
 
-  src = fetchurl {
-    url = "https://s3-eu-west-1.amazonaws.com/softwaremill-public/${pname}-${version}.jar";
-    sha256 = "01jmb6rwh570f2y30b2if5fhcbpdnb2vkxylp9xa09c0x7a2vv4q";
+    src = fetchurl {
+      url = "https://s3-eu-west-1.amazonaws.com/softwaremill-public/${pname}-${version}.jar";
+      sha256 = "01jmb6rwh570f2y30b2if5fhcbpdnb2vkxylp9xa09c0x7a2vv4q";
+    };
+
+    # don't do anything?
+    unpackPhase = "${jdk}/bin/jar xf $src favicon.png";
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    installPhase = ''
+      mkdir -p $out/bin $out/share/elasticmq-server
+
+      cp $src $out/share/elasticmq-server/elasticmq-server.jar
+
+      # TODO: how to add extraArgs? current workaround is to use JAVA_TOOL_OPTIONS environment to specify properties
+      makeWrapper ${jre}/bin/java $out/bin/elasticmq-server \
+        --add-flags "-jar $out/share/elasticmq-server/elasticmq-server.jar"
+    '';
+
+    meta = with lib; {
+      homepage = "https://github.com/softwaremill/elasticmq";
+      description = "Message queueing system with Java, Scala and Amazon SQS-compatible interfaces";
+      license = licenses.asl20;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ peterromfeldhk ];
+    };
   };
-
-  # don't do anything?
-  unpackPhase = "${jdk}/bin/jar xf $src favicon.png";
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  installPhase = ''
-    mkdir -p $out/bin $out/share/elasticmq-server
-
-    cp $src $out/share/elasticmq-server/elasticmq-server.jar
-
-    # TODO: how to add extraArgs? current workaround is to use JAVA_TOOL_OPTIONS environment to specify properties
-    makeWrapper ${jre}/bin/java $out/bin/elasticmq-server \
-      --add-flags "-jar $out/share/elasticmq-server/elasticmq-server.jar"
-  '';
-
-  meta = with lib; {
-    homepage = "https://github.com/softwaremill/elasticmq";
-    description = "Message queueing system with Java, Scala and Amazon SQS-compatible interfaces";
-    license = licenses.asl20;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ peterromfeldhk ];
+in elasticmq-server.overrideAttrs (_: {
+  passthru.tests.elasticmqTest = import ./elasticmq-test.nix {
+    inherit elasticmq-server runCommand python3Packages writeText;
   };
-}
+})

--- a/pkgs/servers/elasticmq-server-bin/default.nix
+++ b/pkgs/servers/elasticmq-server-bin/default.nix
@@ -3,11 +3,11 @@
 let
   elasticmq-server = stdenv.mkDerivation rec {
     pname = "elasticmq-server";
-    version = "0.15.7";
+    version = "1.2.0";
 
     src = fetchurl {
       url = "https://s3-eu-west-1.amazonaws.com/softwaremill-public/${pname}-${version}.jar";
-      sha256 = "01jmb6rwh570f2y30b2if5fhcbpdnb2vkxylp9xa09c0x7a2vv4q";
+      sha256 = "06bn5ixz0pvvhfvavr6njv8c2i9pgd6gj32wnp2f0fn0z1kypn1f";
     };
 
     # don't do anything?

--- a/pkgs/servers/elasticmq-server-bin/default.nix
+++ b/pkgs/servers/elasticmq-server-bin/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "elasticmq-server";
-  version = "0.14.6";
+  version = "0.15.7";
 
   src = fetchurl {
     url = "https://s3-eu-west-1.amazonaws.com/softwaremill-public/${pname}-${version}.jar";
-    sha256 = "1cp2pmkc6gx7gr6109jlcphlky5rr6s1wj528r6hyhzdc01sjhhz";
+    sha256 = "01jmb6rwh570f2y30b2if5fhcbpdnb2vkxylp9xa09c0x7a2vv4q";
   };
 
   # don't do anything?

--- a/pkgs/servers/elasticmq-server-bin/elasticmq-test.nix
+++ b/pkgs/servers/elasticmq-server-bin/elasticmq-test.nix
@@ -1,0 +1,47 @@
+{ elasticmq-server, python3Packages, runCommand, writeText}:
+
+runCommand "${elasticmq-server.name}-tests" (let
+  commonPy = ''
+    import boto3
+    client = boto3.resource(
+      "sqs",
+      endpoint_url="http://localhost:9324",
+      region_name="elasticmq",
+      aws_secret_access_key="x",
+      aws_access_key_id="x",
+      use_ssl=False,
+    )
+    queue = client.get_queue_by_name(QueueName="foobar")
+  '';
+in {
+  buildInputs = with python3Packages; [ python boto3 ];
+  emqConfig = writeText "emq-test.conf" ''
+    generate-node-address = true
+
+    queues {
+      foobar {}
+    }
+  '';
+  putMessagePy = writeText "put_message.py" ''
+    ${commonPy}
+    queue.send_message(MessageBody="bazqux")
+  '';
+  checkMessagePy = writeText "check_message.py" ''
+    ${commonPy}
+    messages = queue.receive_messages()
+    print(f"Received {messages!r}")
+    assert len(messages) == 1
+    assert messages[0].body == "bazqux"
+  '';
+}) ''
+  JAVA_TOOL_OPTIONS="-Dconfig.file=$emqConfig" ${elasticmq-server}/bin/elasticmq-server &
+  SERVER_PID=$!
+  sleep 10
+
+  python $putMessagePy
+  python $checkMessagePy
+  touch $out
+
+  # needed on darwin
+  kill $SERVER_PID
+''


### PR DESCRIPTION
###### Motivation for this change
Added quite a simple test to check basic operation of the queue.

Still, it's the first `passthru.tests` I've written, and I don't know whether e.g. detaching a process here is considered "ok". It feels a little less wrong than doing it in `checkPhase`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
