### PR TITLE
calibre: Add python unrardll

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -99,7 +99,7 @@ mkDerivation rec {
       sip
       # the following are distributed with calibre, but we use upstream instead
       odfpy
-    ]
+    ] ++ lib.optional (unrarSupport) unrardll
   );
 
   installPhase = ''

--- a/pkgs/development/python-modules/unrardll/default.nix
+++ b/pkgs/development/python-modules/unrardll/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, unrar }:
+
+buildPythonPackage rec {
+  pname = "unrardll";
+  version = "0.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4149c0729cf96a0bae80360e7d94dc40af1088c8da7f6eb8d10e09b8632e92ad";
+  };
+
+  buildInputs = [ unrar ];
+
+  pythonImportsCheck = [ "unrardll" ];
+
+  meta = with lib; {
+    description = "Wrap the Unrar DLL to enable unraring of files in python";
+    homepage = "https://github.com/kovidgoyal/unrardll";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7258,6 +7258,8 @@ in {
 
   unpaddedbase64 = callPackage ../development/python-modules/unpaddedbase64 { };
 
+  unrardll = callPackage ../development/python-modules/unrardll { };
+
   unrpa = callPackage ../development/python-modules/unrpa { };
 
   untangle = callPackage ../development/python-modules/untangle { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

CBR format was not supported without this lib.
Close  #86152

Also, Calibre will not start without this patch #98197

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
