### PR TITLE
vulkan-loader: fix pkgconfig libdir path

### DIFF
--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   preConfigure = ''
-    substituteInPlace loader/vulkan.pc.in --replace 'includedir=''${prefix}/include' 'includedir=${vulkan-headers}/include'
+    substituteInPlace loader/vulkan.pc.in \
+      --replace 'includedir=''${prefix}/include' 'includedir=${vulkan-headers}/include' \
+      --replace 'libdir=''${exec_prefix}/@CMAKE_INSTALL_LIBDIR@' 'libdir=@CMAKE_INSTALL_LIBDIR@'
   '';
 
   cmakeFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The current `vulkan.pc` looks like this,

```
prefix=/nix/store/i4gpn47f359vdamcr40ada4nxpf6j9iz-vulkan-loader-1.2.131.2
exec_prefix=/nix/store/i4gpn47f359vdamcr40ada4nxpf6j9iz-vulkan-loader-1.2.131.2
libdir=${exec_prefix}//nix/store/i4gpn47f359vdamcr40ada4nxpf6j9iz-vulkan-loader-1.2.131.2/lib
includedir=/nix/store/spmvmf3gxcgrych5kiax3lv3wanbybc9-vulkan-headers-1.2.131.1/include

Name: Vulkan-Loader
Description: Vulkan Loader
Version: 1.2.131
Libs: -L${libdir} -lvulkan
Libs.private:  -lstdc++ -lm -lgcc_s -lgcc -lc -lgcc_s -lgcc
Cflags: -I${includedir}
```

###### Things done

With this change, `vulkan.pc` looks like this,

```
prefix=/nix/store/xl93a0vf6z98q39dy7i6405hdsk7khp1-vulkan-loader-1.2.131.2
exec_prefix=/nix/store/xl93a0vf6z98q39dy7i6405hdsk7khp1-vulkan-loader-1.2.131.2
libdir=/nix/store/xl93a0vf6z98q39dy7i6405hdsk7khp1-vulkan-loader-1.2.131.2/lib
includedir=/nix/store/spmvmf3gxcgrych5kiax3lv3wanbybc9-vulkan-headers-1.2.131.1/include

Name: Vulkan-Loader
Description: Vulkan Loader
Version: 1.2.131
Libs: -L${libdir} -lvulkan
Libs.private:  -lstdc++ -lm -lgcc_s -lgcc -lc -lgcc_s -lgcc
Cflags: -I${includedir}
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
