### PR TITLE
mypaint: fix crash without hicolor-icon-theme

### DIFF
--- a/pkgs/applications/graphics/mypaint/default.nix
+++ b/pkgs/applications/graphics/mypaint/default.nix
@@ -8,6 +8,7 @@
 , librsvg
 , gobject-introspection
 , libmypaint
+, hicolor-icon-theme
 , mypaint-brushes
 , gdk-pixbuf
 , pkgconfig
@@ -36,7 +37,9 @@ in buildPythonApplication rec {
     swig
     wrapGAppsHook
     gobject-introspection # for setup hook
+    hicolor-icon-theme # fór setup hook
   ];
+
   buildInputs = [
     gtk3
     gdk-pixbuf
@@ -48,6 +51,9 @@ in buildPythonApplication rec {
     librsvg
     pycairo
     pygobject3
+
+    # Mypaint checks for a presence of this theme scaffold and crashes when not present.
+    hicolor-icon-theme
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Mypaint should probably run without having a specific icon theme installed (GNOME's Adwaita, KDE's whatever, or something else should be fine).
But it does not seem to be the case and it looks like it is checking for a presence of `hicolor-icon-theme`:

* `env XDG_DATA_DIRS= $(nix-build -A mypaint --no-out-link)/bin/mypaint` was broken
* `env XDG_DATA_DIRS=$(nix-build -A hicolor-icon-theme --no-out-link)/share $(nix-build -A mypaint --no-out-link)/bin/mypaint` worked

Let's add it to the closure unconditionally, since it is just an empty directory tree and weights almost nothing.

Noticed by @sikmir in https://github.com/NixOS/nixpkgs/pull/54677#issuecomment-595188605

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
