### PR TITLE
python3Packages.ihatemoney: disable sandbox unfriendly tests

### DIFF
--- a/pkgs/development/python-modules/ihatemoney/default.nix
+++ b/pkgs/development/python-modules/ihatemoney/default.nix
@@ -30,6 +30,7 @@
 , wtforms
 , psycopg2 # optional, for postgresql support
 , flask_testing
+, pytestCheckHook
 }:
 
 # ihatemoney is not really a library. It will only ever be imported
@@ -113,12 +114,19 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    flask_testing
+    flask_testing pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "--pyargs ihatemoney.tests.tests" ];
+  disabledTests = [
+    "test_notifications"  # requires running service.
+    "test_invite"         # requires running service.
   ];
 
   passthru.tests = {
-    inherit (nixosTests) ihatemoney;
+    inherit (nixosTests.ihatemoney) ihatemoney-postgresql ihatemoney-sqlite;
   };
+
   meta = with lib; {
     homepage = "https://ihatemoney.org";
     description = "A simple shared budget manager web application";


### PR DESCRIPTION
###### Motivation for this change
also fixed the passthru.tests, as `nix-build` won't normally recurse into a nested set, so `nix-build -A python3Packages.ihatemoney.passthru.tests` would actually build nothing.

ZHF #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/98060
2 packages built:
python37Packages.ihatemoney python38Packages.ihatemoney
```