### PR TITLE
esphome: 1.14.5 -> 1.15.0

### DIFF
--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -1,21 +1,21 @@
-{ lib, python3, platformio, esptool, git, protobuf3_11, fetchpatch }:
+{ lib, python3, platformio, esptool, git, protobuf3_12, fetchpatch }:
 
 let
   python = python3.override {
     packageOverrides = self: super: {
       protobuf = super.protobuf.override {
-        protobuf = protobuf3_11;
+        protobuf = protobuf3_12;
       };
     };
   };
 
 in python.pkgs.buildPythonApplication rec {
   pname = "esphome";
-  version = "1.14.5";
+  version = "1.15.0";
 
   src = python.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "176mi361677d5cqbi0hn52kky845byjs6gdad8pdhihyjgv7a9y9";
+    sha256 = "1npw5rm0mcfydrxxyk4bgzj5vmcwasw1y2idc3bw0ksgv9q69ird";
   };
 
   ESPHOME_USE_SUBPROCESS = "";
@@ -28,7 +28,7 @@ in python.pkgs.buildPythonApplication rec {
 
   # remove all version pinning (E.g tornado==5.1.1 -> tornado)
   postPatch = ''
-    sed -i -e "s/==[0-9.]*//" setup.py
+    sed -i -e "s/==[0-9.]*//" requirements.txt
   '';
 
   makeWrapperArgs = [


### PR DESCRIPTION
upstream switched from setup.py to define the requirements to requirements.txt

###### Motivation for this change

esphome 1.15.0 comes with a lot cool new modules

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - tested building esp32 with new modules
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
