### PR TITLE
opencl-info: fix build

### DIFF
--- a/pkgs/tools/system/opencl-info/default.nix
+++ b/pkgs/tools/system/opencl-info/default.nix
@@ -10,6 +10,14 @@ stdenv.mkDerivation {
     sha256 = "114lxgnjg40ivjjszkv4n3f3yq2lbrvywryvbazf20kqmdz7315l";
   };
 
+  patches = [
+    # The cl.hpp header was removed from opencl-clhpp. This patch
+    # updates opencl-info to use the new cp2.hpp header.
+    #
+    # Submitted upstream: https://github.com/marchv/opencl-info/pull/2
+    ./opencl-info-clhpp2.diff
+  ];
+
   buildInputs = [ opencl-clhpp ocl-icd ];
 
   NIX_LDFLAGS = "-lOpenCL";

--- a/pkgs/tools/system/opencl-info/opencl-info-clhpp2.diff
+++ b/pkgs/tools/system/opencl-info/opencl-info-clhpp2.diff
@@ -1,0 +1,22 @@
+diff --git a/opencl-info.cpp b/opencl-info.cpp
+index a23015d..a6de0c1 100644
+--- a/opencl-info.cpp
++++ b/opencl-info.cpp
+@@ -7,7 +7,7 @@
+ #if defined(__APPLE__) || defined(__MACOSX)
+ #  include <OpenCL/cl.hpp>
+ #else
+-#  include <CL/cl.hpp>
++#  include <CL/cl2.hpp>
+ #endif
+ 
+ #include <iostream>
+@@ -130,7 +130,7 @@ int main() {
+                 PconstEnd;
+                 P(device, CL_DEVICE_LOCAL_MEM_SIZE);
+                 Pbool(device, CL_DEVICE_ERROR_CORRECTION_SUPPORT);
+-                Pbool(device, CL_DEVICE_HOST_UNIFIED_MEMORY);
++                // Pbool(device, CL_DEVICE_HOST_UNIFIED_MEMORY); /* Deprecated in 2.0 */
+                 P(device, CL_DEVICE_PROFILING_TIMER_RESOLUTION);
+                 Pbool(device, CL_DEVICE_ENDIAN_LITTLE);
+                 Pbool(device, CL_DEVICE_AVAILABLE);


### PR DESCRIPTION
###### Motivation for this change
The build of opencl-info recently started failing because opencl-clhpp was
updated. The latest version of opencl-hpp does not ship the deprecated
cl.hpp header anymore.

ZHF: #97479

###### Things done
* [ ]  Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
* Built on platform(s)
  
  * [x]  NixOS
  * [ ]  macOS
  * [ ]  other Linux distributions
* [ ]  Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
* [ ]  Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
* [x]  Tested execution of all binary files (usually in `./result/bin/`)
* [ ]  Determined the impact on package closure size (by running `nix path-info -S` before and after)
* [ ]  Ensured that relevant documentation is up to date
* [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).