### PR TITLE
openrgb: 0.3 -> 0.4

### DIFF
--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchFromGitHub, qmake, libusb1, hidapi, pkg-config }:
+{ mkDerivation, lib, fetchFromGitHub, qmake, libusb1, hidapi, pkg-config, fetchpatch }:
 
 mkDerivation rec {
   pname = "openrgb";
@@ -13,6 +13,14 @@ mkDerivation rec {
 
   nativeBuildInputs = [ qmake pkg-config ];
   buildInputs = [ libusb1 hidapi ];
+
+  patches = [
+    # Make build SOURCE_DATE_EPOCH aware, merged in master
+    (fetchpatch {
+      url = "https://gitlab.com/CalcProgrammer1/OpenRGB/-/commit/f1b7b8ba900db58a1119d8d3e21c1c79de5666aa.patch";
+      sha256 = "17m1hn1kjxfcmd4p3zjhmr5ar9ng0zfbllq78qxrfcq1a0xrkybx";
+    })
+  ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "openrgb";
-  version = "0.3";
+  version = "0.4";
 
   src = fetchFromGitHub {
     owner = "CalcProgrammer1";
     repo = "OpenRGB";
     rev = "release_${version}";
-    sha256 = "1931aisdahjr99d4qqk824ib4x19mvhqgqmkm3j6fc5zd2hnw87m";
+    sha256 = "sha256-tHrRG2Zx7NYqn+WPiRpAlWA/QmxuAYidENanTkC1XVw";
   };
 
   nativeBuildInputs = [ qmake pkg-config ];


### PR DESCRIPTION
###### Motivation for this change

https://gitlab.com/CalcProgrammer1/OpenRGB/-/releases/release_0.4

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
