### PR TITLE
verilog: unstable-2019-08-01 -> unstable-2020-08-24

### DIFF
--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "iverilog";
-  version = "unstable-2019-08-01";
+  version = "unstable-2020-08-24";
 
   src = fetchFromGitHub {
-    owner  = "steveicarus";
+    owner = "steveicarus";
     repo = pname;
-    rev    = "c383d2048c0bd15f5db083f14736400546fb6215";
-    sha256 = "1zs0gyhws0qa315magz3w5m45v97knczdgbf2zn4d7bdb7cv417c";
+    rev = "d8556e4c86e1465b68bdc8d5ba2056ba95a42dfd";
+    sha256 = "sha256-sT9j/0Q2FD5MOGpH/quMGvAuM7t7QavRHKD9lX7Elfs=";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
The build would previously fail due to a change in bison's behavior (see
https://github.com/steveicarus/iverilog/commit/5b699c1be73e789831db01e779a41478c0c62309
for more information). Updating to a more recent version fixes this
issue.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #97479

Saw this was failing when looking for packages to fix for ZHF, and realized I need it for one of my classes this semester... Anyways, I tested this by compiling the first assignment (an 8-to-3 decoder) and verifying the output was the same. Test source can be found here: https://gist.github.com/cole-h/d499079a8ea0c58a80f415e9b5e2bafa.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'll backport this to 20.09 in the morning.

@NixOS/nixos-release-managers