### PR TITLE
Purity checking should also accept $TMP, $TMPDIR and $TEMP, $TEMPDIR

### DIFF
--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -69,9 +69,13 @@ badPath() {
     # directory (including the build directory).
     test \
         "$p" != "/dev/null" -a \
-        "${p#${NIX_STORE}}" = "$p" -a \
-        "${p#${TMP:-/tmp}}" = "$p" -a \
-        "${p#${NIX_BUILD_TOP}}" = "$p"
+        "${p#${NIX_STORE}}"     = "$p" -a \
+        "${p#${NIX_BUILD_TOP}}" = "$p" -a \
+        "${p#/tmp}"             = "$p" -a \
+        "${p#${TMP:-/tmp}}"     = "$p" -a \
+        "${p#${TMPDIR:-/tmp}}"  = "$p" -a \
+        "${p#${TEMP:-/tmp}}"    = "$p" -a \
+        "${p#${TEMPDIR:-/tmp}}" = "$p"
 }
 
 expandResponseParams() {


### PR DESCRIPTION
###### Motivation for this change

@FRidh @jtojnar @matthewbauer @vcunat @pbogdan have to submit a new pull request for an update to #93560 as it was accepted (and hence closed) but later reverted.

The details again are, the `badPath` routine used by the various compiler paths to check purity is hard coded to reject any paths that lie outside of

* `$NIX_STORE`,
* `$NIX_BUILD_TOP`, and
* `/tmp`.

In build environments, however, `/tmp` is frequently overriden by settings the `$TMP`, `$TMPDIR`, and `$TEMP` environment variables, so I submitted a pull request #93560 to make the system use $TMP, if set, instead of `/tmp`.

This broke packages that were hardcoded to use `/tmp` (e.g., `mktemp /tmp/FOOXXXX`). In retrospect, the patch was also somewhat lacking as it should technically should also have accept `$TMPDIR` and `$TEMP` in addition to `$TMP`. This is an updated pull request that accepts all of

* `$NIX_STORE`,
* `$NIX_BUILD_TOP`,
* `/tmp`,
* `$TMP`,
* `$TMPDIR`, and
* `$TEMP`.

 Being strictly more accepting than the previous one, this one should not causes any failures.

###### Things done

I have verified the above GNU helloworld (see above) compiles correctly in the above example once this change is made. This is actually quite extensive as change the `badPath` routine does result in a fairly significant rebuild of dependencies.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
