### PR TITLE
_3270font: 2.0.4 -> 2.1.0

### DIFF
--- a/pkgs/data/fonts/3270font/default.nix
+++ b/pkgs/data/fonts/3270font/default.nix
@@ -1,13 +1,13 @@
 { lib, fetchzip }:
 let
-  version = "2.0.4";
+  version = "2.1.0";
 in
-fetchzip rec {
+fetchzip {
   name = "3270font-${version}";
 
-  url = "https://github.com/rbanffy/3270font/releases/download/v${version}/3270_fonts_ece94f6.zip";
+  url = "https://github.com/rbanffy/3270font/releases/download/v.${version}/3270_fonts_fba25eb.zip";
 
-  sha256 = "04q7dnrlq5hm30iibh3jafb33m5lwsgb3g9n9i188sg02ydkrsl9";
+  sha256 = "04xqgiznd6d3c1rdbbdmd87rjy9bnhh00lm8xzmal1zidcr2g0n9";
 
   postFetch = ''
     mkdir -p $out/share/fonts/


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/rbanffy/3270font/releases/tag/v.2.1.0
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
