### PR TITLE
 thunderbird, thunderbird-bin: 78.2.1 -> 78.2.2 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.2.1";
+  version = "78.2.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/af/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/af/thunderbird-78.2.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "de73b113e488e76caca47b90abb4fa3f1c4d6ce04885d036f2e6aed81fe34038";
+      sha256 = "12d8b417fe101e45460b66faa04e0c99bacd454b563c96b7bd7d5b77cabb8f2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ar/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/ar/thunderbird-78.2.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "d6eeb95b1bd8e53663bd48570a0c2a03f570f906ca715ddf1d9f2cb8de37f3b7";
+      sha256 = "1fa7a01cd370114ce9dc65c2d48e001d6969f953ba138fc4005329b2fce7f1fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ast/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/ast/thunderbird-78.2.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "f244c41515a2382d15697a47b88781120c649e319d86a1c6350fd20cade25809";
+      sha256 = "c002ba6b4cded5b085abfad61daccad36a7936af40eacf77e4378caff42f9138";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/be/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/be/thunderbird-78.2.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "188c8850324bbc04535d4a1dfe1ef1f2e52de8cc2e1df7432623f6afcf8dbf1f";
+      sha256 = "17021647dd58eb851f99e8f63e9d4a6ec302a7a7a1f5a0e561fe96bc63abb5f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/bg/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/bg/thunderbird-78.2.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "3e7ab29fc795b577aa3bd2ac3df872c31a7ed22960e987d9bca6f348becb69a3";
+      sha256 = "e813d46a0ba8dccec07a1bc5201da859a8c23b1cb9140420d902ed9f3fa6f7fd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/br/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/br/thunderbird-78.2.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "c1138c59275149aaa6071cf128e7b480b7f74fa0d8f237552a5c54ce1ae573e0";
+      sha256 = "0bc12e80e5923271973a3037a26a2fd2702118deba326ab98a8a9d776d25c9ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ca/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/ca/thunderbird-78.2.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "4d18b0b11710ab3427bf917ebe17cdf5e98508f517cf5cc4c97822d42a019dd1";
+      sha256 = "f8e6abea863956613d646af01ca09f53311e325d6006a28319cb3f9932a03eaf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/cak/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/cak/thunderbird-78.2.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "5231c3b6c9b57ab528905184b740dd23de470f8bc4814a13000c8fc1fe4877cc";
+      sha256 = "c7603bc86b2d86a9ceddc55a44f9a8a116ec67d1b23ea659f705ad78ecfc02e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/cs/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/cs/thunderbird-78.2.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "04d1614000f1854b5d82e0d1740beb43ed9bef440b43f7bedce32cccec48fd59";
+      sha256 = "058405304cf6523cbcb1d217ebb393a66067b5cbf839d0b588930b59c828d700";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/cy/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/cy/thunderbird-78.2.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "0ef895fdc1878b77650846d2ea4624a50d06838a3c51a91523019bb4d00a1322";
+      sha256 = "e6af1a50954e495bd3145513dd7b7c5b3129862cbe5aa2622229855133233e6c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/da/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/da/thunderbird-78.2.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "e909f7ba1890cebcac435c2cfaab7db1791785e6b5b1e8b205ee3b9962624c8d";
+      sha256 = "39a61048e47af6d96242291581ca29d016f4b667ff373167e7de9d5629f4e4d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/de/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/de/thunderbird-78.2.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "cce1e0acc3c61a66e5eaa065e81e01edb298b6dbf07a2376bf5a96ad2c1e784d";
+      sha256 = "9ab3e2dc60662d37ab7623fafc8dc586c9baa13819c753331539879463bd6b63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/dsb/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/dsb/thunderbird-78.2.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "a5acad173a15e77e21057e7450d997387f88a608dd602df7509fa13743758445";
+      sha256 = "114cd0d19683c0b8c7a5ff0d258d2cf01304eb26f4c7dc466b895c460b129e5b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/el/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/el/thunderbird-78.2.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "7cb4dd233037415d9de96e0c292bd0a288ea62bc875b79a138aaf9639a8f8896";
+      sha256 = "011bb98710b5c6c371e122ada559ec010aa9b965da54bfbc73aef14681f39f97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/en-CA/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/en-CA/thunderbird-78.2.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "158547432a7f38ab87ac5334b891921ef54f199896fe459cf65c81344d900edc";
+      sha256 = "ff39f524ffd7f455940df65c42a40c045cdae4ead311de5dae8c3d563e0e77fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/en-GB/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/en-GB/thunderbird-78.2.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "1f434d2aa74143eb8695fe54f031fdc7270b1dfe7365896b08f9a55c9dcc8197";
+      sha256 = "ce353fc8e6e8e8d2ec1378f76879c0bebb55f867f39488fe48a1995685c85b00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/en-US/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/en-US/thunderbird-78.2.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "f5004ba1ac64911aec7dec3ec60a415500adfb0bfd566197f0f4fb139c71ff2a";
+      sha256 = "e3af4f4b1eaf21c3137047cb5190780fd51e4d27a620efeb6157ffab5ecca950";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/es-AR/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/es-AR/thunderbird-78.2.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "49063e6e19b9c4ee1cd63826fda1c969d9739759a57ffabba5e2f93fc11de06a";
+      sha256 = "30ba14c91750200fc8f4bb8c031fc7b9ecd3efc2d658d9debcafbe8f4b44ad22";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/es-ES/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/es-ES/thunderbird-78.2.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "216fe2514dc21190532b19af814b825d8a39c7dfe91a120848491f98c49f8ec4";
+      sha256 = "0e3d5f0a0f6f505b52d958cf34f26ea98e716516a7f06664aa3806fb1ade55db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/et/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/et/thunderbird-78.2.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "5a89262ffbdc536abf9d780d5d30ce7d0c626a4cf75bfe957689640f94323a34";
+      sha256 = "32acee8023857d5ed54ceb72acb0f5a621ce1884ecf114760f670a3166e7eea9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/eu/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/eu/thunderbird-78.2.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "f59c050361c617e4b2ca92f8e7081a135e976bb99ea4b650b80064aedef2c698";
+      sha256 = "8827e24c546ccf27c8a02e61794675e675c475a833621840152bc840964bce56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/fa/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/fa/thunderbird-78.2.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "b9764595b4cb08584ccce801c08fa19dbbced21c3f89045800d83d531b0c825a";
+      sha256 = "9b072f89cc4288443eb986cb6798d35e08ff003c73d0bbf54a2ccdfea1866d17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/fi/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/fi/thunderbird-78.2.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "98169b3018a61ae6c2303300c1942c7d1d14a5318147a08a883b5a7b7042eba6";
+      sha256 = "9ba017f70955a1aa9c8ff2c94653be569ff0dcdd4784e8ea21e425e5e29140f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/fr/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/fr/thunderbird-78.2.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "49563e87d9543c52d33b7168c78adaab0483f14ceef22759541e927c13620657";
+      sha256 = "7eea9eb22bd47467740e1fa22977dcddd326ca7e9ad7adc8cf7964b9db5da6ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/fy-NL/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/fy-NL/thunderbird-78.2.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "1f3444faf91c24f8608ec59a4f705b42c7520079e4ad6756e693e92cdc8b142d";
+      sha256 = "c0987516569372c9f98d5c8b6b90ad9a1468c4ed8a4b543130a023c25affbeb1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ga-IE/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/ga-IE/thunderbird-78.2.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "28b27f73016f0a4d53a6c47248c26458ca2bdceb46ae231f16086b8cabed5210";
+      sha256 = "344122ad4b549ce1610ce409e7f3ef2ab0144abb3c5ef1fe98a3e499ed292441";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/gd/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/gd/thunderbird-78.2.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "b81b247ebecd1727d27b64f96ba08b08cf59921e9b2e8ae732407b27e233c971";
+      sha256 = "7dc155a4a6bbf1b92822e23a7454e6021a3aa29b807bf9fb16327ecfb627b68f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/gl/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/gl/thunderbird-78.2.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "ea019d11fed7d87173b218d86fcee0dea7d4e20200bc73171fa8c1bc8f7288fe";
+      sha256 = "c99e642618e273f96ef102bafd61c8bd10b626c3ee2d7072c1bb4264a9653fd1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/he/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/he/thunderbird-78.2.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "6308a7e4e2cc35e48bbd67a1a7b8ab37112f47ab228c703a6db681ac7af79cb6";
+      sha256 = "bbf0acf24c1f8e14833b801512b57d80cf5a07662cbfec841a6b7fa3de6facfb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/hr/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/hr/thunderbird-78.2.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "3fb27f1e001817260981567fdb9949ad2f34818e9c919bd16fa0e939cf993cb4";
+      sha256 = "22237f9fa29556853af1d70343d6087f11b677a3648f521e215ffddf0a583407";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/hsb/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/hsb/thunderbird-78.2.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "2240e34fd713b39b410b584a8a6d06525f6abe0db2ee7b76b740a7252ec85e36";
+      sha256 = "2ed485f1cf5e431cfa561bd266624fdf7e14c725e36fa89f653f71a4a1249eda";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/hu/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/hu/thunderbird-78.2.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "f303a1f1219c7b23d71471a00174e6084cee3773af72e855faa63a5384b08aee";
+      sha256 = "8e3b4ad2fdbdd5f84be3a8c77e8c0f4ce09449190eb0d54fe693f5a619d27562";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/hy-AM/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/hy-AM/thunderbird-78.2.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "3e74775e459ebdca2661e2e2f55307429dcc4d4a6623bbb8447946a75c94dd20";
+      sha256 = "bdd7a97b027d30804b60d86559b15b0bfde2f688bc166677d3762887020e2a1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/id/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/id/thunderbird-78.2.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "0c9baf8cff28193f774e13c3a49cfd0ebcf27d8ef73ade151d2371ea69cbafac";
+      sha256 = "259e8fd126c426d8c5bb7c120ccfe28d41183551f41d49f20767e98f8f28d728";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/is/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/is/thunderbird-78.2.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "5c505948333d9259d87aa5f2b53f33ade1bbbfd29b9d5438c2688d34891e29bf";
+      sha256 = "1c74ec8e38bad9396faac387321608efb3463f539a91782db620ca73dfb26efd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/it/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/it/thunderbird-78.2.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "a99896e8ccf8d01099834ee502601cb9de993fd7101e426cb87c240a744f2f88";
+      sha256 = "659fca198575c52c5d90de4456368ea995b2e0dbf7dcb7578e310457142a2421";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ja/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/ja/thunderbird-78.2.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "83be10be5e946b785ac61e9a51c7054357c69af0a8e7bca524e27961dea4eef8";
+      sha256 = "b9464e9364241e94f4e40286f1b0ffdbeb392d9986b9a9cb18c41f5b96baac6c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ka/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/ka/thunderbird-78.2.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "585a1d805663225b1c154e27b54aa1aa5d8a1b96576c0f8ea36bde7844921474";
+      sha256 = "7c73eb7efdca2e7648383c25ec3d0e2a4250b87908c9644e220eb16e1f5a0219";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/kab/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/kab/thunderbird-78.2.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "85128be7e4c28a526d0a395e38e86e5e85dc6c154be6b16fb2df6675effe3d0d";
+      sha256 = "d4d44ccb61058423ed42767d519215bd169dd022d8aa460df7622091522300dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/kk/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/kk/thunderbird-78.2.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "09538c022bbcfcb2a77a7ab11b5569eb56b483817d199cfd0ede68ad556601d0";
+      sha256 = "3b8af8f7eed6da665baf1ed477d5f5f1b797baf8c63f3af6ecdc257d66e446e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ko/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/ko/thunderbird-78.2.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "3e6f472e69d40d46f388096e1d13bc6735860021fc655e3efd4e5b93b1a83240";
+      sha256 = "4129db882fde4040e1e87b4aa724b055dadeee98c46e201d24e9f485f3c2b31a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/lt/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/lt/thunderbird-78.2.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "8b85c0874306afd3a39d8cf851d378f5f1bfce74129b16b02230c516001adc92";
+      sha256 = "fb1d9fc89edbe4434ecfe18d7ccdeb33c4ced3ad5adb1853baf5b115a784a120";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ms/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/ms/thunderbird-78.2.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "b14e7baa06a2d4f98313a7f363b0d998f902164abad13a992878812cc5a0b6c3";
+      sha256 = "b6498d8ba9fbf63cd61cc968f375b0ecc50e3fadff993fa5070a249b679855da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/nb-NO/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/nb-NO/thunderbird-78.2.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "c3718581db153ad8b171b3c454e9d156e3d55ff0969217ac36435d13ac0c7c3a";
+      sha256 = "1d931fad5ca59c3eb29cb8155cbb15a578de28b365cb680e6aab3dc51274078b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/nl/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/nl/thunderbird-78.2.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "802417acdc722e34c21936f840cd347ae86cf5ac8ad2ae05bd1e1ae078c4518c";
+      sha256 = "1378867782f5e0b9cb9efbcc78e5ce9c28d89baca0f353a027fc6878cbb6de58";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/nn-NO/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/nn-NO/thunderbird-78.2.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "5034f1fe526cab8de8091d5f20851a678e742ed37fa80e8491f3891ed89c43a8";
+      sha256 = "bbe5f3cc81eac55401ac4a3a2498906077b1e831d369f7f40a4ddca4dfc146bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/pa-IN/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/pa-IN/thunderbird-78.2.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "01ae1e84d990433b7cbb12dc637deec37b32998803cb60f5834d386e080505f7";
+      sha256 = "ea617550d8e2aa0b99d81ec8e39c587194a0b7978b3444261caf12fcc7a5b172";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/pl/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/pl/thunderbird-78.2.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "84b877dba77c8be4400f4fc76128a85878781c4d8ff7845d265225211092674e";
+      sha256 = "84b15d310cb1fb7217f21891ee24654b13effa4f004315811d3bb221a8fc54c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/pt-BR/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/pt-BR/thunderbird-78.2.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "4daabc0cad02b878d8e17af4402b6b52fdd7783f89192909a43bed09f8aae196";
+      sha256 = "2e5682b09d8c6f6d260dd47b2ac7ab0f710103b0b28755c58375ccb132aea464";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/pt-PT/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/pt-PT/thunderbird-78.2.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "6ce92a7a1ea62398d22ee4e4fbdc383daa5d35d38c83cf1852953757563d17ba";
+      sha256 = "8a7f90d4ce1b9bdc2d117fabd19fd4f6ca362b89138c5470f7d76f7ec456df54";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/rm/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/rm/thunderbird-78.2.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "d876eb51534d8a5796b486f22f9602bcb9c4cd9c99042583f95c4464f7ee99f8";
+      sha256 = "c5a04ab8644dea990c938ab462eb8610471de524f78e09a2293ee9c79260339a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ro/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/ro/thunderbird-78.2.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "ab4bfaea0914401188d486554963c9ab3014237e7116afdf274dce6e55725cae";
+      sha256 = "84b555842d0502dffa99e388bcc6d90355ac4731b66876c279c84c8735a78fd9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/ru/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/ru/thunderbird-78.2.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "e722a13113896bde97dd72d0c7182c26734d7d546d8fe210bbce900854ac925c";
+      sha256 = "d5bdde6bd4e155d78ef4fbc91718468406afc3888a80ab751647163aa087bef5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/si/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/si/thunderbird-78.2.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "595588d25de16c3781c85a9ed5e3c767d4df85f0820d4503770468b1669e9411";
+      sha256 = "0311422b20df0b1081e889aa6301bb8930accd1c5b9b2e0e9850f4565f0ac5c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/sk/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/sk/thunderbird-78.2.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "f30929cad216539754842c0d938b4d5b8ec5f4e813b3ff0d5108d9c4a0fc6df2";
+      sha256 = "b91e58219d46ab7770958ec34a54323b5f7af0cf2548be93de786b76fa92db45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/sl/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/sl/thunderbird-78.2.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "65d716b3fb5cad93d17704b62fd035a86ef6838cfff6ad95e571cedbb9e0974d";
+      sha256 = "e993d4c974b00452696dc68037537e18c550c3b6a634cc2da3cd28014594934f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/sq/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/sq/thunderbird-78.2.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "38c652f6aae768ab7a8b0c1e975c676a3724ae22f5f7e3ffc6224ee032a9dc47";
+      sha256 = "6b18bc35ad9127b6fb149aa71b7e93b556506820e661ddd3a1b9ab298c56ae14";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/sr/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/sr/thunderbird-78.2.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "7f73bcc8efb4452fedb0f9707c5e2b1d0db936fda4c6b9582207043aeddf8747";
+      sha256 = "8fee447a4212f399645923c35de17d882a815adb81bd0b11f9fb1869b5dfaf39";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/sv-SE/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/sv-SE/thunderbird-78.2.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "221974d62563b49f6c030b7a1f6307a71e60ce2a0e107b551363621320bba485";
+      sha256 = "2500816667416a3e4af77098451b98b3e975a1f30e3f393c4e8ebf36ca7495bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/th/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/th/thunderbird-78.2.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "a8641ee0dc5bcd40ec84a4d4640e74e44710b5ac10d629ea0dd42ad2370e8d3b";
+      sha256 = "b035f9424db935281a57a181ac1116e8fa137c27a31b9bfb515bb3fef4ca4c0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/tr/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/tr/thunderbird-78.2.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "1d80d967b5ef98f0e642390c55618d454f2d82acec36bfd56db21e872490ff66";
+      sha256 = "c1cd6f9a2ebe163b8de18d26ecef4fe4beafe8e7212365c2aa71bba3b9fe0967";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/uk/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/uk/thunderbird-78.2.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "fcc24a9885db5511c0b2859e6472d436769da2670573177f7bf332fb363a3ee3";
+      sha256 = "de843a0f9c09bc9d37b5d1bb1925075b80efdbe678f5009cd237cb91bc423b55";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/uz/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/uz/thunderbird-78.2.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "b0f62e8fc5c6da398ad2e1a3488ddb37f0075c90ad54e6028293be7cfcd2f6f0";
+      sha256 = "770bfd792effc548a619deeb0385f9c8cf6475d1233ce79e83028cfed8e41859";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/vi/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/vi/thunderbird-78.2.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "0e38a1b645894ff81a481250ed434157fa2b70792b423c31dab61288612a82f2";
+      sha256 = "8183106b59c8999dc3054ead72dad3a14eabe3827ce3211278a35b20656efd62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/zh-CN/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/zh-CN/thunderbird-78.2.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "04f37793bd17df88573d9d3f8c8412c26cfb3332395689a06f5fca6efb02b2ad";
+      sha256 = "c35ec93bd0e24f2cafb6948546a46ccde62677e6f73e2afa1e378ed040582544";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-x86_64/zh-TW/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-x86_64/zh-TW/thunderbird-78.2.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "6c1e5b71bb2a9e005971050c9643c52090828e1ecb3910d66d2d0dbaa107011c";
+      sha256 = "444861cc1fa351dce587725d67eec87eecb56a581ce94f812ccd4dbc4ae198bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/af/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/af/thunderbird-78.2.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "2601d98ad27a2ed7277f673876c2a7d206fe1cfd8c7c8febdead85884031a416";
+      sha256 = "05eb2e50d4129c39eb28e22f7b3922868d87d310261b765a4a2c721c4ed7c04a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ar/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/ar/thunderbird-78.2.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "5d126b1152b42b6bd6c29ac602b59ab88f3491b0b6f2a69aa1e6ae3d9ded04d6";
+      sha256 = "264e3f57fed68ced27fb89bf8a1e5b715c465fc70a6fbaf8f161e69f80f46c68";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ast/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/ast/thunderbird-78.2.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "7b22fbd980df00d6b1a2c0f14d68a3a7daf06dcb6a13033ca2619371b098445c";
+      sha256 = "5bfbefd9be834682cc144c063f6bffd56a09d2ea7ec9e83f78f0e984350a4006";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/be/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/be/thunderbird-78.2.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "bd59d2a9e70944a736e8e5db100b2cbe937fb8021577fdd912087e2cbe38723f";
+      sha256 = "fa1b7c0432320aa293f89529f23321066e2c4e0e474313d267650bba8b39ed90";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/bg/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/bg/thunderbird-78.2.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "ce3906cafce8ce00c4b69f2b1b584f7e4148d2d40ac12916f1108f78d7d3cdae";
+      sha256 = "1d3f1a298d6ebda804e0aa2a9ad5491c0211dae96ec96e16a8816e5d3e202f63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/br/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/br/thunderbird-78.2.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "2f41237e0dd3dff4e0e4b196f8d02b988d7e5db3ac1984ea5577ce5052d43514";
+      sha256 = "d7f71155d8696d9c17c4cb0e66b987652815761137578819fb4a137c32170347";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ca/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/ca/thunderbird-78.2.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "0ec94acd77cca38d37dd23fb240c3c9e3840defccb491704d01072c1cab1f543";
+      sha256 = "44e651bcd4010a00212ea3e295cc6e3e6e7de9e118078d5631c59158a132126c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/cak/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/cak/thunderbird-78.2.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "1c77ebb51a83c57c7d81ef278f9fceae07f98330a8ccf8f863c2f0b613141e23";
+      sha256 = "8f7849d17ae9a0d7f1b85b128a542d092c49b2b552369ce7de70ed108e4dc07e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/cs/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/cs/thunderbird-78.2.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "adf8c11ff60e697fc5087698088c42c95a15766ccebf24d77141a53dc255c366";
+      sha256 = "0426981c8c381227ec2dd19b59cc2c3a62b91f26541dbb8e57bc97b8f4cf3578";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/cy/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/cy/thunderbird-78.2.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "9b7c51652714c116c9bb22fab4f0fc6dcbce6ad2133cc860067898841d01b5b7";
+      sha256 = "12629cfeafc74a979a621c0c8f4ebee0aa6f35dfd6fbda8a59f26e0a63311c17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/da/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/da/thunderbird-78.2.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "e7245ea0909efccaa9b94701061410437f16273c935484dd3638f5f4fa65aad9";
+      sha256 = "b280271248e99a68c2d38293275fb7ee5631bd96e7a2f67c96c60280e5148f13";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/de/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/de/thunderbird-78.2.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "302394d24f919b0a24dc574001458b265bfc90024bf21b3d98a43b31ae50adf7";
+      sha256 = "1caeeaa0b096378b3cab2e41d832a5c60da4e0a3cf9f84230bfe65edde106536";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/dsb/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/dsb/thunderbird-78.2.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "18ea8d27387581d49dd156957a089f1dbbe05f2772811aeddb1ebe81d26961e6";
+      sha256 = "d1822f534ee3d2e95cc412a7f51eabcdf3f56955650da8806f4acd5e48d19d83";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/el/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/el/thunderbird-78.2.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "bcec06d4b01268ca90d99a98a45c2ef5927ae4152b6b2d356332f3690de08f62";
+      sha256 = "7ec20a9b566728041394245ef5875be10b70fd04a58419fdf2150168aa86abad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/en-CA/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/en-CA/thunderbird-78.2.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "475a1393917665c17bc5e787ef29dd886f1480d544f55d1caacb2a89503da685";
+      sha256 = "62f31fd438ec2e33d5a1d72c57769cea3323d318ed8ad82ebf01050f4ca84fa2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/en-GB/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/en-GB/thunderbird-78.2.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "dda5664fd8d843f3f29b85b855d54e00d15188c57e80c01d79a8be0a2eaa0be1";
+      sha256 = "e857efaa39cd409de86be87934896ecdf82d4e74dd615022995f708d18119a9c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/en-US/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/en-US/thunderbird-78.2.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "b299267b8a113dcd325bc6a928c561fe872535e1e876518e3075b85043aa7b23";
+      sha256 = "54589215c44e291a11e2cb2b2a3de682d4c48367fa8bdac59035b550a07551b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/es-AR/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/es-AR/thunderbird-78.2.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "e3e7cb829b07b7db95cad09c8887b9c91123665cd4601b685e3c7a7b0036992d";
+      sha256 = "b4075d697d141aa13cbcefce1e7082752588d2fc3ba00074550d6e8c1156c5d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/es-ES/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/es-ES/thunderbird-78.2.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "be8428e1cce22aff5000bdc11f632adfc4c1096060a7456d36230ebd6040d12d";
+      sha256 = "7d5f59720037153e0fbf059b0b8aea0dbb5dd20f616deea7744de87ab183023d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/et/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/et/thunderbird-78.2.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "deb81a63704b12ad2a945f5f0dcec878c3b7ec46f551f2d0122c03c52c031f73";
+      sha256 = "9c999d231cb404fcaf3614483e6c74801cd52f9c2ba7988cab50e1d690bc3551";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/eu/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/eu/thunderbird-78.2.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "8a2935dd5f83854b4d98bdab67e7b376a7e1d19a2ff790234516ba8211ed7345";
+      sha256 = "79a74421f364e5d9a5db182d54058eb6c243418a1960b4a653f554584ecd05da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/fa/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/fa/thunderbird-78.2.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "c39189bc1f740a1e5a372eaf3c6e99090f04ed8b1e86016c54ed25612d16f341";
+      sha256 = "db6835853ceb2f597330c9e65c09df48ac308ab01d7320006b9943e3a10b471e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/fi/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/fi/thunderbird-78.2.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "4f23c9941975e67e6e40d7a504a24e4058a27786c5989dd3e25cfc4fab4c4c0e";
+      sha256 = "e96ea32da9cfd941b037d0a6bf95d4a293be6f3f9800e4008c62088f06bdcf6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/fr/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/fr/thunderbird-78.2.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "4de9885664bf4828355d09ceae11fc7cfb603d4514255b4de464c0653ddd45b0";
+      sha256 = "dd6dacbffa7968596666615f52cac80e776f75b4e1943e218856ab80f902f950";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/fy-NL/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/fy-NL/thunderbird-78.2.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "82ae68d970a02ad57aa9c3dfb6c1ef7783c25211e9228c0bad515c3fef385f88";
+      sha256 = "ed009214b863fa44048514870f835682944df010fcd5e1e1c149ec544fbfdaa8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ga-IE/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/ga-IE/thunderbird-78.2.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "e6035d81bfa5c58ab79e71b9895638f23e47e8ab2990794786c5e9f590bb70e2";
+      sha256 = "fad826ef9820facc37bbd278c2bed11802f6b44b70416c803dc6b8fe50220c6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/gd/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/gd/thunderbird-78.2.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "2c628c5ed8ad0c00c42b384f8b925887e624f6a6dee69c86800a9b5137f04886";
+      sha256 = "cccfdd4c3170969ca3f47c0a8398a257650fae0c64ecc375ab044eef969bfa8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/gl/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/gl/thunderbird-78.2.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "49b8e22610f8e602a3870f541209251b61da8cb81df7f0a762d01002fef568e2";
+      sha256 = "dd40efa2751705b0f023a98c01b030c04eb6101fe43062b3607421b1efc462aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/he/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/he/thunderbird-78.2.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "5bb7193eb498d1edd713e18bbac630ba881b0a9b7fca9b05c9b8e4dd1ea1edbf";
+      sha256 = "ff94efe5cd1fae04401d3d6fe364c309c24424c54b0e3787ad080ee1f468443e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/hr/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/hr/thunderbird-78.2.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "c31022ae9a1665cc0b22ab0e911730ccf5cd0dd24614fbd8d3bd51624760baa3";
+      sha256 = "4109b3a8da687d2c4b8e9f6539f40e51475b43243ff1fcb19b78b5d6f6d7594d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/hsb/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/hsb/thunderbird-78.2.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "3e286b3ccf66300ead4d6b98a88a370fa1bac96244b143005c4974f075ceca92";
+      sha256 = "58fd8901df13d7f7fed552326553ce632d36d07f1a0eed63f1e8b671cf519e5e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/hu/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/hu/thunderbird-78.2.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "6d0c88c46d0f4ffb296638e4e8217041d8fdaec3abaa6bda7b7cf97c4bcabc2a";
+      sha256 = "5145b3b137f6a905721a0cafe7b574b66f70891e75187fa082b852b67e195f03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/hy-AM/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/hy-AM/thunderbird-78.2.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "aac23dfa8c299623bca2e3b0501a636c630fbf3f5b08689911569a568b3ad060";
+      sha256 = "7c1e163a78dc5a0791a4a5a730a3ec9d58f24619f5274ce4d4b0197ca4936e5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/id/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/id/thunderbird-78.2.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "5bd5597cb6e91613a39c288d694f3af4f5686dcab1573e3b58c04dce3d1de865";
+      sha256 = "57254afb187662b15338b0133afa378432c9018af4d843ea2f81c1ab40ab4940";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/is/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/is/thunderbird-78.2.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "bcd926c704177945aa7b917fe12940e058d12e6cf8a3eedbf1ab205fb9c41b80";
+      sha256 = "ca0066237afa76925d294eb714bceeb7aaed0a512b9320ace604fcbe2d443f2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/it/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/it/thunderbird-78.2.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "04ca02a4fed6e8d904173d9ce52c16e47d7e9b3d16f5483d986f8188ec79d65c";
+      sha256 = "5c29da94a9408220824f4ab11a0f4e46bfa38230eaf1fef266372620ad9c4220";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ja/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/ja/thunderbird-78.2.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "1dbdc30ec3a06f2e7e7d38d9036fb90a2fdaad42356e9386ecc710d9a51f94b3";
+      sha256 = "ab4685eae09e25018ab2a227d13642a47a0c0e8e6258975967449754bc16697a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ka/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/ka/thunderbird-78.2.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "2db1fa86ac87e0b8001b99c0eea30589db515c58e10548565533014481b1be9a";
+      sha256 = "152394685517d4e3e2ddb39ac6e297d14b4ead115ead325175797bf85d88bedd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/kab/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/kab/thunderbird-78.2.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "8499d0d8a0372617800b039c9198cc372783b8ff4ce385fc692e39b1dca22576";
+      sha256 = "2f3e1b7db83247add30da0372d1c1c125231e689b5005ed5a06359a02aed4180";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/kk/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/kk/thunderbird-78.2.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "29b228042a7f06c22300b123cc0fcdf7a86005d0d4c3c282c97635ebc25ce826";
+      sha256 = "d0d2caffb144d6f64cd73780267cea99dc54f4ae63a0fbcb5a86fc917674d0c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ko/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/ko/thunderbird-78.2.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "a7af79975107cb32b408c7dd26827793c3c11f998705bc711c60f3dd6b7a1173";
+      sha256 = "f42bda1eb1f4a422d4f60345c7e6cda1b7bc57ac3d0899ab32fac16b394e4953";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/lt/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/lt/thunderbird-78.2.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "7a5010761d0af24a6852f32b1ebd6b543b1e1011888ded3f4a4297fc35f455b5";
+      sha256 = "da55137e808a9c64cd6534afe8579b9077b3cfaccce918fca34f07ae2d74e6d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ms/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/ms/thunderbird-78.2.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "8573dc35bd69ff20d05aa06484a2243f5a35ec78c1c31dbccc067f0cb9e6617a";
+      sha256 = "65a44f52ae326b7ad777f4e66d29825f3cb7aae5e18e2c645b5889d664889f2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/nb-NO/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/nb-NO/thunderbird-78.2.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "722c0a4ce2a0d774f8971707ff553d9f2e62af10267ef491e670b020a2d8a49c";
+      sha256 = "6d3abd2b862d3fb1e0285eb6851388a079c129d3132865eb424191f8064798c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/nl/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/nl/thunderbird-78.2.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "63a08123e795ab8e51a2c98f33b0b6424c1f5f2c09a5d1683585f9762813afaf";
+      sha256 = "90f78511b8ecee01c8e441c4c18cb1b40f7f9e2de0350be365dc317d8c06415f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/nn-NO/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/nn-NO/thunderbird-78.2.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "8968de35faf9fe304631ece4e08a9944342a08dc518ac1eec0ba2d5c1ff268ed";
+      sha256 = "2ec0103d3a89c3a57731542bd82e28e0da0b54c62ee0ab7755e395d991dfa5c5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/pa-IN/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/pa-IN/thunderbird-78.2.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "57685a05321195019ef4d3c489dbb14ac0f1bd5ce51fda1f7573392de215e4e3";
+      sha256 = "d169f161bdb32a2ce6e25df9d5a643de9ac4e1345dc90cf1a54560b12bfb03ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/pl/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/pl/thunderbird-78.2.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "d98967c9d54f9314faae53472b9d1506576761cd3de09747d3b407e1f26931e4";
+      sha256 = "5e7fbd12291d16f98f996eb0d3660902c9cddf9849e7082a1963b73afe0e4ec2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/pt-BR/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/pt-BR/thunderbird-78.2.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "14fa89b2d8f659a90e19068130ce1a2da83137b7fb9a5a009d2363ccc2415009";
+      sha256 = "eed9d4a6378496dac0fefdf70f3c2f98d56c4daa1300bc041a3974d03303a0f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/pt-PT/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/pt-PT/thunderbird-78.2.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "279f325e75157e0cedffe6a455e731373b077078f70b89bba76e12e2439350d8";
+      sha256 = "7fef461f1a2b0239c2825a9fdd2dc5237b5b5b0cffa0c9675451449a9e69372c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/rm/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/rm/thunderbird-78.2.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "7432093e7516625957c3dcb90e8668fab1e22c0edba0411e3e2106d49e052fdf";
+      sha256 = "f3cf46324d1f1e5ab7e858fb3f203ac6762ba98986f510486146fb745535123e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ro/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/ro/thunderbird-78.2.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "f5d5f564cf56c66d1f2f9717df7c7f021532dc1912384c9921ca286030f7d82c";
+      sha256 = "921285ad32ed408229b07d34d358cc6dd78bc519cb60370fff01525a7cb0e96e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/ru/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/ru/thunderbird-78.2.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "4c4e31e74c4d10d88044fc49c24b3ae3ffb0b18e4a23295b60ac2d38d723753a";
+      sha256 = "37f28db57fc4d101df92ff5f2ca1ed800de35ecc6b3b00480bc8ee67805f47d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/si/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/si/thunderbird-78.2.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "689be324633f6a872a09d6498d8772562dceca9bca96f7029830c965ad2e4138";
+      sha256 = "96d2ff616eae7bba706bd3af8fa5de0dc2444c0b57b612775e61b0e23007404c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/sk/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/sk/thunderbird-78.2.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "194ff5a23a3a40ba98fb1968965c79f99246c6d93b81254d11df5d22530f1d86";
+      sha256 = "5f3ba3d2bcf1437373df7553dd4296511ea4845b87e0c02e7714f9838cadf281";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/sl/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/sl/thunderbird-78.2.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "9746db435fe3dbf5ab51603780d52862a6afda0e40c1ebc915b309ac93e75e25";
+      sha256 = "f00c798638bc88a107f4ebb0feb0156f2d7667a040ef8fe9104340997df83741";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/sq/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/sq/thunderbird-78.2.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "86f675921cdf0de41855d5e2c3d2d56c163d915ac8a0f8cc9678d1a55f87e069";
+      sha256 = "42e2fb9ed08ce138d50e0fdddfc67d9feccbf6e5aa4cfd50d81f2ed493cb2dee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/sr/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/sr/thunderbird-78.2.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "587e4c867dd43621c8e5e04461c4a2dcf2b0f256476b5b72d8fc6722e573e347";
+      sha256 = "72dc5e5f0024c17e4e1b30b3990d1cd1f1fd240da5c32ca4ddf2737290fa4bac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/sv-SE/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/sv-SE/thunderbird-78.2.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "a46294d3dafc8bfaaa7f5376c2db2402f31f24664e73045c653ea8660079b879";
+      sha256 = "2f3c882db2034adf74d638fc7a6055bb421fe08f890ac6d3c89433a818b06ca3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/th/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/th/thunderbird-78.2.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "6105278c11c3e586240d50c9612730e75caecd08765b5b5cfe010f37d71c971d";
+      sha256 = "3830e09d6aab98fddec1e60fea92ec3c5ba51dee63225c219010a37bc80f633a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/tr/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/tr/thunderbird-78.2.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "4bdd2c91e8f361d1b2ade88cec06accb244adf3d7f1d714feea3e4004ed31968";
+      sha256 = "bdf2cf1a6a0c6cb8ae6d598adf30d84d1f43f399a2135cb041a17329fab78f73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/uk/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/uk/thunderbird-78.2.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "40e2012a5b5dc05cb887a6c4cbb0c8f7bbc25cebd2de1247e5e8dc355cad78fe";
+      sha256 = "4bd587d7bfcd2ec6bc7516b48199c92dac1f6feac4c66779cae231a7fd436df3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/uz/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/uz/thunderbird-78.2.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "15f4aafba6b2bcb102683d9a665d208ab21c5767cf6d59c45d996fa26ef1e12a";
+      sha256 = "5326d6b4f0dc90925bd26c3300ab5441a0edf706229cbde7121cfadeb6b1457f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/vi/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/vi/thunderbird-78.2.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "32640a1c8e42cc79774a3b75539010dfb65e32c703992001eb03916d4fb46e91";
+      sha256 = "ea8db723cb46c60182c4fd557fbb72872cd112c707af66fae20b59a50c595d80";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/zh-CN/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/zh-CN/thunderbird-78.2.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "09b52b6ebf0033738444bacfb53b84b1c98f7d3e10b32c001356083afbe4e89e";
+      sha256 = "f2d5b1463c426dad638480782473442b6208cefe8fdd0eb74a6e01f75fbe6a52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.1/linux-i686/zh-TW/thunderbird-78.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.2.2/linux-i686/zh-TW/thunderbird-78.2.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "606e416a158023f674eda141bf67f9b3956e3e231ba85605173d73cad0d22a59";
+      sha256 = "3a0bff43f1b6b158ee8f5a80e5457fa17da09ba2270d84089a948b677f228ca7";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -69,13 +69,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.2.1";
+  version = "78.2.2";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "2iya9a5qaini524wrdrnxx6wsrgb8fa2b1m42mlypskxjjgb7n66vpxlbpi9x9mqzc63ca2ag36fjpbpsvbv5ppxvpfwk2j1zbfvb5w";
+      "2cbpyx9jn23kc289z8ikzx3035g5z6p076izvld50mj3kqc0v4n3igih3rv1lsdwysik8c0ax5w3pa037lnrp6ridgbnix34gxr4nw6";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Various fixes and changes, including OpenPGP related issues.

https://www.thunderbird.net/en-US/thunderbird/78.2.2/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

After running `thunderbird-bin`, `.cache/fontconfig` is corrupted and other applications fail with segfault on startup. I don't know whether this happens only on my environment or not.  Maybe, mixing fontconfig versions caused this.