### PR TITLE
sm64ex: unstable-2020-06-19 -> unstable-2020-10-09

### DIFF
--- a/pkgs/games/sm64ex/default.nix
+++ b/pkgs/games/sm64ex/default.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sm64ex";
-  version = "unstable-2020-06-19";
+  version = "unstable-2020-10-09";
 
   src = fetchFromGitHub {
     owner = "sm64pc";
     repo = "sm64ex";
-    rev = "f5005418348cf1a53bfa75ff415a513ef0b9b273";
-    sha256 = "0adyshkqk5c4lxhdxc3j6ax4svfka26486qpa5q2gl2nixwg9zxn";
+    rev = "57c203465b2b3eee03dcb796ed1fad07d8283a2c";
+    sha256 = "0k6a3r9f4spa7y2v1lyqs9lwa05lw8xgywllb7w828nal8y33cs6";
   };
 
   nativeBuildInputs = [ python3 pkg-config ];


### PR DESCRIPTION
###### Motivation for this change
Wanted to use this again, decided to update it to the latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`:
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
