### PR TITLE
[WIP] chromium.withPackages/chromium-extensions: init

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -157,6 +157,7 @@ let
       ./patches/remove-webp-include-69.patch
       ./patches/no-build-timestamps.patch
       ./patches/widevine-79.patch
+      ./patches/consistent-extension-id-for-packaged-extensions.patch
       # Unfortunately, chromium regularly breaks on major updates and
       # then needs various patches backported in order to be compiled with GCC.
       # Good sources for such patches and other hints:

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,4 +1,4 @@
-{ newScope, config, stdenv, fetchurl, makeWrapper
+args@{ newScope, config, stdenv, fetchurl, makeWrapper
 , llvmPackages_11, ed, gnugrep, coreutils, xdg_utils
 , glib, gtk3, gnome3, gsettings-desktop-schemas, gn, fetchgit
 , libva ? null
@@ -20,6 +20,7 @@
 , cupsSupport ? true
 , pulseSupport ? config.pulseaudio or stdenv.isLinux
 , commandLineArgs ? ""
+, enableExtensions ? [ ]
 }:
 
 let
@@ -61,6 +62,7 @@ let
 
     plugins = callPackage ./plugins.nix {
       inherit enablePepperFlash;
+      inherit enableExtensions;
     };
   };
 
@@ -223,10 +225,13 @@ in stdenv.mkDerivation {
 
   inherit (chromium.browser) packageName;
   meta = chromium.browser.meta;
-  passthru = {
+  passthru = rec {
     inherit (chromium) upstream-info browser;
     mkDerivation = chromium.mkChromiumDerivation;
     inherit chromeSrc sandboxExecutableName;
     updateScript = ./update.py;
+
+    pkgs = callPackage ../../../../misc/chromium-extensions { };
+    withPackages = f: callPackage ../chromium (args // { enableExtensions = f pkgs; });
   };
 }

--- a/pkgs/applications/networking/browsers/chromium/patches/consistent-extension-id-for-packaged-extensions.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/consistent-extension-id-for-packaged-extensions.patch
@@ -1,0 +1,48 @@
+From 08188f4303c279861121e85d8d3a6402e6208683 Mon Sep 17 00:00:00 2001
+From: ryneeverett <ryneeverett@gmail.com>
+Date: Sat, 26 Sep 2020 14:04:43 +0000
+Subject: [PATCH] Consistent extension id's for packaged extensions
+
+Extension id's are generated from a hash of the extension path. In
+development this is fine as the extension is updated in place, but as a
+nix package this would cause state to be lost on every rebuild when the
+path changes.  Therefore we replace the path with the extension's name
+for the purposes of generating an id.
+---
+ components/crx_file/id_util.cc | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/components/crx_file/id_util.cc b/components/crx_file/id_util.cc
+index a6250c1f60e6..c624b4162e94 100644
+--- a/components/crx_file/id_util.cc
++++ b/components/crx_file/id_util.cc
+@@ -8,6 +8,7 @@
+ 
+ #include "base/files/file_path.h"
+ #include "base/hash/sha1.h"
++#include "base/json/json_reader.h"
+ #include "base/strings/string_number_conversions.h"
+ #include "base/strings/string_util.h"
+ #include "build/build_config.h"
+@@ -62,6 +63,18 @@ std::string GenerateIdForPath(const base::FilePath& path) {
+   const base::StringPiece path_bytes(
+       reinterpret_cast<const char*>(new_path.value().data()),
+       new_path.value().size() * sizeof(base::FilePath::CharType));
++
++  const char* nix_map_chars = getenv("NIX_CHROMIUM_EXTENSION_MAP");
++  if (nix_map_chars) {
++    std::string nix_map_str(nix_map_chars);
++    const auto nix_map_json = base::JSONReader::Read(nix_map_str);
++    const auto* nix_store_mapped = nix_map_json->FindKey(path_bytes);
++    if (nix_store_mapped) {
++      std::string extension_name_str(nix_store_mapped->GetString());
++      return GenerateId(extension_name_str);
++    }
++  }
++
+   return GenerateId(path_bytes);
+ }
+ 
+-- 
+2.25.4
+

--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -90,7 +90,7 @@ let
   extensions = stdenv.mkDerivation {
     name = "chromium-extensions";
     builder = let
-      extpaths = strings.concatMapStringsSep "," (pkg: pkg + "/lib") enableExtensions;
+      extpaths = concatStringsSep "," enableExtensions;
     in pkgs.writeScript "builder.sh" ''
       source $stdenv/setup
 

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
@@ -164,6 +164,7 @@ let
       ./patches/no-build-timestamps.patch
       ./patches/widevine-79.patch
       ./patches/dont-use-ANGLE-by-default.patch
+      ./patches/consistent-extension-id-for-packaged-extensions.patch
       # Unfortunately, chromium regularly breaks on major updates and
       # then needs various patches backported in order to be compiled with GCC.
       # Good sources for such patches and other hints:

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/default.nix
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/default.nix
@@ -1,4 +1,4 @@
-{ newScope, config, stdenv, fetchurl, makeWrapper
+args@{ newScope, config, stdenv, fetchurl, makeWrapper
 , llvmPackages_10, llvmPackages_11, ed, gnugrep, coreutils, xdg_utils
 , glib, gtk3, gnome3, gsettings-desktop-schemas, gn, fetchgit
 , libva ? null
@@ -21,6 +21,7 @@
 , cupsSupport ? true
 , pulseSupport ? config.pulseaudio or stdenv.isLinux
 , commandLineArgs ? ""
+, enableExtensions ? [ ]
 }:
 
 let
@@ -74,6 +75,7 @@ let
 
     plugins = callPackage ./plugins.nix {
       inherit enablePepperFlash;
+      inherit enableExtensions;
     };
 
     ungoogled-chromium = callPackage ./ungoogled.nix {};
@@ -238,10 +240,13 @@ in stdenv.mkDerivation {
 
   inherit (chromium.browser) packageName;
   meta = chromium.browser.meta;
-  passthru = {
+  passthru = rec {
     inherit (chromium) upstream-info browser;
     mkDerivation = chromium.mkChromiumDerivation;
     inherit chromeSrc sandboxExecutableName;
     updateScript = ./update.py;
+
+    pkgs = callPackage ../../../../misc/chromium-extensions { };
+    withPackages = f: callPackage ../ungoogled-chromium (args // { enableExtensions = f pkgs; });
   };
 }

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/patches/consistent-extension-id-for-packaged-extensions.patch
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/patches/consistent-extension-id-for-packaged-extensions.patch
@@ -1,0 +1,48 @@
+From 08188f4303c279861121e85d8d3a6402e6208683 Mon Sep 17 00:00:00 2001
+From: ryneeverett <ryneeverett@gmail.com>
+Date: Sat, 26 Sep 2020 14:04:43 +0000
+Subject: [PATCH] Consistent extension id's for packaged extensions
+
+Extension id's are generated from a hash of the extension path. In
+development this is fine as the extension is updated in place, but as a
+nix package this would cause state to be lost on every rebuild when the
+path changes.  Therefore we replace the path with the extension's name
+for the purposes of generating an id.
+---
+ components/crx_file/id_util.cc | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/components/crx_file/id_util.cc b/components/crx_file/id_util.cc
+index a6250c1f60e6..c624b4162e94 100644
+--- a/components/crx_file/id_util.cc
++++ b/components/crx_file/id_util.cc
+@@ -8,6 +8,7 @@
+ 
+ #include "base/files/file_path.h"
+ #include "base/hash/sha1.h"
++#include "base/json/json_reader.h"
+ #include "base/strings/string_number_conversions.h"
+ #include "base/strings/string_util.h"
+ #include "build/build_config.h"
+@@ -62,6 +63,18 @@ std::string GenerateIdForPath(const base::FilePath& path) {
+   const base::StringPiece path_bytes(
+       reinterpret_cast<const char*>(new_path.value().data()),
+       new_path.value().size() * sizeof(base::FilePath::CharType));
++
++  const char* nix_map_chars = getenv("NIX_CHROMIUM_EXTENSION_MAP");
++  if (nix_map_chars) {
++    std::string nix_map_str(nix_map_chars);
++    const auto nix_map_json = base::JSONReader::Read(nix_map_str);
++    const auto* nix_store_mapped = nix_map_json->FindKey(path_bytes);
++    if (nix_store_mapped) {
++      std::string extension_name_str(nix_store_mapped->GetString());
++      return GenerateId(extension_name_str);
++    }
++  }
++
+   return GenerateId(path_bytes);
+ }
+ 
+-- 
+2.25.4
+

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/plugins.nix
@@ -90,7 +90,7 @@ let
   extensions = stdenv.mkDerivation {
     name = "chromium-extensions";
     builder = let
-      extpaths = strings.concatMapStringsSep "," (pkg: pkg + "/lib") enableExtensions;
+      extpaths = strings.concatStringsSep "," enableExtensions;
     in pkgs.writeScript "builder.sh" ''
       source $stdenv/setup
 

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/plugins.nix
@@ -35,7 +35,7 @@ let
     shEsc = val: "'${replaceStrings ["'"] ["'\\''"] val}'";
     mkSh = val: "'${replaceStrings shSearch shReplace (shEsc val)}'";
     mkFlag = flag: ["--add-flags" (shEsc flag)];
-    mkEnvVar = key: val: ["--set" (shEsc key) (shEsc val)];
+    mkEnvVar = key: val: ["--set" (shEsc key) val];
     envList = mapAttrsToList mkEnvVar envVars;
     quoted = map mkSh (flatten ((map mkFlag flags) ++ envList));
   in ''
@@ -90,16 +90,25 @@ let
   extensions = stdenv.mkDerivation {
     name = "chromium-extensions";
     builder = let
-      extpaths = strings.concatStringsSep "," enableExtensions;
+      extensionLoadPaths = strings.concatStringsSep "," enableExtensions;
+
+      extensionPaths = map (ext: builtins.unsafeDiscardStringContext (toString ext)) enableExtensions;
+      stripHash = storePath: strings.concatStringsSep "-" (lists.drop 1 (lists.flatten (builtins.split "-" (lists.last (builtins.split "/" storePath)))));
+      getExtensionName = storePath: lib.lists.last (builtins.split "^chromium-extensions-" (builtins.parseDrvName (stripHash storePath)).name);
+      extMap = builtins.toJSON (listToAttrs (map (extPath: { name = toString extPath; value = getExtensionName extPath; }) extensionPaths));
     in pkgs.writeScript "builder.sh" ''
       source $stdenv/setup
 
-      extpaths=${extpaths}
+      extpaths="${extensionLoadPaths}"
+      extmap='${extMap}'
       ${mkPluginInfo {
-        allowedVars = [ "extpaths"];
+        allowedVars = [ "extpaths" "extmap" ];
         flags = [
           "--load-extension=@extpaths@"
         ];
+        envVars = {
+          NIX_CHROMIUM_EXTENSION_MAP = "@extmap@";
+        };
       }}
     '';
   };

--- a/pkgs/misc/chromium-extensions/build-chromium-extension.nix
+++ b/pkgs/misc/chromium-extensions/build-chromium-extension.nix
@@ -7,6 +7,7 @@
     unpackPhase ? "",
     configurePhase ? "",
     buildPhase ? "",
+    installPhase ? null,
     preInstall ? "",
     postInstall ? "",
     ...
@@ -16,7 +17,7 @@
 
       inherit configurePhase buildPhase preInstall postInstall;
 
-      installPhase = ''
+      installPhase = if installPhase != null then installPhase else ''
         runHook preInstall
 
         mkdir -p $out

--- a/pkgs/misc/chromium-extensions/build-chromium-extension.nix
+++ b/pkgs/misc/chromium-extensions/build-chromium-extension.nix
@@ -1,0 +1,33 @@
+{ stdenv, pkgs }:
+{
+  buildChromiumExtension = args @ {
+    name ? "${args.pname}-${args.version}",
+    namePrefix ? "chromium-extension-",
+    src ? "",
+    unpackPhase ? "",
+    configurePhase ? "",
+    buildPhase ? "",
+    preInstall ? "",
+    postInstall ? "",
+    ...
+  }:
+    stdenv.mkDerivation(args // {
+      name = namePrefix + name;
+
+      inherit configurePhase buildPhase preInstall postInstall;
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out/lib
+        cp -r . $out/lib
+
+        runHook postInstall
+      '';
+
+      doInstallCheck = true;
+      installCheckPhase = ''
+        test -e $out/lib/manifest.json || (echo "INVALID EXTENSION: missing manifest.json" && exit 1)
+      '';
+    });
+}

--- a/pkgs/misc/chromium-extensions/build-chromium-extension.nix
+++ b/pkgs/misc/chromium-extensions/build-chromium-extension.nix
@@ -19,15 +19,15 @@
       installPhase = ''
         runHook preInstall
 
-        mkdir -p $out/lib
-        cp -r . $out/lib
+        mkdir -p $out
+        cp -r . $out
 
         runHook postInstall
       '';
 
       doInstallCheck = true;
       installCheckPhase = ''
-        test -e $out/lib/manifest.json || (echo "INVALID EXTENSION: missing manifest.json" && exit 1)
+        test -e $out/manifest.json || (echo "INVALID EXTENSION: missing manifest.json" && exit 1)
       '';
     });
 }

--- a/pkgs/misc/chromium-extensions/build-chromium-extension.nix
+++ b/pkgs/misc/chromium-extensions/build-chromium-extension.nix
@@ -30,5 +30,14 @@
       installCheckPhase = ''
         test -e $out/manifest.json || (echo "INVALID EXTENSION: missing manifest.json" && exit 1)
       '';
+
+      # Filter out "key" and "update_url" entries from manifest.json
+      fixupPhase = ''
+        tmpmanifest=$(mktemp)
+        ${stdenv.lib.getBin pkgs.jq}/bin/jq \
+          'with_entries(.|select((.key != "key") and (.key != "update_url")))' \
+          $out/manifest.json >$tmpmanifest
+        mv $tmpmanifest $out/manifest.json
+      '';
     });
 }

