### PR TITLE
python3Packages.pytest-timeout: 1.3.3 -> 1.4.2

### DIFF
--- a/pkgs/development/python-modules/pytest-timeout/default.nix
+++ b/pkgs/development/python-modules/pytest-timeout/default.nix
@@ -1,34 +1,36 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , fetchPypi
-, fetchpatch
-, lib
-, pexpect
 , pytest
+, pytestCheckHook
+, pexpect
+, pytestcov
 }:
 
 buildPythonPackage rec {
   pname = "pytest-timeout";
-  version = "1.3.3";
+  version = "1.4.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1cczcjhw4xx5sjkhxlhc5c1bkr7x6fcyx12wrnvwfckshdvblc2a";
+    sha256 = "0xnsigs0kmpq1za0d4i522sp3f71x5bgpdh3ski0rs74yqy13cr0";
   };
 
-  patches = fetchpatch {
-    url = "https://bitbucket.org/pytest-dev/pytest-timeout/commits/36998c891573d8ec1db1acd4f9438cb3cf2aee2e/raw";
-    sha256 = "05zc2w7mjgv8rm8i1cbxp7k09vlscmay5iy78jlzgjqkrx3wkf46";
-  };
+  propagatedBuildInputs = [ pytest ];
 
-  checkInputs = [ pytest pexpect ];
-  checkPhase = ''
-    # test_suppresses_timeout_when_pdb_is_entered fails under heavy load
-    pytest -ra -k 'not test_suppresses_timeout_when_pdb_is_entered'
-  '';
+  checkInputs = [ pytestCheckHook pexpect pytestcov ];
 
-  meta = with lib;{
+  disabledTests = [
+    "test_suppresses_timeout_when_pdb_is_entered"
+  ];
+  pytestFlagsArray = [
+    "-ra"
+  ];
+
+  meta = with lib; {
     description = "py.test plugin to abort hanging tests";
-    homepage = "https://bitbucket.org/pytest-dev/pytest-timeout/";
+    homepage = "https://github.com/pytest-dev/pytest-timeout/";
+    changelog = "https://github.com/pytest-dev/pytest-timeout/#changelog";
     license = licenses.mit;
     maintainers = with maintainers; [ makefu costrouc ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

* Update version
* switch to pytestCheckHook
* Update meta: hompage & changelog
* explicit runtime dependency on pytest

Based on work by @jpgu-epam in #97527 (supersedes that PR's pytest-timeout due to more tests enabled & updated meta)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
