### PR TITLE
clean: Accept hardcoded /tmp

### DIFF
--- a/pkgs/development/compilers/clean/default.nix
+++ b/pkgs/development/compilers/clean/default.nix
@@ -28,6 +28,9 @@ stdenv.mkDerivation {
     substituteInPlace src/tools/clm/clm.c --replace '/usr/bin/gcc' $(type -p gcc)
     substituteInPlace src/tools/clm/clm.c --replace '/usr/bin/as' $(type -p as)
 
+    # /tmp is hardcoded in some Clean C files.
+    export TMP=/tmp
+
     cd src
   '';
 


### PR DESCRIPTION
###### Motivation for this change

This fixes a build failure caused by a /tmp path being detected as impure. Tested the compiler on some of my homework.

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
