### PR TITLE
cinnamon.blueberry: init at 1.3.9

### DIFF
--- a/pkgs/desktops/cinnamon/blueberry/default.nix
+++ b/pkgs/desktops/cinnamon/blueberry/default.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, wrapGAppsHook
+, gettext
+, file
+, python3
+, pavucontrol
+, fetchFromGitHub
+, utillinux
+, gobject-introspection
+, gnome3
+, glib
+, gtk3
+, xapps
+}:
+
+stdenv.mkDerivation rec {
+  pname = "blueberry";
+  version = "1.3.9";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "0llvz1h2dmvhvwkkvl0q4ggi1nmdbllw34ppnravs5lybqkicyw9";
+  };
+
+  buildInputs = [
+    utillinux # rfkill
+    glib
+    gtk3
+    pavucontrol
+    (python3.withPackages(ps: with ps; [ pygobject3 setproctitle pydbus ]))
+    gnome3.gnome-bluetooth
+    xapps
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    gettext
+    gobject-introspection
+  ];
+
+  postPatch = ''
+    find . -type f -exec sed -i \
+      -e s,/usr/lib/blueberry,$out/lib/blueberry,g \
+      -e s,/usr/bin/pavucontrol,${pavucontrol}/bin/pavucontrol,g \
+      -e s,/usr/share/locale,$out/share/locale,g \
+      -e s,/usr/sbin/rfkill,${utillinux}/bin/rfkill,g \
+      -e s,/usr/bin/rfkill,${utillinux}/bin/rfkill,g \
+      {} +
+  '';
+
+  installPhase = ''
+    mv usr $out
+    mv etc $out/
+  '';
+}

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -12,6 +12,7 @@ lib.makeScope pkgs.newScope (self: with self; {
     installPhase = "mv svg $out/share/iso-flags-svg";
   });
 
+  blueberry = callPackage ./blueberry { };
   cinnamon-common = callPackage ./cinnamon-common { };
   cinnamon-control-center = callPackage ./cinnamon-control-center { };
   cinnamon-desktop = callPackage ./cinnamon-desktop { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add blueberry since it's a default cinnamon package

Current blocker: `(blueberry.py:9081): GLib-GIO-ERROR **: 14:51:53.737: Settings schema 'org.blueberry' is not installed`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
