### PR TITLE
python27Packages.anytree: fix build

### DIFF
--- a/pkgs/development/python-modules/anytree/default.nix
+++ b/pkgs/development/python-modules/anytree/default.nix
@@ -1,13 +1,15 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , substituteAll
-, fetchpatch
-, nose
 , six
 , withGraphviz ? true
 , graphviz
 , fontconfig
+# Tests
+, pytestCheckHook
+, nose
 }:
 
 buildPythonPackage rec {
@@ -26,10 +28,6 @@ buildPythonPackage rec {
     })
   ];
 
-  checkInputs = [
-    nose
-  ];
-
   propagatedBuildInputs = [
     six
   ];
@@ -42,13 +40,13 @@ buildPythonPackage rec {
   # circular dependency anytree → graphviz → pango → glib → gtk-doc → anytree
   doCheck = withGraphviz;
 
-  checkPhase = ''
-    runHook preCheck
+  checkInputs = [ pytestCheckHook nose ];
 
-    nosetests
-
-    runHook postCheck
-  '';
+  pytestFlagsArray = lib.optionals (pythonOlder "3.4") [
+    # Use enums, which aren't available pre-python3.4
+    "--ignore=tests/test_resolver.py"
+    "--ignore=tests/test_search.py"
+  ];
 
   meta = with lib; {
     description = "Powerful and Lightweight Python Tree Data Structure";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF: #97479 

Tests fail on python2.7 b/c the tests use enums (python 3.4+).
Follow-on from closed #97761.
Converts tests to use pytestCheckHook for easier test disabling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
