### PR TITLE
pythonPackages.cfn-lint: 0.35.0 -> 0.35.1

### DIFF
--- a/pkgs/development/python-modules/cfn-lint/default.nix
+++ b/pkgs/development/python-modules/cfn-lint/default.nix
@@ -1,28 +1,34 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pythonOlder
-, pyyaml
-, six
-, requests
 , aws-sam-translator
 , importlib-metadata
 , importlib-resources
 , jsonpatch
 , jsonschema
-, pathlib2
-, setuptools
 , junit-xml
 , networkx
+, pathlib2
+, pyyaml
+, requests
+, setuptools
+, six
+# Test inputs
+, pytestCheckHook
+, mock
+, pydot
 }:
 
 buildPythonPackage rec {
   pname = "cfn-lint";
-  version = "0.35.0";
+  version = "0.35.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "42023d89520e3a29891ec2eb4c326eef9d1f7516fe9abee8b6c97ce064187b45";
+  src = fetchFromGitHub {
+    owner = "aws-cloudformation";
+    repo  = "cfn-python-lint";
+    rev = "v${version}";
+    sha256 = "1ajb0412hw9fg9m4b3xbpfbp8cixmnpjxrkaks6k749xinzsv7qk";
   };
 
   postPatch = ''
@@ -30,20 +36,18 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
-    pyyaml
-    six
-    requests
     aws-sam-translator
     jsonpatch
     jsonschema
-    pathlib2
-    setuptools
     junit-xml
     networkx
+    pathlib2
+    pyyaml
+    requests
+    setuptools
+    six
   ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata importlib-resources ];
 
-  # No tests included in archive
-  doCheck = false;
   pythonImportsCheck = [
     "cfnlint"
     "cfnlint.conditions"
@@ -60,9 +64,13 @@ buildPythonPackage rec {
     "cfnlint.transform"
   ];
 
+  checkInputs = [ pytestCheckHook mock pydot ];
+  preCheck = "export PATH=$out/bin:$PATH";
+
   meta = with lib; {
     description = "Checks cloudformation for practices and behaviour that could potentially be improved";
     homepage = "https://github.com/aws-cloudformation/cfn-python-lint";
+    changelog = "https://github.com/aws-cloudformation/cfn-python-lint/blob/master/CHANGELOG.md";
     license = licenses.mit;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Follow-on that I cleaned up while testing #97762. <strike>That one should be merged first, b/c it's for ZHF.</strike>

* Update version
* Cleanup packaging: run tests & use GitHub source
* Meta: add changelog

Changelog: https://github.com/aws-cloudformation/cfn-python-lint/blob/master/CHANGELOG.md


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
