### PR TITLE
maintainers/scripts/update.nix: Add support for auto-commiting changes

### DIFF
--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -475,11 +475,12 @@ passthru.updateScript = writeScript "update-zoom-us" ''
 <programlisting>
 passthru.updateScript = [ ../../update.sh pname "--requested-release=unstable" ];
 </programlisting>
-      Finally, the attribute can be an attribute set, listing the extra supported features among other things.
+      Finally, the attribute can be an attribute set, listing the attribute path and extra supported features in addition to command.
 <programlisting>
 passthru.updateScript = {
   command = [ ../../update.sh pname ];
-  supportedFeatures = [ "commit" ];
+  attrPath = pname;
+  supportedFeatures = [ … ];
 };
 </programlisting>
       <note>
@@ -488,9 +489,12 @@ passthru.updateScript = {
        </para>
       </note>
      </para>
+     <para>
+       <filename>maintainers/scripts/update.nix</filename> also supports automatically creating commits by running it with <literal>--argstr commit true</literal> but it requires either declaring the <variable>attrPath</variable>, or adding a <literal>commit</literal> to <variable>supportedFeatures</variable> and <link xlink:href="#var-passthru-updateScript-commit">modifying the script accordingly</link>.
+     </para>
      <variablelist>
       <title>Supported features</title>
-      <varlistentry>
+      <varlistentry xml:id="var-passthru-updateScript-commit">
        <term>
         <varname>commit</varname>
        </term>

--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -490,7 +490,7 @@ passthru.updateScript = {
       </note>
      </para>
      <para>
-       <filename>maintainers/scripts/update.nix</filename> also supports automatically creating commits by running it with <literal>--argstr commit true</literal> but it requires either declaring the <variable>attrPath</variable>, or adding a <literal>commit</literal> to <variable>supportedFeatures</variable> and <link xlink:href="#var-passthru-updateScript-commit">modifying the script accordingly</link>.
+       <filename>maintainers/scripts/update.nix</filename> also supports automatically creating commits by running it with <literal>--argstr commit true</literal>. Neither declaring the <variable>attrPath</variable> attribute, or adding a <literal>commit</literal> to <variable>supportedFeatures</variable> and <link xlink:href="#var-passthru-updateScript-commit">modifying the script accordingly</link> is required. It might be useful if you want to customize the values to something else than what <filename>update.nix</filename> detects.
      </para>
      <variablelist>
       <title>Supported features</title>

--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -475,6 +475,7 @@ passthru.updateScript = writeScript "update-zoom-us" ''
 <programlisting>
 passthru.updateScript = [ ../../update.sh pname "--requested-release=unstable" ];
 </programlisting>
+      The script will be run with <variable>UPDATE_NIX_ATTR_PATH</variable> environment variable set to the attribute path it is supposed to update.
       <note>
        <para>
         The script will be usually run from the root of the Nixpkgs repository but you should not rely on that. Also note that the update scripts will be run in parallel by default; you should avoid running <command>git commit</command> or any other commands that cannot handle that.

--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -518,6 +518,9 @@ passthru.updateScript = {
 ]
 </programlisting>
         </para>
+        <para>
+          When the returned array contains exactly one object (e.g. <literal>[{}]</literal>), keys can be omitted and will be determined automatically. Finding out <variable>newVersion</variable> requires <variable>attrPath</variable> to be present either in the update script output or passed to the <variable>passthru.updateScript</variable> attribute set.
+        </para>
        </listitem>
       </varlistentry>
      </variablelist>

--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -475,55 +475,12 @@ passthru.updateScript = writeScript "update-zoom-us" ''
 <programlisting>
 passthru.updateScript = [ ../../update.sh pname "--requested-release=unstable" ];
 </programlisting>
-      Finally, the attribute can be an attribute set, listing the attribute path and extra supported features in addition to command.
-<programlisting>
-passthru.updateScript = {
-  command = [ ../../update.sh pname ];
-  attrPath = pname;
-  supportedFeatures = [ … ];
-};
-</programlisting>
       <note>
        <para>
         The script will be usually run from the root of the Nixpkgs repository but you should not rely on that. Also note that the update scripts will be run in parallel by default; you should avoid running <command>git commit</command> or any other commands that cannot handle that.
        </para>
       </note>
      </para>
-     <para>
-       <filename>maintainers/scripts/update.nix</filename> also supports automatically creating commits by running it with <literal>--argstr commit true</literal>. Neither declaring the <variable>attrPath</variable> attribute, or adding a <literal>commit</literal> to <variable>supportedFeatures</variable> and <link xlink:href="#var-passthru-updateScript-commit">modifying the script accordingly</link> is required. It might be useful if you want to customize the values to something else than what <filename>update.nix</filename> detects.
-     </para>
-     <variablelist>
-      <title>Supported features</title>
-      <varlistentry xml:id="var-passthru-updateScript-commit">
-       <term>
-        <varname>commit</varname>
-       </term>
-       <listitem>
-        <para>
-         Whenever the update script exits with <literal>0</literal> return
-         status, it is expected to print a JSON list containing an object for
-         each updated attribute. Empty list can be returned when the script did
-         not update any files: for example, when the attribute is already the
-         latest version. The required keys can be seen below:
-<programlisting>
-[
-  {
-    "attrPath": "volume_key",
-    "oldVersion": "0.3.11",
-    "newVersion": "0.3.12",
-    "files": [
-      "/path/to/nixpkgs/pkgs/development/libraries/volume-key/default.nix"
-    ]
-  }
-]
-</programlisting>
-        </para>
-        <para>
-          When the returned array contains exactly one object (e.g. <literal>[{}]</literal>), keys can be omitted and will be determined automatically. Finding out <variable>newVersion</variable> requires <variable>attrPath</variable> to be present either in the update script output or passed to the <variable>passthru.updateScript</variable> attribute set.
-        </para>
-       </listitem>
-      </varlistentry>
-     </variablelist>
      <para>
       For information about how to run the updates, execute <command>nix-shell maintainers/scripts/update.nix</command>.
      </para>

--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -475,10 +475,48 @@ passthru.updateScript = writeScript "update-zoom-us" ''
 <programlisting>
 passthru.updateScript = [ ../../update.sh pname "--requested-release=unstable" ];
 </programlisting>
+      Finally, the attribute can be an attribute set, listing the extra supported features among other things.
+<programlisting>
+passthru.updateScript = {
+  command = [ ../../update.sh pname ];
+  supportedFeatures = [ "commit" ];
+};
+</programlisting>
+      <note>
+       <para>
+        The script will be usually run from the root of the Nixpkgs repository but you should not rely on that. Also note that the update scripts will be run in parallel by default; you should avoid running <command>git commit</command> or any other commands that cannot handle that.
+       </para>
+      </note>
      </para>
-     <para>
-      The script will be usually run from the root of the Nixpkgs repository but you should not rely on that. Also note that the update scripts will be run in parallel by default; you should avoid running <command>git commit</command> or any other commands that cannot handle that.
-     </para>
+     <variablelist>
+      <title>Supported features</title>
+      <varlistentry>
+       <term>
+        <varname>commit</varname>
+       </term>
+       <listitem>
+        <para>
+         Whenever the update script exits with <literal>0</literal> return
+         status, it is expected to print a JSON list containing an object for
+         each updated attribute. Empty list can be returned when the script did
+         not update any files: for example, when the attribute is already the
+         latest version. The required keys can be seen below:
+<programlisting>
+[
+  {
+    "attrPath": "volume_key",
+    "oldVersion": "0.3.11",
+    "newVersion": "0.3.12",
+    "files": [
+      "/path/to/nixpkgs/pkgs/development/libraries/volume-key/default.nix"
+    ]
+  }
+]
+</programlisting>
+        </para>
+       </listitem>
+      </varlistentry>
+     </variablelist>
      <para>
       For information about how to run the updates, execute <command>nix-shell maintainers/scripts/update.nix</command>.
      </para>

--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -143,8 +143,10 @@ let
   packageData = package: {
     name = package.name;
     pname = lib.getName package;
+    oldVersion = lib.getVersion package;
     updateScript = map builtins.toString (lib.toList (package.updateScript.command or package.updateScript));
     supportedFeatures = package.updateScript.supportedFeatures or [];
+    attrPath = package.updateScript.attrPath or null;
   };
 
   packagesJson = pkgs.writeText "packages.json" (builtins.toJSON (map packageData packages));

--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -32,9 +32,18 @@ let
       in
         [x] ++ nubOn f xs;
 
+  /* Recursively find all packages (derivations) in `pkgs` matching `cond` predicate.
+
+    Type: packagesWithPath :: AttrPath → (AttrPath → derivation → bool) → (AttrSet | List) → List<AttrSet{attrPath :: str; package :: derivation; }>
+          AttrPath :: [str]
+
+    The packages will be returned as a list of named pairs comprising of:
+      - attrPath: stringified attribute path (based on `rootPath`)
+      - package: corresponding derivation
+   */
   packagesWithPath = rootPath: cond: pkgs:
     let
-      packagesWithPathInner = relativePath: pathContent:
+      packagesWithPathInner = path: pathContent:
         let
           result = builtins.tryEval pathContent;
 
@@ -42,24 +51,28 @@ let
         in
           if result.success then
             let
-              pathContent = result.value;
+              evaluatedPathContent = result.value;
             in
-              if lib.isDerivation pathContent then
-                lib.optional (cond relativePath pathContent) { attrPath = lib.concatStringsSep "." relativePath; package = pathContent; }
-              else if lib.isAttrs pathContent then
+              if lib.isDerivation evaluatedPathContent then
+                lib.optional (cond path evaluatedPathContent) { attrPath = lib.concatStringsSep "." path; package = evaluatedPathContent; }
+              else if lib.isAttrs evaluatedPathContent then
                 # If user explicitly points to an attrSet or it is marked for recursion, we recur.
-                if relativePath == rootPath || pathContent.recurseForDerivations or false || pathContent.recurseForRelease or false then
-                  dedupResults (lib.mapAttrsToList (name: elem: packagesWithPathInner (relativePath ++ [name]) elem) pathContent)
+                if path == rootPath || evaluatedPathContent.recurseForDerivations or false || evaluatedPathContent.recurseForRelease or false then
+                  dedupResults (lib.mapAttrsToList (name: elem: packagesWithPathInner (path ++ [name]) elem) evaluatedPathContent)
                 else []
-              else if lib.isList pathContent then
-                dedupResults (lib.imap0 (i: elem: packagesWithPathInner (relativePath ++ [i]) elem) pathContent)
+              else if lib.isList evaluatedPathContent then
+                dedupResults (lib.imap0 (i: elem: packagesWithPathInner (path ++ [i]) elem) evaluatedPathContent)
               else []
           else [];
     in
       packagesWithPathInner rootPath pkgs;
 
+  /* Recursively find all packages (derivations) in `pkgs` matching `cond` predicate.
+   */
   packagesWith = packagesWithPath [];
 
+  /* Recursively find all packages in `pkgs` with updateScript by given maintainer.
+   */
   packagesWithUpdateScriptAndMaintainer = maintainer':
     let
       maintainer =
@@ -68,18 +81,19 @@ let
         else
           builtins.getAttr maintainer' lib.maintainers;
     in
-      packagesWith (relativePath: pkg: builtins.hasAttr "updateScript" pkg &&
-                                 (if builtins.hasAttr "maintainers" pkg.meta
-                                   then (if builtins.isList pkg.meta.maintainers
-                                           then builtins.elem maintainer pkg.meta.maintainers
-                                           else maintainer == pkg.meta.maintainers
-                                        )
-                                   else false
-                                 )
-                   )
-                   pkgs;
+      packagesWith (path: pkg: builtins.hasAttr "updateScript" pkg &&
+                         (if builtins.hasAttr "maintainers" pkg.meta
+                           then (if builtins.isList pkg.meta.maintainers
+                                   then builtins.elem maintainer pkg.meta.maintainers
+                                   else maintainer == pkg.meta.maintainers
+                                )
+                           else false
+                         )
+                   );
 
-  packagesWithUpdateScript = path:
+  /* Recursively find all packages under `path` in `pkgs` with updateScript.
+   */
+  packagesWithUpdateScript = path: pkgs:
     let
       prefix = lib.splitString "." path;
       pathContent = lib.attrByPath prefix null pkgs;
@@ -87,27 +101,31 @@ let
       if pathContent == null then
         builtins.throw "Attribute path `${path}` does not exists."
       else
-        packagesWithPath prefix (relativePath: pkg: builtins.hasAttr "updateScript" pkg)
+        packagesWithPath prefix (path: pkg: builtins.hasAttr "updateScript" pkg)
                        pathContent;
 
-  packageByName = name:
+  /* Find a package under `path` in `pkgs` and require that it has an updateScript.
+   */
+  packageByName = path: pkgs:
     let
-        package = lib.attrByPath (lib.splitString "." name) null pkgs;
+        package = lib.attrByPath (lib.splitString "." path) null pkgs;
     in
       if package == null then
-        builtins.throw "Package with an attribute name `${name}` does not exists."
+        builtins.throw "Package with an attribute name `${path}` does not exists."
       else if ! builtins.hasAttr "updateScript" package then
-        builtins.throw "Package with an attribute name `${name}` does not have a `passthru.updateScript` attribute defined."
+        builtins.throw "Package with an attribute name `${path}` does not have a `passthru.updateScript` attribute defined."
       else
-        { attrPath = name; inherit package; };
+        { attrPath = path; inherit package; };
 
+  /* List of packages matched based on the CLI arguments.
+   */
   packages =
     if package != null then
-      [ (packageByName package) ]
+      [ (packageByName package pkgs) ]
     else if maintainer != null then
-      packagesWithUpdateScriptAndMaintainer maintainer
+      packagesWithUpdateScriptAndMaintainer maintainer pkgs
     else if path != null then
-      packagesWithUpdateScript path
+      packagesWithUpdateScript path pkgs
     else
       builtins.throw "No arguments provided.\n\n${helpText}";
 
@@ -143,6 +161,8 @@ let
         --argstr commit true
   '';
 
+  /* Transform a matched package into an object for update.py.
+   */
   packageData = { package, attrPath }: {
     name = package.name;
     pname = lib.getName package;
@@ -152,6 +172,8 @@ let
     attrPath = package.updateScript.attrPath or attrPath;
   };
 
+  /* JSON file with data for update.py.
+   */
   packagesJson = pkgs.writeText "packages.json" (builtins.toJSON (map packageData packages));
 
   optionalArgs =

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -31,7 +31,7 @@ def main(max_workers, keep_going, packages):
         eprint()
         eprint('Running update for:')
 
-        with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
             for package in packages:
                 updates[executor.submit(run_update_script, package)] = package
 

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -117,9 +117,13 @@ async def merge_changes(merge_lock: asyncio.Lock, package: Dict, update_info: st
     if temp_dir is not None:
         worktree, branch = temp_dir
         changes = await check_changes(package, worktree, update_info)
-        await commit_changes(package['name'], merge_lock, worktree, branch, changes)
 
-    eprint(f" - {package['name']}: DONE.")
+        if len(changes) > 0:
+            await commit_changes(package['name'], merge_lock, worktree, branch, changes)
+        else:
+            eprint(f" - {package['name']}: DONE, no changes.")
+    else:
+        eprint(f" - {package['name']}: DONE.")
 
 async def updater(temp_dir: Optional[Tuple[str, str]], merge_lock: asyncio.Lock, packages_to_update: asyncio.Queue[Optional[Dict]], keep_going: bool, commit: bool):
     while True:

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -39,7 +39,7 @@ async def run_update_script(merge_lock: asyncio.Lock, temp_dir: Optional[Tuple[s
     eprint(f" - {package['name']}: UPDATING ...")
 
     try:
-        update_process = await check_subprocess(*package['updateScript'], stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=worktree)
+        update_process = await check_subprocess('env', f"UPDATE_NIX_ATTR_PATH={package['attrPath']}", *package['updateScript'], stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=worktree)
         update_info = await update_process.stdout.read()
 
         await merge_changes(merge_lock, package, update_info, temp_dir)

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -1,22 +1,45 @@
 import argparse
+import contextlib
 import concurrent.futures
 import json
 import os
 import subprocess
 import sys
+import tempfile
+import threading
 
 updates = {}
+
+thread_name_prefix='UpdateScriptThread'
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
-def run_update_script(package):
+def run_update_script(package, commit):
+    if commit and 'commit' in package['supportedFeatures']:
+        thread_name = threading.current_thread().name
+        worktree, _branch, lock = temp_dirs[thread_name]
+        lock.acquire()
+        package['thread'] = thread_name
+    else:
+        worktree = None
+
     eprint(f" - {package['name']}: UPDATING ...")
 
-    subprocess.run(package['updateScript'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+    return subprocess.run(package['updateScript'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, cwd=worktree)
 
+@contextlib.contextmanager
+def make_worktree():
+    with tempfile.TemporaryDirectory() as wt:
+        branch_name = f'update-{os.path.basename(wt)}'
+        target_directory = f'{wt}/nixpkgs'
 
-def main(max_workers, keep_going, packages):
+        subprocess.run(['git', 'worktree', 'add', '-b', branch_name, target_directory], check=True)
+        yield (target_directory, branch_name)
+        subprocess.run(['git', 'worktree', 'remove', target_directory], check=True)
+        subprocess.run(['git', 'branch', '-D', branch_name], check=True)
+
+def main(max_workers, keep_going, commit, packages):
     with open(sys.argv[1]) as f:
         packages = json.load(f)
 
@@ -31,15 +54,29 @@ def main(max_workers, keep_going, packages):
         eprint()
         eprint('Running update for:')
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        with contextlib.ExitStack() as stack, concurrent.futures.ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix=thread_name_prefix) as executor:
+            global temp_dirs
+
+            if commit:
+                temp_dirs = {f'{thread_name_prefix}_{str(i)}': (*stack.enter_context(make_worktree()), threading.Lock()) for i in range(max_workers)}
+
             for package in packages:
-                updates[executor.submit(run_update_script, package)] = package
+                updates[executor.submit(run_update_script, package, commit)] = package
 
             for future in concurrent.futures.as_completed(updates):
                 package = updates[future]
 
                 try:
-                    future.result()
+                    p = future.result()
+                    if commit and 'commit' in package['supportedFeatures']:
+                        thread_name = package['thread']
+                        worktree, branch, lock = temp_dirs[thread_name]
+                        changes = json.loads(p.stdout)
+                        for change in changes:
+                            subprocess.run(['git', 'add'] + change['files'], check=True, cwd=worktree)
+                            commit_message = '{attrPath}: {oldVersion} → {newVersion}'.format(**change)
+                            subprocess.run(['git', 'commit', '-m', commit_message], check=True, cwd=worktree)
+                            subprocess.run(['git', 'cherry-pick', branch], check=True)
                     eprint(f" - {package['name']}: DONE.")
                 except subprocess.CalledProcessError as e:
                     eprint(f" - {package['name']}: ERROR")
@@ -54,6 +91,9 @@ def main(max_workers, keep_going, packages):
 
                     if not keep_going:
                         sys.exit(1)
+                finally:
+                    if commit and 'commit' in package['supportedFeatures']:
+                        lock.release()
 
         eprint()
         eprint('Packages updated!')
@@ -65,13 +105,14 @@ def main(max_workers, keep_going, packages):
 parser = argparse.ArgumentParser(description='Update packages')
 parser.add_argument('--max-workers', '-j', dest='max_workers', type=int, help='Number of updates to run concurrently', nargs='?', default=4)
 parser.add_argument('--keep-going', '-k', dest='keep_going', action='store_true', help='Do not stop after first failure')
+parser.add_argument('--commit', '-c', dest='commit', action='store_true', help='Commit the changes')
 parser.add_argument('packages', help='JSON file containing the list of package names and their update scripts')
 
 if __name__ == '__main__':
     args = parser.parse_args()
 
     try:
-        main(args.max_workers, args.keep_going, args.packages)
+        main(args.max_workers, args.keep_going, args.commit, args.packages)
     except (KeyboardInterrupt, SystemExit) as e:
         for update in updates:
             update.cancel()

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -1,3 +1,4 @@
+from typing import Dict, Generator, Tuple, Union
 import argparse
 import contextlib
 import concurrent.futures
@@ -8,28 +9,30 @@ import sys
 import tempfile
 import threading
 
-updates = {}
+updates: Dict[concurrent.futures.Future, Dict] = {}
 
-thread_name_prefix='UpdateScriptThread'
+TempDirs = Dict[str, Tuple[str, str, threading.Lock]]
+
+thread_name_prefix = 'UpdateScriptThread'
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
-def run_update_script(package, commit):
+def run_update_script(package: Dict, commit: bool, temp_dirs: TempDirs) -> subprocess.CompletedProcess:
+    worktree: Union[None, str] = None
+
     if commit and 'commit' in package['supportedFeatures']:
         thread_name = threading.current_thread().name
         worktree, _branch, lock = temp_dirs[thread_name]
         lock.acquire()
         package['thread'] = thread_name
-    else:
-        worktree = None
 
     eprint(f" - {package['name']}: UPDATING ...")
 
     return subprocess.run(package['updateScript'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, cwd=worktree)
 
 @contextlib.contextmanager
-def make_worktree():
+def make_worktree() -> Generator[Tuple[str, str], None, None]:
     with tempfile.TemporaryDirectory() as wt:
         branch_name = f'update-{os.path.basename(wt)}'
         target_directory = f'{wt}/nixpkgs'
@@ -39,7 +42,40 @@ def make_worktree():
         subprocess.run(['git', 'worktree', 'remove', target_directory], check=True)
         subprocess.run(['git', 'branch', '-D', branch_name], check=True)
 
-def main(max_workers, keep_going, commit, packages):
+def commit_changes(worktree: str, branch: str, execution: subprocess.CompletedProcess) -> None:
+    changes = json.loads(execution.stdout)
+    for change in changes:
+        subprocess.run(['git', 'add'] + change['files'], check=True, cwd=worktree)
+        commit_message = '{attrPath}: {oldVersion} → {newVersion}'.format(**change)
+        subprocess.run(['git', 'commit', '-m', commit_message], check=True, cwd=worktree)
+        subprocess.run(['git', 'cherry-pick', branch], check=True)
+
+def merge_changes(package: Dict, future: concurrent.futures.Future, commit: bool, keep_going: bool, temp_dirs: TempDirs) -> None:
+    try:
+        execution = future.result()
+        if commit and 'commit' in package['supportedFeatures']:
+            thread_name = package['thread']
+            worktree, branch, lock = temp_dirs[thread_name]
+            commit_changes(worktree, branch, execution)
+        eprint(f" - {package['name']}: DONE.")
+    except subprocess.CalledProcessError as e:
+        eprint(f" - {package['name']}: ERROR")
+        eprint()
+        eprint(f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------")
+        eprint()
+        eprint(e.stdout.decode('utf-8'))
+        with open(f"{package['pname']}.log", 'wb') as logfile:
+            logfile.write(e.stdout)
+        eprint()
+        eprint(f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------")
+
+        if not keep_going:
+            sys.exit(1)
+    finally:
+        if commit and 'commit' in package['supportedFeatures']:
+            lock.release()
+
+def main(max_workers: int, keep_going: bool, commit: bool, packages: Dict) -> None:
     with open(sys.argv[1]) as f:
         packages = json.load(f)
 
@@ -55,45 +91,18 @@ def main(max_workers, keep_going, commit, packages):
         eprint('Running update for:')
 
         with contextlib.ExitStack() as stack, concurrent.futures.ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix=thread_name_prefix) as executor:
-            global temp_dirs
-
             if commit:
                 temp_dirs = {f'{thread_name_prefix}_{str(i)}': (*stack.enter_context(make_worktree()), threading.Lock()) for i in range(max_workers)}
+            else:
+                temp_dirs = {}
 
             for package in packages:
-                updates[executor.submit(run_update_script, package, commit)] = package
+                updates[executor.submit(run_update_script, package, commit, temp_dirs)] = package
 
             for future in concurrent.futures.as_completed(updates):
                 package = updates[future]
 
-                try:
-                    p = future.result()
-                    if commit and 'commit' in package['supportedFeatures']:
-                        thread_name = package['thread']
-                        worktree, branch, lock = temp_dirs[thread_name]
-                        changes = json.loads(p.stdout)
-                        for change in changes:
-                            subprocess.run(['git', 'add'] + change['files'], check=True, cwd=worktree)
-                            commit_message = '{attrPath}: {oldVersion} → {newVersion}'.format(**change)
-                            subprocess.run(['git', 'commit', '-m', commit_message], check=True, cwd=worktree)
-                            subprocess.run(['git', 'cherry-pick', branch], check=True)
-                    eprint(f" - {package['name']}: DONE.")
-                except subprocess.CalledProcessError as e:
-                    eprint(f" - {package['name']}: ERROR")
-                    eprint()
-                    eprint(f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------")
-                    eprint()
-                    eprint(e.stdout.decode('utf-8'))
-                    with open(f"{package['pname']}.log", 'wb') as f:
-                        f.write(e.stdout)
-                    eprint()
-                    eprint(f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------")
-
-                    if not keep_going:
-                        sys.exit(1)
-                finally:
-                    if commit and 'commit' in package['supportedFeatures']:
-                        lock.release()
+                merge_changes(package, future, commit, keep_going, temp_dirs)
 
         eprint()
         eprint('Packages updated!')

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -91,8 +91,8 @@ async def check_changes(package: Dict, worktree: str, update_info: str):
     if len(changes) == 1:
         # Dynamic data from updater take precedence over static data from passthru.updateScript.
         if 'attrPath' not in changes[0]:
-            if 'attrPath' in package:
-                changes[0]['attrPath'] = package['attrPath']
+            # update.nix is always passing attrPath
+            changes[0]['attrPath'] = package['attrPath']
 
         if 'oldVersion' not in changes[0]:
             # update.nix is always passing oldVersion

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -11,7 +11,7 @@ die() {
 usage() {
     echo "Usage: $scriptName <attr> <version> [<new-source-hash>] [<new-source-url>]"
     echo "                              [--version-key=<version-key>] [--system=<system>] [--file=<file-to-update>]"
-    echo "                              [--ignore-same-hash]"
+    echo "                              [--ignore-same-hash] [--print-changes]"
 }
 
 args=()
@@ -32,6 +32,9 @@ for arg in "$@"; do
         ;;
         --ignore-same-hash)
             ignoreSameHash="true"
+        ;;
+        --print-changes)
+            printChanges="true"
         ;;
         --help)
             usage
@@ -102,6 +105,9 @@ fi
 
 if [[ "$oldVersion" = "$newVersion" ]]; then
     echo "$scriptName: New version same as old version, nothing to do." >&2
+    if [ -n "$printChanges" ]; then
+        printf '[]\n'
+    fi
     exit 0
 fi
 
@@ -197,3 +203,7 @@ fi
 
 rm -f "$nixFile.bak"
 rm -f "$attr.fetchlog"
+
+if [ -n "$printChanges" ]; then
+    printf '[{"attrPath":"%s","oldVersion":"%s","newVersion":"%s","files":["%s"]}]\n' "$attr" "$oldVersion" "$newVersion" "$nixFile"
+fi

--- a/pkgs/desktops/gnome-3/update.nix
+++ b/pkgs/desktops/gnome-3/update.nix
@@ -23,7 +23,4 @@ let
     latest_tag=$(python "${./find-latest-version.py}" "$package_name" "$version_policy" "stable" ${upperBoundFlag})
     update-source-version "$attr_path" "$latest_tag"
   '';
-in {
-  command = [ updateScript packageName attrPath versionPolicy ];
-  inherit attrPath;
-}
+in [ updateScript packageName attrPath versionPolicy ]

--- a/pkgs/desktops/gnome-3/update.nix
+++ b/pkgs/desktops/gnome-3/update.nix
@@ -21,6 +21,9 @@ let
     version_policy="$3"
     PATH=${lib.makeBinPath [ common-updater-scripts python ]}
     latest_tag=$(python "${./find-latest-version.py}" "$package_name" "$version_policy" "stable" ${upperBoundFlag})
-    update-source-version "$attr_path" "$latest_tag"
+    update-source-version "$attr_path" "$latest_tag" --print-changes
   '';
-in [ updateScript packageName attrPath versionPolicy ]
+in {
+  command = [ updateScript packageName attrPath versionPolicy ];
+  supportedFeatures = [ "commit" ];
+}

--- a/pkgs/desktops/gnome-3/update.nix
+++ b/pkgs/desktops/gnome-3/update.nix
@@ -21,9 +21,9 @@ let
     version_policy="$3"
     PATH=${lib.makeBinPath [ common-updater-scripts python ]}
     latest_tag=$(python "${./find-latest-version.py}" "$package_name" "$version_policy" "stable" ${upperBoundFlag})
-    update-source-version "$attr_path" "$latest_tag" --print-changes
+    update-source-version "$attr_path" "$latest_tag"
   '';
 in {
   command = [ updateScript packageName attrPath versionPolicy ];
-  supportedFeatures = [ "commit" ];
+  inherit attrPath;
 }


### PR DESCRIPTION
This replaces https://github.com/NixOS/nixpkgs/pull/59372 and fixes #57609.

I decided to abandon the asyncio_pool library since it seemed buggy and just went with plain asyncio from standard library.
I also managed to figure out how to make the updates work without any changes to `passthru.updateScript` necessary.

## How to best use this to update GNOME
0. Choose a base commit, for example `channels/nixos-unstable` branch.
1. Run the tool `nix-shell maintainers/scripts/update.nix --argstr maintainer jtojnar --argstr commit true`
2. Read the changelogs spit out by `nix run github:jtojnar/what-changed between-commits <base-commit>` ([currently](https://github.com/jtojnar/what-changed/issues/2) only support projects hosted on GNOME servers)
3. Fix expressions that do not build and then use <code>git commit --fixup &lt;package&gt;<kbd>Tab</kbd></code> to create a fixup commit. (Or `--squash` to be able to add extra content to the old commit message.)
4. Push to `gnome-3.38` branch
5. Before merging, run `git rebase --interactive --autosquash <base-commit>`