### PR TITLE
[20.09] cantata: add perl for dynamic playlists

### DIFF
--- a/pkgs/applications/audio/cantata/default.nix
+++ b/pkgs/applications/audio/cantata/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib, fetchFromGitHub, cmake, pkgconfig
-, qtbase, qtsvg, qttools
+, qtbase, qtsvg, qttools, perl
 
 # Cantata doesn't build with cdparanoia enabled so we disable that
 # default for now until I (or someone else) figure it out.
@@ -38,6 +38,8 @@ let
 
   withUdisks = (withTaglib && withDevices);
 
+  perl' = perl.withPackages (ppkgs: [ ppkgs.URI ]);
+
 in mkDerivation {
   name = "${pname}-${version}";
 
@@ -48,7 +50,18 @@ in mkDerivation {
     sha256 = "0ix7xp352bziwz31mw79y7wxxmdn6060p8ry2px243ni1lz1qx1c";
   };
 
-  buildInputs = [ qtbase qtsvg ]
+  patches = [
+    # Cantata wants to check if perl is in the PATH at runtime, but we
+    # patchShebangs the playlists scripts, making that unnecessary (perl will
+    # always be available because it's a dependency)
+    ./dont-check-for-perl-in-PATH.diff
+  ];
+
+  postPatch = ''
+    patchShebangs playlists
+  '';
+
+  buildInputs = [ qtbase qtsvg perl' ]
     ++ lib.optionals withTaglib [ taglib taglib_extras ]
     ++ lib.optionals withReplaygain [ ffmpeg_3 speex mpg123 ]
     ++ lib.optional  withHttpStream qtmultimedia

--- a/pkgs/applications/audio/cantata/dont-check-for-perl-in-PATH.diff
+++ b/pkgs/applications/audio/cantata/dont-check-for-perl-in-PATH.diff
@@ -1,0 +1,17 @@
+diff --git a/playlists/dynamicplaylists.cpp b/playlists/dynamicplaylists.cpp
+index 07b6dce3..6a3f97c9 100644
+--- a/playlists/dynamicplaylists.cpp
++++ b/playlists/dynamicplaylists.cpp
+@@ -211,11 +211,6 @@ void DynamicPlaylists::start(const QString &name)
+         return;
+     }
+ 
+-    if (Utils::findExe("perl").isEmpty()) {
+-        emit error(tr("You need to install \"perl\" on your system in order for Cantata's dynamic mode to function."));
+-        return;
+-    }
+-
+     QString fName(Utils::dataDir(rulesDir, false)+name+constExtension);
+ 
+     if (!QFile::exists(fName)) {
+


### PR DESCRIPTION
Cantata wants to check if perl is available at runtime, but we already patch the
script shebangs, making it unnecessary to be available at runtime --
thus, patch out this check.

(cherry picked from commit fca7cc57ad7ff3f72324636ed3a48d51ed29019f)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @worldofpeace