### PR TITLE
WIP: fritzing: 0.9.3b -> 0.9.4, fix build

### DIFF
--- a/pkgs/applications/science/electronics/fritzing/0002-libgit-dynamic.patch
+++ b/pkgs/applications/science/electronics/fritzing/0002-libgit-dynamic.patch
@@ -1,0 +1,13 @@
+diff --git a/phoenix.pro b/phoenix.pro
+index 2abf6d0d..7b7d2b17 100644
+--- a/phoenix.pro
++++ b/phoenix.pro
+@@ -175,7 +175,7 @@ RC_FILE = fritzing.rc
+ RESOURCES += phoenixresources.qrc
+ 
+ # Disable this if you have (and want) libgit2 dynamically
+-LIBGIT_STATIC = true
++LIBGIT_STATIC = false
+ include(pri/libgit2detect.pri)
+ 
+ include(pri/boostdetect.pri)

--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -4,27 +4,30 @@
 
 mkDerivation rec {
   pname = "fritzing";
-  version = "0.9.3b";
+  version = "0.9.4";
 
   src = fetchFromGitHub {
     owner = "fritzing";
     repo = "fritzing-app";
-    rev = version;
-    sha256 = "0hpyc550xfhr6gmnc85nq60w00rm0ljm0y744dp0z88ikl04f4s3";
+    rev = "CD-498";
+    sha256 = "0aljj2wbmm1vd64nhj6lh9qy856pd5avlgydsznya2vylyz20p34";
   };
 
   parts = fetchFromGitHub {
     owner = "fritzing";
     repo = "fritzing-parts";
-    rev = version;
-    sha256 = "1d2v8k7p176j0lczx4vx9n9gbg3vw09n2c4b6w0wj5wqmifywhc1";
+    rev = "97dfd491bec4355d946792a27a59a199b9abbd8b";
+    sha256 = "0n1i1zp8n96w1jk2xh4y5mw518718fk12nzlwqa2j9ll98q1g40c";
   };
 
-  patches = [(fetchpatch {
-    name = "0001-Squashed-commit-of-the-following.patch";
-    url = "https://aur.archlinux.org/cgit/aur.git/plain/0001-Squashed-commit-of-the-following.patch?h=fritzing";
-    sha256 = "1cv6myidxhy28i8m8v13ghzkvx5978p9dcd8v7885y0l1h3108mf";
-  })];
+  patches = [
+    (fetchpatch {
+      name = "0001-fix-libgit2-version-check.patch";
+      url = "https://github.com/fritzing/fritzing-app/commit/472951243d70eeb40a53b1f7e16e6eab0588d079.patch";
+      sha256 = "0v1zi609cjnqac80xgnk23n54z08g1lia37hbzfl8jcq9sn9adak";
+    })
+    ./0002-libgit-dynamic.patch
+  ];
 
   buildInputs = [ qtbase qtsvg qtserialport boost libgit2 ];
 


### PR DESCRIPTION
###### Motivation for this change

Update and fix build.

ZHF: #97479

###### Things done

The package builds, but it does not find the parts repository. I don't have time to look into it, maybe someone else can continue this.

cc @robberer 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
