### PR TITLE
systemd: enable homed

### DIFF
--- a/pkgs/development/libraries/hidapi/default.nix
+++ b/pkgs/development/libraries/hidapi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, systemd, libusb1
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, udev, libusb1
 , darwin }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   buildInputs = [ ]
-    ++ stdenv.lib.optionals stdenv.isLinux [ libusb1 systemd ];
+    ++ stdenv.lib.optionals stdenv.isLinux [ libusb1 udev ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libusb1/default.nix
+++ b/pkgs/development/libraries/libusb1/default.nix
@@ -2,14 +2,14 @@
 , fetchFromGitHub
 , autoreconfHook
 , pkgconfig
-, enableSystemd ? stdenv.isLinux && !stdenv.hostPlatform.isMusl
-, systemd ? null
+, enableUdev ? stdenv.isLinux && !stdenv.hostPlatform.isMusl
+, udev ? null
 , libobjc
 , IOKit
 , withStatic ? false
 }:
 
-assert enableSystemd -> systemd != null;
+assert enableUdev -> udev != null;
 
 stdenv.mkDerivation rec {
   pname = "libusb";
@@ -26,15 +26,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   propagatedBuildInputs =
-    stdenv.lib.optional enableSystemd systemd ++
+    stdenv.lib.optional enableUdev udev ++
     stdenv.lib.optionals stdenv.isDarwin [ libobjc IOKit ];
 
   dontDisableStatic = withStatic;
 
-  configureFlags = stdenv.lib.optional (!enableSystemd) "--disable-udev";
+  configureFlags = stdenv.lib.optional (!enableUdev) "--disable-udev";
 
-  preFixup = stdenv.lib.optionalString enableSystemd ''
-    sed 's,-ludev,-L${stdenv.lib.getLib systemd}/lib -ludev,' -i $out/lib/libusb-1.0.la
+  preFixup = stdenv.lib.optionalString enableUdev ''
+    sed 's,-ludev,-L${stdenv.lib.getLib udev}/lib -ludev,' -i $out/lib/libusb-1.0.la
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/systemd/0012-Install-default-configuration-into-out-share-factory.patch
+++ b/pkgs/os-specific/linux/systemd/0012-Install-default-configuration-into-out-share-factory.patch
@@ -16,6 +16,7 @@ store again, while having executables looking up files in /etc.
  network/meson.build            |  2 +-
  src/core/meson.build           | 10 +++++-----
  src/coredump/meson.build       |  2 +-
+ src/home/meson.build           |  2 +-
  src/journal-remote/meson.build |  4 ++--
  src/journal/meson.build        |  2 +-
  src/kernel-install/meson.build |  2 +-
@@ -28,7 +29,7 @@ store again, while having executables looking up files in /etc.
  sysctl.d/meson.build           |  2 +-
  tmpfiles.d/meson.build         |  2 +-
  units/meson.build              |  2 +-
- 17 files changed, 29 insertions(+), 26 deletions(-)
+ 18 files changed, 30 insertions(+), 27 deletions(-)
 
 diff --git a/hwdb.d/meson.build b/hwdb.d/meson.build
 index 5c77387a26..6404bc01ba 100644
@@ -144,6 +145,17 @@ index 7fa5942697..34c865dfa0 100644
  endif
  
  tests += [
+diff --git a/src/home/meson.build b/src/home/meson.build
+index 797f3a3c6d..232904ab42 100644
+--- a/src/home/meson.build
++++ b/src/home/meson.build
+@@ -98,5 +98,5 @@ if conf.get('ENABLE_HOMED') == 1
+                      install_dir : polkitpolicydir)
+
+         install_data('homed.conf',
+-                     install_dir : pkgsysconfdir)
++                     install_dir : factoryconfdir)
+ endif
 diff --git a/src/journal-remote/meson.build b/src/journal-remote/meson.build
 index 87b8ba6495..daff8ec967 100644
 --- a/src/journal-remote/meson.build

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -78,6 +78,8 @@
 , withTimedated ? true
 , withTimesyncd ? true
 , withUserDb ? true
+, withHomed ? false, p11-kit, libfido2
+# , withPortabled ? false TODO
 
   # name argument
 , pname ? "systemd"
