### PR TITLE
nixos/xmonad: give users some build and runtime control

### DIFF
--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -76,6 +76,15 @@ in
                  }
         '';
       };
+
+      xmonadCliArgs = mkOption {
+        default = [];
+        type = with lib.types; listOf str;
+        description = ''
+          Command line arguments passed to the xmonad binary.
+        '';
+      };
+
     };
   };
   config = mkIf cfg.enable {
@@ -85,7 +94,7 @@ in
         start = let
           xmonadCommand = if (cfg.config != null) then xmonadBin else "${xmonad}/bin/xmonad";
         in ''
-           systemd-cat -t xmonad ${xmonadCommand} &
+           systemd-cat -t xmonad -- ${xmonadCommand} ${lib.escapeShellArgs cfg.xmonadCliArgs} &
            waitPID=$!
         '';
       }];

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -16,6 +16,7 @@ let
                 cfg.extraPackages cfg.haskellPackages ++
                 optionals cfg.enableContribAndExtras
                 (with cfg.haskellPackages; [ xmonad-contrib xmonad-extras ]);
+    inherit (cfg) ghcArgs;
   } cfg.config;
 
 in
@@ -82,6 +83,15 @@ in
         type = with lib.types; listOf str;
         description = ''
           Command line arguments passed to the xmonad binary.
+        '';
+      };
+
+      ghcArgs = mkOption {
+        default = [];
+        type = with lib.types; listOf str;
+        description = ''
+          Command line arguments passed to the compiler (ghc)
+          invocation when xmonad.config is set.
         '';
       };
 


### PR DESCRIPTION
#### Motivation for this change

Make the `xmonad` module more configurable. Give users some build and runtime control.
Concretely this will add two options:
* `xmonadCliArgs` for passing command line arguments to the final `xmonad` binary  
* `ghcArgs` for passing command line arguments to the `ghc` invocation when compiling