### PR TITLE
foundationdb: add branch 6.2

### DIFF
--- a/pkgs/servers/foundationdb/cmake62.nix
+++ b/pkgs/servers/foundationdb/cmake62.nix
@@ -66,7 +66,7 @@ let
         # fix up the use of the very weird and custom 'fdb_install' command by just
         # replacing it with cmake's ordinary version.
         postPatch = ''
-        for x in bindings/c/CMakeLists.txt fdbserver/CMakeLists.txt fdbmonitor/CMakeLists.txt fdbbackup/CMakeLists.txt fdbcli/CMakeLists.txt; do 
+        for x in bindings/c/CMakeLists.txt fdbserver/CMakeLists.txt fdbmonitor/CMakeLists.txt fdbbackup/CMakeLists.txt fdbcli/CMakeLists.txt; do
             substituteInPlace $x --replace 'fdb_install' 'install'
         done
         '';

--- a/pkgs/servers/foundationdb/cmake62.nix
+++ b/pkgs/servers/foundationdb/cmake62.nix
@@ -1,0 +1,130 @@
+# This builder is for FoundationDB CMake build system.
+
+{ lib, fetchFromGitHub
+, cmake, ninja, boost, python3, openjdk, mono, openssl
+
+, gccStdenv, llvmPackages
+, useClang ? false
+, ...
+}:
+
+let
+  stdenv = if useClang then llvmPackages.libcxxStdenv else gccStdenv;
+
+  tests = with builtins;
+    builtins.replaceStrings [ "\n" ] [ " " ] (lib.fileContents ./test-list.txt);
+
+  makeFdb =
+    { version
+    , branch # unused
+    , sha256
+    , rev ? "refs/tags/${version}"
+    , officialRelease ? true
+    , patches ? []
+    }: stdenv.mkDerivation {
+        pname = "foundationdb";
+        inherit version;
+
+        src = fetchFromGitHub {
+          owner = "apple";
+          repo  = "foundationdb";
+          inherit rev sha256;
+        };
+
+        buildInputs = [ openssl boost ];
+        nativeBuildInputs = [ cmake ninja python3 openjdk mono ]
+          ++ lib.optional useClang [ llvmPackages.lld ];
+
+        separateDebugInfo = true;
+        enableParallelBuilding = true;
+        dontFixCmake = true;
+
+        cmakeFlags =
+          [ "-DCMAKE_BUILD_TYPE=Release"
+            (lib.optionalString officialRelease "-DFDB_RELEASE=TRUE")
+
+            # FIXME: why can't openssl be found automatically?
+            "-DOPENSSL_USE_STATIC_LIBS=FALSE"
+            "-DOPENSSL_INCLUDE_DIR=${openssl.dev}"
+            "-DOPENSSL_CRYPTO_LIBRARY=${openssl.out}/lib/libcrypto.so"
+            "-DOPENSSL_SSL_LIBRARY=${openssl.out}/lib/libssl.so"
+            "-DOPENSSL_TLS_LIBRARY=${openssl.out}/lib/libtls.so"
+
+            # LTO brings up overall build time, but results in much smaller
+            # binaries for all users and the cache.
+            (lib.optionalString (!useClang) "-DUSE_LTO=ON")
+
+            # Gold helps alleviate the link time, especially when LTO is
+            # enabled. But even then, it still takes a majority of the time.
+            # Same with LLD when Clang is available.
+            (lib.optionalString useClang    "-DUSE_LD=LLD")
+            (lib.optionalString (!useClang) "-DUSE_LD=GOLD")
+          ];
+
+        inherit patches;
+
+        # fix up the use of the very weird and custom 'fdb_install' command by just
+        # replacing it with cmake's ordinary version.
+        postPatch = ''
+        for x in bindings/c/CMakeLists.txt fdbserver/CMakeLists.txt fdbmonitor/CMakeLists.txt fdbbackup/CMakeLists.txt fdbcli/CMakeLists.txt; do 
+            substituteInPlace $x --replace 'fdb_install' 'install'
+        done
+        '';
+
+        # the install phase for cmake is pretty wonky right now since it's not designed to
+        # coherently install packages as most linux distros expect -- it's designed to build
+        # packaged artifacts that are shipped in RPMs, etc. we need to add some extra code to
+        # cmake upstream to fix this, and if we do, i think most of this can go away.
+        postInstall = ''
+          mv $out/sbin/fdbserver $out/bin/fdbserver
+          rm -rf \
+            $out/lib/systemd $out/Library $out/usr $out/sbin \
+            $out/var $out/log $out/etc
+
+          mv $out/fdbmonitor/fdbmonitor $out/bin/fdbmonitor && rm -rf $out/fdbmonitor
+
+          rm -rf $out/lib/foundationdb/
+          mkdir $out/libexec && ln -sfv $out/bin/fdbbackup $out/libexec/backup_agent
+
+          mkdir $out/include/foundationdb && \
+            mv $out/include/*.h $out/include/*.options $out/include/foundationdb
+
+          # move results into multi outputs
+          mkdir -p $dev $lib
+          mv $out/include $dev/include
+          mv $out/lib $lib/lib
+
+          # python bindings
+          # NB: use the original setup.py.in, so we can substitute VERSION correctly
+          cp ../LICENSE ./bindings/python
+          substitute ../bindings/python/setup.py.in ./bindings/python/setup.py \
+            --replace 'VERSION' "${version}"
+          rm -f ./bindings/python/setup.py.* ./bindings/python/CMakeLists.txt
+          rm -f ./bindings/python/fdb/*.pth # remove useless files
+          rm -f ./bindings/python/*.rst ./bindings/python/*.mk
+
+          cp -R ./bindings/python/                          tmp-pythonsrc/
+          tar -zcf $pythonsrc --transform s/tmp-pythonsrc/python-foundationdb/ ./tmp-pythonsrc/
+
+          # java bindings
+          mkdir -p $lib/share/java
+          mv lib/fdb-java-*.jar $lib/share/java/fdb-java.jar
+
+          # include the tests
+          mkdir -p $out/share/test
+          (cd ../tests && for x in ${tests}; do
+            cp --parents $x $out/share/test
+          done)
+        '';
+
+        outputs = [ "out" "dev" "lib" "pythonsrc" ];
+
+        meta = with stdenv.lib; {
+          description = "Open source, distributed, transactional key-value store";
+          homepage    = https://www.foundationdb.org;
+          license     = licenses.asl20;
+          platforms   = [ "x86_64-linux" ];
+          maintainers = with maintainers; [ vlche ];
+       };
+    };
+in makeFdb

--- a/pkgs/servers/foundationdb/cmake62.nix
+++ b/pkgs/servers/foundationdb/cmake62.nix
@@ -124,7 +124,7 @@ let
           homepage    = https://www.foundationdb.org;
           license     = licenses.asl20;
           platforms   = [ "x86_64-linux" ];
-          maintainers = with maintainers; [ vlche ];
+          maintainers = with maintainers; [ thoughtpolice ];
        };
     };
 in makeFdb

--- a/pkgs/servers/foundationdb/default.nix
+++ b/pkgs/servers/foundationdb/default.nix
@@ -2,12 +2,16 @@
 , lib, fetchurl, fetchpatch, fetchFromGitHub
 
 , cmake, ninja, which, findutils, m4, gawk
-, python, python3, openjdk, mono, libressl, boost
+, python, python3, openjdk, mono, libressl, boost, openssl
 }@args:
 
 let
   vsmakeBuild = import ./vsmake.nix args;
   cmakeBuild = import ./cmake.nix (args // {
+    gccStdenv    = gccStdenv;
+    llvmPackages = llvmPackages;
+  });
+  cmakeBuild62 = import ./cmake62.nix (args // {
     gccStdenv    = gccStdenv;
     llvmPackages = llvmPackages;
   });
@@ -82,6 +86,22 @@ in with builtins; {
 
     patches = [
       ./patches/clang-libcxx.patch
+      ./patches/suppress-clang-warnings.patch
+      glibc230-fix
+    ];
+  };
+
+  # 6.2 and later versions should always use CMake
+  # ------------------------------------------------------
+
+  foundationdb62 = cmakeBuild62 {
+    version = "6.2.25";
+    branch  = "release-6.2";
+    sha256  = "01p8q0kpcnki65hlk5sav2isjlskqrwq5281maghhk9fzsc1cx26";
+
+    patches = [
+      ./patches/cmakelists-dsuffix.patch
+      ./patches/cmakelists-errors-6.2.patch
       ./patches/suppress-clang-warnings.patch
       glibc230-fix
     ];

--- a/pkgs/servers/foundationdb/patches/cmakelists-dsuffix.patch
+++ b/pkgs/servers/foundationdb/patches/cmakelists-dsuffix.patch
@@ -1,0 +1,28 @@
+diff --git a/bindings/c/CMakeLists.txt b/bindings/c/CMakeLists.txt
+index 75b0a4e32..392b0ea21 100644
+--- a/bindings/c/CMakeLists.txt
++++ b/bindings/c/CMakeLists.txt
+@@ -131,13 +131,11 @@ fdb_install(
+   FILES foundationdb/fdb_c.h
+   ${CMAKE_CURRENT_BINARY_DIR}/foundationdb/fdb_c_options.g.h
+   ${CMAKE_SOURCE_DIR}/fdbclient/vexillographer/fdb.options
+-  DESTINATION include
+-  DESTINATION_SUFFIX /foundationdb
++  DESTINATION include/foundationdb
+   COMPONENT clients)
+ fdb_install(
+   FILES "${project_config}" "${version_config}"
+-  DESTINATION lib
+-  DESTINATION_SUFFIX "/cmake/${targets_export_name}"
++  DESTINATION "lib/cmake/${targets_export_name}"
+   COMPONENT clients)
+ fdb_configure_and_install(
+   FILE "${PROJECT_SOURCE_DIR}/cmake/foundationdb-client.pc.in"
+@@ -146,6 +144,5 @@ fdb_configure_and_install(
+   COMPONENT clients)
+ fdb_install(
+   EXPORT ${targets_export_name}
+-  DESTINATION lib
+-  DESTINATION_SUFFIX "/cmake/${targets_export_name}"
++  DESTINATION "lib/cmake/${targets_export_name}"
+   COMPONENT clients)

--- a/pkgs/servers/foundationdb/patches/cmakelists-errors-6.2.patch
+++ b/pkgs/servers/foundationdb/patches/cmakelists-errors-6.2.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 002c0b748..d819ca0b4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -77,11 +77,12 @@ message(STATUS "Current git version ${CURRENT_GIT_VERSION}")
+ 
+ if(NOT WIN32)
+   add_custom_target(version_file ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/versions.target)
++# dirty hack for nixos to stop cmake complaining about version mismatch
+   execute_process(
+-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/get_version.sh ${CMAKE_CURRENT_SOURCE_DIR}/versions.target
++    COMMAND bash "-c" "cat ${CMAKE_CURRENT_SOURCE_DIR}/versions.target| grep '<Version>' | sed -e 's,^[^>]*>,,' -e 's,<.*,,'"
+     OUTPUT_VARIABLE FDB_VERSION_WNL)
+   execute_process(
+-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/get_package_name.sh ${CMAKE_CURRENT_SOURCE_DIR}/versions.target
++    COMMAND bash "-c" "cat ${CMAKE_CURRENT_SOURCE_DIR}/versions.target | grep '<PackageName>' | sed -e 's,^[^>]*>,,' -e 's,<.*,,'"
+     OUTPUT_VARIABLE FDB_PACKAGE_NAME_WNL)
+   string(STRIP "${FDB_VERSION_WNL}" FDB_VERSION_TARGET_FILE)
+   string(STRIP "${FDB_PACKAGE_NAME_WNL}" FDB_PACKAGE_NAME_TARGET_FILE)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3798,6 +3798,7 @@ in
     foundationdb52
     foundationdb60
     foundationdb61
+    foundationdb62
   ;
 
   foundationdb = foundationdb61;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2177,6 +2177,7 @@ in {
   foundationdb52 = callPackage ../servers/foundationdb/python.nix { foundationdb = pkgs.foundationdb52; };
   foundationdb60 = callPackage ../servers/foundationdb/python.nix { foundationdb = pkgs.foundationdb60; };
   foundationdb61 = callPackage ../servers/foundationdb/python.nix { foundationdb = pkgs.foundationdb61; };
+  foundationdb62 = callPackage ../servers/foundationdb/python.nix { foundationdb = pkgs.foundationdb62; };
 
   foxdot = callPackage ../development/python-modules/foxdot { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
A new branch of Foundationdb exists for quite a long time, current branch is 6.2.25, so this PR adds support for it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
