### PR TITLE
fontmatrix: 0.6.0 → 0.6.0-qt5

### DIFF
--- a/pkgs/applications/graphics/fontmatrix/default.nix
+++ b/pkgs/applications/graphics/fontmatrix/default.nix
@@ -26,7 +26,7 @@ mkDerivation rec {
   meta = with lib; {
     description = "Fontmatrix is a free/libre font explorer for Linux, Windows and Mac";
     homepage = "https://github.com/fontmatrix/fontmatrix";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/graphics/fontmatrix/default.nix
+++ b/pkgs/applications/graphics/fontmatrix/default.nix
@@ -1,23 +1,29 @@
-{ stdenv, fetchFromGitHub, cmake, qt4 }:
+{ lib, mkDerivation, fetchpatch, fetchFromGitHub, cmake, qttools, qtwebkit }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "fontmatrix";
-  version = "0.6.0";
+  version = "0.6.0-qt5";
 
   src = fetchFromGitHub {
-    owner = "fontmatrix";
+    owner = "fcoiffie";
     repo = "fontmatrix";
-    rev = "v${version}";
-    sha256 = "0aqndj1jhm6hjpwmj1qm92z2ljh7w78a5ff5ag47qywqha1ngn05";
+    rev = "1ff8382d8c85c18d9962918f461341ff4fe21993";
+    sha256 = "0yx1gbsjj9ddq1kiqplif1w5x5saw250zbmhmd4phqmaqzr60w0h";
   };
 
-  buildInputs = [ qt4 ];
+  # Add missing QAction include
+  patches = [ (fetchpatch {
+    url = "https://github.com/fcoiffie/fontmatrix/commit/dc6de8c414ae21516b72daead79c8db88309b102.patch";
+    sha256 = "092860fdyf5gq67jqfxnlgwzjgpizi6j0njjv3m62aiznrhig7c8";
+  })];
+
+  buildInputs = [ qttools qtwebkit ];
 
   nativeBuildInputs = [ cmake ];
 
   hardeningDisable = [ "format" ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Fontmatrix is a free/libre font explorer for Linux, Windows and Mac";
     homepage = "https://github.com/fontmatrix/fontmatrix";
     license = licenses.gpl2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3723,7 +3723,7 @@ in
 
   fontforge-fonttools = callPackage ../tools/misc/fontforge/fontforge-fonttools.nix {};
 
-  fontmatrix = callPackage ../applications/graphics/fontmatrix {};
+  fontmatrix = libsForQt514.callPackage ../applications/graphics/fontmatrix {};
 
   foremost = callPackage ../tools/system/foremost { };
 


### PR DESCRIPTION
This is an unofficial port of Fontmatrix 0.6.0 to Qt5

###### Motivation for this change

This package has been broken since #96939

ZHF: #97479

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
