### PR TITLE
saga: use proj 6

### DIFF
--- a/pkgs/applications/gis/saga/default.nix
+++ b/pkgs/applications/gis/saga/default.nix
@@ -6,7 +6,7 @@
 # not native
 , gdal
 , wxGTK31-gtk3
-, proj_5
+, proj
 , dxflib
 , curl
 , libiodbc
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     hdf5
     gdal
     wxGTK31-gtk3
-    proj_5
+    proj
     libharu
     opencv
     vigra


### PR DESCRIPTION
###### Motivation for this change

`proj_5` is old

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
