### PR TITLE
libjson-rpc-cpp: 0.7.0 -> 1.3.0, fix build

### DIFF
--- a/pkgs/development/libraries/libjson-rpc-cpp/default.nix
+++ b/pkgs/development/libraries/libjson-rpc-cpp/default.nix
@@ -1,19 +1,33 @@
-{ stdenv, fetchFromGitHub, cmake, jsoncpp, argtable, curl, libmicrohttpd
-, doxygen, catch, pkgconfig
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, argtable
+, catch2
+, curl
+, doxygen
+, hiredis
+, jsoncpp
+, libmicrohttpd
+, pkgconfig
 }:
 
 stdenv.mkDerivation rec {
   pname = "libjson-rpc-cpp";
-  version = "0.7.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "cinemast";
     repo = "libjson-rpc-cpp";
-    sha256 = "07bg4nyvx0yyhy8c4x9i22kwqpx5jlv36dvpabgbb46ayyndhr7a";
+    sha256 = "1p5kb2dij1ycimkpx6n097y83imj1vlhss1r5vq9lcjzm65a81hh";
     rev = "v${version}";
   };
 
-  NIX_CFLAGS_COMPILE = "-I${catch}/include/catch";
+  patches = [
+    ./microhttpd-mhd-result.patch
+  ];
+
+  NIX_CFLAGS_COMPILE = "-I${catch2}/include/catch2";
 
   postPatch = ''
     for f in cmake/FindArgtable.cmake \
@@ -45,7 +59,7 @@ stdenv.mkDerivation rec {
 
     make install
 
-    sed -i -re "s#-([LI]).*/Build/Install(.*)#-\1$out\2#g" Install/lib/pkgconfig/*.pc
+    sed -i -re "s#-([LI]).*/Build/Install(.*)#-\1$out\2#g" Install/lib*/pkgconfig/*.pc
     for f in Install/lib/*.so* $(find Install/bin -executable -type f); do
       fixRunPath $f
     done
@@ -54,7 +68,16 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake jsoncpp argtable curl libmicrohttpd doxygen catch ];
+  buildInputs = [
+    cmake
+    argtable
+    catch2
+    curl
+    doxygen
+    hiredis
+    jsoncpp
+    libmicrohttpd
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libjson-rpc-cpp/microhttpd-mhd-result.patch
+++ b/pkgs/development/libraries/libjson-rpc-cpp/microhttpd-mhd-result.patch
@@ -1,0 +1,79 @@
+From fa163678134aced775651558f91a006791e26ef8 Mon Sep 17 00:00:00 2001
+From: Anton Lazarev <antonok35@gmail.com>
+Date: Thu, 13 Aug 2020 12:35:21 -0400
+Subject: [PATCH] use microhttpd's MHD_Result return type
+
+ Originally retrieved from https://github.com/cinemast/libjson-rpc-cpp/commit/fa163678134aced775651558f91a006791e26ef8.patch
+ via https://github.com/cinemast/libjson-rpc-cpp/pull/299, included in-tree because
+ it is unmerged
+
+diff --git a/src/jsonrpccpp/server/connectors/httpserver.cpp b/src/jsonrpccpp/server/connectors/httpserver.cpp
+index a8496154..bd4a81d3 100644
+--- a/src/jsonrpccpp/server/connectors/httpserver.cpp
++++ b/src/jsonrpccpp/server/connectors/httpserver.cpp
+@@ -151,10 +151,10 @@ void HttpServer::SetUrlHandler(const string &url,
+   this->SetHandler(NULL);
+ }
+ 
+-int HttpServer::callback(void *cls, MHD_Connection *connection, const char *url,
+-                         const char *method, const char *version,
+-                         const char *upload_data, size_t *upload_data_size,
+-                         void **con_cls) {
++MHD_Result HttpServer::callback(void *cls, MHD_Connection *connection,
++                                const char *url, const char *method,
++                                const char *version, const char *upload_data,
++                                size_t *upload_data_size, void **con_cls) {
+   (void)version;
+   if (*con_cls == NULL) {
+     struct mhd_coninfo *client_connection = new mhd_coninfo;
+diff --git a/src/jsonrpccpp/server/connectors/httpserver.h b/src/jsonrpccpp/server/connectors/httpserver.h
+index ebd70c9b..e5b57898 100644
+--- a/src/jsonrpccpp/server/connectors/httpserver.h
++++ b/src/jsonrpccpp/server/connectors/httpserver.h
+@@ -79,7 +79,7 @@ class HttpServer : public AbstractServerConnector {
+   std::map<std::string, IClientConnectionHandler *> urlhandler;
+   struct sockaddr_in loopback_addr;
+ 
+-  static int callback(void *cls, struct MHD_Connection *connection,
++  static MHD_Result callback(void *cls, struct MHD_Connection *connection,
+                       const char *url, const char *method, const char *version,
+                       const char *upload_data, size_t *upload_data_size,
+                       void **con_cls);
+diff --git a/src/test/testhttpserver.cpp b/src/test/testhttpserver.cpp
+index 6e6db4b6..15a2ba8b 100644
+--- a/src/test/testhttpserver.cpp
++++ b/src/test/testhttpserver.cpp
+@@ -41,7 +41,7 @@ std::string TestHttpServer::GetHeader(const std::string &key) {
+   return "";
+ }
+ 
+-int TestHttpServer::callback(void *cls, MHD_Connection *connection,
++MHD_Result TestHttpServer::callback(void *cls, MHD_Connection *connection,
+                              const char *url, const char *method,
+                              const char *version, const char *upload_data,
+                              size_t *upload_data_size, void **con_cls) {
+@@ -69,7 +69,7 @@ int TestHttpServer::callback(void *cls, MHD_Connection *connection,
+   return MHD_YES;
+ }
+ 
+-int TestHttpServer::header_iterator(void *cls, MHD_ValueKind kind,
++MHD_Result TestHttpServer::header_iterator(void *cls, MHD_ValueKind kind,
+                                     const char *key, const char *value) {
+   (void)kind;
+   TestHttpServer *_this = static_cast<TestHttpServer *>(cls);
+diff --git a/src/test/testhttpserver.h b/src/test/testhttpserver.h
+index f438c640..71573d6a 100644
+--- a/src/test/testhttpserver.h
++++ b/src/test/testhttpserver.h
+@@ -36,9 +36,9 @@ namespace jsonrpc {
+             std::map<std::string,std::string> headers;
+             std::string response;
+ 
+-            static int callback(void *cls, struct MHD_Connection *connection, const char *url, const char *method, const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls);
++            static MHD_Result callback(void *cls, struct MHD_Connection *connection, const char *url, const char *method, const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls);
+ 
+-            static int header_iterator (void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
++            static MHD_Result header_iterator (void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
+     };
+ 
+ } // namespace jsonrpc


### PR DESCRIPTION
###### Motivation for this change
This required a patch to allow it to build with `libmicrohttpd` 0.9.71, which could only be found on an unmerged PR, so I included the patch in-tree so that we had a stable source for this.

Bit of an odd situation though, after having fixed this I realized the only package we have that use(d) this is marked `broken`, so I have little way of testing whether this _actually_ works. ~The result looks about right, though.~ I've just realized the `jsonrpcstub` binary segfaults. I'm putting this on backburner as there are many other issue to take care of for 20.09, but posting it as a draft PR in case anyone interested wants to pick this up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
