### PR TITLE
[20.09] svgbob: fix build

### DIFF
--- a/pkgs/tools/graphics/svgbob/default.nix
+++ b/pkgs/tools/graphics/svgbob/default.nix
@@ -10,8 +10,11 @@ rustPlatform.buildRustPackage rec {
     rev = "0febc4377134a2ea3b3cd43ebdf5ea688a0e7432";
     sha256 = "1n0w5b3fjgbczy1iw52172x1p3y1bvw1qpz77fkaxkhrkgfd7vwr";
   };
-
   sourceRoot = "source/svgbob_cli";
+  postPatch = ''
+    substituteInPlace ../svgbob/src/lib.rs \
+      --replace '#![deny(warnings)]' ""
+  '';
 
   cargoSha256 = "1y9jsnxmz51zychmmzp6mi29pb5ks2qww7lk5bshkhp56v51sm8d";
 


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of #98324

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
