### PR TITLE
[20.09] python3.pkgs.cartopy: 0.17 -> 0.18

### DIFF
--- a/pkgs/development/python-modules/cartopy/default.nix
+++ b/pkgs/development/python-modules/cartopy/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage rec {
   pname = "cartopy";
-  version = "0.17.0";
+  version = "0.18.0";
 
   src = fetchPypi {
     inherit version;
     pname = "Cartopy";
-    sha256 = "0q9ckfi37cxj7jwnqnzij62vwcf4krccx576vv5lhvpgvplxjjs2";
+    sha256 = "0d24fk0cbp29gmkysrwq05vry13swmwi3vx3cpcy04c0ixz33ykz";
   };
 
   checkInputs = [ filelock mock pytest_4 pep8 ];


### PR DESCRIPTION
Fixes build. Formerly cartopy tests were failing, likely since update of
matplotlib to 3.3.0.

(cherry picked from commit 20472523e7538a1d2271d856fe91ae2d40a2c8ae)

Backport of #98210
ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
