### PR TITLE
dotnetCorePackages.sdk_3_1: 3.1.102 -> 3.1.402

### DIFF
--- a/pkgs/applications/blockchains/wasabibackend/deps.nix
+++ b/pkgs/applications/blockchains/wasabibackend/deps.nix
@@ -700,13 +700,13 @@ in [
   })
   (fetchNuGet {
     name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
-    version = "3.1.2";
-    sha256 = "19wfh9yg4n2khbl7pvf6ngx95m5p8lw4l9y935pv7nh4xgwk02p9";
+    version = "3.1.8";
+    sha256 = "140zr3nwkmf6xc52gq4iz6ycyh95fxy0jpgn637pkd9z423z8135";
   })
   (fetchNuGet {
     name = "Microsoft.NETCore.App.Runtime.linux-x64";
-    version = "3.1.2";
-    sha256 = "0a332ia5pabnz7mdfc99a5hlc7drnwzlc7cj9b5c3an6dq636p66";
+    version = "3.1.8";
+    sha256 = "1bv9n9wzsqf9g8h6z10p61xkcx8ad4nnip83qv8yyfvhr4kdmbsa";
   })
   (fetchNuGet {
     name = "System.Collections.NonGeneric";

--- a/pkgs/development/compilers/dotnet/default.nix
+++ b/pkgs/development/compilers/dotnet/default.nix
@@ -95,11 +95,11 @@ rec {
   };
 
   sdk_3_1 = buildNetCoreSdk {
-    version = "3.1.102";
+    version = "3.1.402";
     sha512 = {
-      x86_64-linux = "0lmz8ac5j0i4zcq4904kr6qibvyjcm2ckfg27kqyqfii00qmm80xb5sk3i7f06xqkbgkrqkbg9rsldk75akw6m5dxg932j602bxrb4w";
-      aarch64-linux = "34k6cm69gxm7vcd9m6bp47sdx96j32z6lfhb2vjcdznc6xgs2wy8zcang3b1mjm5919dq7v6iysm6ffcpgjhhphy7prlnaqa69q5mks";
-      x86_64-darwin = "00xs87zj94v6yr6xs294bficp6lxpghyfswhnwqfkx62jy80qr5fa2y7s10ich3cbm2daa8dby56iizdvi7rnlvp23gfkq12gq4w1g8";
+      x86_64-linux = "2zdb5cl4swg7kvnla6kgnnwg3kkb3rj2ccizg43fw89h8nacr1klz3zdl5km9l553lvm364dy8xsdwm79bw1ch0qgff6snnbbxlw5a2";
+      aarch64-linux = "1aq8fhsn15362x99dfp72m67zbswrg30xscy1n983mmq76qn5ha6sy8pyj84l7qcs0n1b7akb77qyi3d2ns8bd2wl6s1dacl24gn10p";
+      x86_64-darwin = "1gk6sgd9gdc6nr64mdfj6lhzdi6ixi5c1r0i1b7bhkg2xycx5cnbgjycrpqh17h6wbp68dz4mkg5hf1y3527hdwypa9k0sqdg3yrdb8";
     };
   };
 }

--- a/pkgs/development/dotnet-modules/python-language-server/deps.nix
+++ b/pkgs/development/dotnet-modules/python-language-server/deps.nix
@@ -54,26 +54,14 @@ in [
 
   (fetchNuGet {
     name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
-    version = "3.0.2";
-    sha256 = "0d4r744n3bk4v7ddfjpy5ils150h0693bil3c7v27n84037hqndj";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
     version = "3.0.3";
     sha256 = "1jcqy8i9fzb1pmkazi80yqr09zi5nk30n57i46ggr5ky45jngfq9";
   })
 
   (fetchNuGet {
     name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
-    version = "3.1.2";
-    sha256 = "19wfh9yg4n2khbl7pvf6ngx95m5p8lw4l9y935pv7nh4xgwk02p9";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
-    version = "3.1.3";
-    sha256 = "0kvnzb9xjii48kg30ac63qdf0fn1y8j3nblbrfaqv2aiy6kp0iwn";
+    version = "3.1.8";
+    sha256 = "140zr3nwkmf6xc52gq4iz6ycyh95fxy0jpgn637pkd9z423z8135";
   })
 
   (fetchNuGet {
@@ -102,20 +90,14 @@ in [
 
   (fetchNuGet {
     name = "Microsoft.NetCore.App.Host.linux-x64";
-    version = "3.0.2";
-    sha256 = "0y14y2x3wbi44i23ndmf4323cii8wrqw9s289gcab3s393l71sf5";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.NetCore.App.Host.linux-x64";
     version = "3.0.3";
     sha256 = "19igfvwsjzwkh90gqzabl6pdkyygslj2iwpsxg680phffzr411w4";
   })
 
   (fetchNuGet {
     name = "Microsoft.NetCore.App.Host.linux-x64";
-    version = "3.1.3";
-    sha256 = "013ibnhsimgqj5l2dqma035xvsvrb47bn65z6xbxgg88383hpgvw";
+    version = "3.1.8";
+    sha256 = "0iawz5mqaf1c4r5cf0ks4wqhgpbqi185l80q4909axh516xsjnvs";
   })
 
   (fetchNuGet {
@@ -132,26 +114,14 @@ in [
 
   (fetchNuGet {
     name = "Microsoft.NetCore.App.Runtime.linux-x64";
-    version = "3.0.2";
-    sha256 = "1h6d0nl495k0bh4my43l578l7m8qwah7ll42aax7jrib2py354f1";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.NetCore.App.Runtime.linux-x64";
     version = "3.0.3";
     sha256 = "1ykgfnphbkyck0gqbbh5n96w59z2bq47g896ygal1j4nblj3s44v";
   })
 
   (fetchNuGet {
     name = "Microsoft.NetCore.App.Runtime.linux-x64";
-    version = "3.1.2";
-    sha256 = "0a332ia5pabnz7mdfc99a5hlc7drnwzlc7cj9b5c3an6dq636p66";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.NetCore.App.Runtime.linux-x64";
-    version = "3.1.3";
-    sha256 = "1ynhzsr8a0hfby2wjhzkdiimj18izgfzp7m2yp3pby2iwb4v3xy9";
+    version = "3.1.8";
+    sha256 = "1bv9n9wzsqf9g8h6z10p61xkcx8ad4nnip83qv8yyfvhr4kdmbsa";
   })
 
   (fetchNuGet {

--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -49,7 +49,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $HOME/.nuget/NuGet
     cp $HOME/.config/NuGet/NuGet.Config $HOME/.nuget/NuGet
 
-    dotnet restore --source nixos osu.Desktop
+    dotnet restore --source "$PWD/nixos" osu.Desktop
 
     runHook postConfigure
   '';

--- a/pkgs/misc/emulators/ryujinx/default.nix
+++ b/pkgs/misc/emulators/ryujinx/default.nix
@@ -13,13 +13,13 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "ryujinx";
-  version = "1.0.5160";
+  version = "1.0.5346";
 
   src = fetchFromGitHub {
     owner = "Ryujinx";
     repo = "Ryujinx";
-    rev = "58f65b6523fb25d989b011c51f963520c811f9f0";
-    sha256 = "19fizqmcr8i3axi3j5hg8p6dxr1pxnl5l58z4pws6nj1xbq8z5mi";
+    rev = "2ce59c44bcb2d789f4d6312b26cf41f36915d73c";
+    sha256 = "0hk8jdacg8ryhh0mpnfjbzrrpy8gv87f4hp0hybyypglmaxz8grm";
   };
 
   nativeBuildInputs = [ dotnet-sdk_3 dotnetPackages.Nuget makeWrapper wrapGAppsHook gobject-introspection ];
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $HOME/.nuget/NuGet
     cp $HOME/.config/NuGet/NuGet.Config $HOME/.nuget/NuGet
 
-    dotnet restore --source nixos Ryujinx.sln
+    dotnet restore --source "$PWD/nixos" Ryujinx.sln
 
     runHook postConfigure
   '';

--- a/pkgs/misc/emulators/ryujinx/deps.nix
+++ b/pkgs/misc/emulators/ryujinx/deps.nix
@@ -56,33 +56,28 @@
   })
   (fetchNuGet {
     name = "LibHac";
-    version = "0.11.3";
-    sha256 = "0xj2ip3bjy29xwy4fn5fncjadwbbg59sa3580cmkj47aab9cddyn";
+    version = "0.12.0";
+    sha256 = "08r9b9cdcbz6339sw8r5dfy2a8iw53df0j3xq9rygkg02xspimld";
   })
   (fetchNuGet {
     name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
-    version = "3.1.2";
-    sha256 = "19wfh9yg4n2khbl7pvf6ngx95m5p8lw4l9y935pv7nh4xgwk02p9";
+    version = "3.1.8";
+    sha256 = "140zr3nwkmf6xc52gq4iz6ycyh95fxy0jpgn637pkd9z423z8135";
   })
   (fetchNuGet {
     name = "Microsoft.AspNetCore.App.Runtime.osx-x64";
-    version = "3.1.2";
-    sha256 = "1v7i4f1k3j8xavbfwb7qr5f680gg5nblrmx5zcsj7l07q4wbnmwl";
+    version = "3.1.8";
+    sha256 = "0dkib4r4v5wqxsi6zca6x3zin1x4lha53dqbgsaiah961h1yhpp4";
   })
   (fetchNuGet {
     name = "Microsoft.AspNetCore.App.Runtime.win-x64";
-    version = "3.1.2";
-    sha256 = "1gciv56vzfpl86lb9gzvyfj8w2qd7jhdrbxph6l1aykwzqbxf7bd";
+    version = "3.1.8";
+    sha256 = "05sv39b6sc8fhh3m8kwq0lp58n8mrv5ivxa60rfqk6v6i7gs8b0f";
   })
   (fetchNuGet {
     name = "Microsoft.CodeCoverage";
-    version = "16.2.0";
-    sha256 = "07h1ylca2j7a4hznq4m4b8nrzv1lw7gcf848k2a3nbm6rapv61ki";
-  })
-  (fetchNuGet {
-    name = "Microsoft.CodeCoverage";
-    version = "16.5.0";
-    sha256 = "0610wzn4qyywf9lb4538vwqhprxc4g0g7gjbmnjzvx97jr5nd5mf";
+    version = "16.7.0";
+    sha256 = "10f6y1q8w61vc8ffqd7jsndwfskkfqbdzfqswyxnrr0qkkqx29v1";
   })
   (fetchNuGet {
     name = "Microsoft.CSharp";
@@ -96,28 +91,28 @@
   })
   (fetchNuGet {
     name = "Microsoft.NETCore.App.Host.osx-x64";
-    version = "3.1.2";
-    sha256 = "0sy1h7ffq8s3bkvf1carf4rn9qf7hn0yv6dcjklgh3g9jhlsq34f";
+    version = "3.1.8";
+    sha256 = "1ip8pgra9z6ha3yc4xqkb85cl9kx2jbwhwzdi3dp8bkqbvlirvkb";
   })
   (fetchNuGet {
     name = "Microsoft.NETCore.App.Host.win-x64";
-    version = "3.1.2";
-    sha256 = "1yqsnl4my2q1ps666162kn0h34wyfajiwqs6snhrww195b59msdv";
+    version = "3.1.8";
+    sha256 = "1d7wlnibf9fgq57hwnjqhlh33hxg417ljf1djb9yan4xik1wl4hb";
   })
   (fetchNuGet {
     name = "Microsoft.NETCore.App.Runtime.linux-x64";
-    version = "3.1.2";
-    sha256 = "0a332ia5pabnz7mdfc99a5hlc7drnwzlc7cj9b5c3an6dq636p66";
+    version = "3.1.8";
+    sha256 = "1bv9n9wzsqf9g8h6z10p61xkcx8ad4nnip83qv8yyfvhr4kdmbsa";
   })
   (fetchNuGet {
     name = "Microsoft.NETCore.App.Runtime.osx-x64";
-    version = "3.1.2";
-    sha256 = "1wb8h30di1mix8liz937snl1w8hbblixrpiazjskxclp3i7m1rg3";
+    version = "3.1.8";
+    sha256 = "1iabp5czrz9wmsqcl0gi8r580vlhky3aak5ndz9fw065wlsqpv7w";
   })
   (fetchNuGet {
     name = "Microsoft.NETCore.App.Runtime.win-x64";
-    version = "3.1.2";
-    sha256 = "0aj005mh57ynscf87cpfshc3ff22l4svf6lqz0hpqsi0hlidqwqx";
+    version = "3.1.8";
+    sha256 = "010c514ls1q9gdnyj0kvknx7a0z034lfbbcxqa8cjiv0snax4pqz";
   })
   (fetchNuGet {
     name = "Microsoft.NETCore.Platforms";
@@ -151,33 +146,18 @@
   })
   (fetchNuGet {
     name = "Microsoft.NET.Test.Sdk";
-    version = "16.2.0";
-    sha256 = "1nr5jxchdy3p7jm4fm73d5yivghjisdsyafma8fs5d1v49bhgckq";
-  })
-  (fetchNuGet {
-    name = "Microsoft.NET.Test.Sdk";
-    version = "16.5.0";
-    sha256 = "19f5bvzci5mmfz81jwc4dax4qdf7w4k67n263383mn8mawf22bfq";
+    version = "16.7.0";
+    sha256 = "1vkp6b82566z2pxn9035wrh4339kz3ki17g5qlwmwdbn4br6lcfy";
   })
   (fetchNuGet {
     name = "Microsoft.TestPlatform.ObjectModel";
-    version = "16.2.0";
-    sha256 = "1ywzyx75d61wm75l7wglxzglg5k9nq66wd56m52hmmg8mf253z57";
-  })
-  (fetchNuGet {
-    name = "Microsoft.TestPlatform.ObjectModel";
-    version = "16.5.0";
-    sha256 = "02h7j1fr0fwcggn0wgddh59k8b2wmly3snckwhswzqvks5rvfnnw";
+    version = "16.7.0";
+    sha256 = "0nmw80ap2rn9h4i1x7qb15n763sh3wy8hjp1i5n0av7100g0yjqz";
   })
   (fetchNuGet {
     name = "Microsoft.TestPlatform.TestHost";
-    version = "16.2.0";
-    sha256 = "05dx9nv1skc5ji79ji5vz6c93b09w9xh70iyy6j5ca978ga92i6g";
-  })
-  (fetchNuGet {
-    name = "Microsoft.TestPlatform.TestHost";
-    version = "16.5.0";
-    sha256 = "08cvss66lqa92h55dxkbrzn796jckhlyj53zz22x3qyr6xi21v5v";
+    version = "16.7.0";
+    sha256 = "0485nv0wcwdwjhif5a7d1i0znaf9acqyawhpqcwschw827chqzrs";
   })
   (fetchNuGet {
     name = "Microsoft.Win32.Primitives";
@@ -188,11 +168,6 @@
     name = "Microsoft.Win32.Primitives";
     version = "4.3.0";
     sha256 = "0j0c1wj4ndj21zsgivsc24whiya605603kxrbiw6wkfdync464wq";
-  })
-  (fetchNuGet {
-    name = "Microsoft.Win32.Registry";
-    version = "4.0.0";
-    sha256 = "1spf4m9pikkc19544p29a47qnhcd885klncahz133hbnyqbkmz9k";
   })
   (fetchNuGet {
     name = "Microsoft.Win32.Registry";
@@ -256,13 +231,8 @@
   })
   (fetchNuGet {
     name = "NUnit3TestAdapter";
-    version = "3.15.1";
-    sha256 = "1nhpvzxbxgymmkb3bd5ci40rg8k71bfx2ghbgc99znvnvhf2034y";
-  })
-  (fetchNuGet {
-    name = "NUnit3TestAdapter";
-    version = "3.16.1";
-    sha256 = "1pzhmapfdszsfza7zjr3zrlz4fssdxsyiwmlj76a40mbhxhfa4q9";
+    version = "3.17.0";
+    sha256 = "0kxc6z3b8ccdrcyqz88jm5yh5ch9nbg303v67q8sp5hhs8rl8nk6";
   })
   (fetchNuGet {
     name = "OpenTK.NetStandard";
@@ -276,18 +246,8 @@
   })
   (fetchNuGet {
     name = "runtime.any.System.Collections";
-    version = "4.0.11";
-    sha256 = "1x44bm1cgv28zmrp095wf9mn8a6a0ivnzp9v14dcbhx06igxzgg0";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Collections";
     version = "4.3.0";
     sha256 = "0bv5qgm6vr47ynxqbnkc7i797fdi8gbjjxii173syrx14nmrkwg0";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Diagnostics.Tools";
-    version = "4.0.1";
-    sha256 = "0qcpm90hrm9gx9pmxlvfml65jm0bwpr5dg3r7l7xm9nvmibvc7n7";
   })
   (fetchNuGet {
     name = "runtime.any.System.Diagnostics.Tools";
@@ -301,11 +261,6 @@
   })
   (fetchNuGet {
     name = "runtime.any.System.Globalization";
-    version = "4.0.11";
-    sha256 = "0240rp66pi5bw1xklmh421hj7arwcdmjmgfkiq1cbc6nrm8ah286";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Globalization";
     version = "4.3.0";
     sha256 = "1daqf33hssad94lamzg01y49xwndy2q97i2lrb7mgn28656qia1x";
   })
@@ -316,18 +271,8 @@
   })
   (fetchNuGet {
     name = "runtime.any.System.IO";
-    version = "4.1.0";
-    sha256 = "0kasfkjiml2kk8prnyn1990nhsahnjggvqwszqjdsfwfl43vpcb5";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.IO";
     version = "4.3.0";
     sha256 = "0l8xz8zn46w4d10bcn3l4yyn4vhb3lrj2zw8llvz7jk14k4zps5x";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Reflection";
-    version = "4.1.0";
-    sha256 = "06kcs059d5czyakx75rvlwa2mr86156w18fs7chd03f7084l7mq6";
   })
   (fetchNuGet {
     name = "runtime.any.System.Reflection";
@@ -336,18 +281,8 @@
   })
   (fetchNuGet {
     name = "runtime.any.System.Reflection.Extensions";
-    version = "4.0.1";
-    sha256 = "05k34ijz9g9csh0vbbv3g3lrxl163izwcfncmbcl7k073h32rzkr";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Reflection.Extensions";
     version = "4.3.0";
     sha256 = "0zyri97dfc5vyaz9ba65hjj1zbcrzaffhsdlpxc9bh09wy22fq33";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Reflection.Primitives";
-    version = "4.0.1";
-    sha256 = "1zxrpvixr5fqzkxpnin6g6gjq6xajy1snghz99ds2dwbhm276rhz";
   })
   (fetchNuGet {
     name = "runtime.any.System.Reflection.Primitives";
@@ -356,18 +291,8 @@
   })
   (fetchNuGet {
     name = "runtime.any.System.Resources.ResourceManager";
-    version = "4.0.1";
-    sha256 = "1jmgs7hynb2rff48623wnyb37558bbh1q28k9c249j5r5sgsr5kr";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Resources.ResourceManager";
     version = "4.3.0";
     sha256 = "03kickal0iiby82wa5flar18kyv82s9s6d4xhk5h4bi5kfcyfjzl";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Runtime";
-    version = "4.1.0";
-    sha256 = "0mjr2bi7wvnkphfjqgkyf8vfyvy15a829jz6mivl6jmksh2bx40m";
   })
   (fetchNuGet {
     name = "runtime.any.System.Runtime";
@@ -376,18 +301,8 @@
   })
   (fetchNuGet {
     name = "runtime.any.System.Runtime.Handles";
-    version = "4.0.1";
-    sha256 = "1kswgqhy34qvc49i981fk711s7knd6z13bp0rin8ms6axkh98nas";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Runtime.Handles";
     version = "4.3.0";
     sha256 = "0bh5bi25nk9w9xi8z23ws45q5yia6k7dg3i4axhfqlnj145l011x";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Runtime.InteropServices";
-    version = "4.1.0";
-    sha256 = "0gm8if0hcmp1qys1wmx4970k2x62pqvldgljsyzbjhiy5644vl8z";
   })
   (fetchNuGet {
     name = "runtime.any.System.Runtime.InteropServices";
@@ -396,28 +311,13 @@
   })
   (fetchNuGet {
     name = "runtime.any.System.Text.Encoding";
-    version = "4.0.11";
-    sha256 = "0m4vgmzi1ky8xlj0r7xcyazxln3j9dlialnk6d2gmgrfnzf8f9m7";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Text.Encoding";
     version = "4.3.0";
     sha256 = "0aqqi1v4wx51h51mk956y783wzags13wa7mgqyclacmsmpv02ps3";
   })
   (fetchNuGet {
     name = "runtime.any.System.Text.Encoding.Extensions";
-    version = "4.0.11";
-    sha256 = "0d1rxxpvg9v7wlibsfgz0r4hwigpadas822qf8m8fs1gma9gs877";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Text.Encoding.Extensions";
     version = "4.3.0";
     sha256 = "0lqhgqi0i8194ryqq6v2gqx0fb86db2gqknbm0aq31wb378j7ip8";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Threading.Tasks";
-    version = "4.0.11";
-    sha256 = "1qzdp09qs8br5qxzlm1lgbjn4n57fk8vr1lzrmli2ysdg6x1xzvk";
   })
   (fetchNuGet {
     name = "runtime.any.System.Threading.Tasks";
@@ -521,18 +421,8 @@
   })
   (fetchNuGet {
     name = "runtime.unix.System.Diagnostics.Debug";
-    version = "4.0.11";
-    sha256 = "05ndbai4vpqrry0ghbfgqc8xblmplwjgndxmdn1zklqimczwjg2d";
-  })
-  (fetchNuGet {
-    name = "runtime.unix.System.Diagnostics.Debug";
     version = "4.3.0";
     sha256 = "1lps7fbnw34bnh3lm31gs5c0g0dh7548wfmb8zz62v0zqz71msj5";
-  })
-  (fetchNuGet {
-    name = "runtime.unix.System.IO.FileSystem";
-    version = "4.0.1";
-    sha256 = "02wnlydnbhai0zy7c3kihg0cis0l1b2z78kyi1ci47c5v0jklwha";
   })
   (fetchNuGet {
     name = "runtime.unix.System.IO.FileSystem";
@@ -551,18 +441,8 @@
   })
   (fetchNuGet {
     name = "runtime.unix.System.Private.Uri";
-    version = "4.0.1";
-    sha256 = "0ic5dgc45jkhcr1g9xmmzjm7ffiw4cymm0fprczlx4fnww4783nm";
-  })
-  (fetchNuGet {
-    name = "runtime.unix.System.Private.Uri";
     version = "4.3.0";
     sha256 = "1jx02q6kiwlvfksq1q9qr17fj78y5v6mwsszav4qcz9z25d5g6vk";
-  })
-  (fetchNuGet {
-    name = "runtime.unix.System.Runtime.Extensions";
-    version = "4.1.0";
-    sha256 = "0x1cwd7cvifzmn5x1wafvj75zdxlk3mxy860igh3x1wx0s8167y4";
   })
   (fetchNuGet {
     name = "runtime.unix.System.Runtime.Extensions";
@@ -581,18 +461,8 @@
   })
   (fetchNuGet {
     name = "runtime.win.System.Diagnostics.Debug";
-    version = "4.0.11";
-    sha256 = "1ylkj4v7aq00svij7aq82d86afpwqgrqf2kpikabxl26p19ry9wm";
-  })
-  (fetchNuGet {
-    name = "runtime.win.System.Diagnostics.Debug";
     version = "4.3.0";
     sha256 = "16fbn4bcynad1ygdq0yk1wmckvs8jvrrf104xa5dc2hlc8y3x58f";
-  })
-  (fetchNuGet {
-    name = "runtime.win.System.IO.FileSystem";
-    version = "4.0.1";
-    sha256 = "1dn9k6x8h27b6vbqh72hsfxax4fwf30jj8lc5328rg52lw29cyn1";
   })
   (fetchNuGet {
     name = "runtime.win.System.IO.FileSystem";
@@ -611,11 +481,6 @@
   })
   (fetchNuGet {
     name = "runtime.win.System.Runtime.Extensions";
-    version = "4.1.0";
-    sha256 = "1zmx2msa04ka8mgh8viahi4pqpp86vdhzij2rg1jg131bwlv59yw";
-  })
-  (fetchNuGet {
-    name = "runtime.win.System.Runtime.Extensions";
     version = "4.3.0";
     sha256 = "1700famsxndccfbcdz9q14qb20p49lax67mqwpgy4gx3vja1yczr";
   })
@@ -623,26 +488,6 @@
     name = "Ryujinx.Graphics.Nvdec.Dependencies";
     version = "4.3.0";
     sha256 = "0szgbdhyhvzpw8nb9k2ww37p5qipab1pdll8idkk57y5xnl2f7ll";
-  })
-  (fetchNuGet {
-    name = "SkiaSharp";
-    version = "1.68.1.1";
-    sha256 = "013yzsk798dwxdf2y5yx675x96nagfapkri5k3pgsjnmyfp1lvzk";
-  })
-  (fetchNuGet {
-    name = "SkiaSharp.NativeAssets.Linux";
-    version = "1.68.1.1";
-    sha256 = "07448kn9x56pxlnkxp2dpr5jmwj62k48y5m4608mwci32vs675hn";
-  })
-  (fetchNuGet {
-    name = "SkiaSharp.Views.Desktop.Common";
-    version = "1.68.1.1";
-    sha256 = "0wkj952iha7w2i8mvl0mksz2wqkx7vi7xylh10xgddld8kkm03r7";
-  })
-  (fetchNuGet {
-    name = "SkiaSharp.Views.Gtk3";
-    version = "1.68.1.1";
-    sha256 = "19fgshim2i60p55j4jcr0biq6k2xwal5dsmbgvyrrajnssaj3r95";
   })
   (fetchNuGet {
     name = "System.AppContext";
@@ -685,24 +530,9 @@
     sha256 = "07y08kvrzpak873pmyxs129g1ch8l27zmg51pcyj2jvq03n0r0fc";
   })
   (fetchNuGet {
-    name = "System.Collections.Immutable";
-    version = "1.2.0";
-    sha256 = "1jm4pc666yiy7af1mcf7766v710gp0h40p228ghj6bavx7xfa38m";
-  })
-  (fetchNuGet {
-    name = "System.Collections.NonGeneric";
-    version = "4.0.1";
-    sha256 = "19994r5y5bpdhj7di6w047apvil8lh06lh2c2yv9zc4fc5g9bl4d";
-  })
-  (fetchNuGet {
     name = "System.Collections.NonGeneric";
     version = "4.3.0";
     sha256 = "07q3k0hf3mrcjzwj8fwk6gv3n51cb513w4mgkfxzm3i37sc9kz7k";
-  })
-  (fetchNuGet {
-    name = "System.Collections.Specialized";
-    version = "4.0.1";
-    sha256 = "1wbv7y686p5x169rnaim7sln67ivmv6r57falrnx8aap9y33mam9";
   })
   (fetchNuGet {
     name = "System.Collections.Specialized";
@@ -711,18 +541,8 @@
   })
   (fetchNuGet {
     name = "System.ComponentModel";
-    version = "4.0.1";
-    sha256 = "0v4qpmqlzyfad2kswxxj2frnaqqhz9201c3yn8fmmarx5vlzg52z";
-  })
-  (fetchNuGet {
-    name = "System.ComponentModel";
     version = "4.3.0";
     sha256 = "0986b10ww3nshy30x9sjyzm0jx339dkjxjj3401r3q0f6fx2wkcb";
-  })
-  (fetchNuGet {
-    name = "System.ComponentModel.EventBasedAsync";
-    version = "4.0.11";
-    sha256 = "07r5i7xwban347nsfw28hhjwpr78ywksjyhywvhj1yr0s7sr00wh";
   })
   (fetchNuGet {
     name = "System.ComponentModel.EventBasedAsync";
@@ -731,18 +551,8 @@
   })
   (fetchNuGet {
     name = "System.ComponentModel.Primitives";
-    version = "4.1.0";
-    sha256 = "0wb5mnaag0w4fnyc40x19j8v2vshxp266razw64bcqfyj1whb1q0";
-  })
-  (fetchNuGet {
-    name = "System.ComponentModel.Primitives";
     version = "4.3.0";
     sha256 = "1svfmcmgs0w0z9xdw2f2ps05rdxmkxxhf0l17xk9l1l8xfahkqr0";
-  })
-  (fetchNuGet {
-    name = "System.ComponentModel.TypeConverter";
-    version = "4.1.0";
-    sha256 = "178cva9p1cs043h5n2fry5xkzr3wc9n0hwbxa8m3ymld9m6wcv0y";
   })
   (fetchNuGet {
     name = "System.ComponentModel.TypeConverter";
@@ -771,28 +581,13 @@
   })
   (fetchNuGet {
     name = "System.Diagnostics.Process";
-    version = "4.1.0";
-    sha256 = "061lrcs7xribrmq7kab908lww6kn2xn1w3rdc41q189y0jibl19s";
-  })
-  (fetchNuGet {
-    name = "System.Diagnostics.Process";
     version = "4.3.0";
     sha256 = "0g4prsbkygq8m21naqmcp70f24a1ksyix3dihb1r1f71lpi3cfj7";
-  })
-  (fetchNuGet {
-    name = "System.Diagnostics.TextWriterTraceListener";
-    version = "4.0.0";
-    sha256 = "1xigiwkwyxak0dhm0p8i2zb7a9syly9cdb5s9zkr9rbad4f2fqhs";
   })
   (fetchNuGet {
     name = "System.Diagnostics.Tools";
     version = "4.0.1";
     sha256 = "19cknvg07yhakcvpxg3cxa0bwadplin6kyxd8mpjjpwnp56nl85x";
-  })
-  (fetchNuGet {
-    name = "System.Diagnostics.TraceSource";
-    version = "4.0.0";
-    sha256 = "1mc7r72xznczzf6mz62dm8xhdi14if1h8qgx353xvhz89qyxsa3h";
   })
   (fetchNuGet {
     name = "System.Diagnostics.Tracing";
@@ -930,16 +725,6 @@
     sha256 = "1sybkfi60a4588xn34nd9a58png36i0xr4y4v4kqpg8wlvy5krrj";
   })
   (fetchNuGet {
-    name = "System.Private.DataContractSerialization";
-    version = "4.1.1";
-    sha256 = "1xk9wvgzipssp1393nsg4n16zbr5481k03nkdlj954hzq5jkx89r";
-  })
-  (fetchNuGet {
-    name = "System.Private.Uri";
-    version = "4.0.1";
-    sha256 = "0k57qhawjysm4cpbfpc49kl4av7lji310kjcamkl23bwgij5ld9j";
-  })
-  (fetchNuGet {
     name = "System.Private.Uri";
     version = "4.3.0";
     sha256 = "04r1lkdnsznin0fj4ya1zikxiqr0h6r6a1ww2dsm60gqhdrf0mvx";
@@ -995,11 +780,6 @@
     sha256 = "02bly8bdc98gs22lqsfx9xicblszr2yan7v2mmw3g7hy6miq5hwq";
   })
   (fetchNuGet {
-    name = "System.Reflection.Metadata";
-    version = "1.3.0";
-    sha256 = "1y5m6kryhjpqqm2g3h3b6bzig13wkiw954x3b7icqjm6xypm1x3b";
-  })
-  (fetchNuGet {
     name = "System.Reflection.Primitives";
     version = "4.0.1";
     sha256 = "1bangaabhsl4k9fg8khn83wm6yial8ik1sza7401621jc6jrym28";
@@ -1038,6 +818,16 @@
     name = "System.Runtime";
     version = "4.3.0";
     sha256 = "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.6.0";
+    sha256 = "0xmzi2gpbmgyfr75p24rqqsba3cmrqgmcv45lsqp5amgrdwd0f0m";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "5.0.0-preview.7.20364.11";
+    sha256 = "19sl184f6rjhfsizq0vapysazd6yd66lf638rszvrdhqlsxssz2m";
   })
   (fetchNuGet {
     name = "System.Runtime.Extensions";
@@ -1080,19 +870,9 @@
     sha256 = "0q18r1sh4vn7bvqgd6dmqlw5v28flbpj349mkdish2vjyvmnb2ii";
   })
   (fetchNuGet {
-    name = "System.Runtime.Loader";
-    version = "4.0.0";
-    sha256 = "0lpfi3psqcp6zxsjk2qyahal7zaawviimc8lhrlswhip2mx7ykl0";
-  })
-  (fetchNuGet {
     name = "System.Runtime.Numerics";
     version = "4.0.1";
     sha256 = "1y308zfvy0l5nrn46mqqr4wb4z1xk758pkk8svbz8b5ij7jnv4nn";
-  })
-  (fetchNuGet {
-    name = "System.Runtime.Serialization.Json";
-    version = "4.0.2";
-    sha256 = "08ypbzs0sb302ga04ds5b2wxa2gg0q50zpa0nvc87ipjhs0v66dn";
   })
   (fetchNuGet {
     name = "System.Runtime.Serialization.Primitives";
@@ -1211,11 +991,6 @@
   })
   (fetchNuGet {
     name = "System.Threading.Overlapped";
-    version = "4.0.1";
-    sha256 = "0fi79az3vmqdp9mv3wh2phblfjls89zlj6p9nc3i9f6wmfarj188";
-  })
-  (fetchNuGet {
-    name = "System.Threading.Overlapped";
     version = "4.3.0";
     sha256 = "1nahikhqh9nk756dh8p011j36rlcp1bzz3vwi2b4m1l2s3vz8idm";
   })
@@ -1241,18 +1016,8 @@
   })
   (fetchNuGet {
     name = "System.Threading.Thread";
-    version = "4.0.0";
-    sha256 = "1gxxm5fl36pjjpnx1k688dcw8m9l7nmf802nxis6swdaw8k54jzc";
-  })
-  (fetchNuGet {
-    name = "System.Threading.Thread";
     version = "4.3.0";
     sha256 = "0y2xiwdfcph7znm2ysxanrhbqqss6a3shi1z3c779pj2s523mjx4";
-  })
-  (fetchNuGet {
-    name = "System.Threading.ThreadPool";
-    version = "4.0.10";
-    sha256 = "0fdr61yjcxh5imvyf93n2m3n5g9pp54bnw2l1d2rdl9z6dd31ypx";
   })
   (fetchNuGet {
     name = "System.Threading.ThreadPool";
@@ -1281,33 +1046,13 @@
   })
   (fetchNuGet {
     name = "System.Xml.XmlDocument";
-    version = "4.0.1";
-    sha256 = "0ihsnkvyc76r4dcky7v3ansnbyqjzkbyyia0ir5zvqirzan0bnl1";
-  })
-  (fetchNuGet {
-    name = "System.Xml.XmlDocument";
     version = "4.3.0";
     sha256 = "0bmz1l06dihx52jxjr22dyv5mxv6pj4852lx68grjm7bivhrbfwi";
-  })
-  (fetchNuGet {
-    name = "System.Xml.XmlSerializer";
-    version = "4.0.11";
-    sha256 = "01nzc3gdslw90qfykq4qzr2mdnqxjl4sj0wp3fixiwdmlmvpib5z";
-  })
-  (fetchNuGet {
-    name = "System.Xml.XPath";
-    version = "4.0.1";
-    sha256 = "0fjqgb6y66d72d5n8qq1h213d9nv2vi8mpv8p28j3m9rccmsh04m";
   })
   (fetchNuGet {
     name = "System.Xml.XPath";
     version = "4.3.0";
     sha256 = "1cv2m0p70774a0sd1zxc8fm8jk3i5zk2bla3riqvi8gsm0r4kpci";
-  })
-  (fetchNuGet {
-    name = "System.Xml.XPath.XmlDocument";
-    version = "4.0.1";
-    sha256 = "0l7yljgif41iv5g56l3nxy97hzzgck2a7rhnfnljhx9b0ry41bvc";
   })
   (fetchNuGet {
     name = "System.Xml.XPath.XmlDocument";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Security patch for .NET released earlier this week

Supersedes #92659

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
