### PR TITLE
lizardfs: fix build

### DIFF
--- a/pkgs/tools/filesystems/lizardfs/default.nix
+++ b/pkgs/tools/filesystems/lizardfs/default.nix
@@ -47,6 +47,12 @@ stdenv.mkDerivation rec {
       url = "https://salsa.debian.org/debian/lizardfs/raw/bfcd5bcf/debian/patches/spdlog.patch";
       sha256 = "0j44rb816i6kfh3y2qdha59c4ja6wmcnlrlq29il4ybxn42914md";
     })
+    # Fix https://github.com/lizardfs/lizardfs/issues/655
+    # (Remove upon update to 3.13)
+    (fetchpatch {
+      url = "https://github.com/lizardfs/lizardfs/commit/5d20c95179be09241b039050bceda3c46980c004.patch";
+      sha256 = "185bfcz2rjr4cnxld2yc2nxwzz0rk4x1fl1sd25g8gr5advllmdv";
+    })
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Build failure was due to upstream issue, now fixed in the v3.13 RC.

https://github.com/lizardfs/lizardfs/issues/655
https://github.com/lizardfs/lizardfs/pull/677

###### Motivation for this change
ZHF 20.09 https://github.com/NixOS/nixpkgs/issues/97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
