### PR TITLE
enlightenment.evisum: init at 0.5.6

### DIFF
--- a/pkgs/desktops/enlightenment/default.nix
+++ b/pkgs/desktops/enlightenment/default.nix
@@ -8,6 +8,7 @@
 
   #### APPLICATIONS
   econnman = callPackage ./econnman { };
+  evisum = callPackage ./evisum { };
   terminology = callPackage ./terminology { };
   rage = callPackage ./rage { };
   ephoto = callPackage ./ephoto { };

--- a/pkgs/desktops/enlightenment/evisum/default.nix
+++ b/pkgs/desktops/enlightenment/evisum/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, meson, ninja, pkg-config, efl }:
+
+stdenv.mkDerivation rec {
+  pname = "evisum";
+  version = "0.5.6";
+
+  src = fetchurl {
+    url = "https://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "1l8pym7738kncvic5ga03sj9d5igigvmcxa9lbg47z2yvdjwzv97";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    efl
+  ];
+
+  meta = with stdenv.lib; {
+    description = "System and process monitor written with EFL";
+    homepage = "https://www.enlightenment.org";
+    license = with licenses; [ isc ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [evisum](https://www.enlightenment.org/news/2020-09-14-evisum-055-release), a process monitor and system monitor using the Enlightenment Foundation Libraries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
