### PR TITLE
chromaprint: add darwin compatibility

### DIFF
--- a/pkgs/development/libraries/chromaprint/default.nix
+++ b/pkgs/development/libraries/chromaprint/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, fetchurl, cmake, boost, ffmpeg }:
+{ lib, stdenv, fetchurl, cmake, boost, ffmpeg, zlib }:
 
-stdenv.mkDerivation rec {
+let frameworks = (import <nixpkgs> {}).darwin.apple_sdk.frameworks;
+in stdenv.mkDerivation rec {
   pname = "chromaprint";
   version = "1.5.0";
 
@@ -11,7 +12,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ boost ffmpeg ];
+  darwinInputs = [
+    frameworks.Accelerate
+    frameworks.CoreGraphics
+    frameworks.CoreVideo
+    zlib
+    ];
+  buildInputs = [ boost ffmpeg ] ++ lib.optional stdenv.isDarwin darwinInputs;
 
   cmakeFlags = [ "-DBUILD_EXAMPLES=ON" "-DBUILD_TOOLS=ON" ];
 
@@ -20,6 +27,6 @@ stdenv.mkDerivation rec {
     description = "AcoustID audio fingerprinting library";
     maintainers = with maintainers; [ ehmry ];
     license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/chromaprint/default.nix
+++ b/pkgs/development/libraries/chromaprint/default.nix
@@ -1,7 +1,6 @@
-{ lib, stdenv, fetchurl, cmake, boost, ffmpeg, zlib }:
+{ lib, stdenv, fetchurl, cmake, boost, ffmpeg, darwin, zlib }:
 
-let frameworks = (import <nixpkgs> {}).darwin.apple_sdk.frameworks;
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "chromaprint";
   version = "1.5.0";
 
@@ -12,13 +11,8 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  darwinInputs = [
-    frameworks.Accelerate
-    frameworks.CoreGraphics
-    frameworks.CoreVideo
-    zlib
-    ];
-  buildInputs = [ boost ffmpeg ] ++ lib.optional stdenv.isDarwin darwinInputs;
+  buildInputs = [ boost ffmpeg ] ++ lib.optionals stdenv.isDarwin
+    (with darwin.apple_sdk.frameworks; [Accelerate CoreGraphics CoreVideo zlib]);
 
   cmakeFlags = [ "-DBUILD_EXAMPLES=ON" "-DBUILD_TOOLS=ON" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Software relying on chromaprint cannot currently be built with nix on macOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
