### PR TITLE
duf: init at 0.1.0

### DIFF
--- a/pkgs/tools/filesystems/duf/default.nix
+++ b/pkgs/tools/filesystems/duf/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "duf";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "muesli";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1akziaa5wjszflyylvnw284pz1aqngl40civzfabjz94pvyjkp76";
+  };
+
+  vendorSha256 = "1aj7rxlylgvxdnnfnfzh20v2jvs8falvjjishxd8rdk1jgfpipl8";
+
+  meta = with lib; {
+    description = "df like graphical disk usage/free utility";
+    homepage = "https://github.com/muesli/duf";
+    license = licenses.mit;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3251,6 +3251,8 @@ in
 
   duc = callPackage ../tools/misc/duc { };
 
+  duf = callPackage ../tools/filesystems/duf { };
+
   duff = callPackage ../tools/filesystems/duff { };
 
   dumptorrent = callPackage ../tools/misc/dumptorrent { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add duf to nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I am a little bit unsure about the similar named duff but I think this is okayish.
