### PR TITLE
[20.09] ntfy: Switch to python3. Also fixes test failure.

### DIFF
--- a/pkgs/tools/misc/ntfy/default.nix
+++ b/pkgs/tools/misc/ntfy/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, pythonPackages, fetchFromGitHub }:
+{ stdenv, python3Packages, fetchFromGitHub }:
 
-pythonPackages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "ntfy";
   version = "2.7.0";
 
@@ -11,11 +11,11 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "09f02cn4i1l2aksb3azwfb70axqhn7d0d0vl2r6640hqr74nc1cv";
   };
 
-  checkInputs = with pythonPackages; [
+  checkInputs = with python3Packages; [
     mock
   ];
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python3Packages; [
     requests ruamel_yaml appdirs
     sleekxmpp dns
     emoji
@@ -25,7 +25,7 @@ pythonPackages.buildPythonApplication rec {
   ];
 
   checkPhase = ''
-    HOME=$(mktemp -d) ${pythonPackages.python.interpreter} setup.py test
+    HOME=$(mktemp -d) ${python3Packages.python.interpreter} setup.py test
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Backport of #98140 for 20.09 (#97479).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
