### PR TITLE
pythonPackages.mohawk: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/mohawk/default.nix
+++ b/pkgs/development/python-modules/mohawk/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, python, mock, nose, pytest, six }:
+
+with lib;
+buildPythonPackage rec {
+  pname = "mohawk";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08wppsv65yd0gdxy5zwq37yp6jmxakfz4a2yx5wwq2d222my786j";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ mock nose pytest ];
+
+  checkPhase = ''
+    pytest mohawk/tests.py
+  '';
+
+  meta = {
+    description = "Python library for Hawk HTTP authorization.";
+    homepage = "https://github.com/kumar303/mohawk";
+    license = licenses.mpl20;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3706,6 +3706,8 @@ in {
 
   modestmaps = callPackage ../development/python-modules/modestmaps { };
 
+  mohawk = callPackage ../development/python-modules/mohawk { };
+
   moinmoin = callPackage ../development/python-modules/moinmoin
     { }; # Needed here because moinmoin is loaded as a Python library.
 


### PR DESCRIPTION
###### Motivation for this change

This is actually part of getting the `alerta` Python package fixed. My understanding from the [20.09 Hydra failure](https://hydra.nixos.org/build/126663768/nixlog/1) is that Alerta is failing because `requests-hawk` is not packaged. And `requests-hawk` needs `mohawk`. So if this is correct my plan was to follow this PR up with `requests-hawk`, then seeing if that fixes Alerta.

This seems to pass all tests with all Python versions, however I am not sure how to actually try importing a Python package from `result`, so I haven't tested this even imports. I guess I could temporarily put a command into the check phase that just tries to import it, but I was hoping someone had some guidance on the best practice for this.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).