### PR TITLE
unnethack: 5.2.0 -> 5.3.2

### DIFF
--- a/pkgs/games/unnethack/default.nix
+++ b/pkgs/games/unnethack/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "GAMEPERM=744" ];
   patches = [
+    # fix regression with bison, merged in master
     (fetchpatch {
       name = "fix-bison.patch";
       url = "https://github.com/UnNetHack/UnNetHack/commit/04f0a3a850a94eb8837ddcef31303968240d1c31.patch";

--- a/pkgs/games/unnethack/default.nix
+++ b/pkgs/games/unnethack/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, fetchgit, utillinux, ncurses, flex, bison }:
+{ stdenv, fetchFromGitHub, fetchpatch, utillinux, ncurses, flex, bison }:
 
 stdenv.mkDerivation rec {
   pname = "unnethack";
-  version = "5.2.0";
+  version = "5.3.2";
 
-  src = fetchgit {
-    url = "https://github.com/UnNetHack/UnNetHack";
-    rev = "refs/tags/${version}";
-    sha256 = "088gd2c7v95f2pm9ky38i28sz73mnsksr2p2hhhflkchxncd21f1";
+  src = fetchFromGitHub {
+    name = "UnNetHack";
+    owner = "UnNetHack";
+    repo = "UnNetHack";
+    rev = version;
+    sha256 = "1rg0mqyplgn3dfh3wz09a600qxk7aidqw4d84kyiincljvhyb7ps";
   };
 
   buildInputs = [ ncurses ];
@@ -22,6 +24,13 @@ stdenv.mkDerivation rec {
                    ];
 
   makeFlags = [ "GAMEPERM=744" ];
+  patches = [
+    (fetchpatch {
+      name = "fix-bison.patch";
+      url = "https://github.com/UnNetHack/UnNetHack/commit/04f0a3a850a94eb8837ddcef31303968240d1c31.patch";
+      sha256 = "1zblbwqqz9nx16k6n31wi2hdvz775lvzmkjblmrx18nbm4ylj0n9";
+    })
+  ];
 
   enableParallelBuilding = true;
 
@@ -54,5 +63,5 @@ stdenv.mkDerivation rec {
     license = "nethack";
     platforms = platforms.all;
     maintainers = with maintainers; [ abbradar ];
-  }; 
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

As part of [ZHF](https://github.com/NixOS/nixpkgs/issues/97479), so it should be backported.

Upgrading the version didn't fix the failure, but adding the bison include directive did.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
