### PR TITLE
cheesecutter: unstable-2019-12-06 -> unstable-2020-04-03

### DIFF
--- a/pkgs/applications/audio/cheesecutter/0001-Drop-baked-in-build-date-for-r13y.patch
+++ b/pkgs/applications/audio/cheesecutter/0001-Drop-baked-in-build-date-for-r13y.patch
@@ -1,3 +1,13 @@
+From eb21fd64a19a0e10c4c3826fc71610fd5850fa2f Mon Sep 17 00:00:00 2001
+From: Christoph Neidahl <christoph.neidahl@gmail.com>
+Date: Sun, 13 Sep 2020 23:18:51 +0200
+Subject: [PATCH 1/2] Drop baked-in build date for r13y
+
+---
+ src/ct2util.d | 2 +-
+ src/ui/ui.d   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
 diff --git a/src/ct2util.d b/src/ct2util.d
 index 523cadc..e462b09 100644
 --- a/src/ct2util.d
@@ -24,3 +34,6 @@ index e418dda..21af408 100644
  		screen.cprint(4, 0, 1, headerColor, hdr);
  		screen.cprint(screen.width - 14, 0, 1, headerColor, "F12 = Help");
  		int c1 = audio.player.isPlaying ? 13 : 12;
+-- 
+2.25.4
+

--- a/pkgs/applications/audio/cheesecutter/0002-Prepend-libSDL.dylib-to-macOS-SDL-loader.patch
+++ b/pkgs/applications/audio/cheesecutter/0002-Prepend-libSDL.dylib-to-macOS-SDL-loader.patch
@@ -1,0 +1,25 @@
+From abc5e8786d41803300b56ef40c08db0d867eb01a Mon Sep 17 00:00:00 2001
+From: Christoph Neidahl <christoph.neidahl@gmail.com>
+Date: Sun, 13 Sep 2020 23:22:33 +0200
+Subject: [PATCH 2/2] Prepend libSDL.dylib to macOS SDL loader
+
+---
+ src/derelict/sdl/sdl.d | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/derelict/sdl/sdl.d b/src/derelict/sdl/sdl.d
+index e31a52f..f7915b1 100644
+--- a/src/derelict/sdl/sdl.d
++++ b/src/derelict/sdl/sdl.d
+@@ -54,7 +54,7 @@ public:
+         super(
+             "sdl.dll",
+             "libSDL.so, libSDL.so.0, libSDL-1.2.so, libSDL-1.2.so.0",
+-            "@executable_path/../Frameworks/SDL.framework/SDL, /Library/Frameworks/SDL.framework/SDL, /System/Library/Frameworks/SDL.framework/SDL"
++            "@rpath/libSDL.dylib, @executable_path/../Frameworks/SDL.framework/SDL, /Library/Frameworks/SDL.framework/SDL, /System/Library/Frameworks/SDL.framework/SDL"
+         );
+     }
+ 
+-- 
+2.25.4
+


### PR DESCRIPTION
ZHF: #97479

Also #81815, @fgaz here's the promised CheeseCutter PR.

###### Motivation for this change
Updated upstream commit & derivation contains fixes for macOS (will backport for ZHF once it's confirmed working by someone & merged). This'll need a Darwin user to help me test the `ccutter` binary.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
(on Linux)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
