### PR TITLE
kismet: 2020-04-R2 -> 2020-09-R2

### DIFF
--- a/pkgs/applications/networking/sniffers/kismet/default.nix
+++ b/pkgs/applications/networking/sniffers/kismet/default.nix
@@ -10,11 +10,11 @@ assert !withPython;
 
 stdenv.mkDerivation rec {
   pname = "kismet";
-  version = "2020-04-R2";
+  version = "2020-09-R2";
 
   src = fetchurl {
     url = "https://www.kismetwireless.net/code/${pname}-${version}.tar.xz";
-    sha256 = "0hxmaln0y6bk9m1rshr4swmg0sqy3ic693vfk8haj7f5gnph96cm";
+    sha256 = "1n6y6sgqf50bng8n0mhs2r1w0ak14mv654sqay72a78wh2s7ywzg";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Kismet 2020-04-R2 fails to build but a later release works fine.

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
