### PR TITLE
pythonPackages.cryptography_2_9: Allow to use version 2.9 with Python3

### DIFF
--- a/pkgs/development/python-modules/cryptography/2.9.nix
+++ b/pkgs/development/python-modules/cryptography/2.9.nix
@@ -5,7 +5,7 @@
 , isPy27
 , ipaddress
 , openssl
-, cryptography_vectors
+, cryptography_vectors_2_9
 , darwin
 , packaging
 , six
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   ++ stdenv.lib.optionals isPy27 [ ipaddress enum34 ];
 
   checkInputs = [
-    cryptography_vectors
+    cryptography_vectors_2_9
     hypothesis
     iso8601
     pretend

--- a/pkgs/development/python-modules/cryptography/vectors-2.9.nix
+++ b/pkgs/development/python-modules/cryptography/vectors-2.9.nix
@@ -1,9 +1,9 @@
-{ buildPythonPackage, fetchPypi, lib, cryptography }:
+{ buildPythonPackage, fetchPypi, lib, cryptography_2_9 }:
 
 buildPythonPackage rec {
   pname = "cryptography_vectors";
   # The test vectors must have the same version as the cryptography package:
-  version = cryptography.version;
+  version = cryptography_2_9.version;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1328,14 +1328,17 @@ in {
   cryptacular = callPackage ../development/python-modules/cryptacular { };
 
   cryptography = if isPy27 then
-    callPackage ../development/python-modules/cryptography/2.9.nix { }
+    cryptography_2_9
   else
     callPackage ../development/python-modules/cryptography { };
 
   cryptography_vectors = if isPy27 then
-    callPackage ../development/python-modules/cryptography/vectors-2.9.nix { }
+    cryptography_vectors_2_9
   else
     callPackage ../development/python-modules/cryptography/vectors.nix { };
+
+  cryptography_2_9 = callPackage ../development/python-modules/cryptography/2.9.nix { };
+  cryptography_vectors_2_9 = callPackage ../development/python-modules/cryptography/vectors-2.9.nix { };
 
   csscompressor = callPackage ../development/python-modules/csscompressor { };
 


### PR DESCRIPTION
##### Motivation for this change

Allow cryptography to be used as a dependency by python modules with the version requirements:
  * cryptography<3
  * python>3

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Signed-off-by: Pamplemousse <xav.maso@gmail.com>