### PR TITLE
netatop: 2.0 -> 3.1

### DIFF
--- a/pkgs/os-specific/linux/netatop/default.nix
+++ b/pkgs/os-specific/linux/netatop/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, kernel, zlib }:
 
 let
-  version = "2.0";
+  version = "3.1";
 in
 
 stdenv.mkDerivation {
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://www.atoptool.nl/download/netatop-${version}.tar.gz";
-    sha256 = "03n248p1l3ps7gj2hdlcbrb1fsw1zcmgzypj4j4l4rynjjh7qvf6";
+    sha256 = "0qjw8glfdmngfvbn1w63q128vxdz2jlabw13y140ga9i5ibl6vvk";
   };
 
   buildInputs = [ zlib ];
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
         -e s,/usr,$out, \
         -e /init.d/d \
         -e /depmod/d \
+        -e /netatop.service/d \
         Makefile
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
- Build failures (#97479)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


None of these previously built:
```
λ nix-build -A linuxPackages_5_4.netatop -A linuxPackages_4_4.netatop -A linuxPackages_latest.netatop
/nix/store/5v3l5p4jd8vcanzqz279ajjgz143q5rs-netatop-5.4.64-3.1
/nix/store/g1zgzmajimsl8gl5ai7wysirsb92jf2z-netatop-4.4.235-3.1
/nix/store/55mlcqxazwfl5lhxhad52h8blx6c4j9g-netatop-5.8.8-3.1
```

**! Needs cherry-pick into 20.09!**