### PR TITLE
ipgrep: 1.0 -> 1.0.1

### DIFF
--- a/pkgs/tools/networking/ipgrep/default.nix
+++ b/pkgs/tools/networking/ipgrep/default.nix
@@ -1,23 +1,25 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python3Packages }:
 
-pythonPackages.buildPythonApplication rec {
-  version = "1.0";
+python3Packages.buildPythonApplication rec {
+  version = "1.0.1";
   pname = "ipgrep";
+
+  disabled = python3Packages.isPy27;
 
   src = fetchFromGitHub {
     owner = "jedisct1";
     repo = pname;
     rev = version;
-    sha256 = "1qaxvbqdalvz05aplhhrg7s4h7yx4clbfd50k46bgavhgcqqv8n3";
+    hash = "sha256-NrhcUFQM+L66KaDRRpAoC+z5s54a+1fqEepTRXVZ5Qs=";
   };
 
   patchPhase = ''
-    mkdir -p ${pname} 
+    mkdir -p ${pname}
     substituteInPlace setup.py \
       --replace "'scripts': []" "'scripts': { '${pname}.py' }"
   '';
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python3Packages; [
     pycares
     urllib3
     requests


### PR DESCRIPTION
###### Motivation for this change

Switch from python2 -> python3, otherwise broken due to aged py2 dependency.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
