### PR TITLE
bloop: add update.sh script

### DIFF
--- a/pkgs/development/tools/build-managers/bloop/default.nix
+++ b/pkgs/development/tools/build-managers/bloop/default.nix
@@ -82,6 +82,8 @@ stdenv.mkDerivation rec {
     installShellCompletion --name bloop.fish --fish ${bloop-fish}
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with stdenv.lib; {
     homepage = "https://scalacenter.github.io/bloop/";
     license = licenses.asl20;

--- a/pkgs/development/tools/build-managers/bloop/update.sh
+++ b/pkgs/development/tools/build-managers/bloop/update.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coursier curl gnused gawk
+
+set -eou pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+if [ ! -f "$ROOT/default.nix" ]; then
+  echo "ERROR: cannot find default.nix in $ROOT"
+  exit 1
+fi
+
+BLOOP_VER=$(curl -Ls -w %{url_effective} -o /dev/null https://github.com/scalacenter/bloop/releases/latest | awk -F'/v' '{print $NF}')
+sed -i "s/version = \".*\"/version = \"${BLOOP_VER}\"/" "$ROOT/default.nix"
+
+BLOOP_CHANNEL_URL="https://github.com/scalacenter/bloop/releases/download/v${BLOOP_VER}/bloop-coursier.json"
+BLOOP_CHANNEL_SHA256=$(nix-prefetch-url ${BLOOP_CHANNEL_URL})
+sed -i "17s/sha256 = \".*\"/sha256 = \"${BLOOP_CHANNEL_SHA256}\"/" "$ROOT/default.nix"
+
+BLOOP_BASH_URL="https://github.com/scalacenter/bloop/releases/download/v${BLOOP_VER}/bash-completions"
+BLOOP_BASH_SHA256=$(nix-prefetch-url ${BLOOP_BASH_URL})
+sed -i "22s/sha256 = \".*\"/sha256 = \"${BLOOP_BASH_SHA256}\"/" "$ROOT/default.nix"
+
+BLOOP_FISH_URL="https://github.com/scalacenter/bloop/releases/download/v${BLOOP_VER}/fish-completions"
+BLOOP_FISH_SHA256=$(nix-prefetch-url ${BLOOP_FISH_URL})
+sed -i "27s/sha256 = \".*\"/sha256 = \"${BLOOP_FISH_SHA256}\"/" "$ROOT/default.nix"
+
+BLOOP_ZSH_URL="https://github.com/scalacenter/bloop/releases/download/v${BLOOP_VER}/zsh-completions"
+BLOOP_ZSH_SHA256=$(nix-prefetch-url ${BLOOP_ZSH_URL})
+sed -i "32s/sha256 = \".*\"/sha256 = \"${BLOOP_ZSH_SHA256}\"/" "$ROOT/default.nix"
+
+# Temporary work dir to calculate hashes
+WORKDIR="/tmp/coursier-build"
+mkdir -p ${WORKDIR}
+export COURSIER_CACHE=${WORKDIR}
+export COURSIER_JVM_CACHE=${WORKDIR}
+
+curl --create-dirs -L -q -o "${WORKDIR}/channel/bloop.json" ${BLOOP_CHANNEL_URL}
+
+coursier install --install-dir "${WORKDIR}/linux" --install-platform "x86_64-pc-linux" --default-channels=false --channel "${WORKDIR}/channel" --only-prebuilt=true bloop
+sed -i '5,$ d' "${WORKDIR}/linux/bloop"
+BLOOP_LINUX_SHA256=$(nix-hash --type sha256 --base32 ${WORKDIR}/linux)
+sed -i "57s/\".*\"/\"${BLOOP_LINUX_SHA256}\"/" "$ROOT/default.nix"
+
+coursier install --install-dir "${WORKDIR}/osx" --install-platform "x86_64-apple-darwin" --default-channels=false --channel "${WORKDIR}/channel" --only-prebuilt=true bloop
+sed -i '5,$ d' "${WORKDIR}/osx/bloop"
+BLOOP_DARWIN_SHA256=$(nix-hash --type sha256 --base32 ${WORKDIR}/osx)
+sed -i "58s/\".*\"/\"${BLOOP_DARWIN_SHA256}\"/" "$ROOT/default.nix"
+
+# Clean temporary work dir
+rm -r ${WORKDIR}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`update.sh` will fetch the latest release and update the version and the hashes properly. This will help automate and keep `bloop` up-to-date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
