### PR TITLE
[20.09] iproute_mptcp: fix preConfigure

### DIFF
--- a/pkgs/os-specific/linux/iproute/mptcp.nix
+++ b/pkgs/os-specific/linux/iproute/mptcp.nix
@@ -11,6 +11,12 @@ iproute.overrideAttrs (oa: rec {
     sha256 = "07fihvwlaj0ng8s8sxqhd0a9h1narcnp4ibk88km9cpsd32xv4q3";
   };
 
+  preConfigure = ''
+    # Don't try to create /var/lib/arpd:
+    sed -e '/ARPDDIR/d' -i Makefile
+    patchShebangs configure
+  '';
+
   meta = with stdenv.lib; {
     homepage = "https://github.com/multipath-tcp/iproute-mptcp";
     description = "IP-Route extensions for MultiPath TCP";


### PR DESCRIPTION
Cherry picked https://github.com/NixOS/nixpkgs/commit/d0edb000191b5fc19971d2dec01decd65aa1957d from https://github.com/NixOS/nixpkgs/pull/97747

###### Motivation for this change
ZHF 20.09 https://github.com/NixOS/nixpkgs/issues/97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
