### PR TITLE
tensorflow: Fix compilation with numpy 1.19.x

### DIFF
--- a/pkgs/development/python-modules/tensorflow/1/default.nix
+++ b/pkgs/development/python-modules/tensorflow/1/default.nix
@@ -132,6 +132,13 @@ let
       })
       ./lift-gast-restriction.patch
 
+      (fetchpatch {
+        # fix compilation with numpy >= 1.19
+        name = "add-const-overload.patch";
+        url = "https://github.com/tensorflow/tensorflow/commit/75ea0b31477d6ba9e990e296bbbd8ca4e7eebadf.patch";
+        sha256 = "1xp1icacig0xm0nmb05sbrf4nw4xbln9fhc308birrv8286zx7wv";
+      })
+
       # cuda 10.2 does not have "-bin2c-path" option anymore
       # https://github.com/tensorflow/tensorflow/issues/34429
       ../cuda-10.2-no-bin2c-path.patch


### PR DESCRIPTION
###### Motivation for this change

Current version does not build.

ZHF: #97479

Context: https://hydra.nixos.org/build/126811197/nixlog/1

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
