### PR TITLE
python38Packages.shouldbe: disable for python3.8

### DIFF
--- a/pkgs/development/python-modules/shouldbe/default.nix
+++ b/pkgs/development/python-modules/shouldbe/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , buildPythonPackage
+, pythonAtLeast
 , fetchPypi
 , nose
 , forbiddenfruit
@@ -8,6 +9,8 @@
 buildPythonPackage rec {
   version = "0.1.2";
   pname = "shouldbe";
+  # incompatible, https://github.com/DirectXMan12/should_be/issues/4
+  disabled = pythonAtLeast "3.8";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/DirectXMan12/should_be/issues/4

upstream hasn't seen any activity in more than a year. May want to consider removing the package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
