### PR TITLE
pam-gnupg: init at 0.1

### DIFF
--- a/pkgs/os-specific/linux/pam_gnupg/default.nix
+++ b/pkgs/os-specific/linux/pam_gnupg/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pam, gnupg }:
+
+stdenv.mkDerivation rec {
+  pname = "pam-gnupg";
+  version = "0.1";
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ pam gnupg ];
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  src = fetchFromGitHub {
+    owner = "cruegge";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0b70mazyvcbg6xyqllm62rwhbz0y94pcy202db1qyy4w8466bhsw";
+  };
+  meta = with stdenv.lib; {
+    description = "Unlocks GnuPG keys on login";
+    longDescription = ''
+      A PAM module that hands over your login password to gpg-agent. This can be useful if you are using a GnuPG-based password manager like pass.
+    '';
+    homepage = "https://github.com/cruegge/pam-gnupg";
+
+    license = licenses.gpl3;
+    maintainers = [ maintainers.nickhu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18225,6 +18225,8 @@ in
 
   pam_ccreds = callPackage ../os-specific/linux/pam_ccreds { };
 
+  pam_gnupg = callPackage ../os-specific/linux/pam_gnupg { };
+
   pam_krb5 = callPackage ../os-specific/linux/pam_krb5 { };
 
   pam_ldap = callPackage ../os-specific/linux/pam_ldap { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Makes it easier to unlock GPG keys by forwarding the login password via
PAM.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).