### PR TITLE
Change owner of and update vimPlugins.nerdtree-git-plugin: init at 2020-09-11

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -2412,14 +2412,14 @@ let
 
   nerdtree-git-plugin = buildVimPluginFrom2Nix {
     pname = "nerdtree-git-plugin";
-    version = "2019-01-09";
+    version = "2020-09-11";
     src = fetchFromGitHub {
-      owner = "albfan";
+      owner = "Xuyuanp";
       repo = "nerdtree-git-plugin";
-      rev = "95e20577cd442ad6256aff9bb2e9c80db05c13f0";
-      sha256 = "15i66mxvygs6xa2jvk7bqdagxx1lcvynmyb9g75whgbv7is80qn7";
+      rev = "a8c031f11dd312f53357729ca47ad493e798aa86";
+      sha256 = "1d64cmywhj43q9fkrh0kcfsxa7ijxcb1fbz38pxaacg082y6l0jy";
     };
-    meta.homepage = "https://github.com/albfan/nerdtree-git-plugin/";
+    meta.homepage = "https://github.com/Xuyuanp/nerdtree-git-plugin/";
   };
 
   neuron-vim = buildVimPluginFrom2Nix {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -3,7 +3,6 @@ airblade/vim-gitgutter
 airblade/vim-rooter
 ajh17/Spacegray.vim
 aklt/plantuml-syntax
-albfan/nerdtree-git-plugin
 altercation/vim-colors-solarized
 alvan/vim-closetag
 alx741/vim-hindent
@@ -604,6 +603,7 @@ xavierd/clang_complete
 xolox/vim-easytags
 xolox/vim-misc
 xuhdev/vim-latex-live-preview
+Xuyuanp/nerdtree-git-plugin
 ycm-core/YouCompleteMe
 Yggdroot/indentLine
 Yilin-Yang/vim-markbar


### PR DESCRIPTION
https://github.com/albfan/nerdtree-git-plugin is an outdated (last commit was made more than year an a half ago) fork of the original plugin https://github.com/Xuyuanp/nerdtree-git-plugin (last commit on 11 September 2020).

In the `nixos-20.09` release the `vimPlugins.nerdtree` doesn’t work with the `vimPlugins.nerdtree-git-plugin` failing with this error:
```
Error detected while processing function 210[2]..211[14]..194[20]..197[8]..161[25]..159[15]..271[5]..NERDTreeGitStatusRefreshListener[5]..NERDTreeGetGitStatusPrefix:                                                                                                                                                                                                        
line    6:                                                                                                                                                                                                                                                                                                                                                                   
E716: Key not present in Dictionary: Slash()                                                                                                                                                                                                                                                                                                                                 
E15: Invalid expression: b:NERDTree.root.path.str() . a:path.Slash()                                                                                                                                                                                                                                                                                                         
Error detected while processing function 210[2]..211[14]..194[20]..197[8]..161:                                                                                                                                                                                                                                                                                              
line   25:                                                                                                                                                                                                                                                                                                                                                                   
E171: Missing :endif                                                                                                                                                                                                                                                                                                                                                         
Error detected while processing function 210[2]..211:                                                                                                                                                                                                                                                                                                                        
line   14:                                                                                                                                                                                                                                                                                                                                                                   
E171: Missing :endif                                                                                                                                                                                                                                                                                                                                                         
Press ENTER or type command to continue 
```
When you try to call `:NERDTree`.

This merge request fixes this bug. Or probably not a bug but just an incompatibility with newer **NERDTree**.

I called `./update --add Xuyuanp/nerdtree-git-plugin` but it does a lot of extra commits I didn’t want for this small patch. So I rolled back to `master` and cherry-picked only the last commit. After that I had to manually remove the old one since `./update.py` doesn’t do this. And I committed the deletion with `--amend`. 

Tested it by this command:
``` sh
nix-shell -E 'let pkgs=import ~/dev/nix/nixpkgs {}; in pkgs.mkShell {buildInputs=[(import nix/apps/neovim.nix {inherit pkgs;})];}' --run 'nvim +NERDTree'
```
against my Neovim config: https://github.com/unclechu/neovimrc/commit/2c40e114e36e8831ee8f2dc099c15f7d7f0c8ad9 where `~/dev/nix/nixpkgs` is:
```
λ (cd ~/dev/nix/nixpkgs && git rev-parse @)
6b75695c9ade9363847217a3c6b781a273ca290a
```