### PR TITLE
verilog: cleanup & test

### DIFF
--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -1,7 +1,17 @@
 { stdenv, fetchFromGitHub, autoconf, gperf, flex, bison, readline, ncurses
 , bzip2, zlib
+# Test inputs
+, perl
 }:
 
+let
+  iverilog-test = fetchFromGitHub {
+    owner = "steveicarus";
+    repo = "ivtest";
+    rev = "6882cb8ec08926c4e356c6092f0c5f8c23328d5c";
+    sha256 = "04sj5nqzwls1y760kgnd9c2whkcrr8kvj9lisd5rvk0w580kjb2x";
+  };
+in
 stdenv.mkDerivation rec {
   pname = "iverilog";
   version = "unstable-2020-08-24";
@@ -23,6 +33,28 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf gperf flex bison ];
 
   buildInputs = [ readline ncurses bzip2 zlib ];
+
+  # tests from .travis.yml
+  doCheck = true; # runs ``make check``
+  # most tests pass, but some that rely on exact text of floating-point numbers fail on aarch64.
+  doInstallCheck = !stdenv.isAarch64;
+  installCheckInputs = [ perl ];
+
+  installCheckPhase = ''
+    # copy tests to allow writing results
+    export TESTDIR=$(mktemp -d)
+    cp -r ${iverilog-test}/* $TESTDIR
+
+    pushd $TESTDIR
+
+    # Run & check tests
+    PATH=$out/bin:$PATH perl vvp_reg.pl
+    # Check the tests, will error if unexpected tests fail. Some failures MIGHT be normal.
+    diff regression_report-devel.txt regression_report.txt
+    PATH=$out/bin:$PATH perl vpi_reg.pl
+
+    popd
+  '';
 
   meta = with stdenv.lib; {
     description = "Icarus Verilog compiler";

--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -15,11 +15,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  prePatch = ''
-    substituteInPlace configure.in \
-      --replace "AC_CHECK_LIB(termcap, tputs)" "AC_CHECK_LIB(termcap, tputs)"
-  '';
-
   preConfigure = ''
     chmod +x $PWD/autoconf.sh
     $PWD/autoconf.sh
@@ -31,9 +26,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Icarus Verilog compiler";
-    repositories.git = "https://github.com/steveicarus/iverilog.git";
     homepage = "http://iverilog.icarus.com/";
-    license = licenses.lgpl21;
+    license = with licenses; [ gpl2Plus lgpl21Plus] ;
     maintainers = with maintainers; [ winden ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Independently from #97513, I was working on cleaning up the package for ZHF, and didn't see that PR before merging.

This cleans up the derivation and adds self-tests along the lines of what is done in CI. https://github.com/steveicarus/iverilog/blob/07bbf4ce0f1aeb6dcfbabe239514c55822779fd9/.travis.yml

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
