### PR TITLE
opencascade: enable macOS build and add features

### DIFF
--- a/pkgs/development/libraries/opencascade/default.nix
+++ b/pkgs/development/libraries/opencascade/default.nix
@@ -1,6 +1,9 @@
 { stdenv, fetchFromGitHub, fetchpatch, libGL, libGLU, libXmu, cmake, ninja,
-  pkgconfig, fontconfig, freetype, expat, freeimage, vtk }:
+  pkgconfig, fontconfig, freetype, expat, freeimage, vtk, gl2ps, tbb,
+  OpenCL, Cocoa
+}:
 
+with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "opencascade-oce";
   version = "0.18.3";
@@ -13,13 +16,21 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ninja pkgconfig ];
-  buildInputs = [ libGL libGLU libXmu freetype fontconfig expat freeimage vtk ];
+  buildInputs = [
+    libGL libGLU libXmu freetype fontconfig expat freeimage vtk
+    gl2ps tbb
+  ]
+    ++ optionals stdenv.isDarwin [OpenCL Cocoa]
+  ;
 
   cmakeFlags = [
     "-DOCE_INSTALL_PREFIX=${placeholder "out"}"
     "-DOCE_WITH_FREEIMAGE=ON"
     "-DOCE_WITH_VTK=ON"
-  ];
+    "-DOCE_WITH_GL2PS=ON"
+    "-DOCE_MULTITHREAD_LIBRARY=TBB"
+  ]
+  ++ optionals stdenv.isDarwin ["-DOCE_OSX_USE_COCOA=ON" "-DOCE_WITH_OPENCL=ON"];
 
   patches = [
     # Use fontconfig instead of hardcoded directory list
@@ -33,6 +44,10 @@ stdenv.mkDerivation rec {
       url = "https://github.com/tpaviot/oce/commit/3b44656e93270d782009b06ec4be84d2a13f8126.patch";
       sha256 = "1ccakkcwy5g0184m23x0mnh22i0lk45xm8kgiv5z3pl7nh35dh8k";
     })
+    (fetchpatch {
+      url = "https://github.com/tpaviot/oce/commit/cf50d078cd5fac03a48fd204938bd240930a08dc.patch";
+      sha256 = "1xv94hcvggmb1c8vqwic1aiw9jw1sxk8mqbaak9xs9ycfqdvgdyc";
+    })
   ];
 
   postPatch = ''
@@ -41,11 +56,11 @@ stdenv.mkDerivation rec {
       --replace FONTCONFIG_LIBRARIES FONTCONFIG_LINK_LIBRARIES
   '';
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "Open CASCADE Technology, libraries for 3D modeling and numerical simulation";
     homepage = "https://github.com/tpaviot/oce";
     maintainers = [ maintainers.viric ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.lgpl21;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14533,7 +14533,9 @@ in
 
   openbabel = callPackage ../development/libraries/openbabel { };
 
-  opencascade = callPackage ../development/libraries/opencascade { };
+  opencascade = callPackage ../development/libraries/opencascade {
+    inherit (darwin.apple_sdk.frameworks) OpenCL Cocoa;
+  };
   opencascade-occt = callPackage ../development/libraries/opencascade-occt { };
 
   opencl-headers = callPackage ../development/libraries/opencl-headers { };


### PR DESCRIPTION
enable/fix macOS build and add options for TBB and GL2PS dependencies

VTK integration needed a patch because implicit conversions in initializer
lists are an error in C++11, which is the default in clang 7 used by nix.



###### Motivation for this change

I'm currently working on KiCad for macOS in nix. KiCad depends on Opencascade. Opencascade-occt works fine, but opencascade (OCE) was only enabled to build on Linux. I've enabled the build on macOS and it "works for me" on macOS 10.15.6, both building opencascade and using it as dependency in KiCad.

VTK-integration of opencascade threw 2 errors for me, both had to do with (implicit) conversions happening in initializer lists, which is illegal in C++11 (or 14?), which is the default in clang-7 (the compiler used by my nix). Upstream opencascade seemed to not have fixed that yet, but does also not include a specific C++ standard to compile with. I assumed this is a bug though and included a patch to make both those implicit conversion explicit, so it compiles fine. I'm not sure if this is the correct thing to do here, though, but, again it seems to work for me. I've enabled this patch only for macOS, since this seems to be not an issue on Linux for some reason, again, I'm not sure why.

I've also added options to build with TBB as parallelization/multithreading library, as well as GL2PS, which is an optional dependency of opencascade. Scripts to build KiCad had these options for opencascade enabled, which is why I added those options. The options are defaulted to `false`, to be backward compatible.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
