### PR TITLE
skk-dicts-unstable: 2017-10-26 -> 2020-03-24

### DIFF
--- a/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
+++ b/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
@@ -3,33 +3,33 @@
 let
   # kana to kanji
   small = fetchurl {
-    url = "https://raw.githubusercontent.com/skk-dev/dict/f61be71246602a49e9f05ded6ac4f9f82031a521/SKK-JISYO.S";
-    sha256 = "15kp4iwz58fp1zg0i13x7w9wwm15v8n2hhm0nf2zsl7az5mn5yi4";
+    url = "https://raw.githubusercontent.com/skk-dev/dict/8b35d07a7d2044d48b063d2774d9f9d00bb7cb48/SKK-JISYO.S";
+    sha256 = "11cjrc8m99hj4xpl2nvzxanlswpapi92vmgk9d6yimdz0jidb6cq";
   };
   medium = fetchurl {
-    url = "https://raw.githubusercontent.com/skk-dev/dict/f61be71246602a49e9f05ded6ac4f9f82031a521/SKK-JISYO.M";
-    sha256 = "1vhagixhrp9lq5x7dldxcanhznawazp00xivpp1z52kx10lnkmv0";
+    url = "https://raw.githubusercontent.com/skk-dev/dict/8b35d07a7d2044d48b063d2774d9f9d00bb7cb48/SKK-JISYO.M";
+    sha256 = "0pwjp9qjmn9sq6zc0k6632l7dc2dbjn45585ibckvvl9iwfqqxdp";
   };
   large = fetchurl {
-    url = "https://raw.githubusercontent.com/skk-dev/dict/f61be71246602a49e9f05ded6ac4f9f82031a521/SKK-JISYO.L";
-    sha256 = "07cv0j95iajkr48j4ln411vnhl3z93yx96zjc03bgs10dbpagaaz";
+    url = "https://raw.githubusercontent.com/skk-dev/dict/8b35d07a7d2044d48b063d2774d9f9d00bb7cb48/SKK-JISYO.L";
+    sha256 = "0ps0a7sbkryd6hxvphq14i7g5wci4gvr0vraac8ia2ww67a2xbyc";
   };
 
   # english to japanese
   edict = fetchurl {
-    url = "https://raw.githubusercontent.com/skk-dev/dict/f61be71246602a49e9f05ded6ac4f9f82031a521/SKK-JISYO.edict";
-    sha256 = "18k8z1wkgwgfwbs6sylf39h1nc1p5l2b00h7mfjlb8p91plkb45w";
+    url = "https://raw.githubusercontent.com/skk-dev/dict/8b35d07a7d2044d48b063d2774d9f9d00bb7cb48/SKK-JISYO.edict";
+    sha256 = "1vrwnq0vvjn61nijbln6wfinqg93802d2a8d4ad82n692v83b1li";
   };
   # misc
   assoc = fetchurl {
-    url = "https://raw.githubusercontent.com/skk-dev/dict/f61be71246602a49e9f05ded6ac4f9f82031a521/SKK-JISYO.assoc";
-    sha256 = "12d6xpp1bfin9nwl35ydl5yc6vx0qpwhxss0khi19n1nsbyqnixm";
+    url = "https://raw.githubusercontent.com/skk-dev/dict/8b35d07a7d2044d48b063d2774d9f9d00bb7cb48/SKK-JISYO.assoc";
+    sha256 = "1smcbyv6srrhnpl7ic9nqds9nz3g2dgqngmhzkrdlwmvcpvakp1v";
   };
 in
 
 stdenv.mkDerivation {
   pname = "skk-dicts-unstable";
-  version = "2017-10-26";
+  version = "2020-03-24";
   srcs = [ small medium large edict assoc ];
   nativeBuildInputs = [ skktools ] ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

To update skk-dicts-unstable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~ no bins
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
