### PR TITLE
emacsPackages.libgit: Fix build

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -196,6 +196,26 @@ let
 
         ivy-rtags = fix-rtags super.ivy-rtags;
 
+        libgit = super.libgit.overrideAttrs(attrs: {
+          nativeBuildInputs = (attrs.nativeBuildInputs or []) ++ [ pkgs.cmake ];
+          buildInputs = attrs.buildInputs ++ [ pkgs.libgit2 ];
+          dontUseCmakeBuildDir = true;
+          postPatch = ''
+            sed -i s/'add_subdirectory(libgit2)'// CMakeLists.txt
+          '';
+          postBuild = ''
+            pushd working/libgit
+            make
+            popd
+          '';
+          postInstall = ''
+            outd=$(echo $out/share/emacs/site-lisp/elpa/libgit-**)
+            mkdir $outd/build
+            install -m444 -t $outd/build ./source/src/libegit2.so
+            rm -r $outd/src $outd/Makefile $outd/CMakeLists.txt
+          '';
+        });
+
         magit = super.magit.overrideAttrs (attrs: {
           # searches for Git at build time
           nativeBuildInputs =


### PR DESCRIPTION
###### Motivation for this change
Closes #97317

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
