### PR TITLE
rgp: 1.7.0.29 -> 1.8

### DIFF
--- a/pkgs/development/tools/rgp/default.nix
+++ b/pkgs/development/tools/rgp/default.nix
@@ -13,16 +13,20 @@
 , libXi
 , ncurses5
 , qtbase
+, qtdeclarative
 , zlib
 }:
 
+let
+  buildNum = "2020-09-11-26";
+in
 stdenv.mkDerivation rec {
   pname = "rgp";
-  version = "1.7.0.29";
+  version = "1.8";
 
   src = fetchurl {
-    url = "https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/download/v${lib.versions.majorMinor version}/RadeonGPUProfiler_${version}.tgz";
-    sha256 = "d7d4aa92231796a509dfcf92e9618cac98ae6572c12efd0871eb43afa4e8240a";
+    url = "https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/download/v${lib.versions.majorMinor version}/RadeonDeveloperTools-${buildNum}.tgz";
+    sha256 = "1lpkh7sfpq697lm4xnkpjfchh8zpy49f4mb3c5qcn7brav5iqwfh";
   };
 
   nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
@@ -38,6 +42,7 @@ stdenv.mkDerivation rec {
     libXi
     ncurses5
     qtbase
+    qtdeclarative
     zlib
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
RGP 1.8 was released: https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/tag/v1.8
Today seems to be release day :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Tested capturing and viewing a profile of vkcube.
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
