### PR TITLE
ocamlPackages.qcheck: 0.7 → 0.15

### DIFF
--- a/pkgs/development/ocaml-modules/qcheck/alcotest.nix
+++ b/pkgs/development/ocaml-modules/qcheck/alcotest.nix
@@ -1,0 +1,13 @@
+{ buildDunePackage, qcheck-core, alcotest }:
+
+buildDunePackage {
+  pname = "qcheck-alcotest";
+
+  inherit (qcheck-core) version src;
+
+  propagatedBuildInputs = [ qcheck-core alcotest ];
+
+  meta = qcheck-core.meta // {
+    description = "Alcotest backend for qcheck";
+  };
+}

--- a/pkgs/development/ocaml-modules/qcheck/core.nix
+++ b/pkgs/development/ocaml-modules/qcheck/core.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, fetchFromGitHub }:
+
+buildDunePackage rec {
+  pname = "qcheck-core";
+  version = "0.15";
+
+  minimumOCamlVersion = "4.03";
+
+  src = fetchFromGitHub {
+    owner = "c-cube";
+    repo = "qcheck";
+    rev = version;
+    sha256 = "1ywaklqm1agvxvzv7pwl8v4zlwc3ykw6l251w43f0gy9cfwqmh3j";
+  };
+
+  meta = {
+    description = "Core qcheck library";
+    homepage = "https://c-cube.github.io/qcheck/";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/qcheck/default.nix
+++ b/pkgs/development/ocaml-modules/qcheck/default.nix
@@ -1,29 +1,14 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, ounit }:
+{ buildDunePackage, qcheck-ounit }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4";
+buildDunePackage {
+  pname = "qcheck";
 
-stdenv.mkDerivation {
+  inherit (qcheck-ounit) version src;
 
-  name = "ocaml${ocaml.version}-qcheck-0.7";
-  src = fetchzip {
-    url = "https://github.com/c-cube/qcheck/archive/0.7.tar.gz";
-    sha256 = "1afy7li74r3ivpvq670gvsj1rmglh5rnvb17p6w8gy5rh30aljah";
+  propagatedBuildInputs = [ qcheck-ounit ];
+
+  meta = qcheck-ounit.meta // {
+    description = "Compatibility package for qcheck";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ounit ];
-
-  configureFlags = [ "--enable-tests" ];
-
-  doCheck = true;
-  checkPhase = "ocaml setup.ml -test";
-
-  createFindlibDestdir = true;
-
-  meta = {
-    description = "QuickCheck inspired property-based testing for OCaml";
-    homepage = "https://github.com/c-cube/qcheck/";
-    license = stdenv.lib.licenses.bsd2;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
-    platforms = ocaml.meta.platforms or [];
-  };
 }

--- a/pkgs/development/ocaml-modules/qcheck/ounit.nix
+++ b/pkgs/development/ocaml-modules/qcheck/ounit.nix
@@ -1,0 +1,14 @@
+{ buildDunePackage, qcheck-core, ounit }:
+
+buildDunePackage {
+  pname = "qcheck-ounit";
+
+  inherit (qcheck-core) version src;
+
+  propagatedBuildInputs = [ qcheck-core ounit ];
+
+  meta = qcheck-core.meta // {
+    description = "OUnit backend for qcheck";
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -886,6 +886,8 @@ let
 
     pycaml = callPackage ../development/ocaml-modules/pycaml { };
 
+    qcheck-alcotest = callPackage ../development/ocaml-modules/qcheck/alcotest.nix { };
+
     qcheck-core = callPackage ../development/ocaml-modules/qcheck/core.nix { };
 
     qcheck-ounit = callPackage ../development/ocaml-modules/qcheck/ounit.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -888,6 +888,8 @@ let
 
     qcheck-core = callPackage ../development/ocaml-modules/qcheck/core.nix { };
 
+    qcheck-ounit = callPackage ../development/ocaml-modules/qcheck/ounit.nix { };
+
     qcheck = callPackage ../development/ocaml-modules/qcheck { };
 
     qtest = callPackage ../development/ocaml-modules/qtest { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -886,6 +886,8 @@ let
 
     pycaml = callPackage ../development/ocaml-modules/pycaml { };
 
+    qcheck-core = callPackage ../development/ocaml-modules/qcheck/core.nix { };
+
     qcheck = callPackage ../development/ocaml-modules/qcheck { };
 
     qtest = callPackage ../development/ocaml-modules/qtest { };


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/c-cube/qcheck/blob/0.15/CHANGELOG.md

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
