### PR TITLE
build-erlang-mk: add support for buildFlags, preserve buildInputs

### DIFF
--- a/pkgs/development/beam-modules/build-erlang-mk.nix
+++ b/pkgs/development/beam-modules/build-erlang-mk.nix
@@ -12,6 +12,7 @@
 , configurePhase ? null
 , meta ? {}
 , enableDebugInfo ? false
+, buildFlags ? []
 , ... }@attrs:
 
 with stdenv.lib;
@@ -42,6 +43,10 @@ let
     buildInputs = [ erlang perl which gitMinimal wget ];
     propagatedBuildInputs = beamDeps;
 
+    buildFlags = [ "SKIP_DEPS=1" ]
+      ++ lib.optional (enableDebugInfo || erlang.debugInfo) ''ERL_OPTS="$ERL_OPTS +debug_info"''
+      ++ buildFlags;
+
     configurePhase = if configurePhase == null
     then ''
       runHook preConfigure
@@ -58,7 +63,7 @@ let
     then ''
         runHook preBuild
 
-        make SKIP_DEPS=1 ERL_OPTS="$ERL_OPTS ${debugInfoFlag}"
+        make $buildFlags "''${buildFlagsArray[@]}"
 
         runHook postBuild
     ''

--- a/pkgs/development/beam-modules/build-erlang-mk.nix
+++ b/pkgs/development/beam-modules/build-erlang-mk.nix
@@ -40,7 +40,7 @@ let
     ''
     else setupHook;
 
-    buildInputs = [ erlang perl which gitMinimal wget ];
+    buildInputs = buildInputs ++ [ erlang perl which gitMinimal wget ];
     propagatedBuildInputs = beamDeps;
 
     buildFlags = [ "SKIP_DEPS=1" ]


### PR DESCRIPTION
###### Motivation for this change

`buildErlangMk` should use `buildFlags`/`makeFlags` as all other `make`-based functions support.
The function also failed to use the user's `buildInputs`.

The first commit fixes `buildFlags` usage, I'm not sure whether `configureFlags` is also relevant.
The second commit fixes not using the passed-in `buildInputs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
