### PR TITLE
protege: init at 5.5.0

### DIFF
--- a/pkgs/applications/science/logic/protege/default.nix
+++ b/pkgs/applications/science/logic/protege/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, fetchzip
+, jre8
+, makeWrapper
+, makeDesktopItem
+, desktop-file-utils
+, iconConvTools
+}:
+
+stdenv.mkDerivation rec {
+  pname = "protege";
+  version = "5.5.0";
+
+  src = fetchzip {
+    url = "https://github.com/protegeproject/protege-distribution/releases/download/v${version}/Protege-${version}-platform-independent.zip";
+    sha256 = "1v82ph1pqvnc1qynhiapzw0jwm9rphsb580lc96zwsvhrr0wd690";
+  };
+
+  nativeBuildInputs = [ makeWrapper desktop-file-utils iconConvTools ];
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = pname;
+    desktopName = "Protege";
+    genericName = meta.description;
+    comment = meta.description;
+    categories = "Development;";
+    icon = pname;
+    extraEntries = ''
+      StartupWMClass=${pname}
+    '';
+  };
+
+  # we need to patch the run.sh located in the extracted sources, note the deliberate whitespace!
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/src
+    mv * $out/src
+
+    substituteInPlace $out/src/run.sh \
+      --replace 'java ' "${jre8}/bin/java "
+    mkdir -p $out/bin
+    makeWrapper $out/src/run.sh $out/bin/${pname}
+
+    mkdir -p $out/share
+    ${desktopItem.buildCommand}
+    icoFileToHiColorTheme $out/src/app/Protege.ico $pname $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Ontology editor and framework for building intelligent systems";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.unix;
+    homepage = "https://protege.stanford.edu";
+    downloadPage = "https://github.com/protegeproject/protege-distribution/releases";
+    changelog = "https://github.com/protegeproject/protege-distribution/releases/tag/v${version}";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25161,6 +25161,8 @@ in
 
   protonmail-bridge = callPackage ../applications/networking/protonmail-bridge { };
 
+  protege = callPackage ../applications/science/logic/protege { };
+
   protonvpn-cli = callPackage ../applications/networking/protonvpn-cli { };
 
   protonvpn-gui = callPackage ../applications/networking/protonvpn-gui { };


### PR DESCRIPTION
###### Motivation for this change

Adds [Protege](https://protege.stanford.edu/), a free, open-source ontology editor and framework for building intelligent systems.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  Not applicable here, not a nixos module
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  It's a new application, no packages do or will depend upon it
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  Tested also using runtime-sandboxing (`nix-shell -I nixpkgs=. --pure -p protege`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  Couldn't run the command due to error, but it's around 60MB large
  `error: Please be informed that this pseudo-package is not the only part of
Nixpkgs that fails to evaluate. You should not evaluate entire Nixpkgs
without some special measures to handle failing packages, like those taken
by Hydra.`
- [ ] Ensured that relevant documentation is up to date
  No documentation needed here
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  Yes, except for the maintainers field. Happy to take a look and update it from time to time, but can't fully commit as maintainer.
