### PR TITLE
python36Packages.ipython: 7.17 -> 7.16.1 (downgrade on Python 3.6 for compatibility)

### DIFF
--- a/pkgs/development/python-modules/ipython/7.16.nix
+++ b/pkgs/development/python-modules/ipython/7.16.nix
@@ -22,12 +22,12 @@
 
 buildPythonPackage rec {
   pname = "ipython";
-  version = "7.17.0";
-  disabled = pythonOlder "3.7";
+  version = "7.16.1";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b70974aaa2674b05eb86a910c02ed09956a33f2dd6c71afc60f0b128a77e7f28";
+    sha256 = "9f4fcb31d3b2c533333893b9172264e4821c1ac91839500f31bd43f2c59b3ccf";
   };
 
   prePatch = lib.optionalString stdenv.isDarwin ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2908,6 +2908,8 @@ in {
 
   ipython = if isPy27 then
     callPackage ../development/python-modules/ipython/5.nix { }
+  else if isPy36 then
+    callPackage ../development/python-modules/ipython/7.16.nix { }
   else
     callPackage ../development/python-modules/ipython { };
 


### PR DESCRIPTION
###### Motivation for this change

IPython 7.17 and higher don't support Python 3.6 anymore.

    nix-repl> :b python36.withPackages (ps: [ ps.ipython ])
    builder for '/nix/store/q8v4f89xwv35a3idb9z345z6n3nzfycb-python3.6-ipython-7.17.0.drv' failed with exit code 1; last 10 log lines:
      Python 3.5 was supported with IPython 7.0 to 7.9.
      Python 3.6 was supported with IPython up to 7.16.

      See IPython `README.rst` file for more information:

          https://github.com/ipython/ipython/blob/master/README.rst

      Python sys.version_info(major=3, minor=6, micro=12, releaselevel='final', serial=0) detected.
    cannot build derivation '/nix/store/mhpdarp18z6skzswrl7sbgzv8hr4gwih-python3-3.6.12-env.drv': 1 dependencies couldn't be built
    [0 built (1 failed)]
    error: build of '/nix/store/mhpdarp18z6skzswrl7sbgzv8hr4gwih-python3-3.6.12-env.drv' failed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
