### PR TITLE
[20.09] docker_18_09: fix build

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -79,7 +79,7 @@ rec {
       sha256 = sha256;
     };
 
-    patches = [
+    patches = lib.optional (versionAtLeast version "19.03") [
       # Replace hard-coded cross-compiler with $CC
       (fetchpatch {
         url = https://github.com/docker/docker-ce/commit/2fdfb4404ab811cb00227a3de111437b829e55cf.patch;


### PR DESCRIPTION
Cherry-picked commit https://github.com/NixOS/nixpkgs/pull/98264/commits/ab967271d759f26fdf13d97c9a669bbeba9db27f from https://github.com/NixOS/nixpkgs/pull/98264
Disables patch for versions before bug was introduced

###### Motivation for this change

ZHF 20.09 https://github.com/NixOS/nixpkgs/issues/97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Ubuntu x86_64)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
