### PR TITLE
nextcloud: 19.0.1 -> 19.0.3, deprecate/remove older versions

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -834,6 +834,31 @@ CREATE ROLE postgres LOGIN SUPERUSER;
      functionally redundent.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The package <package>nextcloud17</package> has been removed and <package>nextcloud18</package> was marked as insecure
+     since both of them will <link xlink:href="https://docs.nextcloud.com/server/19/admin_manual/release_schedule.html">
+     will be EOL (end of life) within the lifetime of 20.09</link>.
+    </para>
+    <para>
+     It's necessary to upgrade to <package>nextcloud19</package>:
+     <itemizedlist>
+      <listitem>
+       <para>
+        From <package>nextcloud17</package>, you have to upgrade to <package>nextcloud18</package> first as
+        Nextcloud doesn't allow going multiple major revisions forward in a single upgrade. This is possible
+        by setting <xref linkend="opt-services.nextcloud.package" /> to <package>nextcloud18</package>.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        From <package>nextcloud18</package>, it's possible to directly upgrade to <package>nextcloud19</package>
+        by setting <xref linkend="opt-services.nextcloud.package" /> to <package>nextcloud19</package>.
+       </para>
+      </listitem>
+     </itemizedlist>
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -85,7 +85,7 @@ in {
     package = mkOption {
       type = types.package;
       description = "Which package to use for the Nextcloud instance.";
-      relatedPackages = [ "nextcloud17" "nextcloud18" "nextcloud19" ];
+      relatedPackages = [ "nextcloud18" "nextcloud19" ];
     };
 
     maxUploadSize = mkOption {
@@ -354,7 +354,7 @@ in {
           recommended to upgrade to nextcloud19 after that.
         '')
         ++ (optional (versionOlder cfg.package.version "19") ''
-          A legacy Nextcloud install (from before NixOS 20.09/unstable) may be installed.
+          A legacy Nextcloud install (from before NixOS 20.09) may be installed.
 
           If/After nextcloud18 is installed successfully, you can safely upgrade to
           nextcloud19. If not, please upgrade to nextcloud18 first since Nextcloud doesn't

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -38,7 +38,7 @@ in {
   };
 
   nextcloud19 = generic {
-    version = "19.0.1";
-    sha256 = "0bavwvjjgx62i150wqh4gqavjva3mnhx6k3im79ib6ck1ph13wsf";
+    version = "19.0.3";
+    sha256 = "0sc9cnsdh8kj60h7i3knh40ngdz1w1wmdqw2v2axfkmax22kjl7w";
   };
 }

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -33,8 +33,8 @@ in {
   };
 
   nextcloud18 = generic {
-    version = "18.0.7";
-    sha256 = "0pka87ccrds17n6n5w5a80mc1s5yrf8d4mf6wsfaypwjbm3wfb2b";
+    version = "18.0.9";
+    sha256 = "0rigg5pv2vnxgmjznlvxfc41s00raxa8jhib5vsznhj55qn99jm1";
   };
 
   nextcloud19 = generic {

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -27,14 +27,22 @@ let
     };
   };
 in {
-  nextcloud17 = generic {
-    version = "17.0.6";
-    sha256 = "0qq7lkgzsn1zakfym5bjqzpcisxmgfcdd927ddqlhddy3zvgxrxx";
-  };
+  nextcloud17 = throw ''
+    Nextcloud v17 has been removed from `nixpkgs` as the support for it will be dropped
+    by upstream within the lifetime of NixOS 20.09[1]. Please upgrade to Nextcloud v18 by
+    declaring
+
+        services.nextcloud.package = pkgs.nextcloud18;
+
+    in your NixOS config.
+
+    [1] https://docs.nextcloud.com/server/18/admin_manual/release_schedule.html
+  '';
 
   nextcloud18 = generic {
     version = "18.0.9";
     sha256 = "0rigg5pv2vnxgmjznlvxfc41s00raxa8jhib5vsznhj55qn99jm1";
+    insecure = true;
   };
 
   nextcloud19 = generic {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #97751. 

ChangeLogs:

* https://nextcloud.com/changelog/#19-0-3
* https://nextcloud.com/changelog/#18-0-9

Also removes `nextcloud17` and deprecates `nextcloud18` since both will be EOLed within the lifetime of 20.09[1]. While `nextcloud17` can be removed entirely now, `nextcloud18` must stay (and marked as insecure) to make sure that users from Nextcloud17 can seamlessly upgrade to `nextcloud19` on 20.09.

[1] https://docs.nextcloud.com/server/19/admin_manual/release_schedule.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
