### PR TITLE
nixos/lorri: add package option

### DIFF
--- a/nixos/modules/services/development/lorri.nix
+++ b/nixos/modules/services/development/lorri.nix
@@ -15,6 +15,15 @@ in {
           issued by the `lorri` command.
         '';
       };
+      package = lib.mkOption {
+        default = pkgs.lorri;
+        type = lib.types.package;
+        description = ''
+          The lorri package to use.
+        '';
+        defaultText = lib.literalExample "pkgs.lorri";
+        example = lib.literalExample "pkgs.lorri";
+      };
     };
   };
 
@@ -34,7 +43,7 @@ in {
       after = [ "lorri.socket" ];
       path = with pkgs; [ config.nix.package git gnutar gzip ];
       serviceConfig = {
-        ExecStart = "${pkgs.lorri}/bin/lorri daemon";
+        ExecStart = "${cfg.package}/bin/lorri daemon";
         PrivateTmp = true;
         ProtectSystem = "strict";
         ProtectHome = "read-only";
@@ -42,6 +51,6 @@ in {
       };
     };
 
-    environment.systemPackages = [ pkgs.lorri ];
+    environment.systemPackages = [ cfg.package ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Sometimes I need `lorri` to track master for changes that have not yet made it into nixpkgs.
Previously, I did this by overriding `src` as shown [here](https://github.com/evanjs/nixos_cfg/blob/d198978219368158f19d83266f9da69b30948319/config/new-modules/profiles/desktop.nix#L191).
As of https://github.com/target/lorri/pull/168 / https://github.com/target/lorri/pull/168/commits/0ccdfa7a39525667ab2901db569b9c28665fe2dd, this is no longer possible.

I did try to utilize `overrideAttrs`, but encountered issues simply setting the `rev` and etc., due to the nature of lorri's `src`.

###### Things done
- Add a `package` option to the `lorri` module
- Tested via `nixos-rebuild switch -I nixpkgs=.` (from a local `nixpkgs` clone)