### PR TITLE
spotify: support --force-device-scale-factor for high-DPI displays

### DIFF
--- a/pkgs/applications/audio/spotify/default.nix
+++ b/pkgs/applications/audio/spotify/default.nix
@@ -64,7 +64,7 @@ let
 in
 
 stdenv.mkDerivation {
-  pname = "spotify";
+  pname = "spotify-unwrapped";
   inherit version;
 
   # fetch from snapcraft instead of the debian repository most repos fetch from.

--- a/pkgs/applications/audio/spotify/wrapper.nix
+++ b/pkgs/applications/audio/spotify/wrapper.nix
@@ -1,0 +1,31 @@
+{ symlinkJoin
+, lib
+, spotify-unwrapped
+, makeWrapper
+
+  # High-DPI support: Spotify's --force-device-scale-factor argument; not added
+  # if `null`, otherwise, should be a number.
+, deviceScaleFactor ? null
+}:
+
+symlinkJoin {
+  name = "spotify-${spotify-unwrapped.version}";
+
+  paths = [ spotify-unwrapped.out ];
+
+  nativeBuildInputs = [ makeWrapper ];
+  preferLocalBuild = true;
+  passthru.unwrapped = spotify-unwrapped;
+  postBuild = ''
+    wrapProgram $out/bin/spotify \
+        ${lib.optionalString (deviceScaleFactor != null) ''
+            --add-flags ${lib.escapeShellArg "--force-device-scale-factor=${
+                builtins.toString deviceScaleFactor
+              }"}
+        ''}
+  '';
+
+  meta = spotify-unwrapped.meta // {
+    priority = (spotify-unwrapped.meta.priority or 0) - 1;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23326,13 +23326,15 @@ in
 
   spek = callPackage ../applications/audio/spek { };
 
-  spotify = callPackage ../applications/audio/spotify {
+  spotify-unwrapped = callPackage ../applications/audio/spotify {
     libgcrypt = libgcrypt_1_5;
     libpng = libpng12;
     curl = curl.override {
       sslSupport = false; gnutlsSupport = true;
     };
   };
+
+  spotify = callPackage ../applications/audio/spotify/wrapper.nix { };
 
   libspotify = callPackage ../development/libraries/libspotify (config.libspotify or {});
 


### PR DESCRIPTION
Add a `deviceScaleFactor` argument to set the `--force-device-scale-factor` in the wrapper. If unset, nothing is added.

This allows e.g.

```nix
spotify.override { deviceScaleFactor = 1.66; }
```

for use with high-DPI displays.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Spotify's text is tiny by default on my monitor and I didn't know there was a way to fix it. I also want the `--force-device-scale-factor` argument to be the same every time i launch it, so adding an argument to the derivation seems like the best solution.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~ (N/A)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
