### PR TITLE
gnomeExtensions.appindicator: 33 -> 34

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/appindicator/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/appindicator/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-appindicator";
-  version = "33";
+  version = "34";
 
   src = fetchFromGitHub {
     owner = "Ubuntu";
     repo = "gnome-shell-extension-appindicator";
     rev = "v${version}";
-    sha256 = "0qm77s080nbf4gqnfzpwp8a7jf7lliz6fxbsd3lasvrr11pgsk87";
+    sha256 = "0p9sk8cv2z242d5783gx2m4l1x9vg5fy1a7yr1wcfshvajlrj23m";
   };
 
   # This package has a Makefile, but it's used for building a zip for


### PR DESCRIPTION
###### Motivation for this change

`gnomeExtensions.appindicator` has a new release. The [full changelog](https://github.com/ubuntu/gnome-shell-extension-appindicator/compare/v33...v34) notably includes a performance and bug [fix](https://github.com/ubuntu/gnome-shell-extension-appindicator/pull/231).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
