### PR TITLE
ocamlPackages.apron: 0.9.12 → 0.9.13

### DIFF
--- a/pkgs/development/ocaml-modules/apron/default.nix
+++ b/pkgs/development/ocaml-modules/apron/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-apron-${version}";
-  version = "0.9.12";
+  version = "0.9.13";
   src = fetchFromGitHub {
     owner = "antoinemine";
     repo = "apron";
     rev = "v${version}";
-    sha256 = "0bciv4wz52p57q0aggmvixvqrsd1slflfyrm1z6fy5c44f4fmjjn";
+    sha256 = "14ymjahqdxj26da8wik9d5dzlxn81b3z1iggdl7rn2nn06jy7lvy";
   };
 
   buildInputs = [ perl gmp mpfr ppl ocaml findlib camlidl ];


### PR DESCRIPTION
###### Motivation for this change

Bug-fix release: https://github.com/antoinemine/apron/releases/tag/v0.9.13

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
