### PR TITLE
zeek: Fix zeek script coreutils and hardlinking

### DIFF
--- a/pkgs/applications/networking/ids/zeek/default.nix
+++ b/pkgs/applications/networking/ids/zeek/default.nix
@@ -14,9 +14,10 @@
 , swig
 , gettext
 , fetchpatch
+, coreutils
 }:
 let
-  preConfigure = (import ./script.nix);
+  preConfigure = (import ./script.nix {inherit coreutils;});
 in
 stdenv.mkDerivation rec {
   pname = "zeek";

--- a/pkgs/applications/networking/ids/zeek/script.nix
+++ b/pkgs/applications/networking/ids/zeek/script.nix
@@ -1,4 +1,10 @@
+{coreutils}:
 ''
+   sed -i 's|/bin/mv|${coreutils}/bin/mv|' scripts/base/frameworks/logging/writers/ascii.zeek
+   sed -i 's|/bin/mv|${coreutils}/bin/mv|' scripts/policy/misc/trim-trace-file.zeek
+   sed -i 's|/bin/cat|${coreutils}/bin/cat|' scripts/base/frameworks/notice/actions/pp-alarms.zeek
+   sed -i 's|/bin/cat|${coreutils}/bin/cat|' scripts/base/frameworks/notice/main.zeek
+
    sed -i "1i##! test dpd" $PWD/scripts/base/frameworks/dpd/__load__.zeek
    sed -i "1i##! test x509" $PWD/scripts/base/files/x509/__load__.zeek
    sed -i "1i##! test files-extract" $PWD/scripts/base/files/extract/__load__.zeek
@@ -32,6 +38,7 @@
    sed -i "1i##! test dns" $PWD/scripts/base/protocols/dns/__load__.zeek
    sed -i "1i##! test ftp" $PWD/scripts/base/protocols/ftp/__load__.zeek
    sed -i "1i##! test http" $PWD/scripts/base/protocols/http/__load__.zeek
+   sed -i "1i##! test tunnels" $PWD/scripts/base/protocols/tunnels/__load__.zeek
    sed -i "1i##! test imap" $PWD/scripts/base/protocols/imap/__load__.zeek
    sed -i "1i##! test irc" $PWD/scripts/base/protocols/irc/__load__.zeek
    sed -i "1i##! test krb" $PWD/scripts/base/protocols/krb/__load__.zeek


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
- replacing /bin/* to `coreutils ` path
- fix tunnel script duplicated hardlink

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
