### PR TITLE
isso: build from master

### DIFF
--- a/pkgs/servers/isso/default.nix
+++ b/pkgs/servers/isso/default.nix
@@ -1,26 +1,32 @@
-{ stdenv, python2, fetchFromGitHub }:
+{ stdenv, python3Packages, fetchFromGitHub }:
 
-with python2.pkgs; buildPythonApplication rec {
+with python3Packages; buildPythonApplication rec {
+
   pname = "isso";
-  version = "0.12.2";
+  # Can not use 0.12.2 because of:
+  # https://github.com/posativ/isso/issues/617
+  version = "unstable-2020-09-14";
 
   # no tests on PyPI
   src = fetchFromGitHub {
     owner = "posativ";
     repo = pname;
-    rev = version;
-    sha256 = "18v8lzwgl5hcbnawy50lfp3wnlc0rjhrnw9ja9260awkx7jra9ba";
+    rev = "f4d2705d4f1b51f444d0629355a6fcbcec8d57b5";
+    sha256 = "02jgfzq3svd54zj09jj7lm2r7ypqqjynzxa9dgnnm0pqvq728wzr";
   };
 
   propagatedBuildInputs = [
-    bleach
-    cffi
-    configparser
-    html5lib
-    ipaddr
+    itsdangerous
     jinja2
     misaka
+    html5lib
     werkzeug
+    bleach
+    flask-caching
+  ];
+
+  buildInputs = [
+    cffi
   ];
 
   checkInputs = [ nose ];


### PR DESCRIPTION
* The published 0.12.2 version is broken therefore switch to build from
master. Related Issue: https://github.com/posativ/isso/issues/617
* cleanup build inputs
* use python3

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #97479


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

## CC

@NixOS/nixos-release-managers