### PR TITLE
Shell programming hygiene

### DIFF
--- a/pkgs/applications/editors/vscode/update.sh
+++ b/pkgs/applications/editors/vscode/update.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p curl gnugrep gnused gawk
 
+set -eou pipefail
+
 ROOT="$(dirname "$(readlink -f "$0")")"
 if [ ! -f "$ROOT/vscode.nix" ]; then
   echo "ERROR: cannot find vscode.nix in $ROOT"


### PR DESCRIPTION
This was brought about because of https://github.com/VSCodium/vscodium/issues/501.

Previously:
```
applications/editors/vscode on  master [⇣!] 
❯ ./update.sh                                                                                              
[87.6 MiB DL]
path is '/nix/store/1fvwx7p6bi34aafqwm32a184dj97s4rf-stable'
[91.0 MiB DL]
path is '/nix/store/yqdd15w09hzvw5galfkrnmyf084lyxzb-stable'
[93.0 MiB DL]
path is '/nix/store/wr4g4lhhlfqdbwsblsnlpaf8sc79g5vd-VSCodium-linux-x64-1.49.0.tar.gz'
[0.0 MiB DL]
error: unable to download 'https://github.com/VSCodium/vscodium/releases/download/1.49.0/VSCodium-darwin-1.49.0.zip': HTTP error 404

applications/editors/vscode on  master [⇣!] took 1m35s 
❯ echo $?    
0
```

And after this PR:
```
applications/editors/vscode on  master [⇣!] 
❯ ./update.sh                                                                                              
[87.6 MiB DL]
path is '/nix/store/1fvwx7p6bi34aafqwm32a184dj97s4rf-stable'
[91.0 MiB DL]
path is '/nix/store/yqdd15w09hzvw5galfkrnmyf084lyxzb-stable'
[93.0 MiB DL]
path is '/nix/store/wr4g4lhhlfqdbwsblsnlpaf8sc79g5vd-VSCodium-linux-x64-1.49.0.tar.gz'
[0.0 MiB DL]
error: unable to download 'https://github.com/VSCodium/vscodium/releases/download/1.49.0/VSCodium-darwin-1.49.0.zip': HTTP error 404

applications/editors/vscode on  master [⇣!] took 1m35s 
❯ echo $?    
1
```