### PR TITLE
[20.09] topydo: Don't fail build on tests

### DIFF
--- a/pkgs/applications/misc/topydo/default.nix
+++ b/pkgs/applications/misc/topydo/default.nix
@@ -22,7 +22,14 @@ buildPythonApplication rec {
     watchdog
   ];
 
-  checkInputs = [ mock freezegun coverage green pylint ];
+  checkInputs = [ mock freezegun pylint ];
+
+  # Skip test that has been reported multiple times upstream without result:
+  # bram85/topydo#271, bram85/topydo#274.
+  checkPhase = ''
+    substituteInPlace test/test_revert_command.py --replace 'test_revert_ls' 'dont_test_revert_ls'
+    python -m unittest discover
+  '';
 
   LC_ALL="en_US.UTF-8";
 


### PR DESCRIPTION
##### Motivation for this change

(cherry picked from commit [`9d30512`](https://github.com/NixOS/nixpkgs/commit/9d30512))

backport of #98110

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] ~Ensured that relevant documentation is up to date~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
