### PR TITLE
ocamlPackages.ptset: init at 1.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/ptset/default.nix
+++ b/pkgs/development/ocaml-modules/ptset/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchurl, buildDunePackage
+, stdlib-shims
+}:
+
+buildDunePackage rec {
+  pname = "ptset";
+  version = "1.0.1";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/backtracking/ptset/releases/download/${version}/ptset-${version}.tbz";
+    sha256 = "1pr80mgk12l93mdq1wfsv2b6ccraxs334d5h92qzjh7bw2g13424";
+  };
+
+  doCheck = true;
+
+  propagatedBuildInputs = [ stdlib-shims ];
+
+  meta = {
+    description = "Integer set implementation using Patricia trees";
+    homepage = "https://github.com/backtracking/ptset";
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -882,6 +882,8 @@ let
 
     ptmap = callPackage ../development/ocaml-modules/ptmap { };
 
+    ptset = callPackage ../development/ocaml-modules/ptset { };
+
     pycaml = callPackage ../development/ocaml-modules/pycaml { };
 
     qcheck = callPackage ../development/ocaml-modules/qcheck { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
