### PR TITLE
foot: 1.4.4 → 1.5.0, fcft: 2.2.6 → 2.3.1, tllist: 1.0.2 → 1.0.4

### DIFF
--- a/pkgs/applications/misc/foot/default.nix
+++ b/pkgs/applications/misc/foot/default.nix
@@ -5,12 +5,12 @@
 
 stdenv.mkDerivation rec {
   pname = "foot";
-  version = "1.4.4";
+  version = "1.5.0";
 
   src = fetchgit {
     url = "https://codeberg.org/dnkl/foot.git";
     rev = "${version}";
-    sha256 = "1cr4sz075v18clh8nlvgyxlbvfkhbsg0qrqgnclip5rwa24ry1lg";
+    sha256 = "0k1aqwydbybf94nag93b92d78rzn4zk3dr5n4mm9lvr76fys3kfs";
   };
 
   nativeBuildInputs = [
@@ -34,5 +34,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = [ maintainers.sternenseemann ];
     platforms = platforms.linux;
+    changelog = "https://codeberg.org/dnkl/foot/releases/tag/${version}";
   };
 }

--- a/pkgs/development/libraries/fcft/default.nix
+++ b/pkgs/development/libraries/fcft/default.nix
@@ -1,18 +1,19 @@
 { stdenv, lib, fetchgit, pkg-config, meson, ninja, scdoc
-,freetype, fontconfig, pixman, tllist, check }:
+,freetype, fontconfig, pixman, tllist, check, harfbuzz
+}:
 
 stdenv.mkDerivation rec {
   pname = "fcft";
-  version = "2.2.6";
+  version = "2.3.1";
 
   src = fetchgit {
     url = "https://codeberg.org/dnkl/fcft.git";
-    rev = "${version}";
-    sha256 = "06zywvvgrch9k4d07bir2sxddwsli2gzpvlvjfcwbrj3bw5x6j1b";
+    rev = version;
+    sha256 = "1ddzdfq6y9db50zimxfsr955zkpr8y6fk4nrblsl0j0vliywlg8l";
   };
 
   nativeBuildInputs = [ pkg-config meson ninja scdoc ];
-  buildInputs = [ freetype fontconfig pixman tllist ];
+  buildInputs = [ freetype fontconfig pixman tllist harfbuzz ];
   checkInputs = [ check ];
 
   mesonFlags = [ "--buildtype=release" ];
@@ -25,5 +26,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fionera ];
     license = licenses.mit;
     platforms = with platforms; linux;
+    changelog = "https://codeberg.org/dnkl/fcft/releases/tag/${version}";
   };
 }

--- a/pkgs/development/libraries/tllist/default.nix
+++ b/pkgs/development/libraries/tllist/default.nix
@@ -2,23 +2,26 @@
 
 stdenv.mkDerivation rec {
   pname = "tllist";
-  version = "1.0.2";
+  version = "1.0.4";
 
   src = fetchgit {
     url = "https://codeberg.org/dnkl/tllist.git";
     rev = "${version}";
-    sha256 = "095wly66z9n2r6h318rackgl4g1w9l1vj96367ngcw7rpva9yppl";
+    sha256 = "1a26vwb7ll6mv3h8rbafsdx4vic1f286hiqn8s359sw8b7yjkvzs";
   };
 
   nativeBuildInputs = [
     meson ninja
   ];
 
+  doCheck = true;
+
   meta = with lib; {
     homepage = "https://codeberg.org/dnkl/tllist";
     description = "C header file only implementation of a typed linked list";
     maintainers = with maintainers; [ fionera ];
     license = licenses.mit;
-    platforms = with platforms; linux;
+    platforms = with platforms; unix;
+    changelog = "https://codeberg.org/dnkl/tllist/releases/tag/${version}";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

<https://codeberg.org/dnkl/foot/releases/tag/1.5.0>

Also update dependencies since their lower bounds have increased with this update.

* <https://codeberg.org/dnkl/tllist/releases/tag/1.0.4>
* <https://codeberg.org/dnkl/tllist/releases/tag/1.0.3>
* <https://codeberg.org/dnkl/fcft/releases/tag/2.3.1>
* <https://codeberg.org/dnkl/fcft/releases/tag/2.3.0>
* <https://codeberg.org/dnkl/fcft/releases/tag/2.2.7>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
