### PR TITLE
hop: 2.5.1 → 3.3.0

### DIFF
--- a/pkgs/development/compilers/bigloo/default.nix
+++ b/pkgs/development/compilers/bigloo/default.nix
@@ -1,17 +1,29 @@
-{ fetchurl, stdenv, gmp }:
+{ fetchurl, stdenv, autoconf, automake, libtool, gmp
+, darwin
+}:
 
 stdenv.mkDerivation rec {
   pname = "bigloo";
-  version = "4.1a-2";
+  version = "4.3h";
 
   src = fetchurl {
-    url = "ftp://ftp-sop.inria.fr/indes/fp/Bigloo/bigloo${version}.tar.gz";
-    sha256 = "09yrz8r0jpj7bda39fdxzrrdyhi851nlfajsyf0b6jxanz6ygcjx";
+    url = "ftp://ftp-sop.inria.fr/indes/fp/Bigloo/bigloo-${version}.tar.gz";
+    sha256 = "0fw08096sf8ma2cncipnidnysxii0h0pc7kcqkjhkhdchknp8vig";
   };
+
+  nativeBuildInputs = [ autoconf automake libtool ];
+
+  buildInputs = stdenv.lib.optional stdenv.isDarwin
+    darwin.apple_sdk.frameworks.ApplicationServices
+  ;
 
   propagatedBuildInputs = [ gmp ];
 
   preConfigure =
+    # For libuv on darwin
+    stdenv.lib.optionalString stdenv.isDarwin ''
+      export LIBTOOLIZE=libtoolize
+    '' +
     # Help libgc's configure.
     '' export CXXCPP="$CXX -E"
     '';

--- a/pkgs/development/compilers/hop/default.nix
+++ b/pkgs/development/compilers/hop/default.nix
@@ -7,6 +7,10 @@ stdenv.mkDerivation rec {
     sha256 = "1bvp7pc71bln5yvfj87s8750c6l53wjl6f8m12v62q9926adhwys";
   };
 
+  postPatch = ''
+    substituteInPlace configure --replace "(os-tmp)" '(getenv "TMPDIR")'
+  '';
+
   buildInputs = [ bigloo ];
 
   preConfigure = ''

--- a/pkgs/development/compilers/hop/default.nix
+++ b/pkgs/development/compilers/hop/default.nix
@@ -1,10 +1,16 @@
 { stdenv, fetchurl, bigloo }:
 
+# Compute the “release” version of bigloo (before the first dash, if any)
+let bigloo-release =
+  let inherit (stdenv.lib) head splitString; in
+  head (splitString "-" (builtins.parseDrvName bigloo.name).version)
+; in
+
 stdenv.mkDerivation rec {
-  name = "hop-2.5.1";
+  name = "hop-3.3.0";
   src = fetchurl {
     url = "ftp://ftp-sop.inria.fr/indes/fp/Hop/${name}.tar.gz";
-    sha256 = "1bvp7pc71bln5yvfj87s8750c6l53wjl6f8m12v62q9926adhwys";
+    sha256 = "14gf9ihmw95zdnxsqhn5jymfivpfq5cg9v0y7yjd5i7c787dncp5";
   };
 
   postPatch = ''
@@ -13,13 +19,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ bigloo ];
 
-  preConfigure = ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -lbigloogc-4.1a";
-  '';
-
   configureFlags = [
     "--bigloo=${bigloo}/bin/bigloo"
-    "--bigloolibdir=${bigloo}/lib/bigloo/4.1a/"
+    "--bigloolibdir=${bigloo}/lib/bigloo/${bigloo-release}/"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
This fixes the build of Hop and then updates it to the most recent version (along with the tightly coupled bigloo compiler).

###### Motivation for this change

Hop is currently broken.

ZHF: #97479

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @thoughtpolice maintainer of bigloo