### PR TITLE
twemoji-color-font: fix build with Inkscape 1

### DIFF
--- a/pkgs/data/fonts/emojione/default.nix
+++ b/pkgs/data/fonts/emojione/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, inkscape, imagemagick, potrace, svgo, scfbuild }:
+{ stdenv, fetchFromGitHub, fetchpatch, inkscape, imagemagick, potrace, svgo, scfbuild }:
 
 stdenv.mkDerivation rec {
   pname = "emojione";
@@ -10,6 +10,22 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1781kxfbhnvylypbkwxc3mx6hi0gcjisfjr9cf0jdz4d1zkf09b3";
   };
+
+  patches = [
+    # Fix build with Inkscape 1.0
+    # https://github.com/eosrei/twemoji-color-font/pull/82
+    (fetchpatch {
+      url = "https://github.com/eosrei/twemoji-color-font/commit/208ad63c2ceb38c528b5237abeb2b85ceedc1d37.patch";
+      sha256 = "7tDWIkpcdir1V6skgXSM3r0FwHy0F6PyJ07OPRsSStA=";
+      postFetch = ''
+        substituteInPlace $out \
+          --replace "inkscape --without-gui" "inkscape --export-png" \
+          --replace TWEMOJI EMOJIONE \
+          --replace "the assets" "the emojione assets" \
+          --replace twemoji emojione
+      '';
+    })
+  ];
 
   preBuild = ''
     sed -i 's,SCFBUILD :=.*,SCFBUILD := scfbuild,' Makefile

--- a/pkgs/data/fonts/twemoji-color-font/default.nix
+++ b/pkgs/data/fonts/twemoji-color-font/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, inkscape, imagemagick, potrace, svgo, scfbuild }:
+{ stdenv, fetchFromGitHub, fetchpatch, inkscape, imagemagick, potrace, svgo, scfbuild }:
 
 stdenv.mkDerivation rec {
   pname = "twemoji-color-font";
@@ -9,6 +9,19 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "00pbgqpkq21wl8fs0q1xp49xb10m48b9sz8cdc58flkd2vqfssw2";
   };
+
+  patches = [
+    # Fix build with Inkscape 1.0
+    # https://github.com/eosrei/twemoji-color-font/pull/82
+    (fetchpatch {
+      url = "https://github.com/eosrei/twemoji-color-font/commit/208ad63c2ceb38c528b5237abeb2b85ceedc1d37.patch";
+      sha256 = "TV8I++BEnVUQg7FNbnrEQ/MLV9n3drmspqjmDZgTGFI=";
+      postFetch = ''
+        substituteInPlace $out \
+          --replace "inkscape --without-gui" "inkscape --export-png"
+      '';
+    })
+  ];
 
   nativeBuildInputs = [ inkscape imagemagick potrace svgo scfbuild ];
   # silence inkscape errors about non-writable home


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Partial fix for https://github.com/NixOS/nixpkgs/issues/86930

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
