### PR TITLE
skk-dicts-unstable: enable to build on mac

### DIFF
--- a/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
+++ b/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, skktools }:
+{ stdenv, fetchurl, libiconv, skktools }:
 
 let
   # kana to kanji
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
   pname = "skk-dicts-unstable";
   version = "2017-10-26";
   srcs = [ small medium large edict assoc ];
-  nativeBuildInputs = [ skktools ];
+  nativeBuildInputs = [ skktools ] ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
   phases = [ "installPhase" ];
   installPhase = ''
@@ -68,6 +68,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/skk-dev/dict";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [ yuriaisaka ];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

To enable to be built on macOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~ no bins
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
