### PR TITLE
linuxPackages.exfat-nofuse: 2019-09-06 -> 2020-04-15

### DIFF
--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -3,16 +3,18 @@
 
 # Upstream build for kernel 4.1 is broken, 3.12 and below seems to be working
 assert lib.versionAtLeast kernel.version  "4.2" || lib.versionOlder kernel.version "4.0";
+# linux kernel above 5.7 comes with its own exfat implementation https://github.com/arter97/exfat-linux/issues/27
+assert lib.versionOlder kernel.version "5.8";
 
 stdenv.mkDerivation rec {
   name = "exfat-nofuse-${version}-${kernel.version}";
-  version = "2019-09-06";
+  version = "2020-04-15";
 
   src = fetchFromGitHub {
-    owner = "AdrianBan";
+    owner = "barrybingo";
     repo = "exfat-nofuse";
-    rev = "5536f067373c196f152061f5000fe0032dc07c48";
-    sha256 = "00mhadsv2iw8z00a6170hwbvk3afx484nn3irmd5f5kmhs34sw7k";
+    rev = "297a5739cd4a942a1d814d05a9cd9b542e7b8fc8";
+    sha256 = "14jahy7n6pr482fjfrlf9ck3f2rkr5ds0n5r85xdfsla37ria26d";
   };
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION


###### Motivation for this change
#97479 , fix builds for newer kernels and add assertion for newer linux kernels which come with native exfat support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
