### PR TITLE
Update Haskell package set to LTS 16.15 (plus other fixes)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -208,11 +208,11 @@ self: super: {
   # Generating the completions should be activated again, once we default to
   # ghc 8.10.
   hnix = dontCheck (super.hnix.override {
-    # The neat-interpolation package from stack is to old for hnix.
-    # https://github.com/haskell-nix/hnix/issues/676
-    # Once neat-interpolation >= 0.4 is in our stack release,
-    # (which should happen soon), we can remove this override
-    neat-interpolation = self.neat-interpolation_0_5_1_2;
+    # 2020-09-18: Those packages are all needed by hnix at versions newer than on stackage
+    neat-interpolation = self.neat-interpolation_0_5_1_2; # at least 0.5.1
+    data-fix = self.data-fix_0_3_0; # at least 0.3
+    prettyprinter = self.prettyprinter_1_7_0; # at least 1.7
+
   });
 
   # Fails for non-obvious reasons while attempting to use doctest.

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1461,7 +1461,6 @@ self: super: {
   jira-wiki-markup = doDistribute self.jira-wiki-markup_1_3_2;
   pandoc = doDistribute self.pandoc_2_10_1;
   pandoc-citeproc = doDistribute self.pandoc-citeproc_0_17_0_2;
-  pandoc-plot = doDistribute self.pandoc-plot_0_9_2_0;
   pandoc-types = doDistribute self.pandoc-types_1_21;
   rfc5051 = doDistribute self.rfc5051_0_2;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1209,14 +1209,9 @@ self: super: {
 
   # this will probably need to get updated with every ghcide update,
   # we need an override because ghcide is tracking haskell-lsp closely.
-  ghcide = dontCheck (appendPatch (super.ghcide.override {
+  ghcide = dontCheck (super.ghcide.overrideScope (self: super: {
     hie-bios = dontCheck super.hie-bios_0_7_1;
     lsp-test = dontCheck self.lsp-test_0_11_0_5;
-  }) (pkgs.fetchpatch {
-    # This patch loosens the hie-bios upper bound.
-    # It is already merged into upstream and won‘t be needed for ghcide 0.4.0
-    url = "https://github.com/haskell/ghcide/commit/3e1b3620948870a4da8808ca0c0897fbd3ecad16.patch";
-    sha256 = "1jwn7jgi740x6wwv1k0mz9d4z0b9p3mzs54pdg4nfq0h2v7zxchz";
   }));
 
   # hasn‘t bumped upper bounds

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3441,6 +3441,7 @@ broken-packages:
   - bitcoin-api
   - bitcoin-api-extra
   - bitcoin-block
+  - bitcoin-compact-filters
   - bitcoin-hs
   - bitcoin-rpc
   - bitcoin-script
@@ -5543,6 +5544,7 @@ broken-packages:
   - graphicstools
   - graphmod-plugin
   - graphql
+  - graphql-utils
   - graphql-w-persistent
   - graphted
   - graphtype
@@ -7515,6 +7517,7 @@ broken-packages:
   - LslPlus
   - lsystem
   - ltext
+  - lti13
   - ltk
   - LTS
   - lua-bc
@@ -11227,6 +11230,7 @@ broken-packages:
   - yesod-auth-ldap
   - yesod-auth-ldap-mediocre
   - yesod-auth-ldap-native
+  - yesod-auth-lti13
   - yesod-auth-nopassword
   - yesod-auth-oauth2
   - yesod-auth-pam

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -72,7 +72,7 @@ default-package-overrides:
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
   # not yet available in Nixpkgs
   - gi-gdkx11 < 4
-  # LTS Haskell 16.13
+  # LTS Haskell 16.15
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -243,7 +243,7 @@ default-package-overrides:
   - asn1-encoding ==0.9.6
   - asn1-parse ==0.9.5
   - asn1-types ==0.3.4
-  - assert-failure ==0.1.2.4
+  - assert-failure ==0.1.2.5
   - assoc ==1.0.2
   - astro ==0.4.2.1
   - async ==2.2.2
@@ -261,12 +261,12 @@ default-package-overrides:
   - attoparsec-iso8601 ==1.0.1.0
   - attoparsec-path ==0.0.0.1
   - audacity ==0.0.2
-  - aur ==7.0.3
-  - aura ==3.1.8
+  - aur ==7.0.4
+  - aura ==3.1.9
   - authenticate ==1.3.5
   - authenticate-oauth ==1.6.0.1
   - auto ==0.4.3.1
-  - autoexporter ==1.1.18
+  - autoexporter ==1.1.19
   - auto-update ==0.1.6
   - avers ==0.0.17.1
   - avro ==0.5.2.0
@@ -402,7 +402,7 @@ default-package-overrides:
   - casing ==0.1.4.1
   - cassava ==0.5.2.0
   - cassava-conduit ==0.5.1
-  - cassava-megaparsec ==2.0.1
+  - cassava-megaparsec ==2.0.2
   - cast ==0.1.0.2
   - category ==0.2.5.0
   - cayley-client ==0.4.13
@@ -454,7 +454,7 @@ default-package-overrides:
   - clumpiness ==0.17.0.2
   - ClustalParser ==1.3.0
   - cmark ==0.6
-  - cmark-gfm ==0.2.1
+  - cmark-gfm ==0.2.2
   - cmark-lucid ==0.1.0.0
   - cmdargs ==0.10.20
   - codec-beam ==0.2.0
@@ -657,7 +657,7 @@ default-package-overrides:
   - distributed-closure ==0.4.2.0
   - distribution-opensuse ==1.1.1
   - distributive ==0.6.2
-  - dl-fedora ==0.7.4
+  - dl-fedora ==0.7.5
   - dlist ==0.8.0.8
   - dlist-instances ==0.1.1.1
   - dlist-nonempty ==0.1.1
@@ -671,7 +671,7 @@ default-package-overrides:
   - doldol ==0.4.1.2
   - do-list ==1.0.1
   - do-notation ==0.1.0.2
-  - dotenv ==0.8.0.6
+  - dotenv ==0.8.0.7
   - dotgen ==0.4.3
   - dotnet-timespan ==0.0.1.0
   - double-conversion ==2.0.2.0
@@ -733,7 +733,7 @@ default-package-overrides:
   - errors ==2.3.0
   - errors-ext ==0.4.2
   - ersatz ==0.4.8
-  - esqueleto ==3.3.3.3
+  - esqueleto ==3.3.4.0
   - essence-of-live-coding ==0.1.0.3
   - essence-of-live-coding-gloss ==0.1.0.3
   - essence-of-live-coding-pulse ==0.1.0.3
@@ -760,7 +760,7 @@ default-package-overrides:
   - extended-reals ==0.2.4.0
   - extensible-effects ==5.0.0.1
   - extensible-exceptions ==0.1.1.4
-  - extra ==1.7.7
+  - extra ==1.7.8
   - extractable-singleton ==0.0.1
   - extrapolate ==0.4.2
   - fail ==4.9.0.0
@@ -902,8 +902,8 @@ default-package-overrides:
   - ghcid ==0.8.7
   - ghci-hexcalc ==0.1.1.0
   - ghcjs-codemirror ==0.0.0.2
-  - ghc-lib ==8.10.2.20200808
-  - ghc-lib-parser ==8.10.2.20200808
+  - ghc-lib ==8.10.2.20200916
+  - ghc-lib-parser ==8.10.2.20200916
   - ghc-lib-parser-ex ==8.10.0.16
   - ghc-parser ==0.2.2.0
   - ghc-paths ==0.1.0.12
@@ -988,7 +988,7 @@ default-package-overrides:
   - hashable-time ==0.2.0.2
   - hashids ==1.0.2.4
   - hashmap ==1.3.3
-  - hashtables ==1.2.3.4
+  - hashtables ==1.2.4.1
   - haskeline ==0.7.5.0
   - haskell-gi ==0.23.1
   - haskell-gi-base ==0.23.0
@@ -1130,7 +1130,7 @@ default-package-overrides:
   - html-entity-map ==0.1.0.0
   - htoml ==1.0.0.3
   - http2 ==2.0.5
-  - HTTP ==4000.3.14
+  - HTTP ==4000.3.15
   - http-api-data ==0.4.1.1
   - http-client ==0.6.4.1
   - http-client-openssl ==0.3.1.0
@@ -1205,7 +1205,7 @@ default-package-overrides:
   - indexed-list-literals ==0.2.1.3
   - indexed-profunctors ==0.1
   - infer-license ==0.2.0
-  - inflections ==0.4.0.5
+  - inflections ==0.4.0.6
   - influxdb ==1.7.1.6
   - ini ==0.4.1
   - inj ==1.0
@@ -1232,11 +1232,11 @@ default-package-overrides:
   - invertible ==0.2.0.7
   - invertible-grammar ==0.1.3
   - io-machine ==0.2.0.0
-  - io-manager ==0.1.0.2
+  - io-manager ==0.1.0.3
   - io-memoize ==1.1.1.0
   - io-region ==0.1.1
   - io-storage ==0.3
-  - io-streams ==1.5.1.0
+  - io-streams ==1.5.2.0
   - io-streams-haproxy ==1.0.1.0
   - ip6addr ==1.0.1
   - iproute ==1.7.9
@@ -1597,7 +1597,7 @@ default-package-overrides:
   - OpenGLRaw ==3.3.4.0
   - openpgp-asciiarmor ==0.1.2
   - opensource ==0.1.1.0
-  - openssl-streams ==1.2.2.0
+  - openssl-streams ==1.2.3.0
   - opentelemetry ==0.4.2
   - opentelemetry-extra ==0.4.2
   - opentelemetry-lightstep ==0.4.2
@@ -1782,7 +1782,7 @@ default-package-overrides:
   - pushbullet-types ==0.4.1.0
   - pusher-http-haskell ==1.5.1.14
   - pvar ==0.2.0.0
-  - PyF ==0.9.0.1
+  - PyF ==0.9.0.2
   - qchas ==1.1.0.1
   - qm-interpolated-string ==0.3.0.0
   - qrcode-core ==0.9.4
@@ -1793,7 +1793,7 @@ default-package-overrides:
   - quickcheck-arbitrary-adt ==0.3.1.0
   - quickcheck-assertions ==0.3.0
   - quickcheck-classes ==0.6.4.0
-  - quickcheck-classes-base ==0.6.0.0
+  - quickcheck-classes-base ==0.6.1.0
   - quickcheck-instances ==0.3.23
   - quickcheck-io ==0.2.0
   - quickcheck-simple ==0.1.1.1
@@ -1886,7 +1886,7 @@ default-package-overrides:
   - rhine ==0.6.0
   - rhine-gloss ==0.6.0.1
   - rigel-viz ==0.2.0.0
-  - rio ==0.1.18.0
+  - rio ==0.1.19.0
   - rio-orphans ==0.1.1.0
   - rio-prettyprint ==0.1.1.0
   - roc-id ==0.1.0.0
@@ -2039,7 +2039,7 @@ default-package-overrides:
   - smallcheck ==1.1.7
   - smash ==0.1.1.0
   - smash-aeson ==0.1.0.0
-  - smash-lens ==0.1.0.0
+  - smash-lens ==0.1.0.1
   - smash-microlens ==0.1.0.0
   - smoothie ==0.4.2.11
   - snap-blaze ==0.2.1.5
@@ -2413,7 +2413,7 @@ default-package-overrides:
   - wai-cors ==0.2.7
   - wai-enforce-https ==0.0.2.1
   - wai-eventsource ==3.0.0
-  - wai-extra ==3.0.29.2
+  - wai-extra ==3.0.31
   - wai-handler-launch ==3.0.3.1
   - wai-logger ==2.3.6
   - wai-middleware-caching ==0.1.0.2
@@ -2512,7 +2512,7 @@ default-package-overrides:
   - yesod-gitrev ==0.2.1
   - yesod-newsfeed ==1.7.0.0
   - yesod-persistent ==1.6.0.4
-  - yesod-recaptcha2 ==1.0.0
+  - yesod-recaptcha2 ==1.0.1
   - yesod-sitemap ==1.6.0
   - yesod-static ==1.6.1.0
   - yesod-test ==1.6.10

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -571,9 +571,20 @@ self: super: builtins.intersectAttrs super {
   }));
 
   # Expects z3 to be on path so we replace it with a hard
+  #
+  # The tests expect additional solvers on the path, replace the
+  # available ones also with hard coded paths, and remove the missing
+  # ones from the test.
   sbv = overrideCabal super.sbv (drv: {
     postPatch = ''
-      sed -i -e 's|"z3"|"${pkgs.z3}/bin/z3"|' Data/SBV/Provers/Z3.hs'';
+      sed -i -e 's|"abc"|"${pkgs.abc-verifier}/bin/abc"|' Data/SBV/Provers/ABC.hs
+      sed -i -e 's|"boolector"|"${pkgs.boolector}/bin/boolector"|' Data/SBV/Provers/Boolector.hs
+      sed -i -e 's|"cvc4"|"${pkgs.cvc4}/bin/cvc4"|' Data/SBV/Provers/CVC4.hs
+      sed -i -e 's|"yices-smt2"|"${pkgs.yices}/bin/yices-smt2"|' Data/SBV/Provers/Yices.hs
+      sed -i -e 's|"z3"|"${pkgs.z3}/bin/z3"|' Data/SBV/Provers/Z3.hs
+
+      sed -i -e 's|\[abc, boolector, cvc4, mathSAT, yices, z3, dReal\]|[abc, boolector, cvc4, yices, z3]|' SBVTestSuite/SBVConnectionTest.hs
+   '';
   });
 
   # The test-suite requires a running PostgreSQL server.

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -105,18 +105,6 @@ symlinkJoin {
         --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"
     fi
 
-    # ghcide 0.2.0 does package discovery without calling our ghc wrapper.
-    # 2020-08-16 We can most likely remove this workaround as soon as we build ghcide with a newer hie-bios (currently we use 0.5.1 from stack)
-    for prg in ghcide; do
-      if [[ -x "$out/bin/$prg" ]]; then
-        wrapProgram $out/bin/$prg  \
-          --set "NIX_${ghcCommandCaps}"        "$out/bin/${ghcCommand}"     \
-          --set "NIX_${ghcCommandCaps}PKG"     "$out/bin/${ghcCommand}-pkg" \
-          --set "NIX_${ghcCommandCaps}_DOCDIR" "${docDir}"                  \
-          --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"
-      fi
-    done
-
   '' + (lib.optionalString (stdenv.targetPlatform.isDarwin && !isGhcjs && !stdenv.targetPlatform.isiOS) ''
     # Work around a linker limit in macOS Sierra (see generic-builder.nix):
     local packageConfDir="$out/lib/${ghc.name}/package.conf.d";


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2020-09-18 20:00 +02:00. You can watch this live on Twitch at https://www.twitch.tv/peti343. In addition to the chat features offered by Twitch, there is also a voice conference at https://discord.gg/YTEa3XR that viewers can use to chat with me and with each other.