--- a/pkgs/misc/chromium-extensions/default.nix
+++ b/pkgs/misc/chromium-extensions/default.nix
@@ -2,6 +2,8 @@
 let
   inherit (import ./build-chromium-extension.nix { inherit stdenv pkgs; }) buildChromiumExtension;
 in {
+  bypass-paywalls = pkgs.callPackage ./extensions/bypass-paywalls { inherit buildChromiumExtension; };
+
   decentraleyes = pkgs.callPackage ./extensions/decentraleyes { inherit buildChromiumExtension; };
 
   https-everywhere = pkgs.callPackage ./extensions/https-everywhere { inherit buildChromiumExtension; };

--- a/pkgs/misc/chromium-extensions/default.nix
+++ b/pkgs/misc/chromium-extensions/default.nix
@@ -2,4 +2,5 @@
 let
   inherit (import ./build-chromium-extension.nix { inherit stdenv pkgs; }) buildChromiumExtension;
 in {
+  ublock = pkgs.callPackage ./extensions/ublock { inherit buildChromiumExtension; };
 }

--- a/pkgs/misc/chromium-extensions/default.nix
+++ b/pkgs/misc/chromium-extensions/default.nix
@@ -2,6 +2,8 @@
 let
   inherit (import ./build-chromium-extension.nix { inherit stdenv pkgs; }) buildChromiumExtension;
 in {
+  decentraleyes = pkgs.callPackage ./extensions/decentraleyes { inherit buildChromiumExtension; };
+
   https-everywhere = pkgs.callPackage ./extensions/https-everywhere { inherit buildChromiumExtension; };
 
   ublock = pkgs.callPackage ./extensions/ublock { inherit buildChromiumExtension; };

--- a/pkgs/misc/chromium-extensions/default.nix
+++ b/pkgs/misc/chromium-extensions/default.nix
@@ -2,5 +2,7 @@
 let
   inherit (import ./build-chromium-extension.nix { inherit stdenv pkgs; }) buildChromiumExtension;
 in {
+  https-everywhere = pkgs.callPackage ./extensions/https-everywhere { inherit buildChromiumExtension; };
+
   ublock = pkgs.callPackage ./extensions/ublock { inherit buildChromiumExtension; };
 }

--- a/pkgs/misc/chromium-extensions/default.nix
+++ b/pkgs/misc/chromium-extensions/default.nix
@@ -1,0 +1,5 @@
+{ stdenv, pkgs }:
+let
+  inherit (import ./build-chromium-extension.nix { inherit stdenv pkgs; }) buildChromiumExtension;
+in {
+}

--- a/pkgs/misc/chromium-extensions/default.nix
+++ b/pkgs/misc/chromium-extensions/default.nix
@@ -6,5 +6,5 @@ in {
 
   https-everywhere = pkgs.callPackage ./extensions/https-everywhere { inherit buildChromiumExtension; };
 
-  ublock = pkgs.callPackage ./extensions/ublock { inherit buildChromiumExtension; };
+  ublock-origin = pkgs.callPackage ./extensions/ublock-origin { inherit buildChromiumExtension; };
 }

--- a/pkgs/misc/chromium-extensions/extensions/bypass-paywalls/default.nix
+++ b/pkgs/misc/chromium-extensions/extensions/bypass-paywalls/default.nix
@@ -1,0 +1,26 @@
+{ buildChromiumExtension, fetchFromGitHub, p7zip }:
+
+buildChromiumExtension rec {
+  pname = "bypass-paywalls";
+  version = "1.7.5";
+
+  src = fetchFromGitHub {
+    owner = "iamadamdev";
+    repo = "bypass-paywalls-chrome";
+    rev = "v${version}";
+    sha256 = "1invkzd5q21jranaaqmi975v8m4ar5x4wx11ylsvz3mrs3dv7ah8";
+  };
+
+  nativeBuildInputs = [ p7zip ];
+
+  buildPhase = ''
+    cd ./build
+    source ./build.sh
+  '';
+
+  preInstall = ''
+    tmpout=$(mktemp -d)
+    7z x -o$tmpout output/bypass-paywalls.crx
+    cd $tmpout
+  '';
+}

--- a/pkgs/misc/chromium-extensions/extensions/decentraleyes/default.nix
+++ b/pkgs/misc/chromium-extensions/extensions/decentraleyes/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, pkgs, buildChromiumExtension }:
+with stdenv.lib;
+buildChromiumExtension rec {
+  pname = "decentraleyes";
+  version = "2.0.14";
+
+  src = pkgs.fetchgit {
+    url = "https://git.synz.io/Synzvato/decentraleyes.git";
+    rev = "v${version}";
+    sha256 = "01bmhhj3yhfy8jad0qrdkjdqipr2vsxzwnx73w6p9kv9vrg8m2pi";
+  };
+
+  meta = {
+    description = "Protects you against tracking through \"free\", centralized, content delivery";
+    homepage = "https://decentraleyes.org/";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ ryneeverett ];
+  };
+}

