### PR TITLE
lefthook: use go 1.14 to build

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -201,7 +201,11 @@ let
 
   lab = callPackage ./lab { };
 
-  lefthook = callPackage ./lefthook { };
+  lefthook = callPackage ./lefthook {
+    # Please use empty attrset once upstream bugs have been fixed
+    # https://github.com/Arkweid/lefthook/issues/151
+    buildGoModule = buildGo114Module;
+  };
 
   legit = callPackage ./legit { };
 

--- a/pkgs/applications/version-management/git-and-tools/lefthook/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/lefthook/default.nix
@@ -1,5 +1,11 @@
 { stdenv, buildGoModule, fetchFromGitHub }:
 
+# Currently `buildGo114Module` is passed as `buildGoModule` from
+# `../default.nix`. Please remove the fixed 1.14 once a new release has been
+# made and the issue linked below has been closed upstream.
+
+# https://github.com/Arkweid/lefthook/issues/151
+
 buildGoModule rec {
   pname = "lefthook";
   version = "0.7.2";


### PR DESCRIPTION
###### Motivation for this change

Due to some changes in `go` from 1.14 to 1.15 the lefthook tool
currently can't start external programs and errors each test it tries
to run, making it effectively useless.

This is a temporary fix to make `lefthook` usable again until the
upstream issue was fixed and a new release has been cut.

Upstream issue: Arkweid/lefthook#151

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

`nixpkgs-review` claims that there is no diff…