### PR TITLE
poco: propagate dependencies imported by CMake scripts

### DIFF
--- a/pkgs/development/libraries/poco/default.nix
+++ b/pkgs/development/libraries/poco/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, cmake, pkg-config, zlib, pcre, expat, sqlite, openssl, unixODBC, libmysqlclient }:
+{ lib, stdenv, fetchurl, fetchpatch, cmake, pkg-config, zlib, pcre, expat, sqlite, openssl, unixODBC, libmysqlclient }:
 
 stdenv.mkDerivation rec {
   pname = "poco";
@@ -9,6 +9,25 @@ stdenv.mkDerivation rec {
     url = "https://pocoproject.org/releases/${pname}-${version}/${pname}-${version}-all.tar.gz";
     sha256 = "1jilzh0h6ik5lr167nax7q6nrpzxl99p11pkl202ig06pgh32nbz";
   };
+
+  patches = [
+    # Use GNUInstallDirs (https://github.com/pocoproject/poco/pull/3105)
+    (fetchpatch {
+      name = "use-gnuinstalldirs.patch";
+      url = "https://github.com/pocoproject/poco/commit/9e8f84dff4575f01be02e0b07364efd1561ce66c.patch";
+      sha256 = "1bj4i93gxr7pwx33bfyhg20ad4ak1rbxkrlpsgzk7rm6mh0mld26";
+      # Files not included in release tarball
+      excludes = [
+        "Encodings/Compiler/CMakeLists.txt"
+        "PocoDoc/CMakeLists.txt"
+        "NetSSL_Win/CMakeLists.txt"
+        "PDF/CMakeLists.txt"
+        "SevenZip/CMakeLists.txt"
+        "ApacheConnector/CMakeLists.txt"
+        "CppParser/CMakeLists.txt"
+      ];
+    })
+  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
 

--- a/pkgs/development/libraries/poco/default.nix
+++ b/pkgs/development/libraries/poco/default.nix
@@ -31,7 +31,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ zlib pcre expat sqlite openssl unixODBC libmysqlclient ];
+  buildInputs = [ openssl unixODBC libmysqlclient ];
+  propagatedBuildInputs = [ zlib pcre expat sqlite ];
+
+  outputs = [ "out" "dev" ];
 
   MYSQL_DIR = libmysqlclient;
   MYSQL_INCLUDE_DIR = "${MYSQL_DIR}/include/mysql";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

poco's CMake scripts search for a few libraries at build time, so they should be propagated to allow dependent packages to build without manually adding these libraries as `buildInputs`. I enabled split outputs to prevent the runtime closure size from increasing.

The only packages affected by this change are `clickhouse`, which builds successfully, and `toggldesktop`, which was already broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
