### PR TITLE
nixosTests.magnetico: wait for open port and make curl actually fail

### DIFF
--- a/nixos/tests/magnetico.nix
+++ b/nixos/tests/magnetico.nix
@@ -27,12 +27,13 @@ in
       start_all()
       machine.wait_for_unit("magneticod")
       machine.wait_for_unit("magneticow")
+      machine.wait_for_open_port(${toString port})
       machine.succeed(
-          "${pkgs.curl}/bin/curl "
+          "${pkgs.curl}/bin/curl --fail "
           + "-u user:password http://localhost:${toString port}"
       )
-      assert "Unauthorised." in machine.succeed(
-          "${pkgs.curl}/bin/curl "
+      machine.fail(
+          "${pkgs.curl}/bin/curl --fail "
           + "-u user:wrongpwd http://localhost:${toString port}"
       )
       machine.shutdown()


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF #97479 

The port is simply not opened yet because the database schema update wasn't completed yet.

Additionally the curl calls would never give a reasonable exit code without `--fail`.

```
machine # [   38.282835] magneticod[819]: 2020-09-18T18:36:17.306Z      INFO    magneticod v0.11.0 has been started.
machine # [   38.323145] magneticod[819]: 2020-09-18T18:36:17.312Z      INFO    Copyright (C) 2017-2020  Mert Bora ALPER <bora@boramalper.org>.
machine # [   38.367219] magneticod[819]: 2020-09-18T18:36:17.312Z      INFO    Dedicated to Cemile Binay, in whose hands I thrived.
machine # [   38.406781] magneticod[819]: 2020-09-18T18:36:17.313Z      INFO    Compiled on 2020-09-11T20:32:29Z
machine: must succeed: /nix/store/5kr4s9crcx6hg9yhbdgzsf9zkmi5ijpg-curl-7.72.0-bin/bin/curl -u user:password http://localhost:8081
machine # [   38.488333] magneticod[819]: 2020-09-18T18:36:17.515Z      WARN    Updating database schema from 0 to 1... (this might take a while)
machine # [   38.527766] magneticod[819]: 2020-09-18T18:36:17.524Z      WARN    Updating database schema from 1 to 2... (this might take a while)
machine # [   38.591597] magneticod[819]: 2020-09-18T18:36:17.547Z      WARN    Updating database schema from 2 to 3... (this might take a while)
machine # curl: (7) Failed to connect to localhost port 8081: Connection refused
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
