### PR TITLE
hime: init at unstable-2020-06-27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9728,4 +9728,10 @@
     github = "wenngle";
     githubId = 63376671;
   };
+  yanganto = {
+    name = "Antonio Yang";
+    email = "yanganto@gmail.com";
+    github = "yanganto";
+    githubId = 10803111;
+  };
 }

--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -29,7 +29,7 @@ in
   options.i18n = {
     inputMethod = {
       enabled = mkOption {
-        type    = types.nullOr (types.enum [ "ibus" "fcitx" "nabi" "uim" ]);
+        type    = types.nullOr (types.enum [ "ibus" "fcitx" "nabi" "uim" "hime" ]);
         default = null;
         example = "fcitx";
         description = ''
@@ -44,6 +44,7 @@ in
           <listitem><para>fcitx: A customizable lightweight input method, extra input engines can be added using <literal>i18n.inputMethod.fcitx.engines</literal>.</para></listitem>
           <listitem><para>nabi: A Korean input method based on XIM. Nabi doesn't support Qt 5.</para></listitem>
           <listitem><para>uim: The universal input method, is a library with a XIM bridge. uim mainly support Chinese, Japanese and Korean.</para></listitem>
+          <listitem><para>hime: An extremely easy-to-use input method framework.</para></listitem>
           </itemizedlist>
         '';
       };

--- a/nixos/modules/i18n/input-method/default.xml
+++ b/nixos/modules/i18n/input-method/default.xml
@@ -35,6 +35,11 @@
     Uim: The universal input method, is a library with a XIM bridge.
    </para>
   </listitem>
+  <listitem>
+   <para>
+    Hime: An extremely easy-to-use input method framework.
+   </para>
+  </listitem>
  </itemizedlist>
  <section xml:id="module-services-input-methods-ibus">
   <title>IBus</title>
@@ -240,5 +245,25 @@ i18n.inputMethod = {
    Note: The <xref linkend="opt-i18n.inputMethod.uim.toolbar"/> option can be
    used to choose uim toolbar.
   </para>
+ </section>
+ <section xml:id="module-services-input-methods-hime">
+  <title>Hime</title>
+
+  <para>
+   Hime is an extremely easy-to-use input method framework. It is lightweight,
+   stable, powerful and supports many commonly used input methods, including
+   Cangjie, Zhuyin, Dayi, Rank, Shrimp, Greek, Japanese Anthy, Korean Pinyin,
+   Latin Alphabet, Rancang hunting birds, cool music, etc...
+  </para>
+
+  <para>
+   The following snippet can be used to configure Hime:
+  </para>
+
+<programlisting>
+i18n.inputMethod = {
+  <link linkend="opt-i18n.inputMethod.enabled">enabled</link> = "hime";
+};
+</programlisting>
  </section>
 </chapter>

--- a/nixos/modules/i18n/input-method/hime.nix
+++ b/nixos/modules/i18n/input-method/hime.nix
@@ -1,0 +1,28 @@
+{ config, pkgs, ... }:
+
+with lib;
+{
+  options = {
+    i18n.inputMethod.hime = {
+      enableChewing = mkOption {
+        type    =  with types; nullOr bool;
+        default = null;
+        description = "enable chewing input method";
+      };
+      enableAnthy = mkOption {
+        type    =  with types; nullOr bool;
+        default = null;
+        description = "enable anthy input method";
+      };
+    };
+  };
+
+  config = mkIf (config.i18n.inputMethod.enabled == "hime") {
+    environment.variables = {
+      GTK_IM_MODULE = "hime";
+      QT_IM_MODULE  = "hime";
+      XMODIFIERS    = "@im=hime";
+    };
+    services.xserver.displayManager.sessionCommands = "${pkgs.hime}/bin/hime &";
+  };
+}

--- a/pkgs/tools/inputmethods/hime/default.nix
+++ b/pkgs/tools/inputmethods/hime/default.nix
@@ -1,0 +1,40 @@
+{
+stdenv, fetchFromGitHub, pkgconfig, which, gtk2, gtk3, qt4, qt5, libXtst, lib,
+enableChewing ? true, libchewing,
+enableAnthy ? true, anthy,
+}:
+
+stdenv.mkDerivation {
+  name = "hime";
+  version = "unstable-2020-06-27";
+
+  src = fetchFromGitHub {
+    owner = "hime-ime";
+    repo = "hime";
+    rev = "c89751a58836906e6916355fd037fc74fd7a7a15";
+    sha256 = "024w67q0clzxigsrvqbxpiy8firjvrqi7wbkkcapzzhzapv3nm8x";
+  };
+
+  nativeBuildInputs = [ which pkgconfig ];
+  buildInputs = [ libXtst gtk2 gtk3 qt4 qt5.qtbase ]
+    ++ lib.optional enableChewing libchewing
+    ++ lib.optional enableAnthy anthy;
+
+  patchPhase = ''
+    patchShebangs configure
+  '';
+
+  # The configure script already auto-detect libchewing and anthy,
+  # so we do not need additional flags for libchewing or anthy
+  configureFlags = [ "--disable-lib64" "--disable-qt5-immodule" ];
+
+
+  meta = with stdenv.lib; {
+    homepage      = "http://hime-ime.github.io/";
+    downloadPage  = "https://github.com/hime-ime/hime/downloads";
+    description   = "A useful input method engine for Asia region";
+    license       = licenses.gpl2Plus;
+    platforms     = platforms.linux;
+    maintainers   = with maintainers; [ yanganto ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5596,6 +5596,13 @@ in
 
   nabi = callPackage ../tools/inputmethods/nabi { };
 
+  hime = callPackage ../tools/inputmethods/hime {};
+
+  hime-all = callPackage ../tools/inputmethods/hime {
+    enableChewing = true;
+    enableAnthy = true;
+  };
+
   nahid-fonts = callPackage ../data/fonts/nahid-fonts { };
 
   namazu = callPackage ../tools/text/namazu { };


### PR DESCRIPTION
###### Motivation for this change
Add hime input method

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
     Result: `No diff detected, stopping review...`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ref: HIME team build script on Arch
https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=hime-git