### PR TITLE
xmenu: version bump 4.3.1 -> 4.4.1

### DIFF
--- a/pkgs/applications/misc/xmenu/default.nix
+++ b/pkgs/applications/misc/xmenu/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xmenu";
-  version = "4.3.1";
+  version = "4.4.1";
 
   src = fetchFromGitHub {
     owner = "phillbush";
     repo = "xmenu";
     rev = "v${version}";
-    sha256 = "0m97w1nwak5drcxxlyisqb73fxkapy2rlph9mg531kbx3k2h30r1";
+    sha256 = "1s70zvsaqnsjqs298vw3py0vcvia68xlks1wcz37pb88bwligz1x";
   };
 
   buildInputs = [ imlib2 libX11 libXft libXinerama ];
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A menu utility for X";
     homepage = "https://github.com/phillbush/xmenu";
-    license = licenses.publicDomain;
+    license = licenses.mit;
     maintainers = with maintainers; [ neonfuz ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Motivation for this change
Version bump, and license change.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
