### PR TITLE
nixos/bitwarden_rs: add environmentFile option

### DIFF
--- a/nixos/modules/services/security/bitwarden_rs/default.nix
+++ b/nixos/modules/services/security/bitwarden_rs/default.nix
@@ -81,6 +81,23 @@ in {
         <link xlink:href="https://github.com/dani-garcia/bitwarden_rs/blob/${bitwarden_rs.version}/.env.template">the environment template file</link>.
       '';
     };
+
+    environmentFile = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      example = "/root/bitwarden_rs.env";
+      description = ''
+        Additional environment file as defined in <citerefentry>
+        <refentrytitle>systemd.exec</refentrytitle><manvolnum>5</manvolnum>
+        </citerefentry>.
+
+        Secrets like <envar>ADMIN_TOKEN</envar> and <envar>SMTP_PASSWORD</envar>
+        may be passed to the service without adding them to the world-readable Nix store.
+
+        Note that this file needs to be available on the host on which
+        <literal>bitwarden_rs</literal> is running.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -101,7 +118,7 @@ in {
       serviceConfig = {
         User = user;
         Group = group;
-        EnvironmentFile = configFile;
+        EnvironmentFile = [ configFile ] ++ optional (cfg.environmentFile != null) cfg.environmentFile;
         ExecStart = "${bitwarden_rs}/bin/bitwarden_rs";
         LimitNOFILE = "1048576";
         LimitNPROC = "64";


### PR DESCRIPTION
###### Motivation for this change
Bitwarden_rs is configured using a systemd environment file, which is locally generated in the module. To pass secrets to the service, one could either use the `config` option or set `services.systemd.bitwarden_rs.environment`.
Both of these approaches would lead to having secrets in the world-readable Nix store.

As [discussed on IRC](https://logs.nix.samueldr.com/nixos-dev/2020-09-07#3952913), there are a few ways to work around this issue. The ideal solution (as outlined by @ju1m) would probably be to allow the merging of single values and lists of the same type to a single list of definitions (for some of the options available in unit files, such as `EnvironmentFile` and `ExecStartPre`).

But even without the improved option merging, exposing an option `environmentFile`, very much like the one in the `alertmanager` module, would make passing secrets easier. The alternative would be to expect users to set `systemd.services.bitwarden_rs.serviceConfig.EnvironmentFile` themselves.

###### Things done
Added the option `environmentFile` to allow passing secrets to the service
without adding them to the Nix store, while keeping the current
configuration via the existing environment file intact.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
