### PR TITLE
[20.09] cawbird: 1.1.0 -> 1.2.1

### DIFF
--- a/pkgs/applications/networking/cawbird/default.nix
+++ b/pkgs/applications/networking/cawbird/default.nix
@@ -16,18 +16,19 @@
 , wrapGAppsHook
 , gobject-introspection
 , glib-networking
+, librest
 , python3
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.0";
+  version = "1.2.1";
   pname = "cawbird";
 
   src = fetchFromGitHub {
     owner = "IBBoard";
     repo = "cawbird";
     rev = "v${version}";
-    sha256 = "0zghryx5y47ff8kxa65lvgmy1cnhvhazxml7r1lxixxj3d88wh7p";
+    sha256 = "11s8x48syy5wjj23ab4bn5jxhi7l5sx7aw6q2ggk99v042hxh3h2";
   };
 
   nativeBuildInputs = [
@@ -50,6 +51,7 @@ stdenv.mkDerivation rec {
     dconf
     gspell
     glib-networking
+    librest
   ] ++ (with gst_all_1; [
     gstreamer
     gst-plugins-base


### PR DESCRIPTION
- regular version bump to 1.2.0, then bugfix release on top
- changes: see
    - https://github.com/IBBoard/cawbird/releases/tag/v1.2.0
    - https://github.com/IBBoard/cawbird/releases/tag/v1.2.1

backport of #97230

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
