### PR TITLE
scrypt: 1.3.0 → 1.3.1, build library, enable tests

### DIFF
--- a/pkgs/tools/security/scrypt/default.nix
+++ b/pkgs/tools/security/scrypt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, utillinux }:
+{ stdenv, fetchurl, openssl, utillinux, getconf }:
 
 stdenv.mkDerivation rec {
   pname = "scrypt";
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--enable-libscrypt-kdf" ];
 
   buildInputs = [ openssl ];
+
+  nativeBuildInputs = [ getconf ];
 
   patchPhase = ''
     for f in Makefile.in autotools/Makefile.am libcperciva/cpusupport/Build/cpusupport.sh configure ; do

--- a/pkgs/tools/security/scrypt/default.nix
+++ b/pkgs/tools/security/scrypt/default.nix
@@ -1,21 +1,31 @@
-{ stdenv, fetchurl, openssl }:
+{ stdenv, fetchurl, openssl, utillinux }:
 
 stdenv.mkDerivation rec {
   pname = "scrypt";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchurl {
     url = "https://www.tarsnap.com/scrypt/${pname}-${version}.tgz";
-    sha256 = "0j17yfrpi2bk5cawb4a4mzpv1vadqxh956hx0pa1gqfisknk8c16";
+    sha256 = "1hnl0r6pmyxiy4dmafmqk1db7wpc0x9rqpzqcwr9d2cmghcj6byz";
   };
+
+  outputs = [ "out" "lib" "dev" ];
+
+  configureFlags = [ "--enable-libscrypt-kdf" ];
 
   buildInputs = [ openssl ];
 
   patchPhase = ''
-    for f in Makefile.in autotools/Makefile.am libcperciva/cpusupport/Build/cpusupport.sh ; do
+    for f in Makefile.in autotools/Makefile.am libcperciva/cpusupport/Build/cpusupport.sh configure ; do
       substituteInPlace $f --replace "command -p " ""
     done
+
+    patchShebangs tests/test_scrypt.sh
   '';
+
+  doCheck = true;
+  checkTarget = "test";
+  checkInputs = [ utillinux ];
 
   meta = with stdenv.lib; {
     description = "Encryption utility";


### PR DESCRIPTION
* update scrypt
* enable running of tests
* build development library libscrypt-kdf,
  install to lib output, headers to dev
* default output remains untouched: contains binary plus man pages

cc @thoughtpolice 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
