### PR TITLE
fierce: fix build

### DIFF
--- a/pkgs/tools/security/fierce/default.nix
+++ b/pkgs/tools/security/fierce/default.nix
@@ -11,7 +11,15 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "11yaz8ap9swx95j3wpqh0b6jhw6spqgfnsyn1liw9zqi4jwgiax7";
   };
 
+  postPatch = ''
+    substituteInPlace requirements.txt --replace 'dnspython==1.16.0' 'dnspython'
+  '';
+
   propagatedBuildInputs = [ python3.pkgs.dns ];
+
+  # tests require network access
+  doCheck = false;
+  pythonImportsCheck = [ "fierce" ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mschwager/fierce";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Because I needed to play with its install requirements, I added a `pythonImportsCheck` to give us a chance to discover brokenness. Technically this isn't a realistic test of end user behaviour as this is really an application, not a python module, but it seems to have a pretty stable import name of `fierce`, so it works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
