### PR TITLE
melody: init at 2.2.1

### DIFF
--- a/pkgs/applications/audio/melody/default.nix
+++ b/pkgs/applications/audio/melody/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, gtk3
+, pkgconfig
+, python3
+, desktop-file-utils
+, vala
+, wrapGAppsHook
+, appstream
+, clutter-gtk
+, cmake
+, gst_all_1
+, json-glib
+, libgee
+, libsoup
+, pantheon
+, sqlite
+, taglib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "melody";
+  version = "2.2.1";
+
+  src = fetchFromGitHub {
+    owner = "artemanufrij";
+    repo = "playmymusic";
+    rev = "bba5fe74134ad7533c41044d8ce41f1a8f69b3b0";
+    sha256 = "0kjzy87bvgp5zpk35n21758ka8wbl8g5xbfiw4aljpxw4sb9isql";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = with gst_all_1; [
+    appstream
+    clutter-gtk
+    cmake
+    gst-plugins-bad
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-ugly
+    gstreamer
+    gtk3
+    json-glib
+    libgee
+    libsoup
+    pantheon.elementary-icon-theme
+    pantheon.granite
+    sqlite
+    taglib
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A music player for listening to local music files, online radio and Audio CD's - Designed for elementary OS";
+    homepage = "https://anufrij.org/melody";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ hotlineguy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27965,4 +27965,6 @@ in
 
   unifi-poller = callPackage ../servers/monitoring/unifi-poller {};
 
+  melody = callPackage ../applications/audio/melody {};
+
 }


### PR DESCRIPTION
###### Motivation for this change
adding the melody music player (https://github.com/artemanufrij/playmymusic) to the repository

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).