### PR TITLE
qcad: replace qt argument

### DIFF
--- a/pkgs/applications/misc/qcad/default.nix
+++ b/pkgs/applications/misc/qcad/default.nix
@@ -1,12 +1,16 @@
 { boost
 , fetchFromGitHub
+, libGLU
 , mkDerivationWith
 , muparser
 , pkgconfig
+, qtbase
 , qmake
-, qt5
+, qtscript
+, qtsvg
+, qtxmlpatterns
+, qttools
 , stdenv
-, libGLU
 }:
 
 mkDerivationWith stdenv.mkDerivation rec {
@@ -25,11 +29,11 @@ mkDerivationWith stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    if ! [ -d src/3rdparty/qt-labs-qtscriptgenerator-${qt5.qtbase.version} ]; then
-      mkdir src/3rdparty/qt-labs-qtscriptgenerator-${qt5.qtbase.version}
+    if ! [ -d src/3rdparty/qt-labs-qtscriptgenerator-${qtbase.version} ]; then
+      mkdir src/3rdparty/qt-labs-qtscriptgenerator-${qtbase.version}
       cp \
         src/3rdparty/qt-labs-qtscriptgenerator-5.14.0/qt-labs-qtscriptgenerator-5.14.0.pro \
-        src/3rdparty/qt-labs-qtscriptgenerator-${qt5.qtbase.version}/qt-labs-qtscriptgenerator-${qt5.qtbase.version}.pro
+        src/3rdparty/qt-labs-qtscriptgenerator-${qtbase.version}/qt-labs-qtscriptgenerator-${qtbase.version}.pro
     fi
  '';
 
@@ -63,7 +67,7 @@ mkDerivationWith stdenv.mkDerivation rec {
 
     # workaround to fix the library browser:
     rm -r $out/lib/plugins/sqldrivers
-    ln -s -t $out/lib/plugins ${qt5.qtbase}/${qt5.qtbase.qtPluginPrefix}/sqldrivers
+    ln -s -t $out/lib/plugins ${qtbase}/${qtbase.qtPluginPrefix}/sqldrivers
 
     install -Dm644 scripts/qcad_icon.svg $out/share/icons/hicolor/scalable/apps/qcad.svg
 
@@ -74,16 +78,16 @@ mkDerivationWith stdenv.mkDerivation rec {
     boost
     muparser
     libGLU
-    qt5.qtbase
-    qt5.qtscript
-    qt5.qtsvg
-    qt5.qtxmlpatterns
+    qtbase
+    qtscript
+    qtsvg
+    qtxmlpatterns
   ];
 
   nativeBuildInputs = [
     pkgconfig
-    qt5.qmake
-    qt5.qttools
+    qmake
+    qttools
   ];
 
   enableParallelBuilding = true;
@@ -93,6 +97,6 @@ mkDerivationWith stdenv.mkDerivation rec {
     homepage = "https://qcad.org";
     license = licenses.gpl3;
     maintainers = with maintainers; [ yvesf ];
-    platforms = qt5.qtbase.meta.platforms;
+    platforms = qtbase.meta.platforms;
   };
 }


### PR DESCRIPTION
change qcad to take the individual packages instead of qt5 as argument

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
