### PR TITLE
mbtileserver: init at 0.6.1

### DIFF
--- a/pkgs/servers/mbtileserver/default.nix
+++ b/pkgs/servers/mbtileserver/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "mbtileserver";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "consbio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0b0982rn5jsv8zxfkrcmhys764nim6136hafc8ccj0mwdyvwafxd";
+  };
+
+  vendorSha256 = null;
+
+  meta = with lib; {
+    description = "A simple Go-based server for map tiles stored in mbtiles format";
+    homepage = "https://github.com/consbio/mbtileserver";
+    license = licenses.isc;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16466,6 +16466,8 @@ in
 
   mattermost-desktop = callPackage ../applications/networking/instant-messengers/mattermost-desktop { };
 
+  mbtileserver = callPackage ../servers/mbtileserver { };
+
   mediatomb = callPackage ../servers/mediatomb { };
 
   memcached = callPackage ../servers/memcached {};


### PR DESCRIPTION
###### Motivation for this change
[mbtileserver](https://github.com/consbio/mbtileserver) - lightweight and performant server (Go-based) for map tiles stored in [MBTiles](https://github.com/mapbox/mbtiles-spec) format.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
