### PR TITLE
Fix arch eval error

### DIFF
--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -60,7 +60,7 @@ rec {
   };
 
   predicates = let
-    featureSupport = feature: x: builtins.elem feature features.${x};
+    featureSupport = feature: x: builtins.elem feature features.${x} or [];
   in {
     sse3Support    = featureSupport "sse3";
     ssse3Support   = featureSupport "ssse3";


### PR DESCRIPTION
An error occurs when using a `platform.gcc.arch` that isn't one of the existing hard-coded options, for example:

```
error: attribute 'armv6-m' missing, at lib/systems/architectures.nix:63:56
```

###### Motivation for this change

The error was introduced recently in #61019, and it'd be nice if this could be backported to 20.09 to avoid a regression from 20.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @volth
