### PR TITLE
pytest-timeout: 1.3.3 -> 1.4.2

### DIFF
--- a/pkgs/development/python-modules/pytest-timeout/default.nix
+++ b/pkgs/development/python-modules/pytest-timeout/default.nix
@@ -4,23 +4,19 @@
 , lib
 , pexpect
 , pytest
+, pytestcov
 }:
 
 buildPythonPackage rec {
   pname = "pytest-timeout";
-  version = "1.3.3";
+  version = "1.4.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1cczcjhw4xx5sjkhxlhc5c1bkr7x6fcyx12wrnvwfckshdvblc2a";
+    sha256 = "0xnsigs0kmpq1za0d4i522sp3f71x5bgpdh3ski0rs74yqy13cr0";
   };
 
-  patches = fetchpatch {
-    url = "https://bitbucket.org/pytest-dev/pytest-timeout/commits/36998c891573d8ec1db1acd4f9438cb3cf2aee2e/raw";
-    sha256 = "05zc2w7mjgv8rm8i1cbxp7k09vlscmay5iy78jlzgjqkrx3wkf46";
-  };
-
-  checkInputs = [ pytest pexpect ];
+  checkInputs = [ pytest pytestcov pexpect ];
   checkPhase = ''
     # test_suppresses_timeout_when_pdb_is_entered fails under heavy load
     pytest -ra -k 'not test_suppresses_timeout_when_pdb_is_entered'


### PR DESCRIPTION
This eliminates the need for the patch at
https://bitbucket.org/pytest-dev/pytest-timeout/commits/36998c891573d8ec1db1acd4f9438cb3cf2aee2e/raw (link
broken).
