### PR TITLE
python3Packages.tinydb: 3.14.1 -> 4.1.1

### DIFF
--- a/pkgs/development/python-modules/tinydb/default.nix
+++ b/pkgs/development/python-modules/tinydb/default.nix
@@ -1,7 +1,9 @@
 { lib
 , buildPythonPackage
+, pythonOlder
 , fetchFromGitHub
-, pytest
+, poetry
+, pytestCheckHook
 , pytestcov
 , pytestrunner
 , pycodestyle
@@ -10,21 +12,21 @@
 
 buildPythonPackage rec {
   pname = "tinydb";
-  version = "v3.14.1";
+  version = "4.1.1";
+  disabled = pythonOlder "3.5";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "msiemens";
     repo = pname;
-    rev = version;
-    sha256 = "02idbvrm8j4mwsjfkzy11f4png19k307p53s4qa2ifzssysxpb96";
+    rev = "v${version}";
+    sha256 = "09cwdmpj91c6q7jympip1lrcd3idbm9cqblgvmrh0v1vy1iv2ki7";
   };
 
-  nativeBuildInputs = [
-    pytestrunner
-  ];
+  nativeBuildInputs = [ poetry ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
     pytestcov
     pycodestyle
     pyyaml
@@ -32,8 +34,9 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A lightweight document oriented database written in pure Python with no external dependencies";
-    homepage = "https://github.com/msiemens/tinydb";
-    license = licenses.asl20;
+    homepage = "https://tinydb.readthedocs.org/";
+    changelog = "https://tinydb.readthedocs.io/en/latest/changelog.html";
+    license = licenses.mit;
     maintainers = with maintainers; [ marcus7070 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

* Fix license
* Update version
* Update homepage & URL links
* Disable on python2.7 (no longer supported).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
