### PR TITLE
docker_18_09: fix build

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -79,7 +79,7 @@ rec {
       sha256 = sha256;
     };
 
-    patches = [
+    patches = lib.optional (versionAtLeast version "19.03") [
       # Replace hard-coded cross-compiler with $CC
       (fetchpatch {
         url = https://github.com/docker/docker-ce/commit/2fdfb4404ab811cb00227a3de111437b829e55cf.patch;


### PR DESCRIPTION
The cross-compiler patch introduced in https://github.com/NixOS/nixpkgs/pull/92140 fixes an issue in Docker CE 19.03+, and will not apply to (and is not needed for) previous versions.

See also:
https://github.com/docker/docker-ce/commit/2a37fdb61567f725bf3a635856a4cfc0f8d7d3e6
https://github.com/docker/docker-ce/commit/2fdfb4404ab811cb00227a3de111437b829e55cf

###### Motivation for this change

ZHF 20.09 https://github.com/NixOS/nixpkgs/issues/97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Ubuntu x86_64)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
