### PR TITLE
meson: 0.55.1 → 0.55.3

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -9,21 +9,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "meson";
-  version = "0.55.1";
+  version = "0.55.3";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "O1dB+ITgSSi9+hlHRn/wavpsmOYjwlzvda33HKOc4IA=";
+    sha256 = "19cjy24mfaswxyvqmns6rd7hx05ybqb663zlgklspfr8l4jjmvbb";
   };
 
   patches = [
-    # Meson 0.55.0 incorrectly considers skipped tests as failures,
-    # which makes some packages like gjs fail to build.
-    (fetchpatch {
-      url = "https://github.com/mesonbuild/meson/commit/7db49db67d4aa7582cf46feb7157235e66aa95b1.diff";
-      sha256 = "1chq52sgk24afdlswssr8n8p6fa2wz8rjlxvkjhpqg1kg3qnqc9p";
-    })
-
     # Upstream insists on not allowing bindir and other dir options
     # outside of prefix for some reason:
     # https://github.com/mesonbuild/meson/issues/2561


### PR DESCRIPTION
###### Motivation for this change
https://github.com/mesonbuild/meson/compare/0.55.1...0.55.2
https://github.com/mesonbuild/meson/compare/0.55.2...0.55.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] successfully built systemd
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
