### PR TITLE
hacksaw: init as 1.0.4

### DIFF
--- a/pkgs/tools/misc/hacksaw/default.nix
+++ b/pkgs/tools/misc/hacksaw/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchCrate, rustPlatform, pkg-config, libXrandr, libX11, python3 }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hacksaw";
+  version = "1.0.4";
+
+  nativeBuildInputs = [ pkg-config python3 ];
+
+  buildInputs = [ libXrandr libX11 ];
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "1l6i91xb81p1li1j2jm0r2rx8dbzl2yh468cl3dw0lqpqy4i65hx";
+  };
+
+  cargoSha256 = "01draql3x71h7xl2xcc69dv7vpi3smnajhrvaihs5vij81pyfrzk";
+
+  meta = with lib; {
+    description = "Lightweight selection tool for usage in screenshot scripts etc.";
+    homepage = "https://github.com/neXromancers/hacksaw";
+    license = with licenses; [ mpl20 ];
+    maintainers = with maintainers; [ TethysSvensson ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20914,6 +20914,8 @@ in
 
   hackrf = callPackage ../applications/radio/hackrf { };
 
+  hacksaw = callPackage ../tools/misc/hacksaw {};
+
   hakuneko = callPackage ../tools/misc/hakuneko { };
 
   hamster = callPackage ../applications/misc/hamster { };


### PR DESCRIPTION
##### Motivation for this change

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
