### PR TITLE
react-native-debugger: 0.9.10 -> 0.11.4

### DIFF
--- a/pkgs/development/tools/react-native-debugger/default.nix
+++ b/pkgs/development/tools/react-native-debugger/default.nix
@@ -71,7 +71,7 @@ in stdenv.mkDerivation rec {
     exec = "React\\ Native\\ Debugger";
     desktopName = "React Native Debugger";
     genericName = "React Native Debugger";
-    categories = "Development;Tools;";
+    categories = "Development;Debugger;";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/react-native-debugger/default.nix
+++ b/pkgs/development/tools/react-native-debugger/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, unzip, cairo, xorg, gdk-pixbuf, fontconfig, pango, gnome2, atk, gtk2, glib
-, freetype, dbus, nss, nspr, alsaLib, cups, expat, udev, makeDesktopItem
+{ stdenv, fetchurl, unzip, cairo, xorg, gdk-pixbuf, fontconfig, pango, gnome3, atk, at_spi2_atk, at-spi2-core
+, gtk3, glib, freetype, dbus, nss, nspr, alsaLib, cups, expat, udev, makeDesktopItem
 }:
 
 let
@@ -10,7 +10,7 @@ let
     fontconfig
     pango
     atk
-    gtk2
+    gtk3
     glib
     freetype
     dbus
@@ -20,8 +20,8 @@ let
     cups
     expat
     udev
-
-    gnome2.GConf
+    at_spi2_atk
+    at-spi2-core
 
     xorg.libX11
     xorg.libXcursor
@@ -38,11 +38,10 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "react-native-debugger";
-  version = "0.9.10";
-
+  version = "0.11.4";
   src = fetchurl {
     url = "https://github.com/jhen0409/react-native-debugger/releases/download/v${version}/rn-debugger-linux-x64.zip";
-    sha256 = "158275sp37smc8lnrcbj56lp7aa6fj9gzb6fzjgz9r980qgzhia6";
+    sha256 = "1dnlxdqcn90r509ff5003fibkrprdr0ydpnwg5p0xzs6rz3k8698";
   };
 
   buildInputs = [ unzip ];
@@ -52,15 +51,15 @@ in stdenv.mkDerivation rec {
     unzip $src -d $out
 
     mkdir $out/{lib,bin,share}
-    mv $out/lib{node,ffmpeg}.so $out/lib
+    mv $out/{libEGL,libGLESv2,libvk_swiftshader,libffmpeg}.so $out/lib
     mv $out/!(lib|share|bin) $out/share
 
     patchelf \
       --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
       --set-rpath ${rpath}:$out/lib \
-      $out/share/React\ Native\ Debugger
+      $out/share/react-native-debugger
 
-    ln -s $out/share/React\ Native\ Debugger $out/bin/React\ Native\ Debugger
+    ln -s $out/share/react-native-debugger $out/bin/react-native-debugger
 
     install -Dm644 "${desktopItem}/share/applications/"* \
       -t $out/share/applications/
@@ -68,7 +67,7 @@ in stdenv.mkDerivation rec {
 
   desktopItem = makeDesktopItem {
     name = "rndebugger";
-    exec = "React\\ Native\\ Debugger";
+    exec = "react-native-debugger";
     desktopName = "React Native Debugger";
     genericName = "React Native Debugger";
     categories = "Development;Debugger;";

--- a/pkgs/development/tools/react-native-debugger/default.nix
+++ b/pkgs/development/tools/react-native-debugger/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, cairo, xorg, gdk-pixbuf, fontconfig, pango, gnome3, atk, at_spi2_atk, at-spi2-core
+{ stdenv, fetchurl, unzip, cairo, xorg, gdk-pixbuf, fontconfig, pango, gnome3, atk, at-spi2-atk, at-spi2-core
 , gtk3, glib, freetype, dbus, nss, nspr, alsaLib, cups, expat, udev, makeDesktopItem
 }:
 
@@ -20,7 +20,7 @@ let
     cups
     expat
     udev
-    at_spi2_atk
+    at-spi2-atk
     at-spi2-core
 
     xorg.libX11


### PR DESCRIPTION
###### Motivation for this change
Small fix for generated desktop file.

ZHF: #97479

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
