### PR TITLE
chromium: 85.0.4183.83 -> 85.0.4183.102

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -55,6 +55,17 @@ let
           sha256 = "0h3wf4152zdvrbb0jbj49q6814lfl3rcy5mj8b2pl9s0ahvkbc6q";
         };
       });
+    } // lib.optionalAttrs (lib.versionAtLeast upstream-info.version "87") {
+      llvmPackages = llvmPackages_11;
+      useOzone = true; # YAY: https://chromium-review.googlesource.com/c/chromium/src/+/2382834 \o/
+      gnChromium = gn.overrideAttrs (oldAttrs: {
+        version = "2020-08-17";
+        src = fetchgit {
+          url = "https://gn.googlesource.com/gn";
+          rev = "6f13aaac55a977e1948910942675c69f2b4f7a94";
+          sha256 = "01hpma1sllpdx09mvr4d6073sg6zmk6iv44kd3r28khymcj4s251";
+        };
+      });
     });
 
     browser = callPackage ./browser.nix { inherit channel enableWideVine; };

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -1,4 +1,9 @@
 {
+  "stable": {
+    "version": "85.0.4183.102",
+    "sha256": "032yh1mfwins7a62zw8kwwq8xw1n52a0a93lqz7qlyjaf9sd8s4a",
+    "sha256bin64": "1i8xaxxnmg80vsia8hxnq58qi9k5nnbrl80d6d23g9lb7dbc9cpm"
+  },
   "beta": {
     "version": "86.0.4240.22",
     "sha256": "1qxacdwknrjwfp44mnqmq24n8sw4yaf0d1qnz39km2m4apc39svp",
@@ -8,10 +13,5 @@
     "version": "86.0.4240.8",
     "sha256": "1x0kbc7xp6599jyn461mbmchbixivnxm0jsyfq0snhxz8x81z55q",
     "sha256bin64": "0y7drzxxfn0vmfq0m426l8xvkgyajb8pjydi0d7kzk6i92sjf45j"
-  },
-  "stable": {
-    "version": "85.0.4183.83",
-    "sha256": "0fz781bxx1rnjwfix2dgzq5w1lg3x6a9vd9k49gh4z5q092slr10",
-    "sha256bin64": "0fa3la2nvqr0w40j2qkbwnh36924fsp2ajsla6aky6hz08mq2q1g"
   }
 }

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -5,13 +5,13 @@
     "sha256bin64": "1i8xaxxnmg80vsia8hxnq58qi9k5nnbrl80d6d23g9lb7dbc9cpm"
   },
   "beta": {
-    "version": "86.0.4240.22",
-    "sha256": "1qxacdwknrjwfp44mnqmq24n8sw4yaf0d1qnz39km2m4apc39svp",
-    "sha256bin64": "05qdzkq9daqjliqj7zxsa03903rv3kwaj627192ls6m33bacz9gp"
+    "version": "86.0.4240.30",
+    "sha256": "1isj0zngb72k1hhn3h0s8mccg1cdmppz1mjmg19f2h306farzmzl",
+    "sha256bin64": "10d8im2adqqnkd6265gngv6xlm5qsz6r13z6cbbchsss0ssr8fxa"
   },
   "dev": {
-    "version": "86.0.4240.8",
-    "sha256": "1x0kbc7xp6599jyn461mbmchbixivnxm0jsyfq0snhxz8x81z55q",
-    "sha256bin64": "0y7drzxxfn0vmfq0m426l8xvkgyajb8pjydi0d7kzk6i92sjf45j"
+    "version": "87.0.4252.0",
+    "sha256": "1lxlsdni63zh79hxvpwgmnfn67kgfzhz3yg9bkxghqchqykkz92y",
+    "sha256bin64": "130hf7b35wcxpw05ddbqq89x10c0kays1vb9qg6xhq3zx2mk6ijw"
   }
 }


### PR DESCRIPTION
https://chromereleases.googleblog.com/2020/09/stable-channel-update-for-desktop.html

This update includes 5 security fixes.

CVEs:
CVE-2020-6573 CVE-2020-6574 CVE-2020-6575 CVE-2020-6576 CVE-2020-15959

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Testing status

| platform | attribute | status | tester |
| --- | --- | --- | --- |
| x86_64 | chromium | | @danielfullmer |
| x86_64 | nixosTests.chromium | | @danielfullmer  |
| x86_64 | google-chrome | | |
| aarch64 | chromium | | @thefloweringash |


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
