### PR TITLE
release*: Support nixpkgsArgs for all release-*.nix files

### DIFF
--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -5,9 +5,11 @@
   supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ]
 , # Strip most of attributes when evaluating to spare memory usage
   scrubJobs ? true
+, # Attributes passed to nixpkgs. Don't build packages marked as unfree.
+  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
 
-with import ./release-lib.nix { inherit supportedSystems scrubJobs; };
+with import ./release-lib.nix { inherit supportedSystems scrubJobs nixpkgsArgs; };
 
 let
   nativePlatforms = all;

--- a/pkgs/top-level/release-python.nix
+++ b/pkgs/top-level/release-python.nix
@@ -5,9 +5,11 @@
 
 { # The platforms for which we build Nixpkgs.
   supportedSystems ? [ "x86_64-linux" ]
+, # Attributes passed to nixpkgs. Don't build packages marked as unfree.
+  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
 
-with import ./release-lib.nix {inherit supportedSystems; };
+with import ./release-lib.nix {inherit supportedSystems nixpkgsArgs; };
 with lib;
 
 let

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -3,9 +3,11 @@
 
 { nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
 , supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
+, # Attributes passed to nixpkgs. Don't build packages marked as unfree.
+  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
 
-with import ./release-lib.nix { inherit supportedSystems; };
+with import ./release-lib.nix { inherit supportedSystems nixpkgsArgs; };
 
 {
 


### PR DESCRIPTION
###### Motivation for this change
This is a bit dirty because there's no easy way to propagate these function arguments while still allowing --arg from the command line. But at least you can now pass `nixpkgsArgs` for `release-small.nix` and co.

###### Things done
- [x] Checked that the modified files still evaluate with `nix-instantiate <file> -A <TAB>`