### PR TITLE
dmidecode version bump to 3.2.8

### DIFF
--- a/pkgs/os-specific/linux/dmidecode/default.nix
+++ b/pkgs/os-specific/linux/dmidecode/default.nix
@@ -1,13 +1,14 @@
 { stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  name = "dmidecode-3.2.8";
-
+  pname = "dmidecode";
+  version = "3.2.8";
   src = fetchurl {
-    url = "mirror://savannah/dmidecode/${name}.tar.xz";
+    # Download version in upstream is 3.2. Version 3.2.8 does not come from upstream and was made up to differentiate the applied recommended patches bellow.
+    url = "mirror://savannah/dmidecode/${pname}-3.2.tar.xz";
     sha256 = "1pcfhcgs2ifdjwp7amnsr3lq95pgxpr150bjhdinvl505px0cw07";
   };
-
+  
   patches = [
     # suggested patches for 3.2 according to https://www.nongnu.org/dmidecode/
     (fetchpatch {

--- a/pkgs/os-specific/linux/dmidecode/default.nix
+++ b/pkgs/os-specific/linux/dmidecode/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  name = "dmidecode-3.2";
+  name = "dmidecode-3.2.8";
 
   src = fetchurl {
     url = "mirror://savannah/dmidecode/${name}.tar.xz";

--- a/pkgs/os-specific/linux/dmidecode/default.nix
+++ b/pkgs/os-specific/linux/dmidecode/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     url = "mirror://savannah/dmidecode/${pname}-3.2.tar.xz";
     sha256 = "1pcfhcgs2ifdjwp7amnsr3lq95pgxpr150bjhdinvl505px0cw07";
   };
-  
+
   patches = [
     # suggested patches for 3.2 according to https://www.nongnu.org/dmidecode/
     (fetchpatch {

--- a/pkgs/os-specific/linux/dmidecode/default.nix
+++ b/pkgs/os-specific/linux/dmidecode/default.nix
@@ -4,7 +4,8 @@ stdenv.mkDerivation rec {
   pname = "dmidecode";
   version = "3.2.8";
   src = fetchurl {
-    # Download version in upstream is 3.2. Version 3.2.8 does not come from upstream and was made up to differentiate the applied recommended patches bellow.
+    # Download version in upstream is 3.2. Version 3.2.8 does not come from upstream
+    # and was made up to differentiate the applied recommended patches below.
     url = "mirror://savannah/dmidecode/${pname}-3.2.tar.xz";
     sha256 = "1pcfhcgs2ifdjwp7amnsr3lq95pgxpr150bjhdinvl505px0cw07";
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
[PR#97614](https://github.com/NixOS/nixpkgs/pull/97614) was missing dmidecode's version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
