### PR TITLE
scripts/build: ensure drv eval didn't error

### DIFF
--- a/maintainers/scripts/build.nix
+++ b/maintainers/scripts/build.nix
@@ -19,8 +19,9 @@ let
                 then packagesWith cond return pkg
                 else [ ]
               );
+            isDerivation = result.success && (pkgs.lib.isDerivation result.value);
           in
-          if result.success then result.value
+          if isDerivation then result.value
           else [ ]
         )
         set


### PR DESCRIPTION
###### Motivation for this change
If the package will throw an error, the current script doesn't inspect the derivation value, so it will later try to build something that error'd.

Added enough logic to inspect the value from the tryEval to prevent this

Example:
```
[10:26:57] jon@nixos-laptop ~/projects/nixpkgs (master)
$ nix-build maintainers/scripts/build.nix --argstr maintainer jonringer
unpacking 'https://github.com/nix-community/NUR/archive/master.tar.gz'...
error: azure-core-1.8.0 not supported for interpreter python2.7
(use '--show-trace' to show detailed location information)
```

with changes:
```
[10:29:08] jon@nixos ~/projects/nixpkgs (fix-maintainer-script)
$ nix-build maintainers/scripts/build.nix --argstr maintainer jonringer
[10:29:15] jon@nixos ~/projects/nixpkgs (fix-maintainer-script)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
