### PR TITLE
tinycdb: add support for static build

### DIFF
--- a/pkgs/development/libraries/tinycdb/default.nix
+++ b/pkgs/development/libraries/tinycdb/default.nix
@@ -1,18 +1,37 @@
 { stdenv, lib, fetchurl }:
+let
+  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+  cross = "${stdenv.hostPlatform.config}";
+  static = stdenv.hostPlatform.isStatic;
 
-stdenv.mkDerivation rec {
+  cc = if !isCross then "cc" else "${cross}-cc";
+  ar = if !isCross then "ar" else "${cross}-ar";
+  ranlib = if !isCross then "ranlib" else "${cross}-ranlib";
+in stdenv.mkDerivation rec {
+  postPatch = ''
+    sed -i 's,set --, set -x; set --,' Makefile
+  '';
   pname = "tinycdb";
   version = "0.78";
-  outputs = [ "out" "dev" "lib" "man" ];
+  # In general, static library (.a) goes to "dev", shared (.so) to
+  # "lib". In case of static build, there is no .so library, so "lib"
+  # output is useless and empty.
+  outputs = [ "out" "dev" "man" ] ++ lib.optional (!static) "lib";
   separateDebugInfo = true;
-  makeFlags = [ "prefix=$(out)" "staticlib" "sharedlib" "cdb-shared" ];
+  makeFlags =
+    [ "prefix=$(out)" "CC=${cc}" "AR=${ar}" "RANLIB=${ranlib}" "static"
+  ] ++ lib.optional (!static) "shared";
   postInstall = ''
-    mkdir -p $lib/lib $dev/lib $out/bin
-    cp libcdb.so* $lib/lib
-    cp cdb-shared $out/bin/cdb
+    mkdir -p $dev/lib $out/bin
     mv $out/lib/libcdb.a $dev/lib
     rmdir $out/lib
-  '';
+  '' + (if static then ''
+    cp cdb $out/bin/cdb
+  '' else ''
+    mkdir -p $lib/lib
+    cp libcdb.so* $lib/lib
+    cp cdb-shared $out/bin/cdb
+  '');
 
   src = fetchurl {
     url = "http://www.corpit.ru/mjt/tinycdb/${pname}-${version}.tar.gz";
@@ -27,7 +46,7 @@ stdenv.mkDerivation rec {
       tinycdb is a small, fast and reliable utility and subroutine
       library for creating and reading constant databases. The database
       structure is tuned for fast reading.
-      '';
+    '';
 
     homepage = "https://www.corpit.ru/mjt/tinycdb.html";
     license = licenses.publicDomain;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).