### PR TITLE
ocamlPackages.zed: 2.0.3 → 3.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/zed/default.nix
+++ b/pkgs/development/ocaml-modules/zed/default.nix
@@ -3,8 +3,8 @@
 let param =
   if stdenv.lib.versionAtLeast ocaml.version "4.02" then
   {
-    version = "2.0.3";
-    sha256 = "0pa9awinqr0plp4b2az78dwpvh01pwaljnn5ydg8mc6hi7rmir55";
+    version = "3.1.0";
+    sha256 = "04vr1a94imsghm98iigc35rhifsz0rh3qz2qm0wam2wvp6vmrx0p";
     buildInputs = [ dune ];
     propagatedBuildInputs = [ charInfo_width ];
     extra = {


### PR DESCRIPTION
###### Motivation for this change

Compatibility with `result` 1.5.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
