### PR TITLE
seq66: init at 0.90.5

### DIFF
--- a/pkgs/applications/audio/seq66/default.nix
+++ b/pkgs/applications/audio/seq66/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkg-config, qttools, which
+, alsaLib, libjack2, liblo, qtbase
+}:
+
+stdenv.mkDerivation rec {
+  pname = "seq66";
+  version = "0.90.5";
+
+  src = fetchFromGitHub {
+    owner = "ahlstromcj";
+    repo = pname;
+    rev = version;
+    sha256 = "1jvra1wzlycfpvffnqidk264zw6fyl4fsghkw5256ldk22aalmq9";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config qttools which ];
+
+  buildInputs = [ alsaLib libjack2 liblo qtbase ];
+
+  postPatch = ''
+    for d in libseq66/include libseq66/src libsessions/include libsessions/src seq_qt5/src seq_rtmidi/include seq_rtmidi/src Seqtool/src; do
+      substituteInPlace "$d/Makefile.am" --replace '$(git_info)' '${version}'
+    done
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ahlstromcj/seq66";
+    description = "Loop based midi sequencer with Qt GUI derived from seq24 and sequencer64";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22945,6 +22945,8 @@ in
 
   seq24 = callPackage ../applications/audio/seq24 { };
 
+  seq66 = qt5.callPackage ../applications/audio/seq66 { };
+
   setbfree = callPackage ../applications/audio/setbfree { };
 
   sfizz = callPackage ../applications/audio/sfizz { };


### PR DESCRIPTION
#### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
