### PR TITLE
plasma5: 5.18.5 -> 5.19.5

### DIFF
--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -118,6 +118,7 @@ let
       ksysguard = callPackage ./ksysguard.nix {};
       kwallet-pam = callPackage ./kwallet-pam.nix {};
       kwayland-integration = callPackage ./kwayland-integration.nix {};
+      kwayland-server = callPackage ./kwayland-server {};
       kwin = callPackage ./kwin {};
       kwrited = callPackage ./kwrited.nix {};
       libkscreen = callPackage ./libkscreen {};

--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma/5.18.5/ )
+WGET_ARGS=( https://download.kde.org/stable/plasma/5.19.5/ )

--- a/pkgs/desktops/plasma-5/kwayland-server/0001-Use-KDE_INSTALL_TARGETS_DEFAULT_ARGS-when-installing.patch
+++ b/pkgs/desktops/plasma-5/kwayland-server/0001-Use-KDE_INSTALL_TARGETS_DEFAULT_ARGS-when-installing.patch
@@ -1,0 +1,25 @@
+From 80bca7370d4b8bafcf18abcda30f02e190f419a4 Mon Sep 17 00:00:00 2001
+From: Tom Hall <tahall256@protonmail.ch>
+Date: Sat, 29 Aug 2020 19:14:30 +0100
+Subject: [PATCH] Use KDE_INSTALL_TARGETS_DEFAULT_ARGS when installing targets
+
+---
+ src/server/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/server/CMakeLists.txt b/src/server/CMakeLists.txt
+index 0f99682..35e3601 100644
+--- a/src/server/CMakeLists.txt
++++ b/src/server/CMakeLists.txt
+@@ -356,7 +356,7 @@ set_target_properties(KWaylandServer PROPERTIES VERSION   ${KWAYLANDSERVER_VERSI
+                                                 SOVERSION ${KWAYLANDSERVER_SOVERSION}
+ )
+ 
+-install(TARGETS KWaylandServer EXPORT KWaylandServerTargets ${KF5_INSTALL_TARGETS_DEFAULT_ARGS})
++install(TARGETS KWaylandServer EXPORT KWaylandServerTargets ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+ 
+ set(SERVER_LIB_HEADERS
+   ${CMAKE_CURRENT_BINARY_DIR}/KWaylandServer/kwaylandserver_export.h
+-- 
+2.26.2
+

--- a/pkgs/desktops/plasma-5/kwayland-server/default.nix
+++ b/pkgs/desktops/plasma-5/kwayland-server/default.nix
@@ -1,0 +1,18 @@
+{
+  mkDerivation, cmake,
+  extra-cmake-modules, kdoctools,
+  kwayland, plasma-wayland-protocols,
+  wayland, wayland-protocols
+}:
+
+mkDerivation {
+  name = "kwayland-server";
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules #kdoctools
+  ];
+  buildInputs = [
+    kwayland plasma-wayland-protocols wayland wayland-protocols
+  ];
+  patches = [ ./0001-Use-KDE_INSTALL_TARGETS_DEFAULT_ARGS-when-installing.patch ];
+}

--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -11,7 +11,7 @@
   breeze-qt5, kactivities, kcompletion, kcmutils, kconfig, kconfigwidgets,
   kcoreaddons, kcrash, kdeclarative, kdecoration, kglobalaccel, ki18n,
   kiconthemes, kidletime, kinit, kio, knewstuff, knotifications, kpackage,
-  kscreenlocker, kservice, kwayland, kwidgetsaddons, kwindowsystem, kxmlgui,
+  kscreenlocker, kservice, kwayland, kwayland-server, kwidgetsaddons, kwindowsystem, kxmlgui,
   plasma-framework, libcap, libdrm, mesa
 }:
 
@@ -30,7 +30,7 @@ mkDerivation {
     breeze-qt5 kactivities kcmutils kcompletion kconfig kconfigwidgets
     kcoreaddons kcrash kdeclarative kdecoration kglobalaccel ki18n kiconthemes
     kidletime kinit kio knewstuff knotifications kpackage kscreenlocker kservice
-    kwayland kwidgetsaddons kwindowsystem kxmlgui plasma-framework
+    kwayland kwayland-server kwidgetsaddons kwindowsystem kxmlgui plasma-framework
     libcap libdrm mesa
   ];
   outputs = [ "bin" "dev" "out" ];

--- a/pkgs/desktops/plasma-5/libksysguard/default.nix
+++ b/pkgs/desktops/plasma-5/libksysguard/default.nix
@@ -3,7 +3,7 @@
   extra-cmake-modules,
   kauth, kcompletion, kconfig, kconfigwidgets, kcoreaddons, ki18n, kiconthemes,
   kservice, kwidgetsaddons, kwindowsystem, plasma-framework, qtscript, qtwebengine,
-  qtx11extras
+  qtx11extras, knewstuff
 }:
 
 mkDerivation {
@@ -15,7 +15,7 @@ mkDerivation {
   buildInputs = [
     kauth kconfig ki18n kiconthemes kwindowsystem kcompletion kconfigwidgets
     kcoreaddons kservice kwidgetsaddons plasma-framework qtscript qtx11extras
-    qtwebengine
+    qtwebengine knewstuff
   ];
   outputs = [ "bin" "dev" "out" ];
 }

--- a/pkgs/desktops/plasma-5/plasma-desktop/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-desktop/default.nix
@@ -19,7 +19,7 @@ mkDerivation {
   name = "plasma-desktop";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
-    boost fontconfig ibus libcanberra_kde libpulseaudio libXcursor libXft
+    boost fontconfig ibus libcanberra_kde libpulseaudio libXcursor libXft xorgserver
     libxkbfile phonon xf86inputevdev xf86inputsynaptics xinput xkeyboard_config
 
     qtdeclarative qtquickcontrols qtquickcontrols2 qtsvg qtx11extras
@@ -35,7 +35,7 @@ mkDerivation {
     ./tzdir.patch
   ];
   postPatch = ''
-    sed '1i#include <cmath>' -i kcms/touchpad/src/backends/x11/synapticstouchpad.cpp
+    sed '1i#include <cmath>' -i kcms/touchpad/backends/x11/synapticstouchpad.cpp
   '';
   CXXFLAGS = [
     "-I${lib.getDev xorgserver}/include/xorg"

--- a/pkgs/desktops/plasma-5/plasma-workspace/0001-startkde.patch
+++ b/pkgs/desktops/plasma-5/plasma-workspace/0001-startkde.patch
@@ -1,19 +1,33 @@
-From 6477e377fcca39c07ef5f91a55084d7d74715d00 Mon Sep 17 00:00:00 2001
-From: Thomas Tuegel <ttuegel@mailbox.org>
-Date: Tue, 28 Jan 2020 05:00:53 -0600
-Subject: [PATCH 1/2] startkde
+From d653bc84c8aed33072237ed858194a8a73b6a2e7 Mon Sep 17 00:00:00 2001
+From: Tom Hall <tahall256@protonmail.ch>
+Date: Mon, 7 Sep 2020 18:09:52 +0100
+Subject: [PATCH] startkde
 
 ---
+ startkde/plasma-session/startup.cpp     |  2 +-
  startkde/startplasma-waylandsession.cpp |  2 +-
  startkde/startplasma-x11.cpp            |  2 +-
- startkde/startplasma.cpp                | 24 ++++++++++--------------
- 3 files changed, 12 insertions(+), 16 deletions(-)
+ startkde/startplasma.cpp                | 22 +++++++++-------------
+ 4 files changed, 12 insertions(+), 16 deletions(-)
 
+diff --git a/startkde/plasma-session/startup.cpp b/startkde/plasma-session/startup.cpp
+index 89cc144ba..8ca9e81d2 100644
+--- a/startkde/plasma-session/startup.cpp
++++ b/startkde/plasma-session/startup.cpp
+@@ -210,7 +210,7 @@ Startup::Startup(QObject *parent):
+     upAndRunning(QStringLiteral("ksmserver"));
+     const AutoStart autostart;
+ 
+-    QProcess::execute(QStringLiteral(CMAKE_INSTALL_FULL_LIBEXECDIR_KF5 "/start_kdeinit_wrapper"));
++    QProcess::execute(QStringLiteral(NIXPKGS_START_KDEINIT_WRAPPER));
+ 
+     KJob* phase1;
+     QProcessEnvironment kdedProcessEnv;
 diff --git a/startkde/startplasma-waylandsession.cpp b/startkde/startplasma-waylandsession.cpp
-index 87c71c6b3..5fc53140e 100644
+index f59654d18..5e3a93db0 100644
 --- a/startkde/startplasma-waylandsession.cpp
 +++ b/startkde/startplasma-waylandsession.cpp
-@@ -67,7 +67,7 @@ int main(int /*argc*/, char** /*argv*/)
+@@ -66,7 +66,7 @@ int main(int argc, char** argv)
      waitForKonqi();
      out << "startplasma-waylandsession: Shutting down...\n";
  
@@ -23,10 +37,10 @@ index 87c71c6b3..5fc53140e 100644
      cleanupX11();
      out << "startplasma-waylandsession: Done.\n";
 diff --git a/startkde/startplasma-x11.cpp b/startkde/startplasma-x11.cpp
-index 3314b6283..14cbe29fa 100644
+index ae1c4d101..0df24b5be 100644
 --- a/startkde/startplasma-x11.cpp
 +++ b/startkde/startplasma-x11.cpp
-@@ -111,7 +111,7 @@ int main(int /*argc*/, char** /*argv*/)
+@@ -110,7 +110,7 @@ int main(int argc, char** argv)
  
      out << "startkde: Shutting down...\n";
  
@@ -36,10 +50,10 @@ index 3314b6283..14cbe29fa 100644
      cleanupPlasmaEnvironment();
      cleanupX11();
 diff --git a/startkde/startplasma.cpp b/startkde/startplasma.cpp
-index 4c9f5cef6..5ea4c2cf1 100644
+index a055d5635..62afb1513 100644
 --- a/startkde/startplasma.cpp
 +++ b/startkde/startplasma.cpp
-@@ -34,7 +34,7 @@ QTextStream out(stderr);
+@@ -40,7 +40,7 @@ QTextStream out(stderr);
  void messageBox(const QString &text)
  {
      out << text;
@@ -48,7 +62,7 @@ index 4c9f5cef6..5ea4c2cf1 100644
  }
  
  QStringList allServices(const QLatin1String& prefix)
-@@ -242,15 +242,15 @@ void setupX11()
+@@ -261,15 +261,15 @@ void setupX11()
  //     If the user has overwritten fonts, the cursor font may be different now
  //     so don't move this up.
  
@@ -69,7 +83,7 @@ index 4c9f5cef6..5ea4c2cf1 100644
  }
  
  // TODO: Check if Necessary
-@@ -267,11 +267,7 @@ bool syncDBusEnvironment()
+@@ -286,11 +286,7 @@ bool syncDBusEnvironment()
  {
      int exitCode;
      // At this point all environment variables are set, let's send it to the DBus session server to update the activation environment
@@ -78,11 +92,11 @@ index 4c9f5cef6..5ea4c2cf1 100644
 -    } else {
 -        exitCode = runSync(QStringLiteral(CMAKE_INSTALL_FULL_LIBEXECDIR "/ksyncdbusenv"), {});
 -    }
-+		exitCode = runSync(QStringLiteral(NIXPKGS_DBUS_UPDATE_ACTIVATION_ENVIRONMENT), { QStringLiteral("--systemd"), QStringLiteral("--all") });
++    exitCode = runSync(QStringLiteral(NIXPKGS_DBUS_UPDATE_ACTIVATION_ENVIRONMENT), { QStringLiteral("--systemd"), QStringLiteral("--all") });
      return exitCode == 0;
  }
  
-@@ -287,7 +283,7 @@ void setupFontDpi()
+@@ -306,7 +302,7 @@ void setupFontDpi()
      //TODO port to c++?
      const QByteArray input = "Xft.dpi: " + QByteArray::number(fontsCfg.readEntry("forceFontDPI", 0));
      QProcess p;
@@ -91,7 +105,7 @@ index 4c9f5cef6..5ea4c2cf1 100644
      p.setProcessChannelMode(QProcess::ForwardedChannels);
      p.write(input);
      p.closeWriteChannel();
-@@ -309,7 +305,7 @@ QProcess* setupKSplash()
+@@ -328,7 +324,7 @@ QProcess* setupKSplash()
          KConfigGroup ksplashCfg = cfg.group("KSplash");
          if (ksplashCfg.readEntry("Engine", QStringLiteral("KSplashQML")) == QLatin1String("KSplashQML")) {
              p = new QProcess;
@@ -100,15 +114,6 @@ index 4c9f5cef6..5ea4c2cf1 100644
          }
      }
      return p;
-@@ -331,7 +327,7 @@ bool startKDEInit()
- {
-     // We set LD_BIND_NOW to increase the efficiency of kdeinit.
-     // kdeinit unsets this variable before loading applications.
--    const int exitCode = runSync(QStringLiteral(CMAKE_INSTALL_FULL_LIBEXECDIR_KF5 "/start_kdeinit_wrapper"), { QStringLiteral("--kded"), QStringLiteral("+kcminit_startup") }, { QStringLiteral("LD_BIND_NOW=true") });
-+    const int exitCode = runSync(QStringLiteral(NIXPKGS_START_KDEINIT_WRAPPER), { QStringLiteral("--kded"), QStringLiteral("+kcminit_startup") }, { QStringLiteral("LD_BIND_NOW=true") });
-     if (exitCode != 0) {
-         messageBox(QStringLiteral("startkde: Could not start kdeinit5. Check your installation."));
-         return false;
 -- 
-2.25.1
+2.28.0
 

--- a/pkgs/desktops/plasma-5/srcs.nix
+++ b/pkgs/desktops/plasma-5/srcs.nix
@@ -4,387 +4,395 @@
 
 {
   bluedevil = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/bluedevil-5.18.5.tar.xz";
-      sha256 = "5350efbaee01c78fd451e96bb2aceb7986d45ab05500476d1e95c4e79ec89a66";
-      name = "bluedevil-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/bluedevil-5.19.5.tar.xz";
+      sha256 = "e857e3c73a3d6c08bb44506f35a8359b480e960d32ae189b9b5bddcbcf5ffe2d";
+      name = "bluedevil-5.19.5.tar.xz";
     };
   };
   breeze = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/breeze-5.18.5.tar.xz";
-      sha256 = "1d08dfd24df4a4fcacad1e3759e559e82f6014ba63dc75dc32a24de6cd133563";
-      name = "breeze-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/breeze-5.19.5.tar.xz";
+      sha256 = "61116665a534a0acd833f9bb499dbe983bb07088c0006988fbd929f60f0ff336";
+      name = "breeze-5.19.5.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/breeze-grub-5.18.5.tar.xz";
-      sha256 = "24c40171601b82d1c7d01eb85d16718a2f46cf23ee792f5524ac89fda3d278b1";
-      name = "breeze-grub-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/breeze-grub-5.19.5.tar.xz";
+      sha256 = "a0b2efc175e75078330b72c3784603e4f52056498266c1637d5e8e039cf81843";
+      name = "breeze-grub-5.19.5.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/breeze-gtk-5.18.5.tar.xz";
-      sha256 = "41c7e83a28c033903d4fcab3da28a4c74ddb72958e66693a2d2e451f716cb7e9";
-      name = "breeze-gtk-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/breeze-gtk-5.19.5.tar.xz";
+      sha256 = "5213b2f6815e542cda6bf9ae153636285e178962c6a59ff9ab4fe5c07dc256c8";
+      name = "breeze-gtk-5.19.5.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/breeze-plymouth-5.18.5.tar.xz";
-      sha256 = "c0d48dc5a02f3236ff657f86ee8cf532cf885a0e8b36bfe79f007e4d5e277281";
-      name = "breeze-plymouth-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/breeze-plymouth-5.19.5.tar.xz";
+      sha256 = "60f0e1b3631493c05b29e59063e3ada81c413f535c75f656aff231afea7f5b3a";
+      name = "breeze-plymouth-5.19.5.tar.xz";
     };
   };
   discover = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/discover-5.18.5.tar.xz";
