### PR TITLE
pydrive2: init at 1.10.0

### DIFF
--- a/pkgs/development/python-modules/pydrive2/default.nix
+++ b/pkgs/development/python-modules/pydrive2/default.nix
@@ -1,0 +1,46 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, google-api-python-client
+, oauth2client
+, pyopenssl
+, pyyaml
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "pydrive2";
+  version = "1.10.0";
+
+  src = fetchPypi {
+    pname = "PyDrive2";
+    inherit version;
+    sha256 = "1av3fkbq8xvrvshy8yiq6ysllwll1mfcaspv4aww1xhyzys1kggp";
+  };
+
+  propagatedBuildInputs = [
+    google-api-python-client
+    oauth2client
+    pyopenssl
+    pyyaml
+    six
+  ];
+
+  pythonImportsCheck = [
+    "googleapiclient"
+    "oauth2client"
+    "OpenSSL"
+    "yaml"
+    "six"
+  ];
+
+  # the tests require GCP credentials
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Google Drive API Python wrapper library";
+    homepage = "https://github.com/iterative/PyDrive2";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ stephenwithph ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6671,6 +6671,8 @@ in {
 
   pydrive = callPackage ../development/python-modules/pydrive { };
 
+  pydrive2 = callPackage ../development/python-modules/pydrive2 { };
+
   pydroid-ipcam = callPackage ../development/python-modules/pydroid-ipcam  { };
 
   pydsdl = callPackage ../development/python-modules/pydsdl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/97268#issuecomment-687736016

###### Things done
~Still a WIP... still wrapping my head around Python and nix.~

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
