### PR TITLE
zict: disable python 2 and 3.5.

### DIFF
--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -23,6 +23,7 @@
 , singledispatch
 , mpi4py
 , bokeh
+, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -35,11 +36,13 @@ buildPythonPackage rec {
     sha256 = "469e505fd7ce75f600188bdb69a95641899d5b372f74246c8f308376b6929e9c";
   };
 
+  disabled = pythonOlder "3.6";
+
   checkInputs = [ pytest pytest-repeat pytest-timeout mock joblib ];
   propagatedBuildInputs = [
       click cloudpickle dask msgpack psutil six
       sortedcontainers tblib toolz tornado zict pyyaml mpi4py bokeh
-  ] ++ lib.optionals (!isPy3k) [ futures singledispatch ];
+  ];
 
   # tests take about 10-15 minutes
   # ignore 5 cli tests out of 1000 total tests that fail due to subprocesses

--- a/pkgs/development/python-modules/streamz/default.nix
+++ b/pkgs/development/python-modules/streamz/default.nix
@@ -10,6 +10,7 @@
 , toolz
 , tornado
 , zict
+, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -37,6 +38,8 @@ buildPythonPackage rec {
     pytest
     requests
   ];
+
+  disabled = pythonOlder "3.6";
 
   # Disable test_tcp_async because fails on sandbox build
   # disable kafka tests

--- a/pkgs/development/python-modules/zict/default.nix
+++ b/pkgs/development/python-modules/zict/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, pytest, heapdict }:
+, pytest, heapdict, pythonOlder }:
 
 buildPythonPackage rec {
   pname = "zict";
@@ -9,6 +9,8 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "8e2969797627c8a663575c2fc6fcb53a05e37cdb83ee65f341fc6e0c3d0ced16";
   };
+
+  disabled = pythonOlder "3.6";
 
   buildInputs = [ pytest ];
   propagatedBuildInputs = [ heapdict ];


### PR DESCRIPTION
Part of ZHF in #97479

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Zero hydra failures

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
