### PR TITLE
redo-sh: 2.0.3 → 4.0.3

### DIFF
--- a/pkgs/development/tools/build-managers/redo-sh/default.nix
+++ b/pkgs/development/tools/build-managers/redo-sh/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, makeWrapper }:
+{ stdenv, fetchurl, makeWrapper, coreutils }:
 
 stdenv.mkDerivation {
-  version = "2.0.3";
+  version = "4.0.3";
   pname = "redo-sh";
 
   src = fetchurl {
     url = "http://news.dieweltistgarnichtso.net/bin/archives/redo-sh.tar.gz";
-    sha256 = "1ycx3hik7vnlbwxacn1dzr48fwsn2ials0sg6k9l3gcyrha5wf1n";
+    sha256 = "1n84ld4fihqa7a6kn3f177dknz89qcvissfwz1m21bwdq950avia";
   };
 
   buildInputs = [ makeWrapper ];
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     mv man "$out/share"
     mv bin "$out"
     for p in $out/bin/*; do
-      wrapProgram "$p" --suffix PATH : "$out/bin"
+      wrapProgram "$p" --prefix PATH : "$out/bin:${coreutils}/bin"
     done
   '';
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     description = "Redo implementation in Bourne Shell";
     homepage = "http://news.dieweltistgarnichtso.net/bin/redo-sh.html";
     license  = licenses.agpl3;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ sternenseemann ];
   };
 }


### PR DESCRIPTION
Additional changes:

* Change platforms from `linux` to `unix`. redo-sh should run as long as
  stdenv.shell is a bourne shell. I don't think we can extend portability to
  `all`, since this also includes stuff like `js-ghcjs` (not sure we have a
  javascript bourne shell already…)
* Explicitly pass coreutils as a dependency so it can be overriden to
  use, say busybox.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Bug fixes, now correctly checks parent directories.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
