### PR TITLE
exiv2: re-enable split outputs

### DIFF
--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -17,9 +17,7 @@ stdenv.mkDerivation rec {
   pname = "exiv2";
   version = "0.27.3";
 
-  # Disabled since splitting the outputs leads to issues, see
-  # https://github.com/NixOS/nixpkgs/pull/97161#issuecomment-689426419
-  # outputs = [ "out" "dev" "doc" "man" ];
+  outputs = [ "out" "dev" "doc" "man" ];
 
   src = fetchFromGitHub {
     owner = "exiv2";
@@ -39,9 +37,13 @@ stdenv.mkDerivation rec {
     # Use correct paths with multiple outputs
     # https://github.com/Exiv2/exiv2/pull/1275
     (fetchpatch {
-      name = "cmake-fix-aarch64.patch";
       url = "https://github.com/Exiv2/exiv2/commit/48f2c9dbbacc0ef84c8ebf4cb1a603327f0b8750.patch";
       sha256 = "vjB3+Ld4c/2LT7nq6uatYwfHTh+HeU5QFPFXuNLpIPA=";
+    })
+    # https://github.com/Exiv2/exiv2/pull/1294
+    (fetchpatch {
+      url = "https://github.com/Exiv2/exiv2/commit/306c8a6fd4ddd70e76043ab255734720829a57e8.patch";
+      sha256 = "0D/omxYxBPGUu3uSErlf48dc6Ukwc2cEN9/J3e7a9eU=";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change
Needs an extra patch to fix CMake config.

This reverts commit f8f840f6643b6f3e189efce119141ccb9386c45d.

Fixes: https://github.com/NixOS/nixpkgs/pull/97161#issuecomment-689426419
Upstream: https://github.com/Exiv2/exiv2/pull/1294

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Checked that `result-dev/lib/cmake/exiv2/exiv2Config.cmake` uses absolute path for `INTERFACE_INCLUDE_DIRECTORIES`
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
