### PR TITLE
python3Packages.websockets: make tests deterministic

### DIFF
--- a/pkgs/development/python-modules/websockets/default.nix
+++ b/pkgs/development/python-modules/websockets/default.nix
@@ -22,6 +22,13 @@ buildPythonPackage rec {
   # Tests fail on Darwin with `OSError: AF_UNIX path too long`
   doCheck = !stdenv.isDarwin;
 
+  # Disable all tests that need to terminate within a predetermined amount of
+  # time.  This is nondeterministic.
+  patchPhase = ''
+    sed -i 's/with self.assertCompletesWithin.*:/if True:/' \
+      tests/test_protocol.py
+  '';
+
   meta = with lib; {
     description = "WebSocket implementation in Python 3";
     homepage = "https://github.com/aaugustin/websockets";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The tests fail on my raspberry pi:
```
FAIL: test_local_close_connection_lost_timeout_after_close (tests.test_protocol.ClientTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/source/tests/test_protocol.py", line 1474, in test_local_close_connection_lost_timeout_after_close
    self.loop.run_until_complete(self.protocol.close(reason="close"))
  File "/nix/store/rsyk9hlvxlpiy6g5riz937lk2jjq5fnf-python3-3.8.5/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/build/source/tests/test_protocol.py", line 300, in assertCompletesWithin
    self.assertLess(dt, max_time, f"Too slow: {dt} >= {max_time}")
AssertionError: 0.03923745600059192 not less than 0.039 : Too slow: 0.03923745600059192 >= 0.039
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
