### PR TITLE
 dnscontrol: 3.2.0 -> 3.3.0, add me as maintainer

### DIFF
--- a/pkgs/applications/networking/dnscontrol/default.nix
+++ b/pkgs/applications/networking/dnscontrol/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildGoModule }:
+{ lib, fetchFromGitHub, buildGoModule }:
 
 buildGoModule rec {
   pname = "dnscontrol";
@@ -13,7 +13,9 @@ buildGoModule rec {
 
   vendorSha256 = "16cc6hb2iwh1zwrrnb7s4dqxqhaj67gq3gfr5xvh5kqafd685hvx";
 
-  meta = with stdenv.lib; {
+  subPackages = [ "." ];
+
+  meta = with lib; {
     description = "Synchronize your DNS to multiple providers from a simple DSL";
     homepage = "https://stackexchange.github.io/dnscontrol/";
     license = licenses.mit;

--- a/pkgs/applications/networking/dnscontrol/default.nix
+++ b/pkgs/applications/networking/dnscontrol/default.nix
@@ -1,19 +1,17 @@
-{ stdenv, fetchFromGitHub, buildGoPackage}:
+{ stdenv, fetchFromGitHub, buildGoModule }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "dnscontrol";
-  version = "3.2.0";
-
-  goPackagePath = "github.com/StackExchange/dnscontrol";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "StackExchange";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1lrn1whmx9zkyvs505zxrsmnr5s6kpj3kjkr6rblfwdlnadkgfj7";
+    sha256 = "0lldkx906imwm8mxcfafpanbgaqh0sdm3zdkwkn7j0nmngyncx9p";
   };
 
-  subPackages = [ "." ];
+  vendorSha256 = "16cc6hb2iwh1zwrrnb7s4dqxqhaj67gq3gfr5xvh5kqafd685hvx";
 
   meta = with stdenv.lib; {
     description = "Synchronize your DNS to multiple providers from a simple DSL";

--- a/pkgs/applications/networking/dnscontrol/default.nix
+++ b/pkgs/applications/networking/dnscontrol/default.nix
@@ -19,6 +19,6 @@ buildGoModule rec {
     description = "Synchronize your DNS to multiple providers from a simple DSL";
     homepage = "https://stackexchange.github.io/dnscontrol/";
     license = licenses.mit;
-    maintainers = with maintainers; [ mmahut ];
+    maintainers = with maintainers; [ mmahut SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I need a feature which is only in 3.3.0.

The ``deps.nix`` is generated using https://github.com/nix-community/vgo2nix/pull/42 because the master version fails with newer go.mods and the vendor dir got removed between 3.2.0 and 3.3.0. This should help updating other go modules in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
