### PR TITLE
grpcio-tools: add setuptools dependency

### DIFF
--- a/pkgs/development/python-modules/grpcio-tools/default.nix
+++ b/pkgs/development/python-modules/grpcio-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, protobuf, grpcio }:
+{ stdenv, buildPythonPackage, fetchPypi, protobuf, grpcio, setuptools }:
 
 buildPythonPackage rec {
   pname = "grpcio-tools";
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   enableParallelBuilding = true;
 
-  propagatedBuildInputs = [ protobuf grpcio ];
+  propagatedBuildInputs = [ protobuf grpcio setuptools ];
 
   # no tests in the package
   doCheck = false;


### PR DESCRIPTION
Without this change this I get:

```
$ nix-shell -p python3Packages.grpcio-tools --pure

[nix-shell:~/dev/cloudflow/examples/snippets/modules/ROOT/examples/akkastreams-grpc-scala]$ python -m grpc_tools.protoc --include_imports --include_source_info --proto_path=. --descriptor_set_out=api_descriptor.pb --python_out=generated_pb2 --grpc_python_out=generated_pb2 sensordata.proto
Traceback (most recent call last):
  File "/nix/store/bs03sg8b0gq2zr4v252hh9psp780qj5q-python3-3.8.5/lib/python3.8/runpy.py", line 185, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/nix/store/bs03sg8b0gq2zr4v252hh9psp780qj5q-python3-3.8.5/lib/python3.8/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/nix/store/s3kqg5qgi8g9kw9s0zzx73ix0bw0g1c8-python3.8-grpcio-tools-1.32.0/lib/python3.8/site-packages/grpc_tools/__init__.py", line 15, in <module>
    from .protoc import main
  File "/nix/store/s3kqg5qgi8g9kw9s0zzx73ix0bw0g1c8-python3.8-grpcio-tools-1.32.0/lib/python3.8/site-packages/grpc_tools/protoc.py", line 17, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Motivation for this change

To be able to use the tool at all :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).