### PR TITLE
[20.09] python3Packages.executor: 21.3 -> 23.1, fix tests

### DIFF
--- a/pkgs/development/python-modules/executor/default.nix
+++ b/pkgs/development/python-modules/executor/default.nix
@@ -1,27 +1,31 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy27, coloredlogs, property-manager, fasteners, pytest, mock, virtualenv }:
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27, coloredlogs, property-manager, fasteners, pytestCheckHook, mock, virtualenv }:
 
 buildPythonPackage rec {
   pname = "executor";
-  version = "21.3";
+  version = "23.1";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "xolox";
     repo = "python-executor";
     rev = version;
-    sha256 = "0rc14vjx3d6irfaw0pczzw1pn0xjl7xikv32hc1fvxv2ibnldv5d";
+    sha256 = "1jfmagw126di0qd82bydwvryqcxc54pqja3rbx3ny3fv1ahi5s7k";
   };
 
   propagatedBuildInputs = [ coloredlogs property-manager fasteners ];
 
-  checkInputs = [ pytest mock virtualenv ];
+  checkInputs = [ pytestCheckHook mock virtualenv ];
 
   # ignore impure tests
-  checkPhase = ''
-    pytest . -k "not option and not retry \
-                 and not remote and not ssh \
-                 and not foreach and not local_context"
-  '';
+  disabledTests = [
+    "option"
+    "retry"
+    "remote"
+    "ssh"
+    "foreach"
+    "local_context"
+    "release"  # meant to be ran on ubuntu to succeed
+  ];
 
   meta = with lib; {
     description = "Programmer friendly subprocess wrapper";


### PR DESCRIPTION
###### Motivation for this change
backport #97494

ZHF: #97479

@NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/97713
6 packages built:
executor python37Packages.executor python37Packages.rotate-backups python37Packages.update-dotdee rotate-backups update-dotdee
```