### PR TITLE
python2Packages.cfn-lint: fix importlib-resources version bounds

### DIFF
--- a/pkgs/development/python-modules/cfn-lint/default.nix
+++ b/pkgs/development/python-modules/cfn-lint/default.nix
@@ -25,6 +25,10 @@ buildPythonPackage rec {
     sha256 = "42023d89520e3a29891ec2eb4c326eef9d1f7516fe9abee8b6c97ce064187b45";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py --replace 'importlib_resources~=1.4;python_version<"3.7" and python_version!="3.4"' 'importlib_resources;python_version<"3.7"'
+  '';
+
   propagatedBuildInputs = [
     pyyaml
     six
@@ -40,6 +44,21 @@ buildPythonPackage rec {
 
   # No tests included in archive
   doCheck = false;
+  pythonImportsCheck = [
+    "cfnlint"
+    "cfnlint.conditions"
+    "cfnlint.core"
+    "cfnlint.decode.node"
+    "cfnlint.decode.cfn_yaml"
+    "cfnlint.decode.cfn_json"
+    "cfnlint.decorators.refactored"
+    "cfnlint.graph"
+    "cfnlint.helpers"
+    "cfnlint.rules"
+    "cfnlint.runner"
+    "cfnlint.template"
+    "cfnlint.transform"
+  ];
 
   meta = with lib; {
     description = "Checks cloudformation for practices and behaviour that could potentially be improved";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

package dependencies don't support python 2
ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
