### PR TITLE
xva-img: init at 1.4.1

### DIFF
--- a/pkgs/tools/virtualization/xva-img/default.nix
+++ b/pkgs/tools/virtualization/xva-img/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, cmake, fetchFromGitHub, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "xva-img";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "eriklax";
+    repo = "xva-img";
+    rev = version;
+    sha256 = "1w3wrbrlgv7h2gdix2rmrmpjyla365kam5621a1aqjzwjqhjkwyq";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ openssl ];
+
+  meta = {
+    maintainers = with lib.maintainers; [ lheckemann willibutz globin ];
+    description = "Tool for converting Xen images to raw and back";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27527,6 +27527,8 @@ in
 
   xteddy = callPackage ../applications/misc/xteddy { };
 
+  xva-img = callPackage ../tools/virtualization/xva-img { };
+
   xwiimote = callPackage ../misc/drivers/xwiimote { };
 
   xzoom = callPackage ../tools/X11/xzoom {};


### PR DESCRIPTION
###### Motivation for this change
Tool for converting images to and from Xen exports

###### Things done

- [x] Built and used on NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @WilliButz @globin 