### PR TITLE
razergenie: 0.8.1 -> 0.9.0

### DIFF
--- a/pkgs/applications/misc/razergenie/default.nix
+++ b/pkgs/applications/misc/razergenie/default.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  version = "0.8.1";
+  version = "0.9.0";
   pname = "razergenie";
 
 in stdenv.mkDerivation {
@@ -15,7 +15,7 @@ in stdenv.mkDerivation {
     owner = "z3ntu";
     repo = "RazerGenie";
     rev = "v${version}";
-    sha256 = "1ggxnaidxbbpkv1h3zwwyci6886sssgslk5adbikbhz9kc9qg239";
+    sha256 = "RI2wJ6Y5Jza3Q075QYkg4t1EyCCgNg7AVqtphI3YtJ8=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
##### Motivation for this change

Get the most recent version of razergenie into nixpkgs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
