### PR TITLE
python3Packages.datasets: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/datasets/default.nix
+++ b/pkgs/development/python-modules/datasets/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, dill
+, filelock
+, numpy
+, pandas
+, pyarrow
+, requests
+, tqdm
+, xxhash
+}:
+
+buildPythonPackage rec {
+  pname = "datasets";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = pname;
+    rev = version;
+    sha256 = "13l52r7nhj2c1a10isy5309d2g6pmaivyqs5w6yjbjj4195jxya5";
+  };
+
+  propagatedBuildInputs = [
+    dill
+    filelock
+    numpy
+    pandas
+    pyarrow
+    requests
+    tqdm
+    xxhash
+  ];
+
+  # Tests require pervasive internet access.
+  doCheck = false;
+
+  # Module import will attempt to create a cache directory.
+  postFixup = "export HF_MODULES_CACHE=$TMPDIR";
+
+  pythonImportsCheck = [ "datasets" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/huggingface/datasets";
+    description = "Fast, efficient, open-access datasets and evaluation metrics for natural language processing";
+    changelog = "https://github.com/huggingface/datasets/releases/tag/${version}";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1436,6 +1436,8 @@ in {
 
   datamodeldict = callPackage ../development/python-modules/datamodeldict { };
 
+  datasets = callPackage ../development/python-modules/datasets { };
+
   datasette = callPackage ../development/python-modules/datasette { };
 
   datashader = callPackage ../development/python-modules/datashader { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This library provides open-access datasets an evaluation metrics for
natural language processing using PyTorch, TensorFlow, NumPy, and
Pandas.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
