### PR TITLE
[20.03] palemoon: Add libpulseaudio to wrapper

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -11,7 +11,7 @@
 
 let
 
-  libPath = lib.makeLibraryPath [ ffmpeg ];
+  libPath = lib.makeLibraryPath [ ffmpeg libpulseaudio ];
   gtkVersion = if withGTK3 then "3" else "2";
 
 in stdenv.mkDerivation rec {


### PR DESCRIPTION
Backport of #97293

###### Motivation for this change
Tl;dr, `palemoon` can't find `libpulse.so` at runtime, magically causing multiple problems down the line. `libpulseaudio` isn't "registered as an ELF dependency" (excuse my lack of technical specifics), it's dynamically loaded akin to the `ffmpeg` libs.

<details>
  <summary>Before-After screenshots from pavucontrol:</summary>

![Bildschirmfoto_2020-09-05_13-41-47](https://user-images.githubusercontent.com/23431373/92323891-9105c580-f03c-11ea-9b7a-6824e84b9172.png)
![Bildschirmfoto_2020-09-05_13-43-07](https://user-images.githubusercontent.com/23431373/92323892-9400b600-f03c-11ea-9bfa-a0b2a561240c.png)
</details>

To comply with upstream's requirements, fix the missing dependency by adding `libpulseaudio` to the wrapper.

###### Things done

Added `libpulseaudio` to the wrapper.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
