### PR TITLE
gnome-2.gnome_mime_data: Move intltool to nativeBuildInputs

### DIFF
--- a/pkgs/desktops/gnome-2/platform/gnome-mime-data/default.nix
+++ b/pkgs/desktops/gnome-2/platform/gnome-mime-data/default.nix
@@ -6,5 +6,5 @@ stdenv.mkDerivation {
     url = "mirror://gnome/sources/gnome-mime-data/2.18/gnome-mime-data-2.18.0.tar.bz2";
     sha256 = "1mvg8glb2a40yilmyabmb7fkbzlqd3i3d31kbkabqnq86xdnn69p";
   };
-  buildInputs = [ intltool ];
+  nativeBuildInputs = [ intltool ];
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes issues with cross-compiling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
