### PR TITLE
corefonts: fix hash mismatch update

### DIFF
--- a/pkgs/data/fonts/corefonts/default.nix
+++ b/pkgs/data/fonts/corefonts/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "0baadsrgpqj15fgjmcn0aim0k0nk7mvivcxinw1zwg61kkcwhalx";
+  outputHash = "089d2m9bvaacj36qdq77pcazji0sbbr796shic3k52cpxkjnzbwh";
 
   meta = with stdenv.lib; {
     homepage = "http://corefonts.sourceforge.net/";


### PR DESCRIPTION
This fixes error:

```
fix hash missmatch
wanted: sha256:0baadsrgpqj15fgjmcn0aim0k0nk7mvivcxinw1zwg61kkcwhalx
got:    sha256:089d2m9bvaacj36qdq77pcazji0sbbr796shic3k52cpxkjnzbwh
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
