### PR TITLE
nixos/jellyfin: add some systemd security options

### DIFF
--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -45,6 +45,46 @@ in
         CacheDirectory = "jellyfin";
         ExecStart = "${cfg.package}/bin/jellyfin --datadir '/var/lib/${StateDirectory}' --cachedir '/var/cache/${CacheDirectory}'";
         Restart = "on-failure";
+
+        # Security options:
+
+        NoNewPrivileges = true;
+
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+
+        # ProtectClock= adds DeviceAllow=char-rtc r
+        DeviceAllow = "";
+
+        LockPersonality = true;
+
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+
+        RemoveIPC = true;
+
+        RestrictNamespaces = true;
+        # AF_NETLINK needed because Jellyfin monitors the network connection
+        RestrictAddressFamilies = [ "AF_NETLINK" "AF_INET" "AF_INET6" ];
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+
+        SystemCallArchitectures = "native";
+        SystemCallErrorNumber = "EPERM";
+        SystemCallFilter = [
+          "@system-service"
+
+          "~@chown" "~@cpu-emulation" "~@debug" "~@keyring" "~@memlock" "~@module"
+          "~@obsolete" "~@privileged" "~@setuid"
+        ];
       };
     };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I was reading through the changes introduced in transmission by https://github.com/NixOS/nixpkgs/pull/92106, and I kinda drank the Kool-Aid and thought that the Jellyfin module (among others) needed some systemd security options.

I have been using jellyfin with most of these options for a few days now, without noticing too much.

All in all, this brings the score of `systemd-analyze security jellyfin` from 9.2, all the way down to 1.6 :tada: 

To harden even more, we could:

- use `ProtectHome = true`
- use `ProtectSystem = "strict"`
- use the `RootDirectory` and ask the end user to provide us with paths to whitelist, and use them in `BindReadOnlyPaths` / `BindPaths`

These three propositions are not in this PR, as they most likely could break existing setups, but I have been using them in my personal server, and they seem to work well:

<details>
  <summary>Possible additional hardening</summary>

```nix
{
  ProtectHome = true;
  ProtectSystem = "strict";

  BindReadOnlyPaths = [
    "/nix/store"

    "/etc/ssl/certs"
    "/etc/static/ssl/certs"

    "/paths/to/allow/read-only"
  ];

  BindPaths = [ "/paths/to/allow/read-write" ];

  RuntimeDirectory = "jellyfin";
  RootDirectory = "/run/jellyfin";
}
```

</details>

**Note**: if you want to test this and you are on NixOS 20.03, note that the `PrivateUsers = true;` doesn't seem to work with systemd 243.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @nyanloutre @purcell what do you think?