### PR TITLE
vscode/vscodium: split update scripts

### DIFF
--- a/pkgs/applications/editors/vscode/update-vscode.sh
+++ b/pkgs/applications/editors/vscode/update-vscode.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused gawk
+
+set -eou pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+if [ ! -f "$ROOT/vscode.nix" ]; then
+  echo "ERROR: cannot find vscode.nix in $ROOT"
+  exit 1
+fi
+
+# VSCode
+
+VSCODE_VER=$(curl -s -L "https://code.visualstudio.com/Download" | grep "is now available" | awk -F'</span>' '{print $1}' | awk -F'>' '{print $NF}')
+VSCODE_VER=$(curl -s -L "https://code.visualstudio.com/updates/v${VSCODE_VER/./_}" | grep "Downloads:" | awk -F'code.visualstudio.com/' '{print $2}' | awk -F'/' '{print $1}')
+sed -i "s/version = \".*\"/version = \"${VSCODE_VER}\"/" "$ROOT/vscode.nix"
+
+VSCODE_LINUX_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/linux-x64/stable"
+VSCODE_LINUX_SHA256=$(nix-prefetch-url ${VSCODE_LINUX_URL})
+sed -i "s/x86_64-linux = \".\{52\}\"/x86_64-linux = \"${VSCODE_LINUX_SHA256}\"/" "$ROOT/vscode.nix"
+
+VSCODE_DARWIN_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/darwin/stable"
+VSCODE_DARWIN_SHA256=$(nix-prefetch-url ${VSCODE_DARWIN_URL})
+sed -i "s/x86_64-darwin = \".\{52\}\"/x86_64-darwin = \"${VSCODE_DARWIN_SHA256}\"/" "$ROOT/vscode.nix"

--- a/pkgs/applications/editors/vscode/update-vscodium.sh
+++ b/pkgs/applications/editors/vscode/update-vscodium.sh
@@ -4,28 +4,10 @@
 set -eou pipefail
 
 ROOT="$(dirname "$(readlink -f "$0")")"
-if [ ! -f "$ROOT/vscode.nix" ]; then
-  echo "ERROR: cannot find vscode.nix in $ROOT"
-  exit 1
-fi
 if [ ! -f "$ROOT/vscodium.nix" ]; then
   echo "ERROR: cannot find vscodium.nix in $ROOT"
   exit 1
 fi
-
-# VSCode
-
-VSCODE_VER=$(curl -s -L "https://code.visualstudio.com/Download" | grep "is now available" | awk -F'</span>' '{print $1}' | awk -F'>' '{print $NF}')
-VSCODE_VER=$(curl -s -L "https://code.visualstudio.com/updates/v${VSCODE_VER/./_}" | grep "Downloads:" | awk -F'code.visualstudio.com/' '{print $2}' | awk -F'/' '{print $1}')
-sed -i "s/version = \".*\"/version = \"${VSCODE_VER}\"/" "$ROOT/vscode.nix"
-
-VSCODE_LINUX_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/linux-x64/stable"
-VSCODE_LINUX_SHA256=$(nix-prefetch-url ${VSCODE_LINUX_URL})
-sed -i "s/x86_64-linux = \".\{52\}\"/x86_64-linux = \"${VSCODE_LINUX_SHA256}\"/" "$ROOT/vscode.nix"
-
-VSCODE_DARWIN_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/darwin/stable"
-VSCODE_DARWIN_SHA256=$(nix-prefetch-url ${VSCODE_DARWIN_URL})
-sed -i "s/x86_64-darwin = \".\{52\}\"/x86_64-darwin = \"${VSCODE_DARWIN_SHA256}\"/" "$ROOT/vscode.nix"
 
 # VSCodium
 


### PR DESCRIPTION
###### Motivation for this change
Recently the versions of vscode and vscodium have diverged (see https://github.com/VSCodium/vscodium/issues/501), meaning that the updates for one package fail while the other succeeds. This PR splits up the update scripts so that one can be run with out the other and vice-versa.

###### Things done
Tested that both scripts still function as expected.