### PR TITLE
liquidsoap: 1.3.4 → 1.4.2

### DIFF
--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -2,13 +2,18 @@
 , ocamlPackages
 , libao, portaudio, alsaLib, libpulseaudio, libjack2
 , libsamplerate, libmad, taglib, lame, libogg
-, libvorbis, speex, libtheora, libopus, fdk_aac
+, libvorbis, speex, libtheora, libopus
 , faad2, flac, ladspaH, ffmpeg, frei0r, dssi
 }:
 
 let
   pname = "liquidsoap";
-  version = "1.3.4";
+  version = "1.4.2";
+
+  ocaml-ffmpeg = fetchurl {
+    url = "https://github.com/savonet/ocaml-ffmpeg/releases/download/v0.4.2/ocaml-ffmpeg-0.4.2.tar.gz";
+    sha256 = "1lx5s1avds9fsh77828ifn71r2g89rxakhs8pp995a675phm9viw";
+  };
 
   packageFilters = map (p: "-e '/ocaml-${p}/d'" )
     [ "gstreamer" "shine" "aacplus" "schroedinger"
@@ -19,9 +24,16 @@ stdenv.mkDerivation {
   name = "${pname}-full-${version}";
 
   src = fetchurl {
-    url = "https://github.com/savonet/${pname}/releases/download/${version}/${pname}-${version}-full.tar.bz2";
-    sha256 = "11l1h42sljfxcdhddc8klya4bk99j7a1pndwnzvscb04pvmfmlk0";
+    url = "https://github.com/savonet/${pname}/releases/download/v${version}/${pname}-${version}-full.tar.gz";
+    sha256 = "0wkwnzj1a0vizv7sr1blwk5gzm2qi0n02ndijnq1i50cwrgxs1a4";
   };
+
+  # Use ocaml-srt and ocaml-fdkaac from nixpkgs
+  # Use ocaml-ffmpeg at 0.4.2 for compatibility with ffmpeg 4.3
+  prePatch = ''
+    rm -rf ocaml-srt*/ ocaml-fdkaac*/ ocaml-ffmpeg*/
+    tar xzf ${ocaml-ffmpeg}
+  '';
 
   preConfigure = /* we prefer system-wide libs */ ''
     sed -i "s|gsed|sed|" Makefile
@@ -42,10 +54,12 @@ stdenv.mkDerivation {
     [ which ocamlPackages.ocaml ocamlPackages.findlib
       libao portaudio alsaLib libpulseaudio libjack2
       libsamplerate libmad taglib lame libogg
-      libvorbis speex libtheora libopus fdk_aac
+      libvorbis speex libtheora libopus
       faad2 flac ladspaH ffmpeg frei0r dssi
       ocamlPackages.xmlm ocamlPackages.ocaml_pcre
       ocamlPackages.camomile
+      ocamlPackages.fdkaac
+      ocamlPackages.srt ocamlPackages.sedlex_2 ocamlPackages.menhir
     ];
 
   hardeningDisable = [ "format" "fortify" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4855,7 +4855,6 @@ in
 
   liquidsoap = callPackage ../tools/audio/liquidsoap/full.nix {
     ffmpeg = ffmpeg-full;
-    ocamlPackages = ocaml-ng.ocamlPackages_4_07;
   };
 
   lksctp-tools = callPackage ../os-specific/linux/lksctp-tools { };


### PR DESCRIPTION
###### Motivation for this change

The `liquidsoap` package has been broken since the update to `ffmpeg` 4.3 in #90541.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