-      sha256 = "d5ce4f4668c50ba9be37e04227db4bbe469e00470c87907f1e217fdcad6e76b6";
-      name = "discover-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/discover-5.19.5.tar.xz";
+      sha256 = "6f989060450fbbfa596424fa6d3c4d0c5ea6ab532d09e58a935a109c628a3f82";
+      name = "discover-5.19.5.tar.xz";
     };
   };
   drkonqi = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/drkonqi-5.18.5.tar.xz";
-      sha256 = "b1a626c4ed2f9de8f8bc3359d8827e7fa6ac17486b8477674e47627fcf6efad1";
-      name = "drkonqi-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/drkonqi-5.19.5.tar.xz";
+      sha256 = "43bcf7141115e98d590384b1e2081de5c055a341ce38c76b0cda9933b00f7771";
+      name = "drkonqi-5.19.5.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kactivitymanagerd-5.18.5.tar.xz";
-      sha256 = "24f32eb4585d427ee62e08a9fa2f057353085c62644d6bec8fb4b2568e507ac7";
-      name = "kactivitymanagerd-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kactivitymanagerd-5.19.5.tar.xz";
+      sha256 = "eec1a0996812d89b98e93a3a2dec15527fd553c2c9c608ad7f1858f01749c3b0";
+      name = "kactivitymanagerd-5.19.5.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kde-cli-tools-5.18.5.tar.xz";
-      sha256 = "e3981d1a17111f4e284b787a6e841d7ff47f4fdbca0ad17e105c0a047e5aaaa8";
-      name = "kde-cli-tools-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kde-cli-tools-5.19.5.tar.xz";
+      sha256 = "07314832aee0b424451120e0aad59fdaab96ba713279dc1937cf36ef9b5389c7";
+      name = "kde-cli-tools-5.19.5.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kdecoration-5.18.5.tar.xz";
-      sha256 = "f09856245f2cb08d9013da4c3128b5438f1e2f58af40031eb547ae765f57a9c8";
-      name = "kdecoration-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kdecoration-5.19.5.tar.xz";
+      sha256 = "ce3ef7bb09405645699939cc3481d1fad67b1c5b758b64adfc4d81e5ffb1c85e";
+      name = "kdecoration-5.19.5.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kde-gtk-config-5.18.5.tar.xz";
-      sha256 = "9d7b1fd8b61f9f99c5a5721ea0227c4562588834a4886d66637f4c092f0e53ab";
-      name = "kde-gtk-config-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kde-gtk-config-5.19.5.tar.xz";
+      sha256 = "e9b79917994a18001691ce675d5f2e95367c872694d82540fb245ab6e57035a3";
+      name = "kde-gtk-config-5.19.5.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kdeplasma-addons-5.18.5.tar.xz";
-      sha256 = "1d135a32a7442f79dba4cb4e23221cd2ad1aad36b54fb12bfa91918daf3ff53f";
-      name = "kdeplasma-addons-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kdeplasma-addons-5.19.5.tar.xz";
+      sha256 = "659e10b553c7db1abd488f77c43a919046f5e7f29126972926afe1350f93ff23";
+      name = "kdeplasma-addons-5.19.5.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kgamma5-5.18.5.tar.xz";
-      sha256 = "3aa89e361646214fb4910409644b941c83a85505d3d8a1d37984598d3e54269f";
-      name = "kgamma5-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kgamma5-5.19.5.tar.xz";
+      sha256 = "d6e70e2638c65283895ead3791957853553d02ee864b2f928c3b0df4611ca023";
+      name = "kgamma5-5.19.5.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/khotkeys-5.18.5.tar.xz";
-      sha256 = "8f02fdf3bbecdc31c305c276fe2b3b2eca6dc10195e65c723ee9148fed81e766";
-      name = "khotkeys-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/khotkeys-5.19.5.tar.xz";
+      sha256 = "568cb61eb385a3776d96b21aa77188377b02e56e3bf46f9d9ffddb83a9b31bda";
+      name = "khotkeys-5.19.5.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kinfocenter-5.18.5.tar.xz";
-      sha256 = "a9679bce4cd2d64e6f471c89de6da410237263b02512768f3acd0a4932b12ec5";
-      name = "kinfocenter-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kinfocenter-5.19.5.tar.xz";
+      sha256 = "ffae6f6fc311cedfac2b380dcbc9f15588952cbcd66b144f4ae717801cb2bc31";
+      name = "kinfocenter-5.19.5.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kmenuedit-5.18.5.tar.xz";
-      sha256 = "59d998972121662d2835d43ff5be36eca7bf62e66e39fd67b7005e8ef8afd5f6";
-      name = "kmenuedit-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kmenuedit-5.19.5.tar.xz";
+      sha256 = "f4701c74c304d46f5146943aa297300fb38a9c3b1efad39d4fbf3238d49989f6";
+      name = "kmenuedit-5.19.5.tar.xz";
     };
   };
   kscreen = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kscreen-5.18.5.tar.xz";
