### PR TITLE
python3Packages.lightparam: fix source and deps

### DIFF
--- a/pkgs/development/python-modules/lightparam/default.nix
+++ b/pkgs/development/python-modules/lightparam/default.nix
@@ -1,23 +1,30 @@
-{ lib, pkgs, buildPythonPackage, fetchPypi, isPy3k
+{ lib, pkgs, buildPythonPackage, fetchFromGitHub, isPy3k
+, ipython
+, ipywidgets
 , numpy
+, pyqt5
 }:
 
 buildPythonPackage rec {
   pname = "lightparam";
   version = "0.4.6";
   disabled = !isPy3k;
-  format = "wheel";
 
-  src = fetchPypi {
-    inherit pname version;
-    format = "wheel";
-    python = "py3";
-    sha256 = "eca63016524208afb6a06db19baf659e698cce3ae2e57be15b37bc988549c631";
+  src = fetchFromGitHub {
+    owner = "portugueslab";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "13hlkvjcyz2lhvlfqyavja64jccbidshhs39sl4fibrn9iq34s3i";
   };
 
   propagatedBuildInputs = [
+    ipython
+    ipywidgets
     numpy
+    pyqt5
   ];
+
+  pythonImportsCheck = [ "lightparam" ];
 
   meta = {
     homepage = "https://github.com/portugueslab/lightparam";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
noticed it was broken reviewing #97846

source was broken:
```
hash mismatch in fixed-output derivation '/nix/store/y7x8gnv9b3ydwag4p33n3hz6a3ypin2p-lightparam-0.4.6-py3-none-any.whl':
  wanted: sha256:0cf6962rig1pbghpprg27b78qscycnprpcbdl2vay222a8b319pc
  got:    sha256:0hxchr7gqs09xzblw4l9rr50vcqrr3iclgj4f3gpihf4mhp0nxkr
```
deps were also broken

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/98065
4 packages built:
python37Packages.lightparam python37Packages.stytra python38Packages.lightparam python38Packages.stytra
```