### PR TITLE
pythonPackages.pyslurm: mark as broken

### DIFF
--- a/pkgs/development/python-modules/pyslurm/default.nix
+++ b/pkgs/development/python-modules/pyslurm/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
     description = "Python bindings to Slurm";
     license = licenses.gpl2;
     maintainers = with maintainers; [ bhipple ];
+    broken = true;  # still needs slurm-19.05, but nixpkgs has slurm-20+ now
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This version of `pyslurm` needs to be built on a outdated version of slurm which is not supported in nixpkgs anymore. `pyslurm` should therefore be marked as broken until a new version is released.

ZHF (#97479)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
