### PR TITLE
f3: clean-ups and compile on darwin

### DIFF
--- a/pkgs/tools/filesystems/f3/default.nix
+++ b/pkgs/tools/filesystems/f3/default.nix
@@ -35,7 +35,10 @@ stdenv.mkDerivation rec {
   ++ lib.optional stdenv.isLinux "extra"; # f3brew, f3fix, f3probe
 
   installFlags = [
-    "PREFIX=$(out)"
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  installTargets = [
     "install"
   ]
   ++ lib.optional stdenv.isLinux "install-extra";
@@ -48,7 +51,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Fight Flash Fraud";
     homepage = "http://oss.digirati.com.br/f3/";
-    license = licenses.gpl2;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ makefu ];
   };
 }

--- a/pkgs/tools/filesystems/f3/default.nix
+++ b/pkgs/tools/filesystems/f3/default.nix
@@ -1,12 +1,10 @@
-{ stdenv, fetchFromGitHub
-, parted, udev
+{ stdenv, lib, fetchFromGitHub
+, parted, systemd ? null
 }:
 
 stdenv.mkDerivation rec {
   pname = "f3";
   version = "7.2";
-
-  enableParallelBuilding = true;
 
   src = fetchFromGitHub {
     owner = "AltraMayor";
@@ -15,24 +13,42 @@ stdenv.mkDerivation rec {
     sha256 = "1iwdg0r4wkgc8rynmw1qcqz62l0ldgc8lrazq33msxnk5a818jgy";
   };
 
-  buildInputs = [ parted udev ];
+  postPatch = ''
+     sed -i 's/-oroot -groot//' Makefile
 
-  patchPhase = "sed -i 's/-oroot -groot//' Makefile";
+     for f in f3write.h2w log-f3wr; do
+      substituteInPlace $f \
+        --replace '$(dirname $0)' $out/bin
+     done
+  '';
 
-  buildFlags   = [ "all"                    # f3read, f3write
-                   "extra"                  # f3brew, f3fix, f3probe
-                 ];
+  buildInputs = [
+    parted
+  ]
+  ++ lib.optional stdenv.isLinux systemd;
 
-  installFlags = [ "PREFIX=$(out)"
-                   "install"
-                   "install-extra"
-                 ];
+  enableParallelBuilding = true;
 
-  meta = {
+  buildFlags   = [
+    "all" # f3read, f3write
+  ]
+  ++ lib.optional stdenv.isLinux "extra"; # f3brew, f3fix, f3probe
+
+  installFlags = [
+    "PREFIX=$(out)"
+    "install"
+  ]
+  ++ lib.optional stdenv.isLinux "install-extra";
+
+  postInstall = ''
+    install -Dm555 -t $out/bin f3write.h2w log-f3wr
+    install -Dm444 -t $out/share/doc/${pname} LICENSE README.rst
+  '';
+
+  meta = with lib; {
     description = "Fight Flash Fraud";
     homepage = "http://oss.digirati.com.br/f3/";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ makefu ];
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ makefu ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Add some documentation as well.

Drive-by clean-up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).