### PR TITLE
exercism: Add NobbZ as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6143,6 +6143,12 @@
     githubId = 6930756;
     name = "Nicolas Mattia";
   };
+  nobbz = {
+    name = "Norbert Melzer";
+    email = "timmelzer+nixpkgs@gmail.com";
+    github = "NobbZ";
+    githubId = 58951;
+  };
   nocent = {
     email = "nocent@protonmail.ch";
     github = "nocent";

--- a/pkgs/applications/misc/exercism/default.nix
+++ b/pkgs/applications/misc/exercism/default.nix
@@ -21,6 +21,6 @@ buildGoModule rec {
    inherit (src.meta) homepage;
    description = "A Go based command line tool for exercism.io";
    license     = licenses.mit;
-   maintainers = [ maintainers.rbasso ];
+   maintainers = [ maintainers.rbasso maintainers.nobbz ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The user @rbasso, who has been an active member in the exercism community a long time ago, and was the only maintainer of the `exercism` package has left GitHub as it seems. His profile is nearly empty and does not show a single GitHub contribution over the last year.

As I am still an active GitHub user, an active member of the exercism.io community and a nixOS user and provided last two version bumps of the package, I think it makes sense to set myself as package maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

