### PR TITLE
[20.09] Fix cli-visualizer

### DIFF
--- a/pkgs/applications/misc/cli-visualizer/default.nix
+++ b/pkgs/applications/misc/cli-visualizer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fftw, ncurses5, libpulseaudio, makeWrapper }:
+{ stdenv, fetchFromGitHub, cmake, fftw, ncurses5, libpulseaudio, makeWrapper }:
 
 stdenv.mkDerivation rec {
   version = "1.8";
@@ -15,13 +15,13 @@ stdenv.mkDerivation rec {
     sed '1i#include <cmath>' -i src/Transformer/SpectrumCircleTransformer.cpp
   '';
 
+  nativeBuildInputs = [ cmake ];
+
   buildInputs = [ fftw ncurses5 libpulseaudio makeWrapper ];
 
   buildFlags = [ "ENABLE_PULSE=1" ];
 
-  installPhase = ''
-    mkdir -p $out/bin
-    cp build/vis $out/bin/vis
+  postInstall = ''
     # See https://github.com/dpayne/cli-visualizer/issues/62#issuecomment-330738075
     wrapProgram $out/bin/vis --set TERM rxvt-256color
   '';


### PR DESCRIPTION
###### Motivation for this change
This fixes the cli-visualizer build.
ZHF: #97479 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
