### PR TITLE
[20.09] qtstyleplugins: Fix build with qt>=5.15

### DIFF
--- a/pkgs/development/libraries/qtstyleplugins/default.nix
+++ b/pkgs/development/libraries/qtstyleplugins/default.nix
@@ -10,6 +10,8 @@ mkDerivation {
     sha256 = "085wyn85nrmzr8nv5zv7fi2kqf8rp1gnd30h72s30j55xvhmxvmy";
   };
 
+  patches = [ ./fix-build-against-Qt-5.15.patch ];
+
   nativeBuildInputs = [ pkgconfig qmake ];
   buildInputs = [ gtk2 ];
 

--- a/pkgs/development/libraries/qtstyleplugins/fix-build-against-Qt-5.15.patch
+++ b/pkgs/development/libraries/qtstyleplugins/fix-build-against-Qt-5.15.patch
@@ -1,0 +1,44 @@
+From 335dbece103e2cbf6c7cf819ab6672c2956b17b3 Mon Sep 17 00:00:00 2001
+From: Fabian Vogt <fvogt@suse.de>
+Date: Thu, 28 May 2020 12:35:42 +0200
+Subject: [PATCH] fix build against Qt 5.15
+
+With 0a93db4d82c051164923a10e4382b12de9049b45 ("Unify application
+palette handling between QGuiApplication and QApplication")
+QApplicationPrivate::setSystemPalette is no longer used and necessary.
+---
+ src/plugins/styles/gtk2/qgtkstyle.cpp   | 2 ++
+ src/plugins/styles/gtk2/qgtkstyle_p.cpp | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/src/plugins/styles/gtk2/qgtkstyle.cpp b/src/plugins/styles/gtk2/qgtkstyle.cpp
+index 36169c9..2544593 100644
+--- a/src/plugins/styles/gtk2/qgtkstyle.cpp
++++ b/src/plugins/styles/gtk2/qgtkstyle.cpp
+@@ -440,7 +440,9 @@ void QGtkStyle::polish(QApplication *app)
+     // not supported as these should be entirely determined by
+     // current Gtk settings
+     if (app->desktopSettingsAware() && d->isThemeAvailable()) {
++#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+         QApplicationPrivate::setSystemPalette(standardPalette());
++#endif
+         QApplicationPrivate::setSystemFont(d->getThemeFont());
+         d->applyCustomPaletteHash();
+         if (!d->isKDE4Session())
+diff --git a/src/plugins/styles/gtk2/qgtkstyle_p.cpp b/src/plugins/styles/gtk2/qgtkstyle_p.cpp
+index e57b3d8..e71beb0 100644
+--- a/src/plugins/styles/gtk2/qgtkstyle_p.cpp
++++ b/src/plugins/styles/gtk2/qgtkstyle_p.cpp
+@@ -508,7 +508,9 @@ void QGtkStyleUpdateScheduler::updateTheme()
+       if (oldTheme != QGtkStylePrivate::getThemeName()) {
+           oldTheme = QGtkStylePrivate::getThemeName();
+           QPalette newPalette = qApp->style()->standardPalette();
++#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+           QApplicationPrivate::setSystemPalette(newPalette);
++#endif
+           QApplication::setPalette(newPalette);
+           if (!QGtkStylePrivate::instances.isEmpty()) {
+               QGtkStylePrivate::instances.last()->initGtkWidgets();
+-- 
+2.26.2
+


### PR DESCRIPTION
(cherry picked from commit ff6c3a9e3485ab0d3ce3687b9795555453b699d0)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
#97479 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
