### PR TITLE
xmlbird: fix build with python 3.8 

### DIFF
--- a/pkgs/tools/misc/birdfont/default.nix
+++ b/pkgs/tools/misc/birdfont/default.nix
@@ -14,7 +14,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ python3 pkgconfig vala_0_44 gobject-introspection wrapGAppsHook ];
   buildInputs = [ xmlbird libgee cairo gdk-pixbuf glib gtk3 webkitgtk libnotify sqlite gsettings-desktop-schemas ];
 
-  postPatch = "patchShebangs .";
+  postPatch = ''
+    substituteInPlace install.py \
+      --replace 'platform.version()' '"Nix"'
+
+    patchShebangs .
+  '';
 
   buildPhase = "./build.py";
 

--- a/pkgs/tools/misc/birdfont/xmlbird.nix
+++ b/pkgs/tools/misc/birdfont/xmlbird.nix
@@ -13,7 +13,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ glib ];
 
-  postPatch = "patchShebangs .";
+  postPatch = ''
+    substituteInPlace configure \
+      --replace 'platform.dist()[0]' '"nix"'
+    patchShebangs .
+  '';
 
   buildPhase = "./build.py";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2560,7 +2560,7 @@ in
   biblatex-check = callPackage ../tools/typesetting/biblatex-check { };
 
   birdfont = callPackage ../tools/misc/birdfont { };
-  xmlbird = callPackage ../tools/misc/birdfont/xmlbird.nix { };
+  xmlbird = callPackage ../tools/misc/birdfont/xmlbird.nix { stdenv = gccStdenv; };
 
   blastem = callPackage ../misc/emulators/blastem {
     inherit (python27Packages) pillow;


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Also fix a similar bug in `birdfont` (`xmlbird`'s only reverse-dependency) which would cause build to fail on debian-based non-nixos systems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
