### PR TITLE
cargo-update: fix Darwin build

### DIFF
--- a/pkgs/tools/package-management/cargo-update/default.nix
+++ b/pkgs/tools/package-management/cargo-update/default.nix
@@ -11,6 +11,7 @@
 , openssl
 , Security
 , zlib
+, xcbuild
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -27,7 +28,10 @@ rustPlatform.buildRustPackage rec {
   cargoPatches = [ ./0001-Generate-lockfile-for-cargo-update-v4.1.1.patch ];
   cargoSha256 = "1yaawp015gdnlfqkdmqsf95gszz0h5j1vpfjh763y7kk0bp7zswl";
 
-  nativeBuildInputs = [ cmake installShellFiles pkg-config ronn ];
+  nativeBuildInputs = [
+    cmake installShellFiles pkg-config ronn
+    xcbuild # The cc crate attempts to run xcbuild.
+  ];
 
   buildInputs = [ libgit2 libssh2 openssl zlib ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ curl Security ];


### PR DESCRIPTION
##### Motivation for this change
darwin build is broken https://hydra.nixos.org/build/126558524

###### Things done

apply a fix found by @danieldk (add a dependency that cc has)

@Gerschtli @filalex77 @JohnTitor 
Let me know if anything.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
