### PR TITLE
backport hovercraft fix

### DIFF
--- a/pkgs/applications/misc/hovercraft/default.nix
+++ b/pkgs/applications/misc/hovercraft/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonApplication rec {
   pname = "hovercraft";
-  version = "2.6";
+  version = "2.7";
   disabled = ! isPy3k;
 
   src = fetchFromGitHub {
     owner = "regebro";
     repo = "hovercraft";
     rev = version;
-    sha256 = "150sn6kvqi2s89di1akl5i0g81fasji2ipr12zq5s4dcnhw4r5wp";
+    sha256 = "0k0gjlqjz424rymcfdjpj6a71ppblfls5f8y2hd800d1as4im8az";
   };
 
   checkInputs = [ manuel ];

--- a/pkgs/applications/misc/hovercraft/default.nix
+++ b/pkgs/applications/misc/hovercraft/default.nix
@@ -31,6 +31,5 @@ buildPythonApplication rec {
     homepage = https://github.com/regebro/hovercraft;
     license = licenses.mit;
     maintainers = with maintainers; [ goibhniu makefu ];
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Backport #82641 , unbreaks package
###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @Mic92 