### PR TITLE
rustscan: 1.8.0 -> 1.10.1

### DIFF
--- a/pkgs/tools/security/rustscan/default.nix
+++ b/pkgs/tools/security/rustscan/default.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rustscan";
-  version = "1.9.0";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "RustScan";
     repo = pname;
     rev = "${version}";
-    sha256 = "0hj7k3yrd5vwxarn1kmxlhj5xlcg71w0vrzgnyrzbcppfxrbrj1m";
+    sha256 = "1x6vi3d250jhy75ybp8gm6cq9ncv0jig5c1v12r26raflhkh7fk3";
   };
 
-  cargoSha256 = "0cknnhzkk7jyi436c4hxif455xxdwg9pc4kw1q1wmgnqdw340xin";
+  cargoSha256 = "0q4p4pa1lh8kw5gmiim0zmmvs3l1kl319a3ji7gmj2fisha4319k";
 
   postPatch = ''
     substituteInPlace src/main.rs \

--- a/pkgs/tools/security/rustscan/default.nix
+++ b/pkgs/tools/security/rustscan/default.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rustscan";
-  version = "1.10.0";
+  version = "1.10.1";
 
   src = fetchFromGitHub {
     owner = "RustScan";
     repo = pname;
     rev = "${version}";
-    sha256 = "1x6vi3d250jhy75ybp8gm6cq9ncv0jig5c1v12r26raflhkh7fk3";
+    sha256 = "0dhy7b73ipsxsr7wlc3r5yy39i3cjrdszhsw9xwjj31692s3b605";
   };
 
-  cargoSha256 = "0q4p4pa1lh8kw5gmiim0zmmvs3l1kl319a3ji7gmj2fisha4319k";
+  cargoSha256 = "00s1iv8yw06647ijw9p3l5n7d899gsks5j8ljag6ha7hgl5vs4ci";
 
   postPatch = ''
     substituteInPlace src/main.rs \
@@ -26,6 +26,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=infer_ulimit_lowering_no_panic"
     "--skip=google_dns_runs"
     "--skip=parse_correct_host_addresses"
+    "--skip=parse_hosts_file_and_incorrect_hosts"
   ];
 
   meta = with lib; {

--- a/pkgs/tools/security/rustscan/default.nix
+++ b/pkgs/tools/security/rustscan/default.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rustscan";
-  version = "1.8.0";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "RustScan";
     repo = pname;
     rev = "${version}";
-    sha256 = "0rkqsh4i58cf18ad97yr4f68s5jg6z0ybz4bw8607lz7cjkfvjay";
+    sha256 = "0hj7k3yrd5vwxarn1kmxlhj5xlcg71w0vrzgnyrzbcppfxrbrj1m";
   };
 
-  cargoSha256 = "0mj214f2md7kjknmcayc5dcfmlk2b8mqkn7kxzdis8qv9a5xcbk8";
+  cargoSha256 = "0cknnhzkk7jyi436c4hxif455xxdwg9pc4kw1q1wmgnqdw340xin";
 
   postPatch = ''
     substituteInPlace src/main.rs \
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   checkFlags = [
     "--skip=infer_ulimit_lowering_no_panic"
     "--skip=google_dns_runs"
-    "--skip=parse_correct_ips_or_hosts"
+    "--skip=parse_correct_host_addresses"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Keep things up to date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
