### PR TITLE
python3Packages.sphinxcontrib-autoapi: init at version 1.5.1

### DIFF
--- a/pkgs/development/python-modules/sphinxcontrib-autoapi/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-autoapi/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, astroid
+, jinja2
+, sphinx
+, pyyaml
+, unidecode
+, mock
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-autoapi";
+  version = "1.5.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19m9yvlqwaw3b05lbb1vcla38irn4riw2ij0vjmnc2xq4f1qfl2d";
+  };
+
+  propagatedBuildInputs = [ astroid jinja2 pyyaml sphinx unidecode ];
+
+  checkInputs = [
+    mock
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/readthedocs/sphinx-autoapi";
+    description = "Provides 'autodoc' style documentation";
+    longDescription = "Sphinx AutoAPI provides 'autodoc' style documentation for multiple programming languages without needing to load, run, or import the project being documented.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ karolchmist ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6775,6 +6775,8 @@ in {
 
   sphinxcontrib-applehelp = callPackage ../development/python-modules/sphinxcontrib-applehelp { };
 
+  sphinxcontrib-autoapi = callPackage ../development/python-modules/sphinxcontrib-autoapi { };
+
   sphinxcontrib-bibtex = callPackage ../development/python-modules/sphinxcontrib-bibtex { };
 
   sphinxcontrib-blockdiag = callPackage ../development/python-modules/sphinxcontrib-blockdiag { };


### PR DESCRIPTION

###### Motivation for this change
This adds Sphinx AutoAPI extension, which provides "autodoc" style documentation for multiple programming languages without needing to load, run, or import the project being documented.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
