### PR TITLE
sslyze: fix build

### DIFF
--- a/pkgs/development/python-modules/sslyze/default.nix
+++ b/pkgs/development/python-modules/sslyze/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   patchPhase = ''
     substituteInPlace setup.py \
-      --replace "cryptography>=2.6,<=2.9" "cryptography>=2.6,<=3"
+      --replace "cryptography>=2.6,<=2.9" "cryptography"
   '';
 
   checkInputs = [ pytest ];
@@ -39,6 +39,7 @@ buildPythonPackage rec {
       tests/plugins_tests/certificate_info/test_certificate_utils.py \
       -k "not (TestScanner and test_client_certificate_missing)"
   '';
+  pythonImportsCheck = [ "sslyze" ];
 
   propagatedBuildInputs = [ nassl cryptography typing-extensions faker ];
 


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Needed to further relax cryptography module version requirements
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
