### PR TITLE
pythonPackages.pulp: fix by adding new dependency amply

### DIFF
--- a/pkgs/development/python-modules/amply/default.nix
+++ b/pkgs/development/python-modules/amply/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+, setuptools_scm
+, docutils
+, pyparsing
+}:
+
+buildPythonPackage rec {
+  pname = "amply";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1j2dqdz1y1nbyw33qq89v0f5rkmqfbga72d9hax909vpcapm6pbf";
+  };
+
+  buildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [
+    docutils
+    pyparsing
+  ];
+
+  checkPhase = ''
+    python tests/test_amply.py
+  '';
+  pythonImportsCheck = [ "amply" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/willu47/amply";
+    description = ''
+      Allows you to load and manipulate AMPL/GLPK data as Python data structures
+    '';
+    maintainers = with maintainers; [ ris ];
+    license = licenses.epl10;
+  };
+}

--- a/pkgs/development/python-modules/pulp/default.nix
+++ b/pkgs/development/python-modules/pulp/default.nix
@@ -2,6 +2,7 @@
 , fetchPypi
 , buildPythonPackage
 , pyparsing
+, amply
 }:
 
 buildPythonPackage rec {
@@ -13,7 +14,7 @@ buildPythonPackage rec {
     sha256 = "9d8ecf532868cc31fa9ff59ee5d5b2049600c5c902c18c794a2bad677c1f92e5";
   };
 
-  propagatedBuildInputs = [ pyparsing ];
+  propagatedBuildInputs = [ pyparsing amply ];
 
   # only one test that requires an extra
   doCheck = false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -270,6 +270,8 @@ in {
 
   amazon_kclpy = callPackage ../development/python-modules/amazon_kclpy { };
 
+  amply = callPackage ../development/python-modules/amply { };
+
   amqp = callPackage ../development/python-modules/amqp { };
 
   amqplib = callPackage ../development/python-modules/amqplib { };


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479 

`pythonPackages.pulp` now requires a new dependency, `amply`, which we didn't have packaged. Add it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
