### PR TITLE
[20.09] python2Packages.hickle: disable

### DIFF
--- a/pkgs/development/python-modules/hickle/default.nix
+++ b/pkgs/development/python-modules/hickle/default.nix
@@ -33,9 +33,13 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [ h5py numpy dill ];
+
+  doCheck = false; # incompatible with latest astropy
   checkInputs = [
     pytest pytestcov pytestrunner coveralls scipy pandas astropy twine check-manifest codecov
   ];
+
+  pythonImportsCheck = [ "hickle" ];
 
   meta = {
     description = "Serialize Python data to HDF5";

--- a/pkgs/development/python-modules/hickle/default.nix
+++ b/pkgs/development/python-modules/hickle/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage
 , fetchPypi
+, pythonOlder
 , h5py
 , numpy
 , dill
@@ -19,6 +20,7 @@
 buildPythonPackage rec {
   pname   = "hickle";
   version = "4.0.1";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change

backport  #98064

```
  Processing ./hickle-4.0.1-py2-none-any.whl
  ERROR: Package 'hickle' requires a different Python: 2.7.18 not in '>=3.5'
```

(cherry picked from commit f1325cdfe7da80f809c4c6f6d22a4d1a22c7422e)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
