### PR TITLE
dvdbackup: add dvdread-6.1 patch

### DIFF
--- a/pkgs/applications/video/dvdbackup/default.nix
+++ b/pkgs/applications/video/dvdbackup/default.nix
@@ -9,6 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "1rl3h7waqja8blmbpmwy01q9fgr5r0c32b8dy3pbf59bp3xmd37g";
   };
 
+  # fix build with libdvdread 6.1 https://bugs.launchpad.net/dvdbackup/+bug/1869226
+  patches = [ ./dvdbackup-dvdread-6.1.patch ];
+
   buildInputs = [ libdvdread libdvdcss dvdauthor ];
 
   meta = {

--- a/pkgs/applications/video/dvdbackup/dvdbackup-dvdread-6.1.patch
+++ b/pkgs/applications/video/dvdbackup/dvdbackup-dvdread-6.1.patch
@@ -1,0 +1,87 @@
+--- a/src/dvdbackup.c.orig 2012-06-24 01:10:29 UTC
++++ b/src/dvdbackup.c
+@@ -1132,7 +1132,7 @@ static int DVDCopyIfoBup(dvd_reader_t* dvd, title_set_
+ 	int size;
+ 
+ 	/* DVD handler */
+-	ifo_handle_t* ifo_file = NULL;
++	dvd_file_t* ifo_file = NULL;
+ 
+ 	if (title_set_info->number_of_title_sets + 1 < title_set) {
+ 		return(1);
+@@ -1181,7 +1181,7 @@ static int DVDCopyIfoBup(dvd_reader_t* dvd, title_set_
+ 	if ((streamout_ifo = open(targetname_ifo, O_WRONLY | O_CREAT | O_TRUNC, 0666)) == -1) {
+ 		fprintf(stderr, _("Error creating %s\n"), targetname_ifo);
+ 		perror(PACKAGE);
+-		ifoClose(ifo_file);
++		DVDCloseFile(ifo_file);
+ 		free(buffer);
+ 		close(streamout_ifo);
+ 		close(streamout_bup);
+@@ -1191,7 +1191,7 @@ static int DVDCopyIfoBup(dvd_reader_t* dvd, title_set_
+ 	if ((streamout_bup = open(targetname_bup, O_WRONLY | O_CREAT | O_TRUNC, 0666)) == -1) {
+ 		fprintf(stderr, _("Error creating %s\n"), targetname_bup);
+ 		perror(PACKAGE);
+-		ifoClose(ifo_file);
++		DVDCloseFile(ifo_file);
+ 		free(buffer);
+ 		close(streamout_ifo);
+ 		close(streamout_bup);
+@@ -1200,31 +1200,31 @@ static int DVDCopyIfoBup(dvd_reader_t* dvd, title_set_
+ 
+ 	/* Copy VIDEO_TS.IFO, since it's a small file try to copy it in one shot */
+ 
+-	if ((ifo_file = ifoOpen(dvd, title_set))== 0) {
++	if ((ifo_file = DVDOpenFile(dvd, title_set, DVD_READ_INFO_FILE))== 0) {
+ 		fprintf(stderr, _("Failed opening IFO for title set %d\n"), title_set);
+-		ifoClose(ifo_file);
++		DVDCloseFile(ifo_file);
+ 		free(buffer);
+ 		close(streamout_ifo);
+ 		close(streamout_bup);
+ 		return 1;
+ 	}
+ 
+-	size = DVDFileSize(ifo_file->file) * DVD_VIDEO_LB_LEN;
++	size = DVDFileSize(ifo_file) * DVD_VIDEO_LB_LEN;
+ 
+ 	if ((buffer = (unsigned char *)malloc(size * sizeof(unsigned char))) == NULL) {
+ 		perror(PACKAGE);
+-		ifoClose(ifo_file);
++		DVDCloseFile(ifo_file);
+ 		free(buffer);
+ 		close(streamout_ifo);
+ 		close(streamout_bup);
+ 		return 1;
+ 	}
+ 
+-	DVDFileSeek(ifo_file->file, 0);
++	DVDFileSeek(ifo_file, 0);
+ 
+-	if (DVDReadBytes(ifo_file->file,buffer,size) != size) {
++	if (DVDReadBytes(ifo_file,buffer,size) != size) {
+ 		fprintf(stderr, _("Error reading IFO for title set %d\n"), title_set);
+-		ifoClose(ifo_file);
++		DVDCloseFile(ifo_file);
+ 		free(buffer);
+ 		close(streamout_ifo);
+ 		close(streamout_bup);
+@@ -1234,7 +1234,7 @@ static int DVDCopyIfoBup(dvd_reader_t* dvd, title_set_
+ 
+ 	if (write(streamout_ifo,buffer,size) != size) {
+ 		fprintf(stderr, _("Error writing %s\n"),targetname_ifo);
+-		ifoClose(ifo_file);
++		DVDCloseFile(ifo_file);
+ 		free(buffer);
+ 		close(streamout_ifo);
+ 		close(streamout_bup);
+@@ -1243,7 +1243,7 @@ static int DVDCopyIfoBup(dvd_reader_t* dvd, title_set_
+ 
+ 	if (write(streamout_bup,buffer,size) != size) {
+ 		fprintf(stderr, _("Error writing %s\n"),targetname_bup);
+-		ifoClose(ifo_file);
++		DVDCloseFile(ifo_file);
+ 		free(buffer);
+ 		close(streamout_ifo);
+ 		close(streamout_bup);
+-----


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes build
ZHF: #97479 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
