### PR TITLE
perlPackages: init Catalyst::Authentication::Store::LDAP at 1.016 (and dependencies)

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1674,6 +1674,21 @@ let
     buildInputs = [ TestWarn ];
   };
 
+  CatalystAuthenticationStoreLDAP = buildPerlPackage {
+    pname = "Catalyst-Authentication-Store-LDAP";
+    version = "1.016";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Authentication-Store-LDAP-1.016.tar.gz";
+      sha256 = "0cm399vxqqf05cjgs1j5v3sk4qc6nmws5nfhf52qvpbwc4m82mq8";
+    };
+    propagatedBuildInputs = [ NetLDAP CatalystPluginAuthentication ClassAccessorFast ];
+    buildInputs = [ TestMore TestMockObject TestException NetLDAPServerTest ];
+    meta = {
+      description= "Authentication from an LDAP Directory";
+      license = with stdenv.lib.licenses; [ artistic1 ];
+    };
+  };
+
   CatalystComponentInstancePerContext = buildPerlPackage {
     pname = "Catalyst-Component-InstancePerContext";
     version = "0.001001";
@@ -14581,6 +14596,47 @@ let
     meta = {
       description = "Check and manipulate IPv6 addresses";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  NetLDAPServer = buildPerlPackage {
+    pname = "Net-LDAP-Server";
+    version = "0.43";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/A/AA/AAR/Net-LDAP-Server-0.43.tar.gz";
+      sha256 = "0qmh3cri3fpccmwz6bhwp78yskrb3qmalzvqn0a23hqbsfs4qv6x";
+    };
+    propagatedBuildInputs = [ NetLDAP ConvertASN1 ];
+    meta = {
+      description = "LDAP server side protocol handling";
+      license = with stdenv.lib.licenses; [ artistic1 ];
+    };
+  };
+
+  NetLDAPSID = buildPerlPackage {
+    pname = "Net-LDAP-SID";
+    version = "0.0001";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/K/KA/KARMAN/Net-LDAP-SID-0.001.tar.gz";
+      sha256 = "1mnnpkmj8kpb7qw50sm8h4sd8py37ssy2xi5hhxzr5whcx0cvhm8";
+    };
+    meta = {
+      description= "Active Directory Security Identifier manipulation";
+      license = with stdenv.lib.licenses; [ artistic2 ];
+    };
+  };
+
+  NetLDAPServerTest = buildPerlPackage {
+    pname = "Net-LDAP-Server-Test";
+    version = "0.22";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/K/KA/KARMAN/Net-LDAP-Server-Test-0.22.tar.gz";
+      sha256 = "13idip7jky92v4adw60jn2gcc3zf339gsdqlnc9nnvqzbxxp285i";
+    };
+    propagatedBuildInputs = [ NetLDAP NetLDAPServer TestMore DataDump NetLDAPSID ];
+    meta = {
+      description= "test Net::LDAP code";
+      license = with stdenv.lib.licenses; [ artistic1 ];
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

This is part of and effort of adding LDAP support to hydra: https://github.com/NixOS/hydra/pull/805

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
