### PR TITLE
Make socket activated user dbus session mandatory

### DIFF
--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -1836,6 +1836,19 @@ addEnvHooks "$hostOffset" myBashFunction
     </varlistentry>
     <varlistentry>
      <term>
+      <literal>move-systemd-user-units.sh</literal>
+     </term>
+     <listitem>
+      <para>
+       This setup hook moves any systemd user units installed in the lib
+       subdirectory into share. In addition, a link is provided from share to
+       lib for compatibility. This is needed for systemd to find user services
+       when installed into the user profile.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
       <literal>set-source-date-epoch-to-latest.sh</literal>
      </term>
      <listitem>

--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -59,7 +59,15 @@
 
   <itemizedlist>
    <listitem>
-    <para />
+    <para>
+     If the <varname>services.dbus</varname> module is enabled, then
+     the user D-Bus session is now always socket activated. The
+     associated options <varname>services.dbus.socketActivated</varname>
+     and <varname>services.xserver.startDbusSession</varname> have
+     therefore been removed and you will receive a warning if
+     they are present in your configuration. This change makes the
+     user D-Bus session available also for non-graphical logins.
+    </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -142,6 +142,7 @@ in
         "/share/kservices5"
         "/share/kservicetypes5"
         "/share/kxmlgui5"
+        "/share/systemd"
       ];
 
     system.path = pkgs.buildEnv {

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -19,6 +19,12 @@ in
 
 {
 
+  imports = [
+    (mkRemovedOptionModule
+      [ "services" "dbus" "socketActivated" ]
+      "The user D-Bus session is now always socket activated and this option can safely be removed.")
+  ];
+
   ###### interface
 
   options = {
@@ -49,14 +55,6 @@ in
           <filename><replaceable>pkg</replaceable>/etc/dbus-1/session.d</filename>
           <filename><replaceable>pkg</replaceable>/share/dbus-1/session.d</filename>
           <filename><replaceable>pkg</replaceable>/share/dbus-1/services</filename>
-        '';
-      };
-
-      socketActivated = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Make the user instance socket activated.
         '';
       };
     };
@@ -108,7 +106,7 @@ in
         reloadIfChanged = true;
         restartTriggers = [ configDir ];
       };
-      sockets.dbus.wantedBy = mkIf cfg.socketActivated [ "sockets.target" ];
+      sockets.dbus.wantedBy = [ "sockets.target" ];
     };
 
     environment.pathsToLink = [ "/etc/dbus-1" "/share/dbus-1" ];

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -37,13 +37,6 @@ let
       . /etc/profile
       cd "$HOME"
 
-      ${optionalString cfg.startDbusSession ''
-        if test -z "$DBUS_SESSION_BUS_ADDRESS"; then
-          /run/current-system/systemd/bin/systemctl --user start dbus.socket
-          export `/run/current-system/systemd/bin/systemctl --user show-environment | grep '^DBUS_SESSION_BUS_ADDRESS'`
-        fi
-      ''}
-
       ${optionalString cfg.displayManager.job.logToJournal ''
         if [ -z "$_DID_SYSTEMD_CAT" ]; then
           export _DID_SYSTEMD_CAT=1

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -151,6 +151,9 @@ in
       ./desktop-managers/default.nix
       (mkRemovedOptionModule [ "services" "xserver" "startGnuPGAgent" ]
         "See the 16.09 release notes for more information.")
+      (mkRemovedOptionModule
+        [ "services" "xserver" "startDbusSession" ]
+        "The user D-Bus session is now always socket activated and this option can safely be removed.")
     ];
 
 
@@ -294,14 +297,6 @@ in
         type = types.nullOr types.int;
         default = null;
         description = "DPI resolution to use for X server.";
-      };
-
-      startDbusSession = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to start a new DBus session when you log in with dbus-launch.
-        '';
       };
 
       updateDbusEnvironment = mkOption {

--- a/pkgs/build-support/setup-hooks/move-systemd-user-units.sh
+++ b/pkgs/build-support/setup-hooks/move-systemd-user-units.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# This setup hook, for each output, moves everything in
+# $output/lib/systemd/user to $output/share/systemd/user, and replaces
+# $output/lib/systemd/user with a symlink to
+# $output/share/systemd/user.
+
+fixupOutputHooks+=(_moveSystemdUserUnits)
+
+_moveSystemdUserUnits() {
+    if [ "${dontMoveSystemdUserUnits:-0}" = 1 ]; then return; fi
+    if [ ! -e "${prefix:?}/lib/systemd/user" ]; then return; fi
+    local source="$prefix/lib/systemd/user"
+    local target="$prefix/share/systemd/user"
+    echo "moving $source/* to $target"
+    mkdir -p "$target"
+    (
+      shopt -s dotglob
+      for i in "$source"/*; do
+          mv "$i" "$target"
+      done
+    )
+    rmdir "$source"
+    ln -s "$target" "$source"
+}

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -61,7 +61,10 @@ let
     ]
       # FIXME this on Darwin; see
       # https://github.com/NixOS/nixpkgs/commit/94d164dd7#commitcomment-22030369
-    ++ lib.optional hostPlatform.isLinux ../../build-support/setup-hooks/audit-tmpdir.sh
+    ++ lib.optionals hostPlatform.isLinux [
+      ../../build-support/setup-hooks/audit-tmpdir.sh
+      ../../build-support/setup-hooks/move-systemd-user-units.sh
+    ]
     ++ [
       ../../build-support/setup-hooks/multiple-outputs.sh
       ../../build-support/setup-hooks/move-sbin.sh


### PR DESCRIPTION
###### Motivation for this change

Removes non-socket activated user D-Bus session. To do this it was also necessary to add a hook that moves systemd user units to a place discoverable through `XDG_DATA_DIRS`. Replaces #67942.

Many CPU hours have died to bring us these two commits.