### PR TITLE
popeye: init at 0.8.10

### DIFF
--- a/pkgs/applications/networking/cluster/popeye/default.nix
+++ b/pkgs/applications/networking/cluster/popeye/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "popeye";
+  version = "0.8.10";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "derailed";
+    repo = "popeye";
+    sha256 = "1cx39xipvvhb12nhvg7kfssnqafajni662b070ynlw8p870bj0sn";
+  };
+
+  buildFlagsArray = ''
+    -ldflags=
+      -s -w
+      -X github.com/derailed/popeye/cmd.version=${version}
+      -X github.com/derailed/popeye/cmd.commit=b7a876eafd4f7ec5683808d8d6880c41c805056a
+      -X github.com/derailed/popeye/cmd.date=2020-08-25T23:02:30Z
+  '';
+
+  vendorSha256 = "0b2bawc9wnqwgvrv614rq5y4ns9di65zqcbb199y2ijpsaw5d9a7";
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A Kubernetes cluster resource sanitizer";
+    homepage = "https://github.com/derailed/popeye";
+    changelog = "https://github.com/derailed/popeye/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = [ maintainers.bryanasdev000 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21629,6 +21629,8 @@ in
 
   k9s = callPackage ../applications/networking/cluster/k9s { };
 
+  popeye = callPackage ../applications/networking/cluster/popeye { };
+
   fluxctl = callPackage ../applications/networking/cluster/fluxctl { };
 
   linkerd = callPackage ../applications/networking/cluster/linkerd { };


### PR DESCRIPTION
###### Motivation for this change

Add popeye, a Kubernetes cluster resource sanitizer at version 0.8.10. A big thanks to @mtrsk and the brazilian telegram group of NixOS for the help.

NOTE: I did not find a good way to pass the version information, so for now, they are locked directly in the package definition based on the information from the last release and its makefile, I also deactivated the tests, as it gave some sandbox-related errors and the expectation of a kubernetes environment. Perhaps in the future it will be useful to enable some of them.

###### Things done

Added package definition at `pkgs/applications/networking/cluster/popeye/default.nix` and added a reference line to `pkgs/top-level/all-packages.nix` below `k9s`.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
