### PR TITLE
python3Packages.hickle: disable tests

### DIFF
--- a/pkgs/development/python-modules/hickle/default.nix
+++ b/pkgs/development/python-modules/hickle/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage
 , fetchPypi
+, pythonOlder
 , h5py
 , numpy
 , dill
@@ -19,6 +20,7 @@
 buildPythonPackage rec {
   pname   = "hickle";
   version = "4.0.1";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/hickle/default.nix
+++ b/pkgs/development/python-modules/hickle/default.nix
@@ -31,9 +31,13 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [ h5py numpy dill ];
+
+  doCheck = false; # incompatible with latest astropy
   checkInputs = [
     pytest pytestcov pytestrunner coveralls scipy pandas astropy twine check-manifest codecov
   ];
+
+  pythonImportsCheck = [ "hickle" ];
 
   meta = {
     description = "Serialize Python data to HDF5";


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing #97846

Incompatible with astropy>=4.0

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/98064
4 packages built:
python37Packages.hickle python37Packages.pywick python38Packages.hickle python38Packages.pywick
```