### PR TITLE
nixos-rebuild: add flake support for build-vm

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
 
   outputs = { self }:
     let
-
       jobs = import ./pkgs/top-level/release.nix {
         nixpkgs = self;
       };
@@ -28,10 +27,31 @@
       lib = lib.extend (final: prev: {
         nixosSystem = { modules, ... } @ args:
           import ./nixos/lib/eval-config.nix (args // {
-            modules = modules ++
-              [ { system.nixos.versionSuffix =
+            modules =
+              let
+                vmConfig = (import ./nixos/lib/eval-config.nix
+                  (args // {
+                    modules = modules ++ [ ./nixos/modules/virtualisation/qemu-vm.nix ];
+                  })).config;
+
+                vmWithBootLoaderConfig = (import ./nixos/lib/eval-config.nix
+                  (args // {
+                    modules = modules ++ [
+                      ./nixos/modules/virtualisation/qemu-vm.nix
+                      { virtualisation.useBootLoader = true; }
+                    ];
+                  })).config;
+              in
+              modules ++ [
+                {
+                  system.nixos.versionSuffix =
                     ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified)}.${self.shortRev or "dirty"}";
                   system.nixos.revision = final.mkIf (self ? rev) self.rev;
+
+                  system.build = {
+                    vm = vmConfig.system.build.vm;
+                    vmWithBootLoader = vmWithBootLoaderConfig.system.build.vm;
+                  };
                 }
               ];
           });

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -438,15 +438,17 @@ if [ -z "$rollback" ]; then
         if [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A vm -k "${extraBuildFlags[@]}")"
         else
-            echo "$0: 'build-vm' is not supported with '--flake'" >&2
-            exit 1
+            nix "${flakeFlags[@]}" build "$flake#$flakeAttr.config.system.build.vm" \
+              "${extraBuildFlags[@]}" "${lockFlags[@]}"
+            pathToConfig="$(readlink -f ./result)"
         fi
     elif [ "$action" = build-vm-with-bootloader ]; then
         if [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A vmWithBootLoader -k "${extraBuildFlags[@]}")"
         else
-            echo "$0: 'build-vm-with-bootloader' is not supported with '--flake'" >&2
-            exit 1
+            nix "${flakeFlags[@]}" build "$flake#$flakeAttr.config.system.build.vmWithBootLoader" \
+              "${extraBuildFlags[@]}" "${lockFlags[@]}"
+            pathToConfig="$(readlink -f ./result)"
         fi
     else
         showSyntax


### PR DESCRIPTION
This relies on users using `nixpkgs.lib.nixosSystem` to define their
system; otherwise, the `vm` and `vmWithBootLoader` attributes will not
exist.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Resolves https://github.com/NixOS/nixpkgs/issues/97487.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested on my machine by running `result/bin/nixos-rebuild build-vm --flake .#scadrial` and `result/bin/run-scadrial-vm`.

I don't know if depending on the use of `nixpkgs.lib.nixosSystem` is bad, but it's the only way I can really see this working.

cc @worldofpeace 