### PR TITLE
[20.09] python.pkgs.geopandas: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/geopandas/default.nix
+++ b/pkgs/development/python-modules/geopandas/default.nix
@@ -1,18 +1,26 @@
 { stdenv, buildPythonPackage, fetchFromGitHub, isPy27
 , pandas, shapely, fiona, descartes, pyproj
-, pytest, Rtree }:
+, pytest, Rtree, fetchpatch }:
 
 buildPythonPackage rec {
   pname = "geopandas";
-  version = "0.8.0";
+  version = "0.8.1";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "geopandas";
     repo = "geopandas";
     rev = "v${version}";
-    sha256 = "033jygbyycl9s6b0kqix9xynhapc2xd8nh47kcfacn514gyncgah";
+    sha256 = "0618p0s0biisxk2s0h43hkc3bs1nwjk84rxbfyd6brfvs9yx4vq7";
   };
+
+  patches = [
+    # Fix for test test_numerical_operations: https://github.com/geopandas/geopandas/issues/1541
+    (fetchpatch {
+      url = "https://github.com/geopandas/geopandas/pull/1544/commits/6ce868a33a2f483b071089d51e178030fa4414d0.patch";
+      sha256 = "1sjgxrqgbhz5krx51hrv230ywszcdl6z8q3bj6830kfad8n8b5dq";
+    })
+  ];
 
   checkInputs = [ pytest Rtree ];
 


### PR DESCRIPTION
###### Motivation for this change
This fixes the geopandas build, which did break with the update of
pandas from 1.0.5 to 1.1.0.

(cherry picked from commit dc2e45e3e580bc2a0fb69a80fdd2207eb1b8ba1a)

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
