### PR TITLE
python3Packages.requests-aws4auth: fix build

### DIFF
--- a/pkgs/development/python-modules/requests-aws4auth/default.nix
+++ b/pkgs/development/python-modules/requests-aws4auth/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k, requests }:
+{ lib, buildPythonPackage, fetchPypi, python, requests }:
 with lib;
 buildPythonPackage rec {
   pname = "requests-aws4auth";
@@ -9,15 +9,12 @@ buildPythonPackage rec {
     sha256 = "2950f6ff686b5a452a269076d990e4821d959b61cfac319c3d3c6daaa5db55ce";
   };
 
-  postPatch = optionalString isPy3k ''
-    sed "s/path_encoding_style/'path_encoding_style'/" \
-      -i requests_aws4auth/service_parameters.py
-  '';
-
   propagatedBuildInputs = [ requests ];
 
-  # The test fail on Python >= 3 because of module import errors.
-  doCheck = !isPy3k;
+  checkPhase = ''
+    cd requests_aws4auth
+    ${python.interpreter} test/requests_aws4auth_test.py
+  '';
 
   meta = {
     description = "Amazon Web Services version 4 authentication for the Python Requests library.";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build and get tests running for all python versions.

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
