### PR TITLE
[20.03] perlPackages.DBI: 1.642 -> 1.643 (for CVE-2020-14392, CVE-2020-14393)

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5078,10 +5078,10 @@ let
 
   DBI = buildPerlPackage {
     pname = "DBI";
-    version = "1.642";
+    version = "1.643";
     src = fetchurl {
-      url = mirror://cpan/authors/id/T/TI/TIMB/DBI-1.642.tar.gz;
-      sha256 = "3f2025023a56286cebd15cb495e36ccd9b456c3cc229bf2ce1f69e9ebfc27f5d";
+      url = mirror://cpan/authors/id/T/TI/TIMB/DBI-1.643.tar.gz;
+      sha256 = "8a2b993db560a2c373c174ee976a51027dd780ec766ae17620c20393d2e836fa";
     };
     postInstall = stdenv.lib.optionalString (perl ? crossVersion) ''
       mkdir -p $out/${perl.libPrefix}/cross_perl/${perl.version}/DBI


### PR DESCRIPTION
###### Motivation for this change

To address:

- CVE-2020-14392: Memory corruption in XS functions when Perl stack is reallocated
- CVE-2020-14393: Fixed a buffer overflow on an overlong DBD class name

https://metacpan.org/pod/distribution/DBI/Changes#Changes-in-DBI-1.643

https://www.suse.com/security/cve/CVE-2020-14392.html
https://www.suse.com/security/cve/CVE-2020-14393.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