-      sha256 = "9b6238447a4a38babdff482724ae3d33786b211e8b4224aaadafaad7435f6ba2";
-      name = "kscreen-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kscreen-5.19.5.tar.xz";
+      sha256 = "0d72c687a405358e6aa6b388a648134e8e9236b7ed60e36a31068960d07b56e8";
+      name = "kscreen-5.19.5.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kscreenlocker-5.18.5.tar.xz";
-      sha256 = "b4269cd027e1fee721760a22ca5d738d3d98622fa222fcf9e57d2da77a4e18d2";
-      name = "kscreenlocker-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kscreenlocker-5.19.5.tar.xz";
+      sha256 = "b13b2081971db1347d6a77dec416725995ca20a5b7bf05f21c72a68e15d6a5b9";
+      name = "kscreenlocker-5.19.5.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/ksshaskpass-5.18.5.tar.xz";
-      sha256 = "c483c17d6ce2e3dffd54fc812f97b88c32f5def6e8c5e7a526e23f5e7f208cc5";
-      name = "ksshaskpass-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/ksshaskpass-5.19.5.tar.xz";
+      sha256 = "51c7dbcc434fb993ae756ce6ef8bf7511033617cc3367478382e1490b6505bcc";
+      name = "ksshaskpass-5.19.5.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/ksysguard-5.18.5.tar.xz";
-      sha256 = "4acb352698b612a21a5eccf22042ab46265d50bbf3aa85844bbca762a64c9e2f";
-      name = "ksysguard-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/ksysguard-5.19.5.tar.xz";
+      sha256 = "e1a66dc9750482ada19da5d3e9ec06893f859930f0e8e5a910a5751e9f267c47";
+      name = "ksysguard-5.19.5.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kwallet-pam-5.18.5.tar.xz";
-      sha256 = "bc4fe3dde503645d6233c3932d3cf74a7f5bf7acefb96bd6dbd224c8919d841a";
-      name = "kwallet-pam-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kwallet-pam-5.19.5.tar.xz";
+      sha256 = "788aed97654b82b3512870dbf2b0d0f521503631d094bba07a7eff1125a7916f";
+      name = "kwallet-pam-5.19.5.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kwayland-integration-5.18.5.tar.xz";
-      sha256 = "82d6943d79a9a2a9bce10623adb2c9af396a2dcf258a723bb349aafbde20e6d5";
-      name = "kwayland-integration-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kwayland-integration-5.19.5.tar.xz";
+      sha256 = "6d1bed734cd256604736417846f891abad9bd7c2a45527fc6fc10560322c8a14";
+      name = "kwayland-integration-5.19.5.tar.xz";
+    };
+  };
+  kwayland-server = {
+    version = "5.19.5";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma/5.19.5/kwayland-server-5.19.5.tar.xz";
+      sha256 = "50fd9c9f68fd514dfd1ad05e65c8767afa154a3eed792f335214eee188c8541a";
+      name = "kwayland-server-5.19.5.tar.xz";
     };
   };
   kwin = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kwin-5.18.5.tar.xz";
