### PR TITLE
pythonPackages.mock-open: 1.3.1 -> 1.4.0

### DIFF
--- a/pkgs/development/python-modules/mock-open/default.nix
+++ b/pkgs/development/python-modules/mock-open/default.nix
@@ -1,16 +1,23 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, mock }:
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch, pythonOlder, mock }:
 
 buildPythonPackage rec {
   pname = "mock-open";
-  version = "1.3.2";
+  version = "1.4.0";
 
   # no tests in PyPI tarball
   src = fetchFromGitHub {
     owner = "nivbend";
     repo = pname;
     rev = "v${version}";
-    sha256 = "08m8mq7wws59zir06b7dzikb6gl6plq3kk2zqrmar6922zcbnk8m";
+    sha256 = "0qlz4y8jqxsnmqg03yp9f87rmnjrvmxm5qvm6n1218gm9k5dixbm";
   };
+
+  patches = lib.optional (pythonOlder "3.0")
+    (fetchpatch {
+      name = "ascii-only.patch";
+      url = "https://github.com/das-g/mock-open/commit/521ff260da127949fe4aceff1667cba223c5b07b.patch";
+      sha256 = "0ampbhk7kwkn0q5d2h9wrflkr8fji2bybmdck4qdzw1qkslfwwrn";
+    });
 
   propagatedBuildInputs = lib.optional (pythonOlder "3.3") mock;
 

--- a/pkgs/development/python-modules/mock-open/default.nix
+++ b/pkgs/development/python-modules/mock-open/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = "mock-open";
-  version = "1.3.1";
+  version = "1.3.2";
 
   # no tests in PyPI tarball
   src = fetchFromGitHub {
     owner = "nivbend";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0ikhrhlkl5c7qbigpsv44jw89ws1z7j06gzyg5dh1ki533ifbjm2";
+    sha256 = "08m8mq7wws59zir06b7dzikb6gl6plq3kk2zqrmar6922zcbnk8m";
   };
 
   propagatedBuildInputs = lib.optional (pythonOlder "3.3") mock;


### PR DESCRIPTION
###### Motivation for this change

- ZHF: #97479 (1.3.1 -> 1.3.2) e3aa742
  - mock-open 1.3.1 had [failing tests](https://hydra.nixos.org/build/126789024/nixlog/1) on Python &ge; 3.7 (nivbend/mock-open#7) that were fixed with 1.3.2 (nivbend/mock-open@2da5008fa55997d5fbf4aff5ec4679a548a587ec)
- upgrade to latest upstream release (1.3.2 -> 1.4.0) f19d0ea
  - requires patch for nivbend/mock-open#10 for Python 2.7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  - :x: `meta.maintainers` is **not** set
