### PR TITLE
gitAndTools.git-imerge: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -112,7 +112,7 @@ let
 
   git-ignore = callPackage ./git-ignore { };
 
-  git-imerge = callPackage ./git-imerge { };
+  git-imerge = python3Packages.callPackage ./git-imerge { };
 
   git-interactive-rebase-tool = callPackage ./git-interactive-rebase-tool {
     inherit (darwin.apple_sdk.frameworks) Security;

--- a/pkgs/applications/version-management/git-and-tools/git-imerge/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-imerge/default.nix
@@ -1,25 +1,24 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ lib, buildPythonApplication, fetchPypi, installShellFiles }:
 
-stdenv.mkDerivation rec {
+buildPythonApplication rec {
   pname = "git-imerge";
-  version = "1.1.0";
+  version = "1.2.0";
 
-  src = fetchFromGitHub {
-    owner = "mhagger";
-    repo = "git-imerge";
-    rev = "v${version}";
-    sha256 = "0vi1w3f0yk4gqhxj2hzqafqq28rihyhyfnp8x7xzib96j2si14a4";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "df5818f40164b916eb089a004a47e5b8febae2b4471a827e3aaa4ebec3831a3f";
   };
 
-  buildInputs = [ pythonPackages.python pythonPackages.wrapPython ];
+  nativeBuildInputs = [ installShellFiles ];
 
-  makeFlags = [ "PREFIX=" "DESTDIR=$(out)" ] ; 
- 
-  meta = with stdenv.lib; {
+  postInstall = ''
+    installShellCompletion --bash completions/git-imerge
+  '';
+
+  meta = with lib; {
     homepage = "https://github.com/mhagger/git-imerge";
     description = "Perform a merge between two branches incrementally";
-    license = licenses.gpl2;
-    platforms = platforms.all;
+    license = licenses.gpl2Plus;
     maintainers = [ maintainers.spwhitt ];
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/mhagger/git-imerge/releases/tag/v1.2.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
