### PR TITLE
pythonPackages.httpx: fix tests

### DIFF
--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , certifi
 , chardet
 , h11
@@ -30,6 +31,14 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "08b6k5g8car3bic90aw4ysb2zvsa5nm8qk3hk4dgamllnnxzl5br";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-cookie-test-timestamp.patch";
+      url = "https://github.com/encode/httpx/pull/1270.patch";
+      sha256 = "1hgrynac6226sgnyzmsr1nr15rn49gbfmk4c2kx3dwkbh6vr7jpd";
+    })
+  ];
 
   propagatedBuildInputs = [
     certifi


### PR DESCRIPTION
###### Motivation for this change
Test suite contained a literal timestamp which expired, causing all builds to fail, fixed upstream but not included in a release yet.

Suppose this counts towards ZHF #97479.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
