### PR TITLE
python: fix passing wrong qt5 version to pythonInterpreters

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib }:
+{ pkgs }:
 
 with pkgs;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10160,10 +10160,10 @@ in
 
   pythonInterpreters = callPackage ./../development/interpreters/python {
     # Overrides that apply to all Python interpreters
-    pkgs = pkgs // {
+    pkgs = pkgs.extend (pkgs: _: {
       qt5 = pkgs.qt514;
       libsForQt5 = pkgs.libsForQt514;
-    };
+    });
   };
   inherit (pythonInterpreters) python27 python36 python37 python38 python39 python3Minimal pypy27 pypy36;
 
@@ -22836,18 +22836,10 @@ in
   quodlibet-xine-full = quodlibet-full.override { xineBackend = true; tag = "-xine-full"; };
 
   qutebrowser = let
-    libsForQt5 = libsForQt515;
-    qt5 = qt515;
-    python = python3.override {
-      packageOverrides = self: super: {
-        pkgs = pkgs // {
-          inherit libsForQt5 qt5;
-        };
-      };
-      self = python3;
-    };
+    pythonI = pkgs.pythonInterpreters.override { inherit pkgs; };
+    verString = lib.concatStrings (lib.take 2 (lib.splitVersion pkgs.python3.version));
   in libsForQt5.callPackage ../applications/networking/browsers/qutebrowser {
-    python3 = python;
+    python3 = pythonI."python${verString}";
   };
 
   rabbitvcs = callPackage ../applications/version-management/rabbitvcs {};


### PR DESCRIPTION
fixes c88f3adb1793cd3b007baff0292cf1fa8d0ab1e6, which resulted in qt 5.15 being used in pythonPackages, despite 5.14 being declared, and adapts qutebrowser accordingly.

###### Motivation for this change


'callPackage { pkgs = pkgs // { … }; }' does not work, because it does not take into account the recursive evaluation of nixpkgs:

`pkgs/development/interpreters/python/default.nix` calls `pkgs/top-level/python-packages.nix` with `callPackage`. Thus, even if the former gets passed the updated `pkgs`, the latter always gets passed `pkgs.pkgs`.

For the change in the qt5 version to apply consistently, 'pkgs.extend' must be used.

qutebrowser only used the right qt5 version (5.15) because all pythonPackages used it anyway.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- ~~Built~~ *Evaluated and traced* on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