-      sha256 = "ca39c63fd740432e95490031fd9d5ac003da034582014fa41c2be2b89627ddf8";
-      name = "kwin-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kwin-5.19.5.tar.xz";
+      sha256 = "36afa37b773d31c0bcb8f4e32fa1f06cc33e15ad00e729ba36f120bbe034903b";
+      name = "kwin-5.19.5.tar.xz";
     };
   };
   kwrited = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/kwrited-5.18.5.tar.xz";
-      sha256 = "45ffa31d3d141ce453fb09fd823d7edd8e6c782b353bce22b8c879ad794fd1fe";
-      name = "kwrited-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/kwrited-5.19.5.tar.xz";
+      sha256 = "c934d9c85581db575da0559713f1c0bba0541749ea36a51f9cbce7454c2af4db";
+      name = "kwrited-5.19.5.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/libkscreen-5.18.5.tar.xz";
-      sha256 = "a962319000324200ec1abe3c58b1b8ab71ed4cc7c88a3c7e03a1c8eca86c287c";
-      name = "libkscreen-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/libkscreen-5.19.5.tar.xz";
+      sha256 = "11351cbed924264c6ccd8b95bd7fcaeed3477abb31e962894b0630ef41bdc165";
+      name = "libkscreen-5.19.5.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/libksysguard-5.18.5.tar.xz";
-      sha256 = "d4d7030a2869a546a211844aa158dcef3598386cc035a8655529938ba102440b";
-      name = "libksysguard-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/libksysguard-5.19.5.tar.xz";
+      sha256 = "d8adb311dae1a699a3fd3fbdc9e6cdde037503ca303b70f12d33b985ee80a0cd";
+      name = "libksysguard-5.19.5.tar.xz";
     };
   };
   milou = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/milou-5.18.5.tar.xz";
