### PR TITLE
haskell.compiler.ghc865Binary: disable stripping once again on ARMv8

### DIFF
--- a/pkgs/development/compilers/ghc/8.6.5-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.5-binary.nix
@@ -117,6 +117,11 @@ stdenv.mkDerivation rec {
   # calls install-strip ...
   dontBuild = true;
 
+  # Stripping exposes a latent bug in patchelf (0.12, but possibly older
+  # versions too) and causes the resulting ghc binary to crash on ARMv8 when
+  # getting loaded by the dynamic linker. See #97407.
+  dontStrip = stdenv.hostPlatform.isAarch64;
+
   # On Linux, use patchelf to modify the executables so that they can
   # find editline/gmp.
   postFixup = stdenv.lib.optionalString stdenv.isLinux ''


### PR DESCRIPTION
###### Motivation for this change

There seems to be a latent bug with strip + patchelf on the GHC stage2
binary which got triggered again by patchelf 0.12. Until this is
properly fixed in patchelf, re-disable stripping.

Not going through staging since all the rebuilds are currently broken at head anyway.

Fixes #97407.

@GrahamcOfBorg build pandoc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
