### PR TITLE
[20.09] pythonPackages.pyjet: fix tests

### DIFF
--- a/pkgs/development/python-modules/pyjet/default.nix
+++ b/pkgs/development/python-modules/pyjet/default.nix
@@ -1,12 +1,15 @@
-{ lib, buildPythonPackage, fetchPypi, cython, nose, numpy }:
+{ lib, buildPythonPackage, fetchFromGitHub, cython, pytest, numpy }:
 
 buildPythonPackage rec {
   pname = "pyjet";
   version = "1.6.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "ab6e63f8a8fd73bbd76ef2a384eea69bc1c201f2ce876faa4151ade6c0b20615";
+  # tests not included in pypi tarball
+  src = fetchFromGitHub {
+    owner = "scikit-hep";
+    repo = pname;
+    rev = version;
+    sha256 = "0b68jnbfk2rw9i1nnwsrbrbgkj7r0w1nw0i9f8fah1wmn78k9csv";
   };
 
   # fix for python37
@@ -19,7 +22,11 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [ numpy ];
-  checkInputs = [ nose ];
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    mv pyjet _pyjet
+    pytest tests/
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/scikit-hep/pyjet";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of #97706 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
