### PR TITLE
pythonPackages.Mako: cleanup & enable PyPy tests

### DIFF
--- a/pkgs/development/python-modules/Mako/default.nix
+++ b/pkgs/development/python-modules/Mako/default.nix
@@ -25,11 +25,12 @@ buildPythonPackage rec {
     ${python.interpreter} -m unittest discover
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Super-fast templating language";
-    homepage = "http://www.makotemplates.org";
-    license = lib.licenses.mit;
-    platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ domenkozar ];
+    homepage = "https://www.makotemplates.org/";
+    changelog = "https://docs.makotemplates.org/en/latest/changelog.html";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ domenkozar ];
   };
 }

--- a/pkgs/development/python-modules/Mako/default.nix
+++ b/pkgs/development/python-modules/Mako/default.nix
@@ -1,11 +1,10 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, python
-, markupsafe
-, nose
-, mock
 , isPyPy
+, markupsafe
+, mock
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -17,13 +16,18 @@ buildPythonPackage rec {
     sha256 = "8195c8c1400ceb53496064314c6736719c6f25e7479cd24c77be3d9361cddc27";
   };
 
-  checkInputs = [ markupsafe nose mock ];
   propagatedBuildInputs = [ markupsafe ];
+  checkInputs = [ pytestCheckHook markupsafe mock ];
 
-  doCheck = !isPyPy;  # https://bitbucket.org/zzzeek/mako/issue/238/2-tests-failed-on-pypy-24-25
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  disabledTests = lib.optionals isPyPy [
+    # https://github.com/sqlalchemy/mako/issues/315
+    "test_alternating_file_names"
+    # https://github.com/sqlalchemy/mako/issues/238
+    "test_file_success"
+    "test_stdin_success"
+    # fails on pypy2.7
+    "test_bytestring_passthru"
+  ];
 
   meta = with lib; {
     description = "Super-fast templating language";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
While fixing #98391, found some out of date things in ``pythonPackages.Mako``.

* Cleaned up meta
* Enabled more tests
* Updated issue links to new non-BitBucket location.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
