### PR TITLE
lib.licenses: add Prosperity-3.0.0 license

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -644,6 +644,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     url = "https://enterprise.dejacode.com/licenses/public/purdue-bsd";
   };
 
+  prosperity30 = {
+    fullName = "Prosperity-3.0.0";
+    free = false;
+    url = "https://prosperitylicense.com/versions/3.0.0.html";
+  };
+
   qhull = spdx {
     spdxId = "Qhull";
     fullName = "Qhull License";


### PR DESCRIPTION
###### Motivation for this change

Adds Prosperity-3.0.0 which is going through motions of addition to SPDX over at https://github.com/spdx/license-list-XML/pull/960. My preference is to add it now and revisit this later to refactor to the SPDX syntax when the license has been added.

See https://blog.licensezero.com/2019/12/15/prosperity-3.html for more information.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
