### PR TITLE
[20.09] vmmlib: fix build

### DIFF
--- a/pkgs/development/libraries/vmmlib/default.nix
+++ b/pkgs/development/libraries/vmmlib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, blas
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, lapack
 , Accelerate, CoreGraphics, CoreVideo
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ pkgconfig cmake ];
-  buildInputs = [ boost blas ]
+  buildInputs = [ boost lapack ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ Accelerate CoreGraphics CoreVideo ];
 
   enableParallelBuilding = true;
@@ -30,11 +30,11 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A vector and matrix math library implemented using C++ templates";
 
-    longDescription = ''vmmlib is a vector and matrix math library implemented 
-            using C++ templates. Its basic functionality includes a vector 
-            and a matrix class, with additional functionality for the 
+    longDescription = ''vmmlib is a vector and matrix math library implemented
+            using C++ templates. Its basic functionality includes a vector
+            and a matrix class, with additional functionality for the
             often-used 3d and 4d vectors and 3x3 and 4x4 matrices.
-            More advanced functionality include solvers, frustum 
+            More advanced functionality include solvers, frustum
             computations and frustum culling classes, and spatial data structures'';
 
     license     = licenses.bsd2;
@@ -43,4 +43,3 @@ stdenv.mkDerivation rec {
     platforms   = platforms.all;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of #98335

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
