### PR TITLE
beauties: init at 0.0.14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9719,6 +9719,13 @@
     githubId = 1016742;
     name = "Rafael García";
   };
+  raitobezarius = {
+    email = "ryan@lahfa.xyz";
+    matrix = "@raitobezarius:matrix.org";
+    github = "RaitoBezarius";
+    githubId = 314564;
+    name = "Ryan Lahfa";
+  };
   raquelgb = {
     email = "raquel.garcia.bautista@gmail.com";
     github = "raquelgb";

--- a/pkgs/development/python-modules/ripe-atlas-cousteau/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-cousteau/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, python-dateutil
+, socketio-client
+, requests
+, websocket-client
+, funcsigs
+, setuptools
+, nose
+, coverage
+, mock
+, jsonschema
+, buildPythonPackage
+, fetchFromGitHub }:
+buildPythonPackage rec {
+  pname = "ripe-atlas-cousteau";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "RIPE-NCC";
+    repo = "ripe-atlas-cousteau";
+    # 1.4.2 tag is not here...
+    rev = if version == "1.4.2" then "${version}" else "v${version}";
+    sha256 = "sha256-hEuqun39NLocFIi2lCftRvkEBbLTeST1wcnGg+l2Oc0=";
+  };
+
+
+  postPatch = ''
+    # websocket-client is a transitive dependency of socketio-client.
+    # <0.99 is not necessary.
+    substituteInPlace setup.py \
+      --replace "websocket-client<0.99" "websocket-client"
+  '';
+
+
+  propagatedBuildInputs = [
+    python-dateutil
+    requests
+    websocket-client
+    socketio-client
+  ];
+
+  checkInputs = [
+    funcsigs # For Python 3.3, which is supposed to be EOL.
+    setuptools
+    nose
+    coverage
+    mock
+    jsonschema
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "A Python client library for RIPE ATLAS API";
+    homepage = "https://github.com/RIPE-NCC/ripe-atlas-cousteau";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/ripe-atlas-cousteau/update.sh
+++ b/pkgs/development/python-modules/ripe-atlas-cousteau/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+set -eu -o pipefail
+
+nix-update python3Packages.ripe-atlas-cousteau

--- a/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, python-dateutil
+, pytz
+, cryptography
+, nose
+, fetchFromGitHub }:
+buildPythonPackage rec {
+  pname = "ripe-atlas-sagan";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "RIPE-NCC";
+    repo = "ripe-atlas-sagan";
+    rev = "v${version}";
+    sha256 = "sha256-xIBIKsQvDmVBa/C8/7Wr3WKeepHaGhoXlgatXSUtWLA=";
+  };
+
+  propagatedBuildInputs = [
+    python-dateutil
+    pytz
+    cryptography
+  ];
+
+  checkInputs = [
+    nose
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "A parsing library for RIPE Atlas measurements results.";
+    homepage = "https://github.com/RIPE-NCC/ripe-atlas-sagan";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/ripe-atlas-sagan/update.sh
+++ b/pkgs/development/python-modules/ripe-atlas-sagan/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+set -eu -o pipefail
+
+nix-update python3Packages.ripe-atlas-sagan

--- a/pkgs/development/python-modules/socketio-client/default.nix
+++ b/pkgs/development/python-modules/socketio-client/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, requests
+, six
+, websocket-client
+, coverage
+, nose
+, fetchFromGitHub }:
+buildPythonPackage rec {
+  pname = "socketio-client";
+  version = "0.7.2";
+
+  src = fetchFromGitHub {
+    owner = "invisibleroads";
+    repo = "socketio-client";
+    rev = version;
+    sha256 = "sha256-71sjiGJDDYElPGUNCH1HaVdvgMt8KeD/kXVDpF615ho=";
+  };
+
+  propagatedBuildInputs = [
+    six
+    websocket-client
+    requests
+  ];
+
+  checkInputs = [
+    coverage
+    nose
+  ];
+
+  # Perform networking tests.
+  doCheck = false;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "A socket.io client library for protocol 1.x";
+    homepage = "https://github.com/invisibleroads/socketIO-client";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/socketio-client/update.sh
+++ b/pkgs/development/python-modules/socketio-client/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+set -eu -o pipefail
+
+nix-update python3Packages.socketio-client

--- a/pkgs/tools/networking/ripe-atlas-tools/default.nix
+++ b/pkgs/tools/networking/ripe-atlas-tools/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "ripe-atlas-tools";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "RIPE-NCC";
+    repo = "ripe-atlas-tools";
+    rev = "v${version}";
+    sha256 = "sha256-VndPqzBG25KrybcmrJAG/9GLUT8nZNiGSEF+Amr+pP8=";
+  };
+
+  checkInputs = with python3.pkgs; [
+    nose
+    coverage
+    mock
+  ];
+
+  # TODO(raitobezarius): cannot import during tests ripe.atlas.cousteau/ripe.atlas.sagan, I do not know why.
+  doCheck = false;
+
+  propagatedBuildInputs = with python3.pkgs; [
+    ripe-atlas-cousteau
+    ripe-atlas-sagan
+
+    ujson
+
+    sphinx
+    sphinx_rtd_theme
+
+    ipy
+    python-dateutil
+    requests
+    tzlocal
+    pyyaml
+    pyopenssl
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "RIPE ATLAS project tools";
+    homepage = "https://github.com/RIPE-NCC/ripe-atlas-tools";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/tools/networking/ripe-atlas-tools/update.sh
+++ b/pkgs/tools/networking/ripe-atlas-tools/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+set -eu -o pipefail
+
+nix-update ripe-atlas-tools

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3720,6 +3720,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit Security;
   };
 
+  ripe-atlas-tools = callPackage ../tools/networking/ripe-atlas-tools { };
+
   roundcube = callPackage ../servers/roundcube { };
 
   roundcubePlugins = dontRecurseIntoAttrs (callPackage ../servers/roundcube/plugins { });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8478,6 +8478,8 @@ in {
 
   ripe-atlas-cousteau = callPackage ../development/python-modules/ripe-atlas-cousteau { };
 
+  ripe-atlas-sagan = callPackage ../development/python-modules/ripe-atlas-sagan { };
+
   riprova = callPackage ../development/python-modules/riprova { };
 
   ripser = callPackage ../development/python-modules/ripser { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9013,6 +9013,8 @@ in {
     usePython = true;
   });
 
+  socketio-client = callPackage ../development/python-modules/socketio-client { };
+
   socialscan = callPackage ../development/python-modules/socialscan { };
 
   socid-extractor =  callPackage ../development/python-modules/socid-extractor { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8476,6 +8476,8 @@ in {
 
   ring-doorbell = callPackage ../development/python-modules/ring-doorbell { };
 
+  ripe-atlas-cousteau = callPackage ../development/python-modules/ripe-atlas-cousteau { };
+
   riprova = callPackage ../development/python-modules/riprova { };
 
   ripser = callPackage ../development/python-modules/ripser { };


### PR DESCRIPTION
##### Motivation for this change

This open the way for a beauties NixOS service, which would enable a little nice web application for minimalist personal services.

This is my first contribution, I'm not sure how to compute the `vendorSha256`, but will do ASAP if possible and will update what I tried.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
