### PR TITLE
miniserve: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/tools/misc/miniserve/default.nix
+++ b/pkgs/tools/misc/miniserve/default.nix
@@ -3,27 +3,26 @@
 , fetchFromGitHub
 , pkg-config
 , zlib
-, openssl
 , Security
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "miniserve";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "svenstaro";
     repo = "miniserve";
     rev = "v${version}";
-    sha256 = "1h4872jb0xz8yzs02q8wfvqrp20y7kdva5ka6bh6nq4jrnnky8zb";
+    sha256 = "1abmg2zk1qipqdl1yfj8ibm1w8n7fazxqccsg1gq4xzlhhfp3m2l";
   };
 
-  cargoSha256 = "1vq1rrav9r9z4y0v7hpn0fcq64slq4zrm2pybmnmb7h9nfxxyr6k";
+  cargoSha256 = "0l750067x8k92ngg32bb8mnbq09aj65sdnpzdhij9n1mh90rkck9";
 
   RUSTC_BOOTSTRAP = 1;
 
   nativeBuildInputs = [ pkg-config zlib ];
-  buildInputs = if stdenv.isDarwin then [ Security ] else [ openssl ];
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
 
   meta = with stdenv.lib; {
     description = "For when you really just want to serve some files over HTTP right now!";
@@ -31,5 +30,6 @@ rustPlatform.buildRustPackage rec {
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ nequissimus zowoq ];
     platforms = platforms.unix;
+    broken = stdenv.isDarwin; # https://github.com/NixOS/nixpkgs/pull/98181
   };
 }


### PR DESCRIPTION
https://github.com/svenstaro/miniserve/releases/tag/v0.9.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Broken on darwin:
```
error: failed to run custom build command for `brotli-sys v0.3.2`
```
Edit: darwin failure seems to be specific to the darwin/rust toolchain in nixpkgs.