### PR TITLE
Remove periods from the end of package descriptions

### DIFF
--- a/pkgs/applications/audio/csound/csound-qt/default.nix
+++ b/pkgs/applications/audio/csound/csound-qt/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
                  ];
 
   meta = with stdenv.lib; {
-    description = "CsoundQt is a frontend for Csound with editor, integrated help, widgets and other features.";
+    description = "CsoundQt is a frontend for Csound with editor, integrated help, widgets and other features";
     homepage = "https://csoundqt.github.io/";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/applications/audio/gspeech/default.nix
+++ b/pkgs/applications/audio/gspeech/default.nix
@@ -63,7 +63,7 @@ python3.pkgs.buildPythonApplication rec {
   strictDeps = false;
 
   meta = with lib; {
-    description = "A minimal GUI for the Text To Speech 'Svox Pico'. Read clipboard or selected text in different languages and manage it : pause, stop, replay.";
+    description = "A minimal GUI for the Text To Speech 'Svox Pico'. Read clipboard or selected text in different languages and manage it : pause, stop, replay";
     homepage = "https://github.com/mothsART/gSpeech";
     maintainers = with maintainers; [ mothsart ];
     license = licenses.gpl3;

--- a/pkgs/applications/audio/mellowplayer/default.nix
+++ b/pkgs/applications/audio/mellowplayer/default.nix
@@ -62,7 +62,7 @@ mkDerivation rec {
   meta = with lib; {
     inherit (qtbase.meta) platforms;
 
-    description = "Cloud music integration for your desktop.";
+    description = "Cloud music integration for your desktop";
     homepage = "https://gitlab.com/ColinDuquesnoy/MellowPlayer";
     license = licenses.gpl2;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/applications/audio/mopidy/tunein.nix
+++ b/pkgs/applications/audio/mopidy/tunein.nix
@@ -20,7 +20,7 @@ python3Packages.buildPythonApplication rec {
   pythonImportsCheck = [ "mopidy_tunein.tunein" ];
 
   meta = with stdenv.lib; {
-    description = "Mopidy extension for playing music from tunein.";
+    description = "Mopidy extension for playing music from tunein";
     homepage = "https://github.com/kingosticks/mopidy-tunein";
     license = licenses.asl20;
     maintainers = with maintainers; [ hexa ];

--- a/pkgs/applications/audio/orca-c/default.nix
+++ b/pkgs/applications/audio/orca-c/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    description = "An esoteric programming language designed to quickly create procedural sequencers.";
+    description = "An esoteric programming language designed to quickly create procedural sequencers";
     homepage = "https://github.com/hundredrabbits/Orca-c";
     license = licenses.mit;
     platforms = platforms.all;

--- a/pkgs/applications/audio/picoloop/default.nix
+++ b/pkgs/applications/audio/picoloop/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     SDL2_image
     SDL2_ttf
     alsaLib
-    libjack2 
+    libjack2
   ];
 
   sourceRoot = "source/picoloop";
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Picoloop is a synth and a stepsequencer (a clone of the famous nanoloop).";
+    description = "Picoloop is a synth and a stepsequencer (a clone of the famous nanoloop)";
     homepage = "https://github.com/yoyz/picoloop";
     platforms = platforms.linux;
     license = licenses.bsd3;

--- a/pkgs/applications/audio/plexamp/default.nix
+++ b/pkgs/applications/audio/plexamp/default.nix
@@ -30,7 +30,7 @@ in appimageTools.wrapType2 {
   '';
 
   meta = with lib; {
-    description = "A beautiful Plex music player for audiophiles, curators, and hipsters.";
+    description = "A beautiful Plex music player for audiophiles, curators, and hipsters";
     homepage = "https://plexamp.com/";
     license = licenses.unfree;
     maintainers = with maintainers; [ killercup ];

--- a/pkgs/applications/audio/pulseaudio-ctl/default.nix
+++ b/pkgs/applications/audio/pulseaudio-ctl/default.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Control pulseaudio volume from the shell or mapped to keyboard shortcuts. No need for alsa-utils.";
+    description = "Control pulseaudio volume from the shell or mapped to keyboard shortcuts. No need for alsa-utils";
     homepage = "https://bbs.archlinux.org/viewtopic.php?id=124513";
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/applications/editors/code-browser/default.nix
+++ b/pkgs/applications/editors/code-browser/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   ++ stdenv.lib.optionals withQt [ "UI=qt" ]
   ++ stdenv.lib.optionals withGtk [ "UI=gtk" ];
   meta = with stdenv.lib; {
-    description = "Folding text editor, designed to hierarchically structure any kind of text file and especially source code.";
+    description = "Folding text editor, designed to hierarchically structure any kind of text file and especially source code";
     homepage = "https://tibleiz.net/code-browser/";
     license = licenses.gpl2;
     platforms = platforms.x86_64;

--- a/pkgs/applications/graphics/gnuclad/default.nix
+++ b/pkgs/applications/graphics/gnuclad/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://launchpad.net/gnuclad";
-    description = "gnuclad tries to help the environment by creating trees.  It's primary use will be generating cladogram trees for the GNU/Linux distro timeline project.";
+    description = "gnuclad tries to help the environment by creating trees.  It's primary use will be generating cladogram trees for the GNU/Linux distro timeline project";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ mog ];
     platforms = platforms.linux;

--- a/pkgs/applications/graphics/lightburn/default.nix
+++ b/pkgs/applications/graphics/lightburn/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "LightBurn is layout, editing, and control software for your laser cutter.";
+    description = "LightBurn is layout, editing, and control software for your laser cutter";
     homepage = "https://lightburnsoftware.com/";
     license = stdenv.lib.licenses.unfree;
     maintainers = with stdenv.lib.maintainers; [ q3k ];

--- a/pkgs/applications/graphics/meshlab/default.nix
+++ b/pkgs/applications/graphics/meshlab/default.nix
@@ -87,7 +87,7 @@ mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    description = "A system for processing and editing 3D triangular meshes.";
+    description = "A system for processing and editing 3D triangular meshes";
     homepage = "https://www.meshlab.net/";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ viric ];

--- a/pkgs/applications/graphics/write_stylus/default.nix
+++ b/pkgs/applications/graphics/write_stylus/default.nix
@@ -53,7 +53,7 @@ mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "http://www.styluslabs.com/";
-    description = "Write is a word processor for handwriting.";
+    description = "Write is a word processor for handwriting";
     platforms = platforms.linux;
     license = stdenv.lib.licenses.unfree;
     maintainers = with maintainers; [ oyren ];

--- a/pkgs/applications/misc/doing/default.nix
+++ b/pkgs/applications/misc/doing/default.nix
@@ -11,7 +11,7 @@ bundlerEnv {
   passthru.updateScript = bundlerUpdateScript "doing";
 
   meta = with lib; {
-    description = "A command line tool for keeping track of what you’re doing and tracking what you’ve done.";
+    description = "A command line tool for keeping track of what you’re doing and tracking what you’ve done";
     longDescription = ''
       doing is a basic CLI for adding and listing "what was I doing" reminders
       in a TaskPaper-formatted text file. It allows for multiple

--- a/pkgs/applications/misc/fslint/default.nix
+++ b/pkgs/applications/misc/fslint/default.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A utility to find and clean various forms of lint on a filesystem.";
+    description = "A utility to find and clean various forms of lint on a filesystem";
     homepage = "https://www.pixelbeat.org/fslint/";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.dasj19 ];

--- a/pkgs/applications/misc/gmtp/default.nix
+++ b/pkgs/applications/misc/gmtp/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "A simple MP3 and Media player client for UNIX and UNIX like systems.";
+    description = "A simple MP3 and Media player client for UNIX and UNIX like systems";
     homepage = "https://gmtp.sourceforge.io";
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ ];

--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
   subPackages = [ "." ];
 
   meta = with stdenv.lib; {
-    description = "A fast and modern static website engine.";
+    description = "A fast and modern static website engine";
     homepage = "https://gohugo.io";
     license = licenses.asl20;
     maintainers = with maintainers; [ schneefux filalex77 Frostman ];

--- a/pkgs/applications/misc/icesl/default.nix
+++ b/pkgs/applications/misc/icesl/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "IceSL is a GPU-accelerated procedural modeler and slicer for 3D printing.";
+    description = "IceSL is a GPU-accelerated procedural modeler and slicer for 3D printing";
     homepage = "http://shapeforge.loria.fr/icesl/index.html";
     license = licenses.inria-icesl;
     platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/applications/misc/marktext/default.nix
+++ b/pkgs/applications/misc/marktext/default.nix
@@ -32,7 +32,7 @@ appimageTools.wrapType2 rec {
   extraInstallCommands = "mv $out/bin/${name} $out/bin/${pname}";
 
   meta = with lib; {
-    description = "A simple and elegant markdown editor, available for Linux, macOS and Windows.";
+    description = "A simple and elegant markdown editor, available for Linux, macOS and Windows";
     homepage = "https://marktext.app";
     license = licenses.mit;
     maintainers = with maintainers; [ nh2 ];

--- a/pkgs/applications/misc/ola/default.nix
+++ b/pkgs/applications/misc/ola/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    description = "A framework for controlling entertainment lighting equipment.";
+    description = "A framework for controlling entertainment lighting equipment";
     homepage = "https://www.openlighting.org/ola/";
     maintainers = with maintainers; [ globin ];
     license = with licenses; [ lgpl21 gpl2Plus ];

--- a/pkgs/applications/misc/osm2xmap/default.nix
+++ b/pkgs/applications/misc/osm2xmap/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/sembruk/osm2xmap";
-    description = "Converter from OpenStreetMap data format to OpenOrienteering Mapper format.";
+    description = "Converter from OpenStreetMap data format to OpenOrienteering Mapper format";
     license = licenses.gpl3;
     maintainers = [ maintainers.mpickering ];
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/applications/misc/plasma-applet-volumewin7mixer/default.nix
+++ b/pkgs/applications/misc/plasma-applet-volumewin7mixer/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ plasma-framework kwindowsystem plasma-pa ];
 
   meta = with stdenv.lib; {
-    description = "A fork of the default volume plasmoid with a Windows 7 theme (vertical sliders).";
+    description = "A fork of the default volume plasmoid with a Windows 7 theme (vertical sliders)";
     homepage = "https://github.com/Zren/plasma-applet-volumewin7mixer";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/misc/qlcplus/default.nix
+++ b/pkgs/applications/misc/qlcplus/default.nix
@@ -36,7 +36,7 @@ mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A free and cross-platform software to control DMX or analog lighting systems like moving heads, dimmers, scanners etc.";
+    description = "A free and cross-platform software to control DMX or analog lighting systems like moving heads, dimmers, scanners etc";
     maintainers = [ maintainers.globin ];
     license = licenses.asl20;
     platforms = platforms.all;

--- a/pkgs/applications/misc/xsuspender/default.nix
+++ b/pkgs/applications/misc/xsuspender/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Auto-suspend inactive X11 applications.";
+    description = "Auto-suspend inactive X11 applications";
     homepage = "https://kernc.github.io/xsuspender/";
     license = licenses.wtfpl;
     maintainers = with maintainers; [ offline ];

--- a/pkgs/applications/misc/yarssr/default.nix
+++ b/pkgs/applications/misc/yarssr/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/tsyrogit/zxcvbn-c";
-    description = "A fork of Yarssr (a RSS reader for the GNOME Tray) from http://yarssr.sf.net with various fixes.";
+    description = "A fork of Yarssr (a RSS reader for the GNOME Tray) from http://yarssr.sf.net with various fixes";
     license = licenses.gpl1;
     platforms = platforms.linux;
     maintainers = with maintainers; [ xurei ];

--- a/pkgs/applications/networking/c14/default.nix
+++ b/pkgs/applications/networking/c14/default.nix
@@ -14,7 +14,7 @@ buildGoPackage rec {
   };
 
   meta = with stdenv.lib; {
-    description = "C14 is designed for data archiving & long-term backups.";
+    description = "C14 is designed for data archiving & long-term backups";
     homepage = "https://www.online.net/en/storage/c14-cold-storage";
     license = licenses.mit;
     maintainers = with maintainers; [ apeyroux ];

--- a/pkgs/applications/networking/cluster/docker-machine/default.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/default.nix
@@ -25,7 +25,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     homepage = "https://docs.docker.com/machine/";
-    description = "Docker Machine is a tool that lets you install Docker Engine on virtual hosts, and manage Docker Engine on the hosts.";
+    description = "Docker Machine is a tool that lets you install Docker Engine on virtual hosts, and manage Docker Engine on the hosts";
     license = licenses.asl20;
     maintainers = with maintainers; [ offline tailhook ];
     platforms = platforms.unix;

--- a/pkgs/applications/networking/cluster/docker-machine/hyperkit.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/hyperkit.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   meta = with lib; {
     homepage = "https://minikube.sigs.k8s.io/docs/drivers/hyperkit";
-    description = "HyperKit driver for docker-machine.";
+    description = "HyperKit driver for docker-machine";
     license = licenses.asl20;
     maintainers = with maintainers; [ atkinschang ];
     platforms = platforms.darwin;

--- a/pkgs/applications/networking/cluster/docker-machine/kvm.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/kvm.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/dhiltgen/docker-machine-kvm";
-    description = "KVM driver for docker-machine.";
+    description = "KVM driver for docker-machine";
     license = licenses.asl20;
     maintainers = with maintainers; [ offline ];
     platforms = platforms.unix;

--- a/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   meta = with lib; {
     homepage = "https://minikube.sigs.k8s.io/docs/drivers/kvm2";
-    description = "KVM2 driver for docker-machine.";
+    description = "KVM2 driver for docker-machine";
     license = licenses.asl20;
     maintainers = with maintainers; [ tadfisher atkinschang ];
     platforms = platforms.linux;

--- a/pkgs/applications/networking/cluster/docker-machine/xhyve.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/xhyve.nix
@@ -31,7 +31,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/machine-drivers/docker-machine-driver-xhyve";
-    description = "Xhyve driver for docker-machine.";
+    description = "Xhyve driver for docker-machine";
     license = licenses.bsd3;
     maintainers = with maintainers; [ periklis ];
     platforms = platforms.darwin;

--- a/pkgs/applications/networking/cluster/jx/default.nix
+++ b/pkgs/applications/networking/cluster/jx/default.nix
@@ -35,7 +35,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "JX is a command line tool for installing and using Jenkins X.";
+    description = "JX is a command line tool for installing and using Jenkins X";
     homepage = "https://jenkins-x.io";
     longDescription = ''
       Jenkins X provides automated CI+CD for Kubernetes with Preview

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -150,7 +150,7 @@ let
     '';
 
     meta = {
-      description = "The various binaries that get packaged into the final k3s binary.";
+      description = "The various binaries that get packaged into the final k3s binary";
       license = licenses.asl20;
       homepage = "https://k3s.io";
       maintainers = [ maintainers.euank ];
@@ -211,7 +211,7 @@ let
     '';
 
     meta = {
-      description = "The k3s go binary which is used by the final wrapped output below.";
+      description = "The k3s go binary which is used by the final wrapped output below";
       license = licenses.asl20;
       homepage = "https://k3s.io";
       maintainers = [ maintainers.euank ];
@@ -257,7 +257,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "A lightweight Kubernetes distribution.";
+    description = "A lightweight Kubernetes distribution";
     license = licenses.asl20;
     homepage = "https://k3s.io";
     maintainers = [ maintainers.euank ];

--- a/pkgs/applications/networking/cluster/k9s/default.nix
+++ b/pkgs/applications/networking/cluster/k9s/default.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    description = "Kubernetes CLI To Manage Your Clusters In Style.";
+    description = "Kubernetes CLI To Manage Your Clusters In Style";
     homepage = "https://github.com/derailed/k9s";
     license = licenses.asl20;
     maintainers = with maintainers; [ Gonzih markus1189 ];

--- a/pkgs/applications/networking/cluster/linkerd/default.nix
+++ b/pkgs/applications/networking/cluster/linkerd/default.nix
@@ -18,7 +18,7 @@ buildGoModule {
   subPackages = [ "cli/cmd" ];
 
   meta = with stdenv.lib; {
-    description = "A service mesh for Kubernetes and beyond.";
+    description = "A service mesh for Kubernetes and beyond";
     homepage = "https://linkerd.io/";
     license = licenses.asl20;
     maintainers = with maintainers; [ Gonzih ];

--- a/pkgs/applications/networking/cluster/terragrunt/default.nix
+++ b/pkgs/applications/networking/cluster/terragrunt/default.nix
@@ -27,7 +27,7 @@ buildGoModule rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A thin wrapper for Terraform that supports locking for Terraform state and enforces best practices.";
+    description = "A thin wrapper for Terraform that supports locking for Terraform state and enforces best practices";
     homepage = "https://github.com/gruntwork-io/terragrunt/";
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/applications/networking/feedreaders/rss2email/default.nix
+++ b/pkgs/applications/networking/feedreaders/rss2email/default.nix
@@ -37,7 +37,7 @@ buildPythonApplication rec {
   '';
 
   meta = with lib; {
-    description = "A tool that converts RSS/Atom newsfeeds to email.";
+    description = "A tool that converts RSS/Atom newsfeeds to email";
     homepage = "https://pypi.python.org/pypi/rss2email";
     license = licenses.gpl2;
     maintainers = with maintainers; [ jb55 Profpatsch ekleog ];

--- a/pkgs/applications/networking/instant-messengers/mirage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mirage/default.nix
@@ -47,7 +47,7 @@ mkDerivation rec {
     '';
 
   meta = with lib; {
-    description = "A fancy, customizable, keyboard-operable Qt/QML+Python Matrix chat client for encrypted and decentralized communication.";
+    description = "A fancy, customizable, keyboard-operable Qt/QML+Python Matrix chat client for encrypted and decentralized communication";
     homepage = "https://github.com/mirukana/mirage";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ colemickens ];

--- a/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
@@ -56,7 +56,7 @@ buildPythonApplication rec {
   '';
 
   meta = with lib; {
-    description = "An end-to-end encryption aware Matrix reverse proxy daemon.";
+    description = "An end-to-end encryption aware Matrix reverse proxy daemon";
     homepage = "https://github.com/matrix-org/pantalaimon";
     license = licenses.asl20;
     maintainers = with maintainers; [ valodim ];

--- a/pkgs/applications/networking/instant-messengers/spectral/default.nix
+++ b/pkgs/applications/networking/instant-messengers/spectral/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin qtmacextras;
 
   meta = with stdenv.lib; {
-    description = "A glossy cross-platform Matrix client.";
+    description = "A glossy cross-platform Matrix client";
     homepage = "https://spectral.im";
     license = licenses.gpl3;
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/applications/networking/mailreaders/evolution/evolution-ews/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution-ews/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    description = "Evolution connector for Microsoft Exchange Server protocols.";
+    description = "Evolution connector for Microsoft Exchange Server protocols";
     homepage = "https://gitlab.gnome.org/GNOME/evolution-ews";
     license = "LGPL-2.1-only OR LGPL-3.0-only"; # https://gitlab.gnome.org/GNOME/evolution-ews/issues/111
     maintainers = [ maintainers.dasj19 ];

--- a/pkgs/applications/networking/omping/default.nix
+++ b/pkgs/applications/networking/omping/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    description = "Open Multicast Ping (omping) is a tool for testing IPv4/IPv6 multicast connectivity on a LAN.";
+    description = "Open Multicast Ping (omping) is a tool for testing IPv4/IPv6 multicast connectivity on a LAN";
     license = licenses.mit;
     platforms = platforms.unix;
     inherit (src.meta) homepage;

--- a/pkgs/applications/networking/p2p/magnetico/default.nix
+++ b/pkgs/applications/networking/p2p/magnetico/default.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description  = "Autonomous (self-hosted) BitTorrent DHT search engine suite.";
+    description  = "Autonomous (self-hosted) BitTorrent DHT search engine suite";
     homepage     = "https://github.com/boramalper/magnetico";
     license      = licenses.agpl3;
     badPlatforms = platforms.darwin;

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     homepage = "https://erdgeist.org/arts/software/opentracker/";
     license = licenses.beerware;
     platforms = platforms.linux;
-    description = "Bittorrent tracker project which aims for minimal resource usage and is intended to run at your wlan router.";
+    description = "Bittorrent tracker project which aims for minimal resource usage and is intended to run at your wlan router";
     maintainers = with maintainers; [ makefu ];
   };
 }

--- a/pkgs/applications/networking/protonvpn-gui/default.nix
+++ b/pkgs/applications/networking/protonvpn-gui/default.nix
@@ -77,7 +77,7 @@ in python3Packages.buildPythonApplication rec {
   '';
 
   meta = with lib; {
-    description = "Linux GUI for ProtonVPN, written in Python.";
+    description = "Linux GUI for ProtonVPN, written in Python";
     homepage = "https://github.com/ProtonVPN/linux-gui";
     maintainers = with maintainers; [ offline ];
     license = licenses.gpl3;

--- a/pkgs/applications/networking/super-productivity/default.nix
+++ b/pkgs/applications/networking/super-productivity/default.nix
@@ -97,7 +97,7 @@ in stdenv.mkDerivation {
   dontStrip = true;
 
   meta = with stdenv.lib; {
-    description = "To Do List / Time Tracker with Jira Integration.";
+    description = "To Do List / Time Tracker with Jira Integration";
     homepage = "https://super-productivity.com";
     license = licenses.mit;
     platforms = [ "x86_64-linux" ];

--- a/pkgs/applications/networking/tsung/default.nix
+++ b/pkgs/applications/networking/tsung/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "http://tsung.erlang-projects.org/";
-    description = "A high-performance benchmark framework for various protocols including HTTP, XMPP, LDAP, etc.";
+    description = "A high-performance benchmark framework for various protocols including HTTP, XMPP, LDAP, etc";
     longDescription = ''
       Tsung is a distributed load testing tool. It is protocol-independent and
       can currently be used to stress HTTP, WebDAV, SOAP, PostgreSQL, MySQL,

--- a/pkgs/applications/office/grisbi/default.nix
+++ b/pkgs/applications/office/grisbi/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    description = "A personnal accounting application.";
+    description = "A personnal accounting application";
     longDescription = ''
       Grisbi is an application written by French developers, so it perfectly
       respects French accounting rules. Grisbi can manage multiple accounts,

--- a/pkgs/applications/office/gtg/default.nix
+++ b/pkgs/applications/office/gtg/default.nix
@@ -61,7 +61,7 @@ python3Packages.buildPythonApplication rec {
   checkPhase = "python3 ../run-tests";
 
   meta = with stdenv.lib; {
-    description = " A personal tasks and TODO-list items organizer.";
+    description = " A personal tasks and TODO-list items organizer";
     longDescription = ''
       "Getting Things GNOME" (GTG) is a personal tasks and ToDo list organizer inspired by the "Getting Things Done" (GTD) methodology.
       GTG is intended to help you track everything you need to do and need to know, from small tasks to large projects.

--- a/pkgs/applications/office/portfolio/default.nix
+++ b/pkgs/applications/office/portfolio/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A simple tool to calculate the overall performance of an investment portfolio.";
+    description = "A simple tool to calculate the overall performance of an investment portfolio";
     homepage = "https://www.portfolio-performance.info/";
     license = licenses.epl10;
     maintainers = with maintainers; [ elohmeier oyren ];

--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -1,7 +1,7 @@
 { stdenv, nixosTests, fetchurl, autoPatchelfHook, atomEnv, makeWrapper, makeDesktopItem, gtk3, wrapGAppsHook, zlib, libxkbfile }:
 
 let
-  description = "Trilium Notes is a hierarchical note taking application with focus on building large personal knowledge bases.";
+  description = "Trilium Notes is a hierarchical note taking application with focus on building large personal knowledge bases";
   desktopItem = makeDesktopItem {
     name = "Trilium";
     exec = "trilium";

--- a/pkgs/applications/radio/noaa-apt/default.nix
+++ b/pkgs/applications/radio/noaa-apt/default.nix
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with lib; {
-    description = "NOAA APT image decoder.";
+    description = "NOAA APT image decoder";
     homepage = "http://noaa-apt.mbernardi.com.ar/";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ trepetti ];

--- a/pkgs/applications/science/biology/bedtools/default.nix
+++ b/pkgs/applications/science/biology/bedtools/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   installPhase = "make prefix=$out SHELL=${stdenv.shell} CXX=${cxx} CC=${cc} install";
 
   meta = with stdenv.lib; {
-    description = "A powerful toolset for genome arithmetic.";
+    description = "A powerful toolset for genome arithmetic";
     license = licenses.gpl2;
     homepage = "https://bedtools.readthedocs.io/en/latest/";
     maintainers = with maintainers; [ jbedo ];

--- a/pkgs/applications/science/biology/mosdepth/default.nix
+++ b/pkgs/applications/science/biology/mosdepth/default.nix
@@ -37,7 +37,7 @@ in stdenv.mkDerivation rec {
   installPhase = "install -Dt $out/bin mosdepth";
 
   meta = with stdenv.lib; {
-    description = "fast BAM/CRAM depth calculation for WGS, exome, or targeted sequencing.";
+    description = "fast BAM/CRAM depth calculation for WGS, exome, or targeted sequencing";
     license = licenses.mit;
     homepage = "https://github.com/brentp/mosdepth";
     maintainers = with maintainers; [ jbedo ];

--- a/pkgs/applications/science/biology/snpeff/default.nix
+++ b/pkgs/applications/science/biology/snpeff/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Genetic variant annotation and effect prediction toolbox.";
+    description = "Genetic variant annotation and effect prediction toolbox";
     license = licenses.lgpl3;
     homepage = "http://snpeff.sourceforge.net/";
     maintainers = with maintainers; [ jbedo ];

--- a/pkgs/applications/science/electronics/flatcam/default.nix
+++ b/pkgs/applications/science/electronics/flatcam/default.nix
@@ -48,7 +48,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   meta = with lib; {
-    description = "2-D post processing for PCB fabrication on CNC routers.";
+    description = "2-D post processing for PCB fabrication on CNC routers";
     homepage = "https://bitbucket.org/jpcgt/flatcam";
     license = licenses.mit;
     maintainers = with maintainers; [ trepetti ];

--- a/pkgs/applications/science/math/bliss/default.nix
+++ b/pkgs/applications/science/math/bliss/default.nix
@@ -22,14 +22,14 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin $out/share/doc/bliss $out/lib $out/include/bliss
-    mv bliss $out/bin 
+    mv bliss $out/bin
     mv html/* COPYING* $out/share/doc/bliss
     mv *.a $out/lib
     mv *.h *.hh $out/include/bliss
   '';
 
   meta = with stdenv.lib; {
-    description = "bliss is an open source tool for computing automorphism groups and canonical forms of graphs. It has both a command line user interface as well as C++ and C programming language APIs.";
+    description = "bliss is an open source tool for computing automorphism groups and canonical forms of graphs. It has both a command line user interface as well as C++ and C programming language APIs";
     homepage = "http://www.tcs.hut.fi/Software/bliss/";
     license = licenses.lgpl3;
     platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/applications/science/physics/elmerfem/default.nix
+++ b/pkgs/applications/science/physics/elmerfem/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://elmerfem.org/";
-    description = "A finite element software for multiphysical problems.";
+    description = "A finite element software for multiphysical problems";
     platforms = platforms.unix;
     maintainers = [ maintainers.wulfsta ];
     license = licenses.lgpl21;

--- a/pkgs/applications/science/programming/scyther/default.nix
+++ b/pkgs/applications/science/programming/scyther/default.nix
@@ -13,7 +13,7 @@ let
   };
 
   meta = with lib; {
-    description = "Scyther is a tool for the automatic verification of security protocols.";
+    description = "Scyther is a tool for the automatic verification of security protocols";
     homepage = "https://www.cs.ox.ac.uk/people/cas.cremers/scyther/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ infinisil ];

--- a/pkgs/applications/version-management/git-up/default.nix
+++ b/pkgs/applications/version-management/git-up/default.nix
@@ -28,7 +28,7 @@ pythonPackages.buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/msiemens/PyGitUp";
-    description = "A git pull replacement that rebases all local branches when pulling.";
+    description = "A git pull replacement that rebases all local branches when pulling";
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.all;

--- a/pkgs/applications/version-management/sparkleshare/default.nix
+++ b/pkgs/applications/version-management/sparkleshare/default.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Share and collaborate by syncing with any Git repository instantly. Linux, macOS, and Windows.";
+    description = "Share and collaborate by syncing with any Git repository instantly. Linux, macOS, and Windows";
     homepage = "https://sparkleshare.org";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ kevincox ];

--- a/pkgs/applications/video/mkclean/default.nix
+++ b/pkgs/applications/video/mkclean/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "mkclean is a command line tool to clean and optimize Matroska (.mkv / .mka / .mks / .mk3d) and WebM (.webm / .weba) files that have already been muxed.";
+    description = "mkclean is a command line tool to clean and optimize Matroska (.mkv / .mka / .mks / .mk3d) and WebM (.webm / .weba) files that have already been muxed";
     homepage = "https://www.matroska.org";
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ chrisaw ];

--- a/pkgs/applications/video/plex-mpv-shim/default.nix
+++ b/pkgs/applications/video/plex-mpv-shim/default.nix
@@ -15,7 +15,7 @@ buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/iwalton3/plex-mpv-shim";
-    description = "Allows casting of videos to MPV via the Plex mobile and web app.";
+    description = "Allows casting of videos to MPV via the Plex mobile and web app";
     license = licenses.mit;
   };
 }

--- a/pkgs/applications/video/webtorrent_desktop/default.nix
+++ b/pkgs/applications/video/webtorrent_desktop/default.nix
@@ -85,7 +85,7 @@
     '';
 
     meta = with stdenv.lib; {
-      description = "Streaming torrent app for Mac, Windows, and Linux.";
+      description = "Streaming torrent app for Mac, Windows, and Linux";
       homepage = "https://webtorrent.io/desktop";
       license = licenses.mit;
       maintainers = [ maintainers.flokli ];

--- a/pkgs/applications/window-managers/i3/layout-manager.nix
+++ b/pkgs/applications/window-managers/i3/layout-manager.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/klaxalk/i3-layout-manager";
-    description = "Saving, loading and managing layouts for i3wm.";
+    description = "Saving, loading and managing layouts for i3wm";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ ];

--- a/pkgs/applications/window-managers/i3/lock-fancy.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     cp icons/lock*.png $out/share/i3lock-fancy/icons
   '';
   meta = with stdenv.lib; {
-    description = "i3lock is a bash script that takes a screenshot of the desktop, blurs the background and adds a lock icon and text.";
+    description = "i3lock is a bash script that takes a screenshot of the desktop, blurs the background and adds a lock icon and text";
     homepage = "https://github.com/meskarune/i3lock-fancy";
     maintainers = with maintainers; [ ];
     license = licenses.mit;

--- a/pkgs/data/fonts/cozette/default.nix
+++ b/pkgs/data/fonts/cozette/default.nix
@@ -19,7 +19,7 @@ fetchzip rec {
   '';
 
   meta = with lib; {
-    description = "A bitmap programming font optimized for coziness.";
+    description = "A bitmap programming font optimized for coziness";
     homepage = "https://github.com/slavfox/cozette";
     license = licenses.mit;
     platforms = platforms.all;

--- a/pkgs/data/fonts/eunomia/default.nix
+++ b/pkgs/data/fonts/eunomia/default.nix
@@ -19,7 +19,7 @@ fetchzip {
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/eunomia/";
-    description = "A futuristic decorative font.";
+    description = "A futuristic decorative font";
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars ];
     license = licenses.ofl;

--- a/pkgs/data/fonts/f5_6/default.nix
+++ b/pkgs/data/fonts/f5_6/default.nix
@@ -19,7 +19,7 @@ fetchzip {
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";
-    description = "A weighted decorative font.";
+    description = "A weighted decorative font";
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars ];
     license = licenses.ofl;

--- a/pkgs/data/fonts/ferrum/default.nix
+++ b/pkgs/data/fonts/ferrum/default.nix
@@ -19,7 +19,7 @@ fetchzip {
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";
-    description = "A decorative font.";
+    description = "A decorative font";
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars ];
     license = licenses.cc0;

--- a/pkgs/data/fonts/fixedsys-excelsior/default.nix
+++ b/pkgs/data/fonts/fixedsys-excelsior/default.nix
@@ -21,7 +21,7 @@ in fetchurl rec {
   sha256 = "32d6f07f1ff08c764357f8478892b2ba5ade23427af99759f34a0ba24bcd2e37";
 
   meta = {
-    description = "Pan-unicode version of Fixedsys, a classic DOS font.";
+    description = "Pan-unicode version of Fixedsys, a classic DOS font";
     homepage = "http://www.fixedsysexcelsior.com/";
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.publicDomain;

--- a/pkgs/data/fonts/lmmath/default.nix
+++ b/pkgs/data/fonts/lmmath/default.nix
@@ -15,7 +15,7 @@ in fetchzip rec {
   sha256 = "05k145bxgxjh7i9gx1ahigxfpc2v2vwzsy2mc41jvvg51kjr8fnn";
 
   meta = with lib; {
-    description = "The Latin Modern Math (LM Math) font completes the modernization of the Computer Modern family of typefaces designed and programmed by Donald E. Knuth.";
+    description = "The Latin Modern Math (LM Math) font completes the modernization of the Computer Modern family of typefaces designed and programmed by Donald E. Knuth";
     homepage = "http://www.gust.org.pl/projects/e-foundry/lm-math";
     # "The Latin Modern Math font is licensed under the GUST Font License (GFL),
     # which is a free license, legally equivalent to the LaTeX Project Public

--- a/pkgs/data/fonts/vegur/default.nix
+++ b/pkgs/data/fonts/vegur/default.nix
@@ -18,7 +18,7 @@ in fetchzip {
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/vegur/";
-    description = "A humanist sans serif font.";
+    description = "A humanist sans serif font";
     platforms = platforms.all;
     maintainers = [ maintainers.samueldr ];
     license = licenses.cc0;

--- a/pkgs/data/misc/conway_polynomials/default.nix
+++ b/pkgs/data/misc/conway_polynomials/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Contains a small database of Conway polynomials.";
+    description = "Contains a small database of Conway polynomials";
     license = licenses.gpl2;
     platforms = platforms.all;
     maintainers = with maintainers; [ timokau ];

--- a/pkgs/desktops/lxde/core/lxrandr/default.nix
+++ b/pkgs/desktops/lxde/core/lxrandr/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libX11 (if withGtk3 then gtk3 else gtk2) xrandr ];
 
   meta = with stdenv.lib; {
-    description = "LXRandR is the standard screen manager of LXDE.";
+    description = "LXRandR is the standard screen manager of LXDE";
     homepage = "https://lxde.org/";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with maintainers; [ rawkode ];

--- a/pkgs/development/compilers/acme/default.nix
+++ b/pkgs/development/compilers/acme/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A multi-platform cross assembler for 6502/6510/65816 CPUs.";
+    description = "A multi-platform cross assembler for 6502/6510/65816 CPUs";
     homepage = "https://sourceforge.net/projects/acme-crossass/";
     license = licenses.gpl2Plus;
     platforms = platforms.all;

--- a/pkgs/development/compilers/bs-platform/default.nix
+++ b/pkgs/development/compilers/bs-platform/default.nix
@@ -18,7 +18,7 @@ in
   };
 }).overrideAttrs (attrs: {
   meta = with stdenv.lib; {
-    description = "A JavaScript backend for OCaml focused on smooth integration and clean generated code.";
+    description = "A JavaScript backend for OCaml focused on smooth integration and clean generated code";
     homepage = "https://bucklescript.github.io";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ turbomack gamb anmonteiro ];

--- a/pkgs/development/compilers/copper/default.nix
+++ b/pkgs/development/compilers/copper/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     make BACKEND=elf64 install prefix=$out
   '';
   meta = with stdenv.lib; {
-    description = "Simple imperative language, statically typed with type inference and genericity.";
+    description = "Simple imperative language, statically typed with type inference and genericity";
     homepage = "https://tibleiz.net/copper/";
     license = licenses.bsd2;
     platforms = platforms.x86_64;

--- a/pkgs/development/compilers/inform7/default.nix
+++ b/pkgs/development/compilers/inform7/default.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    description = "A design system for interactive fiction.";
+    description = "A design system for interactive fiction";
     homepage = "http://inform7.com/";
     license = licenses.artistic2;
     maintainers = with maintainers; [ mbbx6spp ];

--- a/pkgs/development/compilers/mozart/default.nix
+++ b/pkgs/development/compilers/mozart/default.nix
@@ -79,7 +79,7 @@ in stdenv.mkDerivation rec {
   ];
 
   meta = {
-    description = "An open source implementation of Oz 3.";
+    description = "An open source implementation of Oz 3";
     maintainers = [ lib.maintainers.layus ];
     license = lib.licenses.bsd2;
     homepage = "https://mozart.github.io";

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -106,7 +106,7 @@ in makePackage {
   meta = with stdenv.lib; {
     homepage = "http://openjdk.java.net/projects/openjfx/";
     license = licenses.gpl2;
-    description = "The next-generation Java client toolkit.";
+    description = "The next-generation Java client toolkit";
     maintainers = with maintainers; [ abbradar ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };

--- a/pkgs/development/compilers/openjdk/openjfx/14.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/14.nix
@@ -108,7 +108,7 @@ in makePackage {
   meta = with stdenv.lib; {
     homepage = "http://openjdk.java.net/projects/openjfx/";
     license = licenses.gpl2;
-    description = "The next-generation Java client toolkit.";
+    description = "The next-generation Java client toolkit";
     maintainers = with maintainers; [ abbradar ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };

--- a/pkgs/development/compilers/ponyc/pony-stable.nix
+++ b/pkgs/development/compilers/ponyc/pony-stable.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   installFlags = [ "prefix=${placeholder "out"}" "install" ];
 
   meta = {
-    description = "A simple dependency manager for the Pony language.";
+    description = "A simple dependency manager for the Pony language";
     homepage = "https://www.ponylang.org";
     license = stdenv.lib.licenses.bsd2;
     maintainers = with stdenv.lib.maintainers; [ dipinhora kamilchm patternspandemic ];

--- a/pkgs/development/compilers/scala/dotty-bare.nix
+++ b/pkgs/development/compilers/scala/dotty-bare.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Research platform for new language concepts and compiler technologies for Scala.";
+    description = "Research platform for new language concepts and compiler technologies for Scala";
     longDescription = ''
        Dotty is a platform to try out new language concepts and compiler technologies for Scala.
        The focus is mainly on simplification. We remove extraneous syntax (e.g. no XML literals),

--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -52,7 +52,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;
-    description = "A collection of tools, libraries and tests for shader compilation.";
+    description = "A collection of tools, libraries and tests for shader compilation";
     license = [ licenses.asl20 ];
   };
 }

--- a/pkgs/development/compilers/x11basic/default.nix
+++ b/pkgs/development/compilers/x11basic/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "http://x11-basic.sourceforge.net/";
-    description = "A Basic interpreter and compiler with graphics capabilities.";
+    description = "A Basic interpreter and compiler with graphics capabilities";
     license = licenses.gpl2;
     maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.unix;

--- a/pkgs/development/interpreters/alda/default.nix
+++ b/pkgs/development/interpreters/alda/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A music programming language for musicians.";
+    description = "A music programming language for musicians";
     homepage = "https://alda.io";
     license = licenses.epl10;
     maintainers = [ maintainers.ericdallo ];

--- a/pkgs/development/interpreters/racket/minimal.nix
+++ b/pkgs/development/interpreters/racket/minimal.nix
@@ -9,7 +9,7 @@ racket.overrideAttrs (oldAttrs: rec {
   };
 
   meta = oldAttrs.meta // {
-    description = "Racket without bundled packages, such as Dr. Racket.";
+    description = "Racket without bundled packages, such as Dr. Racket";
     longDescription = ''The essential package racket-libs is included,
       as well as libraries that live in collections. In particular, raco
       and the pkg library are still bundled.

--- a/pkgs/development/libraries/flatbuffers/default.nix
+++ b/pkgs/development/libraries/flatbuffers/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   checkTarget = "test";
 
   meta = {
-    description = "Memory Efficient Serialization Library.";
+    description = "Memory Efficient Serialization Library";
     longDescription = ''
       FlatBuffers is an efficient cross platform serialization library for
       games and other memory constrained apps. It allows you to directly

--- a/pkgs/development/libraries/intel-media-sdk/default.nix
+++ b/pkgs/development/libraries/intel-media-sdk/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with stdenv.lib; {
-    description = "Intel Media SDK.";
+    description = "Intel Media SDK";
     license = licenses.mit;
     maintainers = with maintainers; [ midchildan ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/development/libraries/jcal/default.nix
+++ b/pkgs/development/libraries/jcal/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   preAutoreconf = "cd sources/";
 
   meta = with stdenv.lib; {
-    description = "Jalali calendar is a small and portable free software library to manipulate date and time in Jalali calendar system.";
+    description = "Jalali calendar is a small and portable free software library to manipulate date and time in Jalali calendar system";
     homepage =  "http://nongnu.org/jcal/";
     license = licenses.gpl3;
     maintainers = [ maintainers.linarcx ];

--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     inherit version;
     homepage = "https://github.com/open-source-parsers/jsoncpp";
-    description = "A C++ library for interacting with JSON.";
+    description = "A C++ library for interacting with JSON";
     maintainers = with maintainers; [ ttuegel cpages nand0p ];
     license = licenses.mit;
     platforms = platforms.all;

--- a/pkgs/development/libraries/libdynd/default.nix
+++ b/pkgs/development/libraries/libdynd/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   outputDoc = "dev";
 
   meta = with stdenv.lib; {
-    description = "C++ dynamic ndarray library, with Python exposure.";
+    description = "C++ dynamic ndarray library, with Python exposure";
     homepage = "http://libdynd.org";
     license = licenses.bsd2;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libipfix/default.nix
+++ b/pkgs/development/libraries/libipfix/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   };
   meta = with stdenv.lib; {
     homepage = "http://libipfix.sourceforge.net/";
-    description = "The libipfix C-library implements the IPFIX protocol defined by the IP Flow Information Export working group of the IETF.";
+    description = "The libipfix C-library implements the IPFIX protocol defined by the IP Flow Information Export working group of the IETF";
     license = licenses.lgpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ lewo ];

--- a/pkgs/development/libraries/libmysqlconnectorcpp/default.nix
+++ b/pkgs/development/libraries/libmysqlconnectorcpp/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://dev.mysql.com/downloads/connector/cpp/";
-    description = "C++ library for connecting to mysql servers.";
+    description = "C++ library for connecting to mysql servers";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/libnetfilter_acct/default.nix
+++ b/pkgs/development/libraries/libnetfilter_acct/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "http://www.netfilter.org/projects/libnetfilter_acct/";
-    description = "Userspace library providing interface to extended accounting infrastructure.";
+    description = "Userspace library providing interface to extended accounting infrastructure";
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/libroxml/default.nix
+++ b/pkgs/development/libraries/libroxml/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   };
   meta = with stdenv.lib; {
     homepage = "http://www.libroxml.net/";
-    description = "This library is minimum, easy-to-use, C implementation for xml file parsing.";
+    description = "This library is minimum, easy-to-use, C implementation for xml file parsing";
     license = licenses.lgpl3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ mpickering ];

--- a/pkgs/development/libraries/libui/default.nix
+++ b/pkgs/development/libraries/libui/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage    = "https://github.com/andlabs/libui";
-    description = "Simple and portable (but not inflexible) GUI library in C that uses the native GUI technologies of each platform it supports.";
+    description = "Simple and portable (but not inflexible) GUI library in C that uses the native GUI technologies of each platform it supports";
     license     = licenses.mit;
     platforms   = platforms.unix;
   };

--- a/pkgs/development/libraries/muparserx/default.nix
+++ b/pkgs/development/libraries/muparserx/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A C++ Library for Parsing Expressions with Strings, Complex Numbers, Vectors, Matrices and more.";
+    description = "A C++ Library for Parsing Expressions with Strings, Complex Numbers, Vectors, Matrices and more";
     homepage = "https://beltoforion.de/en/muparserx/";
     license = licenses.bsd2;
     maintainers = with maintainers; [ drewrisinger ];

--- a/pkgs/development/libraries/mypaint-brushes/1.0.nix
+++ b/pkgs/development/libraries/mypaint-brushes/1.0.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "http://mypaint.org/";
-    description = "Brushes used by MyPaint and other software using libmypaint.";
+    description = "Brushes used by MyPaint and other software using libmypaint";
     license = licenses.cc0;
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/mypaint-brushes/default.nix
+++ b/pkgs/development/libraries/mypaint-brushes/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "http://mypaint.org/";
-    description = "Brushes used by MyPaint and other software using libmypaint.";
+    description = "Brushes used by MyPaint and other software using libmypaint";
     license = licenses.cc0;
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/pangoxsl/default.nix
+++ b/pkgs/development/libraries/pangoxsl/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   ];
 
   meta = with stdenv.lib; {
-    description = "Implements several of the inline properties defined by XSL that are not currently implemented by Pango.";
+    description = "Implements several of the inline properties defined by XSL that are not currently implemented by Pango";
     homepage = "https://sourceforge.net/projects/pangopdf";
     platforms = platforms.unix;
     license = licenses.lgpl2;

--- a/pkgs/development/libraries/pdal/default.nix
+++ b/pkgs/development/libraries/pdal/default.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    description = "PDAL is Point Data Abstraction Library. GDAL for point cloud data.";
+    description = "PDAL is Point Data Abstraction Library. GDAL for point cloud data";
     homepage = "https://pdal.io";
     license = licenses.bsd3;
     maintainers = with maintainers; [ nh2 ];

--- a/pkgs/development/libraries/properties-cpp/default.nix
+++ b/pkgs/development/libraries/properties-cpp/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://launchpad.net/properties-cpp";
-    description = "A very simple convenience library for handling properties and signals in C++11.";
+    description = "A very simple convenience library for handling properties and signals in C++11";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ edwtjo ];
   };

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "PythonQt is a dynamic Python binding for the Qt framework. It offers an easy way to embed the Python scripting language into your C++ Qt applications.";
+    description = "PythonQt is a dynamic Python binding for the Qt framework. It offers an easy way to embed the Python scripting language into your C++ Qt applications";
     homepage = "http://pythonqt.sourceforge.net/";
     license = licenses.lgpl21;
     platforms = platforms.all;

--- a/pkgs/development/libraries/rlottie/default.nix
+++ b/pkgs/development/libraries/rlottie/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/Samsung/rlottie";
-    description = "A platform independent standalone c++ library for rendering vector based animations and art in realtime.";
+    description = "A platform independent standalone c++ library for rendering vector based animations and art in realtime";
     license = licenses.unfree; # Mixed, see https://github.com/Samsung/rlottie/blob/master/COPYING
     platforms = platforms.all;
     maintainers = with maintainers; [ CRTified ];

--- a/pkgs/development/libraries/science/math/itpp/default.nix
+++ b/pkgs/development/libraries/science/math/itpp/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "IT++ is a C++ library of mathematical, signal processing and communication classes and functions.";
+    description = "IT++ is a C++ library of mathematical, signal processing and communication classes and functions";
     homepage = http://itpp.sourceforge.net/;
     license = licenses.gpl3;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/serialdv/default.nix
+++ b/pkgs/development/libraries/serialdv/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
-    description = "C++ Minimal interface to encode and decode audio with AMBE3000 based devices in packet mode over a serial link.";
+    description = "C++ Minimal interface to encode and decode audio with AMBE3000 based devices in packet mode over a serial link";
     homepage = "https://github.com/f4exb/serialdv";
     platforms = platforms.linux;
     maintainers = with maintainers; [ alkeryn ];

--- a/pkgs/development/libraries/taglib/default.nix
+++ b/pkgs/development/libraries/taglib/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://taglib.org/";
     repositories.git = "git://github.com/taglib/taglib.git";
-    description = "A library for reading and editing audio file metadata.";
+    description = "A library for reading and editing audio file metadata";
     longDescription = ''
       TagLib is a library for reading and editing the meta-data of several
       popular audio formats. Currently it supports both ID3v1 and ID3v2 for MP3

--- a/pkgs/development/libraries/vsqlite/default.nix
+++ b/pkgs/development/libraries/vsqlite/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "http://vsqlite.virtuosic-bytes.com/";
-    description = "C++ wrapper library for sqlite.";
+    description = "C++ wrapper library for sqlite";
     license = licenses.bsd3;
     platforms = platforms.unix;
   };

--- a/pkgs/development/mobile/cocoapods/default.nix
+++ b/pkgs/development/mobile/cocoapods/default.nix
@@ -13,7 +13,7 @@ bundlerApp {
   passthru.updateScript = toString ./update;
 
   meta = with lib; {
-    description     = "CocoaPods manages dependencies for your Xcode projects.";
+    description     = "CocoaPods manages dependencies for your Xcode projects";
     homepage        = "https://github.com/CocoaPods/CocoaPods";
     license         = licenses.mit;
     platforms       = platforms.darwin;

--- a/pkgs/development/python-modules/jc/default.nix
+++ b/pkgs/development/python-modules/jc/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ ruamel_yaml xmltodict pygments ];
 
   meta = with stdenv.lib; {
-    description = "This tool serializes the output of popular command line tools and filetypes to structured JSON output.";
+    description = "This tool serializes the output of popular command line tools and filetypes to structured JSON output";
     homepage = "https://github.com/kellyjonbrazil/jc";
     license = licenses.mit;
     maintainers = with maintainers; [ atemu ];

--- a/pkgs/development/python-modules/pywal/default.nix
+++ b/pkgs/development/python-modules/pywal/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Generate and change colorschemes on the fly. A 'wal' rewrite in Python 3.";
+    description = "Generate and change colorschemes on the fly. A 'wal' rewrite in Python 3";
     homepage = "https://github.com/dylanaraps/pywal";
     license = licenses.mit;
     maintainers = with maintainers; [ Fresheyeball ];

--- a/pkgs/development/python-modules/yq/default.nix
+++ b/pkgs/development/python-modules/yq/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "yq" ];
 
   meta = with lib; {
-    description = "Command-line YAML processor - jq wrapper for YAML documents.";
+    description = "Command-line YAML processor - jq wrapper for YAML documents";
     homepage = "https://github.com/kislyuk/yq";
     license = [ licenses.asl20 ];
     maintainers = [ maintainers.womfoo ];

--- a/pkgs/development/tools/analysis/garcosim/tracefilesim/default.nix
+++ b/pkgs/development/tools/analysis/garcosim/tracefilesim/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    description = "Ease the analysis of existing memory management techniques, as well as the prototyping of new memory management techniques.";
+    description = "Ease the analysis of existing memory management techniques, as well as the prototyping of new memory management techniques";
     homepage = "https://github.com/GarCoSim";
     maintainers = [ maintainers.cmcdragonkai ];
     license = licenses.gpl2;

--- a/pkgs/development/tools/analysis/pev/default.nix
+++ b/pkgs/development/tools/analysis/pev/default.nix
@@ -5,8 +5,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "merces";
     repo = "pev";
-    rev = "aa4ef7f"; 
-    sha256 = "00a3g486343lhqcsf4vrdy5xif6v3cgcf2y8yp5b96x15c0wid36"; 
+    rev = "aa4ef7f";
+    sha256 = "00a3g486343lhqcsf4vrdy5xif6v3cgcf2y8yp5b96x15c0wid36";
     fetchSubmodules = true;
   };
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   installFlags = [ "prefix=$(out)" ];
 
   meta = with stdenv.lib; {
-    description = "pev is a full-featured, open source, multiplatform command line toolkit to work with PE (Portable Executables) binaries.";
+    description = "pev is a full-featured, open source, multiplatform command line toolkit to work with PE (Portable Executables) binaries";
     homepage = "http://pev.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -73,7 +73,7 @@ buildBazelPackage rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/bazelbuild/bazel-watcher";
-    description = "Tools for building Bazel targets when source files change.";
+    description = "Tools for building Bazel targets when source files change";
     license = licenses.asl20;
     maintainers = with maintainers; [ kalbasit ];
     platforms = platforms.all;

--- a/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
@@ -82,7 +82,7 @@ buildBazelPackage rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/buchgr/bazel-remote";
-    description = "A remote HTTP/1.1 cache for Bazel.";
+    description = "A remote HTTP/1.1 cache for Bazel";
     license = licenses.asl20;
     maintainers = [ maintainers.uri-canva ];
     platforms = platforms.darwin ++ platforms.linux;

--- a/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   buildFlagsArray = [ "-ldflags=-s -w -X main.buildVersion=${version} -X main.buildScmRevision=${src.rev}" ];
 
   meta = with stdenv.lib; {
-    description = "Tools for working with Google's bazel buildtool. Includes buildifier, buildozer, and unused_deps.";
+    description = "Tools for working with Google's bazel buildtool. Includes buildifier, buildozer, and unused_deps";
     homepage = "https://github.com/bazelbuild/buildtools";
     license = licenses.asl20;
     maintainers = with maintainers; [ elasticdog uri-canva marsam ];

--- a/pkgs/development/tools/build-managers/bloop/default.nix
+++ b/pkgs/development/tools/build-managers/bloop/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://scalacenter.github.io/bloop/";
     license = licenses.asl20;
-    description = "Bloop is a Scala build server and command-line tool to make the compile and test developer workflows fast and productive in a build-tool-agnostic way.";
+    description = "Bloop is a Scala build server and command-line tool to make the compile and test developer workflows fast and productive in a build-tool-agnostic way";
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ tomahna ];
   };

--- a/pkgs/development/tools/check/default.nix
+++ b/pkgs/development/tools/check/default.nix
@@ -21,7 +21,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   meta = with lib; {
-    description = "A set of utilities for checking Go sources.";
+    description = "A set of utilities for checking Go sources";
     homepage = "https://gitlab.com/opennota/check";
     license = licenses.gpl3;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A linter for Clojure code that sparks joy.";
+    description = "A linter for Clojure code that sparks joy";
     homepage = "https://github.com/borkdude/clj-kondo";
     license = licenses.epl10;
     platforms = graalvm8.meta.platforms;

--- a/pkgs/development/tools/continuous-integration/drone-cli/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-cli/default.nix
@@ -24,6 +24,6 @@ in buildGoModule rec {
   meta = with stdenv.lib; {
     maintainers = with maintainers; [ bricewge ];
     license = licenses.asl20;
-    description = "Command line client for the Drone continuous integration server.";
+    description = "Command line client for the Drone continuous integration server";
   };
 }

--- a/pkgs/development/tools/corundum/default.nix
+++ b/pkgs/development/tools/corundum/default.nix
@@ -8,7 +8,7 @@ bundlerApp {
   passthru.updateScript = bundlerUpdateScript "corundum";
 
   meta = with lib; {
-    description = "Tool and libraries for maintaining Ruby gems.";
+    description = "Tool and libraries for maintaining Ruby gems";
     homepage    = "https://github.com/nyarly/corundum";
     license     = licenses.mit;
     maintainers = with maintainers; [ nyarly nicknovitski ];

--- a/pkgs/development/tools/deadcode/default.nix
+++ b/pkgs/development/tools/deadcode/default.nix
@@ -22,7 +22,7 @@ buildGoPackage rec {
   };
 
   meta = with lib; {
-    description = "deadcode is a very simple utility which detects unused declarations in a Go package.";
+    description = "deadcode is a very simple utility which detects unused declarations in a Go package";
     homepage = "https://github.com/remyoudompheng/go-misc/tree/master/deadcode";
     license = licenses.bsd3;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/tools/deis/default.nix
+++ b/pkgs/development/tools/deis/default.nix
@@ -27,7 +27,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     homepage = "https://deis.io";
-    description = "A command line utility used to interact with the Deis open source PaaS.";
+    description = "A command line utility used to interact with the Deis open source PaaS";
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [

--- a/pkgs/development/tools/deisctl/default.nix
+++ b/pkgs/development/tools/deisctl/default.nix
@@ -21,7 +21,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     homepage = "https://deis.io";
-    description = "A command-line utility used to provision and operate a Deis cluster.";
+    description = "A command-line utility used to provision and operate a Deis cluster";
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [

--- a/pkgs/development/tools/drm_info/default.nix
+++ b/pkgs/development/tools/drm_info/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libdrm json_c pciutils ];
 
   meta = with stdenv.lib; {
-    description = "Small utility to dump info about DRM devices.";
+    description = "Small utility to dump info about DRM devices";
     homepage = "https://github.com/ascent12/drm_info";
     license = licenses.mit;
     maintainers = with maintainers; [ tadeokondrak ];

--- a/pkgs/development/tools/ejson/default.nix
+++ b/pkgs/development/tools/ejson/default.nix
@@ -35,7 +35,7 @@ in buildGoPackage rec {
   '';
 
   meta = with lib; {
-    description = "A small library to manage encrypted secrets using asymmetric encryption.";
+    description = "A small library to manage encrypted secrets using asymmetric encryption";
     license = licenses.mit;
     homepage = "https://github.com/Shopify/ejson";
     platforms = platforms.unix;

--- a/pkgs/development/tools/errcheck/default.nix
+++ b/pkgs/development/tools/errcheck/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   meta = with lib; {
-    description = "errcheck is a program for checking for unchecked errors in go programs.";
+    description = "errcheck is a program for checking for unchecked errors in go programs";
     homepage = "https://github.com/kisielk/errcheck";
     license = licenses.mit;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/tools/gdm/default.nix
+++ b/pkgs/development/tools/gdm/default.nix
@@ -16,7 +16,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   meta = with stdenv.lib; {
-    description = "Minimalist dependency manager for Go written in Go.";
+    description = "Minimalist dependency manager for Go written in Go";
     homepage = "https://github.com/sparrc/gdm";
     license = licenses.unlicense;
     maintainers = [ maintainers.mic92 ];

--- a/pkgs/development/tools/git-ftp/default.nix
+++ b/pkgs/development/tools/git-ftp/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [pandoc man];
 
   meta = with stdenv.lib; {
-    description = "Git powered FTP client written as shell script.";
+    description = "Git powered FTP client written as shell script";
     homepage = "https://git-ftp.github.io/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ tweber ];

--- a/pkgs/development/tools/go-migrate/default.nix
+++ b/pkgs/development/tools/go-migrate/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   meta = with stdenv.lib; {
     homepage    = "https://github.com/golang-migrate/migrate";
-    description = "Database migrations. CLI and Golang library.";
+    description = "Database migrations. CLI and Golang library";
     maintainers = with maintainers; [ offline ];
     license     = licenses.mit;
   };

--- a/pkgs/development/tools/go-outline/default.nix
+++ b/pkgs/development/tools/go-outline/default.nix
@@ -16,7 +16,7 @@ buildGoPackage rec {
   };
 
   meta = {
-    description = "Utility to extract JSON representation of declarations from a Go source file.";
+    description = "Utility to extract JSON representation of declarations from a Go source file";
     homepage = "https://github.com/ramya-rao-a/go-outline";
     maintainers = with stdenv.lib.maintainers; [ vdemeester ];
     license = stdenv.lib.licenses.mit;

--- a/pkgs/development/tools/go-symbols/default.nix
+++ b/pkgs/development/tools/go-symbols/default.nix
@@ -15,7 +15,7 @@ buildGoPackage rec {
   };
 
   meta = {
-    description = "A utility for extracting a JSON representation of the package symbols from a go source tree.";
+    description = "A utility for extracting a JSON representation of the package symbols from a go source tree";
     homepage = "https://github.com/acroca/go-symbols";
     maintainers = with stdenv.lib.maintainers; [ vdemeester ];
     license = stdenv.lib.licenses.mit;

--- a/pkgs/development/tools/goconvey/default.nix
+++ b/pkgs/development/tools/goconvey/default.nix
@@ -17,7 +17,7 @@ buildGoPackage rec {
   };
 
   meta = {
-    description = "Go testing in the browser. Integrates with `go test`. Write behavioral tests in Go.";
+    description = "Go testing in the browser. Integrates with `go test`. Write behavioral tests in Go";
     homepage = "https://github.com/smartystreets/goconvey";
     maintainers = with stdenv.lib.maintainers; [ vdemeester ];
     license = stdenv.lib.licenses.mit;

--- a/pkgs/development/tools/gocyclo/default.nix
+++ b/pkgs/development/tools/gocyclo/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
   };
 
   meta = with lib; {
-    description = "Calculate cyclomatic complexities of functions in Go source code.";
+    description = "Calculate cyclomatic complexities of functions in Go source code";
     homepage = "https://github.com/alecthomas/gocyclo";
     license = licenses.bsd3;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/tools/gomodifytags/default.nix
+++ b/pkgs/development/tools/gomodifytags/default.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   };
 
   meta = {
-    description = "Go tool to modify struct field tags.";
+    description = "Go tool to modify struct field tags";
     homepage = "https://github.com/fatih/gomodifytags";
     maintainers = with stdenv.lib.maintainers; [ vdemeester ];
     license = stdenv.lib.licenses.bsd3;

--- a/pkgs/development/tools/gopkgs/default.nix
+++ b/pkgs/development/tools/gopkgs/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   doCheck = false;
 
   meta = {
-    description = "Tool to get list available Go packages.";
+    description = "Tool to get list available Go packages";
     homepage = "https://github.com/uudashr/gopkgs";
     maintainers = with stdenv.lib.maintainers; [ vdemeester ];
     license = stdenv.lib.licenses.mit;

--- a/pkgs/development/tools/gore/default.nix
+++ b/pkgs/development/tools/gore/default.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    description = "Yet another Go REPL that works nicely.";
+    description = "Yet another Go REPL that works nicely";
     homepage = "https://github.com/motemen/gore";
     license = licenses.mit;
     maintainers = with maintainers; [ offline ];

--- a/pkgs/development/tools/gotests/default.nix
+++ b/pkgs/development/tools/gotests/default.nix
@@ -17,7 +17,7 @@ buildGoPackage rec {
   };
 
   meta = {
-    description = "Generate Go tests from your source code.";
+    description = "Generate Go tests from your source code";
     homepage = "https://github.com/cweill/gotests";
     maintainers = with stdenv.lib.maintainers; [ vdemeester ];
     license = stdenv.lib.licenses.asl20;

--- a/pkgs/development/tools/impl/default.nix
+++ b/pkgs/development/tools/impl/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   meta = with lib; {
-    description = "impl generates method stubs for implementing an interface.";
+    description = "impl generates method stubs for implementing an interface";
     homepage = "https://github.com/josharian/impl";
     license = licenses.mit;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/tools/ineffassign/default.nix
+++ b/pkgs/development/tools/ineffassign/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   };
 
   meta = with lib; {
-    description = "Detect ineffectual assignments in Go code.";
+    description = "Detect ineffectual assignments in Go code";
     homepage = "https://github.com/gordonklaus/ineffassign";
     license = licenses.mit;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/tools/interfacer/default.nix
+++ b/pkgs/development/tools/interfacer/default.nix
@@ -22,7 +22,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   meta = with lib; {
-    description = "A linter that suggests interface types.";
+    description = "A linter that suggests interface types";
     homepage = "https://github.com/mvdan/interfacer";
     license = licenses.bsd3;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/tools/irony-server/default.nix
+++ b/pkgs/development/tools/irony-server/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   ];
 
   meta = with stdenv.lib; {
-    description = "The server part of irony.";
+    description = "The server part of irony";
     homepage = "https://melpa.org/#/irony";
     maintainers = [ maintainers.deepfire ];
     platforms = platforms.unix;

--- a/pkgs/development/tools/jsduck/default.nix
+++ b/pkgs/development/tools/jsduck/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   passthru.updateScript = bundlerUpdateScript "jsduck";
 
   meta = with lib; {
-    description = "Simple JavaScript Duckumentation generator.";
+    description = "Simple JavaScript Duckumentation generator";
     homepage    = "https://github.com/senchalabs/jsduck";
     license     = with licenses; gpl3;
     maintainers = with maintainers; [ periklis nicknovitski ];

--- a/pkgs/development/tools/knightos/scas/default.nix
+++ b/pkgs/development/tools/knightos/scas/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage    = "https://knightos.org/";
-    description = "Assembler and linker for the Z80.";
+    description = "Assembler and linker for the Z80";
     license     = licenses.mit;
     maintainers = with maintainers; [ siraben ];
   };

--- a/pkgs/development/tools/kythe/default.nix
+++ b/pkgs/development/tools/kythe/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A pluggable, (mostly) language-agnostic ecosystem for building tools that work with code.";
+    description = "A pluggable, (mostly) language-agnostic ecosystem for building tools that work with code";
     longDescription = ''
     The Kythe project was founded to provide and support tools and standards
       that encourage interoperability among programs that manipulate source

--- a/pkgs/development/tools/librarian-puppet-go/default.nix
+++ b/pkgs/development/tools/librarian-puppet-go/default.nix
@@ -17,7 +17,7 @@ buildGoPackage rec {
 
   meta = with lib; {
     inherit (src.meta) homepage;
-    description = "librarian-puppet implementation in go.";
+    description = "librarian-puppet implementation in go";
     license = licenses.mit;
     maintainers = with maintainers; [ womfoo ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/development/tools/maligned/default.nix
+++ b/pkgs/development/tools/maligned/default.nix
@@ -21,7 +21,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   meta = with lib; {
-    description = "Tool to detect Go structs that would take less memory if their fields were sorted.";
+    description = "Tool to detect Go structs that would take less memory if their fields were sorted";
     homepage = "https://github.com/mdempsky/maligned";
     license = licenses.bsd3;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/tools/minizinc/default.nix
+++ b/pkgs/development/tools/minizinc/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = "https://www.minizinc.org/";
-    description = "MiniZinc is a medium-level constraint modelling language.";
+    description = "MiniZinc is a medium-level constraint modelling language";
 
     longDescription = ''
       MiniZinc is a medium-level constraint modelling

--- a/pkgs/development/tools/misc/bsdbuild/default.nix
+++ b/pkgs/development/tools/misc/bsdbuild/default.nix
@@ -49,7 +49,7 @@ EOF
 
   meta = {
     homepage = "http://bsdbuild.hypertriton.com";
-    description = "A cross-platform build system.";
+    description = "A cross-platform build system";
 
     longDescription = ''
       BSDBuild is a cross-platform build system. Derived from the

--- a/pkgs/development/tools/misc/fujprog/default.nix
+++ b/pkgs/development/tools/misc/fujprog/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    description = "JTAG programmer for the ULX3S and ULX2S open hardware FPGA development boards.";
+    description = "JTAG programmer for the ULX3S and ULX2S open hardware FPGA development boards";
     homepage = "https://github.com/kost/fujprog";
     license = licenses.bsd2;
     maintainers = with maintainers; [ trepetti ];

--- a/pkgs/development/tools/misc/tockloader/default.nix
+++ b/pkgs/development/tools/misc/tockloader/default.nix
@@ -20,7 +20,7 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     homepage = "https://github.com/tock/tockloader";
     license = licenses.mit;
-    description = "Tool for programming Tock onto hardware boards.";
+    description = "Tool for programming Tock onto hardware boards";
     maintainers = with maintainers; [ hexa ];
   };
 }

--- a/pkgs/development/tools/mockgen/default.nix
+++ b/pkgs/development/tools/mockgen/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
   subPackages = [ "mockgen" ];
 
   meta = with lib; {
-    description = "GoMock is a mocking framework for the Go programming language.";
+    description = "GoMock is a mocking framework for the Go programming language";
     homepage = "https://github.com/golang/mock";
     license = licenses.asl20;
     maintainers = with maintainers; [ bouk ];

--- a/pkgs/development/tools/operator-sdk/default.nix
+++ b/pkgs/development/tools/operator-sdk/default.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "SDK for building Kubernetes applications. Provides high level APIs, useful abstractions, and project scaffolding.";
+    description = "SDK for building Kubernetes applications. Provides high level APIs, useful abstractions, and project scaffolding";
     homepage = "https://github.com/operator-framework/operator-sdk";
     license = licenses.asl20;
     maintainers = with maintainers; [ arnarg ];

--- a/pkgs/development/tools/parinfer-rust/default.nix
+++ b/pkgs/development/tools/parinfer-rust/default.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Infer parentheses for Clojure, Lisp, and Scheme.";
+    description = "Infer parentheses for Clojure, Lisp, and Scheme";
     homepage = "https://github.com/eraserhd/parinfer-rust";
     license = licenses.isc;
     maintainers = with maintainers; [ eraserhd ];

--- a/pkgs/development/tools/pax-rs/default.nix
+++ b/pkgs/development/tools/pax-rs/default.nix
@@ -6,7 +6,7 @@ buildRustPackage rec {
   version = "0.4.0";
 
   meta = with stdenv.lib; {
-    description = "The fastest JavaScript bundler in the galaxy.";
+    description = "The fastest JavaScript bundler in the galaxy";
     longDescription = ''
       The fastest JavaScript bundler in the galaxy. Fully supports ECMAScript module syntax (import/export) in addition to CommonJS require(<string>).
     '';

--- a/pkgs/development/tools/richgo/default.nix
+++ b/pkgs/development/tools/richgo/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   subPackages = [ "." ];
 
   meta = with stdenv.lib; {
-    description = "Enrich `go test` outputs with text decorations.";
+    description = "Enrich `go test` outputs with text decorations";
     homepage = "https://github.com/kyoh86/richgo";
     license = licenses.mit;
     maintainers = with maintainers; [ rvolosatovs ];

--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Automatically generates Rust FFI bindings to C (and some C++) libraries.";
+    description = "Automatically generates Rust FFI bindings to C (and some C++) libraries";
     longDescription = ''
       Bindgen takes a c or c++ header file and turns them into
       rust ffi declarations.

--- a/pkgs/development/tools/rust/cargo-embed/default.nix
+++ b/pkgs/development/tools/rust/cargo-embed/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ libusb1 ];
 
   meta = with lib; {
-    description = "A cargo extension for working with microcontrollers.";
+    description = "A cargo extension for working with microcontrollers";
     homepage = "http://probe.rs/";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ fooker ];

--- a/pkgs/development/tools/rust/cargo-flash/default.nix
+++ b/pkgs/development/tools/rust/cargo-flash/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ libusb1 ];
 
   meta = with lib; {
-    description = "A cargo extension for working with microcontrollers.";
+    description = "A cargo extension for working with microcontrollers";
     homepage = "http://probe.rs/";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ fooker ];

--- a/pkgs/development/tools/rust/cargo-geiger/default.nix
+++ b/pkgs/development/tools/rust/cargo-geiger/default.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with lib; {
-    description = "Detects usage of unsafe Rust in a Rust crate and its dependencies.";
+    description = "Detects usage of unsafe Rust in a Rust crate and its dependencies";
     homepage = "https://github.com/rust-secure-code/cargo-geiger";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ evanjs ];

--- a/pkgs/development/tools/setupcfg2nix/default.nix
+++ b/pkgs/development/tools/setupcfg2nix/default.nix
@@ -10,7 +10,7 @@ buildSetupcfg rec {
   };
   application = true;
   meta = {
-    description = "Generate nix expressions from setup.cfg for a python package.";
+    description = "Generate nix expressions from setup.cfg for a python package";
     homepage = "https://github.com/target/setupcfg2nix";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;

--- a/pkgs/development/tools/systemfd/default.nix
+++ b/pkgs/development/tools/systemfd/default.nix
@@ -8,7 +8,7 @@
   crateOverrides = defaultCrateOverrides // {
     systemfd = attrs: {
         meta = {
-          description = "A convenient helper for passing sockets into another process.";
+          description = "A convenient helper for passing sockets into another process";
           homepage = "https://github.com/mitsuhiko/systemfd";
           license = lib.licenses.asl20;
           maintainers = [ lib.maintainers.adisbladis ];

--- a/pkgs/development/tools/toxiproxy/default.nix
+++ b/pkgs/development/tools/toxiproxy/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   '';
 
   meta = {
-    description = "Proxy for for simulating network conditions.";
+    description = "Proxy for for simulating network conditions";
     maintainers = with lib.maintainers; [ avnik ];
     license = lib.licenses.mit;
   };

--- a/pkgs/development/tools/tracy/default.nix
+++ b/pkgs/development/tools/tracy/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A real time, nanosecond resolution, remote telemetry frame profiler for games and other applications.";
+    description = "A real time, nanosecond resolution, remote telemetry frame profiler for games and other applications";
     homepage = "https://github.com/wolfpld/tracy";
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.bsd3;

--- a/pkgs/development/tools/tychus/default.nix
+++ b/pkgs/development/tools/tychus/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   buildFlags = [ "--tags" "release" ];
 
   meta = {
-    description = "Command line utility to live-reload your application.";
+    description = "Command line utility to live-reload your application";
     homepage = "https://github.com/devlocker/tychus";
     license = stdenv.lib.licenses.mit;
   };

--- a/pkgs/development/tools/vogl/default.nix
+++ b/pkgs/development/tools/vogl/default.nix
@@ -47,7 +47,7 @@ mkDerivation {
   ];
 
   meta = with lib; {
-    description = "OpenGL capture / playback debugger.";
+    description = "OpenGL capture / playback debugger";
     homepage = "https://github.com/ValveSoftware/vogl";
     license = licenses.mit;
     maintainers = [ maintainers.deepfire ];

--- a/pkgs/development/tools/xqilla/default.nix
+++ b/pkgs/development/tools/xqilla/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-xerces=${xercesc}" ];
 
   meta = with stdenv.lib; {
-    description = "XQilla is an XQuery and XPath 2 library and command line utility written in C++, implemented on top of the Xerces-C library.";
+    description = "XQilla is an XQuery and XPath 2 library and command line utility written in C++, implemented on top of the Xerces-C library";
     license     = licenses.asl20 ;
     maintainers = with maintainers; [ obadz ];
     platforms   = platforms.all;

--- a/pkgs/games/fltrator/default.nix
+++ b/pkgs/games/fltrator/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A simple retro style arcade side-scroller game.";
+    description = "A simple retro style arcade side-scroller game";
     longDescription = '' FLTrator is a simple retro style arcade side-scroller game in which you steer a spaceship through a landscape with hostile rockets and other obstacles.
     It has ten different levels and a level editor to create new levels or modify the existing.''; # from https://libregamewiki.org/FLTrator
     homepage = "http://fltrator.sourceforge.net/";

--- a/pkgs/games/frotz/default.nix
+++ b/pkgs/games/frotz/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://davidgriffith.gitlab.io/frotz/";
     changelog = "https://gitlab.com/DavidGriffith/frotz/-/raw/${version}/NEWS";
-    description = "A z-machine interpreter for Infocom games and other interactive fiction.";
+    description = "A z-machine interpreter for Infocom games and other interactive fiction";
     platforms = platforms.unix;
     maintainers = with maintainers; [ nicknovitski  ddelabru ];
     license = licenses.gpl2;

--- a/pkgs/games/gtetrinet/default.nix
+++ b/pkgs/games/gtetrinet/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   meta = {
-    description = "Client for Tetrinet, a multiplayer online Tetris game.";
+    description = "Client for Tetrinet, a multiplayer online Tetris game";
     longDescription = ''
       GTetrinet is a client program for Tetrinet, a multiplayer tetris game
       that is played over the internet.

--- a/pkgs/games/opendungeons/default.nix
+++ b/pkgs/games/opendungeons/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = "-lpthread";
 
   meta = with stdenv.lib; {
-    description = "An open source, real time strategy game sharing game elements with the Dungeon Keeper series and Evil Genius.";
+    description = "An open source, real time strategy game sharing game elements with the Dungeon Keeper series and Evil Genius";
     homepage = "https://opendungeons.github.io";
     license = [ licenses.gpl3Plus licenses.zlib licenses.mit licenses.cc-by-sa-30 licenses.cc0 licenses.ofl licenses.cc-by-30 ];
     platforms = platforms.linux;

--- a/pkgs/games/pacvim/default.nix
+++ b/pkgs/games/pacvim/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/jmoon018/PacVim";
-    description = "PacVim is a game that teaches you vim commands.";
+    description = "PacVim is a game that teaches you vim commands";
     maintainers = with maintainers; [ infinisil ];
     license = licenses.lgpl3;
     platforms = platforms.unix;

--- a/pkgs/games/redeclipse/default.nix
+++ b/pkgs/games/redeclipse/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A first person arena shooter, featuring parkour, impulse boosts, and more.";
+    description = "A first person arena shooter, featuring parkour, impulse boosts, and more";
     longDescription = ''
       Red Eclipse is a fun-filled new take on the first person arena shooter,
       featuring parkour, impulse boosts, and more. The development is geared

--- a/pkgs/games/t4kcommon/default.nix
+++ b/pkgs/games/t4kcommon/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ SDL SDL_image SDL_mixer SDL_net SDL_ttf libpng librsvg libxml2 ];
 
   meta = with stdenv.lib; {
-    description = "A library of code shared between tuxmath and tuxtype.";
+    description = "A library of code shared between tuxmath and tuxtype";
     homepage = "https://github.com/tux4kids/t4kcommon";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.aanderse ];

--- a/pkgs/games/xbill/default.nix
+++ b/pkgs/games/xbill/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv; {
-    description = "Protect a computer network from getting infected.";
+    description = "Protect a computer network from getting infected";
     homepage = "http://www.xbill.org/";
     license = lib.licenses.gpl1;
     maintainers = with lib.maintainers; [ aw ];

--- a/pkgs/misc/cups/drivers/cnijfilter2/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter2/default.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "Canon InkJet printer drivers for the MG7500, MG6700, MG6600, MG5600, MG2900, MB2000, MB2300, iB4000, MB5000, MB5300, iP110, E450, MX490, E480, MG7700, MG6900, MG6800, MG5700, MG3600, and G3000 series.";
+    description = "Canon InkJet printer drivers for the MG7500, MG6700, MG6600, MG5600, MG2900, MB2000, MB2300, iB4000, MB5000, MB5300, iP110, E450, MX490, E480, MG7700, MG6900, MG6800, MG5700, MG3600, and G3000 series";
     homepage = "http://support-th.canon-asia.com/contents/TH/EN/0100712901.html";
     license = licenses.unfree;
     platforms = platforms.linux;

--- a/pkgs/misc/cups/drivers/cnijfilter_4_00/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter_4_00/default.nix
@@ -141,7 +141,7 @@ in stdenv.mkDerivation {
   dontPatchELF = true;
 
   meta = with lib; {
-    description = "Canon InkJet printer drivers for the MG2400 MG2500 MG3500 MG5500 MG6400 MG6500 MG7100 and P200 series.";
+    description = "Canon InkJet printer drivers for the MG2400 MG2500 MG3500 MG5500 MG6400 MG6500 MG7100 and P200 series";
     homepage = "https://www.canon-europe.com/support/consumer_products/products/fax__multifunctionals/inkjet/pixma_mg_series/pixma_mg5550.aspx?type=drivers&driverdetailid=tcm:13-1094072";
     license = licenses.unfree;
     platforms = platforms.linux;

--- a/pkgs/misc/documentation-highlighter/default.nix
+++ b/pkgs/misc/documentation-highlighter/default.nix
@@ -1,7 +1,7 @@
 { stdenv, runCommand }:
 runCommand "documentation-highlighter" {
   meta = {
-    description = "Highlight.js sources for the Nix Ecosystem's documentation.";
+    description = "Highlight.js sources for the Nix Ecosystem's documentation";
     homepage = "https://highlightjs.org";
     license = stdenv.lib.licenses.bsd3;
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -1,20 +1,27 @@
-{stdenv, fetchurl, fetchpatch, makeWrapper, symlinkJoin,
-pkgconfig, libtool,
-gtk2,
-libxml2,
-libxslt,
-libusb-compat-0_1,
-sane-backends,
-rpm, cpio,
-getopt,
-patchelf, autoPatchelfHook, gcc
+{ stdenv
+, fetchurl
+, fetchpatch
+, makeWrapper
+, symlinkJoin
+, pkgconfig
+, libtool
+, gtk2
+, libxml2
+, libxslt
+, libusb-compat-0_1
+, sane-backends
+, rpm
+, cpio
+, getopt
+, patchelf
+, autoPatchelfHook
+, gcc
 }:
-
 let common_meta = {
-    homepage = "http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX";
-    license = with stdenv.lib.licenses; epson;
-    platforms = with stdenv.lib.platforms; linux;
-   };
+  homepage = "http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX";
+  license = with stdenv.lib.licenses; epson;
+  platforms = with stdenv.lib.platforms; linux;
+};
 in
 ############################
 #
@@ -23,7 +30,6 @@ in
 ############################
 
 # adding a plugin for another printer shouldn't be too difficult, but you need the firmware to test...
-
 let plugins = {
   v330 = stdenv.mkDerivation rec {
     name = "iscan-v330-bundle";
@@ -33,7 +39,7 @@ let plugins = {
       # To find new versions, visit
       # http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX and search for
       # some printer like for instance "WF-7210" to get to the most recent
-      # version.  
+      # version.
       # NOTE: Don't forget to update the webarchive link too!
       urls = [
         "https://download2.ebz.epson.net/iscan/plugin/perfection-v330/rpm/x64/iscan-perfection-v330-bundle-${version}.x64.rpm.tar.gz"
@@ -49,17 +55,17 @@ let plugins = {
       mkdir $out{,/share,/lib}
       cp -r ./usr/share/{iscan-data,esci}/ $out/share/
       cp -r ./usr/lib64/esci $out/lib
-      '';
+    '';
 
     passthru = {
       registrationCommand = ''
         $registry --add interpreter usb 0x04b8 0x0142 "$plugin/lib/esci/libesci-interpreter-perfection-v330 $plugin/share/esci/esfwad.bin"
-        '';
+      '';
       hw = "Perfection V330 Photo";
-      };
-    meta = common_meta // { description = "Plugin to support "+passthru.hw+" scanner in sane."; };
+    };
+    meta = common_meta // { description = "Plugin to support " + passthru.hw + " scanner in sane"; };
   };
-  x770 =   stdenv.mkDerivation rec {
+  x770 = stdenv.mkDerivation rec {
     pname = "iscan-gt-x770-bundle";
     version = "2.30.4";
 
@@ -79,20 +85,20 @@ let plugins = {
       cp -r usr/lib64 $out/lib
       mv $out/share/iscan $out/share/esci
       mv $out/lib/iscan $out/lib/esci
-      '';
+    '';
     passthru = {
       registrationCommand = ''
         $registry --add interpreter usb 0x04b8 0x0130 "$plugin/lib/esci/libesint7C $plugin/share/esci/esfw7C.bin"
-        '';
+      '';
       hw = "Perfection V500 Photo";
-      };
-    meta = common_meta // { description = "iscan esci x770 plugin for "+passthru.hw; };
     };
+    meta = common_meta // { description = "iscan esci x770 plugin for " + passthru.hw; };
+  };
   f720 = stdenv.mkDerivation rec {
     pname = "iscan-gt-f720-bundle";
     version = "2.30.4";
 
-    nativeBuildInputs= [ autoPatchelfHook ];
+    nativeBuildInputs = [ autoPatchelfHook ];
     buildInputs = [ gcc.cc.lib ];
     src = fetchurl {
       urls = [
@@ -107,16 +113,16 @@ let plugins = {
       mkdir $out
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
-      '';
+    '';
 
     passthru = {
       registrationCommand = ''
         $registry --add interpreter usb 0x04b8 0x0131 "$plugin/lib/esci/libesci-interpreter-gt-f720 $plugin/share/esci/esfw8b.bin"
-        '';
+      '';
       hw = "GT-F720, GT-S620, Perfection V30, Perfection V300 Photo";
-      };
+    };
 
-    meta = common_meta // { description = "iscan esci f720 plugin for "+passthru.hw; };
+    meta = common_meta // { description = "iscan esci f720 plugin for " + passthru.hw; };
   };
   s80 = stdenv.mkDerivation rec {
     pname = "iscan-gt-s80-bundle";
@@ -139,7 +145,7 @@ let plugins = {
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
       mkdir $out/share/esci
-      '';
+    '';
 
     passthru = {
       registrationCommand = ''
@@ -147,11 +153,11 @@ let plugins = {
         $registry --add interpreter usb 0x04b8 0x0137 "$plugin/lib/esci/libesci-interpreter-gt-s50.so"
         $registry --add interpreter usb 0x04b8 0x0143 "$plugin/lib/esci/libesci-interpreter-gt-s50.so"
         $registry --add interpreter usb 0x04b8 0x0144 "$plugin/lib/esci/libesci-interpreter-gt-s80.so"
-        '';
+      '';
       hw = "ES-D200, ED-D350, ES-D400, GT-S50, GT-S55, GT-S80, GT-S85";
-      };
+    };
 
-    meta = common_meta // { description = "iscan esci s80 plugin for "+passthru.hw; };
+    meta = common_meta // { description = "iscan esci s80 plugin for " + passthru.hw; };
   };
   s650 = stdenv.mkDerivation rec {
     name = "iscan-gt-s650-bundle";
@@ -175,16 +181,16 @@ let plugins = {
       cp -r usr/lib64 $out/lib
       mv $out/share/iscan $out/share/esci
       mv $out/lib/iscan $out/lib/esci
-      '';
+    '';
 
     passthru = {
       registrationCommand = ''
         $registry --add interpreter usb 0x04b8 0x013c "$plugin/lib/esci/libiscan-plugin-gt-s650 $plugin/share/esci/esfw010c.bin"
         $registry --add interpreter usb 0x04b8 0x013d "$plugin/lib/esci/libiscan-plugin-gt-s650 $plugin/share/esci/esfw010c.bin"
-        '';
+      '';
       hw = "GT-S650, Perfection V19, Perfection V39";
     };
-    meta = common_meta // { description = "iscan GT-S650 for "+passthru.hw; };
+    meta = common_meta // { description = "iscan GT-S650 for " + passthru.hw; };
   };
   network = stdenv.mkDerivation rec {
     pname = "iscan-nt-bundle";
@@ -209,7 +215,7 @@ let plugins = {
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
       mkdir $out/share/esci
-      '';
+    '';
     passthru = {
       registrationCommand = "";
       hw = "network";
@@ -219,9 +225,6 @@ let plugins = {
   };
 };
 in
-
-
-
 let fwdir = symlinkJoin {
   name = "esci-firmware-dir";
   paths = stdenv.lib.mapAttrsToList (name: value: value + /share/esci) plugins;
@@ -278,14 +281,14 @@ stdenv.mkDerivation rec {
     })
     ./firmware_location.patch
     ./sscanf.patch
-    ];
+  ];
   patchFlags = [ "-p0" ];
 
-  configureFlags = [ "--enable-dependency-reduction" "--disable-frontend"];
+  configureFlags = [ "--enable-dependency-reduction" "--disable-frontend" ];
 
   postConfigure = ''
     echo '#define NIX_ESCI_PREFIX "'${fwdir}'"' >> config.h
-    '';
+  '';
 
   postInstall = ''
     mkdir -p $out/etc/sane.d
@@ -294,18 +297,20 @@ stdenv.mkDerivation rec {
     ln -s ${iscan-data}/share/iscan-data $out/share/iscan-data
     mkdir -p $out/lib/iscan
     ln -s ${plugins.network}/lib/iscan/network $out/lib/iscan/network
-    '';
+  '';
   postFixup = ''
     # iscan-registry is a shell script requiring getopt
     wrapProgram $out/bin/iscan-registry --prefix PATH : ${getopt}/bin
     registry=$out/bin/iscan-registry;
-    '' +
-    stdenv.lib.concatStrings (stdenv.lib.mapAttrsToList (name: value: ''
-    plugin=${value};
-    ${value.passthru.registrationCommand}
-    '') plugins);
+  '' +
+  stdenv.lib.concatStrings (stdenv.lib.mapAttrsToList
+    (name: value: ''
+      plugin=${value};
+      ${value.passthru.registrationCommand}
+    '')
+    plugins);
   meta = common_meta // {
-    description = "sane-epkowa backend for some epson scanners.";
+    description = "sane-epkowa backend for some epson scanners";
     longDescription = ''
       Includes gui-less iscan (aka. Image Scan! for Linux).
       Supported hardware: at least :

--- a/pkgs/misc/emulators/np2kai/default.nix
+++ b/pkgs/misc/emulators/np2kai/default.nix
@@ -187,7 +187,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A PC-9801 series emulator.";
+    description = "A PC-9801 series emulator";
     homepage = "https://github.com/AZO234/NP2kai";
     license = licenses.mit;
     maintainers = with maintainers; [ OPNA2608 ];

--- a/pkgs/misc/hdt/default.nix
+++ b/pkgs/misc/hdt/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "http://www.rdfhdt.org/";
-    description = "Header Dictionary Triples (HDT) is a compression format for RDF data that can also be queried for Triple Patterns.";
+    description = "Header Dictionary Triples (HDT) is a compression format for RDF data that can also be queried for Triple Patterns";
     license = licenses.lgpl21;
     platforms = platforms.linux;
     maintainers = [ maintainers.koslambrou ];

--- a/pkgs/misc/riscv-pk/default.nix
+++ b/pkgs/misc/riscv-pk/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "RISC-V Proxy Kernel and Bootloader.";
+    description = "RISC-V Proxy Kernel and Bootloader";
     homepage = "https://github.com/riscv/riscv-pk";
     license = stdenv.lib.licenses.bsd3;
     platforms = stdenv.lib.platforms.riscv;

--- a/pkgs/misc/screensavers/betterlockscreen/default.nix
+++ b/pkgs/misc/screensavers/betterlockscreen/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with stdenv.lib; {
-    description = "Betterlockscreen is a simple minimal lock screen which allows you to cache images with different filters and lockscreen with blazing speed.";
+    description = "Betterlockscreen is a simple minimal lock screen which allows you to cache images with different filters and lockscreen with blazing speed";
     homepage = "https://github.com/pavanjadhaw/betterlockscreen";
     license = licenses.mit;
     platforms = platforms.linux;

--- a/pkgs/misc/screensavers/i3lock-pixeled/default.nix
+++ b/pkgs/misc/screensavers/i3lock-pixeled/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Simple i3lock helper which pixels a screenshot by scaling it down and up to get a pixeled version of the screen when the lock is active.";
+    description = "Simple i3lock helper which pixels a screenshot by scaling it down and up to get a pixeled version of the screen when the lock is active";
     homepage = "https://gitlab.com/Ma27/i3lock-pixeled";
     license = licenses.mit;
     platforms = platforms.linux;

--- a/pkgs/misc/screensavers/xautolock/default.nix
+++ b/pkgs/misc/screensavers/xautolock/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   installTargets = [ "install" "install.man" ];
 
   meta = with stdenv.lib; {
-    description = "Launch a given program when your X session has been idle for a given time.";
+    description = "Launch a given program when your X session has been idle for a given time";
     homepage = "http://www.ibiblio.org/pub/linux/X11/screensavers";
     maintainers = with maintainers; [ peti ];
     platforms = platforms.linux;

--- a/pkgs/os-specific/darwin/osxsnarf/default.nix
+++ b/pkgs/os-specific/darwin/osxsnarf/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "prefix=${placeholder "out"}" ];
 
   meta = with lib; {
-    description = "A Plan 9-inspired way to share your OS X clipboard.";
+    description = "A Plan 9-inspired way to share your OS X clipboard";
     homepage = "https://github.com/eraserhd/osxsnarf";
     license = licenses.unlicense;
     platforms = platforms.darwin;

--- a/pkgs/os-specific/linux/cpuset/default.nix
+++ b/pkgs/os-specific/linux/cpuset/default.nix
@@ -19,7 +19,7 @@ python2Packages.buildPythonApplication rec {
   };
 
   meta = with stdenv.lib; {
-    description = "Cpuset is a Python application that forms a wrapper around the standard Linux filesystem calls to make using the cpusets facilities in the Linux kernel easier.";
+    description = "Cpuset is a Python application that forms a wrapper around the standard Linux filesystem calls to make using the cpusets facilities in the Linux kernel easier";
     homepage    = "https://github.com/wykurz/cpuset";
     license     = licenses.gpl2;
     maintainers = with maintainers; [ wykurz ];

--- a/pkgs/os-specific/linux/firmware/system76-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/system76-firmware/default.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = {
-    description = "Tools for managing firmware updates for system76 devices.";
+    description = "Tools for managing firmware updates for system76 devices";
     homepage = "https://github.com/pop-os/system76-firmware";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.shlevy ];

--- a/pkgs/os-specific/linux/intel-compute-runtime/default.nix
+++ b/pkgs/os-specific/linux/intel-compute-runtime/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage    = "https://github.com/intel/compute-runtime";
-    description = "Intel Graphics Compute Runtime for OpenCL. Replaces Beignet for Gen8 (Broadwell) and beyond.";
+    description = "Intel Graphics Compute Runtime for OpenCL. Replaces Beignet for Gen8 (Broadwell) and beyond";
     license     = licenses.mit;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ gloaming ];

--- a/pkgs/os-specific/linux/libevdevc/default.nix
+++ b/pkgs/os-specific/linux/libevdevc/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "DESTDIR=$(out)" "LIBDIR=/lib" ];
 
   meta = with stdenv.lib; {
-    description = "ChromiumOS libevdev. Renamed to avoid conflicts with the standard libevdev found in Linux distros.";
+    description = "ChromiumOS libevdev. Renamed to avoid conflicts with the standard libevdev found in Linux distros";
     license = licenses.bsd3;
     platforms = platforms.linux;
     homepage = "https://chromium.googlesource.com/chromiumos/platform/libevdev/";

--- a/pkgs/os-specific/linux/libgestures/default.nix
+++ b/pkgs/os-specific/linux/libgestures/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "DESTDIR=$(out)" "LIBDIR=/lib" ];
 
   meta = with stdenv.lib; {
-    description = "ChromiumOS libgestures modified to compile for Linux.";
+    description = "ChromiumOS libgestures modified to compile for Linux";
     license = licenses.bsd3;
     platforms = platforms.linux;
     homepage = "https://chromium.googlesource.com/chromiumos/platform/gestures";

--- a/pkgs/os-specific/linux/lksctp-tools/default.nix
+++ b/pkgs/os-specific/linux/lksctp-tools/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    description = "Linux Kernel Stream Control Transmission Protocol Tools.";
+    description = "Linux Kernel Stream Control Transmission Protocol Tools";
     homepage = "http://lksctp.sourceforge.net/";
     license = with licenses; [ gpl2 lgpl21 ]; # library is lgpl21
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/usbguard/default.nix
+++ b/pkgs/os-specific/linux/usbguard/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    description = "The USBGuard software framework helps to protect your computer against BadUSB.";
+    description = "The USBGuard software framework helps to protect your computer against BadUSB";
     homepage = "https://usbguard.github.io/";
     license = licenses.gpl2;
     maintainers = [ maintainers.tnias ];

--- a/pkgs/os-specific/linux/xf86-input-cmt/default.nix
+++ b/pkgs/os-specific/linux/xf86-input-cmt/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    description = "Chromebook touchpad driver.";
+    description = "Chromebook touchpad driver";
     license = licenses.bsd3;
     platforms = platforms.linux;
     homepage = "https://www.github.com/hugegreenbug/xf86-input-cmt";

--- a/pkgs/os-specific/solo5/default.nix
+++ b/pkgs/os-specific/solo5/default.nix
@@ -45,7 +45,7 @@ in stdenv.mkDerivation {
     null;
 
   meta = with lib; {
-    description = "Sandboxed execution environment.";
+    description = "Sandboxed execution environment";
     homepage = "https://github.com/solo5/solo5";
     license = licenses.isc;
     maintainers = [ maintainers.ehmry ];

--- a/pkgs/servers/code-server/default.nix
+++ b/pkgs/servers/code-server/default.nix
@@ -174,7 +174,7 @@ in stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    description = "Run VS Code on a remote server.";
+    description = "Run VS Code on a remote server";
     longDescription = ''
       code-server is VS Code running on a remote server, accessible through the
       browser.

--- a/pkgs/servers/dante/default.nix
+++ b/pkgs/servers/dante/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   dontAddDisableDepTrack = stdenv.isDarwin;
 
   meta = with stdenv.lib; {
-    description = "A circuit-level SOCKS client/server that can be used to provide convenient and secure network connectivity.";
+    description = "A circuit-level SOCKS client/server that can be used to provide convenient and secure network connectivity";
     homepage    = "https://www.inet.no/dante/";
     maintainers = [ maintainers.arobyn ];
     license     = licenses.bsdOriginal;

--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "A web server based on Nginx and has many advanced features, originated by Taobao.";
+    description = "A web server based on Nginx and has many advanced features, originated by Taobao";
     homepage    = "https://tengine.taobao.org";
     license     = licenses.bsd2;
     platforms   = platforms.all;

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -84,7 +84,7 @@ in stdenv.mkDerivation rec {
   passthru.tests.unit-php = nixosTests.unit-php;
 
   meta = {
-    description = "Dynamic web and application server, designed to run applications in multiple languages.";
+    description = "Dynamic web and application server, designed to run applications in multiple languages";
     homepage    = "https://unit.nginx.org/";
     license     = licenses.asl20;
     platforms   = platforms.linux;

--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "API Support for your favorite torrent trackers.";
+    description = "API Support for your favorite torrent trackers";
     homepage = "https://github.com/Jackett/Jackett/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ edwtjo nyanloutre purcell ];

--- a/pkgs/servers/monitoring/plugins/default.nix
+++ b/pkgs/servers/monitoring/plugins/default.nix
@@ -77,7 +77,7 @@ _EOF
   '';
 
   meta = {
-    description = "Official monitoring plugins for Nagios/Icinga/Sensu and others.";
+    description = "Official monitoring plugins for Nagios/Icinga/Sensu and others";
     homepage    = "https://www.monitoring-plugins.org";
     license     = licenses.gpl2;
     platforms   = platforms.linux;

--- a/pkgs/servers/monitoring/plugins/labs_consol_de.nix
+++ b/pkgs/servers/monitoring/plugins/labs_consol_de.nix
@@ -55,7 +55,7 @@ in {
     pname       = "check_mssql_health";
     version     = "2.6.4.15";
     sha256      = "12z0b3c2p18viy7s93r6bbl8fvgsqh80136d07118qhxshp1pwxg";
-    description = "Check plugin for Microsoft SQL Server.";
+    description = "Check plugin for Microsoft SQL Server";
     buildInputs = [ perlPackages.DBDsybase ];
   };
 
@@ -63,7 +63,7 @@ in {
     pname       = "check_nwc_health";
     version     = "7.10.0.6";
     sha256      = "092rhaqnk3403z0y60x38vgh65gcia3wrd6gp8mr7wszja38kxv2";
-    description = "Check plugin for network equipment.";
+    description = "Check plugin for network equipment";
     buildInputs = [ perlPackages.NetSNMP ];
   };
 
@@ -71,7 +71,7 @@ in {
     pname       = "check_ups_health";
     version     = "2.8.3.3";
     sha256      = "0qc2aglppwr9ms4p53kh9nr48625sqrbn46xs0k9rx5sv8hil9hm";
-    description = "Check plugin for UPSs.";
+    description = "Check plugin for UPSs";
     buildInputs = [ perlPackages.NetSNMP ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/keylight-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/keylight-exporter.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mdlayher/keylight_exporter";
-    description = "Prometheus exporter for Elgato Key Light devices.";
+    description = "Prometheus exporter for Elgato Key Light devices";
     license = licenses.mit;
     maintainers = with maintainers; [ mdlayher ];
   };

--- a/pkgs/servers/monitoring/prometheus/modemmanager-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/modemmanager-exporter.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mdlayher/modemmanager_exporter";
-    description = "Prometheus exporter for ModemManager and its devices.";
+    description = "Prometheus exporter for ModemManager and its devices";
     license = licenses.mit;
     maintainers = with maintainers; [ mdlayher ];
   };

--- a/pkgs/servers/monitoring/prometheus/nextcloud-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/nextcloud-exporter.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   passthru.tests = { inherit (nixosTests.prometheus-exporters) nextcloud; };
 
   meta = with lib; {
-    description = "Prometheus exporter for Nextcloud servers.";
+    description = "Prometheus exporter for Nextcloud servers";
     homepage = "https://github.com/xperimental/nextcloud-exporter";
     license = licenses.mit;
     maintainers = with maintainers; [ willibutz ];

--- a/pkgs/servers/monitoring/prometheus/wireguard-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/wireguard-exporter.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   passthru.tests = { inherit (nixosTests.prometheus-exporters) wireguard; };
 
   meta = with lib; {
-    description = "A Prometheus exporter for WireGuard, written in Rust.";
+    description = "A Prometheus exporter for WireGuard, written in Rust";
     homepage = "https://github.com/MindFlavor/prometheus_wireguard_exporter";
     license = licenses.mit;
     maintainers = with maintainers; [ ma27 globin ];

--- a/pkgs/servers/monitoring/telegraf/default.nix
+++ b/pkgs/servers/monitoring/telegraf/default.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
   passthru.tests = { inherit (nixosTests) telegraf; };
 
   meta = with lib; {
-    description = "The plugin-driven server agent for collecting & reporting metrics.";
+    description = "The plugin-driven server agent for collecting & reporting metrics";
     license = licenses.mit;
     homepage = "https://www.influxdata.com/time-series-platform/telegraf/";
     maintainers = with maintainers; [ mic92 roblabla foxit64 ];

--- a/pkgs/servers/openbgpd/default.nix
+++ b/pkgs/servers/openbgpd/default.nix
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "OpenBGPD is a FREE implementation of the Border Gateway Protocol, Version 4. It allows ordinary machines to be used as routers exchanging routes with other systems speaking the BGP protocol.";
+    description = "OpenBGPD is a FREE implementation of the Border Gateway Protocol, Version 4. It allows ordinary machines to be used as routers exchanging routes with other systems speaking the BGP protocol";
     license = licenses.isc;
     homepage = "http://www.openbgpd.org/";
     maintainers = with maintainers; [ kloenk ];

--- a/pkgs/servers/pinnwand/default.nix
+++ b/pkgs/servers/pinnwand/default.nix
@@ -48,7 +48,7 @@ in with python.pkgs; buildPythonApplication rec {
   meta = with lib; {
     homepage = "https://supakeen.com/project/pinnwand/";
     license = licenses.mit;
-    description = "A Python pastebin that tries to keep it simple.";
+    description = "A Python pastebin that tries to keep it simple";
     maintainers = with maintainers; [ hexa ];
   };
 }

--- a/pkgs/servers/pinnwand/steck.nix
+++ b/pkgs/servers/pinnwand/steck.nix
@@ -24,7 +24,7 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     homepage = "https://github.com/supakeen/steck";
     license = licenses.mit;
-    description = "Client for pinnwand pastebin.";
+    description = "Client for pinnwand pastebin";
     maintainers = with maintainers; [ hexa ];
   };
 }

--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -59,7 +59,7 @@
     '';
 
   meta = with lib; {
-    description = "The music player for music lovers.";
+    description = "The music player for music lovers";
     homepage = "https://roonlabs.com";
     license = licenses.unfree;
     maintainers = with maintainers; [ lovesegfault steell ];

--- a/pkgs/servers/sql/dolt/default.nix
+++ b/pkgs/servers/sql/dolt/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   doCheck = false;
 
     meta = with lib; {
-        description = "Relational database with version control and CLI a-la Git.";
+        description = "Relational database with version control and CLI a-la Git";
         homepage = "https://github.com/liquidata-inc/dolt";
         license = licenses.asl20;
         maintainers = with maintainers; [ danbst ];

--- a/pkgs/servers/tang/default.nix
+++ b/pkgs/servers/tang/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "man" ];
 
   meta = {
-    description = "Server for binding data to network presence.";
+    description = "Server for binding data to network presence";
     homepage = "https://github.com/latchset/tang";
     maintainers = with lib.maintainers; [ fpletz ];
     license = lib.licenses.gpl3Plus;

--- a/pkgs/servers/tautulli/default.nix
+++ b/pkgs/servers/tautulli/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta  = with stdenv.lib; {
-    description = "A Python based monitoring and tracking tool for Plex Media Server.";
+    description = "A Python based monitoring and tracking tool for Plex Media Server";
     homepage = "https://tautulli.com/";
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/servers/web-apps/jirafeau/default.nix
+++ b/pkgs/servers/web-apps/jirafeau/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Jirafeau is a web site permitting to upload a file in a simple way and give an unique link to it.";
+    description = "Jirafeau is a web site permitting to upload a file in a simple way and give an unique link to it";
     license = licenses.agpl3;
     homepage = "https://gitlab.com/mojo42/Jirafeau";
     platforms = platforms.all;

--- a/pkgs/servers/web-apps/pgpkeyserver-lite/default.nix
+++ b/pkgs/servers/web-apps/pgpkeyserver-lite/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mattrude/pgpkeyserver-lite";
-    description = "A lightweight static front-end for a sks keyserver.";
+    description = "A lightweight static front-end for a sks keyserver";
     license = licenses.gpl3;
     maintainers = with maintainers; [ calbrecht globin ];
   };

--- a/pkgs/shells/zsh/antigen/default.nix
+++ b/pkgs/shells/zsh/antigen/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "The plugin manager for zsh.";
+    description = "The plugin manager for zsh";
     homepage = "http://antigen.sharats.me";
     license = stdenv.lib.licenses.mit;
   };

--- a/pkgs/shells/zsh/zsh-prezto/default.nix
+++ b/pkgs/shells/zsh/zsh-prezto/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     cp ./* $out/ -R
   '';
   meta = with stdenv.lib; {
-    description = "Prezto is the configuration framework for Zsh; it enriches the command line interface environment with sane defaults, aliases, functions, auto completion, and prompt themes.";
+    description = "Prezto is the configuration framework for Zsh; it enriches the command line interface environment with sane defaults, aliases, functions, auto completion, and prompt themes";
     homepage = "https://github.com/sorin-ionescu/prezto";
     license = licenses.mit;
     maintainers = with maintainers; [ ];

--- a/pkgs/tools/admin/daemontools/default.nix
+++ b/pkgs/tools/admin/daemontools/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   meta = {
     license = stdenv.lib.licenses.publicDomain;
     homepage = "https://cr.yp.to/daemontools.html";
-    description = "A collection of tools for managing UNIX services.";
+    description = "A collection of tools for managing UNIX services";
 
     maintainers = with stdenv.lib.maintainers; [ kevincox ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/tools/admin/lexicon/default.nix
+++ b/pkgs/tools/admin/lexicon/default.nix
@@ -75,7 +75,7 @@ buildPythonApplication rec {
   '';
 
   meta = with lib; {
-    description = "Manipulate DNS records on various DNS providers in a standardized way.";
+    description = "Manipulate DNS records on various DNS providers in a standardized way";
     homepage = "https://github.com/AnalogJ/lexicon";
     maintainers = with maintainers; [ flyfloh ];
     license = licenses.mit;

--- a/pkgs/tools/audio/picotts/default.nix
+++ b/pkgs/tools/audio/picotts/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   sourceRoot = "source/pico";
   preConfigure = "./autogen.sh";
   meta = {
-    description = "Text to speech voice sinthesizer from SVox.";
+    description = "Text to speech voice sinthesizer from SVox";
     homepage = "https://github.com/naggety/picotts";
     license = stdenv.lib.licenses.asl20;
     maintainers = [ stdenv.lib.maintainers.canndrew ];

--- a/pkgs/tools/compression/pbzx/default.nix
+++ b/pkgs/tools/compression/pbzx/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     cp pbzx $out/bin
   '';
   meta = with lib; {
-    description = "Stream parser of Apple's pbzx compression format.";
+    description = "Stream parser of Apple's pbzx compression format";
     platforms = platforms.unix;
     license = licenses.gpl3;
     maintainers = [ maintainers.matthewbauer ];

--- a/pkgs/tools/filesystems/convoy/default.nix
+++ b/pkgs/tools/filesystems/convoy/default.nix
@@ -18,7 +18,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/rancher/convoy";
-    description = "A Docker volume plugin, managing persistent container volumes.";
+    description = "A Docker volume plugin, managing persistent container volumes";
     license = licenses.asl20;
     maintainers = with maintainers; [ offline ];
     platforms = platforms.linux;

--- a/pkgs/tools/inputmethods/keyfuzz/default.nix
+++ b/pkgs/tools/inputmethods/keyfuzz/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   version = "0.2";
 
   meta = with stdenv.lib; {
-    description = "Manipulate the scancode/keycode translation tables of keyboard drivers.";
+    description = "Manipulate the scancode/keycode translation tables of keyboard drivers";
     homepage    = "http://0pointer.de/lennart/projects/keyfuzz/";
     license     = licenses.gpl2Plus;
     platforms   = platforms.linux;

--- a/pkgs/tools/misc/adafruit-ampy/default.nix
+++ b/pkgs/tools/misc/adafruit-ampy/default.nix
@@ -20,7 +20,7 @@ buildPythonApplication rec {
   meta = with stdenv.lib; {
     homepage = "https://github.com/pycampers/ampy";
     license = licenses.mit;
-    description = "Utility to interact with a MicroPython board over a serial connection.";
+    description = "Utility to interact with a MicroPython board over a serial connection";
     maintainers = with maintainers; [ etu ];
   };
 }

--- a/pkgs/tools/misc/asciinema-scenario/default.nix
+++ b/pkgs/tools/misc/asciinema-scenario/default.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "109ij5h31bhn44l0wywgpnnlfjgyairxr5l19s6bz47sbka0xyxk";
 
   meta = with stdenv.lib; {
-    description = "Create asciinema videos from a text file.";
+    description = "Create asciinema videos from a text file";
     homepage = "https://github.com/garbas/asciinema-scenario/";
     maintainers = with maintainers; [ garbas ];
     license = with licenses; [ mit ];

--- a/pkgs/tools/misc/chafa/default.nix
+++ b/pkgs/tools/misc/chafa/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
                    ];
 
   meta = with stdenv.lib; {
-    description = "Terminal graphics for the 21st century.";
+    description = "Terminal graphics for the 21st century";
     homepage = "https://hpjansson.org/chafa/";
     license = licenses.lgpl3Plus;
     platforms = platforms.all;

--- a/pkgs/tools/misc/dijo/default.nix
+++ b/pkgs/tools/misc/dijo/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage {
   cargoSha256 = "0pm048xf8hkva8q8fjmhrdnk7h2im28ix7xy784xwkkdnilm4j7f";
 
   meta = with lib; {
-    description = "Scriptable, curses-based, digital habit tracker.";
+    description = "Scriptable, curses-based, digital habit tracker";
     homepage = "https://github.com/NerdyPepper/dijo";
     license = licenses.mit;
     maintainers = with maintainers; [ infinisil ];

--- a/pkgs/tools/misc/dmg2img/default.nix
+++ b/pkgs/tools/misc/dmg2img/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     platforms = stdenv.lib.platforms.unix;
-    description = "An Apple's compressed dmg to standard (hfsplus) image disk file convert tool.";
+    description = "An Apple's compressed dmg to standard (hfsplus) image disk file convert tool";
     license = stdenv.lib.licenses.gpl3;
   };
 }

--- a/pkgs/tools/misc/go.rice/default.nix
+++ b/pkgs/tools/misc/go.rice/default.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/GeertJohan/go.rice";
-    description = "A Go package that makes working with resources such as html, js, css, images, templates very easy.";
+    description = "A Go package that makes working with resources such as html, js, css, images, templates very easy";
     license = licenses.bsd2;
     maintainers = with maintainers; [ blaggacao ];
   };

--- a/pkgs/tools/misc/gotify-cli/default.nix
+++ b/pkgs/tools/misc/gotify-cli/default.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
   meta = with lib; {
     license = licenses.mit;
     homepage = "https://github.com/gotify/cli";
-    description = "A command line interface for pushing messages to gotify/server.";
+    description = "A command line interface for pushing messages to gotify/server";
     maintainers = with maintainers; [ ma27 ];
   };
 }

--- a/pkgs/tools/misc/hacksaw/default.nix
+++ b/pkgs/tools/misc/hacksaw/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "01draql3x71h7xl2xcc69dv7vpi3smnajhrvaihs5vij81pyfrzk";
 
   meta = with lib; {
-    description = "Lightweight selection tool for usage in screenshot scripts etc.";
+    description = "Lightweight selection tool for usage in screenshot scripts etc";
     homepage = "https://github.com/neXromancers/hacksaw";
     license = with licenses; [ mpl20 ];
     maintainers = with maintainers; [ TethysSvensson ];

--- a/pkgs/tools/misc/ical2org/default.nix
+++ b/pkgs/tools/misc/ical2org/default.nix
@@ -17,7 +17,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   meta = with stdenv.lib; {
-    description = "Convert an iCal file to org agenda format, optionally deduplicating entries.";
+    description = "Convert an iCal file to org agenda format, optionally deduplicating entries";
     homepage = "https://github.com/rjhorniii/ical2org";
     license = licenses.gpl3;
     maintainers = with maintainers; [ swflint ];

--- a/pkgs/tools/misc/kargo/default.nix
+++ b/pkgs/tools/misc/kargo/default.nix
@@ -30,7 +30,7 @@ buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/kubespray/kargo-cli";
-    description = "A tool helps to deploy a kubernetes cluster with Ansible.";
+    description = "A tool helps to deploy a kubernetes cluster with Ansible";
     platforms = platforms.linux;
     license = licenses.gpl3;
     maintainers = with maintainers; [ ];

--- a/pkgs/tools/misc/lice/default.nix
+++ b/pkgs/tools/misc/lice/default.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonPackage rec {
   };
 
   meta = with stdenv.lib; {
-    description = "Print license based on selection and user options.";
+    description = "Print license based on selection and user options";
     homepage = "https://github.com/licenses/lice";
     license = licenses.bsd3;
     maintainers = with maintainers; [ swflint ];

--- a/pkgs/tools/misc/logtop/default.nix
+++ b/pkgs/tools/misc/logtop/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    description = "Displays a real-time count of strings received from stdin.";
+    description = "Displays a real-time count of strings received from stdin";
     longDescription = ''
       logtop displays a real-time count of strings received from stdin.
       It can be useful in some cases, like getting the IP flooding your

--- a/pkgs/tools/misc/lokalise2-cli/default.nix
+++ b/pkgs/tools/misc/lokalise2-cli/default.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Translation platform for developers. Upload language files, translate, integrate via API.";
+    description = "Translation platform for developers. Upload language files, translate, integrate via API";
     homepage = "https://lokalise.com";
     license = licenses.bsd3;
     maintainers = with maintainers; [ timstott ];

--- a/pkgs/tools/misc/noti/default.nix
+++ b/pkgs/tools/misc/noti/default.nix
@@ -26,7 +26,7 @@ buildGoPackage rec {
   '';
 
   meta = with lib; {
-    description = "Monitor a process and trigger a notification.";
+    description = "Monitor a process and trigger a notification";
     longDescription = ''
       Monitor a process and trigger a notification.
 

--- a/pkgs/tools/misc/nyancat/default.nix
+++ b/pkgs/tools/misc/nyancat/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Nyancat in your terminal, rendered through ANSI escape sequences.";
+    description = "Nyancat in your terminal, rendered through ANSI escape sequences";
     homepage = "https://nyancat.dakko.us";
     license = licenses.ncsa;
     maintainers = with maintainers; [ midchildan ];

--- a/pkgs/tools/misc/pandoc-plantuml-filter/default.nix
+++ b/pkgs/tools/misc/pandoc-plantuml-filter/default.nix
@@ -19,7 +19,7 @@ buildPythonApplication rec {
 
   meta = with lib; {
     homepage = "https://github.com/timofurrer/pandoc-plantuml-filter";
-    description = "Pandoc filter which converts PlantUML code blocks to PlantUML images.";
+    description = "Pandoc filter which converts PlantUML code blocks to PlantUML images";
     license = licenses.mit;
     maintainers = with maintainers; [ cmcdragonkai ];
   };

--- a/pkgs/tools/misc/shunit2/default.nix
+++ b/pkgs/tools/misc/shunit2/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/kward/shunit2";
-    description = "A xUnit based unit test framework for Bourne based shell scripts.";
+    description = "A xUnit based unit test framework for Bourne based shell scripts";
     maintainers = with maintainers; [ cdepillabout utdemir ];
     license = licenses.asl20;
     platforms = platforms.unix;

--- a/pkgs/tools/misc/silicon/default.nix
+++ b/pkgs/tools/misc/silicon/default.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
   meta = with lib; {
-    description = "Create beautiful image of your source code.";
+    description = "Create beautiful image of your source code";
     homepage = "https://github.com/Aloxaf/silicon";
     license = with licenses; [ mit /* or */ asl20 ];
     maintainers = with maintainers; [ evanjs ];

--- a/pkgs/tools/misc/statserial/default.nix
+++ b/pkgs/tools/misc/statserial/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://sites.google.com/site/tranter/software";
-    description = "Display serial port modem status lines.";
+    description = "Display serial port modem status lines";
     license = licenses.gpl2;
 
     longDescription =

--- a/pkgs/tools/misc/td/default.nix
+++ b/pkgs/tools/misc/td/default.nix
@@ -8,7 +8,7 @@ bundlerApp {
   passthru.updateScript = bundlerUpdateScript "td";
 
   meta = with lib; {
-    description = "CLI to manage data on Treasure Data, the Hadoop-based cloud data warehousing.";
+    description = "CLI to manage data on Treasure Data, the Hadoop-based cloud data warehousing";
     homepage    = "https://github.com/treasure-data/td";
     license     = licenses.asl20;
     maintainers =  with maintainers; [ groodt nicknovitski ];

--- a/pkgs/tools/misc/thefuck/default.nix
+++ b/pkgs/tools/misc/thefuck/default.nix
@@ -30,7 +30,7 @@ buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/nvbn/thefuck";
-    description = "Magnificent app which corrects your previous console command.";
+    description = "Magnificent app which corrects your previous console command";
     license = licenses.mit;
     maintainers = with maintainers; [ ma27 ];
   };

--- a/pkgs/tools/misc/wootility/default.nix
+++ b/pkgs/tools/misc/wootility/default.nix
@@ -35,7 +35,7 @@ appimageTools.wrapType2 rec {
 
   meta = with lib; {
     homepage = "https://wooting.io/wootility";
-    description = "Wootility is customization and management software for Wooting keyboards.";
+    description = "Wootility is customization and management software for Wooting keyboards";
     platforms = [ "x86_64-linux" ];
     license = "unknown";
     maintainers = with maintainers; [ davidtwco ];

--- a/pkgs/tools/misc/yubikey-manager-qt/default.nix
+++ b/pkgs/tools/misc/yubikey-manager-qt/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     inherit version;
-    description = "Cross-platform application for configuring any YubiKey over all USB interfaces.";
+    description = "Cross-platform application for configuring any YubiKey over all USB interfaces";
     homepage = "https://developers.yubico.com/yubikey-manager-qt/";
     license = licenses.bsd2;
     maintainers = [ maintainers.cbley ];

--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -47,7 +47,7 @@ python3Packages.buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://developers.yubico.com/yubikey-manager";
-    description = "Command line tool for configuring any YubiKey over all USB transports.";
+    description = "Command line tool for configuring any YubiKey over all USB transports";
 
     license = licenses.bsd2;
     platforms = platforms.unix;

--- a/pkgs/tools/networking/dnstracer/default.nix
+++ b/pkgs/tools/networking/dnstracer/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lresolv";
 
   meta = with stdenv.lib; {
-    description = "Dnstracer determines where a given Domain Name Server (DNS) gets its information from, and follows the chain of DNS servers back to the servers which know the data.";
+    description = "Dnstracer determines where a given Domain Name Server (DNS) gets its information from, and follows the chain of DNS servers back to the servers which know the data";
     homepage = "http://www.mavetju.org/unix/general.php";
     license = licenses.bsd2;
     maintainers = with maintainers; [ andir ];

--- a/pkgs/tools/networking/goreplay/default.nix
+++ b/pkgs/tools/networking/goreplay/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
   meta = {
     homepage = "https://github.com/buger/goreplay";
     license = stdenv.lib.licenses.lgpl3Only;
-    description = "GoReplay is an open-source tool for capturing and replaying live HTTP traffic.";
+    description = "GoReplay is an open-source tool for capturing and replaying live HTTP traffic";
     platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ lovek323 ];
   };

--- a/pkgs/tools/networking/mcrcon/default.nix
+++ b/pkgs/tools/networking/mcrcon/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://bukkit.org/threads/admin-rcon-mcrcon-remote-connection-client-for-minecraft-servers.70910/";
-    description = "Minecraft console client with Bukkit coloring support.";
+    description = "Minecraft console client with Bukkit coloring support";
     longDescription = ''
       Mcrcon is a powerful Minecraft RCON terminal client with Bukkit coloring support.
       It is well suited for remote administration and to be used as part of automated server maintenance scripts.

--- a/pkgs/tools/networking/ocserv/default.nix
+++ b/pkgs/tools/networking/ocserv/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://gitlab.com/openconnect/ocserv";
     license = licenses.gpl2;
-    description = "This program is openconnect VPN server (ocserv), a server for the openconnect VPN client.";
+    description = "This program is openconnect VPN server (ocserv), a server for the openconnect VPN client";
     maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/networking/persepolis/default.nix
+++ b/pkgs/tools/networking/persepolis/default.nix
@@ -62,7 +62,7 @@ buildPythonApplication rec {
   ];
 
   meta = with stdenv.lib; {
-    description = "Persepolis Download Manager is a GUI for aria2.";
+    description = "Persepolis Download Manager is a GUI for aria2";
     homepage = "https://persepolisdm.github.io/";
     license = licenses.gpl3;
     maintainers = [ maintainers.linarcx ];

--- a/pkgs/tools/networking/quickserve/default.nix
+++ b/pkgs/tools/networking/quickserve/default.nix
@@ -27,7 +27,7 @@ in stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    description = "A simple HTTP server for quickly sharing files.";
+    description = "A simple HTTP server for quickly sharing files";
     homepage = "https://xyne.archlinux.ca/projects/quickserve/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ lassulus ];

--- a/pkgs/tools/networking/radsecproxy/default.nix
+++ b/pkgs/tools/networking/radsecproxy/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://software.nordu.net/radsecproxy/";
-    description = "A generic RADIUS proxy that supports both UDP and TLS (RadSec) RADIUS transports.";
+    description = "A generic RADIUS proxy that supports both UDP and TLS (RadSec) RADIUS transports";
     license = licenses.bsd3;
     maintainers = with maintainers; [ sargon ];
     platforms = with platforms; linux;

--- a/pkgs/tools/networking/tcptraceroute/default.nix
+++ b/pkgs/tools/networking/tcptraceroute/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
    buildInputs = [ libpcap libnet ];
 
    meta = {
-     description = "A traceroute implementation using TCP packets.";
+     description = "A traceroute implementation using TCP packets";
      homepage = "https://github.com/mct/tcptraceroute";
      license = stdenv.lib.licenses.gpl2;
      maintainers = [ ];

--- a/pkgs/tools/networking/tendermint/default.nix
+++ b/pkgs/tools/networking/tendermint/default.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
   buildFlagsArray = [ "-ldflags=-s -w -X github.com/tendermint/tendermint/version.GitCommit=${src.rev}" ];
 
   meta = with stdenv.lib; {
-    description = "Byzantine-Fault Tolerant State Machines. Or Blockchain, for short.";
+    description = "Byzantine-Fault Tolerant State Machines. Or Blockchain, for short";
     homepage = "https://tendermint.com/";
     license = licenses.asl20;
     maintainers = with maintainers; [ alexfmpe ];

--- a/pkgs/tools/nix/nix-script/default.nix
+++ b/pkgs/tools/nix/nix-script/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    description = "A shebang for running inside nix-shell.";
+    description = "A shebang for running inside nix-shell";
     homepage    = "https://github.com/bennofs/nix-script";
     license     = licenses.bsd3;
     maintainers = with maintainers; [ bennofs rnhmjoj ];

--- a/pkgs/tools/package-management/elm-github-install/default.nix
+++ b/pkgs/tools/package-management/elm-github-install/default.nix
@@ -12,7 +12,7 @@ bundlerEnv rec {
   passthru.updateScript = bundlerUpdateScript "elm-github-install";
 
   meta = with lib; {
-    description = "Install Elm packages from git repositories.";
+    description = "Install Elm packages from git repositories";
     homepage    = "https://github.com/gdotdesign/elm-github-install";
     license     = licenses.unfree;
     maintainers = with maintainers; [ roberth nicknovitski ];

--- a/pkgs/tools/package-management/morph/default.nix
+++ b/pkgs/tools/package-management/morph/default.nix
@@ -35,7 +35,7 @@ buildGoPackage rec {
   outputs = [ "out" "lib" ];
 
   meta = with lib; {
-    description = "Morph is a NixOS host manager written in Golang.";
+    description = "Morph is a NixOS host manager written in Golang";
     license = licenses.mit;
     homepage = "https://github.com/dbcdk/morph";
     maintainers = with maintainers; [adamt johanot];

--- a/pkgs/tools/package-management/mynewt-newt/default.nix
+++ b/pkgs/tools/package-management/mynewt-newt/default.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
 
   meta = with stdenv.lib; {
     homepage = "https://mynewt.apache.org/";
-    description = "Build and package management tool for embedded development.";
+    description = "Build and package management tool for embedded development";
     longDescription = ''
       Apache Newt is a smart build and package management tool,
       designed for C and C++ applications in embedded contexts. Newt

--- a/pkgs/tools/security/acsccid/default.nix
+++ b/pkgs/tools/security/acsccid/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "acsccid is a PC/SC driver for Linux/Mac OS X and it supports ACS CCID smart card readers.";
+    description = "acsccid is a PC/SC driver for Linux/Mac OS X and it supports ACS CCID smart card readers";
     longDescription = ''
       acsccid is a PC/SC driver for Linux/Mac OS X and it supports ACS CCID smart card
       readers. This library provides a PC/SC IFD handler implementation and

--- a/pkgs/tools/security/ecdsatool/default.nix
+++ b/pkgs/tools/security/ecdsatool/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   buildInputs = with pkgs; [libuecc];
 
   meta = with stdenv.lib; {
-    description = "Create and manipulate ECC NISTP256 keypairs.";
+    description = "Create and manipulate ECC NISTP256 keypairs";
     homepage = "https://github.com/kaniini/ecdsatool/";
     license = with licenses; [free];
     platforms = platforms.unix;

--- a/pkgs/tools/security/fpm2/default.nix
+++ b/pkgs/tools/security/fpm2/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gnupg gtk2 libxml2 intltool ];
 
   meta = {
-    description = "FPM2 is GTK2 port from Figaro's Password Manager originally developed by John Conneely, with some new enhancements.";
+    description = "FPM2 is GTK2 port from Figaro's Password Manager originally developed by John Conneely, with some new enhancements";
     homepage    = "https://als.regnet.cz/fpm2/";
     license     = licenses.gpl2;
     platforms   = platforms.linux;

--- a/pkgs/tools/security/genpass/default.nix
+++ b/pkgs/tools/security/genpass/default.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation libiconv Security ];
 
   meta = with stdenv.lib; {
-    description = "A simple yet robust commandline random password generator.";
+    description = "A simple yet robust commandline random password generator";
     homepage = "https://github.com/cyplo/genpass";
     license = licenses.agpl3;
     maintainers = with maintainers; [ cyplo ];

--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -54,7 +54,7 @@ buildGoModule rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "The slightly more awesome Standard Unix Password Manager for Teams. Written in Go.";
+    description = "The slightly more awesome Standard Unix Password Manager for Teams. Written in Go";
     homepage = "https://www.gopass.pw/";
     license = licenses.mit;
     maintainers = with maintainers; [ andir rvolosatovs ];

--- a/pkgs/tools/security/hashdeep/default.nix
+++ b/pkgs/tools/security/hashdeep/default.nix
@@ -14,7 +14,7 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook ];
 
   meta = with stdenv.lib; {
-    description = "A set of cross-platform tools to compute hashes.";
+    description = "A set of cross-platform tools to compute hashes";
     homepage = "https://github.com/jessek/hashdeep";
     license = licenses.gpl2;
     platforms = with platforms; linux ++ freebsd ++ openbsd;

--- a/pkgs/tools/security/hologram/default.nix
+++ b/pkgs/tools/security/hologram/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/AdRoll/hologram/";
-    description = "Easy, painless AWS credentials on developer laptops.";
+    description = "Easy, painless AWS credentials on developer laptops";
     maintainers = with maintainers; [ nand0p ];
     license = licenses.asl20;
   };

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -33,7 +33,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     homepage = "https://www.keybase.io/";
-    description = "The Keybase official command-line utility and service.";
+    description = "The Keybase official command-line utility and service";
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ avaq carlsverre np rvolosatovs filalex77 ];
     license = licenses.bsd3;

--- a/pkgs/tools/security/minica/default.nix
+++ b/pkgs/tools/security/minica/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
   '';
 
   meta = with lib; {
-    description = "A simple tool for generating self signed certificates.";
+    description = "A simple tool for generating self signed certificates";
     longDescription = ''
       Minica is a simple CA intended for use in situations where the CA
       operator also operates each host where a certificate will be used. It

--- a/pkgs/tools/security/zzuf/default.nix
+++ b/pkgs/tools/security/zzuf/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   preConfigure = "./bootstrap";
 
   meta = with stdenv.lib; {
-    description = "Transparent application input fuzzer.";
+    description = "Transparent application input fuzzer";
     homepage = "http://caca.zoy.org/wiki/zzuf";
     license = licenses.wtfpl;
     platforms = platforms.linux;

--- a/pkgs/tools/system/incron/default.nix
+++ b/pkgs/tools/system/incron/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A cron-like daemon which handles filesystem events.";
+    description = "A cron-like daemon which handles filesystem events";
     homepage = "https://github.com/ar-/incron";
     license = licenses.gpl2;
     maintainers = [ maintainers.aanderse ];

--- a/pkgs/tools/system/jump/default.nix
+++ b/pkgs/tools/system/jump/default.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "Jump helps you navigate faster by learning your habits.";
+    description = "Jump helps you navigate faster by learning your habits";
     longDescription = ''
       Jump integrates with the shell and learns about your
       navigational habits by keeping track of the directories you visit. It

--- a/pkgs/tools/system/pcstat/default.nix
+++ b/pkgs/tools/system/pcstat/default.nix
@@ -16,7 +16,7 @@ buildGoPackage {
   goDeps = ./deps.nix;
 
   meta = with stdenv.lib; {
-    description = "Page Cache stat: get page cache stats for files on Linux.";
+    description = "Page Cache stat: get page cache stats for files on Linux";
     homepage = "https://github.com/tobert/pcstat";
     license = licenses.asl20;
     maintainers = with maintainers; [ aminechikhaoui ];

--- a/pkgs/tools/text/miller/default.nix
+++ b/pkgs/tools/text/miller/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook flex libtool ];
 
   meta = with stdenv.lib; {
-    description = "Miller is like awk, sed, cut, join, and sort for name-indexed data such as CSV, TSV, and tabular JSON.";
+    description = "Miller is like awk, sed, cut, join, and sort for name-indexed data such as CSV, TSV, and tabular JSON";
     homepage    = "http://johnkerl.org/miller/";
     license     = licenses.bsd2;
     maintainers = with maintainers; [ mstarzyk ];

--- a/pkgs/tools/text/platinum-searcher/default.nix
+++ b/pkgs/tools/text/platinum-searcher/default.nix
@@ -18,7 +18,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/monochromegane/the_platinum_searcher";
-    description = "A code search tool similar to ack and the_silver_searcher(ag).";
+    description = "A code search tool similar to ack and the_silver_searcher(ag)";
     license = licenses.mit;
   };
 }

--- a/pkgs/tools/typesetting/docbookrx/default.nix
+++ b/pkgs/tools/typesetting/docbookrx/default.nix
@@ -48,7 +48,7 @@ in stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "(An early version of) a DocBook to AsciiDoc converter written in Ruby.";
+    description = "(An early version of) a DocBook to AsciiDoc converter written in Ruby";
     homepage = "https://asciidoctor.org/";
     license = licenses.mit;
     maintainers = with maintainers; [ ];

--- a/pkgs/tools/typesetting/kramdown-asciidoc/default.nix
+++ b/pkgs/tools/typesetting/kramdown-asciidoc/default.nix
@@ -26,7 +26,7 @@ let
     # };
 
     meta = with lib; {
-      description = "A kramdown extension for converting Markdown documents to AsciiDoc.";
+      description = "A kramdown extension for converting Markdown documents to AsciiDoc";
       homepage = "https://asciidoctor.org/";
       license = licenses.mit;
       maintainers = with maintainers; [ ];

--- a/pkgs/tools/virtualization/cloudmonkey/default.nix
+++ b/pkgs/tools/virtualization/cloudmonkey/default.nix
@@ -16,7 +16,7 @@ buildPythonApplication rec {
   };
 
   meta = with lib; {
-    description = "CLI for Apache CloudStack.";
+    description = "CLI for Apache CloudStack";
     homepage = "https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+cloudmonkey+CLI";
     license = [ licenses.asl20 ];
     maintainers = [ maintainers.womfoo ];


### PR DESCRIPTION
###### Motivation for this change
Addresses #97685

###### Things done
Got the list of packages to fix with a Nix script (see #97685), then went over the paths with an `awk` file;

```awk
{ system("sed --in-place='' -re 's#(description\\s*=\\s*\".+)\\.\"#\\1\"#' " $0)}
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
