### PR TITLE
[20.09] python3Packages.word2vec: fix build and tests

### DIFF
--- a/pkgs/development/python-modules/word2vec/default.nix
+++ b/pkgs/development/python-modules/word2vec/default.nix
@@ -1,14 +1,23 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, fetchzip
 , cython
 , numpy
 , scikitlearn
 , six
-, python
+, setuptools_scm
+, gcc
+, pytest
+, pytestcov
 , isPy27
 }:
-
+let
+  testData = fetchzip {
+    url = "http://mattmahoney.net/dc/text8.zip";
+    sha256 = "0w3l64bww9znmmvd9cqbfmh3dddnlrjicz43y5qq6fhi9cfqjfar";
+  };
+in
 buildPythonPackage rec {
   pname = "word2vec";
   version = "0.11.1";
@@ -19,17 +28,25 @@ buildPythonPackage rec {
     sha256 = "222d8ffb47f385c43eba45e3f308e605fc9736b2b7137d74979adf1a31e7c8b4";
   };
 
+  nativeBuildInputs = [ setuptools_scm gcc ];
+
   propagatedBuildInputs = [ cython numpy scikitlearn six ];
 
+  checkInputs = [ pytest pytestcov ];
+
+  # Checks require test data downloaded separately
+  # See project source Makefile:test-data rule for reference
   checkPhase = ''
-   cd word2vec/tests;
-    ${python.interpreter} test_word2vec.py
+    PATH=$PATH:$out/bin
+    mkdir data
+    head -c 100000 ${testData}/text8 > data/text8-small
+    pytest
   '';
 
   meta = with stdenv.lib; {
     description = "Tool for computing continuous distributed representations of words";
     homepage = "https://github.com/danielfrg/word2vec";
-    license     = licenses.asl20;
+    license = licenses.asl20;
     maintainers = with maintainers; [ NikolaMandic ];
   };
 


### PR DESCRIPTION
(cherry picked from commit 6a4e785931e8e9ccd008f43cff2126861f2f182d)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
