### PR TITLE
tdm: 2.07 -> 2.08

### DIFF
--- a/pkgs/games/tdm/default.nix
+++ b/pkgs/games/tdm/default.nix
@@ -4,7 +4,7 @@
 
 let
   pname = "tdm";
-  version = "2.07";
+  version = "2.08";
 
   desktop = makeDesktopItem {
     desktopName = pname;
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
   name = "${pname}-${version}";
   src = fetchurl {
     url = "https://www.thedarkmod.com/sources/thedarkmod.${version}.src.7z";
-    sha256 = "17wdpip8zvm2njz0xrf7xcxl73hnsc6i83zj18kn8rnjkpy50dd6";
+    sha256 = "0bmv07j6s6q3m7hnpx7cwrycjkbvlf0y9sg9migakni0jg9yz5ps";
   };
   nativeBuildInputs = [
     p7zip sconsPackages.scons_3_1_2 gnum4 makeWrapper
@@ -39,13 +39,15 @@ in stdenv.mkDerivation {
   preBuild = ''
     pushd tdm_update
     scons BUILD=release TARGET_ARCH=x64
-    install -Dm755 tdm_update.linux $out/share/libexec/tdm_update.linux
+    install -Dm755 bin/tdm_update.linux64 $out/share/libexec/tdm_update.linux
     popd
   '';
 
   # why oh why can it find ld but not strip?
   postPatch = ''
     sed -i 's!strip \$!${binutils-unwrapped}/bin/strip $!' SConstruct
+    # This adds math.h needed for math::floor
+    sed -i 's|#include "Util.h"|#include "Util.h"\n#include <math.h>|' tdm_update/ConsoleUpdater.cpp
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tagging @dhtnseri @Lassulus .

Among other things, this version fixes a series of GSGL issues that cause a "black screen" (present in version 2.07) on Intel cards.
However, on my system this version fails to detect the soundcard via OpenAL. With 2.07 I have sound.
Might need to wait for 2.09 to have both video and sound working :sweat_smile: 

Can one of you confirm if sound works on your system with 2.08?
If yes this could be dependent on the version of OpenAL.
