### PR TITLE
mariadb-connector-c: multiple outputs

### DIFF
--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -3,6 +3,8 @@
 , proj, gdal, geos, sqlite, postgresql, libmysqlclient, python2Packages, libLAS, proj-datumgrid
 }:
 
+let inherit (stdenv) lib; in
+
 stdenv.mkDerivation rec {
   name = "grass";
   version = "7.6.1";
@@ -42,7 +44,7 @@ stdenv.mkDerivation rec {
     "--with-postgres-libs=${postgresql.lib}/lib/"
     # it complains about missing libmysqld but doesn't really seem to need it
     "--with-mysql"
-    "--with-mysql-includes=${libmysqlclient}/include/mysql"
+    "--with-mysql-includes=${lib.getDev libmysqlclient}/include/mysql"
     "--with-mysql-libs=${libmysqlclient}/lib/mysql"
     "--with-blas"
     "--with-liblas=${libLAS}/bin/liblas-config"

--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -19,15 +19,16 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     export QMAKEFEATURES=${libcommuni}/features
-    qmakeFlags="$qmakeFlags \
-      COMMUNI_INSTALL_PREFIX=$out \
-      COMMUNI_INSTALL_BINS=$out/bin \
-      COMMUNI_INSTALL_PLUGINS=$out/lib/communi/plugins \
-      COMMUNI_INSTALL_ICONS=$out/share/icons/hicolor \
-      COMMUNI_INSTALL_DESKTOP=$out/share/applications \
-      COMMUNI_INSTALL_THEMES=$out/share/communi/themes
-    "
   '';
+
+  qmakeFlags = [
+    "COMMUNI_INSTALL_PREFIX=${placeholder "out"}"
+    "COMMUNI_INSTALL_BINS=${placeholder "out"}/bin"
+    "COMMUNI_INSTALL_PLUGINS=${placeholder "out"}/lib/communi/plugins"
+    "COMMUNI_INSTALL_ICONS=${placeholder "out"}/share/icons/hicolor"
+    "COMMUNI_INSTALL_DESKTOP=${placeholder "out"}/share/applications"
+    "COMMUNI_INSTALL_THEMES=${placeholder "out"}/share/communi/themes"
+  ];
 
   postInstall = stdenv.lib.optionalString stdenv.isLinux ''
     substituteInPlace "$out/share/applications/communi.desktop" \

--- a/pkgs/development/libraries/gdal/2.4.0.nix
+++ b/pkgs/development/libraries/gdal/2.4.0.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     "--with-poppler=${poppler.dev}" # optional
     "--with-libz=${zlib.dev}"       # optional
     "--with-pg=${postgresql}/bin/pg_config"
-    "--with-mysql=${libmysqlclient}/bin/mysql_config"
+    "--with-mysql=${getDev libmysqlclient}/bin/mysql_config"
     "--with-geotiff=${libgeotiff.dev}"
     "--with-sqlite3=${sqlite.dev}"
     "--with-spatialite=${libspatialite}"

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     "--with-poppler=${poppler.dev}" # optional
     "--with-libz=${zlib.dev}" # optional
     "--with-pg=yes" # since gdal 3.0 doesn't use ${postgresql}/bin/pg_config
-    "--with-mysql=${libmysqlclient}/bin/mysql_config"
+    "--with-mysql=${getDev libmysqlclient}/bin/mysql_config"
     "--with-geotiff=${libgeotiff}"
     "--with-sqlite3=${sqlite.dev}"
     "--with-spatialite=${libspatialite}"

--- a/pkgs/development/libraries/glpk/default.nix
+++ b/pkgs/development/libraries/glpk/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchurl
 , fetchpatch
+, libmysqlclient
 # Excerpt from glpk's INSTALL file:
 # This feature allows the exact simplex solver to use the GNU MP
 # bignum library. If it is disabled, the exact simplex solver uses the
@@ -21,9 +22,11 @@ stdenv.mkDerivation rec {
     sha256 = "040sfaa9jclg2nqdh83w71sv9rc1sznpnfiripjdyr48cady50a2";
   };
 
-  buildInputs = stdenv.lib.optionals withGmp [
-    gmp
-  ];
+  buildInputs =
+    [ libmysqlclient
+    ] ++ stdenv.lib.optionals withGmp [
+      gmp
+    ];
 
   configureFlags = stdenv.lib.optionals withGmp [
     "--with-gmp"
@@ -46,6 +49,13 @@ stdenv.mkDerivation rec {
       sha256 = "0z99z9gd31apb6x5n5n26411qzx0ma3s6dnznc4x61x86bhq31qf";
     })
   ];
+
+  postPatch =
+    # Do not hardcode the include path for libmysqlclient.
+    ''
+      substituteInPlace configure \
+        --replace '-I/usr/include/mysql' '$(mysql_config --include)'
+    '';
 
   doCheck = true;
 

--- a/pkgs/development/libraries/libdbi-drivers/default.nix
+++ b/pkgs/development/libraries/libdbi-drivers/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     "--with-dbi-libdir=${libdbi}/lib"
   ] ++ optionals (libmysqlclient != null) [
     "--with-mysql"
-    "--with-mysql-incdir=${libmysqlclient}/include/mysql"
+    "--with-mysql-incdir=${getDev libmysqlclient}/include/mysql"
     "--with-mysql-libdir=${libmysqlclient}/lib/mysql"
   ] ++ optionals (sqlite != null) [
     "--with-sqlite3"

--- a/pkgs/development/libraries/opendbx/default.nix
+++ b/pkgs/development/libraries/opendbx/default.nix
@@ -1,5 +1,7 @@
 { stdenv, fetchurl, readline, libmysqlclient, postgresql, sqlite }:
 
+let inherit (stdenv.lib) getDev; in
+
 stdenv.mkDerivation rec {
   name = "opendbx-1.4.6";
 
@@ -9,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    export CPPFLAGS="-I${libmysqlclient}/include/mysql"
+    export CPPFLAGS="-I${getDev libmysqlclient}/include/mysql"
     export LDFLAGS="-L${libmysqlclient}/lib/mysql -L${postgresql}/lib"
     configureFlagsArray=(--with-backends="mysql pgsql sqlite3")
   '';

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -169,7 +169,7 @@ with super;
   luadbi-mysql = super.luadbi-mysql.override({
     extraVariables = {
       # Can't just be /include and /lib, unfortunately needs the trailing 'mysql'
-      MYSQL_INCDIR="${pkgs.libmysqlclient}/include/mysql";
+      MYSQL_INCDIR="${pkgs.libmysqlclient.dev}/include/mysql";
       MYSQL_LIBDIR="${pkgs.libmysqlclient}/lib/mysql";
     };
     buildInputs = [

--- a/pkgs/tools/backup/mydumper/default.nix
+++ b/pkgs/tools/backup/mydumper/default.nix
@@ -1,6 +1,8 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig
 , glib, zlib, pcre, libmysqlclient, libressl }:
 
+let inherit (stdenv.lib) getDev; in
+
 stdenv.mkDerivation rec {
   version = "0.9.5";
   pname = "mydumper";
@@ -15,6 +17,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [ glib zlib pcre libmysqlclient libressl ];
+
+  cmakeFlags = [ "-DMYSQL_INCLUDE_DIR=${getDev libmysqlclient}/include/mysql" ];
 
   meta = with stdenv.lib; {
     description = ''High-perfomance MySQL backup tool'';

--- a/pkgs/tools/networking/kea/default.nix
+++ b/pkgs/tools/networking/kea/default.nix
@@ -1,6 +1,8 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, openssl, botan2, log4cplus
 , boost, python3, postgresql, libmysqlclient, gmp, bzip2 }:
 
+let inherit (stdenv) lib; in
+
 stdenv.mkDerivation rec {
   pname = "kea";
   version = "1.5.0-P1";
@@ -20,7 +22,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--localstatedir=/var"
     "--with-pgsql=${postgresql}/bin/pg_config"
-    "--with-mysql=${libmysqlclient}/bin/mysql_config"
+    "--with-mysql=${lib.getDev libmysqlclient}/bin/mysql_config"
   ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/tools/networking/mailutils/default.nix
+++ b/pkgs/tools/networking/mailutils/default.nix
@@ -18,9 +18,6 @@ stdenv.mkDerivation rec {
       */Makefile{.in,.am}
     sed -i 's:/usr/lib/mysql:${libmysqlclient}/lib/mysql:' configure.ac
     sed -i 's/0\.18/0.19/' configure.ac
-    sed -i -e 's:mysql/mysql.h:mysql.h:' \
-           -e 's:mysql/errmsg.h:errmsg.h:' \
-      sql/mysql.c
   '';
 
   nativeBuildInputs = [

--- a/pkgs/tools/networking/pmacct/default.nix
+++ b/pkgs/tools/networking/pmacct/default.nix
@@ -19,7 +19,7 @@ assert withSQLite -> sqlite != null;
 assert withPgSQL -> postgresql != null;
 assert withMysql -> libmysqlclient != null;
 
-let inherit (stdenv.lib) optional; in
+let inherit (stdenv.lib) getDev optional optionalString; in
 
 stdenv.mkDerivation rec {
   version = "1.7.5";
@@ -39,6 +39,9 @@ stdenv.mkDerivation rec {
     ++ optional withSQLite sqlite
     ++ optional withPgSQL postgresql
     ++ optional withMysql [ libmysqlclient zlib ];
+
+  MYSQL_CONFIG =
+    optionalString withMysql "${getDev libmysqlclient}/bin/mysql_config";
 
   configureFlags = [
     "--with-pcap-includes=${libpcap}/include"


### PR DESCRIPTION
(cherry picked from commit c0825ddbe925d50be9c1068546a51e34e1835903)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
