### PR TITLE
csvkit: fix failing test

### DIFF
--- a/pkgs/tools/text/csvkit/default.nix
+++ b/pkgs/tools/text/csvkit/default.nix
@@ -12,7 +12,14 @@ python3.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with python3.pkgs; [
     agate
     agate-excel
-    agate-dbf
+    # dbf test fail with agate-dbf-0.2.2
+    (agate-dbf.overridePythonAttrs(old: rec {
+      version = "0.2.1";
+      src = python3.pkgs.fetchPypi {
+        inherit (old) pname;
+        inherit version;
+        sha256 = "0brprva3vjypb5r9lk6zy10jazp681rxsqxzhz2lr869ir4krj80";
+      };}))
     # sql test fail with agate-sql-0.5.4
     (agate-sql.overridePythonAttrs(old: rec {
       version = "0.5.3";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF: #97479

The build for this package was failing due to failing tests that were caused by a breaking change in a dependency. The requirements.txt for this package does not pin specific versions so it was trying to build with the new version of the dependency and failing. This commit overrides the version of the dependency that is used to build the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
