### PR TITLE
microserver: init at 0.1.8

### DIFF
--- a/pkgs/servers/microserver/default.nix
+++ b/pkgs/servers/microserver/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+   pname = "microserver";
+   version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "robertohuertasm";
+    repo = "microserver";
+    rev = "v${version}";
+    sha256 = "1i9689ra5jnmhkxabrx4zcp5f422w9ql9m4xzldqwmpnckm736v6";
+  };
+
+  cargoSha256 = "1yn3xmmhpixiviayicl2szlzfjx5crffp3pq75d5nz6ky3miai9l";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/robertohuertasm/microserver";
+    description = "Simple ad-hoc server with SPA support";
+    maintainers = with maintainers; [ flosse ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5432,6 +5432,8 @@ in
 
   microcom = callPackage ../applications/misc/microcom { };
 
+  microserver = callPackage ../servers/microserver { };
+
   midisheetmusic = callPackage ../applications/audio/midisheetmusic { };
 
   mikutter = callPackage ../applications/networking/instant-messengers/mikutter { };


### PR DESCRIPTION
###### Motivation for this change

I use this fast and tiny server during development. 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
