### PR TITLE
wasmer: enable cranelift backend

### DIFF
--- a/pkgs/development/interpreters/wasmer/default.nix
+++ b/pkgs/development/interpreters/wasmer/default.nix
@@ -22,6 +22,12 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
 
+  # Since wasmer 0.17 no backends are enabled by default. Backends are now detected
+  # using the [makefile](https://github.com/wasmerio/wasmer/blob/master/Makefile).
+  # Enabling cranelift as this used to be the old default. At least one backend is
+  # needed for the run subcommand to work.
+  cargoBuildFlags = [ "--features 'backend-cranelift'" ];
+
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Since wasmer 0.17 no backends are enabled by default. Backends are now detected
using the [makefile](https://github.com/wasmerio/wasmer/blob/master/Makefile).
This change enables cranelift as this used to be the old default. At
least one backend is needed for the `run` subcommand to work. If we want
to replicate the actual logic in the makefile, we would probably want to
enable the singlepass and llvm backend as well. However enabling llvm
backend introduces a dependency on openssl, so we opted for replicating
the old default behavior.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
 - Before
   - /nix/store/mhs0bxgzm2mpabbdxybh5ykcj7q9flxm-wasmer-0.17.0	  **38.7M**
   - /nix/store/mhs0bxgzm2mpabbdxybh5ykcj7q9flxm-wasmer-0.17.0	   **40568536**
  - After
    - /nix/store/hng0a6rkdpaka9335p92pjhxw798lqc7-wasmer-0.17.0	  **45.7M**
    - /nix/store/hng0a6rkdpaka9335p92pjhxw798lqc7-wasmer-0.17.0	   **47912800**
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
