### PR TITLE
marwaita-peppermint: init at 0.3

### DIFF
--- a/pkgs/data/themes/marwaita-peppermint/default.nix
+++ b/pkgs/data/themes/marwaita-peppermint/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, fetchFromGitHub
+, gdk-pixbuf
+, gtk-engine-murrine
+, gtk_engines
+, librsvg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "marwaita-peppermint";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "darkomarko42";
+    repo = pname;
+    rev = version;
+    sha256 = "0g1n84px69wjjxclw76d59v8ccs4bkml71kzkvh12s9jcjw4zkc6";
+  };
+
+  buildInputs = [
+    gdk-pixbuf
+    gtk_engines
+    librsvg
+  ];
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/themes
+    cp -a Marwaita* $out/share/themes
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Marwaita GTK theme with Peppermint Os Linux style";
+    homepage = "https://www.pling.com/p/1399569/";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18922,6 +18922,8 @@ in
 
   marwaita-manjaro = callPackage ../data/themes/marwaita-manjaro { };
 
+  marwaita-peppermint = callPackage ../data/themes/marwaita-peppermint { };
+
   matcha-gtk-theme = callPackage ../data/themes/matcha { };
 
   materia-theme = callPackage ../data/themes/materia-theme { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [marwaita-peppermint](https://www.pling.com/p/1399569/), which is the Marwaita GTK theme with Peppermint Os Linux style.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
