### PR TITLE
wordgrinder: Correct build failure

### DIFF
--- a/pkgs/applications/office/wordgrinder/default.nix
+++ b/pkgs/applications/office/wordgrinder/default.nix
@@ -12,11 +12,17 @@ stdenv.mkDerivation rec {
     sha256 = "08lnq5wmspfqdjmqm15gizcq0xr7mg4h62qhvwj63v0sd6ks1cal";
   };
 
+  # The `Makefile` uses a dedicated directory to store temporary artifacts.
+  # Override through `makeFlags` to ensure purity of the build.
+  objdir = "tmp/wg-build";
+
   makeFlags = [
+    "OBJDIR=./${objdir}"
     "PREFIX=$(out)"
   ];
 
   preBuild = stdenv.lib.optionalString stdenv.isLinux ''
+    mkdir -p ./${objdir}
     makeFlagsArray+=('XFT_PACKAGE=--cflags={} --libs={-lX11 -lXft}')
   '';
 

--- a/pkgs/applications/office/wordgrinder/default.nix
+++ b/pkgs/applications/office/wordgrinder/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out)"
-    "LUA_INCLUDE=${lua52Packages.lua}/include"
-    "LUA_LIB=${lua52Packages.lua}/lib/liblua.so"
   ];
 
   preBuild = stdenv.lib.optionalString stdenv.isLinux ''


### PR DESCRIPTION
###### Motivation for this change

Update `wordgrinder` for it to build properly.
ZHF: #97479

~Opened davidgiven/wordgrinder#114 upstream for an elegant way to fix the failure.~ (unnecessary)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] ~Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] ~Ensured that relevant documentation is up to date~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
