### PR TITLE
[20.09] python3Packages.python-snap7: init 0.11

### DIFF
--- a/pkgs/development/python-modules/python-snap7/default.nix
+++ b/pkgs/development/python-modules/python-snap7/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, snap7, fetchFromGitHub, six, setuptools }:
+
+buildPythonPackage rec {
+  pname = "python-snap7";
+  version = "0.11";
+
+  src = fetchFromGitHub {
+    owner = "gijzelaerr";
+    repo = "python-snap7";
+    rev = "899a94c6eeca76fb9b18afd5056e5003646d7f94";
+    sha256 = "169zd1nxq86nmi6132vxl1f6wxm9w3waihq2wn14kkmld1vkmvfd";
+  };
+
+  propagatedBuildInputs = [ setuptools six ];
+
+  prePatch = ''
+    substituteInPlace snap7/common.py \
+      --replace "lib_location = None" "lib_location = '${snap7}/lib/libsnap7.so'"
+  '';
+
+  # Tests require root privileges to open privilaged ports
+  # We cannot run them
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "snap7"
+    "snap7.six"
+    "snap7.util"
+  ];
+
+  meta = with lib; {
+    description = "Python wrapper for the snap7 PLC communication library ";
+    homepage = "https://github.com/gijzelaerr/python-snap7";
+    license = licenses.mit;
+    maintainers = with maintainers; [ freezeboy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5738,6 +5738,10 @@ in {
 
   python-slugify = callPackage ../development/python-modules/python-slugify { };
 
+  python-snap7 = callPackage ../development/python-modules/python-snap7 {
+    inherit (pkgs) snap7;
+  };
+
   python-snappy = callPackage ../development/python-modules/python-snappy { inherit (pkgs) snappy; };
 
   python-socketio = callPackage ../development/python-modules/python-socketio { };


### PR DESCRIPTION
(cherry picked from commit 7849d114789b88ce68dc87d7dadd315b3cdb3140)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Initial PR #97881 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
