### PR TITLE
gnomeExtensions.dash-to-panel: 38 -> 39

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/dash-to-panel/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/dash-to-panel/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-dash-to-panel";
-  version = "38";
+  version = "39";
 
   src = fetchFromGitHub {
     owner = "home-sweet-gnome";
     repo = "dash-to-panel";
     rev = "v${version}";
-    sha256 = "1kvybb49l1vf0fvh8d0c6xkwnry8m330scamf5x40y63d4i213j1";
+    sha256 = "0r7kbmrizl9ilqy7gzzvjwxcv8xpp13n5n0a8s84blg97cih0hw2";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Compatibility issues with gnome-shell 3.36.5 have been fixed:
https://github.com/home-sweet-gnome/dash-to-panel/releases/tag/v39

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
