### PR TITLE
codimd: build with nodejs-12_x instead of nodejs-10_x

### DIFF
--- a/pkgs/servers/web-apps/codimd/default.nix
+++ b/pkgs/servers/web-apps/codimd/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchpatch, makeWrapper
-, which, nodejs, mkYarnPackage, python2 }:
+, which, nodejs, mkYarnPackage, python2, nixosTests }:
 
 mkYarnPackage rec {
   name = "codimd";
@@ -62,6 +62,8 @@ mkYarnPackage rec {
 
     runHook postDist
   '';
+
+  passthru.tests = { inherit (nixosTests) codimd; };
 
   meta = with stdenv.lib; {
     description = "Realtime collaborative markdown notes on all platforms";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2708,7 +2708,7 @@ in
   cmt = callPackage ../applications/audio/cmt {};
 
   codimd = callPackage ../servers/web-apps/codimd {
-    nodejs = nodejs-10_x;
+    nodejs = nodejs-12_x;
   };
 
   colord = callPackage ../tools/misc/colord { };


### PR DESCRIPTION
###### Motivation for this change
#97377

###### Things done
The codimd test is now also exposed via passthru.tests

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

fixes #97377