### PR TITLE
gnomeExtensions.gsconnect: 39 -> 41

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-gsconnect";
-  version = "39";
+  version = "41";
 
   src = fetchFromGitHub {
     owner = "andyholmes";
     repo = "gnome-shell-extension-gsconnect";
     rev = "v${version}";
-    sha256 = "0d2wypf36p95v756arf06gfilpb48gp55i1xbqnqvcd10n3q4zc2";
+    sha256 = "0lcj7k16jki54bsyh01j4ss4hhfddnahcw02zlmlkl637qdv1b5j";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/extensions/gsconnect/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/extensions/gsconnect/fix-paths.patch
@@ -1,5 +1,7 @@
---- a/data/org.gnome.Shell.Extensions.GSConnect.desktop
-+++ b/data/org.gnome.Shell.Extensions.GSConnect.desktop
+diff --git i/data/org.gnome.Shell.Extensions.GSConnect.desktop.in w/data/org.gnome.Shell.Extensions.GSConnect.desktop.in
+index ffb23342..b405c73b 100644
+--- i/data/org.gnome.Shell.Extensions.GSConnect.desktop.in
++++ w/data/org.gnome.Shell.Extensions.GSConnect.desktop.in
 @@ -1,7 +1,7 @@
  [Desktop Entry]
  Type=Application
@@ -9,18 +11,22 @@
  Terminal=false
  NoDisplay=true
  Icon=org.gnome.Shell.Extensions.GSConnect
---- a/src/extension.js
-+++ b/src/extension.js
+diff --git i/src/extension.js w/src/extension.js
+index 5f32aa68..872c0c61 100644
+--- i/src/extension.js
++++ w/src/extension.js
 @@ -1,5 +1,7 @@
  'use strict';
  
 +'@typelibPath@'.split(':').forEach(path => imports.gi.GIRepository.Repository.prepend_search_path(path));
 +
  const Gio = imports.gi.Gio;
- const GLib = imports.gi.GLib;
+ const GObject = imports.gi.GObject;
  const Gtk = imports.gi.Gtk;
---- a/src/prefs.js
-+++ b/src/prefs.js
+diff --git i/src/prefs.js w/src/prefs.js
+index 07e93099..1c166710 100644
+--- i/src/prefs.js
++++ w/src/prefs.js
 @@ -1,5 +1,7 @@
  'use strict';
  


### PR DESCRIPTION
Update patch so it'll apply on v41.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
