### PR TITLE
openjdk: add derivation to generate bespoke minimal JRE's

### DIFF
--- a/doc/languages-frameworks/java.xml
+++ b/doc/languages-frameworks/java.xml
@@ -32,7 +32,7 @@ nativeBuildInputs = [ jdk ];
  </para>
 
  <para>
-  If your Java package provides a program, you need to generate a wrapper script to run it using the OpenJRE. You can use <literal>makeWrapper</literal> for this:
+  If your Java package provides a program, you need to generate a wrapper script to run it using a JRE. You can use <literal>makeWrapper</literal> for this:
 <programlisting>
 nativeBuildInputs = [ makeWrapper ];
 
@@ -43,7 +43,21 @@ installPhase =
       --add-flags "-cp $out/share/java/foo.jar org.foo.Main"
   '';
 </programlisting>
-  Note the use of <literal>jre</literal>, which is the part of the OpenJDK package that contains the Java Runtime Environment. By using <literal>${jre}/bin/java</literal> instead of <literal>${jdk}/bin/java</literal>, you prevent your package from depending on the JDK at runtime.
+Since the introduction of the Java Platform Module System in Java 9, Java distributions typically no longer ship with a general-purpose JRE: instead, they allow generating a JRE with only the modules required for your application(s). Because we can't predict what modules will be needed on a general-purpose system, the default <package>jre</package> package is the full JDK. When building a minimal system/image, you can override the <literal>modules</literal> parameter on <literal>jre_minimal</literal> to build a JRE with only the modules relevant for you:
+<programlisting>
+let
+  my_jre = pkgs.jre_minimal.override {
+    modules = [
+      # The modules used by 'something' and 'other' combined:
+      "java.base"
+      "java.logging"
+    ];
+  };
+  something = (pkgs.something.override { jre = my_jre; });
+  other = (pkgs.other.override { jre = my_jre; });
+in
+  ...
+</programlisting>
  </para>
 
  <para>

--- a/pkgs/development/compilers/openjdk/jre.nix
+++ b/pkgs/development/compilers/openjdk/jre.nix
@@ -1,0 +1,19 @@
+{ jdk
+, runCommand
+, patchelf
+, lib
+, modules ? [ "java.base" ]
+}:
+
+let
+  jre = runCommand "${jdk.name}-jre" {
+    nativeBuildInputs = [ patchelf ];
+    buildInputs = [ jdk ];
+    passthru = {
+      home = "${jre}";
+    };
+  }   ''
+      jlink --module-path ${jdk}/lib/openjdk/jmods --add-modules ${lib.concatStringsSep "," modules} --output $out
+      patchelf --shrink-rpath $out/bin/* $out/lib/jexec $out/lib/jspawnhelper $out/lib/*.so $out/lib/*/*.so
+  '';
+in jre

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9267,9 +9267,18 @@ in
   /* default JDK */
 
   jdk = jdk14;
-  # jdk14 lacks a jre output. See https://github.com/NixOS/nixpkgs/issues/79490
+
+  # Since the introduction of the Java Platform Module System in Java 9, Java
+  # no longer ships a separate JRE package.
+  #
+  # If you are building a 'minimal' system/image, you are encouraged to use
+  # 'jre_minimal' to build a bespoke JRE containing only the modules you need.
+  #
+  # For a general-purpose system, 'jre' defaults to the full JDK:
   jre = jdk14;
   jre_headless = jdk14_headless;
+
+  jre_minimal = callPackage ../development/compilers/openjdk/jre.nix { };
 
   openjdk = openjdk14;
   openjdk_headless = openjdk14_headless;


### PR DESCRIPTION
###### Motivation for this change

Explain why nowadays the default JRE is now the JDK, and make it easy to create a minimal JRE for scenario's where this makes sense #79490.

You would use this something like:

```
{ pkgs ? import <nixpkgs> {} }:

let
  my_jre = pkgs.jre_minimal.override {
    modules = [
      # The modules used by 'something' and 'other' combined:
      "java.base"
      "java.logging"
    ];
  };
in
pkgs.mkShell {
  buildInputs = [
    (pkgs.something.override { jre = my_jre; })
    (pkgs.other.override { jre = my_jre; })
  ];
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).