### PR TITLE
cc-wrapper: Fix for prebuilt android

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -47,7 +47,7 @@ rec {
   armv7a-android-prebuilt = {
     config = "armv7a-unknown-linux-androideabi";
     sdkVer = "29";
-    ndkVer = "18b";
+    ndkVer = "21";
     platform = platforms.armv7a-android;
     useAndroidPrebuilt = true;
   };
@@ -55,7 +55,7 @@ rec {
   aarch64-android-prebuilt = {
     config = "aarch64-unknown-linux-android";
     sdkVer = "29";
-    ndkVer = "18b";
+    ndkVer = "21";
     platform = platforms.aarch64-multiplatform;
     useAndroidPrebuilt = true;
   };

--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -53,7 +53,9 @@ in
 
 rec {
   # Misc tools
-  binaries = runCommand "ndk-gcc-binutils" {
+  binaries = runCommand "ndk-toolchain-binutils" {
+    pname = "ndk-toolchain-binutils";
+    inherit (androidndk) version;
     isClang = true; # clang based cc, but bintools ld
     nativeBuildInputs = [ makeWrapper ];
     propagatedBuildInputs = [ androidndk ];

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -1,4 +1,4 @@
-{requireFile, autoPatchelfHook, pkgs, pkgs_i686, licenseAccepted ? false}:
+{requireFile, autoPatchelfHook, pkgs, pkgsHostHost, pkgs_i686, licenseAccepted ? false}:
 
 { toolsVersion ? "25.2.5"
 , platformToolsVersion ? "29.0.6"
@@ -144,7 +144,7 @@ rec {
   ) cmakeVersions;
 
   ndk-bundle = import ./ndk-bundle {
-    inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs lib platform-tools;
+    inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs pkgsHostHost lib platform-tools;
     package = packages.ndk-bundle.${ndkVersion};
   };
 

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -1,4 +1,4 @@
-{ config, pkgs ? import <nixpkgs> {}
+{ config, pkgs ? import <nixpkgs> {}, pkgsHostHost ? pkgs.pkgsHostHost
 , pkgs_i686 ? import <nixpkgs> { system = "i686-linux"; }
 , licenseAccepted ? config.android_sdk.accept_license or false
 }:
@@ -6,7 +6,7 @@
 rec {
   composeAndroidPackages = import ./compose-android-packages.nix {
     inherit (pkgs) requireFile autoPatchelfHook;
-    inherit pkgs pkgs_i686 licenseAccepted;
+    inherit pkgs pkgsHostHost pkgs_i686 licenseAccepted;
   };
 
   buildApp = import ./build-app.nix {

--- a/pkgs/development/mobile/androidenv/deploy-androidpackage.nix
+++ b/pkgs/development/mobile/androidenv/deploy-androidpackage.nix
@@ -5,7 +5,8 @@ let
   extraParams = removeAttrs args [ "package" "os" "buildInputs" "patchInstructions" ];
 in
 stdenv.mkDerivation ({
-  name = package.name + "-" + package.revision;
+  pname = package.name;
+  version = package.revision;
   src = if os != null && builtins.hasAttr os package.archives then package.archives.${os} else package.archives.all;
   buildInputs = [ unzip ] ++ buildInputs;
   preferLocalBuild = true;

--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -1,7 +1,11 @@
-{deployAndroidPackage, lib, package, os, autoPatchelfHook, makeWrapper, pkgs, platform-tools}:
+{ lib, pkgs, pkgsHostHost, makeWrapper, autoPatchelfHook
+, deployAndroidPackage, package, os, platform-tools
+}:
 
 let
-  runtime_paths = lib.makeBinPath [ pkgs.coreutils pkgs.file pkgs.findutils pkgs.gawk pkgs.gnugrep pkgs.gnused pkgs.jdk pkgs.python3 pkgs.which ] + ":${platform-tools}/platform-tools";
+  runtime_paths = lib.makeBinPath (with pkgsHostHost; [
+    coreutils file findutils gawk gnugrep gnused jdk python3 which
+  ]) + ":${platform-tools}/platform-tools";
 in
 deployAndroidPackage {
   inherit package os;


### PR DESCRIPTION
###### Motivation for this change

We don't want to use Nix-built GCC's libs with prebuilt clang in this case.

CC @bkchr & @matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