--- a/pkgs/misc/chromium-extensions/extensions/https-everywhere/default.nix
+++ b/pkgs/misc/chromium-extensions/extensions/https-everywhere/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, pkgs, buildChromiumExtension }:
+with stdenv.lib;
+buildChromiumExtension rec {
+  pname = "https-everywhere";
+  version = "2020.8.13";
+
+  src = pkgs.fetchgit {
+    url = "https://github.com/EFForg/https-everywhere.git";
+    rev = version;
+    sha256 = "0l0xi2ywb9jf3sqjh6d581lh6rpiim018jj8bkwcx2xyidsl309m";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    pkgs.bash
+    pkgs.getopt
+    pkgs.python36
+  ];
+
+  patchPhase = ''
+    # Skip building unneeded artifacts which would require further dependencies or patching.
+    sed -i '/$BROWSER/d; /$crx_cws/d; /$crx_eff/d; /$zip/d' ./make.sh
+  '';
+
+  buildPhase = ''
+    export HOME=$(mktemp -d)
+    ${pkgs.bash}/bin/bash -e -o pipefail ./make.sh
+  '';
+
+  preInstall = ''
+    cd pkg/crx-eff
+  '';
+
+  meta = {
+    description = "A browser extension that encrypts your communications with many websites that offer HTTPS but still allow unencrypted connections";
+    homepage = "https://github.com/EFForg/https-everywhere";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ryneeverett ];
+  };
+}

