### PR TITLE
recoll: qt4 -> qt5, fix build

### DIFF
--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, lib, bison
-, qt4, xapian, file, python, perl
+{ mkDerivation, stdenv, fetchurl, lib, bison
+, qtbase, xapian, file, python, perl
 , djvulibre, groff, libxslt, unzip, poppler_utils, antiword, catdoc, lyx
 , libwpd, unrtf, untex
 , ghostscript, gawk, gnugrep, gnused, gnutar, gzip, libiconv, zlib
@@ -7,7 +7,7 @@
 
 assert stdenv.hostPlatform.system != "powerpc-linux";
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   ver = "1.24.5";
   name = "recoll-${ver}";
 
@@ -16,12 +16,12 @@ stdenv.mkDerivation rec {
     sha256 = "10m3a0ghnyipjcxapszlr8adyy2yaaxx4vgrkxrfmz13814z89cv";
   };
 
-  configureFlags = [ "--enable-recollq" ]
+  configureFlags = [ "--enable-recollq" "--disable-webkit" ]
     ++ lib.optionals (!withGui) [ "--disable-qtgui" "--disable-x11mon" ]
     ++ (if stdenv.isLinux then [ "--with-inotify" ] else [ "--without-inotify" ]);
 
   buildInputs = [ xapian file python bison zlib ]
-    ++ lib.optional withGui qt4
+    ++ lib.optional withGui qtbase
     ++ lib.optional stdenv.isDarwin libiconv;
 
   patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   # the filters search through ${PATH} using a sh proc 'checkcmds' for the
   # filtering utils. Short circuit this by replacing the filtering command with
-  # the absolute path to the filtering command. 
+  # the absolute path to the filtering command.
   postInstall = ''
     for f in $out/share/recoll/filters/* ; do
       if [[ ! "$f" =~ \.zip$ ]]; then
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     description = "A full-text search tool";
     longDescription = ''
       Recoll is an Xapian frontend that can search through files, archive
-      members, email attachments. 
+      members, email attachments.
     '';
     homepage = "https://www.lesbonscomptes.com/recoll/";
     license = licenses.gpl2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6588,7 +6588,7 @@ in
 
   recutils = callPackage ../tools/misc/recutils { };
 
-  recoll = callPackage ../applications/search/recoll { };
+  recoll = libsForQt5.callPackage ../applications/search/recoll { };
 
   redoc-cli = nodePackages.redoc-cli;
 


### PR DESCRIPTION
###### Motivation for this change

fix recoll for nixos-20.09
(to be backported to release-20.09)
#33239 #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
