### PR TITLE
Use U-Boot for the Raspberry Pi 4-specific image

### DIFF
--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
@@ -17,8 +17,7 @@
   # The serial ports listed here are:
   # - ttyS0: for Tegra (Jetson TX1)
   # - ttyAMA0: for QEMU's -machine virt
-  # Also increase the amount of CMA to ensure the virtual console on the RPi3 works.
-  boot.kernelParams = ["cma=32M" "console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
+  boot.kernelParams = ["console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
 
   boot.initrd.availableKernelModules = [
     # Allows early (earlier) modesetting for the Raspberry Pi

--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
@@ -30,13 +30,25 @@
   sdImage = {
     populateFirmwareCommands = let
       configTxt = pkgs.writeText "config.txt" ''
+        [pi3]
         kernel=u-boot-rpi3.bin
 
+        [pi4]
+        kernel=u-boot-rpi4.bin
+        enable_gic=1
+        armstub=armstub8-gic.bin
+
+        # Otherwise the resolution will be weird in most cases, compared to
+        # what the pi3 firmware does by default.
+        disable_overscan=1
+
+        [all]
         # Boot in 64-bit mode.
         arm_64bit=1
 
-        # U-Boot used to need this to work, regardless of whether UART is actually used or not.
-        # TODO: check when/if this can be removed.
+        # U-Boot needs this to work, regardless of whether UART is actually used or not.
+        # Look in arch/arm/mach-bcm283x/Kconfig in the U-Boot tree to see if this is still
+        # a requirement in the future.
         enable_uart=1
 
         # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
@@ -45,8 +57,17 @@
       '';
       in ''
         (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
-        cp ${pkgs.ubootRaspberryPi3_64bit}/u-boot.bin firmware/u-boot-rpi3.bin
+
+        # Add the config
         cp ${configTxt} firmware/config.txt
+
+        # Add pi3 specific files
+        cp ${pkgs.ubootRaspberryPi3_64bit}/u-boot.bin firmware/u-boot-rpi3.bin
+
+        # Add pi4 specific files
+        cp ${pkgs.ubootRaspberryPi4_64bit}/u-boot.bin firmware/u-boot-rpi4.bin
+        cp ${pkgs.raspberrypi-armstubs}/armstub8-gic.bin firmware/armstub8-gic.bin
+        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-4-b.dtb firmware/
       '';
     populateRootCommands = ''
       mkdir -p ./files/boot

--- a/nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix
@@ -3,36 +3,6 @@
 { config, lib, pkgs, ... }:
 
 {
-  imports = [
-    ../../profiles/base.nix
-    ../../profiles/installation-device.nix
-    ./sd-image.nix
-  ];
-
-  boot.loader.grub.enable = false;
-  boot.loader.raspberryPi.enable = true;
-  boot.loader.raspberryPi.version = 4;
+  imports = [ ./sd-image-aarch64.nix ];
   boot.kernelPackages = pkgs.linuxPackages_rpi4;
-
-  boot.consoleLogLevel = lib.mkDefault 7;
-
-  sdImage = {
-    firmwareSize = 128;
-    firmwarePartitionName = "NIXOS_BOOT";
-    # This is a hack to avoid replicating config.txt from boot.loader.raspberryPi
-    populateFirmwareCommands =
-      "${config.system.build.installBootLoader} ${config.system.build.toplevel} -d ./firmware";
-    # As the boot process is done entirely in the firmware partition.
-    populateRootCommands = "";
-  };
-
-  fileSystems."/boot/firmware" = {
-    # This effectively "renames" the attrsOf entry set in sd-image.nix
-    mountPoint = "/boot";
-    neededForBoot = true;
-  };
-
-  # the installation media is also the installation target,
-  # so we don't want to provide the installation configuration.nix.
-  installer.cloneConfig = false;
 }

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -314,6 +314,18 @@ in {
     filesToInstall = ["u-boot.bin"];
   };
 
+  ubootRaspberryPi4_32bit = buildUBoot {
+    defconfig = "rpi_4_32b_defconfig";
+    extraMeta.platforms = ["armv7l-linux"];
+    filesToInstall = ["u-boot.bin"];
+  };
+
+  ubootRaspberryPi4_64bit = buildUBoot {
+    defconfig = "rpi_4_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    filesToInstall = ["u-boot.bin"];
+  };
+
   ubootRaspberryPiZero = buildUBoot {
     defconfig = "rpi_0_w_defconfig";
     extraMeta.platforms = ["armv6l-linux"];

--- a/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig }:
+
+let
+  inherit (stdenv.lib) optionals;
+in
+stdenv.mkDerivation {
+  pname = "raspberrypi-armstubs";
+  version = "2020-10-08";
+
+  src = fetchFromGitHub {
+    owner = "raspberrypi";
+    repo = "tools";
+    rev = "fc0e73c13865450e95edd046200e42a6e52d8256";
+    sha256 = "1g6ikpjcrm5x0rk5aiwjdd8grf997qkvgamcrdxy6k9ln746h25s";
+  };
+
+  NIX_CFLAGS_COMPILE = [
+    "-march=armv8-a+crc"
+  ];
+
+  preConfigure = ''
+    cd armstubs
+  '';
+
+  makeFlags = [
+    "CC8=${stdenv.cc.targetPrefix}cc"
+    "LD8=${stdenv.cc.targetPrefix}ld"
+    "OBJCOPY8=${stdenv.cc.targetPrefix}objcopy"
+    "OBJDUMP8=${stdenv.cc.targetPrefix}objdump"
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "LD=${stdenv.cc.targetPrefix}ld"
+    "OBJCOPY=${stdenv.cc.targetPrefix}objcopy"
+    "OBJDUMP=${stdenv.cc.targetPrefix}objdump"
+  ]
+  ++ optionals (stdenv.isAarch64) [ "armstub8.bin" "armstub8-gic.bin" ]
+  ++ optionals (stdenv.isAarch32) [ "armstub7.bin" "armstub8-32.bin" "armstub8-32-gic.bin" ]
+  ;
+
+  installPhase = ''
+    mkdir -vp $out/
+    cp -v *.bin $out/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Firmware related ARM stubs for the Raspberry Pi";
+    homepage = https://github.com/raspberrypi/tools;
+    license = licenses.bsd3;
+    platforms = [ "armv6l-linux" "armv7l-linux" "aarch64-linux" ];
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -819,6 +819,12 @@ let
 
       # See comments on https://github.com/NixOS/nixpkgs/commit/9b67ea9106102d882f53d62890468071900b9647
       CRYPTO_AEGIS128_SIMD = whenAtLeast "5.4" no;
+
+      # Distros should configure the default as a kernel option.
+      # We previously defined it on the kernel command line as cma=
+      # The kernel command line will override a platform-specific configuration from its device tree.
+      # https://github.com/torvalds/linux/blob/856deb866d16e29bd65952e0289066f6078af773/kernel/dma/contiguous.c#L35-L44
+      CMA_SIZE_MBYTES = freeform "32";
     };
   };
 in

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19396,6 +19396,8 @@ in
     ubootRaspberryPi2
     ubootRaspberryPi3_32bit
     ubootRaspberryPi3_64bit
+    ubootRaspberryPi4_32bit
+    ubootRaspberryPi4_64bit
     ubootRaspberryPiZero
     ubootRock64
     ubootRockPi4

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19209,6 +19209,8 @@ in
 
   raspberrypi-eeprom = callPackage ../os-specific/linux/raspberrypi-eeprom {};
 
+  raspberrypi-armstubs = callPackage ../os-specific/linux/firmware/raspberrypi/armstubs.nix {};
+
   regionset = callPackage ../os-specific/linux/regionset { };
 
   rfkill_udev = callPackage ../os-specific/linux/rfkill/udev.nix { };


### PR DESCRIPTION
This is part of the effort to slowly move the Raspberry Pi 4 support to the mainline-based generic AArch64 image.

With this change, the image is now structurally compatible with the mainline AArch64 image. This means that when mainline Linux has been verified to work on the Raspberry Pi 4 enough for the end-user to gain a foothold into ARM-land, we can finally remove the Raspberry Pi 4-specific SD image.

The idea being that if mainline is not working well enough for specific use cases, or incompatible with the Raspberry Pi Foundation's ecosystem of hardware, drivers and software, the user now has the ability to either switch the running kernel and rebuild, or even now build AArch64 packages. The Raspberry Pi 4 might be that user's first and only way to build AArch64 things!

With this change, we should be able to somewhat reduce the difficulties in supporting, and answering questions about the Raspberry Pi 4. It should work, structurally speaking, just like the Raspberry Pi 3 images.

One last change, for the rpi-5.4.y kernel branch, we need to drop the `cma=` parameter from the kernel command line. The kernel command line takes precedence from the pre-configured CMA set in the FDT; which in turn allocates in an area that VC cannot read. The pre-configured CMA value works just fine. Using the configuration option (1) clears up the kernel command-line a bit, and (2) fixes that issue since it has lower precedence.

This includes changes from:

 * Closes #97258 by including the commit directly (Thanks! @Luflosi)
 * Closes #70796 by being basically the same change (oops)
 * Closes #97732 by integrating its (fixed) changes

**This changes nothing for existing Raspberry Pi 4B users.** Only images made from the moment this change lands are going to be different.

Should this get backported? Well, the main part of this PR, changing to U-Boot for the Raspberry Pi 4 image, does not apply as there is no Raspberry Pi 4 image on stable. The kernel update might be relevant, but might bring breaking changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc #63720
