### PR TITLE
[20.09]: python3Packages.nmigen: fix build

### DIFF
--- a/pkgs/development/python-modules/nmigen/default.nix
+++ b/pkgs/development/python-modules/nmigen/default.nix
@@ -8,6 +8,7 @@
 , jinja2
 
 # for tests
+, pytestCheckHook
 , yosys
 , symbiyosys
 , yices
@@ -18,6 +19,7 @@ buildPythonPackage rec {
   version = "unstable-2020-04-02";
   # python setup.py --version
   realVersion = "0.2.dev49+g${lib.substring 0 7 src.rev}";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "nmigen";
@@ -26,17 +28,22 @@ buildPythonPackage rec {
     sha256 = "sha256-3+mxHyg0a92/BfyePtKT5Hsk+ra+fQzTjCJ2Ech44/s=";
   };
 
-  disabled = pythonOlder "3.6";
-
   nativeBuildInputs = [ setuptools_scm ];
 
   propagatedBuildInputs = [ setuptools pyvcd jinja2 ];
 
-  checkInputs = [ yosys symbiyosys yices ];
+  checkInputs = [ pytestCheckHook yosys symbiyosys yices ];
 
   preBuild = ''
     export SETUPTOOLS_SCM_PRETEND_VERSION="${realVersion}"
   '';
+
+  # Fail b/c can't find sby (symbiyosys) executable, which should be on path.
+  disabledTests = [
+    "test_distance"
+    "test_reversible"
+    "FIFOFormalCase"
+  ];
 
   meta = with lib; {
     description = "A refreshed Python toolbox for building complex digital hardware";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes ``python3Packages.nmigen`` build on ``release-20.09`` branch.

Backport of #97617 
ZHF: #97479 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
