### PR TITLE
systemd: 246 -> 246.4

### DIFF
--- a/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
+++ b/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
@@ -1,4 +1,4 @@
-From 54fb14592fc41752c3cd26552c974dd1ad4b9e73 Mon Sep 17 00:00:00 2001
+From 46c8ccfeb61253cd3dff5f34013670c7e3366ef5 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Tue, 8 Jan 2013 15:46:30 +0100
 Subject: [PATCH 01/18] Start device units for uninitialised encrypted devices
@@ -28,5 +28,5 @@ index 1c60eec587..b2486da130 100644
  SUBSYSTEM=="block", ENV{ID_PART_GPT_AUTO_ROOT}=="1", ENV{ID_FS_TYPE}!="crypto_LUKS", SYMLINK+="gpt-auto-root"
  SUBSYSTEM=="block", ENV{ID_PART_GPT_AUTO_ROOT}=="1", ENV{ID_FS_TYPE}=="crypto_LUKS", SYMLINK+="gpt-auto-root-luks"
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
+++ b/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
@@ -1,4 +1,4 @@
-From d52880eeae09aaacd308430499f55810157b1a6d Mon Sep 17 00:00:00 2001
+From 139c420de62e078182eaf48b541c4b912d445fd9 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Fri, 12 Apr 2013 13:16:57 +0200
 Subject: [PATCH 02/18] Don't try to unmount /nix or /nix/store
@@ -38,5 +38,5 @@ index 8a5e80eeaa..fab35ed6f3 100644
                  || path_equal(path, "/usr")
  #endif
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
+++ b/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
@@ -1,4 +1,4 @@
-From 794073e466a3b6c8e138f0e6d15c8d6465a1a4a9 Mon Sep 17 00:00:00 2001
+From a889dbe796cd72425f38dec3d2aaab44a914ac60 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Wed, 16 Apr 2014 10:59:28 +0200
 Subject: [PATCH 03/18] Fix NixOS containers
