### PR TITLE
Add an "addPackages" utility to python buildEnv

### DIFF
--- a/pkgs/development/interpreters/python/with-packages.nix
+++ b/pkgs/development/interpreters/python/with-packages.nix
@@ -1,3 +1,9 @@
 { buildEnv, pythonPackages }:
 
-f: let packages = f pythonPackages; in buildEnv.override { extraLibs = packages; }
+f: let
+  buildEnv' = extraLibs: let
+    env = buildEnv.override { inherit extraLibs; };
+    addPackages = g: buildEnv' (extraLibs ++ (g pythonPackages));
+    in env.overrideAttrs (self:
+      { passthru = self.passthru // { inherit addPackages; };});
+in buildEnv' (f pythonPackages)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This change adds the ability to add packages to an existing python env. That is, if `s1` and `s2` are some functions that select python packages, and `py1 = python.withPackages s1` is a python environment, this change allows `py2 = py1.addPackages s2`. The resulting environment is the same as `python.withPackages s1-and-s2`, where `s1-and-s2` is the function that selects the packages from `s1` and `s2`.

This feature would help provide more modular python environments. I'm developing a nix lib for modular and portable shell environments, [env-th](https://github.com/trevorcook/env-th). A change such as the one proposed here would allow multiple such shell environments to be merged together. 

###### Things done

I've tested this in the nix repl. Below shows a session where I defined a python environment with `numpy` and `pyzmq` in two ways. The first way, `py2a`, uses a `withPackages`. The second way, `py2b`, uses the new utility. I show in the output below that they return the same derivation. 

```
trevorcook:~/nixpkgs$ nix repl ./default.nix
Welcome to Nix version 2.3.2. Type :? for help.

Loading 'default.nix'...
Added 12433 variables.
nix-repl> s1 = pkgs : [pkgs.numpy]

nix-repl> s2 = pkgs : [pkgs.pyzmq]

nix-repl> s1-and-s2 = pkgs: [pkgs.numpy pkgs.pyzmq]

nix-repl> py1 = python37.withPackages s1

nix-repl> py2a = python37.withPackages s1-and-s2

nix-repl> py2a
«derivation /nix/store/fpn8lnk8mqx966q6lhzf1a1ry1fgp3qf-python3-3.7.9-env.drv»

nix-repl> py2b = py1.addPackages s2

nix-repl> py2b
«derivation /nix/store/fpn8lnk8mqx966q6lhzf1a1ry1fgp3qf-python3-3.7.9-env.drv»

nix-repl> py2a == py2b
true

nix-repl> :b py2b

this derivation produced the following outputs:
  out -> /nix/store/4qcf02ycgxzlawb2ms7mgqv5szc5mz0v-python3-3.7.9-env
```

This is a new feature, so there shouldn't be a problem with breaking existing packages. However, it is a change to a very significant feature, so I do expect a lot of scrutiny. For one, there is already a shortcoming in my approach in that it will only
work with environments made with `withPackages`. Changing the `buildEnv` attribute would need to be targeted otherwise and I haven't found a clean way to do that yet. 


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