-      sha256 = "7ec763833c025aa719d1e25f3c5c1c8b6c934a48bf346517e94660e09d8582b2";
-      name = "milou-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/milou-5.19.5.tar.xz";
+      sha256 = "edc6e5c646a98f6f3eada802995c1308c84a5ae7aef467e9d4ce1deaf8a9040e";
+      name = "milou-5.19.5.tar.xz";
     };
   };
   oxygen = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/oxygen-5.18.5.tar.xz";
-      sha256 = "479bdfa80b3f2216075470ab4be1e3159a17620870acf276144b9639134609f8";
-      name = "oxygen-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/oxygen-5.19.5.tar.xz";
+      sha256 = "4217d4da0f851d6e3fc25cdaa3f3123611e5e89d676ba33fa1c0fd02cddb0c35";
+      name = "oxygen-5.19.5.tar.xz";
     };
   };
   plasma-browser-integration = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-browser-integration-5.18.5.tar.xz";
-      sha256 = "3a087a836657b5304e2e0ef9ebefb84ce1f896bfbfc5dbf948d4b3eb7b709383";
-      name = "plasma-browser-integration-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-browser-integration-5.19.5.tar.xz";
+      sha256 = "29cb30b86f9f25857ba7e67bcb892e9a1dabfd4eec1767b0c4ca0a1400d61dcf";
+      name = "plasma-browser-integration-5.19.5.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-desktop-5.18.5.tar.xz";
-      sha256 = "aeb106018fd90da79c8a3c444d880282846a842029b1223e7830db2d4b42df9f";
-      name = "plasma-desktop-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-desktop-5.19.5.tar.xz";
+      sha256 = "c63e1c81edc438656f9159e235be31e3b1b11a3f8ecbe5b97b21fcc91eb71a70";
+      name = "plasma-desktop-5.19.5.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-integration-5.18.5.tar.xz";
-      sha256 = "c99b987efb2ab965cc2a55793ef94c7ccb2152ca5d75956a40ec99261ad4b870";
-      name = "plasma-integration-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-integration-5.19.5.tar.xz";
+      sha256 = "f7fdd854e78e366a310116ef190bd7bed42df15a059d8ad75b763cbcebfb6389";
+      name = "plasma-integration-5.19.5.tar.xz";
     };
   };
   plasma-nano = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-nano-5.18.5.tar.xz";
