### PR TITLE
portmod: init at 2.0_beta7

### DIFF
--- a/pkgs/development/python-modules/baron/default.nix
+++ b/pkgs/development/python-modules/baron/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchPypi, buildPythonPackage, rply, pytestCheckHook, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "baron";
+  version = "0.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fib74nkqnl1i2zzlhbbfpw3whwc4951p9x61r2xrxhwp4r9yn5h";
+  };
+
+  propagatedBuildInputs = [ rply ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  doCheck = isPy3k;
+
+  meta = with lib; {
+    homepage = "https://github.com/gristlabs/asttokens";
+    description = "Abstraction on top of baron, a FST for python to make writing refactoring code a realistic task";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ marius851000 ];
+  };
+}

--- a/pkgs/development/python-modules/patool/default.nix
+++ b/pkgs/development/python-modules/patool/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, lib, buildPythonPackage, fetchFromGitHub, pytestCheckHook, p7zip,
+  unzip, cabextract, zip, zopfli, lzip, zpaq, gnutar, gnugrep, diffutils, file,
+  gzip, bzip2, xz}:
+
+# unrar is unfree, as well as 7z with unrar support, not including it (patool doesn't support unar)
+
+let
+  compression-utilities = [
+    p7zip
+    unzip
+    gnutar
+    cabextract
+    zip
+    zopfli
+    lzip
+    zpaq
+    gzip
+    gnugrep
+    diffutils
+    bzip2
+    file
+    xz
+  ];
+in
+buildPythonPackage rec {
+  pname = "patool";
+  version = "1.12";
+
+  #pypi doesn't have test data
+  src = fetchFromGitHub {
+    owner = "wummel";
+    repo = pname;
+    rev = "upstream/${version}";
+    sha256 = "0v4r77sm3yzh7y1whfwxmp01cchd82jbhvbg9zsyd2yb944imzjy";
+  };
+
+  prePatch = ''
+    substituteInPlace patoolib/util.py \
+      --replace "path = None" 'path = append_to_path(os.environ["PATH"], "${lib.makeBinPath compression-utilities}")'
+  '';
+
+  checkInputs = [ pytestCheckHook ] ++ compression-utilities;
+
+  disabledTests = [
+    "test_unzip"
+    "test_unzip_file"
+    "test_zip"
+    "test_zip_file"
+  ];
+
+  meta = with lib; {
+    description = "portable archive file manager";
+    homepage = "https://wummel.github.io/patool/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ marius851000 ];
+  };
+}

--- a/pkgs/development/python-modules/pypblib/default.nix
+++ b/pkgs/development/python-modules/pypblib/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pypblib";
+  version = "0.0.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qlhykm9flj6cv3v0b9q40gy21yz0lnp0wxlxvb3ijkpy45r7pbi";
+  };
+
+  pythonImportsCheck = [ "pypblib" ];
+
+  meta = with lib; {
+    homepage = "https://pypi.org/project/pypblib/";
+    description = "PBLib Python3 Bindings";
+    license = licenses.mit;
+    maintainers = [ maintainers.marius851000 ];
+  };
+}

--- a/pkgs/development/python-modules/python-sat/default.nix
+++ b/pkgs/development/python-modules/python-sat/default.nix
@@ -1,0 +1,24 @@
+{ buildPythonPackage, fetchFromGitHub, lib, six, pypblib, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "python-sat";
+  version = "0.1.6.dev6";
+
+  src = fetchFromGitHub {
+    owner = "pysathq";
+    repo = "pysat";
+    rev = version;
+    sha256 = "1gckxhqkvzyw7pmwg8xzxq146jysqy0s23l5mjc3awm6swdij66y";
+  };
+
+  propagatedBuildInputs = [ six pypblib ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Toolkit to provide interface for various SAT (without optional dependancy py-aiger-cnf)";
+    homepage = "https://github.com/pysathq/pysat";
+    license = licenses.mit;
+    maintainers = [ maintainers.marius851000 ];
+  };
+}

--- a/pkgs/development/python-modules/redbaron/default.nix
+++ b/pkgs/development/python-modules/redbaron/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchPypi, buildPythonPackage, baron, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "redbaron";
+  version = "0.9.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0bqkq0wn20cc3qrcd1ifq74p4m570j345bkq4axl08kbr8whfba7";
+  };
+
+  propagatedBuildInputs = [ baron ];
+
+  preCheck = ''
+    rm -rf tests/__pycache__
+    rm tests/test_bounding_box.py
+  ''; #error about fixtures
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    homepage = "https://github.com/gristlabs/asttokens";
+    description = "Abstraction on top of baron, a FST for python to make writing refactoring code a realistic task";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ marius851000 ];
+  };
+}

