### PR TITLE
[20.09] solfege: backport build fix

### DIFF
--- a/pkgs/misc/solfege/default.nix
+++ b/pkgs/misc/solfege/default.nix
@@ -15,6 +15,7 @@ buildPythonApplication rec {
   patches = [
     ./css.patch
     ./menubar.patch
+    ./texinfo.patch
     ./webbrowser.patch
   ];
 

--- a/pkgs/misc/solfege/texinfo.patch
+++ b/pkgs/misc/solfege/texinfo.patch
@@ -1,0 +1,20 @@
+Fix build with texinfo 6.7. Otherwise
+
+    makeinfo -I topdocs --no-split --no-headers --output AUTHORS topdocs/AUTHORS.texi
+
+fails with
+
+    utf8 "\xC1" does not map to Unicode at /nix/store/...-texinfo-6.7/share/texinfo/Texinfo/ParserNonXS.pm line 1796, <FH> line 38.
+
+--- a/topdocs/AUTHORS.texi
++++ b/topdocs/AUTHORS.texi
+@@ -1,2 +1,3 @@
+ \input texinfo
++@documentencoding ISO-8859-1
+ @setfilename AUTHORS.info
+--- a/topdocs/README.texi
++++ b/topdocs/README.texi
+@@ -1,2 +1,3 @@
+ \input texinfo
++@documentencoding ISO-8859-1
+ @setfilename README.info


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

This is simply a cherry-pick of 19f7f150a4ab1ff3a1583cc173ff10bcc224ffb2 which already fixed `solfege` in master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
