### PR TITLE
python3Packages.graphite_beacon: fix deps, add nixos test

### DIFF
--- a/pkgs/development/python-modules/graphite_beacon/default.nix
+++ b/pkgs/development/python-modules/graphite_beacon/default.nix
@@ -1,6 +1,8 @@
 { stdenv, buildPythonPackage, fetchPypi
-, tornado, pyyaml, funcparserlib
+, tornado_5, pyyaml, funcparserlib
+, nixosTests
 }:
+
 buildPythonPackage rec {
   pname = "graphite_beacon";
   version = "0.27.0";
@@ -10,11 +12,17 @@ buildPythonPackage rec {
     sha256 = "03bp4wyfn3xhcqyvs5hnk1n87m4smsmm1p7qp459m7j8hwpbq2ks";
   };
 
-  propagatedBuildInputs = [ tornado pyyaml funcparserlib ];
+  propagatedBuildInputs = [ tornado_5 pyyaml funcparserlib ];
 
   postPatch = ''
     substituteInPlace requirements.txt --replace "==" ">="
   '';
+
+  pythonImportsCheck = [ "graphite_beacon" ];
+
+  passthru.tests = {
+    nixos = nixosTests.graphite;
+  };
 
   meta = with stdenv.lib; {
     description = "A simple alerting application for Graphite metrics";


### PR DESCRIPTION
###### Motivation for this change
fixes a package and a test

ZHF #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/98055
3 packages built:
python27Packages.graphite_beacon python37Packages.graphite_beacon python38Packages.graphite_beacon
```