### PR TITLE
nixos/ejabberd: Fix tests

### DIFF
--- a/nixos/tests/xmpp/ejabberd.nix
+++ b/nixos/tests/xmpp/ejabberd.nix
@@ -5,6 +5,10 @@ import ../make-test-python.nix ({ pkgs, ... }: {
   };
   nodes = {
     client = { nodes, pkgs, ... }: {
+      networking.extraHosts = ''
+        ${nodes.server.config.networking.primaryIPAddress} example.com
+      '';
+
       environment.systemPackages = [
         (pkgs.callPackage ./xmpp-sendmessage.nix { connectTo = nodes.server.config.networking.primaryIPAddress; })
       ];
@@ -46,6 +50,11 @@ import ../make-test-python.nix ({ pkgs, ... }: {
               module: ejabberd_service
               access: local
               shaper: fast
+            -
+              port: 5444
+              module: ejabberd_http
+              request_handlers:
+                "/upload": mod_http_upload
 
           ## Disabling digest-md5 SASL authentication. digest-md5 requires plain-text
           ## password storage (see auth_password_format option).
@@ -180,6 +189,7 @@ import ../make-test-python.nix ({ pkgs, ... }: {
             mod_client_state: {}
             mod_configure: {} # requires mod_adhoc
             ## mod_delegation: {} # for xep0356
+            mod_disco: {}
             #mod_irc:
             #  host: "irc.@HOST@"
             #  default_encoding: "utf-8"
@@ -187,9 +197,9 @@ import ../make-test-python.nix ({ pkgs, ... }: {
             ## mod_http_fileserver:
             ##   docroot: "/var/www"
             ##   accesslog: "/var/log/ejabberd/access.log"
-            #mod_http_upload:
-            #  thumbnail: false # otherwise needs the identify command from ImageMagick installed
-            #  put_url: "https://@HOST@:5444"
+            mod_http_upload:
+              thumbnail: false # otherwise needs the identify command from ImageMagick installed
+              put_url: "http://@HOST@:5444/upload"
             ##   # docroot: "@HOME@/upload"
             #mod_http_upload_quota:
             #  max_days: 14

--- a/nixos/tests/xmpp/xmpp-sendmessage.nix
+++ b/nixos/tests/xmpp/xmpp-sendmessage.nix
@@ -36,7 +36,11 @@ class CthonTest(ClientXMPP):
         def timeout_callback(arg):
             log.error("ERROR: Cannot upload file. XEP_0363 seems broken")
             sys.exit(1)
-        url = await self['xep_0363'].upload_file("${dummyFile}",timeout=10, timeout_callback=timeout_callback)
+        try:
+            url = await self['xep_0363'].upload_file("${dummyFile}",timeout=10, timeout_callback=timeout_callback)
+        except:
+            log.error("ERROR: Cannot run upload command. XEP_0363 seems broken")
+            sys.exit(1)
         log.info('Upload success!')
         # Test MUC
         self.plugin['xep_0045'].join_muc('testMucRoom', 'cthon98', wait=True)


### PR DESCRIPTION

###### Motivation for this change

This commit fixes the ejabberd tests for hydra as part of ZHF:
ZHF: #97479 

mod_http_upload and mod_disco need to be explicitly enabled, and a
handler needs to be setup to make it work. Also, the client needs to be
able to contact the server.

The commit also fixes the situation where http upload failed: in that
case the client would wait forever because nothing catched the error.

Finally, there remains a non-reproducible error where ejabberd server
fails to start with an error like:
format: "Failed to create cookie file '/var/lib/ejabberd/.erlang.cookie': eacces"
(happens ~15%) I tried to check existence of /var/lib/ejabberd/ in
pre-start script and saw nothing that would explain this error, so I
gave up about this error in particular.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC  @NixOS/nixos-release-managers