-      sha256 = "d2f29b05894573517cb3336088e102d3604b1c2735e9bbe605119f559f0c6341";
-      name = "plasma-nano-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-nano-5.19.5.tar.xz";
+      sha256 = "71a2b5ae19cb2468ae215b8321894f3c9702774143be2b4de93c818414090e61";
+      name = "plasma-nano-5.19.5.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-nm-5.18.5.tar.xz";
-      sha256 = "1e091d01993708220f89501bb8a289279bf527d0593fd9e4b9223e6e8caf9aaa";
-      name = "plasma-nm-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-nm-5.19.5.tar.xz";
+      sha256 = "433fe0329bacaede666d4d0962c5dedf6b4449f7c7ad08870ae9554ad64f2bb9";
+      name = "plasma-nm-5.19.5.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-pa-5.18.5.tar.xz";
-      sha256 = "28765c07f584e7688a85c9761155e606440936de2ebb678917dac2c85f5d0209";
-      name = "plasma-pa-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-pa-5.19.5.tar.xz";
+      sha256 = "b00eb9bc7c7bd35f3ae78f58522cea8d1dd86b9b20585dff83fb93ef64af91d8";
+      name = "plasma-pa-5.19.5.tar.xz";
     };
   };
   plasma-phone-components = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-phone-components-5.18.5.tar.xz";
