### PR TITLE
fritzing: 0.9.3b -> 0.9.4

### DIFF
--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -1,40 +1,80 @@
 { mkDerivation, stdenv, fetchpatch, fetchFromGitHub, qmake, pkgconfig
-, qtbase, qtsvg, qtserialport, boost, libgit2
+, qtbase, qtsvg, qttools, qtserialport, boost, libgit2
 }:
+
+let
+  # build number corresponding to a release, has no further relation
+  # see https://github.com/fritzing/fritzing-app/releases/tag/CD-498
+  fritzingBuild = "498";
+  # SHA256 of the fritzing-parts HEAD on the master branch,
+  # which contains the latest stable parts definitions
+  partsSha = "e79a69765026f3fda8aab1b3e7a4952c28047a62";
+in
 
 mkDerivation rec {
   pname = "fritzing";
-  version = "0.9.3b";
+  version = "0.9.4-${fritzingBuild}";
 
   src = fetchFromGitHub {
     owner = "fritzing";
     repo = "fritzing-app";
-    rev = version;
-    sha256 = "0hpyc550xfhr6gmnc85nq60w00rm0ljm0y744dp0z88ikl04f4s3";
+    rev = "CD-${fritzingBuild}";
+    sha256 = "0aljj2wbmm1vd64nhj6lh9qy856pd5avlgydsznya2vylyz20p34";
   };
 
   parts = fetchFromGitHub {
     owner = "fritzing";
     repo = "fritzing-parts";
-    rev = version;
-    sha256 = "1d2v8k7p176j0lczx4vx9n9gbg3vw09n2c4b6w0wj5wqmifywhc1";
+    name = "fritzing-parts";
+    rev = partsSha;
+    sha256 = "0spka33a5qq34aq79j01arw1aly4vh0hzv7mahryhdlcdk22qqvc";
   };
-
-  patches = [(fetchpatch {
-    name = "0001-Squashed-commit-of-the-following.patch";
-    url = "https://aur.archlinux.org/cgit/aur.git/plain/0001-Squashed-commit-of-the-following.patch?h=fritzing";
-    sha256 = "1cv6myidxhy28i8m8v13ghzkvx5978p9dcd8v7885y0l1h3108mf";
-  })];
 
   buildInputs = [ qtbase qtsvg qtserialport boost libgit2 ];
 
-  nativeBuildInputs = [ qmake pkgconfig ];
+  nativeBuildInputs = [ qmake pkgconfig qttools ];
+
+  patches = [(fetchpatch {
+    name = "fix-libgit2-version.patch";
+    url = "https://github.com/fritzing/fritzing-app/commit/472951243d70eeb40a53b1f7e16e6eab0588d079.patch";
+    sha256 = "0v1zi609cjnqac80xgnk23n54z08g1lia37hbzfl8jcq9sn9adak";
+  })];
+
+  postPatch = ''
+    substituteInPlace phoenix.pro \
+      --replace 'LIBGIT_STATIC = true' 'LIBGIT_STATIC = false'
+
+    substituteInPlace tools/linux_release_script/release.sh \
+      --replace 'git status' 'echo >/dev/null' \
+      --replace 'git clean' 'echo >/dev/null' \
+      --replace 'git clone' 'echo >/dev/null' \
+      --replace 'release_folder="' 'release_folder="$out" #' \
+      --replace './Fritzing -db' '# run after fixup'
+
+    substituteInPlace src/fapplication.cpp \
+      --replace 'PartsChecker::getSha(dir.absolutePath());' '"${partsSha}";'
+  '';
+
+  buildPhase = ''
+    bash tools/linux_release_script/release.sh ${version}
+  '';
+
+  installPhase = ''
+    rm "$out/Fritzing" # remove script file
+    mkdir "$out/bin"
+    mv "$out/lib/Fritzing" "$out/bin/Fritzing"
+    mkdir --parents "$out/share/applications" "$out/share/metainfo"
+    mv --target-directory="$out/share/applications" "$out/org.fritzing.Fritzing.desktop"
+    mv --target-directory="$out/share/metainfo" "$out/org.fritzing.Fritzing.appdata.xml"
+    cp --recursive --no-target-directory "$parts" "$out/fritzing-parts"
+  '';
+
+  postFixup = ''
+    # generate the parts.db file
+    QT_QPA_PLATFORM=offscreen "$out/bin/Fritzing" -db "$out/fritzing-parts/parts.db" -pp "$out/fritzing-parts" -folder "$out"
+  '';
 
   qmakeFlags = [ "phoenix.pro" ];
-
-  preConfigure = ''
-    ln -s "$parts" parts
-  '';
 
   meta = {
     description = "An open source prototyping tool for Arduino-based projects";


### PR DESCRIPTION
###### Motivation for this change

ZHF: #97479

Fritzing does not build currently, because it is not compatible with libgit2 1.x (they are using libgit 0.28.1 -- see https://github.com/fritzing/fritzing-app/blob/a799673d7f79a619d8c94a87d07cf0cebde1b1d9/.travis.yml#L87)

Also, a new version has been released on Dec, 1st 2019. See https://github.com/fritzing/fritzing-app/releases/tag/CD-498 (I could also separate the patches, if we only want to backport the fix of 0.9.3b to the release-20.09 branch).

Since their build scripts are a bit unorthodox, and I did not want to replicate all the different steps in the nixpkgs build again, I chose to patch the `tools/linux_release_script/release.sh`.

Caveat: I did only fix the build on Linux, since I cannot test on macOS. Should we use `broken = lib.isDarwin` here?

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
