### PR TITLE
sozu: 0.11.46 -> 0.11.50; fix Darwin build

### DIFF
--- a/pkgs/servers/sozu/default.nix
+++ b/pkgs/servers/sozu/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, rustPlatform, fetchFromGitHub }:
+{ stdenv, rustPlatform, fetchFromGitHub, Security }:
 
 rustPlatform.buildRustPackage rec {
     pname = "sozu";
-    version = "0.11.46";
+    version = "0.11.50";
 
     src = fetchFromGitHub {
         owner = "sozu-proxy";
         repo = pname;
         rev = version;
-        sha256 = "0anng5qvdx9plxs9qqr5wmjjz0gx5113jq28xwbxaaklvd4ni7cm";
+        sha256 = "1srg2b8vwc4vp07kg4fizqj1rbm9hvf6hj1mjdh6yvb9cpbw3jz7";
     };
 
-    cargoSha256 = "19c2s9h4jk9pff72wdqw384mvrf40d8x4sx7qysnpb4hayq2ijh3";
+    cargoSha256 = "5WOigCiQZQ5DaTd15vV8pUh8Xl3UIe9yLG1ptUtY+iA=";
+
+    buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
 
     meta = with stdenv.lib; {
         description = "Open Source HTTP Reverse Proxy built in Rust for Immutable Infrastructures";


### PR DESCRIPTION
###### Motivation for this change
darwin build failing https://hydra.nixos.org/build/126539600

###### Things done

update sozu to 0.11.50

add missing security dependency for Darwin

@filalex77 let me know if anything

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