-      sha256 = "d0c091367ae07c71457a0c03d1023ac48d8665385a6a1b0e32f6ae7ad1fa7070";
-      name = "plasma-phone-components-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-phone-components-5.19.5.tar.xz";
+      sha256 = "408a242f502ad5a9cf5eaaeb5b306353b5aae28a69fee9bcc047d5268ee54a02";
+      name = "plasma-phone-components-5.19.5.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-sdk-5.18.5.tar.xz";
-      sha256 = "5f399231d16d62f9880f953891477f74e0b1f7b931448a4b0fbb97f37acd2fe5";
-      name = "plasma-sdk-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-sdk-5.19.5.tar.xz";
+      sha256 = "8c434adbb6c68ce42581152269d7e0717f16362017290a96f2c5f1922930da20";
+      name = "plasma-sdk-5.19.5.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-tests-5.18.5.tar.xz";
-      sha256 = "3251ea30cb3c62de9bba2deb152370ea9e0e56b7506efd655888f1892c18413a";
-      name = "plasma-tests-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-tests-5.19.5.tar.xz";
+      sha256 = "31dffd8f449c02165cdeb99d16dc562d913de1a3e693b445a22649ff712390fb";
+      name = "plasma-tests-5.19.5.tar.xz";
     };
   };
   plasma-thunderbolt = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-thunderbolt-5.18.5.tar.xz";
-      sha256 = "c61dc7abe350ead15ca4d6111606aaf19773c38a0307ae8a7d8a7c60b82be5d1";
-      name = "plasma-thunderbolt-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-thunderbolt-5.19.5.tar.xz";
+      sha256 = "959b4eb43b58d46895c94c94c082b28277ca197cdcaa25880800502ace6d0295";
+      name = "plasma-thunderbolt-5.19.5.tar.xz";
     };
   };
   plasma-vault = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-vault-5.18.5.tar.xz";
