### PR TITLE
[20.09] python3Packages.graspy: 0.2.0 -> 0.3.0; unbreak tests

### DIFF
--- a/pkgs/development/python-modules/graspy/default.nix
+++ b/pkgs/development/python-modules/graspy/default.nix
@@ -2,8 +2,9 @@
 , buildPythonPackage
 , isPy27
 , fetchFromGitHub
-, pytest
+, pytestCheckHook
 , pytestcov
+, hyppo
 , matplotlib
 , networkx
 , numpy
@@ -14,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "graspy";
-  version = "0.2";
+  version = "0.3";
 
   disabled = isPy27;
 
@@ -22,10 +23,11 @@ buildPythonPackage rec {
     owner = "neurodata";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1ss7d71lwblimg7ri88ir9w59j0ri13wl75091hjf7q0mchqr6yd";
+    sha256 = "0lab76qiryxvwl6zrcikhnxil1xywl0wkkm2vzi4v9mdzpa7w29r";
   };
 
   propagatedBuildInputs = [
+    hyppo
     matplotlib
     networkx
     numpy
@@ -34,14 +36,9 @@ buildPythonPackage rec {
     seaborn
   ];
 
-  checkInputs = [ pytest pytestcov ];
-
-  checkPhase = ''
-    runHook preCheck
-    # `test_autogmm` takes too long; fixed in next release (graspy/pull/328)
-    pytest tests -k 'not test_autogmm'
-    runHook postCheck
-  '';
+  checkInputs = [ pytestCheckHook pytestcov ];
+  pytestFlagsArray = [ "tests" "--ignore=docs" ];
+  disabledTests = [ "gridplot_outputs" ];
 
   meta = with lib; {
     homepage = "https://graspy.neurodata.io";

--- a/pkgs/development/python-modules/hyppo/default.nix
+++ b/pkgs/development/python-modules/hyppo/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchFromGitHub
+, pytestCheckHook , pytestcov , numba
+, numpy
+, scikitlearn
+, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "hyppo";
+  version = "0.1.3";
+
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "neurodata";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0qdnb1l4hz4dgwhapz1fp9sb2vxxvr8h2ngsbvyf50h3kapcn19r";
+  };
+
+  propagatedBuildInputs = [
+    numba
+    numpy
+    scikitlearn
+    scipy
+  ];
+
+  checkInputs = [ pytestCheckHook pytestcov ];
+  pytestFlagsArray = [ "--ignore=docs" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/neurodata/hyppo";
+    description = "Indepedence testing in Python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2759,6 +2759,8 @@ in {
 
   hypothesis = if isPy3k then callPackage ../development/python-modules/hypothesis { } else self.hypothesis_4;
 
+  hyppo = callPackage ../development/python-modules/hyppo { };
+
   i3ipc = callPackage ../development/python-modules/i3ipc { };
 
   i3-py = callPackage ../development/python-modules/i3-py { };


### PR DESCRIPTION
python3Packages.hyppo: init at 0.1.3

(backport of #97695.)
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
