### PR TITLE
libavif: init at 0.8.1

### DIFF
--- a/pkgs/development/libraries/libavif/default.nix
+++ b/pkgs/development/libraries/libavif/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, fetchFromGitHub
+, libaom
+, cmake
+, pkg-config
+, zlib
+, libpng
+, libjpeg
+, dav1d
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libavif";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "AOMediaCodec";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1fs222cn1d60pv5fjsr92axk5dival70b6yqw0wng5ikk9zsdkhy";
+  };
+
+  # reco: encode libaom slowest but best, decode dav1d fastest
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DAVIF_CODEC_AOM=ON"
+    "-DAVIF_CODEC_DAV1D=ON"
+    "-DAVIF_BUILD_APPS=ON"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libaom
+    zlib
+    libpng
+    libjpeg
+    dav1d
+  ];
+
+  meta = with stdenv.lib; {
+    description  = "C implementation of the AV1 Image File Format";
+    longDescription = ''
+      Libavif aims to be a friendly, portable C implementation of the
+      AV1 Image File Format. It is a work-in-progress, but can already
+      encode and decode all AOM supported YUV formats and bit depths
+      (with alpha). It also features an encoder and a decoder
+      (avifenc/avifdec).
+    '';
+    homepage    = "https://github.com/AOMediaCodec/libavif";
+    changelog   = "https://github.com/AOMediaCodec/libavif/blob/v${version}/CHANGELOG.md";
+    maintainers = with maintainers; [ mkg20001 ];
+    platforms   = platforms.all;
+    license     = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13207,6 +13207,8 @@ in
 
   libavc1394 = callPackage ../development/libraries/libavc1394 { };
 
+  libavif = callPackage ../development/libraries/libavif { };
+
   libb2 = callPackage ../development/libraries/libb2 { };
 
   libbap = callPackage ../development/libraries/libbap {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