--- a/pkgs/games/portmod/default.nix
+++ b/pkgs/games/portmod/default.nix
@@ -1,0 +1,98 @@
+{ lib, stdenv, callPackage, python3Packages, fetchFromGitLab, cacert,
+  rustPlatform, bubblewrap, git, perlPackages, imagemagick7, fetchurl, fetchzip,
+  jre, makeWrapper, tr-patcher, tes3cmd }:
+
+let
+  version = "2.0_beta9";
+
+  src = fetchFromGitLab {
+    owner = "portmod";
+    repo = "Portmod";
+    rev = "v${version}";
+    sha256 = "0a598rb0z6gsdyr4n0lc0yc583njjii07p6vxw75xsh7292vxksc";
+  };
+
+  portmod-rust = rustPlatform.buildRustPackage rec {
+    inherit src version;
+    pname = "portmod-rust";
+
+    cargoSha256 = "14p1aywwbkf2pk85sir5g9ni08zam2hid0kaz111718b006nrxh7";
+
+    nativeBuildInputs = [ python3Packages.python ];
+
+    doCheck = false;
+  };
+
+  bin-programs = [
+    bubblewrap
+    git
+    python3Packages.virtualenv
+    tr-patcher
+    tes3cmd
+    imagemagick7
+  ];
+
+in
+python3Packages.buildPythonApplication rec {
+  inherit src version;
+
+  pname = "portmod";
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  # build the rust library independantly
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "from setuptools_rust import Binding, RustExtension" "" \
+      --replace "RustExtension(\"portmod.portmod\", binding=Binding.PyO3, strip=True)" ""
+  '';
+
+  propagatedBuildInputs = with python3Packages; [
+    setuptools_scm
+    setuptools
+    requests
+    chardet
+    colorama
+    restrictedpython
+    appdirs
+    GitPython
+    progressbar2
+    python-sat
+    redbaron
+    patool
+    packaging
+  ];
+
+  checkInputs = with python3Packages; [
+    pytestCheckHook
+  ] ++ bin-programs;
+
+  preCheck = ''
+    cp ${portmod-rust}/lib/libportmod.so portmod/portmod.so
+    export HOME=$(mktemp -d)
+  '';
+
+  # some test require network access
+  disabledTests = [
+    "test_masters_esp"
+    "test_logging"
+    "test_execute_network_permissions"
+    "test_execute_permissions_bleed"
+    "test_git"
+  ];
+
+  # for some reason, installPhase doesn't copy the compiled binary
+  postInstall = ''
+    cp ${portmod-rust}/lib/libportmod.so $out/${python3Packages.python.sitePackages}/portmod/portmod.so
+
+    makeWrapperArgs+=("--prefix" "GIT_SSL_CAINFO" ":" "${cacert}/etc/ssl/certs/ca-bundle.crt" \
+      "--prefix" "PATH" ":" "${lib.makeBinPath bin-programs }")
+  '';
+
+  meta = {
+    description = "mod manager for openMW based on portage";
+    homepage = "https://gitlab.com/portmod/portmod";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ marius851000 ];
+  };
+}

