### PR TITLE
x265: 3.2 -> 3.4

### DIFF
--- a/pkgs/development/libraries/x265/default.nix
+++ b/pkgs/development/libraries/x265/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, cmake, nasm, numactl
+{ stdenv, fetchFromBitbucket, cmake, nasm, numactl
 , numaSupport ? stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isx86 || stdenv.hostPlatform.isAarch64)  # Enabled by default on NUMA platforms
 , debugSupport ? false # Run-time sanity checks (debugging)
 , werrorSupport ? false # Warnings as errors
@@ -23,31 +23,23 @@ let
     (mkFlag werrorSupport "WARNINGS_AS_ERRORS")
   ];
 
-  version = "3.2";
+  version = "3.4";
 
-  src = fetchurl {
-    urls = [
-      "https://get.videolan.org/x265/x265_${version}.tar.gz"
-      "ftp://ftp.videolan.org/pub/videolan/x265/x265_${version}.tar.gz"
-    ];
-    sha256 = "0fqkhfhr22gzavxn60cpnj3agwdf5afivszxf3haj5k1sny7jk9n";
+  src = fetchFromBitbucket {
+    owner = "multicoreware";
+    repo = "x265_git";
+    rev = "${version}";
+    sha256 = "1jzgv2hxhcwmsdf6sbgyzm88a46dp09ll1fqj92g9vckvh9a7dsn";
   };
-
-  patches = [
-    # Fix build on ARM (#406)
-    (fetchpatch {
-      url = "https://bitbucket.org/multicoreware/x265/issues/attachments/406/multicoreware/x265/1527562952.26/406/X265-2.8-asm-primitives.patch";
-      sha256 = "1vf8bpl37gbd9dcbassgkq9i0rp24qm3bl6hx9zv325174bn402v";
-    })
-  ];
 
   buildLib = has12Bit: stdenv.mkDerivation rec {
     name = "libx265-${if has12Bit then "12" else "10"}-${version}";
-    inherit src patches;
+    inherit src;
     enableParallelBuilding = true;
 
     postPatch = ''
       sed -i 's/unknown/${version}/g' source/cmake/version.cmake
+      sed -i 's/0.0/${version}/g' source/cmake/version.cmake
     '';
 
     cmakeLibFlags = [
@@ -72,12 +64,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "x265";
-  inherit version src patches;
+  inherit version src;
 
   enableParallelBuilding = true;
 
   postPatch = ''
     sed -i 's/unknown/${version}/g' source/cmake/version.cmake
+    sed -i 's/0.0/${version}/g' source/cmake/version.cmake
   '';
 
   cmakeFlags = [


### PR DESCRIPTION
- Change version from `3.2` to `3.4`
- Use `fetchFromBitbucket` to fetch the archive from `multicoreware/x265_git` instead of the videolan server (doesn't have the latest version)
- Remove the ARM patch, doesn't work anymore but doesn't seems necessary since this [commit](https://bitbucket.org/multicoreware/x265_git/commits/ec7396adaa6afd2c8aab1918cfe4bb6e384740c3)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
