### PR TITLE
telepresence: 0.105 -> 0.108

### DIFF
--- a/pkgs/tools/networking/telepresence/default.nix
+++ b/pkgs/tools/networking/telepresence/default.nix
@@ -3,7 +3,7 @@
 , iptables, bash }:
 
 let
-  sshuttle-telepresence = 
+  sshuttle-telepresence =
     let
       sshuttleTelepresenceRev = "32226ff14d98d58ccad2a699e10cdfa5d86d6269";
     in
@@ -22,13 +22,13 @@ let
       });
 in pythonPackages.buildPythonPackage rec {
   pname = "telepresence";
-  version = "0.105";
+  version = "0.108";
 
   src = fetchFromGitHub {
     owner = "telepresenceio";
     repo = "telepresence";
     rev = version;
-    sha256 = "0fccbd54ryd9rcbhfh5lx8qcc3kx3k9jads918rwnzwllqzjf7sg";
+    sha256 = "1bidsmxgw4dyx1pb1kxawpza78lw5f3g4l0ym0sqxlvwg6kjqi4f";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

upgrade telepresence from 0.105 -> 0.108

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
