### PR TITLE
protontricks: 1.4.1 -> 1.4.2

### DIFF
--- a/pkgs/tools/package-management/protontricks/default.nix
+++ b/pkgs/tools/package-management/protontricks/default.nix
@@ -1,18 +1,24 @@
-{ stdenv, lib, buildPythonApplication, fetchFromGitHub
-, setuptools_scm, vdf
-, wine, winetricks, zenity
+{ stdenv
+, lib
+, buildPythonApplication
+, fetchFromGitHub
+, setuptools_scm
+, vdf
+, wine
+, winetricks
+, zenity
 , pytest
 }:
 
 buildPythonApplication rec {
   pname = "protontricks";
-  version = "1.4.1";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "Matoking";
     repo = pname;
     rev = version;
-    sha256 = "083ncg6yjd7s3dx91zd52w166x709mnxknwwr78ggka8d8vlyi0b";
+    sha256 = "0ri4phi1rna9snrxa6gl23walyack09mgax7zpjqfpxivwls3ach";
   };
 
   # Fix interpreter in mock run.sh for tests
@@ -47,7 +53,7 @@ buildPythonApplication rec {
     description = "A simple wrapper for running Winetricks commands for Proton-enabled games";
     homepage = "https://github.com/Matoking/protontricks";
     license = licenses.gpl3;
-    platforms = with platforms; linux;
     maintainers = with maintainers; [ metadark ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/Matoking/protontricks/releases/tag/1.4.2

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).