### PR TITLE
[20.09] barman: init 2.11

### DIFF
--- a/pkgs/tools/misc/barman/default.nix
+++ b/pkgs/tools/misc/barman/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonApplication, fetchurl, lib
+, dateutil, argcomplete, argh, psycopg2, boto3
+}:
+
+buildPythonApplication rec {
+  pname = "barman";
+  version = "2.11";
+
+  outputs = [ "out" "man" ];
+  src = fetchurl {
+    url = "mirror://sourceforge/pgbarman/${version}/barman-${version}.tar.gz";
+    sha256 = "0w5lh4aavab9ynfy2mq09ga6j4vss4k0vlc3g6f5a9i4175g9pmr";
+  };
+
+  propagatedBuildInputs = [ dateutil argh psycopg2 boto3 argcomplete ];
+
+  # Tests are not present in tarball
+  checkPhase = ''
+    $out/bin/barman --help > /dev/null
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.2ndquadrant.com/en/resources/barman/";
+    description = "Backup and Disaster Recovery Manager for PostgreSQL";
+    maintainers = with maintainers; [ freezeboy ];
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -873,6 +873,8 @@ in
 
   automirror = callPackage ../tools/misc/automirror { };
 
+  barman = python3Packages.callPackage ../tools/misc/barman { };
+
   bash-my-aws = callPackage ../tools/admin/bash-my-aws { };
 
   bashcards = callPackage ../tools/misc/bashcards { };


### PR DESCRIPTION
(cherry picked from commit 1be6ac06ab633f539e309cdfe090a948d23a8901)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Initial PR: #97880 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
