### PR TITLE
perfect-hash: init at 0.4.1

### DIFF
--- a/pkgs/development/tools/misc/perfect-hash/default.nix
+++ b/pkgs/development/tools/misc/perfect-hash/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, python3, fetchFromGitHub }:
+python3.pkgs.buildPythonApplication rec {
+  pname = "perfect-hash";
+  version = "0.4.1";
+
+  # Archive on pypi does not contain examples, which are very helpful to
+  # understand how to use this program, so we use git source.
+  src = fetchFromGitHub {
+    owner = "ilanschnell";
+    repo = "perfect-hash";
+    rev = version;
+    sha256 = "0gkc3n613hl0q4jknrh2nm1n96j97p36q9jjgarb9d8yii9q7792";
+  };
+
+  postInstall = ''
+    mkdir -p $out/share/doc/perfect-hash
+    cp README.md $out/share/doc/perfect-hash
+    cp -r examples $out/share/doc/perfect-hash
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Minimal perfect hash function generator";
+    longDescription = ''
+      Generate a minimal perfect hash function for a given set of keys.
+      A given code template is filled with parameters, such that the
+      output is code which implements the hash function. Templates can
+      easily be constructed for any programming language.
+    '';
+    license = licenses.bsd3;
+    maintainers = [ maintainers.kaction ];
+
+    homepage = "https://github.com/ilanschnell/perfect-hash";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11403,6 +11403,8 @@ in
 
   pax-rs = callPackage ../development/tools/pax-rs { };
 
+  perfect-hash = callPackage ../development/tools/misc/perfect-hash { };
+
   peg = callPackage ../development/tools/parsing/peg { };
 
   pgcli = pkgs.python3Packages.pgcli;


### PR DESCRIPTION
Description:

    Generate a minimal perfect hash function for a given set of keys. A
    given code template is filled with parameters, such that the output
    is code which implements the hash function. Templates can easily be
    constructed for any programming language.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
     /nix/store/inldg49pn8a6d2y44sx12hmyvjf6hh7z-perfect-hash-0.4.1 139826760
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).