### PR TITLE
maestral-qt: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/applications/networking/maestral-qt/default.nix
+++ b/pkgs/applications/networking/maestral-qt/default.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "maestral-qt";
-  version = "1.1.0";
+  version = "1.2.0";
   disabled = python3.pkgs.pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral-qt";
     rev = "v${version}";
-    sha256 = "0clzzwwbrynfbvawhaaa4mp2qi8smng31mmz0is166z6g67bwdl6";
+    sha256 = "sha256-bEVxtp2MqEsjQvcVXmrWcwys3AMg+lPcdYn4IlYhyqw=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/development/python-modules/dbus-next/default.nix
+++ b/pkgs/development/python-modules/dbus-next/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, dbus, dbus-python, pytest, pytestcov, pytest-asyncio, pytest-timeout
+}:
+
+buildPythonPackage rec {
+  pname = "dbus-next";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "altdesktop";
+    repo = "python-dbus-next";
+    rev = "v${version}";
+    sha256 = "sha256-C/aFDHmt6Qws6ek+++wM5GRN6TEvMGMiFktKIXRdGL0=";
+  };
+
+  checkInputs = [
+    dbus
+    dbus-python
+    pytest
+    pytestcov
+    pytest-asyncio
+    pytest-timeout
+  ];
+
+  # test_peer_interface hits a timeout
+  checkPhase = ''
+    dbus-run-session --config-file=${dbus.daemon}/share/dbus-1/session.conf \
+      ${python.interpreter} -m pytest -sv --cov=dbus_next \
+      -k "not test_peer_interface"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/altdesktop/python-dbus-next";
+    description = "A zero-dependency DBus library for Python with asyncio support";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sfrijters ];
+  };
+}

--- a/pkgs/development/python-modules/dropbox/default.nix
+++ b/pkgs/development/python-modules/dropbox/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "dropbox";
-  version = "10.3.1";
+  version = "10.4.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6de5f6f36aad32d4382f3d0ad88ee85a22d81d638c960667b8e1ada05db2f98c";
+    sha256 = "sha256-INA50DD3wfVPItGCgywZCe5bViatUkaaGdJ0vwcEHgY=";
   };
 
   # Set DROPBOX_TOKEN environment variable to a valid token.

--- a/pkgs/development/python-modules/maestral/default.nix
+++ b/pkgs/development/python-modules/maestral/default.nix
@@ -3,27 +3,28 @@
 , fetchFromGitHub
 , pythonOlder
 , python
-, blinker, bugsnag, click, dropbox, fasteners, keyring, keyrings-alt, pathspec, Pyro5, requests, u-msgpack-python, watchdog
+, blinker, bugsnag, click, dbus-next, dropbox, fasteners, keyring, keyrings-alt, pathspec, Pyro5, requests, sqlalchemy, u-msgpack-python, watchdog
 , sdnotify
 , systemd
 }:
 
 buildPythonPackage rec {
   pname = "maestral";
-  version = "1.1.0";
+  version = "1.2.0";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral";
     rev = "v${version}";
-    sha256 = "0d1pxbg69ll07w4bbpzs7zz1yn82qyrym95b0mqmhrrg2ysxjngg";
+    sha256 = "sha256-/xm6sGios5N68X94GqFFzH1jNSMK1OnvQiEykU9IAZU=";
   };
 
   propagatedBuildInputs = [
     blinker
     bugsnag
     click
+    dbus-next
     dropbox
     fasteners
     keyring
@@ -31,6 +32,7 @@ buildPythonPackage rec {
     pathspec
     Pyro5
     requests
+    sqlalchemy
     u-msgpack-python
     watchdog
   ] ++ stdenv.lib.optionals stdenv.isLinux [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10860,8 +10860,8 @@ in
     if stdenv.targetPlatform.isi686
       then gcc6.cc
     else if stdenv.targetPlatform == stdenv.hostPlatform && targetPackages.stdenv.cc.isGNU
-	  # Can only do this is in the native case, otherwise we might get infinite
-	  # recursion if `targetPackages.stdenv.cc.cc` itself uses `gccForLibs`.
+    # Can only do this is in the native case, otherwise we might get infinite
+    # recursion if `targetPackages.stdenv.cc.cc` itself uses `gccForLibs`.
       then targetPackages.stdenv.cc.cc
     else gcc.cc;
 
@@ -23237,7 +23237,7 @@ in
 
   maestral = with python3Packages; toPythonApplication maestral;
 
-  maestral-gui = libsForQt514.callPackage ../applications/networking/maestral-qt { };
+  maestral-gui = libsForQt5.callPackage ../applications/networking/maestral-qt { };
 
   insync = callPackage ../applications/networking/insync { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1460,6 +1460,8 @@ in {
 
   dbfread = callPackage ../development/python-modules/dbfread { };
 
+  dbus-next = callPackage ../development/python-modules/dbus-next { };
+
   dbus-python = callPackage ../development/python-modules/dbus { inherit (pkgs) dbus pkgconfig; };
 
   dcmstack = callPackage ../development/python-modules/dcmstack { };


### PR DESCRIPTION
###### Motivation for this change

New release https://github.com/SamSchott/maestral/releases/tag/v1.2.0

~~The first commit is a duplicate of #98073 to make sure this branch actually works.~~ The PR that caused this issue has been reverted in a4e50bb197f032ec447a13f56910ff035b32017f.
This PR also includes necessary dependency updates for the maestral base package, and transitively dropbox. The updated maestral package also requires a new package dbus-next.

The dbus-next package has testing disabled at the moment because I get and I'm not sure what to do about this.

```
running install tests
no Makefile or custom buildPhase, doing nothing
pythonCatchConflictsPhase
pythonRemoveBinBytecodePhase
pythonImportsCheckPhase
Executing pythonImportsCheckPhase
setuptoolsCheckPhase
Executing setuptoolsCheckPhase
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing dbus_next.egg-info/PKG-INFO
writing dependency_links to dbus_next.egg-info/dependency_links.txt
writing top-level names to dbus_next.egg-info/top_level.txt
reading manifest file 'dbus_next.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'dbus_next.egg-info/SOURCES.txt'
running build_ext
error: [Errno 2] No such file or directory: '/build/dbus_next-0.1.4/test/data/introspection.xml'
note: keeping build directory '/tmp/nix-build-python3.8-dbus-next-0.1.4.drv-0'
error: --- Error --- nix-daemon
builder for '/nix/store/06g2adww93xpq9957frc5pqmfd5z01y3-python3.8-dbus-next-0.1.4.drv' failed with exit code 1; last 10 log lines:
  WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
  running egg_info
  writing dbus_next.egg-info/PKG-INFO
  writing dependency_links to dbus_next.egg-info/dependency_links.txt
  writing top-level names to dbus_next.egg-info/top_level.txt
  reading manifest file 'dbus_next.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  writing manifest file 'dbus_next.egg-info/SOURCES.txt'
  running build_ext
  error: [Errno 2] No such file or directory: '/build/dbus_next-0.1.4/test/data/introspection.xml'
error: --- Error -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- nix-build
error: --- Error --- nix-daemon
1 dependencies of derivation '/nix/store/8p39zvlwmqm8kh6vinxzxii001pyisbg-maestral-qt-1.2.0.drv' failed to build
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
