### PR TITLE
kakounePlugins.kakoune-gdb: init at 2019-11-24

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/default.nix
+++ b/pkgs/applications/editors/kakoune/plugins/default.nix
@@ -8,6 +8,7 @@
   kak-auto-pairs = pkgs.callPackage ./kak-auto-pairs.nix { };
   kak-buffers = pkgs.callPackage ./kak-buffers.nix { };
   kak-fzf = pkgs.callPackage ./kak-fzf.nix { };
+  kakoune-gdb = pkgs.callPackage ./kakoune-gdb.nix { };
   kak-plumb = pkgs.callPackage ./kak-plumb.nix { };
   kak-powerline = pkgs.callPackage ./kak-powerline.nix { };
   kak-prelude = pkgs.callPackage ./kak-prelude.nix { };

--- a/pkgs/applications/editors/kakoune/plugins/kakoune-gdb.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kakoune-gdb.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  name = "kakoune-gdb";
+  version = "2019-11-24";
+
+  src = fetchFromGitHub {
+    owner = "occivink";
+    repo = name;
+    rev = "57e2467e00a907d2bea798b66c56dcb5c1112efd";
+    sha256 = "06djnkfjawfakh14gsg3bxj301yxkc8i6v02yzdaha1j4287lpra";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/kak/autoload/plugins
+    cp gdb.kak $out/share/kak/autoload/plugins
+    cp gdb-output-handler.perl $out/share/kak/autoload/plugins
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A gdb integration plugin";
+    homepage = "https://nixos.org/manual/nixpkgs/stable/";
+    license = licenses.unlicense;
+    platform = platforms.all;
+    maintainers = with maintainers; [ buffet ];
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

Note: This plugin depends on socat and gdb, I'm not exactly sure how to express that, since I can't just add them to this package.

###### Motivation for this change

It's a useful plugin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
