### PR TITLE
lxd: Download Alpine image instead of relying on external source

### DIFF
--- a/nixos/tests/lxd-nftables.nix
+++ b/nixos/tests/lxd-nftables.nix
@@ -7,6 +7,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "lxd-nftables";
+
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ patryk27 ];
   };

--- a/nixos/tests/lxd.nix
+++ b/nixos/tests/lxd.nix
@@ -8,12 +8,12 @@ let
   # generally, sufficient for our tests.
   alpine-meta = pkgs.fetchurl {
     url = "https://tarballs.nixos.org/alpine/3.12/lxd.tar.xz";
-    sha256 = "sha256-1tcKaO9lOkvqfmG/7FMbfAEToAuFy2YMewS8ysBKuLA=";
+    hash = "sha256-1tcKaO9lOkvqfmG/7FMbfAEToAuFy2YMewS8ysBKuLA=";
   };
 
   alpine-rootfs = pkgs.fetchurl {
     url = "https://tarballs.nixos.org/alpine/3.12/rootfs.tar.xz";
-    sha256 = "sha256-Tba9sSoaiMtQLY45u7p5DMqXTSDgs/763L/SQp0bkCA=";
+    hash = "sha256-Tba9sSoaiMtQLY45u7p5DMqXTSDgs/763L/SQp0bkCA=";
   };
 
   lxd-config = pkgs.writeText "config.yaml" ''

--- a/nixos/tests/lxd.nix
+++ b/nixos/tests/lxd.nix
@@ -68,6 +68,7 @@ in {
   testScript = ''
     machine.wait_for_unit("sockets.target")
     machine.wait_for_unit("lxd.service")
+    machine.wait_for_file("/var/lib/lxd/unix.socket")
 
     # It takes additional second for lxd to settle
     machine.sleep(1)

--- a/nixos/tests/lxd.nix
+++ b/nixos/tests/lxd.nix
@@ -6,15 +6,14 @@ let
   #
   # I've chosen to import Alpine Linux, because its image is turbo-tiny and,
   # generally, sufficient for our tests.
-
   alpine-meta = pkgs.fetchurl {
-    url = "https://uk.images.linuxcontainers.org/images/alpine/3.11/i386/default/20200608_13:00/lxd.tar.xz";
-    sha256 = "1hkvaj3rr333zmx1759njy435lps33gl4ks8zfm7m4nqvipm26a0";
+    url = "https://tarballs.nixos.org/alpine/3.12/lxd.tar.xz";
+    sha256 = "sha256-1tcKaO9lOkvqfmG/7FMbfAEToAuFy2YMewS8ysBKuLA=";
   };
 
   alpine-rootfs = pkgs.fetchurl {
-    url = "https://uk.images.linuxcontainers.org/images/alpine/3.11/i386/default/20200608_13:00/rootfs.tar.xz";
-    sha256 = "1v82zdra4j5xwsff09qlp7h5vbsg54s0j7rdg4rynichfid3r347";
+    url = "https://tarballs.nixos.org/alpine/3.12/rootfs.tar.xz";
+    sha256 = "sha256-Tba9sSoaiMtQLY45u7p5DMqXTSDgs/763L/SQp0bkCA=";
   };
 
   lxd-config = pkgs.writeText "config.yaml" ''
@@ -44,8 +43,10 @@ let
             type: disk
   '';
 
+
 in {
   name = "lxd";
+
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ patryk27 ];
   };
@@ -53,7 +54,7 @@ in {
   machine = { lib, ... }: {
     virtualisation = {
       # Since we're testing `limits.cpu`, we've gotta have a known number of
-      # cores to lay on
+      # cores to lean on
       cores = 2;
 
       # Ditto, for `limits.memory`


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/97484.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