--- a/pkgs/games/tes3cmd/default.nix
+++ b/pkgs/games/tes3cmd/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, perlPackages, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "tes3cmd";
+  version = "0.40-pre-release-2";
+
+  src = fetchFromGitHub {
+    owner = "john-moonsugar";
+    repo = pname;
+    rev = "f72e9ed9dd18e8545dd0dc2a4056c250cf505790";
+    sha256 = "01zqplp8yb0xnl54963n0zkz66rf3hn2x3i255jlhdhx1c43jba7";
+  };
+
+  buildInputs = [ perlPackages.perl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp tes3cmd $out/bin/tes3cmd
+  '';
+
+  meta = with lib; {
+    description = "A command line tool for examining and modifying plugins for the Elder Scrolls game Morrowind by Bethesda Softworks.";
+    homepage = "https://github.com/john-moonsugar/tes3cmd";
+    license = licenses.mit;
+    maintainers = [ maintainers.marius851000 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/tr-patcher/default.nix
+++ b/pkgs/games/tr-patcher/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchurl, fetchzip, jre, makeWrapper }:
+
+let
+translation-file = fetchurl {
+  url = "https://gitlab.com/bmwinger/tr-patcher/-/raw/master/lib/Translation.txt?inline=false";
+  sha256 = "136zd2s73b4n1w2n34wxi656bm448748nn3y7a64fd89ysg9n7n8";
+};
+in
+stdenv.mkDerivation rec {
+  pname = "tr-patcher";
+  version = "1.0.5";
+
+  # use the pre compiled source, as compilation is a bit complex
+  src = fetchzip {
+    url = "https://gitlab.com/bmwinger/tr-patcher/uploads/b57899980b2351c136393f02977c4fab/tr-patcher-shadow.zip";
+    sha256 = "0va7nbmlgf3p2nc0z2b9n1285y4q5rpyjr4w93rdnx38wrhinxnw";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -Dm644 lib/tr-patcher-all.jar $out/lib/tr-patcher.jar
+    install -Dm644 ${translation-file} $out/lib/Translation.txt
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/tr-patcher \
+    --add-flags "-jar $out/lib/tr-patcher.jar"
+  '';
+
+  meta = with lib; {
+    description = "Allow to update dependancies of the Tamriel-Data mod for morrowind";
+    homepage = "https://gitlab.com/bmwinger/tr-patcher";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.marius851000 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25010,6 +25010,8 @@ in
 
   openmw-tes3mp = libsForQt5.callPackage ../games/openmw/tes3mp.nix { };
 
+  tr-patcher = callPackage ../games/tr-patcher { };
+
   tes3cmd = callPackage ../games/tes3cmd { };
 
   openraPackages = import ../games/openra pkgs;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25010,6 +25010,8 @@ in
 
   openmw-tes3mp = libsForQt5.callPackage ../games/openmw/tes3mp.nix { };
 
+  tes3cmd = callPackage ../games/tes3cmd { };
+
   openraPackages = import ../games/openra pkgs;
 
   openra = openraPackages.engines.release;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2298,6 +2298,8 @@ in
 
   patdiff = callPackage ../tools/misc/patdiff { };
 
+  patool = with python3Packages; toPythonApplication patool;
+
   pbpst = callPackage ../applications/misc/pbpst { };
 
   pbzx = callPackage ../tools/compression/pbzx { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25010,6 +25010,8 @@ in
 
   openmw-tes3mp = libsForQt5.callPackage ../games/openmw/tes3mp.nix { };
 
+  portmod = callPackage ../games/portmod { };
+
   tr-patcher = callPackage ../games/tr-patcher { };
 
   tes3cmd = callPackage ../games/tes3cmd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5741,6 +5741,8 @@ in {
 
   python-rtmidi = callPackage ../development/python-modules/python-rtmidi { };
 
+  python-sat = callPackage ../development/python-modules/python-sat { };
+
   python-simple-hipchat = callPackage ../development/python-modules/python-simple-hipchat { };
   python_simple_hipchat = self.python-simple-hipchat;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -752,6 +752,8 @@ in {
 
   bap = callPackage ../development/python-modules/bap { bap = pkgs.ocaml-ng.ocamlPackages_4_06.bap; };
 
+  baron = callPackage ../development/python-modules/baron { };
+
   base58 = callPackage ../development/python-modules/base58 { };
 
   baselines = callPackage ../development/python-modules/baselines { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5171,6 +5171,8 @@ in {
 
   pyparted = callPackage ../development/python-modules/pyparted { };
 
+  pypblib = callPackage ../development/python-modules/pypblib { };
+
   pypcap = callPackage ../development/python-modules/pypcap { };
 
   pypdf2 = callPackage ../development/python-modules/pypdf2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6004,6 +6004,8 @@ in {
 
   recommonmark = callPackage ../development/python-modules/recommonmark { };
 
+  redbaron = callPackage ../development/python-modules/redbaron { };
+
   redis = callPackage ../development/python-modules/redis { };
 
   rednose = callPackage ../development/python-modules/rednose { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4290,6 +4290,8 @@ in {
 
   pathtools = callPackage ../development/python-modules/pathtools { };
 
+  patool = callPackage ../development/python-modules/patool { };
+
   patsy = callPackage ../development/python-modules/patsy { };
 
   paver = callPackage ../development/python-modules/paver { };


### PR DESCRIPTION
###### Motivation for this change
wanted to add the portmod package. I use it, and wanted it to be in the nixpkgs.

###### Things done

mainly in additional to portmod, add patool.

I was able to install the meta-momw/expanded-vanilla , but with some modification in the environment: needed to set "TMPDIR=/tmp" (the default temp dir doesn't have enought size) and to have unrar in the PATH.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
