### PR TITLE
mongodb-compass: 1.17.0 -> 1.22.1

### DIFF
--- a/pkgs/tools/misc/mongodb-compass/default.nix
+++ b/pkgs/tools/misc/mongodb-compass/default.nix
@@ -1,13 +1,14 @@
 { stdenv, fetchurl, dpkg
-, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib
-, gnome2, gnome3, libnotify, libxcb, nspr, nss, systemd, xorg, wrapGAppsHook }:
+, alsaLib, at-spi2-atk, at-spi2-core, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib
+, gnome2, gnome3, libnotify, libsecret, libuuid, libxcb, nspr, nss, systemd, xorg, wrapGAppsHook }:
 
 let
-
-  version = "1.17.0";
+  version = "1.22.1";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
+    at-spi2-atk
+    at-spi2-core
     atk
     cairo
     cups
@@ -22,6 +23,8 @@ let
     gnome3.gtk
     gnome2.pango
     libnotify
+    libsecret
+    libuuid
     libxcb
     nspr
     nss
@@ -46,7 +49,7 @@ let
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
         url = "https://downloads.mongodb.com/compass/mongodb-compass_${version}_amd64.deb";
-        sha256 = "085xq1ik8kyza1kq9kn0pf98zk6g2qa21clxhn48rgnqk20aninv";
+        sha256 = "1wbjj2w4dii644lprvmwnlval53yqh4y0f58cad657jjw8101rd9";
       }
     else
       throw "MongoDB compass is not supported on ${stdenv.hostPlatform.system}";
@@ -62,20 +65,30 @@ in stdenv.mkDerivation {
 
   buildCommand = ''
     IFS=$'\n'
-    dpkg -x $src $out
-    cp -av $out/usr/* $out
+
+    # The deb file contains a setuid binary, so 'dpkg -x' doesn't work here
+    dpkg --fsys-tarfile $src | tar --extract
+
+    mkdir -p $out
+    mv usr/* $out
+
+    # cp -av $out/usr/* $out
     rm -rf $out/share/lintian
-    #The node_modules are bringing in non-linux files/dependencies
+
+    # The node_modules are bringing in non-linux files/dependencies
     find $out -name "*.app" -exec rm -rf {} \; || true
     find $out -name "*.dll" -delete
     find $out -name "*.exe" -delete
+
     # Otherwise it looks "suspicious"
     chmod -R g-w $out
+
     for file in `find $out -type f -perm /0111 -o -name \*.so\*`; do
       echo "Manipulating file: $file"
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
-      patchelf --set-rpath ${rpath}:$out/share/mongodb-compass "$file" || true
+      patchelf --set-rpath ${rpath}:$out/lib/mongodb-compass "$file" || true
     done
+
     wrapGAppsHook $out/bin/mongodb-compass
   '';
 


### PR DESCRIPTION
Fixes segmentation fault and upgrades the package

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

MongoDB Compass was marked as broken in release 20.03 due to a segmentation fault. Apparently there was an issue with setuid of the chromium executable.

I followed the PKGBUILD from the AUR package of mongodb-compass and changed the build accordingly, while also upgrading the package version.

I use this build successfully as a package override on my 20.03 installation and I thought of contributing my code to the community. I hope this will work with unstable as well.

I haven't updated meta.maintainer because I'm not the original author of this file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
