### PR TITLE
vcv-rack: fix broken pffft reference

### DIFF
--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -10,7 +10,7 @@ let
   pfft-source = fetchFromBitbucket {
     owner = "jpommier";
     repo = "pffft";
-    rev = "29e4f76ac53bef048938754f32231d7836401f79";
+    rev = "74d7261be17cf659d5930d4830609406bd7553e3";
     sha256 = "084csgqa6f1a270bhybjayrh3mpyi2jimc87qkdgsqcp8ycsx1l1";
   };
   nanovg-source = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change
VCV-Rack fails to install due to broken https://bitbucket.org/jpommier/pffft revision (revision does't exist anymore, results in 404 when trying to download from bitbucket):
```
$ nix-env -i VCV-Rack

...

trying https://bitbucket.org/jpommier/pffft/get/29e4f76ac53bef048938754f32231d7836401f79.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
error: cannot download source from any mirror
builder for '/nix/store/zvvly7vp99xs40a7qplvl6ch0v27ggg6-source.drv' failed with exit code 1
cannot build derivation '/nix/store/i5c7ciilfyrjf4s3zxmgjmgy3zikvafq-VCV-Rack-1.1.6.drv': 1 dependencies couldn't be built
error: build of '/nix/store/i5c7ciilfyrjf4s3zxmgjmgy3zikvafq-VCV-Rack-1.1.6.drv' failed
```

###### Things done

Updated the revision to current `master` head. Checksum of the tarball didn't change so this change should be safe to merge.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
