### PR TITLE
[20.09] nixos/nfsd: run rpc-statd as a normal user [WIP]

### DIFF
--- a/nixos/modules/services/network-filesystems/nfsd.nix
+++ b/nixos/modules/services/network-filesystems/nfsd.nix
@@ -8,6 +8,8 @@ let
 
   exports = pkgs.writeText "exports" cfg.exports;
 
+  rpcUser = "statd";
+
 in
 
 {
@@ -140,36 +142,40 @@ in
 
     environment.etc.exports.source = exports;
 
-    systemd.services.nfs-server =
-      { enable = true;
-        wantedBy = [ "multi-user.target" ];
+    systemd.services.nfs-server = {
+      enable = true;
+      wantedBy = [ "multi-user.target" ];
+    };
 
-        preStart =
-          ''
-            mkdir -p /var/lib/nfs/v4recovery
-          '';
+    systemd.services.nfs-mountd = {
+      enable = true;
+      restartTriggers = [ exports ];
+
+      preStart = optionalString cfg.createMountPoints ''
+        # create export directories:
+        # skip comments, take first col which may either be a quoted
+        # "foo bar" or just foo (-> man export)
+        sed '/^#.*/d;s/^"\([^"]*\)".*/\1/;t;s/[ ].*//' ${exports} \
+        | xargs -d '\n' mkdir -p
+      '';
+    };
+
+    # rpc-statd will drop privileges by changing user from root to the owner of
+    # /var/lib/nfs
+    systemd.tmpfiles.rules = [
+      "d /var/lib/nfs 0700 ${rpcUser} ${rpcUser} - -"
+    ] ++ map (e:
+      "d /var/lib/nfs/${e} 0755 root root - -"
+    ) [ "recovery" "v4recovery" "sm" "sm.bak" ];
+
+    users = {
+      groups."${rpcUser}" = {};
+      users."${rpcUser}" = {
+        description = "NFS RPC user";
+        group = rpcUser;
+        isSystemUser = true;
       };
-
-    systemd.services.nfs-mountd =
-      { enable = true;
-        restartTriggers = [ exports ];
-
-        preStart =
-          ''
-            mkdir -p /var/lib/nfs
-
-            ${optionalString cfg.createMountPoints
-              ''
-                # create export directories:
-                # skip comments, take first col which may either be a quoted
-                # "foo bar" or just foo (-> man export)
-                sed '/^#.*/d;s/^"\([^"]*\)".*/\1/;t;s/[ ].*//' ${exports} \
-                | xargs -d '\n' mkdir -p
-              ''
-            }
-          '';
-      };
-
+    };
   };
 
 }

--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -101,13 +101,6 @@ in
       };
 
     systemd.services.rpc-statd =
-      { restartTriggers = [ nfsConfFile ];
-
-        preStart =
-          ''
-            mkdir -p /var/lib/nfs/{sm,sm.bak}
-          '';
-      };
-
+      { restartTriggers = [ nfsConfFile ]; };
   };
 }


### PR DESCRIPTION
##### Motivation for this change

Run `rpc-statd` as an unprivileged user.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
