### PR TITLE
maintainers/build: skip packages that don't evaluate

### DIFF
--- a/maintainers/scripts/build.nix
+++ b/maintainers/scripts/build.nix
@@ -13,8 +13,12 @@ let
           let
             result = builtins.tryEval
               (
-                if pkgs.lib.isDerivation pkg && cond name pkg
-                then [ (return name pkg) ]
+                if pkgs.lib.isDerivation pkg && cond name pkg then
+                  # Skip packages whose closure fails on evaluation.
+                  # This happens for pkgs like `python27Packages.djangoql`
+                  # that have disabled Python pkgs as dependencies.
+                  builtins.seq pkg.outPath
+                    [ (return name pkg) ]
                 else if pkg.recurseForDerivations or false || pkg.recurseForRelease or false
                 then packagesWith cond return pkg
                 else [ ]


### PR DESCRIPTION
#### Motivation
`build.nix` fails when it selects packages that have disabled Python pkgs (like with `disabled = !isPy3k;`) as dependencies.

#### Example
```
nix-build --show-trace  maintainers/scripts/build.nix --argstr maintainer earvstedt
# Output
error: ... while evaluating ... 'python2.7-djangoql-0.14.0'
...
Django-2.2.15 not supported for interpreter python2.7
```
Explanation:
`python27Packages.djangoql` is not `disabled` but has the `disabled` Py3k-only dependency `django`.

#### Discussion
To check which pkgs should be built, `build.nix` only evaluates the `meta.maintainers` attribute of each pkg.
If the maintainer doesn't match or if evaluation of `meta.maintainers` fails, the package is skipped.
When a pkg is selected to be built but one of its dependencies is disabled the build fails.

The workaround to skip all packages whose closure doesn't evaluate is not ideal as this may ignore actual package defects.
But most of these potential eval failures should already get caught by `ofborg` before merging.

This is relevant for ZHF: #97479 

I'll add a backport in case this PR gets merged.