### PR TITLE
raylib: init at 3.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -182,6 +182,12 @@
     githubId = 124545;
     name = "Anthony Cowley";
   };
+  adamlwgriffiths = {
+    email = "adam.lw.griffiths@gmail.com";
+    github = "adamlwgriffiths";
+    githubId = 1239156;
+    name = "Adam Griffiths";
+  };
   adamt = {
     email = "mail@adamtulinius.dk";
     github = "adamtulinius";

--- a/pkgs/development/libraries/raylib/default.nix
+++ b/pkgs/development/libraries/raylib/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake,
+  mesa, libGLU, glfw,
+  libX11, libXi, libXcursor, libXrandr, libXinerama,
+  alsaSupport ? stdenv.hostPlatform.isLinux, alsaLib,
+  pulseSupport ? stdenv.hostPlatform.isLinux, libpulseaudio,
+  includeEverything ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "raylib";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "raysan5";
+    repo = pname;
+    rev = version;
+    sha256 = "0syvd5js1lbx3g4cddwwncqg95l6hb3fdz5nsh5pqy7fr6v84kwj";
+  };
+
+  patches = [
+    # fixes examples not compiling in 3.5.0
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/raysan5/raylib/pull/1470.patch";
+      sha256 = "1ff5l839wl8dxwrs2bwky7kqa8kk9qmsflg31sk5vbil68dzbzg0";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    mesa libGLU glfw libX11 libXi libXcursor libXrandr libXinerama
+  ] ++ lib.optional alsaSupport alsaLib
+    ++ lib.optional pulseSupport libpulseaudio;
+
+  # https://github.com/raysan5/raylib/wiki/CMake-Build-Options
+  cmakeFlags = [
+    "-DUSE_EXTERNAL_GLFW=ON"
+    "-DSHARED=ON"
+    "-DBUILD_EXAMPLES=OFF"
+  ] ++ lib.optional includeEverything "-DINCLUDE_EVERYTHING=ON";
+
+  # fix libasound.so/libpulse.so not being found
+  preFixup = ''
+    ${lib.optionalString alsaSupport "patchelf --add-needed ${alsaLib}/lib/libasound.so $out/lib/libraylib.so.${version}"}
+    ${lib.optionalString pulseSupport "patchelf --add-needed ${libpulseaudio}/lib/libpulse.so $out/lib/libraylib.so.${version}"}
+  '';
+
+  meta = with lib; {
+    description = "A simple and easy-to-use library to enjoy videogames programming";
+    homepage = "http://www.raylib.com/";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ adamlwgriffiths ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16337,6 +16337,8 @@ in
 
   raul = callPackage ../development/libraries/audio/raul { };
 
+  raylib = callPackage ../development/libraries/raylib { };
+
   readline = readline6;
   readline6 = readline63;
 


### PR DESCRIPTION
###### Motivation for this change

Add raylib ~~3.0.0~~ 3.5.0
Fixes #98029

Execution was tested using the provided examples for both static (rlgl_standalone) and dynamic (other examples).

TODO:
* Optionally supports Wayland, wasn't sure how to handle that in nix packages properly
* Supports Android, again, unsure how to handle that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
