### PR TITLE
[20.03] adns: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/development/libraries/adns/default.nix
+++ b/pkgs/development/libraries/adns/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl }:
 
 let
-  version = "1.5.1";
+  version = "1.5.2";
 in
 stdenv.mkDerivation {
   pname = "adns";
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
       "ftp://ftp.chiark.greenend.org.uk/users/ian/adns/adns-${version}.tar.gz"
       "mirror://gnu/adns/adns-${version}.tar.gz"
     ];
-    sha256 = "1ssfh94ck6kn98nf2yy6743srpgqgd167va5ja3bwx42igqjc42v";
+    sha256 = "0z9ambw4pjnvwhn4bhxbrh20zpjsfj1ixm2lxa8x1x6w36g3ip6q";
   };
 
   preConfigure =


### PR DESCRIPTION
#### Motivation for this change

Security update which fixes various CVEs:

CVE-2017-9103
CVE-2017-9104
CVE-2017-9109
CVE-2017-9105
CVE-2017-9106
CVE-2017-9107
CVE-2017-9108

Closes #91310

(cherry picked from commit b3bcf1022cadaec983164155f8e85424487b2d9b)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
