### PR TITLE
pigpio: init at 79

### DIFF
--- a/pkgs/applications/misc/pigpio/default.nix
+++ b/pkgs/applications/misc/pigpio/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "pigpio";
+  version = "79";
+
+  src = fetchFromGitHub {
+    owner = "joan2937";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0wgcy9jvd659s66khrrp5qlhhy27464d1pildrknpdava19b1r37";
+  };
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace '$(DESTDIR)/opt/pigpio/cgi' '$(DESTDIR)/$(prefix)/cgi' \
+      --replace 'ldconfig' '# ldconfig'
+  '';
+
+  meta = with lib; {
+    description = "Raspberry Pi GPIO module";
+    homepage = "https://github.com/joan2937/pigpio";
+    license = licenses.unlicense;
+    platforms = with platforms; [ arm aarch64 ];
+    maintainers = with maintainers; [ misuzu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25171,6 +25171,8 @@ in
 
   pidgin-opensteamworks = callPackage ../applications/networking/instant-messengers/pidgin-plugins/pidgin-opensteamworks { };
 
+  pigpio = callPackage ../applications/misc/pigpio { };
+
   purple-facebook = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-facebook { };
 
   pikopixel = callPackage ../applications/graphics/pikopixel { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Raspberry Pi GPIO module: https://github.com/joan2937/pigpio

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
