### PR TITLE
python3Packages.sslyze: Update dependencies

### DIFF
--- a/pkgs/development/python-modules/sslyze/default.nix
+++ b/pkgs/development/python-modules/sslyze/default.nix
@@ -19,11 +19,6 @@ buildPythonPackage rec {
     sha256 = "06mwzxw6xaqin2gwzcqb9r7qhbyx3k7zcxygxywi2bpxyjv9lq32";
   };
 
-  patchPhase = ''
-    substituteInPlace setup.py \
-      --replace "cryptography>=2.6,<=2.9" "cryptography>=2.6,<=3"
-  '';
-
   checkInputs = [ pytest ];
 
   checkPhase = ''
@@ -48,5 +43,6 @@ buildPythonPackage rec {
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.agpl3;
     maintainers = with maintainers; [ veehaitch ];
+    broken = true; # Needs cryptography <= 2.9, but nixpkgs has cryptography > 3 now
   };
 }


### PR DESCRIPTION
##### Motivation for this change

It does not seem to support cryptography >= 3:
  https://github.com/nabla-c0d3/sslyze/issues/455

~Depends on #98118 .~ ([there **should not** be multiple versions of `cryptography` in `nixpkgs`](https://discourse.nixos.org/t/why-shouldnt-there-be-different-version-of-the-same-library-in-nixpkgs/9029/3))

ZHF: #97479

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
