### PR TITLE
python3Packages.batchgenerators: 0.20.0 -> 0.20.1

### DIFF
--- a/pkgs/development/python-modules/batchgenerators/default.nix
+++ b/pkgs/development/python-modules/batchgenerators/default.nix
@@ -3,7 +3,7 @@
 , isPy27
 , fetchFromGitHub
 , fetchpatch
-, pytest
+, pytestCheckHook
 , unittest2
 , future
 , numpy
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "batchgenerators";
-  version = "0.20.0";
+  version = "0.20.1";
 
   disabled = isPy27;
 
@@ -24,11 +24,12 @@ buildPythonPackage rec {
     owner = "MIC-DKFZ";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0cc3i4wznqb7lk8n6jkprvkpsby6r7khkxqwn75k8f01mxgjfpvf";
+    sha256 = "1f91yflv9rschyl5bnfn735hp1rxrzcxkx18aajmlzb067h0ip8m";
 
   };
 
   patches = [
+    # lift Pillow bound; should be merged in next release
     (fetchpatch {
       url = "https://github.com/MIC-DKFZ/batchgenerators/pull/59.patch";
       sha256 = "171b3dm40yn0wi91m9s2nq3j565s1w39jpdf1mvc03rn75i8vdp0";
@@ -39,9 +40,7 @@ buildPythonPackage rec {
     future numpy pillow scipy scikitlearn scikitimage threadpoolctl
   ];
 
-  checkInputs = [ pytest unittest2 ];
-
-  checkPhase = "pytest tests";
+  checkInputs = [ pytestCheckHook unittest2 ];
 
   meta = {
     description = "2D and 3D image data augmentation for deep learning";

--- a/pkgs/development/python-modules/threadpoolctl/default.nix
+++ b/pkgs/development/python-modules/threadpoolctl/default.nix
@@ -3,7 +3,7 @@
 , isPy27
 , fetchFromGitHub
 , flit
-, pytest
+, pytestCheckHook
 , pytestcov
 , numpy
 , scipy
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "threadpoolctl";
-  version = "2.0.0";
+  version = "2.1.0";
 
   disabled = isPy27;
   format = "flit";
@@ -20,13 +20,10 @@ buildPythonPackage rec {
     owner = "joblib";
     repo = pname;
     rev = version;
-    sha256 = "16z4n82f004i4l1jw6qrzazda1m6v2yjnpqlp71ipa8mzy9kw7dw";
+    sha256 = "0sl6mp3b2gb0dvqkhnkmrp2g3r5c7clyyyxzq44xih6sw1pgx9df";
   };
 
-  checkInputs = [ pytest pytestcov numpy scipy ];
-
-  checkPhase = "pytest tests -k 'not test_nested_prange_blas'";
-  # cython doesn't get run on the tests when added to nativeBuildInputs, breaking this test
+  checkInputs = [ pytestCheckHook pytestcov numpy scipy ];
 
   meta = with lib; {
     homepage = "https://github.com/joblib/threadpoolctl";


### PR DESCRIPTION
python3Packages.threadpoolctl: 2.0.0 -> 2.1.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
