### PR TITLE
appstream-qt: multiple outputs

### DIFF
--- a/pkgs/development/libraries/appstream/qt.nix
+++ b/pkgs/development/libraries/appstream/qt.nix
@@ -1,16 +1,23 @@
-{ stdenv, appstream, qtbase, qttools }:
+{ stdenv, mkDerivation, appstream, qtbase, qttools }:
 
 # TODO: look into using the libraries from the regular appstream derivation as we keep duplicates here
 
-stdenv.mkDerivation {
+mkDerivation {
   pname = "appstream-qt";
   inherit (appstream) version src prePatch;
+
+  outputs = [ "out" "dev" ];
 
   buildInputs = appstream.buildInputs ++ [ appstream qtbase ];
 
   nativeBuildInputs = appstream.nativeBuildInputs ++ [ qttools ];
 
   mesonFlags = appstream.mesonFlags ++ [ "-Dqt=true" ];
+
+  postFixup = ''
+    sed -i "$dev/lib/cmake/AppStreamQt/AppStreamQtConfig.cmake" \
+      -e "/INTERFACE_INCLUDE_DIRECTORIES/ s@\''${PACKAGE_PREFIX_DIR}@$dev@"
+  '';
 
   meta = appstream.meta // {
     description = "Software metadata handling library - Qt";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Reduce closure size by using multiple outputs for `appstream-qt`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
