### PR TITLE
restic: 0.9.6 -> 0.10.0 (incomplete)

### DIFF
--- a/pkgs/tools/backup/restic/default.nix
+++ b/pkgs/tools/backup/restic/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub, installShellFiles, makeWrapper
+{ stdenv, lib, buildGoModule, fetchFromGitHub, installShellFiles, makeWrapper
 , nixosTests, rclone }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "restic";
-  version = "0.9.6";
+  version = "0.10.0";
 
   goPackagePath = "github.com/restic/restic";
 
@@ -11,8 +11,10 @@ buildGoPackage rec {
     owner = "restic";
     repo = "restic";
     rev = "v${version}";
-    sha256 = "0lydll93n1lcn1fl669b9cikmzz9d6vfpc8ky3ng5fi8kj3v1dz7";
+    sha256 = "0nrh52cjymzcf093sqqa3kfw2nimnx6qwn8aw0wsci2v2r84yzzx";
   };
+
+  vendorSha256 = "1pfixq3mbfn12gyablc4g0j8r00md3887q0l8xgxy76z0d8w924s";
 
   subPackages = [ "cmd/restic" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New version: https://github.com/restic/restic/releases/tag/v0.10.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note:

This is currently incomplete. The package builds, but restic's tests fail because `fusermount` is unavailable. I'm not sure how this should be solved. Example:
```
integration_fuse_test.go:63: unexpected error: fusermount: exec: "fusermount": executable file not found in $PATH
```