### PR TITLE
nifticlib: 2.0.0 -> 3.0.1

### DIFF
--- a/pkgs/development/libraries/science/biology/nifticlib/default.nix
+++ b/pkgs/development/libraries/science/biology/nifticlib/default.nix
@@ -1,22 +1,30 @@
-{ stdenv, fetchurl, cmake, zlib }:
+{ stdenv, fetchFromGitHub, cmake, zlib }:
 
 stdenv.mkDerivation rec {
-  pname    = "nifticlib";
-  pversion = "2.0.0";
-  name  = "${pname}-${pversion}";
+  pname = "nifticlib";
+  version = "3.0.1";
 
-  src = fetchurl {
-    url    = "mirror://sourceforge/project/niftilib/${pname}/${pname}_2_0_0/${name}.tar.gz";
-    sha256 = "123z9bwzgin5y8gi5ni8j217k7n683whjsvg0lrpii9flgk8isd3";
+  src = fetchFromGitHub {
+    owner = "NIFTI-Imaging";
+    repo = "nifti_clib";
+    rev = "v${version}";
+    sha256 = "0hamm6nvbjdjjd5md4jahzvn5559frigxaiybnjkh59ckxwb1hy4";
   };
+
+  cmakeFlags = [ "-DDOWNLOAD_TEST_DATA=OFF" ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib ];
 
-  doCheck = false; # fails 7 out of 293 tests
+  checkPhase = ''
+    runHook preCheck
+    ctest -LE 'NEEDS_DATA'
+    runHook postCheck
+  '';
+  doCheck = true;
 
   meta = with stdenv.lib; {
-    homepage = "https://sourceforge.net/projects/niftilib";
+    homepage = "https://nifti-imaging.github.io";
     description = "Medical imaging format C API";
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.unix;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
