### PR TITLE
nixops: add virtualbox base image

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -166,6 +166,56 @@ in {
         '';
     };
 
+    system.build.nixopsVboxImage =
+      let
+        machine = import ../../../nixos {
+          system = "x86_64-linux";
+          # config taken from "${pkgs.nixops}/share/nix/nixops/virtualbox-image-nixops.nix"
+          configuration =
+            { config, ... }:
+            let
+              clientKeyPath = "/root/.vbox-nixops-client-key";
+            in
+            { imports = [ ./virtualbox-image.nix ];
+              services.openssh.enable = true;
+              systemd.services.get-vbox-nixops-client-key = {
+                description = "Get NixOps SSH Key";
+                wantedBy = [ "multi-user.target" ];
+                before = [ "sshd.service" ];
+                requires = [ "dev-vboxguest.device" ];
+                after = [ "dev-vboxguest.device" ];
+                path = [ config.boot.kernelPackages.virtualboxGuestAdditions ];
+                script = ''
+                  set -o pipefail
+                  VBoxControl -nologo guestproperty get /VirtualBox/GuestInfo/Charon/ClientPublicKey | sed 's/Value: //' > ${clientKeyPath}.tmp
+                  mv ${clientKeyPath}.tmp ${clientKeyPath}
+
+                  if [[ ! -f /etc/ssh/ssh_host_ed25519_key ]]; then
+                    VBoxControl -nologo guestproperty get /VirtualBox/GuestInfo/NixOps/PrivateHostEd25519Key | sed 's/Value: //' > /etc/ssh/ssh_host_ed25519_key.tmp
+                    mv /etc/ssh/ssh_host_ed25519_key.tmp /etc/ssh/ssh_host_ed25519_key
+                    chmod 0600 /etc/ssh/ssh_host_ed25519_key
+                  fi
+                '';
+              };
+              services.openssh.authorizedKeysFiles = [ ".vbox-nixops-client-key" ];
+              boot.vesa = false;
+              boot.loader.timeout = 1;
+              # VirtualBox doesn't seem to lease IP addresses persistently, so we
+              # may get a different IP address if dhcpcd is restarted.  So don't
+              # restart dhcpcd.
+              systemd.services.dhcpcd.restartIfChanged = false;
+            };
+        };
+        ova = machine.config.system.build.virtualBoxOVA;
+      in pkgs.runCommand
+        "virtualbox-nixops-image-${machine.config.system.nixos.version}"
+        { nativeBuildInputs = [ ova ]; }
+        ''
+          mkdir ova
+          tar -xf ${ova}/*.ova -C ova
+          mv ova/nixos*.vmdk $out
+        '';
+
     fileSystems = {
       "/" = {
         device = "/dev/disk/by-label/nixos";

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -224,6 +224,17 @@ in rec {
   );
 
 
+  # A virtualbox base image to use with nixops
+  nixopsVboxImage =
+
+    with import ./.. { system = "x86_64-linux"; };
+
+    hydraJob ((import lib/eval-config.nix {
+      inherit system;
+      modules = [ ./modules/virtualisation/virtualbox-image.nix ];
+    }).config.system.build.nixopsVboxImage);
+
+
   # Ensure that all packages used by the minimal NixOS config end up in the channel.
   dummy = forAllSystems (system: pkgs.runCommand "dummy"
     { toplevel = (import lib/eval-config.nix {


### PR DESCRIPTION
###### Motivation for this change
NixOps' virtualbox module has the problem to constantly depend on an outdated base image of NixOS.
The following issues are most likely a consequence of this:
https://github.com/NixOS/nixops/issues/1207
https://github.com/NixOS/nixops/issues/835
https://github.com/NixOS/nixops/issues/908

The general problem seems to be that the base images are manually built by maintainers and hardcoded in the nixops vbox module.
Therefore, by design, any stable nixops version found in nixpkgs can never refer to an up-to-date base image of the same nixpkgs version.

###### Things done
Following the suggestion from https://github.com/nix-community/nixops-vbox/issues/9, I'd like to add the image to nixpkgs which will allow nixops users to always get a recent base image from the nixos cache.
Future versions of nixops could just point to this nixpkgs attribute and allow for an improved user experience.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
