### PR TITLE
python3Packages.pyhaversion: add missing semantic-version

### DIFF
--- a/pkgs/development/python-modules/pyhaversion/default.nix
+++ b/pkgs/development/python-modules/pyhaversion/default.nix
@@ -5,6 +5,7 @@
 # propagatedBuildInputs
 , aiohttp
 , async-timeout
+, semantic-version
 # buildInputs
 , pytestrunner
 # checkInputs
@@ -27,6 +28,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     aiohttp
     async-timeout
+    semantic-version
   ];
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
#97479 , fix pyhaversion build by adding missing dependency

tested py3.6,3.7,3.8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
