### PR TITLE
terraform-providers: add version to patchGoModVendor providers

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -17,7 +17,7 @@ let
       };
       # Terraform allow checking the provider versions, but this breaks
       # if the versions are not provided via file paths.
-      postBuild = "mv go/bin/${repo}{,_v${version}}";
+      postBuild = "mv $NIX_BUILD_TOP/go/bin/${repo}{,_v${version}}";
     };
 
   # Google is now using the vendored go modules, which works a bit differently
@@ -39,6 +39,8 @@ let
       # just build and install into $GOPATH/bin
       buildPhase = ''
         go install -mod=vendor -v -p 16 .
+
+        runHook postBuild
       '';
 
       # don't run the tests, they are broken in this setup


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add version to binaries produced via patchGoModVendor to allow run-time provider
version validation by terraform.

This was initially introduced in 4e63119c540 (terraform: add the version component to terraform provider paths (#34497), 2018-02-06)
but broken in 3e5149a79ad (terraform-providers: fix the google and google-beta providers, 2020-03-24)
for terraform-providers.google and terraform-providers.google-beta, and in 20f55a9fc07 (terraform-providers.ibm: move to update-all script, 2020-04-26)
for terraform-providers.ibm.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