@@ -98,8 +100,11 @@ assert withEfi -> (gnu-efi != null);
 assert withRemote -> lib.getDev curl != null;
 assert withCoredump -> withCompression;
 
+assert withHomed -> withCryptsetup;
+
 assert withCryptsetup ->
 (cryptsetup != null);
+
 let
   wantCurl = withRemote || withImportd;
 
@@ -191,18 +196,19 @@ stdenv.mkDerivation {
       pam
     ]
 
-    ++ lib.optional withApparmor libapparmor
-    ++ lib.optional wantCurl (lib.getDev curl)
+    ++ lib.optional  withApparmor libapparmor
+    ++ lib.optional  wantCurl (lib.getDev curl)
     ++ lib.optionals withCompression [ bzip2 lz4 xz ]
-    ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)
-    ++ lib.optional withEfi gnu-efi
-    ++ lib.optional withKexectools kexectools
-    ++ lib.optional withLibseccomp libseccomp
-    ++ lib.optional withNetworkd iptables
-    ++ lib.optional withPCRE2 pcre2
-    ++ lib.optional withResolved libgpgerror
-    ++ lib.optional withSelinux libselinux
-    ++ lib.optional withRemote libmicrohttpd
+    ++ lib.optional  withCryptsetup (lib.getDev cryptsetup.dev)
+    ++ lib.optional  withEfi gnu-efi
+    ++ lib.optional  withKexectools kexectools
+    ++ lib.optional  withLibseccomp libseccomp
+    ++ lib.optional  withNetworkd iptables
+    ++ lib.optional  withPCRE2 pcre2
+    ++ lib.optional  withResolved libgpgerror
+    ++ lib.optional  withSelinux libselinux
+    ++ lib.optional  withRemote libmicrohttpd
+    ++ lib.optionals withHomed [ p11-kit libfido2 ]
     ;
 
   #dontAddPrefix = true;
@@ -226,7 +232,7 @@ stdenv.mkDerivation {
     "-Dgcrypt=${lib.boolToString (libgcrypt != null)}"
     "-Dimportd=${lib.boolToString withImportd}"
     "-Dlz4=${lib.boolToString withCompression}"
-    "-Dhomed=false"
+    "-Dhomed=${stdenv.lib.boolToString withHomed}"
     "-Dlogind=${lib.boolToString withLogind}"
     "-Dlocaled=${lib.boolToString withLocaled}"
     "-Dhostnamed=${lib.boolToString withHostnamed}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13126,7 +13126,10 @@ in
 
   herqq = libsForQt514.callPackage ../development/libraries/herqq { };
 
-  hidapi = callPackage ../development/libraries/hidapi { };
+  hidapi = callPackage ../development/libraries/hidapi {
+    # TODO: remove once `udev` is `systemdMinimal` everywhere.
+    udev = systemdMinimal;
+  };
 
   highfive = callPackage ../development/libraries/highfive { };
 
@@ -13703,7 +13706,9 @@ in
 
   libfakekey = callPackage ../development/libraries/libfakekey { };
 
-  libfido2 = callPackage ../development/libraries/libfido2 { };
+  libfido2 = callPackage ../development/libraries/libfido2 {
+    udev = systemdMinimal;
+  };
 
   libfilezilla = callPackage ../development/libraries/libfilezilla {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
@@ -14394,6 +14399,8 @@ in
   libusb1 = callPackage ../development/libraries/libusb1 {
     inherit (darwin) libobjc;
     inherit (darwin.apple_sdk.frameworks) IOKit;
+    # TODO: remove once `udev` is `systemdMinimal` everywhere.
+    udev = systemdMinimal;
   };
 
   libusbmuxd = callPackage ../development/libraries/libusbmuxd { };
@@ -18834,6 +18841,8 @@ in
     glib = null;
     libgcrypt = null;
     lvm2 = null;
+    libfido2 = null;
+    p11-kit = null;
   };
 
 


### PR DESCRIPTION
###### Motivation for this change
Fixes #91243
Contains #98998 (merged)

###### Things done
Please also see https://github.com/NixOS/nixpkgs/pull/72802#issuecomment-695337602

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC: @Mic92 (changed your systemd patch)
