### PR TITLE
keyutils: 1.6.1 -> 1.6.3

### DIFF
--- a/pkgs/os-specific/linux/keyutils/default.nix
+++ b/pkgs/os-specific/linux/keyutils/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "keyutils";
-  version = "1.6.1";
+  version = "1.6.3";
 
   src = fetchurl {
     url = "https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git/snapshot/${pname}-${version}.tar.gz";
-    sha256 = "0mzmw8c7gqmqaxm3sa0xki8ycjla47xxhqg0yh17pl00d7ydqw9w";
+    sha256 = "sha256-ph1XBhNq5MBb1I+GGGvP29iN2L1RB+Phlckkz8Gzm7Q=";
   };
 
   patches = [
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
 
   BUILDDATE = "1970-01-01";
   outputs = [ "out" "lib" "dev" ];
+
+  enableParallelBuilding = true;
 
   installFlags = [
     "ETCDIR=$(out)/etc"


### PR DESCRIPTION
###### Motivation for this change

Any C++ project that consumes this needs this update to avoid a variable
named `private` that clashes with the reserved word.

nix-review is running...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).