### PR TITLE
coursier: add update.sh script

### DIFF
--- a/pkgs/development/tools/coursier/default.nix
+++ b/pkgs/development/tools/coursier/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     install -Dm755 ${zshCompletion version} $out/share/zsh/site-functions/_coursier
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with stdenv.lib; {
     homepage = "https://get-coursier.io/";
     description = "A Scala library to fetch dependencies from Maven / Ivy repositories";

--- a/pkgs/development/tools/coursier/update.sh
+++ b/pkgs/development/tools/coursier/update.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused gawk
+
+set -eou pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+if [ ! -f "$ROOT/default.nix" ]; then
+  echo "ERROR: cannot find default.nix in $ROOT"
+  exit 1
+fi
+
+COURSIER_VER=$(git ls-remote --tags --refs --sort=version:refname https://github.com/coursier/coursier | awk -F"/v" '{ print $NF }' | tail -1)
+sed -i "s/version = \".*\"/version = \"${COURSIER_VER}\"/" "$ROOT/default.nix"
+
+COURSIER_ZSH_URL="https://raw.githubusercontent.com/coursier/coursier/v${COURSIER_VER}/modules/cli/src/main/resources/completions/zsh"
+COURSIER_ZSH_SHA256=$(nix-prefetch-url ${COURSIER_ZSH_URL})
+sed -i "6s/sha256 = \".*\"/sha256 = \"${COURSIER_ZSH_SHA256}\"/" "$ROOT/default.nix"
+
+COURSIER_URL="https://github.com/coursier/coursier/releases/download/v${COURSIER_VER}/coursier"
+COURSIER_SHA256=$(nix-prefetch-url ${COURSIER_URL})
+sed -i "15s/sha256 = \".*\"/sha256 = \"${COURSIER_SHA256}\"/" "$ROOT/default.nix"

--- a/pkgs/development/tools/coursier/update.sh
+++ b/pkgs/development/tools/coursier/update.sh
@@ -9,7 +9,7 @@ if [ ! -f "$ROOT/default.nix" ]; then
   exit 1
 fi
 
-COURSIER_VER=$(git ls-remote --tags --refs --sort=version:refname https://github.com/coursier/coursier | awk -F"/v" '{ print $NF }' | tail -1)
+COURSIER_VER=$(git -c 'versionsort.suffix=-' ls-remote --refs --tags --sort='version:refname' https://github.com/coursier/coursier | awk -F"/v" '{ print $NF }' | tail -1)
 sed -i "s/version = \".*\"/version = \"${COURSIER_VER}\"/" "$ROOT/default.nix"
 
 COURSIER_ZSH_URL="https://raw.githubusercontent.com/coursier/coursier/v${COURSIER_VER}/modules/cli/src/main/resources/completions/zsh"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`update.sh` will fetch the latest release based on the latest tags and update the version and the hashes properly. This will help automate and keep `coursier` up-to-date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
