### PR TITLE
systemd: 246.4 -> 246.6

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -200,9 +200,7 @@ def main():
     else:
         # Update bootloader to latest if needed
         systemd_version = subprocess.check_output(["@systemd@/bin/bootctl", "--version"], universal_newlines=True).split()[1]
-        # Ideally this should use check_output as well, but as a temporary
-        # work-around for #97433 we ignore any errors.
-        sdboot_status = subprocess.run(["@systemd@/bin/bootctl", "--path=@efiSysMountPoint@", "status"], universal_newlines=True, stdout=subprocess.PIPE).stdout
+        sdboot_status = subprocess.check_output(["@systemd@/bin/bootctl", "--path=@efiSysMountPoint@", "status"], universal_newlines=True)
 
         # See status_binaries() in systemd bootctl.c for code which generates this
         m = re.search("^\W+File:.*/EFI/(BOOT|systemd)/.*\.efi \(systemd-boot (\d+)\)$",

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  version = "246.5";
+  version = "246.6";
 in stdenv.mkDerivation {
   inherit version;
   pname = "systemd";
@@ -29,7 +29,7 @@ in stdenv.mkDerivation {
     owner = "systemd";
     repo = "systemd-stable";
     rev = "v${version}";
-    sha256 = "0nwchkk1f69pla68v52fzlc0zvwrgw74ri8imx2rcd6b68cwcwwm";
+    sha256 = "1yhj2jlighqqpw1xk9q52f3pncjn47ipi224k35d6syb94q2b988";
   };
 
   # If these need to be regenerated, `git am path/to/00*.patch` them into a

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  version = "246.4";
+  version = "246.5";
 in stdenv.mkDerivation {
   inherit version;
   pname = "systemd";
@@ -29,7 +29,7 @@ in stdenv.mkDerivation {
     owner = "systemd";
     repo = "systemd-stable";
     rev = "v${version}";
-    sha256 = "0ns12w55yv680p4l7f2i9il7scdph7hips68d9k8cyvxk2w9xg0x";
+    sha256 = "0nwchkk1f69pla68v52fzlc0zvwrgw74ri8imx2rcd6b68cwcwwm";
   };
 
   # If these need to be regenerated, `git am path/to/00*.patch` them into a


### PR DESCRIPTION
This bumps systemd to the latest stable maintenance release.

d0f0f048ec (tag: v246.5, systemd-stable/v246-stable) sd-path: use ROOTPREFIX without suffixed slash
e662cf6d51 hashmap: make sure to initialize shared hash key atomically
da310c6b45 socket: downgrade log warnings about inability to set socket buffer sizes
ab6fcd9135 core: fix securebits setting
4f6925484d capability-util: add new function for raising setpcap
771436884d network: do not add prefix to RA if radv is not configured
fb2afc5f30 man: document the random delay of persistent timers
b2006ddc8f test-network: add test for ENOBUFS issue #17012
8758580ef5 backlight: do not claim that ID_BACKLIGHT_CLAMP= property is not set
57fc184a6c fs-util,tmpfiles: fix error handling of fchmod_opath()
db0f031e70 bootctl: don't accidentally propagate errors in "bootctl status"
3e2c806681 ethtool-util: don't pass error value that isn't used to log_syntax
b671730edb network: don't fail on various config parse errors
0ad86030c5 man: document that sd_bus_message_close_container() may only be called at end of container
f3da018017 cryptsetup: Fix null pointer dereference (#16987)
6f65eaf9c2 core: fix set keep caps for ambient capabilities
08338a234e core: fix comments on ambient capabilities
f0e6d9876d network: make log_link_error() or friends return void
35766dc61b core: make log_unit_error() or friends return void
3ed10b2ee8 core/slice: explicitly specify return value
2f6406914b udev: do not discard const qualifier
07671aa4cc sd-device: make log_device_error() or friends return void
d4bea73972 udev: explicitly specify return value
7db399be1e udev: return negative errno for invalid EVDEV_ABS_XXX= property
8c8d188e85 udev: make log_rule_error() or friends return void
4921375fd3 socket: fix copy/paste error
0f7fd97749 udev: warn if failed to set buffer size for device monitor
fc763d38d8 network: increase receive buffer size for device monitor
3bf7797f1f network: do not start device monitor if /sys is read-only
ebc0729c6a network: honor the buffer size specified in networkd.socket
ef3d2e178b core/socket: use fd_set_{rcv,snd}buf()
5dd4cc4b10 sd-device-monitor: use fd_set_rcvbuf()
fe9b92e566 util: introduce fd_set_{snd,rcv}buf()
4dcae66688 util: try to set with SO_{RCV,SND}BUFFORCE when requested size is larger than the kernel limit
4b6b523946 util: refuse to set too large value for socket buffer size
b4be8edb45 network: ignore error on increasing netlink receive buffer size
5ce47fb491 tree-wide: if get_block_device() returns zero devno, check for it in all cases
8ea6ec18e7 btrfs: if BTRFS_IOC_DEV_INFO returns /dev/root generate a friendly error message
e1ff4947d2 basic/log: make log_{info,warning,...} return void
8019995e9a tree-wide: correct cases where return log_{error,warning} is used without value
932f4c3e8b test-execute/exec-dynamicuser-statedir.service: fix quoting
16b9426f70 man: fix quickhelp listing in sysusers.d(5)
bde903d9e9 network: fix NDisc handling for the case when multiple routers exist
c965063b64 network: expose route_{hash,compare}_func()
6d24a40669 network: expose address_{hash,compare}_func()
054838a2e0 util: expose in6_addr_{hash,compare}_func()
58bd4a70de network: fixes gateway assignment through DHCPv4
8ad5382fe3 bash-completion: resolvectl: support 'log-level' command
a98bd75072 resolvectl: add 'log-level' to help message
78262fe807 core/socket: we may get ENOTCONN from socket_instantiate_service()
fecb3f00c4 homed: remember the secret even when the for_state is FIXATING_FOR_ACQUIRE

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
