### PR TITLE
vector: 0.8.1 -> 0.10.0; fix Darwin build

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -5,25 +5,27 @@
 
 , features ?
     (if stdenv.isAarch64
-     then [ "shiplift/unix-socket" "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ]
-     else [ "leveldb" "leveldb/leveldb-sys-2" "shiplift/unix-socket" "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ])
+     then [ "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ]
+     else [ "leveldb" "leveldb/leveldb-sys-2" "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ])
+, coreutils
+, CoreServices
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "vector";
-  version = "0.8.1";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner  = "timberio";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "0k15scvjcg2v4z80vq27yrn2wm50fp8xj8lga2czzs0zxhlv21nl";
+    sha256 = "0q6x3fvwwh18iyznqlr09n3zppzgw9jaz973s8haz54hnxj16wx0";
   };
 
-  cargoSha256 = "1al8jzjxjhxwb5n1d52pvl59d11g0bdg2dcw8ir2nclya1w68f2w";
+  cargoSha256 = "Y/vDYXWQ65zZ86vTwP4aCZYCMZuqbz6tpfv4uRkFAzc=";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl protobuf rdkafka ]
-                ++ stdenv.lib.optional stdenv.isDarwin [ Security libiconv ];
+                ++ stdenv.lib.optional stdenv.isDarwin [ Security libiconv coreutils CoreServices ];
 
   # needed for internal protobuf c wrapper library
   PROTOC="${protobuf}/bin/protoc";


### PR DESCRIPTION
##### Motivation for this change
darwin build is broken https://hydra.nixos.org/build/126541180

###### Things done

update dependency to latest released (0.10.0)

remove deprecated feature shiplift @thoughtpolice let me know if I'm wrong there

add buildInput for darwin

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
