### PR TITLE
pythonPackages.pandas: 1.1.1 -> 1.1.4 & cleanup

### DIFF
--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -33,11 +33,11 @@ let
 
 in buildPythonPackage rec {
   pname = "pandas";
-  version = "1.1.1";
+  version = "1.1.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "53328284a7bb046e2e885fd1b8c078bd896d7fc4575b915d4936f54984a2ba67";
+    sha256 = "a979d0404b135c63954dea79e6246c45dd45371a88631cdbb4877d844e6de3b6";
   };
 
   checkInputs = [ pytest glibcLocales moto hypothesis ];

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -1,27 +1,29 @@
-{ buildPythonPackage
+{ stdenv
+, buildPythonPackage
 , fetchPypi
 , python
-, stdenv
-, pytest
-, glibcLocales
+, isPy38
+, beautifulsoup4
+, bottleneck
 , cython
 , dateutil
-, scipy
-, moto
-, numexpr
-, pytz
-, xlrd
-, bottleneck
-, sqlalchemy
-, lxml
 , html5lib
-, beautifulsoup4
-, hypothesis
+, lxml
+, numexpr
 , openpyxl
+, pytz
+, sqlalchemy
+, scipy
 , tables
+, xlrd
 , xlwt
+# Test Inputs
+, glibcLocales
+, hypothesis
+, moto
+, pytest
+# Darwin inputs
 , runtimeShell
-, isPy38
 , libcxx ? null
 }:
 
@@ -43,18 +45,18 @@ in buildPythonPackage rec {
   nativeBuildInputs = [ cython ];
   buildInputs = optional isDarwin libcxx;
   propagatedBuildInputs = [
-    dateutil
-    scipy
-    numexpr
-    pytz
-    xlrd
-    bottleneck
-    sqlalchemy
-    lxml
-    html5lib
     beautifulsoup4
+    bottleneck
+    dateutil
+    html5lib
+    numexpr
+    lxml
     openpyxl
+    pytz
+    scipy
+    sqlalchemy
     tables
+    xlrd
     xlwt
   ];
 
@@ -128,14 +130,15 @@ in buildPythonPackage rec {
     runHook postCheck
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     # https://github.com/pandas-dev/pandas/issues/14866
     # pandas devs are no longer testing i686 so safer to assume it's broken
     broken = stdenv.isi686;
     homepage = "https://pandas.pydata.org/";
+    changelog = "https://pandas.pydata.org/docs/whatsnew/index.html";
     description = "Python Data Analysis Library";
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = with stdenv.lib.maintainers; [ raskin fridh knedlsepp ];
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ raskin fridh knedlsepp ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/pandas-dev/pandas/releases/tag/v1.1.4

Mostly bugfix & regression fixes.

While upgrading, I saw a few things in the nix file that could use some cleanup:
* Add changelog
* sort dependencies
* Convert tests to more-standard ``pytestCheckHook``

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Didn't do ``nix-review`` because of large rebuild