### PR TITLE
streamlit: fix build

### DIFF
--- a/pkgs/applications/science/machine-learning/streamlit/default.nix
+++ b/pkgs/applications/science/machine-learning/streamlit/default.nix
@@ -1,6 +1,6 @@
 {   lib, buildPythonApplication, fetchPypi
   , altair, astor, base58, blinker, boto3, botocore, click, enum-compat
-  , future, pillow, protobuf, requests, toml, tornado, tzlocal, validators, watchdog
+  , future, pillow, protobuf, requests, toml, tornado_5, tzlocal, validators, watchdog
   , jinja2, setuptools
 }:
 
@@ -16,7 +16,7 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [
     altair astor base58 blinker boto3 botocore click enum-compat
-    future pillow protobuf requests toml tornado tzlocal validators watchdog
+    future pillow protobuf requests toml tornado_5 tzlocal validators watchdog
     jinja2 setuptools
   ];
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing another package:

```
  ERROR: No matching distribution found for tornado<6.0,>=5.0 (from streamlit==0.50.2)
  builder for '/nix/store/pmqmrlxqcgyym7dw1lxkfqgi51fch31z-streamlit-0.50.2.drv' failed with exit code 1
```

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/98062
1 package built:
streamlit
```