### PR TITLE
[20.03] nodePackages.node-red: fix build

### DIFF
--- a/pkgs/development/node-packages/default-v10.nix
+++ b/pkgs/development/node-packages/default-v10.nix
@@ -66,6 +66,10 @@ nodePackages // {
     buildInputs = [ nodePackages.node-pre-gyp ];
   };
 
+  node-red = nodePackages.node-red.override {
+    buildInputs = [ nodePackages.node-pre-gyp ];
+  };
+
   node2nix =  nodePackages.node2nix.override {
     buildInputs = [ pkgs.makeWrapper ];
     postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

resolves build issue #89205

Signed-off-by: Anton Arapov <arapov@gmail.com>
(cherry picked from commit e5701710e381d3b2de21bf968051bbeca7c831bb)


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
