### PR TITLE
GnuPG: add scdaemon shared access patch

### DIFF
--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -36,6 +36,18 @@ stdenv.mkDerivation rec {
     ./tests-add-test-cases-for-import-without-uid.patch
     ./allow-import-of-previously-known-keys-even-without-UI.patch
     ./accept-subkeys-with-a-good-revocation-but-no-self-sig.patch
+
+    /* Add option to enable scdaemon shared-access to smartcard
+
+    See here for detailed description of the issue: https://wiki.archlinux.org/index.php/GnuPG#Shared_access_with_pcscd
+    Upstream GnuPG issue, closed as wontfix: https://dev.gnupg.org/T3267
+    GPGTools issue where this patch was created: https://gpgtools.lighthouseapp.com/projects/66001/tickets/690-add-support-to-scdaemon-for-shared-access-mode
+    */
+    (fetchpatch {
+      name = "scdaemon_shared-access.patch";
+      url = "https://raw.githubusercontent.com/GPGTools/MacGPG2/7f6df478aea90e25816f53b441a40993823c0973/patches/gnupg/scdaemon_shared-access.patch";
+      sha256 = "1b34ac03cp0q92rl9n6vihz9amb5lp473qwhmkcwh9bfbi2vxrls";
+    })
   ];
   postPatch = ''
     sed -i 's,hkps://hkps.pool.sks-keyservers.net,hkps://keys.openpgp.org,g' configure doc/dirmngr.texi doc/gnupg.info-1


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

GnuPG stubbornly refuses to share access to smartcards, which, among other things, makes it not work properly with Yubikey-manager.

This adds a patch maintained by [MacOS GPGTools](https://github.com/GPGTools/MacGPG2) which adds an option to enable shared smartcard access.

There is no change in default behavior, and patch applies cleanly without modifications, so I see no reason why Nix should not have it as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
