### PR TITLE
mlton: fix build

### DIFF
--- a/pkgs/development/compilers/mlton/default.nix
+++ b/pkgs/development/compilers/mlton/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchgit, patchelf, gmp }:
+{ stdenv, fetchurl, fetchgit, patchelf, gmp, which }:
 rec {
   mlton20130715 = import ./20130715.nix {
     inherit stdenv fetchurl patchelf gmp;
@@ -13,7 +13,7 @@ rec {
     version = "20180207";
     rev = "on-20180207-release";
     sha256 = "00rdd2di5x1dzac64il9z05m3fdzicjd3226wwjyynv631jj3q2a";
-    inherit stdenv fetchgit gmp;
+    inherit stdenv fetchgit gmp which;
   };
 
   mltonHEAD = import ./from-git-source.nix {
@@ -21,6 +21,6 @@ rec {
     version = "HEAD";
     rev = "e149c9917cfbfe6aba5c986a958ed76d5cc6cfde";
     sha256 = "0a0j1i0f0fxw2my1309srq5j3vz0kawrrln01gxms2m5hy5dl50d";
-    inherit stdenv fetchgit gmp;
+    inherit stdenv fetchgit gmp which;
   };
 }

--- a/pkgs/development/compilers/mlton/default.nix
+++ b/pkgs/development/compilers/mlton/default.nix
@@ -1,26 +1,21 @@
-{ stdenv, fetchurl, fetchgit, patchelf, gmp, which }:
+{ callPackage }:
+
 rec {
-  mlton20130715 = import ./20130715.nix {
-    inherit stdenv fetchurl patchelf gmp;
-  };
+  mlton20130715 = callPackage ./20130715.nix {};
 
-  mlton20180207Binary = import ./20180207-binary.nix {
-    inherit stdenv fetchurl patchelf gmp;
-  };
+  mlton20180207Binary = callPackage ./20180207-binary.nix {};
 
-  mlton20180207 = import ./from-git-source.nix {
+  mlton20180207 = callPackage ./from-git-source.nix {
     mltonBootstrap = mlton20180207Binary;
     version = "20180207";
     rev = "on-20180207-release";
     sha256 = "00rdd2di5x1dzac64il9z05m3fdzicjd3226wwjyynv631jj3q2a";
-    inherit stdenv fetchgit gmp which;
   };
 
-  mltonHEAD = import ./from-git-source.nix {
+  mltonHEAD = callPackage ./from-git-source.nix {
     mltonBootstrap = mlton20180207Binary;
     version = "HEAD";
     rev = "e149c9917cfbfe6aba5c986a958ed76d5cc6cfde";
     sha256 = "0a0j1i0f0fxw2my1309srq5j3vz0kawrrln01gxms2m5hy5dl50d";
-    inherit stdenv fetchgit gmp which;
   };
 }

--- a/pkgs/development/compilers/mlton/from-git-source.nix
+++ b/pkgs/development/compilers/mlton/from-git-source.nix
@@ -6,6 +6,7 @@
 , sha256
 , stdenv
 , version
+, which
 }:
 
 stdenv.mkDerivation {
@@ -15,6 +16,8 @@ stdenv.mkDerivation {
   src = fetchgit {
     inherit url rev sha256;
   };
+
+  nativeBuildInputs = [ which ];
 
   buildInputs = [mltonBootstrap gmp];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Failed to build because `which` is missing.
https://hydra.nixos.org/build/126588345/nixlog/1

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
