### PR TITLE
uqm: fix build

### DIFF
--- a/pkgs/games/uqm/default.nix
+++ b/pkgs/games/uqm/default.nix
@@ -65,6 +65,8 @@ in stdenv.mkDerivation rec {
     ln -s "${videos}" "uqm-${version}/content/addons/3dovideo"
   '';
 
+  NIX_LDFLAGS = "-lpng";
+
   postPatch = ''
     # Using _STRINGS_H as include guard conflicts with glibc.
     sed -i -e '/^#/s/_STRINGS_H/_UQM_STRINGS_H/g' src/uqm/comm/*/strings.h
@@ -79,6 +81,7 @@ in stdenv.mkDerivation rec {
     echo "INPUT_install_bindir_VALUE='$out/bin'" >> config.state
     echo "INPUT_install_libdir_VALUE='$out/lib'" >> config.state
     echo "INPUT_install_sharedir_VALUE='$out/share'" >> config.state
+    echo "CHOICE_debug_VALUE=nodebug" >> config.state
     PREFIX=$out ./build.sh uqm config
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #97479

###### Things done

1. The build failed with impurity error due to it wanting to write to `/tmp`. Replaced with `$TMP`.
1. The game expects libpng to be available but the build doesn’t seem to link to it in any way. Added explicitly with patchelf.
1. Enabled release build mode (debug build was default).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
