### PR TITLE
dropbear: enable static build on musl

### DIFF
--- a/pkgs/tools/networking/dropbear/default.nix
+++ b/pkgs/tools/networking/dropbear/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, glibc, zlib
+{ stdenv, lib, fetchurl, zlib
 , enableStatic ? false
 , sftpPath ? "/run/current-system/sw/libexec/sftp-server"
 }:
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   dontDisableStatic = enableStatic;
 
-  configureFlags = lib.optional enableStatic "LDFLAGS=-static";
+  configureFlags = lib.optional enableStatic "LDFLAGS=-static --enable-static";
 
   CFLAGS = "-DSFTPSERVER_PATH=\\\"${sftpPath}\\\"";
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     ./pass-path.patch
   ];
 
-  buildInputs = [ zlib ] ++ lib.optionals enableStatic [ glibc.static zlib.static ];
+  buildInputs = [ zlib ] ++ lib.optionals enableStatic [ zlib.static ] ++ lib.optionals (enableStatic && stdenv.cc.libc ? static) [ stdenv.cc.libc.static ];
 
   meta = with stdenv.lib; {
     homepage = "http://matt.ucc.asn.au/dropbear/dropbear.html";


### PR DESCRIPTION
Adds the --enable-static configuration flag that is required in
the case of static builds. Removes explicit mentions of glibc,
and uses generic `stdenv.cc.libc`. The static attribute of the
libc is passed only when it exists.

###### Motivation for this change

Dropbear currently doesn't build with musl & AArch64. It is
affected by this bug https://github.com/NixOS/nixpkgs/issues/97351,
but even bypassing that, the resulting build segfaults. I don't
know the exact reason for this, but I think that building with musl,
and passing only a partial set of the flags required for a working
static build, the end result not working was not a huge wonder.
I tested this change to work correctly on AArch64 and x86_64,
both with musl and glibc static build.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
