### PR TITLE
chez-modules: Fix path to csv-site.

### DIFF
--- a/pkgs/development/chez-modules/chez-mit/default.nix
+++ b/pkgs/development/chez-modules/chez-mit/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   buildInputs = [ chez chez-srfi ];
 
   buildPhase = ''
-    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv9.5-site
+    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv-site
     make PREFIX=$out CHEZ=${chez}/bin/scheme
   '';
 

--- a/pkgs/development/chez-modules/chez-scmutils/default.nix
+++ b/pkgs/development/chez-modules/chez-scmutils/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   buildInputs = [ chez chez-srfi chez-mit ];
 
   buildPhase = ''
-    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv9.5-site:${chez-mit}/lib/csv9.5-site
+    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv-site:${chez-mit}/lib/csv-site
     make PREFIX=$out CHEZ=${chez}/bin/scheme
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

It seems that the installation path for chez modules no longer includes
the Chez version. This fixes the build for `chez-mit` and `chez-scmutils`.

ZHF: #97479

Note: I have tried to load the libraries in a `nix-shell -p chez chez-scmutils`, but it seems like some environment variables need to be set manually to get that working. I don't know whether that was the case beforehand. I suppose @jitwit or @thoughtpolice would know.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~ (no tests for chez found)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] ~Tested execution of all binary files (usually in `./result/bin/`)~ (no binaries)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
