### PR TITLE
python3Packages.runway-python: add missing deps

### DIFF
--- a/pkgs/development/python-modules/runway-python/default.nix
+++ b/pkgs/development/python-modules/runway-python/default.nix
@@ -5,6 +5,7 @@
 , flask-compress
 , flask-cors
 , flask-sockets
+, imageio
 , numpy
 , scipy
 , pillow
@@ -25,7 +26,22 @@ buildPythonPackage rec {
     sha256 = "695d78f8edeb6a7ca98d8351adb36948d56cceeffe8a84896c9fbfd349fc4cb8";
   };
 
-  propagatedBuildInputs = [ flask flask-compress flask-cors flask-sockets numpy scipy pillow gevent wget six colorcet unidecode urllib3 ];
+  propagatedBuildInputs = [
+    colorcet
+    flask
+    flask-compress
+    flask-cors
+    flask-sockets
+    gevent
+    imageio
+    numpy
+    pillow
+    scipy
+    six
+    unidecode
+    urllib3
+    wget
+  ];
 
   # tests are not packaged in the released tarball
   doCheck = false;


### PR DESCRIPTION
##### Motivation for this change

backport #98063

ZHF: #97479
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
