### PR TITLE
filezilla: 3.49.1 -> 3.50.0

### DIFF
--- a/pkgs/applications/networking/ftp/filezilla/default.nix
+++ b/pkgs/applications/networking/ftp/filezilla/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchurl
+, autoreconfHook
 , dbus
 , gettext
 , gnutls
@@ -16,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "filezilla";
-  version = "3.49.1";
+  version = "3.50.0";
 
   src = fetchurl {
     url = "https://download.filezilla-project.org/client/FileZilla_${version}_src.tar.bz2";
-    sha256 = "1dmkwpc0vy7058bh9a10ida0k64rxggap8ysl5xx3457y468rk2f";
+    sha256 = "sha256-4NuHJpylIIqtFKAkFTN7T57+PEnC1NFOZukhx4oTXBA=";
   };
 
   # https://www.linuxquestions.org/questions/slackware-14/trouble-building-filezilla-3-47-2-1-current-4175671182/#post6099769
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
     "--disable-autoupdatecheck"
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   buildInputs = [
     dbus

--- a/pkgs/development/libraries/libfilezilla/default.nix
+++ b/pkgs/development/libraries/libfilezilla/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , fetchurl
-
+, autoreconfHook
 , gettext
 , gnutls
 , nettle
@@ -11,14 +11,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libfilezilla";
-  version = "0.24.0";
+  version = "0.24.1";
 
   src = fetchurl {
     url = "https://download.filezilla-project.org/${pname}/${pname}-${version}.tar.bz2";
-    sha256 = "1372i9f501kn8p1vkqdydaqvvi6lzxsnw2yzyxx5j4syqd4p0qa5";
+    sha256 = "sha256-/dW07hkWr3sdQC591GfwXfdiS7ZfuVoIdaA3EuzC1v0=";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   buildInputs = [ gettext gnutls nettle ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv ApplicationServices ];


### PR DESCRIPTION
###### Motivation for this change

Regular update. ALso includes a corresponding libfilezilla update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).