### PR TITLE
[20.09] python3Packages.lightparam: fix source and deps

### DIFF
--- a/pkgs/development/python-modules/lightparam/default.nix
+++ b/pkgs/development/python-modules/lightparam/default.nix
@@ -1,23 +1,30 @@
-{ lib, pkgs, buildPythonPackage, fetchPypi, isPy3k
+{ lib, pkgs, buildPythonPackage, fetchFromGitHub, isPy3k
+, ipython
+, ipywidgets
 , numpy
+, pyqt5
 }:
 
 buildPythonPackage rec {
   pname = "lightparam";
   version = "0.4.6";
   disabled = !isPy3k;
-  format = "wheel";
 
-  src = fetchPypi {
-    inherit pname version;
-    format = "wheel";
-    python = "py3";
-    sha256 = "eca63016524208afb6a06db19baf659e698cce3ae2e57be15b37bc988549c631";
+  src = fetchFromGitHub {
+    owner = "portugueslab";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "13hlkvjcyz2lhvlfqyavja64jccbidshhs39sl4fibrn9iq34s3i";
   };
 
   propagatedBuildInputs = [
+    ipython
+    ipywidgets
     numpy
+    pyqt5
   ];
+
+  pythonImportsCheck = [ "lightparam" ];
 
   meta = {
     homepage = "https://github.com/portugueslab/lightparam";


### PR DESCRIPTION
###### Motivation for this change
backport #98065

(cherry picked from commit 2a35f664394b379e0c0785cc769ff6ccc791be39)

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