-      sha256 = "cae2713823e8c59c7a2beb96d362a15024fe260cf10419ba037e8a798f3c1b41";
-      name = "plasma-vault-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-vault-5.19.5.tar.xz";
+      sha256 = "7f81321f32f3784683fa7d9511dca9bfba70a7a9181a33e832d864c639b05204";
+      name = "plasma-vault-5.19.5.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-workspace-5.18.5.tar.xz";
-      sha256 = "14e82033be745f4db46a70d319e2c86012295ea31056092bc974004189b92354";
-      name = "plasma-workspace-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-workspace-5.19.5.tar.xz";
+      sha256 = "490329e08e63016edd696a9132bf80b76ef51dacf53308b865d2e27b67ce8127";
+      name = "plasma-workspace-5.19.5.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plasma-workspace-wallpapers-5.18.5.tar.xz";
-      sha256 = "f8da3bd7b97a9944639ed0860303b8a7a008905246313e1983367810a3a84d6d";
-      name = "plasma-workspace-wallpapers-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plasma-workspace-wallpapers-5.19.5.tar.xz";
+      sha256 = "4aeec36035356cca71c0966e9d7dbc7d9fca6be4c27abd990f0fa954a91374f9";
+      name = "plasma-workspace-wallpapers-5.19.5.tar.xz";
     };
   };
   plymouth-kcm = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/plymouth-kcm-5.18.5.tar.xz";
-      sha256 = "e8f75dd8c8a45cd706a0a6e62826d1eb4fff9c3912cbaadba8c06e9de915d2e3";
-      name = "plymouth-kcm-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/plymouth-kcm-5.19.5.tar.xz";
+      sha256 = "ca9b6faa00e451a7fa3d689e540903c9877fd1194fa6964c1fc127d887ddff76";
+      name = "plymouth-kcm-5.19.5.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.18.5";
+    version = "1-5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/polkit-kde-agent-1-5.18.5.tar.xz";
-      sha256 = "5e1733cb51c826c6215da4fbbc9c9568240275cf86b9922cd7a643d192a75a91";
-      name = "polkit-kde-agent-1-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/polkit-kde-agent-1-5.19.5.tar.xz";
+      sha256 = "076129f450a82780f354d7ec18300094db3f7233cb52f4e57298b973750adb30";
+      name = "polkit-kde-agent-1-5.19.5.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/powerdevil-5.18.5.tar.xz";
-      sha256 = "e000185ee61bff81fe28896a7d6353746c82c7f4d2626792fd22d34b5f49f548";
-      name = "powerdevil-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/powerdevil-5.19.5.tar.xz";
+      sha256 = "d15f013c50928097f6b719aca46ec2a93a997dcbb7584bcb09f18015cca8ac1a";
+      name = "powerdevil-5.19.5.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/sddm-kcm-5.18.5.tar.xz";
-      sha256 = "cc99c185d701acc7442f33ef17b2396894dcf164f3f583c25105ac3f2528c33b";
-      name = "sddm-kcm-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/sddm-kcm-5.19.5.tar.xz";
+      sha256 = "3ba2c6821fc847fca2cb8123748bf05cdd9c45557a0ecab5dc43a37a5ebde738";
+      name = "sddm-kcm-5.19.5.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/systemsettings-5.18.5.tar.xz";
-      sha256 = "cde5b714261aaa54f937887657c3d3e74814c5447448b989159ee6035be4783b";
-      name = "systemsettings-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/systemsettings-5.19.5.tar.xz";
+      sha256 = "ba8fdc2b8c861e7271bad7f6c5cdb92b0c2eee08ef81b86e28bba064259e2ff9";
+      name = "systemsettings-5.19.5.tar.xz";
     };
   };
   user-manager = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/user-manager-5.18.5.tar.xz";
-      sha256 = "741d293947fa3fb3966f047bab121597bf1071be010684daff4a91626cf54484";
-      name = "user-manager-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/user-manager-5.19.5.tar.xz";
+      sha256 = "39260b2575f6287c8086984417bba18682ca2ba3840d93f95667d0d2faa461cc";
+      name = "user-manager-5.19.5.tar.xz";
     };
   };
   xdg-desktop-portal-kde = {
-    version = "5.18.5";
+    version = "5.19.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.18.5/xdg-desktop-portal-kde-5.18.5.tar.xz";
-      sha256 = "807452708a0318b8e21b43f9ec7e016d1de51cac5d8714d70c577bb6f3976224";
-      name = "xdg-desktop-portal-kde-5.18.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.19.5/xdg-desktop-portal-kde-5.19.5.tar.xz";
+      sha256 = "055e7c379dc3e0edb8d87515468b8d16a70bd99765f269a211ce655eb3e1ea45";
+      name = "xdg-desktop-portal-kde-5.19.5.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to a more recent version of the plasma desktop. #94103. This update looks to be more straightforward than the update to 5.18.5 was, though it's impossible to say for sure until it's had more extensive testing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
