### PR TITLE
puppy: init at 0.0.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7025,6 +7025,12 @@
     githubId = 1973389;
     name = "Reuben D'Netto";
   };
+  rebecca = {
+    name = "Rebecca Turner";
+    email = "rbt@sent.as";
+    github = "9999years";
+    githubId = 15312184;
+  };
   redbaron = {
     email = "ivanov.maxim@gmail.com";
     github = "redbaron";

--- a/pkgs/tools/misc/puppy/default.nix
+++ b/pkgs/tools/misc/puppy/default.nix
@@ -1,0 +1,19 @@
+{ lib, rustPlatform, fetchCrate }:
+rustPlatform.buildRustPackage rec {
+  pname = "puppy";
+  version = "0.0.7";
+  src = fetchCrate {
+    inherit version;
+    crateName = pname;
+    sha256 = "0zxksg3ywnddm5i7ipcp2v103j64yrh3vd0z9isxv9caa6adlb1b";
+  };
+  cargoSha256 = "1qr6ng9hh2jz5qmqcp2l002djq9kqxxr42wsl827pj3vpgx3bp92";
+
+  meta = with lib; {
+    description = "A fortune(1)-like program that outputs puppy tweets";
+    homepage = "https://github.com/eiais/puppy.rs";
+    license = licenses.mit;
+    maintainers = [ maintainers.rebecca ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2344,6 +2344,8 @@ in
 
   pueue = callPackage ../applications/misc/pueue { };
 
+  puppy = callPackage ../tools/misc/puppy { };
+
   pixiecore = callPackage ../tools/networking/pixiecore {};
 
   pyCA = python3Packages.callPackage ../applications/video/pyca {};


### PR DESCRIPTION
Adds @eiais' [puppy](https://github.com/eiais/puppy.rs/) program to nixpkgs.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~ N/A
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] ~~Determined the impact on package closure size (by running `nix path-info -S` before and after)~~
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
