### PR TITLE
python3Packages.{segments,clldutils,csvw}: init

### DIFF
--- a/pkgs/development/python-modules/clldutils/default.nix
+++ b/pkgs/development/python-modules/clldutils/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, attrs
+, colorlog
+, csvw
+, dateutil
+, tabulate
+, mock
+, postgresql
+, pytestCheckHook
+, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "clldutils";
+  version = "3.5.2";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "clld";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0qlqp9yq4lbi9ik2psgw0svxlb7raadqaxdh2dgkn85d7h20y4nd";
+  };
+
+  patchPhase = ''
+    substituteInPlace setup.cfg --replace "--cov" ""
+  '';
+
+  propagatedBuildInputs = [
+    dateutil
+    tabulate
+    colorlog
+    attrs
+    csvw
+  ];
+
+  checkInputs = [
+    mock
+    postgresql
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  meta = with lib; {
+    description = "CSV on the Web";
+    homepage = "https://github.com/cldf/csvw";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/csvw/default.nix
+++ b/pkgs/development/python-modules/csvw/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, attrs
+, isodate
+, dateutil
+, rfc3986
+, uritemplate
+, mock
+, pytestCheckHook
+, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "csvw";
+  version = "1.8.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "cldf";
+    repo = "csvw";
+    rev = "v${version}";
+    sha256 = "0maxrsiv9i9hkg627hwqyq8g6jg3g8iv8gdqaxz4aysjd9xddydd";
+  };
+
+  patchPhase = ''
+    substituteInPlace setup.cfg --replace "--cov" ""
+  '';
+
+  propagatedBuildInputs = [
+    attrs
+    isodate
+    dateutil
+    rfc3986
+    uritemplate
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  meta = with lib; {
+    description = "CSV on the Web";
+    homepage = "https://github.com/cldf/csvw";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/segments/default.nix
+++ b/pkgs/development/python-modules/segments/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, regex
+, csvw
+, clldutils
+, mock
+, pytestCheckHook
+, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "segments";
+  version = "2.1.3";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "cldf";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "12lnpk834r3y7hw5x7nvswa60ddh69ylvr44k46gqcfba160hhb0";
+  };
+
+  patchPhase = ''
+    substituteInPlace setup.cfg --replace "--cov" ""
+  '';
+
+  propagatedBuildInputs = [
+    regex
+    csvw
+    clldutils
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  meta = with lib; {
+    description = "Unicode Standard tokenization routines and orthography profile segmentation";
+    homepage = "https://github.com/cldf/segments";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1186,6 +1186,8 @@ in {
 
   clize = callPackage ../development/python-modules/clize { };
 
+  clldutils = callPackage ../development/python-modules/clldutils { };
+
   closure-linter = callPackage ../development/python-modules/closure-linter { };
 
   cloudflare = callPackage ../development/python-modules/cloudflare { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1353,6 +1353,8 @@ in {
 
   csvs-to-sqlite = callPackage ../development/python-modules/csvs-to-sqlite { };
 
+  csvw = callPackage ../development/python-modules/csvw { };
+
   cucumber-tag-expressions = callPackage ../development/python-modules/cucumber-tag-expressions { };
 
   cufflinks = callPackage ../development/python-modules/cufflinks { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6345,6 +6345,8 @@ in {
 
   seekpath = callPackage ../development/python-modules/seekpath { };
 
+  segments = callPackage ../development/python-modules/segments { };
+
   selectors2 = callPackage ../development/python-modules/selectors2 { };
 
   selectors34 = callPackage ../development/python-modules/selectors34 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Part of our (@Mic92 and my) plan to package Mozilla TTS.

Phonemizer (up next) requires segments, which in turn requires clldutils and csvw.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
