### PR TITLE
lazygit: 0.22.1 -> 0.22.8

### DIFF
--- a/pkgs/development/tools/lazygit/default.nix
+++ b/pkgs/development/tools/lazygit/default.nix
@@ -1,12 +1,8 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "lazygit";
-  version = "0.22.1";
-
-  goPackagePath = "github.com/jesseduffield/lazygit";
-
-  subPackages = [ "." ];
+  version = "0.22.8";
 
   src = fetchFromGitHub {
     owner = "jesseduffield";
@@ -14,6 +10,11 @@ buildGoPackage rec {
     rev = "v${version}";
     sha256 = "1jq093nsfh7xqvsjvaad9wvqd3rjrpyp5fl8qxwbhaj3sxx19v7g";
   };
+
+  vendorSha256 = null;
+  subPackages = [ "." ];
+
+  buildFlagsArray = [ "-ldflags=-X main.version=${version} -X main.buildSource=nix" ];
 
   meta = with stdenv.lib; {
     description = "Simple terminal UI for git commands";


### PR DESCRIPTION
- Bumped version from `0.22.1` to `0.22.8`
- Switched to `buildGoModule` instead of `buildGoPackage`
- Added `buildFlagsArray`
  - `main.version=${version}` to have the correct version number when doing `lazygit --version` (instead of `version=unversioned`)
  - `main.buildSource=nix` to have `build source=nix` returned when doing `lazygit --version` (instead of `build source=unknown`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
