### PR TITLE
nvtop: Make independent of Nvidia driver version

### DIFF
--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, nvidia_x11, cudatoolkit, ncurses }:
+{ stdenv, fetchFromGitHub, cmake, cudatoolkit, ncurses, addOpenGLRunpath }:
 
 stdenv.mkDerivation rec {
   pname = "nvtop";
@@ -6,22 +6,26 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "Syllo";
-    repo  = "nvtop";
+    repo = "nvtop";
     rev = version;
     sha256 = "1b6yz54xddip1r0k8cbqg41dpyhds18fj29bj3yf40xvysklb0f4";
   };
 
   cmakeFlags = [
     "-DNVML_INCLUDE_DIRS=${cudatoolkit}/include"
-    "-DNVML_LIBRARIES=${nvidia_x11}/lib/libnvidia-ml.so"
+    "-DNVML_LIBRARIES=${cudatoolkit}/targets/x86_64-linux/lib/stubs/libnvidia-ml.so"
     "-DCMAKE_BUILD_TYPE=Release"
   ];
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ ncurses nvidia_x11 cudatoolkit ];
+  nativeBuildInputs = [ cmake addOpenGLRunpath ];
+  buildInputs = [ ncurses cudatoolkit ];
+
+  postFixup = ''
+    addOpenGLRunpath $out/bin/nvtop
+  '';
 
   meta = with stdenv.lib; {
-    description = "A (h)top like like task monitor for NVIDIA GPUs";
+    description = "A (h)top like task monitor for NVIDIA GPUs";
     homepage = "https://github.com/Syllo/nvtop";
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14607,9 +14607,7 @@ in
 
   nvidia-optical-flow-sdk = callPackage ../development/libraries/nvidia-optical-flow-sdk { };
 
-  nvtop = callPackage ../tools/system/nvtop {
-    nvidia_x11 = linuxPackages.nvidia_x11.override { libsOnly = true; };
-  };
+  nvtop = callPackage ../tools/system/nvtop { };
 
   ocl-icd = callPackage ../development/libraries/ocl-icd { };
 


### PR DESCRIPTION
###### Motivation for this change

For packages relying on Nvidia drivers we don't want to hard-code the
location of a particular driver version in the RPATH. Otherwise the
software might fail with errors such as:

> Impossible to initialize nvidia nvml : Driver/library version mismatch

To fix this the usual pattern in nixpkgs is to add `/run/opengl-driver/lib`
to the RPATH of these binaries.
This is the global location where Nvidia libraries are available on
NixOS and so this makes sure that the nvtop binary can be run with all
versions of the driver.

At build time however these libraries are not available at that
particular location. For precisely this use case, Nvidia ships stub
versions of the driver libraries with the cudatoolkit. So we just need
to point CMake to that directory.

Fixes: #98328

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
