### PR TITLE
gnome-passwordsafe: init at 3.99.2

### DIFF
--- a/pkgs/applications/misc/gnome-passwordsafe/default.nix
+++ b/pkgs/applications/misc/gnome-passwordsafe/default.nix
@@ -1,0 +1,80 @@
+{ stdenv
+, meson
+, ninja
+, pkg-config
+, gettext
+, fetchFromGitLab
+, python3
+, libhandy
+, libpwquality
+, wrapGAppsHook
+, gtk3
+, glib
+, gdk-pixbuf
+, gobject-introspection
+, desktop-file-utils
+, appstream-glib }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "gnome-passwordsafe";
+  version = "3.99.2";
+  format = "other";
+  strictDeps = false; # https://github.com/NixOS/nixpkgs/issues/56943
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World";
+    repo = "PasswordSafe";
+    rev = version;
+    sha256 = "0pi2l4gwf8paxm858mxrcsk5nr0c0zw5ycax40mghndb6b1qmmhf";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    gettext
+    pkg-config
+    wrapGAppsHook
+    desktop-file-utils
+    appstream-glib
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    gtk3
+    glib
+    gdk-pixbuf
+    libhandy
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pygobject3
+    construct
+
+    # pykeepass 3.2.1 changed some exception types, and is not backwards compatible.
+    # Remove override once the MR is merged upstream.
+    # https://gitlab.gnome.org/World/PasswordSafe/-/merge_requests/79
+    (pykeepass.overridePythonAttrs (old: rec {
+      version = "3.2.0";
+      src = fetchPypi {
+        pname = "pykeepass";
+        inherit version;
+        sha256 = "1ysjn92bixq8wkwhlbhrjj9z0h80qnlnj7ks5478ndkzdw5gxvm1";
+      };
+      propagatedBuildInputs = old.propagatedBuildInputs ++ [ pycryptodome ];
+    }))
+
+  ] ++ [
+    libpwquality # using the python bindings
+  ];
+
+  meta = with stdenv.lib; {
+    broken = stdenv.hostPlatform.isStatic; # libpwquality doesn't provide bindings when static
+    description = "Password manager for GNOME which makes use of the KeePass v.4 format";
+    homepage = "https://gitlab.gnome.org/World/PasswordSafe";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mvnetbiz ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3977,6 +3977,8 @@ in
 
   gnome-keysign = callPackage ../tools/security/gnome-keysign { };
 
+  gnome-passwordsafe = callPackage ../applications/misc/gnome-passwordsafe { };
+
   gnome-podcasts = callPackage ../applications/audio/gnome-podcasts { };
 
   gnome-photos = callPackage ../applications/graphics/gnome-photos {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Wanted application to replace keepass
other interest in this application: https://discourse.nixos.org/t/trouble-building-passwordsafe-a-meson-python-gtk3-package/4652

###### Things done
Added gnome-passwordsafe 3.99.2 application
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
