### PR TITLE
keysmith: replace hardcoded qt prefixes

### DIFF
--- a/pkgs/tools/security/keysmith/default.nix
+++ b/pkgs/tools/security/keysmith/default.nix
@@ -30,8 +30,8 @@ mkDerivation rec {
   postInstall = ''
     mv $out/bin/org.kde.keysmith $out/bin/.org.kde.keysmith-wrapped
     makeWrapper $out/bin/.org.kde.keysmith-wrapped $out/bin/org.kde.keysmith \
-      --set QML2_IMPORT_PATH "${lib.getLib kirigami2}/lib/qt-5.12.7/qml:${lib.getBin qtquickcontrols2}/lib/qt-5.12.7/qml:${lib.getBin qtdeclarative}/lib/qt-5.12.7/qml:${qtgraphicaleffects}/lib/qt-5.12.7/qml" \
-      --set QT_PLUGIN_PATH "${lib.getBin qtbase}/lib/qt-5.12.7/plugins"
+      --set QML2_IMPORT_PATH "${lib.getLib kirigami2}/${qtbase.qtQmlPrefix}:${lib.getBin qtquickcontrols2}/${qtbase.qtQmlPrefix}:${lib.getBin qtdeclarative}/${qtbase.qtQmlPrefix}:${qtgraphicaleffects}/${qtbase.qtQmlPrefix}" \
+      --set QT_PLUGIN_PATH "${lib.getBin qtbase}/${qtbase.qtPluginPrefix}"
     ln -s $out/bin/org.kde.keysmith $out/bin/keysmith
   '';
 


### PR DESCRIPTION
###### Motivation for this change

The keysmith package refers explicitly to Qt 5.12.7 in prefixes, but is now being built with Qt 5.14. I believe this change should mean that the prefixes will always match the Qt version which it is being built against.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
