### PR TITLE
[20.09] palemoon: 28.12.0 -> 28.13.0

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -16,13 +16,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "28.12.0";
+  version = "28.13.0";
 
   src = fetchFromGitHub {
     owner = "MoonchildProductions";
     repo = "Pale-Moon";
     rev = "${version}_Release";
-    sha256 = "1cc75972nhmxkkynkky1m2fijbf3qlzvpxsd98mxlx0b7h4d3l5l";
+    sha256 = "1lza6239kb32wnwd9cwddn11npg1qx7p69l7qy63h9c59w29iypa";
     fetchSubmodules = true;
   };
 
@@ -88,11 +88,15 @@ in stdenv.mkDerivation rec {
     ac_add_options --disable-debug
     ac_add_options --disable-necko-wifi
     ac_add_options --disable-updater
+
     ac_add_options --with-pthreads
 
     # Please see https://www.palemoon.org/redist.shtml for restrictions when using the official branding.
     ac_add_options --enable-official-branding
     export MOZILLA_OFFICIAL=1
+
+    # For versions after 28.12.0
+    ac_add_options --enable-phoenix-extensions
 
     ac_add_options --x-libraries=${lib.makeLibraryPath [ xorg.libX11 ]}
 


### PR DESCRIPTION
(cherry picked from commit 5efe403c935af24b6a43092607cd48896f8bb537)

Backport of #97930

###### Motivation for this change
Version bump, CVE fixes.

> Security issues fixed: CVE-2020-15664, CVE-2020-15666, CVE-2020-15667, CVE-2020-15668 and CVE-2020-15669.

###### Things done

Version bumped, mozconfig adjusted to upstream changes.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
