### PR TITLE
pythonPackages.pamqp: revert bump to fix pythonPackages.rabbitpy, bump pythonPackages.rabbitpy

### DIFF
--- a/pkgs/development/python-modules/pamqp/default.nix
+++ b/pkgs/development/python-modules/pamqp/default.nix
@@ -9,12 +9,12 @@
 }:
 
 buildPythonPackage rec {
-  version = "3.0.1";
+  version = "2.3.0";
   pname = "pamqp";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0a9b49bde3f554ec49b47ebdb789133979985f24d5f4698935ed589a2d4392a4";
+    sha256 = "1s4lwbsiikz3czqad7jarb7k303q0wamla0rirghvwl9bslgbl2w";
   };
 
   buildInputs = [ mock nose pep8 pylint mccabe ];

--- a/pkgs/development/python-modules/rabbitpy/default.nix
+++ b/pkgs/development/python-modules/rabbitpy/default.nix
@@ -7,7 +7,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.0.0";
+  version = "2.0.1";
   pname = "rabbitpy";
 
   # No tests in the pypi tarball, so we directly fetch from git
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     owner = "gmr";
     repo = pname;
     rev = version;
-    sha256 = "0fd80zlr4p2sh77rxyyfi9l0h2zqi2csgadr0rhnpgpqsy10qck6";
+    sha256 = "0m5z3i3d5adrz1wh6y35xjlls3cq6p4y9p1mzghw3k7hdvg26cck";
   };
 
   propagatedBuildInputs = [ pamqp ];
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   postPatch = ''
     # See: https://github.com/gmr/rabbitpy/issues/118
     substituteInPlace setup.py \
-      --replace 'pamqp>=1.6.1,<2.0' 'pamqp'
+      --replace 'pamqp>=2,<3' 'pamqp'
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

In attempting to fix `pythonPackages.rabbitpy` for ZHF I realized it wouldn't be possible with the recent bump of `pythonPackages.pamqp`, because no version of `rabbitpy` yet exists that supports `pamqp` 3.x. Seeing as there's only one other package (`pythonPackages.aioamqp`) depending on `pamqp`, and it seems fine with the old 2.3.0, I wondered if the best thing to do would be just to revert the bump for this release?

At the same time I bumped `rabbitpy` itself as I realized it was due.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
