### PR TITLE
gitoxide: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/applications/version-management/gitoxide/default.nix
+++ b/pkgs/applications/version-management/gitoxide/default.nix
@@ -1,24 +1,29 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, openssl }:
 
 rustPlatform.buildRustPackage rec {
   pname = "gitoxide";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "Byron";
     repo = "gitoxide";
     rev = "v${version}";
-    sha256 = "0xpic9jx7nrxi5d8lqch2vxpvipx994d717c4n0kgr3ipyij1347";
+    sha256 = "0sx3z9l9n9qq2zj91pgm7znhxjsj59zvwms3aivfglhawwj3iwyj";
   };
 
-  cargoSha256 = "104lyfni75h1i30s2jlzf66sp1czfd9ywqz78kj4i7lfdf6fc4x9";
+  cargoSha256 = "0ykkh86p4csi0v3pb2idjk94w9m32a34a5qrvna7ml5yz84m8hva";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  # Needed to get openssl-sys to use pkgconfig.
+  OPENSSL_NO_VENDOR = 1;
 
   meta = with lib; {
     description =
       "A command-line application for interacting with git repositories";
     homepage = "https://github.com/Byron/gitoxide";
-    # NOTE: the master branch is dual-licensed with APACHE but v0.3.0 is only MIT
-    license = licenses.mit;
+    license = with licenses; [ mit /* or */ asl20 ];
     maintainers = [ maintainers.syberant ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
To update the package I'm maintaining.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
