### PR TITLE
cpuid: init at 20200427

### DIFF
--- a/pkgs/os-specific/linux/cpuid/default.nix
+++ b/pkgs/os-specific/linux/cpuid/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchurl, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "cpuid";
+  version = "20200427";
+
+  src = fetchurl {
+    name = "${pname}-${version}.src.tar.gz";
+    url = "http://etallen.com/cpuid/${pname}-${version}.src.tar.gz";
+    sha256 = "1m31238z2ya8f8pzpyklwp0ksf5xicqrw1z941hhhx913wzldaf1";
+  };
+
+  # For pod2man during the build process.
+  nativeBuildInputs = [ perl ];
+
+  # As runtime dependency for cpuinfo2cpuid.
+  buildInputs = [ perl ];
+
+  # The Makefile hardcodes $(BUILDROOT)/usr as installation
+  # destination. Just nuke all mentions of /usr to get the right
+  # installation location.
+  patchPhase = ''
+    sed -i -e 's,/usr/,/,' Makefile
+  '';
+
+  installPhase = ''
+    make install BUILDROOT=$out
+
+    if [ ! -x $out/bin/cpuid ]; then
+      echo Failed to properly patch Makefile.
+      exit 1
+    fi
+  '';
+
+  meta = {
+    description = "Linux tool to dump x86 CPUID information about the CPU";
+    longDescription = ''
+      cpuid dumps detailed information about the CPU(s) gathered from the CPUID
+      instruction, and also determines the exact model of CPU(s). It supports
+      Intel, AMD, VIA, Hygon, and Zhaoxin CPUs, as well as older Transmeta,
+      Cyrix, UMC, NexGen, Rise, and SiS CPUs.
+    '';
+
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    license = stdenv.lib.licenses.gpl2;
+    homepage = "http://etallen.com/cpuid.html";
+    maintainers = with stdenv.lib.maintainers; [ blitz ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -962,6 +962,8 @@ in
 
   cozy = callPackage ../applications/audio/cozy-audiobooks { };
 
+  cpuid = callPackage ../os-specific/linux/cpuid { };
+
   ctrtool = callPackage ../tools/archivers/ctrtool { };
 
   crowbar = callPackage ../tools/security/crowbar { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

cpuid is a tool to describe x86 CPU features. This is useful for
people doing low-level software development. Output looks like this:

```sh
% cpuid -1
CPU:
   vendor_id = "GenuineIntel"
   version information (1/eax):
      processor type  = primary processor (0)
      family          = 0x6 (6)
      model           = 0xe (14)
      stepping id     = 0xb (11)
      extended family = 0x0 (0)
      extended model  = 0x8 (8)
      (family synth)  = 0x6 (6)
      (model synth)   = 0x8e (142)
      (simple synth)  = Intel Core (unknown type) (Whiskey Lake-U W0 / Amber Lake-Y W0) [Kaby Lake] {Skylake}, 14nm
   miscellaneous (1/ebx):
      process local APIC physical ID = 0x1 (1)
      maximum IDs for CPUs in pkg    = 0x10 (16)
      CLFLUSH line size              = 0x8 (8)
      brand index                    = 0x0 (0)
   brand id = 0x00 (0): unknown
   feature information (1/edx):
      x87 FPU on chip                        = true
      VME: virtual-8086 mode enhancement     = true
      DE: debugging extensions               = true
      PSE: page size extensions              = true
      TSC: time stamp counter                = true
      RDMSR and WRMSR support                = true
      PAE: physical address extensions       = true
[ ... skip lots of other output ...]
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
