### PR TITLE
ocamlPackages.ptmap: 2.0.4 → 2.0.5

### DIFF
--- a/pkgs/development/ocaml-modules/ptmap/default.nix
+++ b/pkgs/development/ocaml-modules/ptmap/default.nix
@@ -1,43 +1,29 @@
-{ stdenv, fetchzip, ocaml, findlib, obuild }:
+{ lib, buildDunePackage, fetchurl
+, seq
+, stdlib-shims
+}:
 
-let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.07"
-  then {
-    version = "2.0.4";
-    sha256 = "05a391m1l04zigi6ghywj7f5kxy2w6186221k7711wmg56m94yjw";
-  } else {
-    version = "2.0.3";
-    sha256 = "19xykhqk7q25r1pj8rpfj53j2r9ls8mxi1w5m2wqshrf20gf078h";
-  }
-; in
+buildDunePackage rec {
+  pname = "ptmap";
+  version = "2.0.5";
 
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-ptmap-${param.version}";
+  useDune2 = true;
 
-  src = fetchzip {
-    url = "https://github.com/backtracking/ptmap/archive/v${param.version}.tar.gz";
-    inherit (param) sha256;
+  src = fetchurl {
+    url = "https://github.com/backtracking/ptmap/releases/download/${version}/ptmap-${version}.tbz";
+    sha256 = "1apk61fc1y1g7x3m3c91fnskvxp6i0vk5nxwvipj56k7x2pzilgb";
   };
 
-  buildInputs = [ ocaml findlib obuild ];
+  propagatedBuildInputs = [ seq ];
 
-  createFindlibDestdir = true;
+  doCheck = true;
 
-  buildPhase = ''
-    substituteInPlace ptmap.obuild --replace 'build-deps: qcheck' ""
-    obuild configure
-    obuild build lib-ptmap
-  '';
-
-  installPhase = ''
-    obuild install --destdir $out/lib/ocaml/${ocaml.version}/site-lib
-  '';
+  checkInputs = [ stdlib-shims ];
 
   meta = {
     homepage = "https://www.lri.fr/~filliatr/software.en.html";
-    platforms = ocaml.meta.platforms or [];
     description = "Maps over integers implemented as Patricia trees";
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = with stdenv.lib.maintainers; [ volth ];
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ volth ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc maintainer @volth 