### PR TITLE
gitolite: fix updating of gitweb access list and description

### DIFF
--- a/pkgs/applications/version-management/gitolite/default.nix
+++ b/pkgs/applications/version-management/gitolite/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     wrapProgram $out/bin/gitolite-shell \
-      --prefix PATH : "${git}/bin"
+      --prefix PATH : ${lib.makeBinPath [ git perl ]}
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Currently when `git push` a gitolite repository:
```
remote: /nix/store/apcg7hcpaiy5ajy73y59fxhddxgszz4f-gitolite-3.6.12/bin/triggers/post-compile/update-gitweb-access-list: line 39: perl: command not found
remote: /nix/store/apcg7hcpaiy5ajy73y59fxhddxgszz4f-gitolite-3.6.12/bin/triggers/post-compile/update-description-file: line 13: perl: command not found
```

###### Things done
- [X] Add `perl` to `gitolite-shell`'s `PATH.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
