### PR TITLE
ott: 0.30 → 0.31

### DIFF
--- a/pkgs/applications/science/logic/ott/default.nix
+++ b/pkgs/applications/science/logic/ott/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, ocaml }:
+{ stdenv, fetchFromGitHub, pkgconfig, ocaml, opaline }:
 
 stdenv.mkDerivation rec {
   pname = "ott";
@@ -11,17 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "0l81126i2qkz11fs5yrjdgymnqgjcs5avb7f951h61yh1s68jpnn";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig opaline ];
   buildInputs = [ ocaml ];
 
-  installPhase = ''
-    mkdir -p $out/bin
-    cp src/ott.opt $out/bin
-    ln -s $out/bin/ott.opt $out/bin/ott
+  installTargets = "ott.install";
 
-    mkdir -p $out/share/emacs/site-lisp
-    cp emacs/ott-mode.el $out/share/emacs/site-lisp
-    '';
+  postInstall = "opaline -prefix $out";
 
   meta = {
     description = "Ott: tool for the working semanticist";


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/ott-lang/ott/releases/tag/0.31

Install everything, including the support library for Menhir.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
