### PR TITLE
buildFHSUserEnvBubblewrap: use arrays for constructing argument list

### DIFF
--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -50,7 +50,7 @@ let
       "ssl/certs"
       "pki"
     ];
-  in concatStringsSep " \\\n  "
+  in concatStringsSep "\n  "
   (map (file: "--ro-bind-try /etc/${file} /etc/${file}") files);
 
   init = run: writeShellScriptBin "${name}-init" ''
@@ -59,21 +59,21 @@ let
   '';
 
   bwrapCmd = { initArgs ? "" }: ''
-    blacklist="/nix /dev /proc /etc"
-    ro_mounts=""
+    blacklist=(/nix /dev /proc /etc)
+    ro_mounts=()
     for i in ${env}/*; do
       path="/''${i##*/}"
       if [[ $path == '/etc' ]]; then
         continue
       fi
-      ro_mounts="$ro_mounts --ro-bind $i $path"
-      blacklist="$blacklist $path"
+      ro_mounts+=(--ro-bind "$i" "$path")
+      blacklist+=("$path")
     done
 
     if [[ -d ${env}/etc ]]; then
       for i in ${env}/etc/*; do
         path="/''${i##*/}"
-        ro_mounts="$ro_mounts --ro-bind $i /etc$path"
+        ro_mounts+=(--ro-bind "$i" "/etc$path")
       done
     fi
 
@@ -81,24 +81,27 @@ let
     # loop through all directories in the root
     for dir in /*; do
       # if it is a directory and it is not in the blacklist
-      if [[ -d "$dir" ]] && grep -v "$dir" <<< "$blacklist" >/dev/null; then
+      if [[ -d "$dir" ]] && [[ ! "''${blacklist[@]}" =~ "$dir" ]]; then
         # add it to the mount list
         auto_mounts+=(--bind "$dir" "$dir")
       fi
     done
 
-    exec ${bubblewrap}/bin/bwrap \
-      --dev-bind /dev /dev \
-      --proc /proc \
-      --chdir "$(pwd)" \
-      --unshare-all \
-      --share-net \
-      --die-with-parent \
-      --ro-bind /nix /nix \
-      ${etcBindFlags} \
-      $ro_mounts \
-      "''${auto_mounts[@]}" \
+    cmd=(
+      ${bubblewrap}/bin/bwrap
+      --dev-bind /dev /dev
+      --proc /proc
+      --chdir "$(pwd)"
+      --unshare-all
+      --share-net
+      --die-with-parent
+      --ro-bind /nix /nix
+      ${etcBindFlags}
+      "''${ro_mounts[@]}"
+      "''${auto_mounts[@]}"
       ${init runScript}/bin/${name}-init ${initArgs}
+    )
+    exec "''${cmd[@]}"
   '';
 
   bin = writeShellScriptBin name (bwrapCmd { initArgs = ''"$@"''; });


### PR DESCRIPTION
This is all in all a cleaner way of doing it and prevents issues with spaces in paths

Fixes #97234

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review pr 98325` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>35 packages built:</summary>
<br>- Sylk
<br>- android-studio
<br>- androidStudioPackages.beta
<br>- androidStudioPackages.canary
<br>- androidStudioPackages.dev
<br>- deltachat-electron
<br>- devdocs-desktop
<br>- electronplayer
<br>- irccloud
<br>- joplin-desktop
<br>- kodiPlugins.steam-launcher
<br>- ledger-live-desktop
<br>- lutris
<br>- lutris-free
<br>- marktext
<br>- minetime
<br>- molotov
<br>- mycrypto
<br>- notable
<br>- p3x-onenote
<br>- plexamp
<br>- runwayml
<br>- ssb-patchwork
<br>- standardnotes
<br>- station
<br>- steam
<br>- steam-run
<br>- steam-run-native
<br>- steamcmd
<br>- timeular
<br>- tusk
<br>- unityhub
<br>- wootility
<br>- zettlr
<br>- zulip
</details>
