### PR TITLE
wakeonlan service: use powerUpCommands

### DIFF
--- a/nixos/modules/services/networking/wakeonlan.nix
+++ b/nixos/modules/services/networking/wakeonlan.nix
@@ -51,6 +51,6 @@ in
 
   ###### implementation
 
-  config.powerManagement.powerDownCommands = lines;
+  config.powerManagement.powerUpCommands = lines;
 
 }


### PR DESCRIPTION
###### Motivation for this change

powerDownCommands is supposed to run before shutdown, but the current
implementation only runs before-sleep, thus not enabling wakeonlan on
devices when powering off even if the hardware supports it.

Taking into consideration the possibility of unexpected shutdown, it is
preferable to move the commands to powerUpCommands instead which is
executed at boot time as well as after resume - that should cover all
use cases for wakeonlan.

Fixes #91352


I'll fill in a second PR to rename powerDownCommands into preSleepCommands (like resumeCommands) after this gets merged, it looks like nothing that currently uses powerDownCommands actually cares about power off time.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
