### PR TITLE
python3.pkgs.pysdl2: fix build

### DIFF
--- a/pkgs/development/python-modules/pysdl2/PySDL2-dll.patch
+++ b/pkgs/development/python-modules/pysdl2/PySDL2-dll.patch
@@ -1,119 +1,100 @@
-diff -ru PySDL2-0.9.6-old/sdl2/dll.py PySDL2-0.9.6/sdl2/dll.py
---- PySDL2-0.9.6-old/sdl2/dll.py	2018-03-08 10:18:37.583471745 +0100
-+++ PySDL2-0.9.6/sdl2/dll.py	2018-03-08 10:20:06.705517520 +0100
-@@ -45,29 +45,31 @@
+diff -ru PySDL2-0.9.7-old/sdl2/dll.py PySDL2-0.9.7/sdl2/dll.py
+--- PySDL2-0.9.7-old/sdl2/dll.py	2020-02-15 09:36:29.000000000 +0100
++++ PySDL2-0.9.7/sdl2/dll.py	2020-09-23 20:24:09.365497270 +0200
+@@ -94,15 +94,16 @@
      """Function wrapper around the different DLL functions. Do not use or
      instantiate this one directly from your user code.
      """
 -    def __init__(self, libinfo, libnames, path=None):
--        self._dll = None
++    def __init__(self, libinfo, libfile):
+         self._dll = None
+         self._libname = libinfo
+         self._version = None
 -        foundlibs = _findlib(libnames, path)
 -        dllmsg = "PYSDL2_DLL_PATH: %s" % (os.getenv("PYSDL2_DLL_PATH") or "unset")
 -        if len(foundlibs) == 0:
 -            raise RuntimeError("could not find any library for %s (%s)" %
 -                               (libinfo, dllmsg))
--        for libfile in foundlibs:
--            try:
--                self._dll = CDLL(libfile)
--                self._libfile = libfile
--                break
--            except Exception as exc:
--                # Could not load the DLL, move to the next, but inform the user
--                # about something weird going on - this may become noisy, but
--                # is better than confusing the users with the RuntimeError below
--                warnings.warn(repr(exc), DLLWarning)
--        if self._dll is None:
--            raise RuntimeError("found %s, but it's not usable for the library %s" %
--                               (foundlibs, libinfo))
++        #foundlibs = _findlib(libnames, path)
++        #dllmsg = "PYSDL2_DLL_PATH: %s" % (os.getenv("PYSDL2_DLL_PATH") or "unset")
++        #if len(foundlibs) == 0:
++        #    raise RuntimeError("could not find any library for %s (%s)" %
++        #                       (libinfo, dllmsg))
++        foundlibs = [ libfile ]
+         for libfile in foundlibs:
+             try:
+                 self._dll = CDLL(libfile)
+@@ -117,9 +118,9 @@
+         if self._dll is None:
+             raise RuntimeError("found %s, but it's not usable for the library %s" %
+                                (foundlibs, libinfo))
 -        if path is not None and sys.platform in ("win32",) and \
 -            path in self._libfile:
 -            os.environ["PATH"] = "%s;%s" % (path, os.environ["PATH"])
-+    def __init__(self, libfile):
-+        self._dll = CDLL(libfile)
-+        self._libfile = libfile
-+        # self._dll = None
-+        # foundlibs = _findlib(libnames, path)
-+        # dllmsg = "PYSDL2_DLL_PATH: %s" % (os.getenv("PYSDL2_DLL_PATH") or "unset")
-+        # if len(foundlibs) == 0:
-+        #     raise RuntimeError("could not find any library for %s (%s)" %
-+        #                        (libinfo, dllmsg))
-+        # for libfile in foundlibs:
-+        #     try:
-+        #         self._dll = CDLL(libfile)
-+        #         self._libfile = libfile
-+        #         break
-+        #     except Exception as exc:
-+        #         # Could not load the DLL, move to the next, but inform the user
-+        #         # about something weird going on - this may become noisy, but
-+        #         # is better than confusing the users with the RuntimeError below
-+        #         warnings.warn(repr(exc), DLLWarning)
-+        # if self._dll is None:
-+        #     raise RuntimeError("found %s, but it's not usable for the library %s" %
-+        #                        (foundlibs, libinfo))
-+        # if path is not None and sys.platform in ("win32",) and \
-+        #     path in self._libfile:
-+        #     os.environ["PATH"] = "%s;%s" % (path, os.environ["PATH"])
++        #if path is not None and sys.platform in ("win32",) and \
++        #    path in self._libfile:
++        #    os.environ["PATH"] = "%s;%s" % (path, os.environ["PATH"])
  
