### PR TITLE
acme: 120 -> unstable-2020-12-27

### DIFF
--- a/pkgs/development/compilers/acme/default.nix
+++ b/pkgs/development/compilers/acme/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "acme";
-  version = "120";
+  version = "unstable-2020-12-27";
 
   src = fetchsvn {
     url = "svn://svn.code.sf.net/p/acme-crossass/code-0/trunk";
-    rev = version;
-    sha256 = "0w17b8f8bis22m6l5bg8qg8nniy20f8yg2xmzjipblmc39vpv6s2";
+    rev = "314";
+    sha256 = "08zg26rh19nlif7id91nv0syx5n243ssxhfw0nk2r2bhjm5jrjz1";
   };
 
   sourceRoot = "code-0-r${src.rev}/src";


### PR DESCRIPTION
###### Motivation for this change
Changed the `version` to the unstable scheme, since SVN revisions prolly don't count as releases. Otherwise regular version bump.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <br />- acme
  <br />- cheesecutter
</details>

- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
