### PR TITLE
nixos/nextcloud: fix `nginx`-config for Nextcloud 19 and older

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -542,6 +542,9 @@ in {
       environment.systemPackages = [ occ ];
 
       services.nginx.enable = mkDefault true;
+
+      # FIXME(ma27) make sure that the config works fine with Nextcloud 19
+      # *and* Nextcloud 20 as soon as it gets released.
       services.nginx.virtualHosts.${cfg.hostName} = {
         root = cfg.package;
         locations = {
@@ -555,7 +558,7 @@ in {
           };
           "/" = {
             priority = 900;
-            extraConfig = "try_files $uri $uri/ /index.php$request_uri;";
+            extraConfig = "rewrite ^ /index.php;";
           };
           "~ ^/store-apps" = {
             priority = 201;
@@ -579,7 +582,7 @@ in {
           "~ ^/(?:\\.|autotest|occ|issue|indie|db_|console)".extraConfig = ''
             return 404;
           '';
-          "~ \\.php(?:$|/)" = {
+          "~ ^\\/(?:index|remote|public|cron|core\\/ajax\\/update|status|ocs\\/v[12]|updater\\/.+|oc[ms]-provider\\/.+|.+\\/richdocumentscode\\/proxy)\\.php(?:$|\\/)" = {
             priority = 500;
             extraConfig = ''
               include ${config.services.nginx.package}/conf/fastcgi.conf;


### PR DESCRIPTION

###### Motivation for this change

It seems as I misconfigured `nginx` for certain cases such as the
`ldap`-plugin[1] in 42f6244899d1ef8839c6e0c0a9340e1334d40264. This patch
fixes the `nginx`-config to match the upstream recommendations[2].

Also added a comment to the module to remind myself to ensure that
`nginx` will work with both v19 and v20 as soon as the latter is
released and can be packaged in `nixpkgs`.

Co-authored-by: nivadis <nivadis@users.noreply.github.com>

[1] https://github.com/nextcloud/server/issues/16194#issuecomment-688839888
[2] https://docs.nextcloud.com/server/19/admin_manual/installation/nginx.html

cc @mweinelt @nivadis @flokli 
**Needs** backport to `20.09` and `20.03`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
