### PR TITLE
nix-prefetch: fix compatibility with nixUnstable again

### DIFF
--- a/pkgs/tools/package-management/nix-prefetch/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch/default.nix
@@ -21,10 +21,16 @@ in stdenv.mkDerivation rec {
   };
 
   patches = [
-    # Fix compatibility with nixUnstable: https://github.com/msteen/nix-prefetch/pull/8
+    # Fix compatibility with nixUnstable
+    # https://github.com/msteen/nix-prefetch/pull/9
     (fetchpatch {
-      url = "https://github.com/msteen/nix-prefetch/commit/817a7695d98663386fa27a6c04d1617e0a83e1ab.patch";
-      sha256 = "1zfgvafg30frwrh56k2wj4g76cljyjylm47ll60ms0yfx55spa7x";
+      url = "https://github.com/msteen/nix-prefetch/commit/2722cda48ab3f4795105578599b29fc99518eff4.patch";
+      sha256 = "037m388sbl72kyqnk86mw7lhjhj9gzfglw3ri398ncfmmkq8b7r4";
+    })
+    # https://github.com/msteen/nix-prefetch/pull/12
+    (fetchpatch {
+      url = "https://github.com/msteen/nix-prefetch/commit/de96564e9f28df82bccd0584953094e7dbe87e20.patch";
+      sha256 = "0mxai6w8cfs7k8wfbsrpg5hwkyb0fj143nm0v142am0ky8ahn0d9";
     })
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The parsing regex for output hash is broken for the current nix in unstable channel.
This PR ports patches to fix it.

Behavior on current master:
```
$ nix run nixpkgs.nix-prefetch -c nix-prefetch hello.src
The fetcher will be called as follows:
> fetchurl {
>   sha256 = "0ssi1wpaf7plaswqqjwigppsg5fyh99vdlb9kzl7c9lng89ndq1i";
>   url = "mirror://gnu/hello/hello-2.10.tar.gz";
> }

trying https://ftpmirror.gnu.org/hello/hello-2.10.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
100  708k  100  708k    0     0   111k      0  0:00:06  0:00:06 --:--:--  189k
hash mismatch in fixed-output derivation '/nix/store/3x7dwzq014bblazs7kq20p9hyzz0qh8g-hello-2.10.tar.gz':
  wanted: sha256:0000000000000000000000000000000000000000000000000000
  got:    sha256:0ssi1wpaf7plaswqqjwigppsg5fyh99vdlb9kzl7c9lng89ndq1i
error: build of '/nix/store/mhsd2ar52m4d0f2hmlkhbpj4rnc4kws0-hello-2.10.tar.gz.drv' failed
```

https://github.com/msteen/nix-prefetch/pull/8 tried to fix the issue but closed in flavor of https://github.com/msteen/nix-prefetch/pull/9, which is also closed and redo-ed in master (https://github.com/msteen/nix-prefetch/commit/2722cda48ab3f4795105578599b29fc99518eff4). However, it still has bug, which is finally fixed by https://github.com/msteen/nix-prefetch/pull/12

I opened an issue to upstream about making a new release in https://github.com/msteen/nix-prefetch/issues/13 but there's no response until now.
So I patch here to make it work at least.

@Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

