### PR TITLE
xwallpaper: remove libseccomp dependency

### DIFF
--- a/pkgs/tools/X11/xwallpaper/default.nix
+++ b/pkgs/tools/X11/xwallpaper/default.nix
@@ -1,5 +1,14 @@
-{ stdenv, fetchFromGitHub, pkg-config, autoreconfHook, pixman, xcbutil, xcbutilimage
-, libjpeg, libpng, libXpm }:
+{ stdenv
+, fetchFromGitHub
+, pkg-config
+, autoreconfHook
+, pixman
+, xcbutil
+, xcbutilimage
+, libjpeg
+, libpng
+, libXpm
+}:
 
 stdenv.mkDerivation rec {
   pname = "xwallpaper";

--- a/pkgs/tools/X11/xwallpaper/default.nix
+++ b/pkgs/tools/X11/xwallpaper/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkg-config, autoreconfHook, pixman, xcbutil, xcbutilimage
-, libseccomp, libjpeg, libpng, libXpm }:
+, libjpeg, libpng, libXpm }:
 
 stdenv.mkDerivation rec {
   pname = "xwallpaper";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   preConfigure = "./autogen.sh";
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
-  buildInputs = [ pixman xcbutilimage xcbutil libseccomp libjpeg libpng libXpm ];
+  buildInputs = [ pixman xcbutilimage xcbutil libjpeg libpng libXpm ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/stoeckmann/xwallpaper";


### PR DESCRIPTION
###### Motivation for this change
libseccomp has been upgraded to 2.5.0, which xwallpaper [currently does not support](https://github.com/stoeckmann/xwallpaper/issues/23). Luckily this dependency is optional, so for now I've simply removed it, making the application usable again.

Also ran `nixpkgs-fmt` on the file, as this looks a lot nicer IMO.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
