### PR TITLE
dart: Fix dart2native by patching all ELFs

### DIFF
--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -69,9 +69,7 @@ stdenv.mkDerivation {
     mkdir -p $out
     cp -R * $out/
     echo $libPath
-    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-             --set-rpath $libPath \
-             $out/bin/dart
+    find $out/bin -executable -type f -exec patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) {} \;
   '';
 
   libPath = makeLibraryPath [ stdenv.cc.cc ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`dart2native` (and probably other binaries) from `dart` were not working. For example:

Before:

    $ /nix/store/ihlzjcxahcack6chfzphb74bkccmq6br-dart-2.7.2/bin/dart2native hello.dart
    Failed to generate native files:
    ProcessException: No such file or directory
      Command: /nix/store/ihlzjcxahcack6chfzphb74bkccmq6br-dart-2.7.2/bin/utils/gen_snapshot --snapshot-kind=app-aot-elf --elf=/tmp/HSHJQU/snapshot.aot /tmp/HSHJQU/kernel.dill

After:

    $ /nix/store/czw7kpdmcqa76a9j00v2pjygrq7gy4c7-dart-2.7.2/bin/dart2native hello.dart
    Generated: /home/thiagoko/hello.exe

    $ ./hello.exe
    Hello, World!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
