### PR TITLE
qpdf: 9.1.1 -> 10.0.1

### DIFF
--- a/pkgs/development/libraries/qpdf/default.nix
+++ b/pkgs/development/libraries/qpdf/default.nix
@@ -1,23 +1,19 @@
-{ stdenv, fetchurl, libjpeg, zlib, perl }:
+{ stdenv, fetchFromGitHub, libjpeg, zlib, perl }:
 
-let version = "9.1.1";
-in
 stdenv.mkDerivation rec {
   pname = "qpdf";
-  inherit version;
+  version = "10.0.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/qpdf/qpdf/${version}/${pname}-${version}.tar.gz";
-    sha256 = "0dj27wb9xg6pg95phbflfvy9rwxn1gh3kc4n175g0pf41r0zrim2";
+  src = fetchFromGitHub {
+    owner = "qpdf";
+    repo = "qpdf";
+    rev = "release-qpdf-${version}";
+    sha256 = "0g3rqf4wd1n9cms7ra1jnszsgw5bygv37jq2l20d8z5fajckhyyi";
   };
 
   nativeBuildInputs = [ perl ];
 
   buildInputs = [ zlib libjpeg ];
-
-  postPatch = ''
-    patchShebangs qpdf/fix-qdf
-  '';
 
   preCheck = ''
     patchShebangs qtest/bin/qtest-driver


### PR DESCRIPTION
Use fetchFromGitHub. Remove 1 patchShebangs hook now unneeded.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
