### PR TITLE
orocos-kdl: init at 1.4.0

### DIFF
--- a/pkgs/development/libraries/orocos-kdl/default.nix
+++ b/pkgs/development/libraries/orocos-kdl/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub, cmake, eigen }:
+
+stdenv.mkDerivation rec {
+  pname = "orocos-kdl";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "orocos";
+    repo = "orocos_kinematics_dynamics";
+    rev = "v${version}";
+    sha256 = "0qj56j231h0rnjbglakammxn2lwmhy5f2qa37v1f6pcn81dn13vv";
+  };
+
+  sourceRoot = "source/orocos_kdl";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ eigen ];
+
+  meta = with lib; {
+    description = "Kinematics and Dynamics Library";
+    homepage = "https://www.orocos.org/kdl.html";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ lopsided98 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/pykdl/default.nix
+++ b/pkgs/development/python-modules/pykdl/default.nix
@@ -1,0 +1,20 @@
+{ lib, stdenv, toPythonModule, cmake, orocos-kdl, python, sip }:
+
+toPythonModule (stdenv.mkDerivation {
+  pname = "pykdl";
+  inherit (orocos-kdl) version src;
+
+  sourceRoot = "source/python_orocos_kdl";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ orocos-kdl ];
+  propagatedBuildInputs = [ python sip ];
+
+  meta = with lib; {
+    description = "Kinematics and Dynamics Library (Python bindings)";
+    homepage = "https://www.orocos.org/kdl.html";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ lopsided98 ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9474,6 +9474,8 @@ in
 
   orc = callPackage ../development/compilers/orc { };
 
+  orocos-kdl = callPackage ../development/libraries/orocos-kdl { };
+
   metaocaml_3_09 = callPackage ../development/compilers/ocaml/metaocaml-3.09.nix { };
 
   ber_metaocaml = callPackage ../development/compilers/ocaml/ber-metaocaml.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4976,6 +4976,8 @@ in {
 
   pyjwt = callPackage ../development/python-modules/pyjwt { };
 
+  pykdl = callPackage ../development/python-modules/pykdl { };
+
   pykdtree = callPackage ../development/python-modules/pykdtree { inherit (pkgs.llvmPackages) openmp; };
 
   pykeepass = callPackage ../development/python-modules/pykeepass { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds the [Orocos Kinematic and Dynamics library](https://www.orocos.org/kdl.html), along with its Python bindings (PyKDL). This library is an important dependency for newer versions of the Robot Operating System (ROS).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
