### PR TITLE
telegraf:  1.15.2 -> 1.16.2  + module improvements

### DIFF
--- a/nixos/modules/services/monitoring/telegraf.nix
+++ b/nixos/modules/services/monitoring/telegraf.nix
@@ -60,6 +60,8 @@ in {
         ExecReload="${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         User = "telegraf";
         Restart = "on-failure";
+        # for ping probes
+        AmbientCapabilities = [ "CAP_NET_RAW" ];
       };
     };
 

--- a/nixos/tests/telegraf.nix
+++ b/nixos/tests/telegraf.nix
@@ -6,12 +6,15 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
   machine = { ... }: {
     services.telegraf.enable = true;
+    services.telegraf.environmentFile = pkgs.writeText "secrets" ''
+      SECRET=example
+    '';
     services.telegraf.extraConfig = {
       agent.interval = "1s";
       agent.flush_interval = "1s";
       inputs.exec = {
         commands = [
-          "${pkgs.runtimeShell} -c 'echo example,tag=a i=42i'"
+          "${pkgs.runtimeShell} -c 'echo $SECRET,tag=a i=42i'"
         ];
         timeout = "5s";
         data_format = "influx";

--- a/nixos/tests/telegraf.nix
+++ b/nixos/tests/telegraf.nix
@@ -6,9 +6,9 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
   machine = { ... }: {
     services.telegraf.enable = true;
-    services.telegraf.environmentFile = pkgs.writeText "secrets" ''
+    services.telegraf.environmentFiles = [pkgs.writeText "secrets" ''
       SECRET=example
-    '';
+    ''];
     services.telegraf.extraConfig = {
       agent.interval = "1s";
       agent.flush_interval = "1s";

--- a/pkgs/servers/monitoring/telegraf/default.nix
+++ b/pkgs/servers/monitoring/telegraf/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "telegraf";
-  version = "1.15.2";
+  version = "1.16.2";
 
   excludedPackages = "test";
 
@@ -12,19 +12,10 @@ buildGoModule rec {
     owner = "influxdata";
     repo = "telegraf";
     rev = "v${version}";
-    sha256 = "045wjpq29dr0s48ns3a4p8pw1j0ssfcw6m91iim4pkrppj7bm2di";
+    sha256 = "sha256-XdlXUwGn2isGn7SqCGaAjntposBEd6WbbdfN6dEycDI=";
   };
 
-  patches = [
-    # https://github.com/influxdata/telegraf/pull/7988
-    # fix broken cgo vendoring
-    (fetchpatch {
-      url = "https://github.com/influxdata/telegraf/commit/63e1f41d8ff246d191d008ff7f69d69cc34b4fae.patch";
-      sha256 = "0ikifc4414bid3g6hhxz18cw71z63s5g805klx98vrndjlpbqkzw";
-    })
-  ];
-
-  vendorSha256 = "0f95xigpkindd7dmci8kqpqq5dlirimbqh8ai73142asbrd5h4yr";
+  vendorSha256 = "02fqx817w6f9grfc69ri06a6qygbr5chan6w9waq2y0mxvmypz28";
 
   buildFlagsArray = [ ''-ldflags=
     -w -s -X main.version=${version}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
