### PR TITLE
openblas: enable multiple outputs

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -100,6 +100,9 @@ in
 stdenv.mkDerivation rec {
   pname = "openblas";
   version = "0.3.10";
+
+  outputs = [ "out" "dev" ];
+
   src = fetchFromGitHub {
     owner = "xianyi";
     repo = "OpenBLAS";


### PR DESCRIPTION
###### Motivation for this change
noticed cmake and pkgconfig files were being propagated when reviewing https://github.com/NixOS/nixpkgs/pull/98335

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

modest closure decrease:
```
$ nix path-info -Sh ./result
/nix/store/9ygjz2yfbfizgs4i7qrz1ync14mfh7bf-openblas-0.3.10	  68.0M
# with changes
$ nix path-info -Sh ./result
/nix/store/v8slfaawv5bg40zf44ab9aqi54sr88p6-openblas-0.3.10	  66.6M
```