### PR TITLE
[20.09] busybox: Fix 404 error by using git instead

### DIFF
--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -12,7 +12,7 @@ let
     ((optional (group != null) group) ++ [ owner repo ]);
 
   escapedSlug = replaceStrings ["." "/"] ["%2E" "%2F"] slug;
-  escapedRev = replaceStrings ["+"] ["%2B"] rev;
+  escapedRev = replaceStrings ["+" "%" "/"] ["%2B" "%25" "%2F"] rev;
 in
 
 fetchzip ({

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPackages, fetchurl, fetchzip
+{ stdenv, lib, buildPackages, fetchurl, fetchFromGitLab
 , enableStatic ? false
 , enableMinimal ? false
 # Allow forcing musl without switching stdenv itself, e.g. for our bootstrapping:
@@ -32,12 +32,18 @@ let
     CONFIG_FEATURE_WTMP n
   '';
 
-  debianName = "busybox_1.30.1-5";
-  debianTarball = fetchzip {
-    url = "http://deb.debian.org/debian/pool/main/b/busybox/${debianName}.debian.tar.xz";
-    sha256 = "03m4rvs2pd0hj0mdkdm3r4m1gh0bgwr0cvnqds297xnkfi5s01nx";
+  # The debian version lacks behind the upstream version and also contains
+  # a debian-specific suffix. We only fetch the debian repository to get the
+  # default.script
+  debianVersion = "1.30.1-6";
+  debianSource = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "installer-team";
+    repo = "busybox";
+    rev = "debian/1%${debianVersion}";
+    sha256 = "sha256-6r0RXtmqGXtJbvLSD1Ma1xpqR8oXL2bBKaUE/cSENL8=";
   };
-  debianDispatcherScript = "${debianTarball}/tree/udhcpc/etc/udhcpc/default.script";
+  debianDispatcherScript = "${debianSource}/debian/tree/udhcpc/etc/udhcpc/default.script";
   outDispatchPath = "$out/default.script";
 in
 


### PR DESCRIPTION
Backport of #97894

CC: @worldofpeace 

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
