### PR TITLE
coqPackages.metalib: 20170713 → 20200527

### DIFF
--- a/pkgs/development/coq-modules/metalib/default.nix
+++ b/pkgs/development/coq-modules/metalib/default.nix
@@ -1,46 +1,23 @@
-{ stdenv, fetchgit, coq, haskellPackages, which, ott
-}:
+{ stdenv, fetchFromGitHub, coq }:
 
 stdenv.mkDerivation rec {
-  name = "metalib-${coq.coq-version}-${version}";
-  version = "20170713";
+  name = "coq${coq.coq-version}-metalib-${version}";
+  version = "20200527";
 
-  src = fetchgit {
-    url = "https://github.com/plclub/metalib.git";
-    rev = "44e40aa082452dd333fc1ca2d2cc55311519bd52";
-    sha256 = "1pra0nvx69q8d4bvpcvh9ngic1cy6z1chi03x56nisfqnc61b6y9";
+  src = fetchFromGitHub {
+    owner = "plclub";
+    repo = "metalib";
+    rev = "597fd7d0c93eb159274e84a39d554f10f1efccf8";
+    sha256 = "0wbypc05d2lqfm9qaw98ynr5yc1p0ipsvyc3bh1rk9nz7zwirmjs";
   };
 
-  # The 'lngen' command-line utility is built from Haskell sources
-  lngen = with haskellPackages; mkDerivation {
-    pname = "lngen";
-    version = "0.0.1";
-    src = fetchgit {
-      url = "https://github.com/plclub/lngen";
-      rev = "ea73ad315de33afd25f87ca738c71f358f1cd51c";
-      sha256 = "1a0sj8n3lmsl1wlnqfy176k9lb9s8rl422bvg3ihl2i70ql8wisd";
-    };
-    isLibrary = true;
-    isExecutable = true;
-    libraryHaskellDepends = [ base containers mtl parsec syb ];
-    executableHaskellDepends = [ base ];
-    homepage = "https://github.com/plclub/lngen";
-    description = "Tool for generating Locally Nameless definitions and proofs in Coq, working together with Ott";
-    license = stdenv.lib.licenses.mit;
-  };
+  sourceRoot = "source/Metalib";
 
-  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 which coq lngen ott findlib ];
-  propagatedBuildInputs = [ coq ];
+  buildInputs = [ coq ];
 
   enableParallelBuilding = true;
 
-  buildPhase = ''
-    (cd Metalib; make)
-  '';
-
-  installPhase = ''
-    (cd Metalib; make -f CoqSrc.mk DSTROOT=/ COQLIB=$out/lib/coq/${coq.coq-version}/ install)
-  '';
+  installFlags = "COQMF_COQLIB=$(out)/lib/coq/${coq.coq-version}";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/plclub/metalib";
@@ -50,7 +27,7 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" "8.8" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.10" "8.11" "8.12" ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Current version does not build.

ZHF: #97479

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
