### PR TITLE
dconf2nix: 0.0.5 -> 0.0.6

### DIFF
--- a/pkgs/development/tools/haskell/dconf2nix/dconf2nix.nix
+++ b/pkgs/development/tools/haskell/dconf2nix/dconf2nix.nix
@@ -1,13 +1,13 @@
-{ mkDerivation, base, containers, fetchgit, optparse-applicative
-, parsec, stdenv, text
+{ mkDerivation, base, containers, fetchgit, hedgehog
+, optparse-applicative, parsec, stdenv, template-haskell, text
 }:
 mkDerivation {
   pname = "dconf2nix";
-  version = "0.0.5";
+  version = "0.0.6";
   src = fetchgit {
     url = "https://github.com/gvolpe/dconf2nix.git";
-    sha256 = "0immbx4bgfq3xmbbrpw441nx0sdpm4cp64s7qbvcbvllp4gbivpg";
-    rev = "848ff9966db21c66e61a19c04ab6dfc9270eb78e";
+    sha256 = "0ql3xrr05kg1xrfxq86mhzh5ky33sngx57sahzck3rb8fv2g6amv";
+    rev = "cf976e033c1a89f897924baa219c3b227fe68489";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -16,6 +16,9 @@ mkDerivation {
     base containers optparse-applicative parsec text
   ];
   executableHaskellDepends = [ base ];
+  testHaskellDepends = [
+    base containers hedgehog parsec template-haskell text
+  ];
   description = "Convert dconf files to Nix, as expected by Home Manager";
   license = stdenv.lib.licenses.asl20;
 }


### PR DESCRIPTION
###### Motivation for this change

Update `dconf2nix` to `v0.0.6`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
