### PR TITLE
truvari: fix build

### DIFF
--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -25,13 +25,15 @@ python3Packages.buildPythonApplication rec {
 
   prePatch = ''
     substituteInPlace ./setup.py \
-      --replace '"progressbar2==3.41.0",' '"progressbar2==3.47.0",' \
-      --replace '"pysam==0.15.2",' '"pysam==0.15.4",' \
-      --replace '"pyfaidx==0.5.5.2",' '"pyfaidx==0.5.8",'
+      --replace '"progressbar2==3.41.0",' '"progressbar2",' \
+      --replace '"pysam==0.15.2",' '"pysam",' \
+      --replace '"pyfaidx==0.5.5.2",' '"pyfaidx",' \
+      --replace '"intervaltree==3.0.2",' '"intervaltree",'
   '';
 
   meta = with lib; {
     description = "Structural variant comparison tool for VCFs";
+    homepage = "https://github.com/spiralgenetics/truvari";
     license = licenses.mit;
     maintainers = with maintainers; [ scalavision ];
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Be less strict about versions. I'd feel better about this if there were proper runnable tests for this. But if they're just advocating regular users to install through `pip install truvari`, they're likely to get far _more_ unreliable results.

I did start out bumping this to its latest version, 2.0.2, but after adding packages for 3 new dependencies I realized I would have ended up maintaining these packages I know nothing about and may have no users. :shrug: (Edit: I went and finished this off under #98283, not sure which of these we want to use now)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
