### PR TITLE
gambatte: add alsa dependency, 2016-05-03 -> 2020-03-14

### DIFF
--- a/pkgs/games/gambatte/default.nix
+++ b/pkgs/games/gambatte/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchFromGitHub, scons, qt4 }:
+{ stdenv, fetchFromGitHub, scons, qt4, alsaLib }:
 
 stdenv.mkDerivation {
   pname = "gambatte";
-  version = "2016-05-03";
+  version = "2020-03-14";
 
   src = fetchFromGitHub {
     owner = "sinamas";
     repo = "gambatte";
-    rev = "f8a810b103c4549f66035dd2be4279c8f0d95e77";
-    sha256 = "1arv4zkh3fhrghsykl4blazc9diw09m44pyff1059z5b98smxy3v";
+    rev = "56e3371151b5ee86dcdcf4868324ebc6de220bc9";
+    sha256 = "0cc6zcvxpvi5hgcssb1zy0fkj9nk7n0d2xm88a4v05kpm5zw7sh2";
   };
 
-  buildInputs = [ scons qt4 ];
+  buildInputs = [ scons qt4 alsaLib ];
 
   patches = [ ./fix-scons-paths.patch ];
 


### PR DESCRIPTION
Add `alsaLib` dependency to `gambatte` to fix [failing build](https://hydra.nixos.org/build/126785495).
Also bumps the version, although this is not necessary to fix the build.

###### Motivation for this change
Fixing the build in preparation for backporting to ZHF 20.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
