### PR TITLE
pythonPackages.hiredis: fix tests

### DIFF
--- a/pkgs/development/python-modules/hiredis/default.nix
+++ b/pkgs/development/python-modules/hiredis/default.nix
@@ -16,8 +16,10 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ redis ];
 
   checkPhase = ''
+    mv hiredis _hiredis
     ${python.interpreter} test.py
   '';
+  pythonImportsCheck = [ "hiredis" ];
 
   meta = with stdenv.lib; {
     description = "Wraps protocol parsing code in hiredis, speeds up parsing of multi bulk replies";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Tests just require the source-directory-hiding trick

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
