### PR TITLE
libmodsecurity bump version and fix CVE-2020-15598

### DIFF
--- a/pkgs/tools/security/libmodsecurity/default.nix
+++ b/pkgs/tools/security/libmodsecurity/default.nix
@@ -4,14 +4,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libmodsecurity";
-  version = "3.0.3";
+  version = "3.0.4";
 
   src = fetchFromGitHub {
     owner = "SpiderLabs";
     repo = "ModSecurity";
     fetchSubmodules = true;
     rev = "v${version}";
-    sha256 = "00g2407g2679zv73q67zd50z0f1g1ij734ssv2pp77z4chn5dzib";
+    sha256 = "07vry10cdll94sp652hwapn0ppjv3mb7n2s781yhy7hssap6f2vp";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig doxygen ];

--- a/pkgs/tools/security/libmodsecurity/default.nix
+++ b/pkgs/tools/security/libmodsecurity/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, pkgconfig
 , doxygen, perl, valgrind
 , curl, geoip, libxml2, lmdb, lua, pcre, yajl }:
 
@@ -15,6 +15,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig doxygen ];
+
+  patches = [
+    (fetchpatch {
+      name = "cve-2020-15598.patch";
+      url = "https://gist.githubusercontent.com/crsgists/0e1f6f7f1bd1f239ded64cecee46a11d/raw/181bc852065e9782367f1dc67c96d4d250e73a46/cve-2020-15598.patch";
+      sha256 = "1bcb12563qkanxq2h5dfrw5vgwgj73midc1cfl7gj443zcqhf3si";
+    })
+  ];
 
   buildInputs = [ perl valgrind curl geoip libxml2 lmdb lua pcre yajl ];
 


### PR DESCRIPTION
###### Motivation for this change

I am using this software and there are patches.

There is a dispute whether this is a vuln or not:
- https://coreruleset.org/20200914/cve-2020-15598/
- https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/modsecurity-regular-expressions-and-disputed-cve-2020-15598/
- NIST has not published anything yet: https://nvd.nist.gov/vuln/detail/CVE-2020-15598
- related upstream issue: https://github.com/SpiderLabs/ModSecurity/issues/2401

###### Things done

Bumped the version. Applied the patch. Rebuilt the server. The website is still working and modsecurity still blocks shady requests.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC maintainer: @Izorkin 