### PR TITLE
melody: init at 2.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2233,6 +2233,12 @@
       fingerprint = "4749 0887 CF3B 85A1 6355  C671 78C7 DD40 DF23 FB16";
     }];
   };
+  dpercy = {
+    email = "dpercy@dpercy.dev";
+    github = "dpercy";
+    githubId = 349909;
+    name = "David Percy";
+  };
   dpflug = {
     email = "david@pflug.email";
     github = "dpflug";
@@ -2798,6 +2804,16 @@
     github = "fdns";
     githubId = 541748;
     name = "Felipe Espinoza";
+  };
+  felschr = {
+    email = "dev@felschr.com";
+    github = "felschr";
+    githubId = 3314323;
+    name = "Felix Tenley";
+    keys = [{
+      longkeyid = "ed25519/0x910ACB9F6BD26F58";
+      fingerprint = "6AB3 7A28 5420 9A41 82D9  0068 910A CB9F 6BD2 6F58";
+    }];
   };
   ffinkdevs = {
     email = "fink@h0st.space";
@@ -5536,10 +5552,14 @@
     name = "Michael Mercier";
   };
   midchildan = {
-    email = "midchildan+nix@gmail.com";
+    email = "git@midchildan.org";
     github = "midchildan";
     githubId = 7343721;
     name = "midchildan";
+    keys = [{
+      longkeyid = "rsa4096/0x186A1EDAC5C63F83";
+      fingerprint = "FEF0 AE2D 5449 3482 5F06  40AA 186A 1EDA C5C6 3F83";
+    }];
   };
   mikefaille = {
     email = "michael@faille.io";
@@ -5670,6 +5690,12 @@
     github = "mlieberman85";
     githubId = 622577;
     name = "Michael Lieberman";
+  };
+  mlvzk = {
+    name = "mlvzk";
+    email = "mlvzk@users.noreply.github.com";
+    github = "mlvzk";
+    githubId = 44906333;
   };
   mmahut = {
     email = "marek.mahut@gmail.com";
@@ -6116,6 +6142,12 @@
     github = "nmattia";
     githubId = 6930756;
     name = "Nicolas Mattia";
+  };
+  nobbz = {
+    name = "Norbert Melzer";
+    email = "timmelzer+nixpkgs@gmail.com";
+    github = "NobbZ";
+    githubId = 58951;
   };
   nocent = {
     email = "nocent@protonmail.ch";
@@ -7994,6 +8026,12 @@
     github = "stephenmw";
     githubId = 231788;
     name = "Stephen Weinberg";
+  };
+  stephenwithph = {
+    name = "StephenWithPH";
+    email = "StephenWithPH@users.noreply.github.com";
+    github = "StephenWithPH";
+    githubId = 2990492;
   };
   sterfield = {
     email = "sterfield@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9610,4 +9610,10 @@
       fingerprint = "F1C5 760E 45B9 9A44 72E9  6BFB D65C 9AFB 4C22 4DA3";
     }];
   };
+  hotlineguy = {
+    name = "Marius Schmidt";
+    email = "63499838+hotlineguy@users.noreply.github.com";
+    github = "hotlineguy";
+    githubId = 63499838;
+  };
 }

--- a/pkgs/applications/audio/melody/default.nix
+++ b/pkgs/applications/audio/melody/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, gtk3
+, pkgconfig
+, python3
+, desktop-file-utils
+, vala
+, wrapGAppsHook
+, appstream
+, clutter-gtk
+, cmake
+, gst_all_1
+, json-glib
+, libgee
+, libsoup
+, pantheon
+, sqlite
+, taglib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "melody";
+  version = "2.2.1";
+
+  src = fetchFromGitHub {
+    owner = "artemanufrij";
+    repo = "playmymusic";
+    rev = "bba5fe74134ad7533c41044d8ce41f1a8f69b3b0";
+    sha256 = "0kjzy87bvgp5zpk35n21758ka8wbl8g5xbfiw4aljpxw4sb9isql";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = with gst_all_1; [
+    appstream
+    clutter-gtk
+    cmake
+    gst-plugins-bad
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-ugly
+    gstreamer
+    gtk3
+    json-glib
+    libgee
+    libsoup
+    pantheon.elementary-icon-theme
+    pantheon.granite
+    sqlite
+    taglib
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A music player for listening to local music files, online radio and Audio CD's - Designed for elementary OS";
+    homepage = "https://anufrij.org/melody";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ hotlineguy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27968,4 +27968,6 @@ in
 
   unifi-poller = callPackage ../servers/monitoring/unifi-poller {};
 
+  melody = callPackage ../applications/audio/melody {};
+
 }


### PR DESCRIPTION
###### Motivation for this change
Add the Melody Package (https://github.com/artemanufrij/playmymusic) to the package repository.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

First, well second, time commiting. Apparently, i managed to mess up the former branch. I'm sorry about that.