### PR TITLE
vdr-vaapidevice: 0.7.0 -> 20190526

### DIFF
--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -49,7 +49,8 @@ in {
 
   vaapidevice = stdenv.mkDerivation {
 
-    name = "vdr-vaapidevice-0.7.0";
+    pname = "vdr-vaapidevice";
+    version = "20190525";
 
     buildInputs = [
       vdr libxcb xcbutilwm ffmpeg_3
@@ -61,14 +62,14 @@ in {
     makeFlags = [ "DESTDIR=$(out)" ];
 
     postPatch = ''
-      substituteInPlace softhddev.c --replace /usr/bin/X ${xorgserver}/bin/X
+      substituteInPlace vaapidev.c --replace /usr/bin/X ${xorgserver}/bin/X
     '';
 
     src = fetchFromGitHub {
       owner = "pesintta";
       repo = "vdr-plugin-vaapidevice";
-      sha256 = "072y61fpkh3i2dragg0nsd4g3malgwxkwpdrb1ykdljyzf52s5hs";
-      rev = "c99afc23a53e6d91f9afaa99af59b30e68e626a8";
+      sha256 = "1gwjp15kjki9x5742fhaqk3yc2bbma74yp2vpn6wk6kj46nbnwp6";
+      rev = "d19657bae399e79df107e316ca40922d21393f80";
     };
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update plugin vdr-vaapidevice to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
