### PR TITLE
caddy1: fix build

### DIFF
--- a/pkgs/servers/caddy/v1.nix
+++ b/pkgs/servers/caddy/v1.nix
@@ -21,9 +21,10 @@ buildGoModule rec {
     cat << EOF > caddy/main.go
     package main
     import "github.com/caddyserver/caddy/caddy/caddymain"
+    var run = caddymain.Run // replaced for tests
     func main() {
       caddymain.EnableTelemetry = false
-      caddymain.Run()
+      run()
     }
     EOF
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
`caddy/main.go` gets overwritten in order to build `caddy1` with telemetry
disabled, but the global variable `run` got neglected, and this in turn
broke the test in `caddy/main_test.go`.

This commit fixes that, and build can now complete.

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).



Thanks to @nilp0inter for helping me test this change!
