### PR TITLE
pythonPackages.sslyze: downgrade cryptography to 2.9

### DIFF
--- a/pkgs/development/python-modules/sslyze/default.nix
+++ b/pkgs/development/python-modules/sslyze/default.nix
@@ -3,7 +3,7 @@
 , pytest
 , buildPythonPackage
 , nassl
-, cryptography
+, cryptography_2_9
 , typing-extensions
 , faker
 }:
@@ -18,11 +18,6 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "06mwzxw6xaqin2gwzcqb9r7qhbyx3k7zcxygxywi2bpxyjv9lq32";
   };
-
-  patchPhase = ''
-    substituteInPlace setup.py \
-      --replace "cryptography>=2.6,<=2.9" "cryptography>=2.6,<=3"
-  '';
 
   checkInputs = [ pytest ];
 
@@ -40,7 +35,7 @@ buildPythonPackage rec {
       -k "not (TestScanner and test_client_certificate_missing)"
   '';
 
-  propagatedBuildInputs = [ nassl cryptography typing-extensions faker ];
+  propagatedBuildInputs = [ nassl cryptography_2_9 typing-extensions faker ];
 
   meta = with lib; {
     homepage = "https://github.com/nabla-c0d3/sslyze";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1332,6 +1332,8 @@ in {
   else
     callPackage ../development/python-modules/cryptography { };
 
+  cryptography_2_9 = callPackage ../development/python-modules/cryptography/2.9.nix { };
+
   cryptography_vectors = if isPy27 then
     callPackage ../development/python-modules/cryptography/vectors-2.9.nix { }
   else


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The sslyze package is not compatible with `cryptography>=3.0`. We still have the 2.9 version around for python2, expose it as `cryptography_2_9` and use that.

ZHF #97479 

https://hydra.nixos.org/build/126784363/nixlog/1


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
