### PR TITLE
pythonPackages.pq: fix build

### DIFF
--- a/pkgs/development/python-modules/pq/default.nix
+++ b/pkgs/development/python-modules/pq/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, psycopg2
 , isPy27
 }:
 
@@ -15,22 +14,9 @@ buildPythonPackage rec {
     sha256 = "f54143844e73f4182532e68548dee447dd78dd00310a087e8cdee756d476a173";
   };
 
-  # psycopg2cffi is compatible with psycopg2 and author states that
-  # module is compatible with psycopg2
-  postConfigure = ''
-    substituteInPlace setup.py \
-      --replace "psycopg2cffi" "psycopg2"
-
-    substituteInPlace pq/tests.py \
-      --replace "psycopg2cffi" "psycopg2"
-  '';
-
-  checkInputs = [
-    psycopg2
-  ];
-
   # tests require running postgresql cluster
   doCheck = false;
+  pythonImportsCheck = [ "pq" ];
 
   meta = with lib; {
     description = "PQ is a transactional queue for PostgreSQL";


### PR DESCRIPTION
###### Motivation for this change
We can't run the tests anyway, so remove fragile attempts to patch them.

ZHF: #97479


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
