### PR TITLE
chez: add env hook

### DIFF
--- a/pkgs/development/chez-modules/chez-mit/default.nix
+++ b/pkgs/development/chez-modules/chez-mit/default.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation {
   buildInputs = [ chez chez-srfi ];
 
   buildPhase = ''
-    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv-site
     make PREFIX=$out CHEZ=${chez}/bin/scheme
   '';
 

--- a/pkgs/development/chez-modules/chez-scmutils/default.nix
+++ b/pkgs/development/chez-modules/chez-scmutils/default.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation {
   buildInputs = [ chez chez-srfi chez-mit ];
 
   buildPhase = ''
-    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv-site:${chez-mit}/lib/csv-site
     make PREFIX=$out CHEZ=${chez}/bin/scheme
   '';
 

--- a/pkgs/development/compilers/chez/default.nix
+++ b/pkgs/development/compilers/chez/default.nix
@@ -65,6 +65,8 @@ stdenv.mkDerivation rec {
     rm -rf $out/lib/csv${version}/examples
   '';
 
+  setupHook = ./setup-hook.sh;
+
   meta = {
     description  = "A powerful and incredibly fast R6RS Scheme compiler";
     homepage     = "https://cisco.github.io/ChezScheme/";

--- a/pkgs/development/compilers/chez/setup-hook.sh
+++ b/pkgs/development/compilers/chez/setup-hook.sh
@@ -1,0 +1,5 @@
+addChezLibraryPath() {
+  addToSearchPath CHEZSCHEMELIBDIRS "$1/lib/csv-site"
+}
+
+addEnvHooks "$targetOffset" addChezLibraryPath


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

As a follow-up to #97927, chez can now find its libraries in a
nix-shell, and derivations for such libraries don't need to handle the
search path themselves.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] `scheme` has been tested interactively, try `echo '(import (srfi :1))' | nix-shell -I nixpkgs=$(pwd) -p chez chez-srfi --run scheme`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
