### PR TITLE
[20.09] Fixes for python3.pkgs.{jedi,python-language-server,engineio}

### DIFF
--- a/pkgs/development/python-modules/jedi/default.nix
+++ b/pkgs/development/python-modules/jedi/default.nix
@@ -1,23 +1,22 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest, glibcLocales, tox, pytestcov, parso }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, fetchPypi, pytest, glibcLocales, tox, pytestcov, parso }:
 
 buildPythonPackage rec {
   pname = "jedi";
-  version = "0.17.2";
+  # switch back to stable version on the next release.
+  # current stable is incompatible with parso
+  version = "2020-08-06";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20";
+  src = fetchFromGitHub {
+    owner = "davidhalter";
+    repo = "jedi";
+    rev = "216f976fd5cab7a460e5d287e853d11759251e52";
+    sha256 = "1kb2ajzigadl95pnwglg8fxz9cvpg9hx30hqqj91jkgrc7djdldj";
+    fetchSubmodules = true;
   };
 
   checkInputs = [ pytest glibcLocales tox pytestcov ];
 
   propagatedBuildInputs = [ parso ];
-
-  # remove next bump, >=0.17.2, already fixed in master
-  prePatch = ''
-    substituteInPlace requirements.txt \
-      --replace "parso>=0.7.0,<0.8.0" "parso"
-  '';
 
   checkPhase = ''
     LC_ALL="en_US.UTF-8" py.test test

--- a/pkgs/development/python-modules/python-engineio/default.nix
+++ b/pkgs/development/python-modules/python-engineio/default.nix
@@ -9,17 +9,18 @@
 , tornado
 , websocket_client
 , websockets
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "python-engineio";
-  version = "3.13.0";
+  version = "3.13.2";
 
   src = fetchFromGitHub {
     owner = "miguelgrinberg";
     repo = "python-engineio";
     rev = "v${version}";
-    sha256 = "1fgfrgcvjg3fyza5lhl1l9cfq073xrwwhh3xs178csrjz4s8s378";
+    sha256 = "1hn5nnxp7y2dpf52vrwdxza2sqmzj8admcnwgjkmcxk65s2dhvy1";
   };
 
   propagatedBuildInputs = [
@@ -34,14 +35,18 @@ buildPythonPackage rec {
     tornado
     websocket_client
     websockets
+    pytestCheckHook
   ];
 
-  # make /etc/protocols accessible to fix socket.getprotobyname('tcp') in sandbox
   preCheck = stdenv.lib.optionalString stdenv.isLinux ''
-    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols \
+    echo "nameserver 127.0.0.1" > resolv.conf
+    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/resolv.conf=$(realpath resolv.conf) \
       LD_PRELOAD=${libredirect}/lib/libredirect.so
   '';
   postCheck = "unset NIX_REDIRECTS LD_PRELOAD";
+
+  # somehow effective log level does not change?
+  disabledTests = [ "test_logger" ];
 
   meta = with stdenv.lib; {
     description = "Engine.IO server";

--- a/pkgs/development/python-modules/python-language-server/default.nix
+++ b/pkgs/development/python-modules/python-language-server/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder, isPy27
+{ stdenv, buildPythonPackage, fetchFromGitHub, fetchpatch, pythonOlder, isPy27
 , backports_functools_lru_cache, configparser, futures, future, jedi, pluggy, python-jsonrpc-server, flake8
 , pytestCheckHook, mock, pytestcov, coverage, setuptools, ujson
 , # Allow building a limited set of providers, e.g. ["pycodestyle"].
@@ -29,6 +29,14 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "sha256-/tVzaoyUO6+7DSvnf3JxpcTY0rU+hHBu5qlru/ZTpxU=";
   };
+
+  patches = [
+    # https://github.com/palantir/python-language-server/pull/851
+    (fetchpatch {
+      url = "https://github.com/palantir/python-language-server/commit/f513f3297132492dd41e001d943980e6c4f40809.patch";
+      sha256 = "04c9hrb3dzlfchjk4625ipazyfcbq6qq2kj2hg3zf2xsny2jcvi5";
+    })
+  ];
 
   postPatch = ''
     # https://github.com/palantir/python-jsonrpc-server/issues/36

--- a/pkgs/development/python-modules/python-language-server/default.nix
+++ b/pkgs/development/python-modules/python-language-server/default.nix
@@ -21,13 +21,13 @@ in
 
 buildPythonPackage rec {
   pname = "python-language-server";
-  version = "0.33.1";
+  version = "0.34.1";
 
   src = fetchFromGitHub {
     owner = "palantir";
     repo = "python-language-server";
     rev = version;
-    sha256 = "064ck4ikrrrhq8wjpbs5k6hzkrjvfg91pd6351471xpsij0kj16f";
+    sha256 = "sha256-/tVzaoyUO6+7DSvnf3JxpcTY0rU+hHBu5qlru/ZTpxU=";
   };
 
   postPatch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
backport of #97209

ZHF: #97479

cc @NixOS/nixos-release-managers 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
