### PR TITLE
pytricia: unstable-2019-01-16 -> 1.0.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -54,6 +54,11 @@
    </listitem>
    <listitem>
     <para>
+     Python package pytricia upgraded to 1.0.2.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      Two new options, <link linkend="opt-services.openssh.authorizedKeysCommand">authorizedKeysCommand</link>
      and <link linkend="opt-services.openssh.authorizedKeysCommandUser">authorizedKeysCommandUser</link>, have
      been added to the <literal>openssh</literal> module. If you have <literal>AuthorizedKeysCommand</literal>

--- a/pkgs/development/python-modules/pytricia/default.nix
+++ b/pkgs/development/python-modules/pytricia/default.nix
@@ -1,21 +1,19 @@
-{ stdenv
+{ lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 }:
 
 buildPythonPackage rec {
   pname = "pytricia";
-  version = "unstable-2019-01-16";
+  version = "1.0.2";
 
-  src = fetchFromGitHub {
-    owner = "jsommers";
-    repo = pname;
-    rev = "4ba88f68c3125f789ca8cd1cfae156e1464bde87";
-    sha256 = "0qp5774xkm700g35k5c76pck8pdzqlyzbaqgrz76a1yh67s2ri8h";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05cvq7r3mv7xq72ziwr3vl8s4a6246vdhmhs39jvg8amrvyhlv3z";
   };
 
-  meta = with stdenv.lib; {
-    description = "A library for fast IP address lookup in Python";
+  meta = with lib; {
+    description = "An efficient IP address storage and lookup module for Python";
     homepage = "https://github.com/jsommers/pytricia";
     license = with licenses; [ lgpl3Plus ];
     maintainers = with maintainers; [ mkg ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to newest version on Pypi.

Fixes version per #68518.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
