### PR TITLE
[20.09] Backport lp solve

### DIFF
--- a/pkgs/applications/science/math/lp_solve/default.nix
+++ b/pkgs/applications/science/math/lp_solve/default.nix
@@ -23,13 +23,13 @@ stdenv.mkDerivation rec {
     cd lp_solve*/lpsolve55
     bash ccc
     mkdir -pv $out/lib
-    cp -v bin/*/* $out/lib
+    find bin -type f -exec cp -v "{}" $out/lib \;
     )
     (
     cd lp_solve*/lp_solve
     bash ccc
     mkdir -pv $out/bin
-    cp -v bin/*/* $out/bin
+    find bin -type f -exec cp -v "{}" $out/bin \;
     )
     (
     mkdir -pv $out/include


### PR DESCRIPTION
(cherry picked from commit 3fc3fd14cf82759ca0ddc7a0a7a4fa10fe567834)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Initial PR: #97757 
ZHF: #97479 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
