### PR TITLE
nixos/onedrive: Remove verbose flag

### DIFF
--- a/nixos/modules/services/networking/onedrive.nix
+++ b/nixos/modules/services/networking/onedrive.nix
@@ -53,7 +53,7 @@ in {
       serviceConfig = {
         Type = "simple";
         ExecStart = ''
-          ${cfg.package}/bin/onedrive --monitor --verbose --confdir=%h/.config/%i
+          ${cfg.package}/bin/onedrive --monitor --confdir=%h/.config/%i
         '';
         Restart="on-failure";
         RestartSec=3;


### PR DESCRIPTION
I have decided that verbose isn't appropriate for a "production" service. 

[x] Fits contributing.md