### PR TITLE
cri-o: 1.18.3 -> 1.19.0

### DIFF
--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -99,7 +99,6 @@ in
       [crio.runtime]
       cgroup_manager = "systemd"
       log_level = "${cfg.logLevel}"
-      manage_ns_lifecycle = true
       pinns_path = "${cfg.package}/bin/pinns"
       hooks_dir = []
 

--- a/pkgs/applications/virtualization/cri-o/default.nix
+++ b/pkgs/applications/virtualization/cri-o/default.nix
@@ -15,13 +15,13 @@
 
 buildGoModule rec {
   pname = "cri-o";
-  version = "1.18.3";
+  version = "1.19.0";
 
   src = fetchFromGitHub {
     owner = "cri-o";
     repo = "cri-o";
     rev = "v${version}";
-    sha256 = "1csdbyypqwxkfc061pdv7nj52a52b9xxzb6qgxcznd82w7wgfb3g";
+    sha256 = "1lrr8y0k6609z4gb8cg277rq58sh0bqd2b4mzjlynyjdgp3xskfq";
   };
   vendorSha256 = null;
 
@@ -41,10 +41,6 @@ buildGoModule rec {
 
   BUILDTAGS = "apparmor seccomp selinux containers_image_openpgp containers_image_ostree_stub";
   buildPhase = ''
-    patchShebangs .
-
-    sed -i '/version.buildDate/d' Makefile
-
     make binaries docs BUILDTAGS="$BUILDTAGS"
   '';
 

--- a/pkgs/applications/virtualization/cri-o/wrapper.nix
+++ b/pkgs/applications/virtualization/cri-o/wrapper.nix
@@ -10,7 +10,6 @@
 , utillinux # nsenter
 , cni-plugins # not added to path
 , iptables
-, socat
 }:
 
 let
@@ -22,7 +21,6 @@ let
     conmon
     utillinux
     iptables
-    socat
   ] ++ extraPackages);
 
 in runCommand cri-o.name {


### PR DESCRIPTION

###### Motivation for this change
Update CRI-O to the latest version.
cc @NixOS/podman 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
