### PR TITLE
pythonPackages.pecan: 1.3.3 -> 1.4.0, fix build; pythonPackages.WSME: fix build

### DIFF
--- a/pkgs/development/python-modules/WSME/default.nix
+++ b/pkgs/development/python-modules/WSME/default.nix
@@ -1,7 +1,23 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k
-, pbr, six, simplegeneric, netaddr, pytz, webob
-, cornice, nose, webtest, pecan, transaction, cherrypy, sphinx
-, flask, flask-restful, suds-jurko, glibcLocales }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pbr
+, six
+, simplegeneric
+, netaddr
+, pytz
+, webob
+# Test inputs
+, cherrypy
+, flask
+, flask-restful
+, glibcLocales
+, nose
+, pecan
+, sphinx
+, transaction
+, webtest
+}:
 
 buildPythonPackage rec {
   pname = "WSME";
@@ -12,38 +28,37 @@ buildPythonPackage rec {
     sha256 = "965b9ce48161e5c50d84aedcf50dca698f05bf07e9d489201bccaec3141cd304";
   };
 
-  postPatch = ''
-    # remove turbogears tests as we don't have it packaged
-    rm tests/test_tg*
-    # WSME seems incompatible with recent SQLAlchemy version
-    rm wsmeext/tests/test_sqlalchemy*
-    # https://bugs.launchpad.net/wsme/+bug/1510823
-    ${if isPy3k then "rm tests/test_cornice.py" else ""}
-  '';
-
-  checkPhae = ''
-    nosetests --exclude test_buildhtml \
-              --exlcude test_custom_clientside_error \
-              --exclude test_custom_non_http_clientside_error
-  '';
-
-  # UnicodeEncodeError, ImportError, ...
-  doCheck = !isPy3k;
-
   nativeBuildInputs = [ pbr ];
 
   propagatedBuildInputs = [
-    six simplegeneric netaddr pytz webob
+    netaddr
+    pytz
+    simplegeneric
+    six
+    webob
   ];
 
   checkInputs = [
-    cornice nose webtest pecan transaction cherrypy sphinx
-    flask flask-restful suds-jurko glibcLocales
+    nose
+    cherrypy
+    flask
+    flask-restful
+    glibcLocales
+    pecan
+    sphinx
+    transaction
+    webtest
   ];
+
+  # from tox.ini, tests don't work with pytest
+  checkPhase = ''
+    nosetests wsme/tests tests/pecantest tests/test_sphinxext.py tests/test_flask.py --verbose
+  '';
 
   meta = with lib; {
     description = "Simplify the writing of REST APIs, and extend them with additional protocols";
-    homepage = "http://git.openstack.org/cgit/openstack/wsme";
+    homepage = "https://pythonhosted.org/WSME/";
+    changelog = "https://pythonhosted.org/WSME/changes.html";
     license = licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/pecan/default.nix
+++ b/pkgs/development/python-modules/pecan/default.nix
@@ -1,38 +1,59 @@
 { stdenv
 , fetchPypi
 , buildPythonPackage
+, isPy27
 # Python deps
-, singledispatch
 , logutils
-, webtest
 , Mako
+, singledispatch
+, six
+, webtest
+# Test Inputs
+, pytestCheckHook
 , genshi
-, Kajiki
-, sqlalchemy
 , gunicorn
 , jinja2
-, virtualenv
+, Kajiki
 , mock
+, sqlalchemy
+, uwsgi
+, virtualenv
 }:
 
 buildPythonPackage rec {
   pname = "pecan";
-  version = "1.3.3";
+  version = "1.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b5461add4e3f35a7ee377b3d7f72ff13e93f40f3823b3208ab978b29bde936ff";
+    sha256 = "4b2acd6802a04b59e306d0a6ccf37701d24376f4dc044bbbafba3afdf9d3389a";
   };
 
-  propagatedBuildInputs = [ singledispatch logutils ];
-  buildInputs = [
-    webtest Mako genshi Kajiki sqlalchemy gunicorn jinja2 virtualenv
+  propagatedBuildInputs = [
+    logutils
+    Mako
+    singledispatch
+    six
+    webtest
   ];
 
-  checkInputs = [ mock ];
+  checkInputs = [
+    pytestCheckHook
+    genshi
+    gunicorn
+    jinja2
+    mock
+    sqlalchemy
+    virtualenv
+  ] ++ stdenv.lib.optionals isPy27 [ Kajiki ];
+
+  pytestFlagsArray = [
+    "--pyargs pecan "
+  ];
 
   meta = with stdenv.lib; {
     description = "Pecan";
-    homepage = "https://github.com/pecan/pecan";
+    homepage = "http://www.pecanpy.org/";
+    changelog = "https://pecan.readthedocs.io/en/latest/changes.html";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
While reviewing #98151, noticed this package was broken. Found out the issue was the upstream ``pythonPackages.pecan`` not propagating python dependencies, so build would fail. Fixed both.

ZHF: #97479 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
