### PR TITLE
dvdbackup: fix build with libdvdread >= 6.1.0

### DIFF
--- a/pkgs/applications/video/dvdbackup/default.nix
+++ b/pkgs/applications/video/dvdbackup/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libdvdread, libdvdcss, dvdauthor }:
+{ stdenv, fetchurl, fetchpatch, libdvdread, libdvdcss, dvdauthor }:
 
 stdenv.mkDerivation rec {
   version = "0.4.2";
@@ -10,6 +10,13 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libdvdread libdvdcss dvdauthor ];
+
+  # see https://bugs.launchpad.net/dvdbackup/+bug/1869226
+  patchFlags = [ "-p0" ];
+  patches = [ (fetchpatch {
+    url = "https://git.slackbuilds.org/slackbuilds/plain/multimedia/dvdbackup/patches/dvdbackup-dvdread-6.1.patch";
+    sha256 = "1v3xl01bwq1592i5x5dyh95r0mmm1zvvwf92fgjc0smr0k3davfz";
+  })];
 
   meta = {
     description = "A tool to rip video DVDs from the command line";


### PR DESCRIPTION
###### Motivation for this change
fix build

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
