### PR TITLE
thermald: 2.2 -> 2.3

### DIFF
--- a/nixos/modules/services/hardware/thermald.nix
+++ b/nixos/modules/services/hardware/thermald.nix
@@ -23,6 +23,15 @@ in {
         default = null;
         description = "the thermald manual configuration file.";
       };
+
+      adaptive = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable adaptive mode, only working on kernel versions greater than 5.8.
+          Thermald will detect this itself, safe to enable on kernel versions below 5.8.
+        '';
+      };
     };
   };
 
@@ -39,6 +48,7 @@ in {
             --no-daemon \
             ${optionalString cfg.debug "--loglevel=debug"} \
             ${optionalString (cfg.configFile != null) "--config-file ${cfg.configFile}"} \
+            ${optionalString cfg.adaptive "--adaptive"} \
             --dbus-enable
         '';
       };

--- a/pkgs/tools/system/thermald/default.nix
+++ b/pkgs/tools/system/thermald/default.nix
@@ -1,33 +1,63 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libtool
-, pkgconfig, dbus, dbus-glib, libxml2, autoconf-archive }:
+{ autoconf
+, autoconf-archive
+, automake
+, dbus
+, dbus-glib
+, docbook_xml_dtd_412
+, docbook-xsl-nons
+, fetchFromGitHub
+, gtk-doc
+, libevdev
+, libtool
+, libxml2
+, lzma
+, pkgconfig
+, stdenv
+, upower
+}:
 
 stdenv.mkDerivation rec {
   pname = "thermald";
-  version = "2.2";
+  version = "2.3";
+
+  outputs = [ "out" "devdoc" ];
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "thermal_daemon";
     rev = "v${version}";
-    sha256 = "1nrhv3bypyc48h9smj5cpq63rawm6vqyg3cwkhpz69rgjnf1283m";
+    sha256 = "0cisaca2c2z1x9xvxc4lr6nl6yqx5bww6brh73m0p1n643jgq1dl";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ autoconf automake libtool dbus dbus-glib libxml2 autoconf-archive ];
+  nativeBuildInputs = [
+    autoconf
+    autoconf-archive
+    automake
+    docbook-xsl-nons
+    docbook_xml_dtd_412
+    gtk-doc
+    libtool
+    pkgconfig
+  ];
 
-  patchPhase = ''sed -e 's/upstartconfdir = \/etc\/init/upstartconfdir = $(out)\/etc\/init/' -i data/Makefile.am'';
-
-  preConfigure = ''
-    export PKG_CONFIG_PATH="${dbus.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
-    ./autogen.sh
-  '';
+  buildInputs = [
+    dbus
+    dbus-glib
+    libevdev
+    libxml2
+    lzma
+    upower
+  ];
 
   configureFlags = [
     "--sysconfdir=${placeholder "out"}/etc"
     "--localstatedir=/var"
+    "--enable-gtk-doc"
     "--with-dbus-sys-dir=${placeholder "out"}/share/dbus-1/system.d"
     "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
   ];
+
+  preConfigure = "NO_CONFIGURE=1 ./autogen.sh";
 
   postInstall = ''
     cp ./data/thermal-conf.xml $out/etc/thermald/
@@ -36,7 +66,8 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Thermal Daemon";
     homepage = "https://01.org/linux-thermal-daemon";
-    license = licenses.gpl2;
+    changelog = "https://github.com/intel/thermal_daemon/blob/master/README.txt";
+    license = licenses.gpl2Plus;
     platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = with maintainers; [ abbradar ];
   };


### PR DESCRIPTION


###### Motivation for this change
Supports DPTF, which works in conjunction with the patches in kernel 5.8.

Also cleanup the derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
