### PR TITLE
sc68: init at unstable-2020-05-18

### DIFF
--- a/pkgs/applications/audio/sc68/default.nix
+++ b/pkgs/applications/audio/sc68/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, fetchsvn
+, pkg-config
+, which
+, autoconf
+, automake
+, libtool
+, hexdump
+, libao
+, zlib
+, curl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sc68";
+  version = "unstable-2020-05-18";
+
+  src = fetchsvn {
+    url = "svn://svn.code.sf.net/p/sc68/code/";
+    rev = "693";
+    sha256 = "0liz5yjwiy41y160ag83zz9s5l8mk72fscxgvjv9g5qf4gwffnfa";
+  };
+
+  preConfigure = "tools/svn-bootstrap.sh";
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkg-config which autoconf automake libtool hexdump ];
+
+  buildInputs = [ libao zlib curl ];
+
+  meta = with stdenv.lib; {
+    description = "Atari ST and Amiga music player";
+    homepage = "http://sc68.atari.org/project.html";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22857,6 +22857,8 @@ in
 
   sawfish = callPackage ../applications/window-managers/sawfish { };
 
+  sc68 = callPackage ../applications/audio/sc68 { };
+
   sidplayfp = callPackage ../applications/audio/sidplayfp { };
 
   sndpeek = callPackage ../applications/audio/sndpeek { };


### PR DESCRIPTION
###### Motivation for this change
Packages sc68, a command-line player for Atari ST and (some) Amiga modules.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
