### PR TITLE
systemd-confinement: handle ExecStarts etc being lists

### DIFF
--- a/nixos/modules/security/systemd-confinement.nix
+++ b/nixos/modules/security/systemd-confinement.nix
@@ -135,7 +135,7 @@ in {
           ];
           execPkgs = lib.concatMap (opt: let
             isSet = config.serviceConfig ? ${opt};
-          in lib.optional isSet config.serviceConfig.${opt}) execOpts;
+          in lib.flatten (lib.optional isSet config.serviceConfig.${opt})) execOpts;
           unitAttrs = toplevelConfig.systemd.units."${name}.service";
           allPkgs = lib.singleton (builtins.toJSON unitAttrs);
           unitPkgs = if fullUnit then allPkgs else execPkgs;


### PR DESCRIPTION
systemd-confinement's automatic package extraction does not work correctly
if ExecStarts ExecReload etc are lists.

Add an extra flatten to make things smooth.

Fixes #96840.
(will need backporting to 20.03 to properly fix it actually)

###### Motivation for this change
#96840 describes the problem but basically recent nginx update broke confinement for it due to this bug in confinement handling.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
