### PR TITLE
django-picklefield: Source from Github, fix test and build

### DIFF
--- a/pkgs/development/python-modules/django-picklefield/default.nix
+++ b/pkgs/development/python-modules/django-picklefield/default.nix
@@ -1,15 +1,24 @@
-{ lib, buildPythonPackage, fetchPypi, django }:
+{ lib, buildPythonPackage, fetchFromGitHub, django, python }:
 
 buildPythonPackage rec {
   pname = "django-picklefield";
   version = "3.0.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "15ccba592ca953b9edf9532e64640329cd47b136b7f8f10f2939caa5f9ce4287";
+  src = fetchFromGitHub {
+    owner = "gintas";
+    repo = "django-picklefield";
+    rev = "v${version}";
+    sha256 = "0ni7bc86k0ra4pc8zv451pzlpkhs1nyil1sq9jdb4m2mib87b5fk";
   };
 
   propagatedBuildInputs = [ django ];
+
+  dontUseSetuptoolsCheck = true;
+
+  # Taken from project's tox.ini
+  checkPhase = ''
+    ${python.interpreter} -m django test -v3 --settings=tests.settings
+  '';
 
   meta = {
     description = "A pickled object field for Django";


### PR DESCRIPTION
##### Motivation for this change

This package is required by mailman, and was failing to build, possibly since django 1_11 was [dropped](https://github.com/NixOS/nixpkgs/commit/54568a1bea064634759e89e46b54c15854188015).

###### Things done

Sourced package from GitHub since the Pypi package did not contain any tests, and then configured checkPhase to run these tests.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
