### PR TITLE
lorri: remove unnecessary output override

### DIFF
--- a/pkgs/tools/misc/lorri/default.nix
+++ b/pkgs/tools/misc/lorri/default.nix
@@ -37,6 +37,8 @@ in (rustPlatform.buildRustPackage rec {
     inherit sha256;
   };
 
+  outputs = [ "out" "man" "doc" ];
+
   inherit cargoSha256;
   doCheck = false;
 
@@ -68,7 +70,4 @@ in (rustPlatform.buildRustPackage rec {
       nixos = nixosTests.lorri;
     };
   };
-}).overrideAttrs (old: {
-  # add man and doc outputs to put our documentation into
-  outputs = old.outputs or [ "out" ] ++ [ "man" "doc" ];
 })


### PR DESCRIPTION
cc @zowoq 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
