### PR TITLE
python3Packages.pyfakefs: disable on python 2.7

### DIFF
--- a/pkgs/development/python-modules/pyfakefs/default.nix
+++ b/pkgs/development/python-modules/pyfakefs/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, buildPythonPackage, fetchPypi, python, pytest, glibcLocales, isPy37 }:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, python, pytest, glibcLocales }:
 
 buildPythonPackage rec {
   version = "4.1.0";
   pname = "pyfakefs";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
@@ -24,8 +25,6 @@ buildPythonPackage rec {
       --replace "test_rename_dir_to_existing_dir" "notest_rename_dir_to_existing_dir"
   '');
 
-  # https://github.com/jmcgeheeiv/pyfakefs/issues/508
-  doCheck = !isPy37;
   checkInputs = [ pytest glibcLocales ];
 
   checkPhase = ''
@@ -39,6 +38,7 @@ buildPythonPackage rec {
     description = "Fake file system that mocks the Python file system modules";
     license     = licenses.asl20;
     homepage    = "http://pyfakefs.org/";
+    changelog   = "https://github.com/jmcgeheeiv/pyfakefs/blob/master/CHANGES.md";
     maintainers = with maintainers; [ gebner ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Disable ``pythonPackages.pyfakefs`` for unsupported python versions.

ZHF: #97479

Update meta & enable tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
