### PR TITLE
python3Packages.dask: 2.22.0 -> 2.25.0

### DIFF
--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "dask";
-  version = "2.22.0";
+  version = "2.25.0";
 
   disabled = pythonOlder "3.5";
 
@@ -24,17 +24,13 @@ buildPythonPackage rec {
     owner = "dask";
     repo = pname;
     rev = version;
-    sha256 = "08nvxj81cz9x92dh2gbmm4imkr8cfljfi2hxkballv2ygwcbzg8g";
+    sha256 = "1irp6s577yyjvrvkg00hh1wnl8vrv7pbnbr09mk67z9y7s6xhiw3";
   };
 
   checkInputs = [
     pytestCheckHook
     pytest_xdist # takes >10mins to run single-threaded
   ];
-
-  pytestFlagsArray = [ "-n $NIX_BUILD_CORES" ];
-
-  dontUseSetuptoolsCheck = true;
 
   propagatedBuildInputs = [
     bokeh
@@ -56,6 +52,7 @@ buildPythonPackage rec {
       --replace "cmdclass=versioneer.get_cmdclass()," ""
   '';
 
+  pytestFlagsArray = [ "-n $NIX_BUILD_CORES" ];
   disabledTests = [
     "test_argwhere_str"
     "test_count_nonzero_str"
@@ -65,7 +62,8 @@ buildPythonPackage rec {
 
   meta = {
     description = "Minimal task scheduling abstraction";
-    homepage = "https://github.com/ContinuumIO/dask/";
+    homepage = "https://dask.org/";
+    changelog = "https://docs.dask.org/en/latest/changelog.html";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fridh ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
New dask version

https://github.com/dask/dask/releases/tag/2.25.0
Changelog: https://docs.dask.org/en/latest/changelog.html

Also update meta.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
