### PR TITLE
python3Packages.google_resumable_media: v0.7.1 -> v1.0.0, python3Packages.google_crc32c: init at v1.0.0

### DIFF
--- a/pkgs/development/python-modules/google_crc32c/default.nix
+++ b/pkgs/development/python-modules/google_crc32c/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "google-crc32c";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1biyzc2sfjb91b19b9axafzn5mr66vy31lbmfralgn7cnrhbjfcl";
+  };
+
+  doCheck = false;  # tests do not ship with pypi package; avoid building from source
+  pythonImportsCheck = [ "google_crc32c" ];
+
+  meta = with stdenv.lib; {
+    description = "Python wrapper of the C library 'Google CRC32C'";
+    homepage = "https://github.com/googleapis/python-crc32c";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ siriobalmelli ];
+  };
+}

--- a/pkgs/development/python-modules/google_resumable_media/default.nix
+++ b/pkgs/development/python-modules/google_resumable_media/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, google_crc32c
 , six
 , requests
 , setuptools
@@ -10,15 +11,15 @@
 
 buildPythonPackage rec {
   pname = "google-resumable-media";
-  version = "0.7.1";
+  version = "1.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "57841f5e65fb285c01071f439724745b2549a72eb75e5fd979198eb518608ed0";
+    sha256 = "1wpw5r83jvxqzmhr8bnl17ff4fjl2wknr752kx90lj71mmmwqfhp";
   };
 
   checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ requests setuptools six ];
+  propagatedBuildInputs = [ google_crc32c requests setuptools six ];
 
   checkPhase = ''
     py.test tests/unit

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2455,6 +2455,8 @@ in {
 
   google-compute-engine = callPackage ../tools/virtualization/google-compute-engine { };
 
+  google_crc32c = callPackage ../development/python-modules/google_crc32c { };
+
   google-i18n-address = callPackage ../development/python-modules/google-i18n-address { };
 
   google-music = callPackage ../development/python-modules/google-music { };


### PR DESCRIPTION
Commit f6514b57 upgraded `python3Packages.google_resumable_media` and broke it:

```
ERROR: Could not find a version that satisfies the requirement google-crc32c<0.2dev,>=0.1.0; python_version >= "3.5" (from google-resumable-media==0.7.1) (from versions: none)
ERROR: No matching distribution found for google-crc32c<0.2dev,>=0.1.0; python_version >= "3.5" (from google-resumable-media==0.7.1)
builder for '/nix/store/diqkd6pk13ihmd5lgic98d88h0frcgv8-python3.8-google-resumable-media-0.7.1.drv' failed with exit code 1
```

This patch series:

- upgrades `python3Packages.google_resumable_media` to the latest version
- adds the `python3Packages.google_crc32c` dependency introduced in f6514b57

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
