### PR TITLE
openjdk: add jdk11 jre and headless jre

### DIFF
--- a/pkgs/development/compilers/openjdk/jre.nix
+++ b/pkgs/development/compilers/openjdk/jre.nix
@@ -1,0 +1,43 @@
+{ jdk
+, runCommand
+, patchelf
+, lib
+, modules ? [
+  "java.base"
+  "java.compiler"
+  "java.datatransfer"
+  "java.desktop"
+  "java.instrument"
+  "java.logging"
+  "java.management"
+  "java.management.rmi"
+  "java.naming"
+  "java.net.http"
+  "java.prefs"
+  "java.rmi"
+  "java.scripting"
+  "java.security.jgss"
+  "java.security.sasl"
+  "java.se"
+  "java.smartcardio"
+  "java.sql"
+  "java.sql.rowset"
+  "java.transaction.xa"
+  "java.xml"
+  "java.xml.crypto"
+  "jdk.unsupported"
+]
+}:
+
+let
+  jre = runCommand "${jdk.name}-jre" rec {
+    nativeBuildInputs = [ patchelf ];
+    buildInputs = [ jdk ];
+    passthru = {
+      home = "${jre}";
+    };
+  }   ''
+      jlink --module-path ${jdk}/lib/openjdk/jmods --add-modules ${lib.concatStringsSep "," modules} --output $out
+      patchelf --shrink-rpath $out/bin/* $out/lib/jexec $out/lib/jspawnhelper $out/lib/*.so $out/lib/*/*.so
+  '';
+in jre

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9179,6 +9179,14 @@ in
     else
       openjdk11.override { headless = true; };
 
+  openjdk11_jre = callPackage ../development/compilers/openjdk/jre.nix {
+    jdk = openjdk11;
+  };
+
+  openjdk11_headless_jre = callPackage ../development/compilers/openjdk/jre.nix {
+    jdk = openjdk11_headless;
+  };
+
   openjdk14-bootstrap =
     if adoptopenjdk-hotspot-bin-13.meta.available then
       adoptopenjdk-hotspot-bin-13
@@ -9223,6 +9231,8 @@ in
 
   jdk11 = openjdk11;
   jdk11_headless = openjdk11_headless;
+  jre11 = openjdk11_jre;
+  jre11_headless = openjdk11_headless_jre;
 
   jdk14 = openjdk14;
   jdk14_headless = openjdk14_headless;


### PR DESCRIPTION
###### Motivation for this change

See also #79490

This should bring jdk11 (mostly) up to par with jdk8, so the next step would be to switch the default Java version from 8 to 11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
