### PR TITLE
[20.09] pythonPackages.holidays: fix build by adding korean-lunar-calendar dependency

### DIFF
--- a/pkgs/development/python-modules/holidays/default.nix
+++ b/pkgs/development/python-modules/holidays/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, buildPythonPackage, fetchPypi, six, dateutil, convertdate }:
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, convertdate
+, dateutil
+, korean-lunar-calendar
+, six
+}:
 
 buildPythonPackage rec {
   pname = "holidays";
@@ -9,7 +16,13 @@ buildPythonPackage rec {
     sha256 = "839281f2b1ae7ac576da7951472482f6e714818296853107ea861fa60f5013cc";
   };
 
-  propagatedBuildInputs = [ six dateutil convertdate ];
+  propagatedBuildInputs = [
+    convertdate
+    dateutil
+    korean-lunar-calendar
+    six
+  ];
+  pythonImportsCheck = [ "holidays" ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/dr-prodigy/python-holidays";

--- a/pkgs/development/python-modules/korean-lunar-calendar/default.nix
+++ b/pkgs/development/python-modules/korean-lunar-calendar/default.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "korean-lunar-calendar";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "korean_lunar_calendar";
+    sha256 = "0p97r21298ipgvsqh978aq2n6cvybzp8bskcvj15mm1f76qm9khj";
+  };
+
+  # no real tests
+  pythonImportsCheck = [ "korean_lunar_calendar" ];
+
+  meta = with stdenv.lib; {
+    description = "A library to convert Korean lunar-calendar to Gregorian calendar.";
+    homepage = "https://github.com/usingsky/korean_lunar_calendar_py";
+    license = licenses.mit;
+    maintainers = [ maintainers.ris ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3191,6 +3191,8 @@ in {
 
   konfig = callPackage ../development/python-modules/konfig { };
 
+  korean-lunar-calendar = callPackage ../development/python-modules/korean-lunar-calendar { };
+
   kubernetes = callPackage ../development/python-modules/kubernetes { };
 
   labelbox = callPackage ../development/python-modules/labelbox { };


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of #97845

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
