### PR TITLE
mcpp: add patch for CVE-2019-14274

### DIFF
--- a/pkgs/development/compilers/mcpp/default.nix
+++ b/pkgs/development/compilers/mcpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "mcpp";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags = [ "--enable-mcpplib" ];
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-14274.patch";
+      url = "https://github.com/h8liu/mcpp/commit/ea453aca2742be6ac43ba4ce0da6f938a7e5a5d8.patch";
+      sha256 = "0svkdr3w9b45v6scgzvggw9nsh6a3k7g19fqk0w3vlckwmk5ydzr";
+    })
+  ];
 
   meta = with stdenv.lib; {
     homepage = "http://mcpp.sourceforge.net/";


### PR DESCRIPTION
Fixes #67197

###### Motivation for this change
 
Patch CVE-2019-14274. In fact, I'd prefer to see mcpp removed altogether. If anyone feels inclined to do that, please step up. :-) See #68571 for discussion on how to remove mcpp (Xorg dependency).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
