### PR TITLE
buildRustPackage: support setting test-threads

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -119,6 +119,18 @@ The above are just guidelines, and exceptions may be granted on a case-by-case b
 However, please check if it's possible to disable a problematic subset of the
 test suite and leave a comment explaining your reasoning.
 
+#### Setting `test-threads`
+
+`buildRustPackage` will use parallel test threads by default,
+sometimes it may be necessary to disable this so the tests run consecutively.
+
+```nix
+rustPlatform.buildRustPackage {
+  /* ... */
+  cargoParallelTestThreads = false;
+}
+```
+
 ### Building a package in `debug` mode
 
 By default, `buildRustPackage` will use `release` mode for builds. If a package

--- a/pkgs/applications/networking/browsers/castor/default.nix
+++ b/pkgs/applications/networking/browsers/castor/default.nix
@@ -39,8 +39,7 @@ rustPlatform.buildRustPackage rec {
   postInstall = "make PREFIX=$out copy-data";
 
   # Sometimes tests fail when run in parallel
-  #checkFlags = [ "--test-threads=1" ];
-  doCheck = false;
+  cargoParallelTestThreads = false;
 
   meta = with stdenv.lib; {
     description = "A graphical client for plain-text protocols written in Rust with GTK. It currently supports the Gemini, Gopher and Finger protocols";
@@ -49,4 +48,3 @@ rustPlatform.buildRustPackage rec {
     maintainers = with maintainers; [ fgaz ];
   };
 }
-

--- a/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/default.nix
@@ -15,8 +15,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ ncurses5 ] ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv Security ];
 
-  #checkFlagsArray = [ "--test-threads=1" ];
-  doCheck = false;
+  cargoParallelTestThreads = false;
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/MitMaro/git-interactive-rebase-tool";

--- a/pkgs/development/tools/the-way/default.nix
+++ b/pkgs/development/tools/the-way/default.nix
@@ -16,8 +16,8 @@ rustPlatform.buildRustPackage rec {
   buildInputs = stdenv.lib.optionals stdenv.isDarwin  [ AppKit Security ];
 
   cargoSha256 = "0adhgp6blwx7s1hlwqzzsgkzc43q9avxx8a9ykvvv2s1w7m9ql78";
-  #checkFlags = "--test-threads=1";
-  doCheck = false;
+  checkFlagsArray = stdenv.lib.optionals stdenv.isDarwin [ "--skip=copy" ];
+  cargoParallelTestThreads = false;
 
   postInstall = ''
     $out/bin/the-way config default tmp.toml


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Setting `--test-threads=$NIX_BUILD_CORES` breaks packages that require `--test-threads=1`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
