### PR TITLE
amdvlk: 2020.Q3.4 -> 2020.Q3.5 and add 32-bit build

### DIFF
--- a/nixos/doc/manual/configuration/gpu-accel.xml
+++ b/nixos/doc/manual/configuration/gpu-accel.xml
@@ -183,7 +183,12 @@ GPU1:
 	be forced as follows:
 
 	<programlisting><xref linkend="opt-hardware.opengl.extraPackages"/> = [
-  <package>amdvlk</package>
+  pkgs.<package>amdvlk</package>
+];
+
+# To enable Vulkan support for 32-bit applications, also add:
+<xref linkend="opt-hardware.opengl.extraPackages32"/> = [
+  pkgs.driversi686Linux.<package>amdvlk</package>
 ];
 
 # For amdvlk

--- a/pkgs/development/libraries/amdvlk/default.nix
+++ b/pkgs/development/libraries/amdvlk/default.nix
@@ -15,8 +15,11 @@
 , xorg
 , zlib
 }:
+let
 
-stdenv.mkDerivation rec {
+  suffix = if stdenv.system == "x86_64-linux" then "64" else "32";
+
+in stdenv.mkDerivation rec {
   pname = "amdvlk";
   version = "2020.Q3.4";
 
@@ -62,14 +65,24 @@ stdenv.mkDerivation rec {
 
   cmakeDir = "../drivers/xgl";
 
+  # LTO is disabled in gcc for i686 as of #66528
+  cmakeFlags = stdenv.lib.optionals stdenv.is32bit ["-DXGL_ENABLE_LTO=OFF"];
+
+  postPatch = stdenv.lib.optionalString stdenv.is32bit ''
+    substituteInPlace drivers/pal/cmake/PalCompilerOptions.cmake \
+      --replace "pal_setup_gcc_ipo()" ""
+  '';
+
   installPhase = ''
-    install -Dm755 -t $out/lib icd/amdvlk64.so
-    install -Dm644 -t $out/share/vulkan/icd.d ../drivers/AMDVLK/json/Redhat/amd_icd64.json
+    install -Dm755 -t $out/lib icd/amdvlk${suffix}.so
+    install -Dm644 -t $out/share/vulkan/icd.d ../drivers/AMDVLK/json/Redhat/amd_icd${suffix}.json
 
-    substituteInPlace $out/share/vulkan/icd.d/amd_icd64.json --replace \
+    substituteInPlace $out/share/vulkan/icd.d/amd_icd${suffix}.json --replace \
       "/usr/lib64" "$out/lib"
+    substituteInPlace $out/share/vulkan/icd.d/amd_icd${suffix}.json --replace \
+      "/usr/lib" "$out/lib"
 
-    patchelf --set-rpath "$rpath" $out/lib/amdvlk64.so
+    patchelf --set-rpath "$rpath" $out/lib/amdvlk${suffix}.so
   '';
 
   # Keep the rpath, otherwise vulkaninfo and vkcube segfault
@@ -80,7 +93,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/GPUOpen-Drivers/AMDVLK";
     changelog = "https://github.com/GPUOpen-Drivers/AMDVLK/releases/tag/v-${version}";
     license = licenses.mit;
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = with maintainers; [ danieldk Flakebi ];
   };
 }

--- a/pkgs/development/libraries/amdvlk/default.nix
+++ b/pkgs/development/libraries/amdvlk/default.nix
@@ -21,13 +21,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "amdvlk";
-  version = "2020.Q3.4";
+  version = "2020.Q3.5";
 
   src = fetchRepoProject {
     name = "${pname}-src";
     manifest = "https://github.com/GPUOpen-Drivers/AMDVLK.git";
     rev = "refs/tags/v-${version}";
-    sha256 = "13yy1v43wyw2dbanl39sk1798344smmycgvl3gla61ipqls0qfgd";
+    sha256 = "08fj3cg3axnwadlpfim23g5nyjl69044fqxdr57af6y79441njay";
   };
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12159,6 +12159,7 @@ in
   # Multi-arch "drivers" which we want to build for i686.
   driversi686Linux = recurseIntoAttrs {
     inherit (pkgsi686Linux)
+      amdvlk
       mesa
       vaapiIntel
       libvdpau-va-gl


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
AMDVLK 2020.Q3.5 was released: https://github.com/GPUOpen-Drivers/AMDVLK/releases/tag/v-2020.Q3.5
I took the opportunity to include 32-bit support (fixes #93027).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Tested with vkcube and Dota 2
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
