### PR TITLE
hicolor-icon-theme: fix quoting shell variables in setup hook

### DIFF
--- a/pkgs/data/icons/hicolor-icon-theme/setup-hook.sh
+++ b/pkgs/data/icons/hicolor-icon-theme/setup-hook.sh
@@ -28,17 +28,17 @@ symlinkParentIconThemes() {
             theme_name="${theme%/*}"
             theme_name="${theme_name##*/}"
             echo "  theme: $theme_name"
-            inheritance=$(sed -rne 's,^Inherits=(.*)$,\1,p' $theme)
+            inheritance=$(sed -rne 's,^Inherits=(.*)$,\1,p' "$theme")
             IFS=',' read -ra parent_themes <<< "$inheritance"
             for parent_theme in "${parent_themes[@]}"; do
                 parent_path=""
                 if [ -e "$out/share/icons/$parent_theme" ]; then
-                    parent_path="$(realpath $out/share/icons/$parent_theme)"
+                    parent_path="$(realpath "$out/share/icons/$parent_theme")"
                 else
                     IFS=':' read -ra dirs <<< $XDG_ICON_DIRS
                     for parent_dir in  "${dirs[@]}"; do
                         if [ -e "$parent_dir/icons/$parent_theme/index.theme" ]; then
-                            parent_path=$(realpath "$parent_dir/icons/$parent_theme")
+                            parent_path="$(realpath "$parent_dir/icons/$parent_theme")"
                             ln -s "$parent_path" "$out/share/icons/"
                             break
                         fi


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Without quoting the hook fails with themes with spaces in the name.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
