### PR TITLE
nixos/activation: fix type for activationScripts and userActivationScripts

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -5,6 +5,19 @@ with lib;
 
 let
 
+  stringWithDepsType = (
+    types.coercedTo types.str noDepEntry (
+      types.submodule {
+        options.text = mkOption {
+          type = types.str;
+          default = "";
+        };
+        options.deps = mkOption {
+          type = types.listOf types.str;
+          default = [];
+        };
+      }));
+
   addAttributeName = mapAttrs (a: v: v // {
     text = ''
       #### Activation script snippet ${a}:
@@ -62,7 +75,7 @@ in
         idempotent and fast.
       '';
 
-      type = types.attrsOf types.unspecified; # FIXME
+      type = types.attrsOf stringWithDepsType;
 
       apply = set: {
         script =
@@ -125,7 +138,7 @@ in
         idempotent and fast.
       '';
 
-      type = types.attrsOf types.unspecified;
+      type = types.attrsOf stringWithDepsType;
 
       apply = set: {
         script = ''


### PR DESCRIPTION
The problem: activationScripts (in my use case, deps) cannot be
overriden because merging of types.unspecified depends on the module
evaluation order.

> types.unspecified.merge [] [ { value = { text = "a"; dep = "b"; }; } { value = { dep = "c"; }; } ]
{ dep = "c"; text = "a"; }

The fix: give it a good type that handles merging in the typical way!

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
