### PR TITLE
spyder: 4.1.4 -> 4.1.5

### DIFF
--- a/pkgs/development/python-modules/spyder-kernels/default.nix
+++ b/pkgs/development/python-modules/spyder-kernels/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "spyder-kernels";
-  version = "1.9.3";
+  version = "1.9.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "877109d0691376f8ffb380ec1daf9b867958231065660277dbc5ccf0b4bf87d0";
+    sha256 = "ca9d997c475b714b54d2fd67aa140837ec3630e91cbbc2e0cd190f1b0bd9fe9d";
   };
 
   propagatedBuildInputs = [
@@ -23,7 +23,9 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Jupyter kernels for Spyder's console";
-    homepage = "https://github.com/spyder-ide/spyder-kernels";
+    homepage = "https://docs.spyder-ide.org/current/ipythonconsole.html";
+    downloadPage = "https://github.com/spyder-ide/spyder-kernels/releases";
+    changelog = "https://github.com/spyder-ide/spyder-kernels/blob/master/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ gebner ];
   };

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "spyder";
-  version = "4.1.4";
+  version = "4.1.5";
 
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6946b2128afaf1b64e878a74d33f9abd60c91f75949b3d05f305b3c3f5fec1e2";
+    sha256 = "d467f020b694193873a237ce6744ae36bd5a59f4d2b7ffbeb15dda68b03f5aa1";
   };
 
   nativeBuildInputs = [ pyqtwebengine.wrapQtAppsHook ];
@@ -69,7 +69,9 @@ buildPythonPackage rec {
       environment for the Python language with advanced editing, interactive
       testing, debugging and introspection features.
     '';
-    homepage = "https://github.com/spyder-ide/spyder/";
+    homepage = "https://www.spyder-ide.org/";
+    downloadPage = "https://github.com/spyder-ide/spyder/releases";
+    changelog = "https://github.com/spyder-ide/spyder/blob/master/CHANGELOG.md";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ gebner ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Follow-up from #98407. Requires that to build properly, but that's intended for cherry-picking to [20.09].

Update meta attributes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