-     def bind_function(self, funcname, args=None, returns=None, optfunc=None):
+     def bind_function(self, funcname, args=None, returns=None, added=None):
          """Binds the passed argument and return value types to the specified
-@@ -110,7 +112,7 @@
+@@ -220,7 +221,7 @@
      return
  
  try:
 -    dll = DLL("SDL2", ["SDL2", "SDL2-2.0"], os.getenv("PYSDL2_DLL_PATH"))
-+    dll = DLL("SDL2")
++    dll = DLL("SDL2", "@sdl2@")
  except RuntimeError as exc:
      raise ImportError(exc)
  
-diff -ru PySDL2-0.9.6-old/sdl2/sdlgfx.py PySDL2-0.9.6/sdl2/sdlgfx.py
---- PySDL2-0.9.6-old/sdl2/sdlgfx.py	2018-03-08 10:18:37.585471769 +0100
-+++ PySDL2-0.9.6/sdl2/sdlgfx.py	2018-03-08 10:20:06.705517520 +0100
-@@ -34,8 +34,7 @@
+diff -ru PySDL2-0.9.7-old/sdl2/sdlgfx.py PySDL2-0.9.7/sdl2/sdlgfx.py
+--- PySDL2-0.9.7-old/sdl2/sdlgfx.py	2020-02-02 11:07:00.000000000 +0100
++++ PySDL2-0.9.7/sdl2/sdlgfx.py	2020-09-23 20:23:56.997419129 +0200
+@@ -39,8 +39,7 @@
             ]
  
  try:
 -    dll = DLL("SDL2_gfx", ["SDL2_gfx", "SDL2_gfx-1.0"],
 -              os.getenv("PYSDL2_DLL_PATH"))
-+    dll = DLL("SDL2_gfx")
++    dll = DLL("SDL2_gfx", "@sdl2_gfx@")
  except RuntimeError as exc:
      raise ImportError(exc)
  
-diff -ru PySDL2-0.9.6-old/sdl2/sdlimage.py PySDL2-0.9.6/sdl2/sdlimage.py
---- PySDL2-0.9.6-old/sdl2/sdlimage.py	2018-03-08 10:18:37.585471769 +0100
-+++ PySDL2-0.9.6/sdl2/sdlimage.py	2018-03-08 10:20:06.705517520 +0100
-@@ -26,8 +26,7 @@
+diff -ru PySDL2-0.9.7-old/sdl2/sdlimage.py PySDL2-0.9.7/sdl2/sdlimage.py
+--- PySDL2-0.9.7-old/sdl2/sdlimage.py	2020-02-02 11:07:00.000000000 +0100
++++ PySDL2-0.9.7/sdl2/sdlimage.py	2020-09-23 20:23:50.085375658 +0200
+@@ -27,8 +27,7 @@
             ]
  
  try:
 -    dll = DLL("SDL2_image", ["SDL2_image", "SDL2_image-2.0"],
 -              os.getenv("PYSDL2_DLL_PATH"))
-+    dll = DLL("SDL2_image")
++    dll = DLL("SDL2_image", "@sdl2_image@")
  except RuntimeError as exc:
      raise ImportError(exc)
  
-diff -ru PySDL2-0.9.6-old/sdl2/sdlmixer.py PySDL2-0.9.6/sdl2/sdlmixer.py
---- PySDL2-0.9.6-old/sdl2/sdlmixer.py	2018-03-08 10:18:37.585471769 +0100
-+++ PySDL2-0.9.6/sdl2/sdlmixer.py	2018-03-08 10:20:27.415758478 +0100
-@@ -50,8 +50,7 @@
+diff -ru PySDL2-0.9.7-old/sdl2/sdlmixer.py PySDL2-0.9.7/sdl2/sdlmixer.py
+--- PySDL2-0.9.7-old/sdl2/sdlmixer.py	2020-02-02 11:07:00.000000000 +0100
++++ PySDL2-0.9.7/sdl2/sdlmixer.py	2020-09-23 20:23:46.117350771 +0200
+@@ -53,8 +53,7 @@
            ]
  
  try:
 -    dll = DLL("SDL2_mixer", ["SDL2_mixer", "SDL2_mixer-2.0"],
 -              os.getenv("PYSDL2_DLL_PATH"))
-+    dll = DLL("SDL2_mixer")
++    dll = DLL("SDL2_mixer", "@sdl2_mixer@")
  except RuntimeError as exc:
      raise ImportError(exc)
  
-diff -ru PySDL2-0.9.6-old/sdl2/sdlttf.py PySDL2-0.9.6/sdl2/sdlttf.py
---- PySDL2-0.9.6-old/sdl2/sdlttf.py	2018-03-08 10:18:37.585471769 +0100
-+++ PySDL2-0.9.6/sdl2/sdlttf.py	2018-03-08 10:20:06.705517520 +0100
-@@ -38,8 +38,7 @@
+diff -ru PySDL2-0.9.7-old/sdl2/sdlttf.py PySDL2-0.9.7/sdl2/sdlttf.py
+--- PySDL2-0.9.7-old/sdl2/sdlttf.py	2020-02-02 11:07:00.000000000 +0100
++++ PySDL2-0.9.7/sdl2/sdlttf.py	2020-09-23 20:23:40.069312931 +0200
+@@ -39,8 +39,7 @@
            ]
  
  try:
 -    dll = DLL("SDL2_ttf", ["SDL2_ttf", "SDL2_ttf-2.0"],
 -              os.getenv("PYSDL2_DLL_PATH"))
-+    dll = DLL("SDL2_ttf")
++    dll = DLL("SDL2_ttf", "@sdl2_ttf@")
  except RuntimeError as exc:
      raise ImportError(exc)
  


### PR DESCRIPTION
Update patches after version bump.

I ran examples bundled with the library and they seem to run okay.

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
