### PR TITLE
bluej: init at 4.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1439,6 +1439,12 @@
     githubId = 89596;
     name = "Florian Friesdorf";
   };
+  charvp = {
+    email = "nixpkgs@cvpetegem.be";
+    github = "charvp";
+    githubId = 42220376;
+    name = "Charlotte Van Petegem";
+  };
   chattered = {
     email = "me@philscotted.com";
     name = "Phil Scott";

--- a/pkgs/applications/editors/bluej/default.nix
+++ b/pkgs/applications/editors/bluej/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, makeWrapper, jdk }:
+
+stdenv.mkDerivation rec {
+  pname = "bluej";
+  version = "4.2.2";
+  src = fetchurl {
+    # We use the deb here. First instinct might be to go for the "generic" JAR
+    # download, but that is actually a graphical installer that is much harder
+    # to unpack than the deb.
+    url = "https://www.bluej.org/download/files/BlueJ-linux-${builtins.replaceStrings ["."] [""] version}.deb";
+    sha256 = "5c2241f2208e98fcf9aad7c7a282bcf16e6fd543faa5fdb0b99b34d1023113c3";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  unpackPhase = ''
+    ar xf $src
+    tar xf data.tar.xz
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r usr/* $out
+
+    makeWrapper ${jdk}/bin/java $out/bin/bluej \
+      --add-flags "-Djavafx.embed.singleThread=true -Dawt.useSystemAAFontSettings=on -Xmx512M -cp \"$out/share/bluej/bluej.jar\" bluej.Boot"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple integrated development environment for Java";
+    homepage = "https://www.bluej.org/";
+    license = licenses.gpl2ClasspathPlus;
+    maintainers = [ maintainers.charvp ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19838,6 +19838,10 @@ in
     gtk = gtk3;
   };
 
+  bluej = callPackage ../applications/editors/bluej/default.nix {
+    jdk = jetbrains.jdk;
+  };
+
   bluejeans-gui = callPackage ../applications/networking/instant-messengers/bluejeans { };
 
   blugon = callPackage ../applications/misc/blugon { };


### PR DESCRIPTION
##### Motivation for this change

I need it for a university course I'm a teaching assistent for. Based on #59718 (and the review comments left there).

###### Things done

Running the program works (only with the jetbrains JDK, sadly, openjdk hangs on the boot splash). In the program, creating a new project, compiling a class, creating a new object and calling a method on that object works.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
