### PR TITLE
home-assistant: drop protobuf override

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -35,13 +35,6 @@ let
     (mkOverride "bcrypt" "3.1.7"
       "0hhywhxx301cxivgxrpslrangbfpccc8y83qbwn1f57cab3nj00b")
 
-    # required by aioesphomeapi
-    (self: super: {
-      protobuf = super.protobuf.override {
-        protobuf = protobuf3_6;
-      };
-    })
-
     # hass-frontend does not exist in python3.pkgs
     (self: super: {
       hass-frontend = self.callPackage ./frontend.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The aioesphome library was updated in d49fc3600efc56bd557bc3ea5ff867330dabae5f and that requires a newer protobuf version. So let's drop the override in home-assistant.

```
Requirement already satisfied: zeroconf<1.0,>=0.28.0 in /nix/store/5m4yrsfh12pfz07p2c4jdx7j27bv5j0z-python3.8-zeroconf-0.28.2/lib/python3.8/site-packages (from aioesphomeapi==2.6.3) (0.28.2)
ERROR: Could not find a version that satisfies the requirement protobuf<4.0,>=3.12.2 (from aioesphomeapi==2.6.3) (from versions: none)
ERROR: No matching distribution found for protobuf<4.0,>=3.12.2 (from aioesphomeapi==2.6.3)
```

**Untested**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
