### PR TITLE
iwd: 1.8 -> 1.9

### DIFF
--- a/pkgs/os-specific/linux/ell/default.nix
+++ b/pkgs/os-specific/linux/ell/default.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "ell";
-  version = "0.32";
+  version = "0.33";
 
   outputs = [ "out" "dev" ];
 
   src = fetchgit {
      url = "https://git.kernel.org/pub/scm/libs/${pname}/${pname}.git";
      rev = version;
-     sha256 = "07hm9lrhhb5y53l13yja2kr3xmjgs0azk3x7w2si99cplwkgxak2";
+     sha256 = "0li788l57m2ic1i33fag4nnblqghbwqjyqkgppi8s2sifcvswfbw";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -13,12 +13,12 @@
 
 stdenv.mkDerivation rec {
   pname = "iwd";
-  version = "1.8";
+  version = "1.9";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/network/wireless/iwd.git";
     rev = version;
-    sha256 = "0ds8nhbnkhxzhnnsi7vj3y2v8wq0nxqbmidhiac7mpxgjkc684gf";
+    sha256 = "193wa13i2prfz1zr7nvwbgrxgacms57zj1n7x28yy5hmm3nnwbrd";
   };
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION

###### Motivation for this change

ChangeLog: https://git.kernel.org/pub/scm/network/wireless/iwd.git/tree/ChangeLog?h=1.9

__Note__: before merging we have to fix the build error of `ell` on `aarch64-linux`:

```
ell> PASS: unit/test-endian
ell> PASS: unit/test-time
ell> PASS: unit/test-plugin
ell> PASS: unit/test-base64
ell> PASS: unit/test-random
ell> PASS: unit/test-net
ell> PASS: unit/test-hwdb
ell> PASS: unit/test-queue
ell> PASS: unit/test-dbus-util
ell> PASS: unit/test-io
ell> PASS: unit/test-netlink
ell> PASS: unit/test-util
ell> PASS: unit/test-utf8
ell> PASS: unit/test-ecdh
ell> PASS: unit/test-ecc
ell> PASS: unit/test-checksum
ell> PASS: unit/test-path
ell> PASS: unit/test-uuid
ell> PASS: unit/test-dbus-watch
ell> PASS: unit/test-ringbuf
ell> PASS: unit/test-dhcp6
ell> ./build-aux/test-driver: line 107: 20626 Aborted                 (core dumped) "$@" > $log_file 2>&1
ell> FAIL: unit/test-cipher
ell> PASS: unit/test-rtnl
ell> PASS: unit/test-string
ell> PASS: unit/test-gvariant-message
ell> PASS: unit/test-genl-msg
ell> PASS: unit/test-uintset
ell> PASS: unit/test-hashmap
ell> PASS: unit/test-settings
ell> CCLD     unit/test-dbus-properties
ell> PASS: unit/test-dir-watch
ell> PASS: unit/test-dhcp
ell> PASS: unit/test-dbus
ell> PASS: unit/test-dbus-message-fds
ell> CCLD     unit/test-dbus-message
ell> CCLD     unit/test-gvariant-util
ell> PASS: unit/test-dbus-properties
ell> PASS: unit/test-dbus-message
ell> PASS: unit/test-gvariant-util
ell> PASS: unit/test-dbus-service
ell> PASS: unit/test-main
ell> PASS: unit/test-pbkdf2
ell> ================================
ell> ell 0.33: ./test-suite.log
ell> ================================
ell> # TOTAL: 41
ell> # PASS:  40
ell> # SKIP:  0
ell> # XFAIL: 0
ell> # FAIL:  1
ell> # XPASS: 0
ell> # ERROR: 0
ell> .. contents:: :depth: 2
ell> FAIL: unit/test-cipher
ell> ======================
ell> test-cipher: unit/test-cipher.c:92: test_aes_ctr: Assertion `l_cipher_encrypt(cipher, buf, buf, FIXED_LEN)' failed.
ell> FAIL unit/test-cipher (exit status: 134)
ell> ============================================================================
ell> Testsuite summary for ell 0.33
ell> ============================================================================
ell> # TOTAL: 41
ell> # PASS:  40
ell> # SKIP:  0
ell> # XFAIL: 0
ell> # FAIL:  1
ell> # XPASS: 0
ell> # ERROR: 0
ell> ============================================================================
ell> See ./test-suite.log
ell> ============================================================================
ell> make[3]: *** [Makefile:2083: test-suite.log] Error 1
ell> make[2]: *** [Makefile:2191: check-TESTS] Error 2
ell> make[1]: *** [Makefile:2704: check-am] Error 2
ell> make: *** [Makefile:2706: check] Error 2
error: --- Error --- nix-daemon
builder for '/nix/store/hz69mdv94c9znx2hlb0s7r8c0d0q4raf-ell-0.33.drv' failed with exit code 2; last 10 log lines:
  # FAIL:  1
  # XPASS: 0
  # ERROR: 0
  ============================================================================
  See ./test-suite.log
  ============================================================================
  make[3]: *** [Makefile:2083: test-suite.log] Error 1
  make[2]: *** [Makefile:2191: check-TESTS] Error 2
  make[1]: *** [Makefile:2704: check-am] Error 2
  make: *** [Makefile:2706: check] Error 2
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
error: --- Error --- nix-daemon
1 dependencies of derivation '/nix/store/a1ivyqk0974jxwndwp9fnxxlkzrbnyi2-iwd-1.9.drv' failed to build

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
