### PR TITLE
[20.09] pythonPackages.pysnow: fix build & tests

### DIFF
--- a/pkgs/development/python-modules/pysnow/default.nix
+++ b/pkgs/development/python-modules/pysnow/default.nix
@@ -1,11 +1,12 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy27
-, pythonAtLeast
+, fetchFromGitHub
+, poetry
 , brotli
 , ijson
 , nose
+, httpretty
 , requests_oauthlib
 , python_magic
 , pytz
@@ -15,11 +16,23 @@ buildPythonPackage rec {
   pname = "pysnow";
   version = "0.7.16";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "5df61091470e48b5b3a6ea75637f69d3aacae20041487ea457a9a0e3093fba8c";
+  # tests not included in pypi tarball
+  src = fetchFromGitHub {
+    owner = "rbw";
+    repo = pname;
+    rev = version;
+    sha256 = "0dj90w742klfcjnx7yhp0nzki2mzafqzzr0rk2dp6vxn8h58z8ww";
   };
+  format = "pyproject";
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'ijson = "^2.5.1"' 'ijson = "*"' \
+      --replace 'pytz = "^2019.3"' 'pytz = "*"' \
+      --replace 'oauthlib = "^3.1.0"' 'oauthlib = "*"'
+  '';
+
+  nativeBuildInputs = [ poetry ];
   propagatedBuildInputs = [
     brotli
     ijson
@@ -28,11 +41,11 @@ buildPythonPackage rec {
     requests_oauthlib
   ];
 
-  checkInputs = [ nose ];
-
+  checkInputs = [ nose httpretty ];
   checkPhase = ''
     nosetests --cover-package=pysnow --with-coverage --cover-erase
   '';
+  pythonImportsCheck = [ "pysnow" ];
 
   meta = with lib; {
     description = "ServiceNow HTTP client library written in Python";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of #97716 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