@@ -10,7 +10,7 @@ container, so checking early whether it exists will fail.
  1 file changed, 2 insertions(+)
 
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 3b9493f232..0117a9939d 100644
+index 43712565c2..07f294c78a 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
 @@ -5122,6 +5122,7 @@ static int run(int argc, char *argv[]) {
@@ -30,5 +30,5 @@ index 3b9493f232..0117a9939d 100644
  
          } else {
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
+++ b/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
@@ -1,4 +1,4 @@
-From caa8dcfa87cf2e46a7a1cce9c16f929916cf9186 Mon Sep 17 00:00:00 2001
+From 5098b1aad07356e04fcd12f2c77ea4fd17460411 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Thu, 1 May 2014 14:10:10 +0200
 Subject: [PATCH 04/18] Look for fsck in the right place
@@ -21,5 +21,5 @@ index 80f7107b9d..74e48a385f 100644
                  cmdline[i++] = "-T";
  
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
+++ b/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
@@ -1,4 +1,4 @@
-From e5d73359928b79bd846bda29ce61fe276d8c0b76 Mon Sep 17 00:00:00 2001
+From b46f1b20e990f01af4bdf3dd6fef45f5b4a5993e Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Fri, 19 Dec 2014 14:46:17 +0100
 Subject: [PATCH 05/18] Add some NixOS-specific unit directories
@@ -120,5 +120,5 @@ index 8424837824..b1c541bc52 100644
  
  systemd_system_generator_dir=${root_prefix}/lib/systemd/system-generators
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
+++ b/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
@@ -1,4 +1,4 @@
-From 1a3de021d9b8da060a77af6e26d2b61bafefda74 Mon Sep 17 00:00:00 2001
+From 4c9f9d192182f1051dba1c547e182e7c8f549b0f Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Mon, 11 May 2015 15:39:38 +0200
 Subject: [PATCH 06/18] Get rid of a useless message in user sessions
@@ -13,7 +13,7 @@ in containers.
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/core/unit.c b/src/core/unit.c
-index 2c09def06f..c70540e1a3 100644
+index 1bda568560..5b44970763 100644
 --- a/src/core/unit.c
 +++ b/src/core/unit.c
 @@ -2150,7 +2150,8 @@ static void unit_check_binds_to(Unit *u) {
@@ -27,5 +27,5 @@ index 2c09def06f..c70540e1a3 100644
          /* A unit we need to run is gone. Sniff. Let's stop this. */
          r = manager_add_job(u->manager, JOB_STOP, u, JOB_FAIL, NULL, &error, NULL);
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
+++ b/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
@@ -1,4 +1,4 @@
-From 6c12e0d2afe80563e692fc1f2f545a487c83418c Mon Sep 17 00:00:00 2001
+From 539f3af04963a6826d2b2d0ba2095af99a7a6294 Mon Sep 17 00:00:00 2001
 From: Gabriel Ebner <gebner@gebner.org>
 Date: Sun, 6 Dec 2015 14:26:36 +0100
 Subject: [PATCH 07/18] hostnamed, localed, timedated: disable methods that
@@ -104,5 +104,5 @@ index c467b85477..3e78b2f575 100644
          if (r < 0)
                  return r;
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0008-Fix-hwdb-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0008-Fix-hwdb-paths.patch
@@ -1,4 +1,4 @@
-From 1e40be83eca9a831509ae764081c2252934478c3 Mon Sep 17 00:00:00 2001
+From 5c2a1a6d33f7cdbcb8ddcc70b91ba4c7f3c383b3 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 7 Jul 2016 02:47:13 +0300
 Subject: [PATCH 08/18] Fix hwdb paths
@@ -28,5 +28,5 @@ index b3febdbb31..eba00a5bc7 100644
  _public_ int sd_hwdb_new(sd_hwdb **ret) {
          _cleanup_(sd_hwdb_unrefp) sd_hwdb *hwdb = NULL;
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+++ b/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
@@ -1,4 +1,4 @@
-From 5e235e1f720f37fc5581b40c9a13d365368e74a8 Mon Sep 17 00:00:00 2001
+From a8ccba372d865429b578e72fd104a693b96101b3 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Tue, 11 Oct 2016 13:12:08 +0300
 Subject: [PATCH 09/18] Change /usr/share/zoneinfo to /etc/zoneinfo
@@ -66,10 +66,10 @@ index 15cc1b8851..d0abde5933 100644
                  return -EINVAL;
  
 diff --git a/src/firstboot/firstboot.c b/src/firstboot/firstboot.c
-index a3f442518e..feff49e280 100644
+index c9fc8dd5cd..44fc04dc88 100644
 --- a/src/firstboot/firstboot.c
 +++ b/src/firstboot/firstboot.c
-@@ -459,7 +459,7 @@ static int process_timezone(void) {
+@@ -460,7 +460,7 @@ static int process_timezone(void) {
          if (isempty(arg_timezone))
                  return 0;
  
@@ -79,7 +79,7 @@ index a3f442518e..feff49e280 100644
          (void) mkdir_parents(etc_localtime, 0755);
          if (symlink(e, etc_localtime) < 0)
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 0117a9939d..d86445b40f 100644
+index 07f294c78a..cf86d1f494 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
 @@ -1699,8 +1699,8 @@ static int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t u
@@ -128,5 +128,5 @@ index 3e78b2f575..de5477a08f 100644
                          return -ENOMEM;
  
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
+++ b/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
@@ -1,4 +1,4 @@
-From 141d1d7acf5f018df86f0a5f7fbe49a8e928fd73 Mon Sep 17 00:00:00 2001
+From 84a2d35d4e75295edf7e190a94dfaf65db4973b6 Mon Sep 17 00:00:00 2001
 From: Imuli <i@imu.li>
 Date: Wed, 19 Oct 2016 08:46:47 -0400
 Subject: [PATCH 10/18] localectl: use /etc/X11/xkb for list-x11-*
@@ -23,5 +23,5 @@ index e0664de826..c521f33a2a 100644
                  return log_error_errno(errno, "Failed to open keyboard mapping list. %m");
  
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
+++ b/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
@@ -1,4 +1,4 @@
-From db3946f465c0066fb1775a92c1fcc6450134904d Mon Sep 17 00:00:00 2001
+From 81ee9b5cd46f78de139c39e2a18f39e658c60169 Mon Sep 17 00:00:00 2001
 From: Franz Pletz <fpletz@fnordicwalking.de>
 Date: Sun, 11 Feb 2018 04:37:44 +0100
 Subject: [PATCH 11/18] build: don't create statedir and don't touch prefixdir
@@ -8,10 +8,10 @@ Subject: [PATCH 11/18] build: don't create statedir and don't touch prefixdir
  1 file changed, 3 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index dbbddb68e2..bbeb23223d 100644
+index ba9e7afe53..2ef9d4d770 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -3369,9 +3369,6 @@ install_data('LICENSE.GPL2',
+@@ -3371,9 +3371,6 @@ install_data('LICENSE.GPL2',
               'src/libsystemd/sd-bus/GVARIANT-SERIALIZATION',
               install_dir : docdir)
  
@@ -22,5 +22,5 @@ index dbbddb68e2..bbeb23223d 100644
  
  check_help = find_program('tools/check-help.sh')
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0012-Install-default-configuration-into-out-share-factory.patch
+++ b/pkgs/os-specific/linux/systemd/0012-Install-default-configuration-into-out-share-factory.patch
@@ -1,4 +1,4 @@
-From 245af064c4d315d868cc12201b3663f61702cce3 Mon Sep 17 00:00:00 2001
+From 7dbe84b7c43669dccd90db8ac33c38a70e6b6914 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
 Date: Mon, 26 Feb 2018 14:25:57 +0000
 Subject: [PATCH 12/18] Install default configuration into $out/share/factory
@@ -44,7 +44,7 @@ index 5c77387a26..6404bc01ba 100644
          meson.add_install_script('sh', '-c',
                                   'test -n "$DESTDIR" || @0@/systemd-hwdb update'
 diff --git a/meson.build b/meson.build
-index bbeb23223d..1a9c56fad2 100644
+index 2ef9d4d770..ae7acbd769 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -163,6 +163,9 @@ udevhwdbdir = join_paths(udevlibexecdir, 'hwdb.d')
@@ -57,7 +57,7 @@ index bbeb23223d..1a9c56fad2 100644
  bootlibdir = join_paths(prefixdir, 'lib/systemd/boot/efi')
  testsdir = join_paths(prefixdir, 'lib/systemd/tests')
  systemdstatedir = join_paths(localstatedir, 'lib/systemd')
-@@ -2651,7 +2654,7 @@ if conf.get('ENABLE_BINFMT') == 1
+@@ -2653,7 +2656,7 @@ if conf.get('ENABLE_BINFMT') == 1
          meson.add_install_script('sh', '-c',
                                   mkdir_p.format(binfmtdir))
          meson.add_install_script('sh', '-c',
@@ -66,7 +66,7 @@ index bbeb23223d..1a9c56fad2 100644
  endif
  
  if conf.get('ENABLE_REPART') == 1
-@@ -2767,7 +2770,7 @@ executable(
+@@ -2769,7 +2772,7 @@ executable(
          install_dir : rootlibexecdir)
  
  install_data('src/sleep/sleep.conf',
@@ -75,7 +75,7 @@ index bbeb23223d..1a9c56fad2 100644
  
  public_programs += executable(
          'systemd-sysctl',
-@@ -3101,7 +3104,7 @@ if conf.get('HAVE_KMOD') == 1
+@@ -3103,7 +3106,7 @@ if conf.get('HAVE_KMOD') == 1
          meson.add_install_script('sh', '-c',
                                   mkdir_p.format(modulesloaddir))
          meson.add_install_script('sh', '-c',
@@ -84,7 +84,7 @@ index bbeb23223d..1a9c56fad2 100644
  endif
  
  public_programs += executable(
-@@ -3352,7 +3355,7 @@ install_subdir('factory/etc',
+@@ -3354,7 +3357,7 @@ install_subdir('factory/etc',
                 install_dir : factorydir)
  
  install_data('xorg/50-systemd-user.sh',
@@ -297,10 +297,10 @@ index 0a9582d8b9..3c56ca7d83 100644
 +                mkdir_p.format(join_paths(factoryconfdir, 'tmpfiles.d')))
  endif
 diff --git a/units/meson.build b/units/meson.build
-index aa2ed115ea..12e2925226 100644
+index 275daad3f4..491abd8eef 100644
 --- a/units/meson.build
 +++ b/units/meson.build
-@@ -323,7 +323,7 @@ install_data('user-.slice.d/10-defaults.conf',
+@@ -324,7 +324,7 @@ install_data('user-.slice.d/10-defaults.conf',
  
  meson.add_install_script(meson_make_symlink,
                           join_paths(pkgsysconfdir, 'user'),
@@ -310,5 +310,5 @@ index aa2ed115ea..12e2925226 100644
                           join_paths(dbussystemservicedir, 'org.freedesktop.systemd1.service'),
                           join_paths(dbussessionservicedir, 'org.freedesktop.systemd1.service'))
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
+++ b/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
@@ -1,4 +1,4 @@
-From bfaa53731ffe984c93c5321099d1341b5059f029 Mon Sep 17 00:00:00 2001
+From 4cbc82570aa8671d260c37df58688cc07106e4b6 Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Fri, 2 Nov 2018 21:15:42 +0100
 Subject: [PATCH 13/18] inherit systemd environment when calling generators.
@@ -16,10 +16,10 @@ executables that are being called from managers.
  1 file changed, 8 insertions(+), 3 deletions(-)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index 41e0d73736..d02de06f09 100644
+index 6b7908fc6c..dff265c76f 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
-@@ -4095,9 +4095,14 @@ static int manager_run_generators(Manager *m) {
+@@ -4098,9 +4098,14 @@ static int manager_run_generators(Manager *m) {
          argv[4] = NULL;
  
          RUN_WITH_UMASK(0022)
@@ -38,5 +38,5 @@ index 41e0d73736..d02de06f09 100644
  
  finish:
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0014-add-rootprefix-to-lookup-dir-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0014-add-rootprefix-to-lookup-dir-paths.patch
@@ -1,4 +1,4 @@
-From d8b93ef32f3b95a6ce6548a8ad1504a485ffbe81 Mon Sep 17 00:00:00 2001
+From 1f39dba787e07d0a6944416ec172ee5d7cc86acd Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Thu, 9 May 2019 11:15:22 +0200
 Subject: [PATCH 14/18] add rootprefix to lookup dir paths
@@ -34,5 +34,5 @@ index 970654a1ad..bb261040f8 100644
  #define CONF_PATHS(n)                           \
          CONF_PATHS_USR(n)                       \
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0015-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
+++ b/pkgs/os-specific/linux/systemd/0015-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
@@ -1,4 +1,4 @@
-From b3bc0aa899c51d19edfb53af2b00dde64123ab06 Mon Sep 17 00:00:00 2001
+From f7c462d37063b0077345395f54377c39d1ef0590 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 25 Jul 2019 20:45:55 +0300
 Subject: [PATCH 15/18] systemd-shutdown: execute scripts in
@@ -23,5 +23,5 @@ index 06c9710c6e..dadcc3117d 100644
          /* The log target defaults to console, but the original systemd process will pass its log target in through a
           * command line argument, which will override this default. Also, ensure we'll never log to the journal or
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0016-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
+++ b/pkgs/os-specific/linux/systemd/0016-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
@@ -1,4 +1,4 @@
-From 2679210f4ce804713bf1d244ac0fb8ac7b9b1e5f Mon Sep 17 00:00:00 2001
+From ff7cfe2d112eb166cd1937c3cc8c25491e508313 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 25 Jul 2019 20:46:58 +0300
 Subject: [PATCH 16/18] systemd-sleep: execute scripts in
@@ -10,7 +10,7 @@ This is needed for NixOS to use such scripts as systemd directory is immutable.
  1 file changed, 1 insertion(+)
 
 diff --git a/src/sleep/sleep.c b/src/sleep/sleep.c
-index 7029352ca5..6d9c636872 100644
+index 600e9c23c0..66ef1a99e1 100644
 --- a/src/sleep/sleep.c
 +++ b/src/sleep/sleep.c
 @@ -182,6 +182,7 @@ static int execute(char **modes, char **states) {
@@ -22,5 +22,5 @@ index 7029352ca5..6d9c636872 100644
          };
  
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
+++ b/pkgs/os-specific/linux/systemd/0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
@@ -1,4 +1,4 @@
-From 561b0cc9a1faed5729d6f701304a65c2968394ec Mon Sep 17 00:00:00 2001
+From 600ac2dd3fc15c5717fcdf8f37899fdabf97268c Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sat, 7 Mar 2020 22:40:27 +0100
 Subject: [PATCH 17/18] kmod-static-nodes.service: Update ConditionFileNotEmpty
@@ -23,5 +23,5 @@ index 0971edf9ec..87105a87b9 100644
  [Service]
  Type=oneshot
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
+++ b/pkgs/os-specific/linux/systemd/0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
@@ -1,4 +1,4 @@
-From 0d9d7c03054babdbd1fa5f6f266b56e8c96e9ba5 Mon Sep 17 00:00:00 2001
+From 42419ff4dc7a36607189f8d3765aa836d5c5eaf9 Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sun, 8 Mar 2020 01:05:54 +0100
 Subject: [PATCH 18/18] path-util.h: add placeholder for DEFAULT_PATH_NORMAL
@@ -29,5 +29,5 @@ index 30031fca8e..d97145539a 100644
  #if HAVE_SPLIT_USR
  #  define DEFAULT_PATH DEFAULT_PATH_SPLIT_USR
 -- 
-2.27.0
+2.28.0
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  version = "246";
+  version = "246.4";
 in stdenv.mkDerivation {
   inherit version;
   pname = "systemd";
@@ -29,7 +29,7 @@ in stdenv.mkDerivation {
     owner = "systemd";
     repo = "systemd-stable";
     rev = "v${version}";
-    sha256 = "0zrkyxrh5rm45f2l1rnjyv229bcyzawfw7c63jqxwix75px60dyw";
+    sha256 = "0ns12w55yv680p4l7f2i9il7scdph7hips68d9k8cyvxk2w9xg0x";
   };
 
   # If these need to be regenerated, `git am path/to/00*.patch` them into a


### PR DESCRIPTION
This bumps systemd to the latest stable maintenance release.

 - dc2e82af33 core: create per-user inaccessible node from the service manager
 - 0b3c497347 nspawn,pid1: pass "inaccessible" nodes from cntr mgr to pid1 payload via /run/host
 - 2239965c29 coredump: don't convert s → µs twice
 - 61d29b7f8c firstboot: fill empty color if ansi_color unavailable from os-release
 - 9678a3daf6 varlink: do not parse invalid messages twice
 - 4e516dcbc1 userdbctl: add forgotten --output mode in help
 - aee20dfbd8 shared/{user,group}-record-nss: adjust filtering of "valid" passwords
 - 5933d77afe doc: cross link sd_listen_fd() docs a bit
 - 97fdde3239 Rework how we cache mtime to figure out if units changed
 - 0500968241 core: always try to reload not-found unit
 - 8ae22f0d64 pid1: use the cache mtime not clock to "mark" load attempts
 - 715507c277 core: rename manager_unit_file_maybe_loadable_from_cache()
 - 20ad76d0a7 man: document fd ownership for sd-bus fd marshalling
 - 38ae73fafd resolved: make sure we initialize t->answer_errno before completing the transaction
 - a1ba0fbef6 homed: fix log message to honor real homework path
 - d6b1e659b3 src/shared/dissect-image.c: fix build without blkdid (#16901)
 - e42f9add21 analyze: fix error handling in one case
 - 4804ce1488 units: add missing usb-gadget.target
 - 5ad4e68c37 man: extend on the usec/sec discrepancy
 - 2fb612371d login/logind: Include sys/stat.h for struct stat usage
 - 5e884e7ee0 partition/makefs: Include missing sys/file.h header
 - 7bbc3807da network: dhcp6: logs only new address
 - 2056429e0f Don't run test-repart when loop devices are not available
 - dcbea51c5a man: clarify that several networkctl commands takes device names
 - 16e4cfcc82 networkctl: label command does not take any argument
 - 2352921244 missing: Add new Linux capability
 - 8b29c4a4f9 tty-ask-pw-agent: properly propagate error
 - f7ce2e9839 tty-ask-pw-agent: the message string might not be set
 - 29cba5c9ef tty-ask-pw-agent: make sure "--list" works correctly
 - e1ce367d73 add "list" verb to autocompleted commands
 - 1f4cb5da1e shell-completion/zsh: add missing verbs for networkctl
 - a4236a2764 path: Improve $PATH search directory case
 - b7cef386bd path: Skip directories when finalising $PATH search
 - 122945f315 rules: don't install 80-drivers.rules when kmod is disabled
 - 42fab2d454 zsh: correct journalctl command completion parsing
 - ed3f97f962 basic/missing_syscall: fix syscall numbers for arm64 :(
 - ba6e7f7c46 shared/install: fix preset operations for non-service instantiated units
 - d39f139348 nss-resolve: treat BUS_ERROR_NO_SUCH_UNIT the same as SD_BUS_ERROR_SERVICE_UNKNOWN too
 - 9bb3e64d71 various: treat BUS_ERROR_NO_SUCH_UNIT the same as SD_BUS_ERROR_SERVICE_UNKNOWN
 - 6d802dd596 man: drop reference to long gone .busname unit type
 - a29656804b man: fix a fix of a typo in systemd.service example
 - 21ce0f5b33 network: can: Fix CAN initialization
 - cab5cde8c9 man: update autogenerated dbus api lists
 - 0d8000522b man: fix invalid tag place
 - ea94f218be man: add conditionals to more man pages
 - ef91325349 meson: add ENABLE_ANALYZE conditional
 - 83f7c0a7ec core: add missing conditions/asserts to unit file parsing
 - 716718155d analyze: rework condition testing
 - 5c4c7581bc sd-bus: fix error handling on readv()
 - 6cd058f305 user-runtime-dir: deal gracefully with missing logind properties
 - 6a2d73638d shared/seccomp: do not use ifdef guards around textual syscall names
 - 7355ac9689 machine-id-setup: don't use KVM or container manager supplied uuid if in chroot env
 - 496a71f444 man: Fix typo in systemd-tmpfiles
 - 6c5d216ad8 homework: downgrade chattr failure log message
 - 1708f06a00 homework: explicitly close cryptsetup context, to not keep loopback device busy
 - a21eaa2a3a homework: correct error passed into log message
 - 3a2d169f36 homework: sync everything to disk before we rename LUKS loopback file into place
 - 84e1ab74d2 homed: downgrade quota message in containers
 - 8b62cadf36 analyze-security: do not assign badness to filtered-out syscalls
 - 29854a5437 NEWS: clarify two points
 - 4cb4fb82f7 meson: add min version for libfdisk
 - 76331f86f6 load-fragment: fix grammar in error messages
 - 1e53c2d70f Fix function description in logind man page
 - 669066564d network: do not fail if UseMTU=yes on DHCP lease lost
 - a2a3f16cdc missing_syscall: do not use function name that may conflict with glibc
 - 4091dcd469 missing_syscall: fix pidfd_{send_signal,open} numbers for alpha
 - 7875daf52b network: wait for previous address removal before configuring static addresses
 - 120064b4a1 network: only process non-error message
 - f44ec1de15 test: accept that char device 0/0 can now be created witout privileges
 - 946e4c43bb tools/make-man-index: fix purpose text that contains tags
 - dae0586e91 test-fs-util: skip encrypted path test if we get EACCES
 - 0d026c9b0d Newer Glibc use faccessat2 to implement faccessat
 - fde6520d46 namespace: fix minor memory leak
 - 208ba581f4 man: fix incorrectly placed full stop
 - 6c81d57828 man: fix typo
 - 53a8d2588e bless-boot: add missing verb to --help
 - 4cfa0ac4fd user-record: deal with invalid GECOS fields gracefully
 - ae5234ef48 user-util: add mangle_gecos() call for turning strings into fields suitable as GECOS fields
 - 972391ac39 fix typo in systemctl help
 - 443aacfcda man: clarify that LogNamespace= is for system services only
 - 5aec8fe54e _sd-common.h: avoid parsing errors with Coverity
 - f9ad4ea2ca analyze: fix 'cat-config systemd/zram-generator.conf'
 - dda6fec1df man: describe that changing Storage= does not move existing data
 - 2bbd33e476 core: reset bus error before reuse
 - b81504a3c7 nspawn: Fix incorrect usage of putenv
 - cb263973ac man: fix typo in systemd.service
 - 73b432e7ef network: fix DHCPv6 Prefix Delegation example after option rename

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
