### PR TITLE
[20.09] unnethack: 5.2.0 -> 5.3.2, fix build

### DIFF
--- a/pkgs/games/unnethack/default.nix
+++ b/pkgs/games/unnethack/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, fetchgit, utillinux, ncurses, flex, bison }:
+{ stdenv, fetchFromGitHub, fetchpatch, utillinux, ncurses, flex, bison }:
 
 stdenv.mkDerivation rec {
   pname = "unnethack";
-  version = "5.2.0";
+  version = "5.3.2";
 
-  src = fetchgit {
-    url = "https://github.com/UnNetHack/UnNetHack";
-    rev = "refs/tags/${version}";
-    sha256 = "088gd2c7v95f2pm9ky38i28sz73mnsksr2p2hhhflkchxncd21f1";
+  src = fetchFromGitHub {
+    name = "UnNetHack";
+    owner = "UnNetHack";
+    repo = "UnNetHack";
+    rev = version;
+    sha256 = "1rg0mqyplgn3dfh3wz09a600qxk7aidqw4d84kyiincljvhyb7ps";
   };
 
   buildInputs = [ ncurses ];
@@ -22,6 +24,14 @@ stdenv.mkDerivation rec {
                    ];
 
   makeFlags = [ "GAMEPERM=744" ];
+  patches = [
+    # fix regression with bison, merged in master
+    (fetchpatch {
+      name = "fix-bison.patch";
+      url = "https://github.com/UnNetHack/UnNetHack/commit/04f0a3a850a94eb8837ddcef31303968240d1c31.patch";
+      sha256 = "1zblbwqqz9nx16k6n31wi2hdvz775lvzmkjblmrx18nbm4ylj0n9";
+    })
+  ];
 
   enableParallelBuilding = true;
 
@@ -54,5 +64,5 @@ stdenv.mkDerivation rec {
     license = "nethack";
     platforms = platforms.all;
     maintainers = with maintainers; [ abbradar ];
-  }; 
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

Backport of #97595.

ZHF: #97479

cc @NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
