### PR TITLE
[20.09] haskellPackages.hakyll: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -144,7 +144,22 @@ self: super: {
     then dontCheck (overrideCabal super.hakyll (drv: {
       testToolDepends = [];
     }))
-    else super.hakyll;
+    else overrideCabal super.hakyll {
+      patches = [
+        (pkgs.fetchpatch {
+          url = "https://github.com/jaspervdj/hakyll/pull/787/commits/b71955f7db1fd6532d3988be671281d1f6fcdd1d.patch";
+          sha256 = "Q9dFJpd9vmV1StjBpscDymprdF0Cdfil/tHD6c/ejBs=";
+        })
+        (pkgs.fetchpatch {
+          url = "https://github.com/jaspervdj/hakyll/pull/787/commits/d5197f78ca42264e506acca2735293704495f0a0.patch";
+          sha256 = "ogOBWviarMUc4rGaqAZiIePd9aRehvXwHOIoGIT+kgI=";
+        })
+        (pkgs.fetchpatch {
+          url = "https://github.com/jaspervdj/hakyll/pull/787/commits/d2bd8a4b0a42a547c79cef2035ee8f538417ea47.patch";
+          sha256 = "e3kx5TeCF2CO0Yp9iDke9UvIc4yigWF0zGdYG3Vf3xY=";
+        })
+      ];
+    };
 
   double-conversion = if !pkgs.stdenv.isDarwin
     then super.double-conversion

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5671,7 +5671,6 @@ broken-packages:
   - hakyll-contrib
   - hakyll-contrib-csv
   - hakyll-contrib-elm
-  - hakyll-contrib-hyphenation
   - hakyll-contrib-links
   - hakyll-convert
   - hakyll-dhall

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5666,7 +5666,6 @@ broken-packages:
   - hakismet
   - hakka
   - hako
-  - hakyll
   - hakyll-agda
   - hakyll-blaze-templates
   - hakyll-contrib


### PR DESCRIPTION
###### Motivation for this change


###### Things done

I appended the commits from https://github.com/jaspervdj/hakyll/pull/787.

Edit: This also fixes `hakyll-contrib-hyphenation`, so I marked it as unbroken.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
