### PR TITLE
[20.09] Revert "nixos/monit: Allow splitting the config in multiple files"

### DIFF
--- a/nixos/modules/services/monitoring/monit.nix
+++ b/nixos/modules/services/monitoring/monit.nix
@@ -4,29 +4,19 @@ with lib;
 
 let
   cfg = config.services.monit;
-  extraConfig = pkgs.writeText "monitConfig" cfg.extraConfig;
 in
 
 {
-  imports = [
-    (mkRenamedOptionModule [ "services" "monit" "config" ] ["services" "monit" "extraConfig" ])
-  ];
-
   options.services.monit = {
 
     enable = mkEnableOption "Monit";
 
-    configFiles = mkOption {
-      type = types.listOf types.path;
-      default = [];
-      description = "List of paths to be included in the monitrc file";
-    };
-
-    extraConfig = mkOption {
+    config = mkOption {
       type = types.lines;
       default = "";
-      description = "Additional monit config as string";
+      description = "monitrc content";
     };
+
   };
 
   config = mkIf cfg.enable {
@@ -34,7 +24,7 @@ in
     environment.systemPackages = [ pkgs.monit ];
 
     environment.etc.monitrc = {
-      text = concatMapStringsSep "\n" (path: "include ${path}")  (cfg.configFiles ++ [extraConfig]);
+      text = cfg.config;
       mode = "0400";
     };
 


### PR DESCRIPTION
(cherry picked from commit 61863c5155c8b324ac3d16f77b726c7ee3d9bd2f)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

These changes are unnecessary and make it harder to use monit. More details at https://github.com/NixOS/nixpkgs/pull/87553

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
