### PR TITLE
choose: init at 1.3.1

### DIFF
--- a/pkgs/tools/text/choose/default.nix
+++ b/pkgs/tools/text/choose/default.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "choose";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "theryangeary";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0j3861pxqw0lnamb201c7h5w7npzyiwwb6c1xzxjv72m2ccvz76j";
+  };
+
+  cargoSha256 = "1p18926pfff1yayb2i28v0nz37j52hqqv7244yfrzgidi29kyvbc";
+
+  meta = with stdenv.lib; {
+    description = "A human-friendly and fast alternative to cut and (sometimes) awk";
+    homepage = "https://github.com/theryangeary/choose";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ sohalt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3401,6 +3401,8 @@ in
 
   cholmod-extra = callPackage ../development/libraries/science/math/cholmod-extra { };
 
+  choose = callPackage ../tools/text/choose { };
+
   emscripten = callPackage ../development/compilers/emscripten { };
 
   emscriptenPackages = recurseIntoAttrs (callPackage ./emscripten-packages.nix { });


### PR DESCRIPTION
###### Motivation for this change
I want to use this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
