### PR TITLE
liboping: fix build on Darwin

### DIFF
--- a/pkgs/development/libraries/liboping/default.nix
+++ b/pkgs/development/libraries/liboping/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses ? null, perl ? null }:
+{ stdenv, fetchurl, ncurses ? null, perl ? null, lib }:
 
 stdenv.mkDerivation rec {
   name = "liboping-1.10.0";
@@ -8,7 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1n2wkmvw6n80ybdwkjq8ka43z2x8mvxq49byv61b52iyz69slf7b";
   };
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=format-truncation";
+  NIX_CFLAGS_COMPILE = lib.optionalString
+    stdenv.cc.isGNU "-Wno-error=format-truncation";
 
   buildInputs = [ ncurses perl ];
 


### PR DESCRIPTION
#### Motivation for this change
ZHF 20.09 https://github.com/NixOS/nixpkgs/issues/97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
