### PR TITLE
[20.09] clpeak: fix build

### DIFF
--- a/pkgs/tools/misc/clpeak/clpeak-clhpp2.diff
+++ b/pkgs/tools/misc/clpeak/clpeak-clhpp2.diff
@@ -1,0 +1,72 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 86fec9e..b9d0341 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,7 +22,7 @@ elseif(WIN32 AND ${OpenCL_LIBRARIES} MATCHES "OpenCL.lib")
+   set(OpenCL_LIBRARIES ${OpenCL_LIBRARIES} cfgmgr32.lib)
+ endif()
+ 
+-FIND_PATH(HPP_FOUND CL/cl.hpp PATHS ${OpenCL_INCLUDE_DIRS})
++FIND_PATH(HPP_FOUND CL/cl2.hpp PATHS ${OpenCL_INCLUDE_DIRS})
+ if(NOT HPP_FOUND)
+   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+   include(BuildCLHpp)
+diff --git a/include/clpeak.h b/include/clpeak.h
+index c090d31..0d9d5e2 100644
+--- a/include/clpeak.h
++++ b/include/clpeak.h
+@@ -1,14 +1,10 @@
+ #ifndef CLPEAK_HPP
+ #define CLPEAK_HPP
+ 
+-#define __CL_ENABLE_EXCEPTIONS
+-
+-#include <CL/cl.hpp>
+-
+ #include <iostream>
+ #include <stdio.h>
+ #include <iomanip>
+-#include <string.h>
++#include <string>
+ #include <sstream>
+ #include <common.h>
+ #include <logger.h>
+diff --git a/include/common.h b/include/common.h
+index 91318cb..6aaca04 100644
+--- a/include/common.h
++++ b/include/common.h
+@@ -1,7 +1,11 @@
+ #ifndef COMMON_H
+ #define COMMON_H
+ 
+-#include <CL/cl.hpp>
++#define CL_HPP_ENABLE_EXCEPTIONS
++#define CL_HPP_MINIMUM_OPENCL_VERSION 120
++#define CL_HPP_TARGET_OPENCL_VERSION 120
++#include <CL/cl2.hpp>
++
+ #if defined(__APPLE__) || defined(__MACOSX) || defined(__FreeBSD__)
+ #include <sys/types.h>
+ #endif
+diff --git a/src/clpeak.cpp b/src/clpeak.cpp
+index 8708463..4a47842 100644
+--- a/src/clpeak.cpp
++++ b/src/clpeak.cpp
+@@ -3,7 +3,7 @@
+ 
+ #define MSTRINGIFY(...) #__VA_ARGS__
+ 
+-static const char *stringifiedKernels =
++static const std::string stringifiedKernels =
+ #include "global_bandwidth_kernels.cl"
+ #include "compute_sp_kernels.cl"
+ #include "compute_hp_kernels.cl"
+@@ -65,7 +65,7 @@ int clPeak::runAll()
+ 
+       cl::Context ctx(CL_DEVICE_TYPE_ALL, cps);
+       vector<cl::Device> devices = ctx.getInfo<CL_CONTEXT_DEVICES>();
+-      cl::Program::Sources source(1, make_pair(stringifiedKernels, (strlen(stringifiedKernels) + 1)));
++      cl::Program::Sources source(1, stringifiedKernels);
+       cl::Program prog = cl::Program(ctx, source);
+ 
+       for (size_t d = 0; d < devices.size(); d++)

--- a/pkgs/tools/misc/clpeak/default.nix
+++ b/pkgs/tools/misc/clpeak/default.nix
@@ -12,6 +12,14 @@ stdenv.mkDerivation rec {
     sha256 = "1wkjpvn4r89c3y06rv7gfpwpqw6ljmqwz0w0mljl9y5hn1r4pkx2";
   };
 
+  patches = [
+    # The cl.hpp header was removed from opencl-clhpp. This patch
+    # updates clpeak to use the new cp2.hpp header. The patch comes
+    # from the following PR and was updated to apply against more
+    # recent versions: https://github.com/krrishnarraj/clpeak/pull/46
+    ./clpeak-clhpp2.diff
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ ocl-icd opencl-clhpp ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The build of clpeak recently started failing because opencl-clhpp was
updated. The latest version of opencl-hpp does not ship the deprecated
cl.hpp header anymore.

(cherry picked from commit 5f6738228d48e5f1c0ec4acca4379c7c7d0648ac)

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
