### PR TITLE
ocamlPackages.qtest: 2.7 → 2.11

### DIFF
--- a/pkgs/development/ocaml-modules/qtest/default.nix
+++ b/pkgs/development/ocaml-modules/qtest/default.nix
@@ -1,28 +1,22 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, qcheck, ounit }:
+{ lib, buildDunePackage, fetchFromGitHub, qcheck }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4"
-then throw "qtest is not available for OCaml ${ocaml.version}"
-else
+buildDunePackage rec {
+  pname = "qtest";
+  version = "2.11";
 
-let version = "2.7"; in
-
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-qtest-${version}";
-  src = fetchzip {
-    url = "https://github.com/vincent-hugot/iTeML/archive/v${version}.tar.gz";
-    sha256 = "0z72m2drp67qchvsxx4sg2qjrrq8hp6p9kzdx16ibx58pvpw1sh2";
+  src = fetchFromGitHub {
+    owner = "vincent-hugot";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "10fi2093ny8pp3jsi1gdqsllp3lr4r5mfcs2hrm7qvbnhrdbb0g3";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
-  propagatedBuildInputs = [ qcheck ounit ];
-
-  installFlags = [ "BIN=$(out)/bin" ];
-  preInstall = "mkdir -p $out/bin";
+  propagatedBuildInputs = [ qcheck ];
 
   meta = {
-    description = "Inline (Unit) Tests for OCaml (formerly “qtest”)";
-    homepage = "https://github.com/vincent-hugot/iTeML";
-    platforms = ocaml.meta.platforms or [];
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    description = "Inline (Unit) Tests for OCaml";
+    inherit (src.meta) homepage;
+    maintainers = with lib.maintainers; [ vbgl ];
+    license = lib.licenses.gpl3;
   };
 }


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
