### PR TITLE
[20.09] nwg-launchers: 0.2.0 -> 0.3.3; fix nwggrid not showing apps

### DIFF
--- a/pkgs/applications/misc/nwg-launchers/default.nix
+++ b/pkgs/applications/misc/nwg-launchers/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nwg-launchers";
-  version = "0.2.0";
+  version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = "nwg-piotr";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1mlym0mpg6njwgwniwlk95fk6wfwlzq8nwmkb5mkjlm2nqv5bdv1";
+    sha256 = "1p1bwsn7l4vp7y183735pgsfbh7dssdfn0wjzacl4s87arjdcgvb";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
(cherry picked from commit 1d5fb043fa848fffd18512e47ea57168fce5de6f)

original pr: #97920
upstream bug: https://github.com/nwg-piotr/nwg-launchers/issues/74

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

nwggrid wasn't showing any apps because it didn't respect XDG's specs or something like that.

I'm not sure if it's a good enough reason for a backport since it's my first one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/ys5fpzziivrm1qk97z5khnfmfvpzqa91-nwg-launchers-0.2.0	 294.6M
/nix/store/7g8rhw9zqss4p1zplcis456qy6r81r5j-nwg-launchers-0.3.3	 294.7M