### PR TITLE
lockdep: 4.1.2 -> 5.0.21, fix build, enable tests

### DIFF
--- a/pkgs/os-specific/linux/lockdep/default.nix
+++ b/pkgs/os-specific/linux/lockdep/default.nix
@@ -1,16 +1,47 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, bash, flex, bison, valgrind }:
 
 stdenv.mkDerivation rec {
   pname = "lockdep";
-  version = "4.1.2";
-  fullver = "4.1.2";
 
+  # it would be nice to be able to pick a kernel version in sync with something
+  # else we already ship, but it seems userspace lockdep isn't very well maintained
+  # and appears broken in many kernel releases
+  version = "5.0.21";
+  fullver = "5.0.21";
   src = fetchurl {
-    url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "1mdyjhnzhh254cblahqmpsk226z006z6sm9dmwvg6jlhpsw4cjhy";
+    url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
+    sha256 = "1my2m9hvnvdrvzcg0fgqgaga59y2cd5zlpv7xrfj2nn98sjhglwq";
   };
 
-  preConfigure = "cd tools/lib/lockdep";
+  # ensure *this* kernel's userspace-headers are picked up before we
+  # fall back to those in glibc, as they will be from a mismatched
+  # kernel version
+  postPatch = ''
+    substituteInPlace tools/lib/lockdep/Makefile \
+      --replace 'CONFIG_INCLUDES =' $'CONFIG_INCLUDES = -I../../../usr/include\n#'
+  '';
+
+  nativeBuildInputs = [ flex bison ];
+
+  buildPhase = ''
+    make defconfig
+    make headers_install
+    cd tools/lib/lockdep
+    make
+  '';
+
+  doCheck = true;
+  checkInputs = [ valgrind ];
+  checkPhase = ''
+    # there are more /bin/bash references than just shebangs
+    for f in lockdep run_tests.sh tests/*.sh; do
+      substituteInPlace $f \
+        --replace '/bin/bash' '${bash}/bin/bash'
+    done
+
+    ./run_tests.sh
+  '';
+
   installPhase = ''
     mkdir -p $out/bin $out/lib $out/include
 


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

This required a bit of an overhaul to ensure we're compiling against *this* kernel's headers, not those in glibc which are presumably from some other random kernel version. I looked at using the `makeKernelHeaders` function used to build `linuxHeaders`, but it's really designed to work with just our current main kernel version. So I just provided `flex` and `bison` and let `make headers_install` do its thing.

While it would be nice to use a kernel version we already ship elsewhere or update to a more recent kernel version, the userspace lockdep tool is apparently not very heavily maintained and the build of this tool reportedly got broken soon after the release chosen here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
