### PR TITLE
Uptade pytest-timeout and x265 derivations

### DIFF
--- a/pkgs/development/libraries/x265/default.nix
+++ b/pkgs/development/libraries/x265/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, cmake, nasm, numactl
+{ stdenv, fetchFromGitHub, cmake, nasm, numactl
 , numaSupport ? stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isx86 || stdenv.hostPlatform.isAarch64)  # Enabled by default on NUMA platforms
 , debugSupport ? false # Run-time sanity checks (debugging)
 , highbitdepthSupport ? false # false=8bits per channel, true=10/12bits per channel
@@ -17,25 +17,16 @@ in
 
 stdenv.mkDerivation rec {
   pname = "x265";
-  version = "3.2";
+  version = "3.4";
 
-  src = fetchurl {
-    urls = [
-      "https://get.videolan.org/x265/x265_${version}.tar.gz"
-      "ftp://ftp.videolan.org/pub/videolan/x265/x265_${version}.tar.gz"
-    ];
-    sha256 = "0fqkhfhr22gzavxn60cpnj3agwdf5afivszxf3haj5k1sny7jk9n";
-  };
+  src = fetchFromGitHub {
+            owner  = "videolan";
+            repo   = "x265";
+            rev    = "${version}";
+            sha256 = "048c906xpp3m12m2xnb6zf2y39milxajp2n0kffa41pdya3zqn95";
+        };
 
   enableParallelBuilding = true;
-
-  patches = [
-    # Fix build on ARM (#406)
-    (fetchpatch {
-      url = "https://bitbucket.org/multicoreware/x265/issues/attachments/406/multicoreware/x265/1527562952.26/406/X265-2.8-asm-primitives.patch";
-      sha256 = "1vf8bpl37gbd9dcbassgkq9i0rp24qm3bl6hx9zv325174bn402v";
-    })
-  ];
 
   postPatch = ''
     sed -i 's/unknown/${version}/g' source/cmake/version.cmake

--- a/pkgs/development/python-modules/pytest-timeout/default.nix
+++ b/pkgs/development/python-modules/pytest-timeout/default.nix
@@ -8,27 +8,21 @@
 
 buildPythonPackage rec {
   pname = "pytest-timeout";
-  version = "1.3.3";
+  version = "1.4.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1cczcjhw4xx5sjkhxlhc5c1bkr7x6fcyx12wrnvwfckshdvblc2a";
-  };
-
-  patches = fetchpatch {
-    url = https://bitbucket.org/pytest-dev/pytest-timeout/commits/36998c891573d8ec1db1acd4f9438cb3cf2aee2e/raw;
-    sha256 = "05zc2w7mjgv8rm8i1cbxp7k09vlscmay5iy78jlzgjqkrx3wkf46";
+    sha256 = "0xnsigs0kmpq1za0d4i522sp3f71x5bgpdh3ski0rs74yqy13cr0";
   };
 
   checkInputs = [ pytest pexpect ];
   checkPhase = ''
-    # test_suppresses_timeout_when_pdb_is_entered fails under heavy load
-    pytest -ra -k 'not test_suppresses_timeout_when_pdb_is_entered'
+    pytest -ra -k 'not test_suppresses_timeout_when_debugger_is_entered and not test_cov'
   '';
 
   meta = with lib;{
     description = "py.test plugin to abort hanging tests";
-    homepage = https://bitbucket.org/pytest-dev/pytest-timeout/;
+    homepage = "https://github.com/pytest-dev/pytest-timeout";
     license = licenses.mit;
     maintainers = with maintainers; [ makefu costrouc ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update the following derivations and remove old patches on those:

pytest-timeout: 1.3.3 -> 1.4.2
x265: 3.2 -> 3.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
