### PR TITLE
pkgs/build-support/writers: allow passing ghc arguments in writeHaskell

### DIFF
--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -164,12 +164,13 @@ rec {
   #   '';
   writeHaskell = name: {
     libraries ? [],
-    ghc ? pkgs.ghc
+    ghc ? pkgs.ghc,
+    ghcArgs ? []
   }:
     makeBinWriter {
       compileScript = ''
         cp $contentPath tmp.hs
-        ${ghc.withPackages (_: libraries )}/bin/ghc tmp.hs
+        ${ghc.withPackages (_: libraries )}/bin/ghc ${lib.escapeShellArgs ghcArgs} tmp.hs
         mv tmp $out
         ${pkgs.binutils-unwrapped}/bin/strip --strip-unneeded "$out"
       '';


### PR DESCRIPTION
###### Motivation for this change

I would like to pass additional arguments to the `ghc` invocation in `writeHaskell`.
I have some personal use cases but would also like to use this new power to add a similar option to the `xmonad` module, which also uses `writeHaskell`. 


###### Things done

Tested locally

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

  