### PR TITLE
python27.pkgs.joblib: Disable package

### DIFF
--- a/pkgs/development/python-modules/joblib/default.nix
+++ b/pkgs/development/python-modules/joblib/default.nix
@@ -1,4 +1,5 @@
 { lib
+, pythonOlder
 , buildPythonPackage
 , fetchPypi
 , stdenv
@@ -13,6 +14,7 @@
 buildPythonPackage rec {
   pname = "joblib";
   version = "0.16.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change

The version 0.16.0 doesn't support Python older than 3.6.
cc @drewrisinger 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
