### PR TITLE
akira: 2020-05-01 -> 0.0.13

### DIFF
--- a/pkgs/applications/graphics/akira/default.nix
+++ b/pkgs/applications/graphics/akira/default.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "akira";
-  version = "2020-05-01";
+  version = "0.0.13";
 
   src = fetchFromGitHub {
     owner = "akiraux";
     repo = "Akira";
-    rev = "87c495fa0a686b1e9b84aff7d9c0a9553da2c466";
-    sha256 = "0ikz6dyx0z2wqskas628hbrbhx3z5gy7i4acrvspfhhg6rk88aqd";
+    rev = "v${version}";
+    sha256 = "1i20q78jagy8xky68nmd0n7mqvh88r98kp626rnlgyzvlc3c22cm";
   };
 
   nativeBuildInputs = [
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     description = "Native Linux Design application built in Vala and GTK";
     homepage = "https://github.com/akiraux/Akira";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ filalex77 ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ filalex77 neonfuz ] ++ pantheon.maintainers;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Version bump  2020-05-01 -> 0.0.13

Upstream started using tagged versions so the package is no longer dated snapshots. I added myself as a maintainer because I intend on following the development of this software and I'm willing to maintain the nix package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
