### PR TITLE
fontconfig: Add CoreFoundation to buildInputs

### DIFF
--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     expat
-  ] ++ stdenv.lib.optional stdenv.isDarwin CoreFoundation;
+  ] ++ lib.optional stdenv.isDarwin CoreFoundation;
 
   propagatedBuildInputs = [
     freetype

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -9,6 +9,7 @@
 , gperf
 , dejavu_fonts
 , autoreconfHook
+, CoreFoundation
 }:
 
 stdenv.mkDerivation rec {
@@ -73,7 +74,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     expat
-  ];
+  ] ++ stdenv.lib.optional stdenv.isDarwin CoreFoundation;
 
   propagatedBuildInputs = [
     freetype

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12311,7 +12311,9 @@ in
 
   cfitsio = callPackage ../development/libraries/cfitsio { };
 
-  fontconfig = callPackage ../development/libraries/fontconfig { };
+  fontconfig = callPackage ../development/libraries/fontconfig {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation;
+  };
 
   folly = callPackage ../development/libraries/folly { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

fontconfig depends on CoreFoundation, but did not have CoreFoundation in its buildInputs. This built fine, but resulted in a dylib with a non-absolute rpath as reference:

```
otool -L /nix/store/zy90l8cw2qj316xdadhmpf9i3wyisn4g-fontconfig-2.13.92-lib/lib/libfontconfig.dylib
/nix/store/zy90l8cw2qj316xdadhmpf9i3wyisn4g-fontconfig-2.13.92-lib/lib/libfontconfig.dylib:
	/nix/store/zy90l8cw2qj316xdadhmpf9i3wyisn4g-fontconfig-2.13.92-lib/lib/libfontconfig.1.dylib (compatibility version 14.0.0, current version 14.0.0)
	/nix/store/j7m6j79aw01gs1kqiv7n8gdgaj3kdjdn-freetype-2.10.2/lib/libfreetype.6.dylib (compatibility version 24.0.0, current version 24.2.0)
	/nix/store/ik820r3rrfr7x7k1iyc6w9xj6mhinynm-bzip2-1.0.6.0.1/lib/libbz2.1.dylib (compatibility version 2.0.0, current version 2.6.0)
	/nix/store/xr4cvl6blqrs6vwklnigpb43h4jqz04k-libpng-apng-1.6.37/lib/libpng16.16.dylib (compatibility version 54.0.0, current version 54.0.0)
	/nix/store/jmbhjg7yzgpxbhvj87n3svkqsvdvmbi7-zlib-1.2.11/lib/libz.dylib (compatibility version 1.0.0, current version 1.2.11)
	/nix/store/bqhgv3ppas6gbdpspb9yqdfshspb9rkd-expat-2.2.8/lib/libexpat.1.dylib (compatibility version 8.0.0, current version 8.10.0)
	/nix/store/bpfk6g2y6a7jilf55p08pbdajjq6ha2p-gettext-0.20.1/lib/libintl.8.dylib (compatibility version 10.0.0, current version 10.6.0)
	@rpath/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1454.90.0)
	/nix/store/bwny9pyjhghmv8jq5836ms422iwiqi5l-Libsystem-osx-10.12.6/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
```

With CoreFoundation as buildInput the dylib has only absolute paths to references:

```
otool -L /nix/store/n1c1ghp21c0n7c5a8vc4fqjmaysyvgfr-fontconfig-2.13.92-lib/lib/libfontconfig.dylib
/nix/store/n1c1ghp21c0n7c5a8vc4fqjmaysyvgfr-fontconfig-2.13.92-lib/lib/libfontconfig.dylib:
	/nix/store/n1c1ghp21c0n7c5a8vc4fqjmaysyvgfr-fontconfig-2.13.92-lib/lib/libfontconfig.1.dylib (compatibility version 14.0.0, current version 14.0.0)
	/nix/store/slm1f903cz47r2hi8v543mj3fcakvwrc-freetype-2.10.2/lib/libfreetype.6.dylib (compatibility version 24.0.0, current version 24.2.0)
	/nix/store/bafwypxc11wp51phssmh9h6vqmwzmnxf-bzip2-1.0.6.0.1/lib/libbz2.1.dylib (compatibility version 2.0.0, current version 2.6.0)
	/nix/store/0hr8d4x5w1046a6mcwgfnyj85f7ylf8g-libpng-apng-1.6.37/lib/libpng16.16.dylib (compatibility version 54.0.0, current version 54.0.0)
	/nix/store/ilrm722frr4fb3096wjc6wbspdf7pgyr-zlib-1.2.11/lib/libz.dylib (compatibility version 1.0.0, current version 1.2.11)
	/nix/store/cjflr1cvpkq74ln7j2qndri3a5513797-expat-2.2.8/lib/libexpat.1.dylib (compatibility version 8.0.0, current version 8.10.0)
	/nix/store/vrxrz8fqi2cmv0z7kxfza2nycbbbkh1k-gettext-0.21/lib/libintl.8.dylib (compatibility version 11.0.0, current version 11.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1677.104.0)
	/nix/store/hw4x6gakgd43f13zys92ng0hj0acisls-Libsystem-osx-10.12.6/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
```

Fixes (at least in part) #98203
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
