### PR TITLE
kicad: remove gettext from buildInputs, add to nativeBuildInputs

### DIFF
--- a/pkgs/applications/science/electronics/kicad/libraries.nix
+++ b/pkgs/applications/science/electronics/kicad/libraries.nix
@@ -62,8 +62,7 @@ in
           inherit name;
         } // (libSources.${name} or { })
       );
-      buildInputs = [ gettext ];
-      nativeBuildInputs = [ cmake ];
+      nativeBuildInputs = [ cmake gettext ];
       meta = {
         license = licenses.gpl2; # https://github.com/KiCad/kicad-i18n/issues/3
         platforms = stdenv.lib.platforms.all;


### PR DESCRIPTION
###### Motivation for this change

`gettext` is (wrongly, imho) used as buildInput, when it should be in nativeBuildInputs.

The kicad-i18n library only calls the msgfmt tool from gettext, but does not compile, link, etc anything.

**Edit:** See https://gitlab.com/kicad/code/kicad-i18n/-/blob/master/CMakeLists.txt the CMake file in question.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
