### PR TITLE
virtualbox: 6.1.10 -> 6.1.14

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -23,7 +23,7 @@ let
   buildType = "release";
   # Use maintainers/scripts/update.nix to update the version and all related hashes or
   # change the hashes in extpack.nix and guest-additions/default.nix as well manually.
-  version = "6.1.10";
+  version = "6.1.14";
 
   iasl' = iasl.overrideAttrs (old: rec {
     inherit (old) pname;
@@ -40,7 +40,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
-    sha256 = "37d8b30c0be82a50c858f3fc70cde967882239b6212bb32e138d3615b423c477";
+    sha256 = "91fa05bcfce36316ca93e3927c9550ea66286fff4c5bec900b753fca278ce1a0";
   };
 
   outputs = [ "out" "modsrc" ];
@@ -120,6 +120,8 @@ in stdenv.mkDerivation {
     NIX_CFLAGS_COMPILE=$(echo "$NIX_CFLAGS_COMPILE" | sed 's,\-isystem ${lib.getDev stdenv.cc.libc}/include,,g')
 
     cat >> LocalConfig.kmk <<LOCAL_CONFIG
+    VBOX_WITH_VIRTIO               :=
+
     VBOX_WITH_TESTCASES            :=
     VBOX_WITH_TESTSUITE            :=
     VBOX_WITH_VALIDATIONKIT        :=

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -24,6 +24,7 @@ let
   # Use maintainers/scripts/update.nix to update the version and all related hashes or
   # change the hashes in extpack.nix and guest-additions/default.nix as well manually.
   version = "6.1.14";
+  tarballVersion = "${version}a";
 
   iasl' = iasl.overrideAttrs (old: rec {
     inherit (old) pname;
@@ -39,8 +40,8 @@ in stdenv.mkDerivation {
   inherit version;
 
   src = fetchurl {
-    url = "https://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
-    sha256 = "91fa05bcfce36316ca93e3927c9550ea66286fff4c5bec900b753fca278ce1a0";
+    url = "https://download.virtualbox.org/virtualbox/${version}/VirtualBox-${tarballVersion}.tar.bz2";
+    sha256 = "16f3cb83ab3c4dacf2a9d3cc638cbd18db23767828bba6b8ba1c1b57abeb6aef";
   };
 
   outputs = [ "out" "modsrc" ];
@@ -120,8 +121,6 @@ in stdenv.mkDerivation {
     NIX_CFLAGS_COMPILE=$(echo "$NIX_CFLAGS_COMPILE" | sed 's,\-isystem ${lib.getDev stdenv.cc.libc}/include,,g')
 
     cat >> LocalConfig.kmk <<LOCAL_CONFIG
-    VBOX_WITH_VIRTIO               :=
-
     VBOX_WITH_TESTCASES            :=
     VBOX_WITH_TESTSUITE            :=
     VBOX_WITH_VALIDATIONKIT        :=

--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -12,7 +12,7 @@ fetchurl rec {
     # Manually sha256sum the extensionPack file, must be hex!
     # Thus do not use `nix-prefetch-url` but instead plain old `sha256sum`.
     # Checksums can also be found at https://www.virtualbox.org/download/hashes/${version}/SHA256SUMS
-    let value = "03067f27f4da07c5d0fdafc56d27e3ea23a60682b333b2a1010fb74ef9a40c28";
+    let value = "b224e796e886b19bce69f0aaedf6ca82bad0ca29c61fb0ed86166efb84356942";
     in assert (builtins.stringLength value) == 64; value;
 
   meta = {

--- a/pkgs/applications/virtualization/virtualbox/extra_symbols.patch
+++ b/pkgs/applications/virtualization/virtualbox/extra_symbols.patch
@@ -1,21 +1,25 @@
 diff --git a/src/VBox/HostDrivers/linux/Makefile b/src/VBox/HostDrivers/linux/Makefile
-index 6e44129b..e68ce128 100644
+index 8ba33952..3b8abe60 100644
 --- a/src/VBox/HostDrivers/linux/Makefile
 +++ b/src/VBox/HostDrivers/linux/Makefile
-@@ -95,13 +95,13 @@ vboxpci: vboxdrv
- install:
- 	@$(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) -C vboxdrv install
- 	@if [ -d vboxnetflt ]; then \
+@@ -99,17 +99,17 @@ install-vboxdrv:
+ 
+ install-vboxnetflt:
+ 	+@if [ -d vboxnetflt ]; then \
 -	    $(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) -C vboxnetflt install; \
-+		$(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) KBUILD_EXTRA_SYMBOLS=$(abspath vboxnetflt/Module.symvers) -C vboxnetflt install; \
++	    $(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) KBUILD_EXTRA_SYMBOLS=$(abspath vboxnetflt/Module.symvers) -C vboxnetflt install; \
  	fi
- 	@if [ -d vboxnetadp ]; then \
+ 
+ install-vboxnetadp:
+ 	+@if [ -d vboxnetadp ]; then \
 -	    $(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) -C vboxnetadp install; \
 +	    $(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) KBUILD_EXTRA_SYMBOLS=$(abspath vboxnetadp/Module.symvers) -C vboxnetadp install; \
  	fi
- 	@if [ -d vboxpci ]; then \
+ 
+ install-vboxpci:
+ 	+@if [ -d vboxpci ]; then \
 -	    $(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) -C vboxpci install; \
 +	    $(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) KBUILD_EXTRA_SYMBOLS=$(abspath vboxpci/Module.symvers) -C vboxpci install; \
  	fi
  
- else
+ install: install-vboxdrv install-vboxnetflt install-vboxnetadp install-vboxpci

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "62a0c6715bee164817a6f58858dec1d60f01fd0ae00a377a75bbf885ddbd0a61";
+    sha256 = "dd9f176abb89043c01cea7ec7e20130e76db71bd83beafeb2dc5858d4c9c86cd";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";


### PR DESCRIPTION
###### Motivation for this change

6.1.14 is the latest release of VirtualBox. And it contains some necessary changes to be built on Linux 5.8 kernel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
