### PR TITLE
[20.09] lldb_5, lldb_6: add patch for >=python-3.7

### DIFF
--- a/pkgs/development/compilers/llvm/5/lldb.nix
+++ b/pkgs/development/compilers/llvm/5/lldb.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetch
+, fetchpatch
 , cmake
 , zlib
 , ncurses
@@ -19,6 +20,15 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetch "lldb" "05j2a63yzln43852nng8a7y47spzlyr1cvdmgmbxgd29c8r0bfkq";
+
+  patches = [
+    # Fix PythonString::GetString for >=python-3.7
+    (fetchpatch {
+      url = "https://github.com/llvm/llvm-project/commit/5457b426f5e15a29c0acc8af1a476132f8be2a36.patch";
+      sha256 = "1zbx4m0m8kbg0wq6740jcw151vb2pb1p25p401wiq8diqqagkjps";
+      stripLen = 1;
+    })
+  ];
 
   postPatch = ''
     # Fix up various paths that assume llvm and clang are installed in the same place

--- a/pkgs/development/compilers/llvm/6/lldb.nix
+++ b/pkgs/development/compilers/llvm/6/lldb.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetch
+, fetchpatch
 , cmake
 , zlib
 , ncurses
@@ -19,6 +20,15 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetch "lldb" "05178zkyh84x32n91md6wm22lkzzrrfwa5cpmgzn0yrg3y2771bb";
+
+  patches = [
+    # Fix PythonString::GetString for >=python-3.7
+    (fetchpatch {
+      url = "https://github.com/llvm/llvm-project/commit/5457b426f5e15a29c0acc8af1a476132f8be2a36.patch";
+      sha256 = "1zbx4m0m8kbg0wq6740jcw151vb2pb1p25p401wiq8diqqagkjps";
+      stripLen = 1;
+    })
+  ];
 
   postPatch = ''
     # Fix up various paths that assume llvm and clang are installed in the same place


### PR DESCRIPTION
(cherry picked from commit 9f11f7ae4ae426b52ed9287246db5e2acc99553c)

Backport of #97715
ZHF: #97479
cc @NixOS/nixos-release-managers


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested that Python plugin works, as per lldb doc:

```
script help(lldb)
```