### PR TITLE
castor, gitAndTools.git-interactive-rebase-tool, the-way: disable checks

### DIFF
--- a/pkgs/applications/networking/browsers/castor/default.nix
+++ b/pkgs/applications/networking/browsers/castor/default.nix
@@ -39,7 +39,8 @@ rustPlatform.buildRustPackage rec {
   postInstall = "make PREFIX=$out copy-data";
 
   # Sometimes tests fail when run in parallel
-  checkFlags = [ "--test-threads=1" ];
+  #checkFlags = [ "--test-threads=1" ];
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "A graphical client for plain-text protocols written in Rust with GTK. It currently supports the Gemini, Gopher and Finger protocols";

--- a/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/default.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ ncurses5 ] ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv Security ];
 
-  checkFlagsArray = [ "--test-threads=1" ];
+  #checkFlagsArray = [ "--test-threads=1" ];
+  doCheck = false;
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/MitMaro/git-interactive-rebase-tool";

--- a/pkgs/development/tools/the-way/default.nix
+++ b/pkgs/development/tools/the-way/default.nix
@@ -12,7 +12,8 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "1a747bmc6s007ram0w4xf1y2nb3pphvqnlx59098lr3v7gllp7x3";
-  checkFlags = "--test-threads=1";
+  #checkFlags = "--test-threads=1";
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Terminal code snippets manager";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

These three have been broken since https://github.com/NixOS/nixpkgs/pull/95622 as we can't pass `test-threads` twice.

Just disabling the checks for now as 20.09 branch off is close and a proper fix will probably cause a rust rebuild.

```
Running cargo test --release --target x86_64-unknown-linux-gnu --frozen --  --test-threads=1
   Compiling git-interactive-rebase-tool v1.2.1 (/build/source)
    Finished release [optimized] target(s) in 6.78s
     Running target/x86_64-unknown-linux-gnu/release/deps/interactive_rebase_tool-2ed5e41c7143da47
error: Option 'test-threads' given more than once
error: test failed, to rerun pass '--bin interactive-rebase-tool'
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
