### PR TITLE
shadowfox: Add ldflags

### DIFF
--- a/pkgs/tools/networking/shadowfox/default.nix
+++ b/pkgs/tools/networking/shadowfox/default.nix
@@ -15,7 +15,9 @@ buildGoModule rec {
 
   doCheck = false;
 
-  buildFlags = [ "--tags" "release" ];
+  buildFlagsArray = [
+    "-ldflags=-X main.tag=v${version}"
+  ];
 
   meta = with stdenv.lib; {
     description = ''


### PR DESCRIPTION
shadowfox-updater compares the version of itself with that of the latest
version released upon startup. If it doesn't know it's own version, this
comparison always falsely leads to it suggesting the user to update it
upon startup, where in fact it is updated. This is a confusing behavior
only NixOS users suffer and now it's solved.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
