### PR TITLE
cryptodev: 1.9 -> 1.11

### DIFF
--- a/pkgs/os-specific/linux/cryptodev/default.nix
+++ b/pkgs/os-specific/linux/cryptodev/default.nix
@@ -1,14 +1,14 @@
-{ fetchurl, stdenv, kernel ? false }:
+{ fetchFromGitHub, stdenv, kernel ? false }:
 
 stdenv.mkDerivation rec {
-  pname = "cryptodev-linux-1.9";
+  pname = "cryptodev-linux-1.11";
   name = "${pname}-${kernel.version}";
 
-  src = fetchurl {
-    urls = [
-      "http://nwl.cc/pub/cryptodev-linux/${pname}.tar.gz"
-    ];
-    sha256 = "0l3r8s71vkd0s2h01r7fhqnc3j8cqw4msibrdxvps9hfnd4hnk4z";
+  src = fetchFromGitHub {
+    owner = "cryptodev-linux";
+    repo = "cryptodev-linux";
+    rev = pname;
+    sha256 = "1ky850qiyacq8p3lng7n3w6h3x2clqrz4lkv2cv3psy92mg9pvc9";
   };
 
   hardeningDisable = [ "pic" ];
@@ -22,6 +22,5 @@ stdenv.mkDerivation rec {
     homepage = "http://cryptodev-linux.org/";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
-    broken = !stdenv.lib.versionOlder kernel.version "4.13";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
- Update
- Unbreak for newer kernels
- Fix hydra failure for 4.4 kernels (#97479)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

**! Needs to be cherry-picked into 20.09 !**
