### PR TITLE
pythonPackages.bcrypt: use 3.1.x for python older than 3.6

### DIFF
--- a/pkgs/development/python-modules/bcrypt/3_1.nix
+++ b/pkgs/development/python-modules/bcrypt/3_1.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, buildPythonPackage, fetchPypi
+, isPyPy, cffi, pytest, six }:
+
+buildPythonPackage rec {
+  version = "3.1.7";
+  pname = "bcrypt";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0b0069c752ec14172c5f78208f1863d7ad6755a6fae6fe76ec2c80d13be41e42";
+  };
+
+  checkInputs = [ pytest ];
+
+  propagatedBuildInputs = [ six ] ++ lib.optional (!isPyPy) cffi;
+
+  meta = with lib; {
+    description = "Modern password hashing for your software and your servers";
+    homepage = "https://github.com/pyca/bcrypt/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ domenkozar ];
+  };
+}

--- a/pkgs/development/python-modules/trytond/default.nix
+++ b/pkgs/development/python-modules/trytond/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonApplication
 , fetchPypi
+, pythonOlder
 , mock
 , lxml
 , relatorio
@@ -25,6 +26,8 @@ with stdenv.lib;
 buildPythonApplication rec {
   pname = "trytond";
   version = "5.6.5";
+  disabled = pythonOlder "3.5";
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "a373d73b141d71f8e30d728dd8380955bc0f33daaa097201fa9a952e3663e6d8";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -778,7 +778,10 @@ in {
 
   bcdoc = callPackage ../development/python-modules/bcdoc { };
 
-  bcrypt = callPackage ../development/python-modules/bcrypt { };
+  bcrypt = if pythonOlder "3.6" then
+    callPackage ../development/python-modules/bcrypt/3_1.nix { }
+  else
+    callPackage ../development/python-modules/bcrypt { };
 
   beaker = callPackage ../development/python-modules/beaker { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
pythonPackages.bcrypt was disabled for python older than 3.6: https://github.com/NixOS/nixpkgs/commit/87371b8f6338af8398410443868c1f7750840c4b

We still have some applications that cannot be upgraded from python 2 that require python-bcrypt
mysql-workbench, syncthing-gtk: https://github.com/NixOS/nixpkgs/issues/97642

ZHF: #97479

###### Things done
Added back pythonPackages.bcrypt 3.1.7 only for python older than 3.6
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
