### PR TITLE
can-isotp: 20180629 -> 20200910

### DIFF
--- a/pkgs/os-specific/linux/can-isotp/default.nix
+++ b/pkgs/os-specific/linux/can-isotp/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation {
   pname = "can-isotp";
-  version = "20180629";
+  version = "20200910";
 
   hardeningDisable = [ "pic" ];
   
   src = fetchFromGitHub {
     owner = "hartkopp";
     repo = "can-isotp";
-    rev = "6003f9997587e6a563cebf1f246bcd0eb6deff3d";
-    sha256 = "0b2pqb0vd1wgv2zpl7lvfavqkzr8mrwhrv7zdqkq3rz9givcv8w7";
+    rev = "21a3a59e2bfad246782896841e7af042382fcae7";
+    sha256 = "1laax93czalclg7cy9iq1r7hfh9jigh7igj06y9lski75ap2vhfq";
   };
 
   KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes can-isotp build, also updates it to the latest version

This will be backported to 20.09 as part of ZHF

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
