### PR TITLE
Revert "nixos/raspberrypi-builder: fix cross using buildPackages"

### DIFF
--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi-builder.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi-builder.nix
@@ -3,8 +3,8 @@
 pkgs.substituteAll {
   src = ./raspberrypi-builder.sh;
   isExecutable = true;
-  inherit (pkgs.buildPackages) bash;
-  path = with pkgs.buildPackages; [coreutils gnused gnugrep];
+  inherit (pkgs) bash;
+  path = [pkgs.coreutils pkgs.gnused pkgs.gnugrep];
   firmware = pkgs.raspberrypifw;
   inherit configTxt;
 }


### PR DESCRIPTION
###### Motivation for this change

The reverted commit enforces buildPackages in the builder but neglects the fact that the builder is intended to run on the target system.  Because of that, the builder will fail when remotely building a  configuration eg. with nixops or nix-copy-closure.