--- a/pkgs/misc/chromium-extensions/extensions/ublock-origin/default.nix
+++ b/pkgs/misc/chromium-extensions/extensions/ublock-origin/default.nix
@@ -4,7 +4,7 @@ let
   uassets = import ../../libs/uassets { inherit stdenv fetchFromGitHub; };
 in
 buildChromiumExtension rec {
-  pname = "ublock";
+  pname = "ublock-origin";
   version = "1.29.2";
 
   src = fetchFromGitHub {

--- a/pkgs/misc/chromium-extensions/extensions/ublock/default.nix
+++ b/pkgs/misc/chromium-extensions/extensions/ublock/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, pkgs, buildChromiumExtension, fetchFromGitHub }:
+with stdenv.lib;
+let
+  uassets = import ../../libs/uassets { inherit stdenv fetchFromGitHub; };
+in
+buildChromiumExtension rec {
+  pname = "ublock";
+  version = "1.29.2";
+
+  src = fetchFromGitHub {
+    owner = "gorhill";
+    repo = "uBlock";
+    rev = version;
+    sha256 = "1z38084inkphlq3y7fkqj9gdk3xa5yj9amhqhm3saqvfrzkngzcs";
+  };
+
+  buildInputs = [
+    pkgs.bash
+    pkgs.python
+    uassets
+  ];
+
+  patchPhase = ''
+    # Fail build phase on any script failure.
+    sed -i 's/^bash/bash -e -o pipefail/g' ./tools/*.sh
+    # Patch in static assets from separate package.
+    substituteInPlace ./tools/make-assets.sh --replace ../uAssets ${uassets}
+  '';
+
+  buildPhase = ''
+    ${pkgs.bash}/bin/bash -e -o pipefail ./tools/make-chromium.sh
+  '';
+
+  preInstall = ''
+    cd dist/build/uBlock0.chromium
+  '';
+
+  meta = {
+    description = "An efficient blocker add-on for various browsers";
+    homepage = "https://github.com/gorhill/uBlock";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ryneeverett ];
+  };
+}

--- a/pkgs/misc/chromium-extensions/libs/uassets/default.nix
+++ b/pkgs/misc/chromium-extensions/libs/uassets/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+with stdenv.lib;
+
+stdenv.mkDerivation {
+  pname = "uassets";
+  version = "git-2020-09-14";
+
+  src = fetchFromGitHub {
+    owner = "uBlockOrigin";
+    repo = "uAssets";
+    rev = "c8b9400997e1ad4628ca4a4c8c9b4a43d9d4ea42";
+    sha256 = "1ll9dgn7rbsiq2ingyd801pgid4rjs97rs4h5lp4hnzmwjp9xiql";
+  };
+
+  installPhase = ''
+    cp -r . $out
+  '';
+
+  meta = {
+    description = "Resources for uBlock Origin, uMatrix: static filter lists, ready-to-use rulesets, etc";
+    homepage = "https://github.com/uBlockOrigin/uAssets";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ryneeverett ];
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Resolve #76863.

This supports the syntax:

    (chromium.withPackages(ps: [
      ps.<extension-package>
    ]))

Upon investigation into the many api's chromium has had for loading
extensions over the years, it appears that the only remaining way to
load extensions from a local path is by flag which indicates that adding
them to the wrapper like this is the only sane option. Chromium's
existing plugins.nix already does most of the lifting towards creating
the wrapper.

This also adds a builder -- buildChromiumExtension -- which basically just
requires that the current working directory be the plugin in the
installPhase.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Things to do (help wanted)

- [ ] Run chromium test. (I don't have the horsepower locally or the ofborg bits.)
- [ ] Documentation. (where should this go?)
- [ ] Persistent extension state. (see comments)
- [ ] Decentraleyes loads welcome page every time? (see comments)