### PR TITLE
openfortivpn: allow config in /etc/openfortivpn

### DIFF
--- a/pkgs/tools/networking/openfortivpn/default.nix
+++ b/pkgs/tools/networking/openfortivpn/default.nix
@@ -1,34 +1,48 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, openssl, ppp, pkgconfig }:
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig
+, openssl, ppp
+, systemd ? null }:
 
-with stdenv.lib;
+let
+  withSystemd = stdenv.isLinux && !(systemd == null);
 
-let repo = "openfortivpn";
-    version = "1.14.1";
-
-in stdenv.mkDerivation {
-  name = "${repo}-${version}";
+in
+stdenv.mkDerivation rec {
+  pname = "openfortivpn";
+  version = "1.14.1";
 
   src = fetchFromGitHub {
     owner = "adrienverge";
-    inherit repo;
+    repo = pname;
     rev = "v${version}";
     sha256 = "1r9lp19fmqx9dw33j5967ydijbnacmr80mqnhbbxyqiw4k5c10ds";
   };
 
+  # we cannot write the config file to /etc and as we don't need the file, so drop it
+  postPatch = ''
+    substituteInPlace Makefile.am \
+      --replace '$(DESTDIR)$(confdir)' /tmp
+  '';
+
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ openssl ppp ];
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=unused-function";
+  buildInputs = [
+    openssl ppp
+  ]
+  ++ lib.optional withSystemd systemd;
 
-  configureFlags = [ "--with-pppd=${ppp}/bin/pppd" ];
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--with-pppd=${ppp}/bin/pppd"
+  ]
+  ++ lib.optional withSystemd "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system";
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Client for PPP+SSL VPN tunnel services";
     homepage = "https://github.com/adrienverge/openfortivpn";
-    license = stdenv.lib.licenses.gpl3;
-    maintainers = [ stdenv.lib.maintainers.madjar ];
-    platforms = with stdenv.lib.platforms; linux ++ darwin;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ madjar ];
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

openfortivpn would look in the nix store for config files, which
obviously doesn't work, so make it go to /etc/openfortivpn instead so
we *can* configure it system-wide.

Also add systemd units on Linux.

Cc @madjar

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).