### PR TITLE
nixos/nfs: fix permissions

### DIFF
--- a/nixos/modules/services/network-filesystems/nfsd.nix
+++ b/nixos/modules/services/network-filesystems/nfsd.nix
@@ -163,10 +163,11 @@ in
     # rpc-statd will drop privileges by changing user from root to the owner of
     # /var/lib/nfs
     systemd.tmpfiles.rules = [
-      "d /var/lib/nfs 0700 ${rpcUser} ${rpcUser} - -"
-    ] ++ map (e:
-      "d /var/lib/nfs/${e} 0755 root root - -"
-    ) [ "recovery" "v4recovery" "sm" "sm.bak" ];
+      "d /var/lib/nfs            0700 ${rpcUser} ${rpcUser} - -"
+      "d /var/lib/nfs/sm         0755 ${rpcUser} nogroup    - -"
+      "d /var/lib/nfs/sm.bak     0755 ${rpcUser} nogroup    - -"
+      "d /var/lib/nfs/v4recovery 0755 root       root       - -"
+    ];
 
     users = {
       groups."${rpcUser}" = {};


### PR DESCRIPTION
###### Motivation for this change

Further to #96844

Fixes #97582

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).