### PR TITLE
Add patch to goaccess so it will build on darwin

### DIFF
--- a/pkgs/tools/misc/goaccess/default.nix
+++ b/pkgs/tools/misc/goaccess/default.nix
@@ -14,6 +14,15 @@ stdenv.mkDerivation rec {
     "--enable-utf8"
   ];
 
+  # Required for goaccess to build on OSX.
+  # Won't be required once goaccess cuts a new release
+  prePatch = if stdenv.hostPlatform.isDarwin
+  then ''
+    substituteInPlace src/parser.c \
+      --replace '#include <malloc.h>' ""
+  ''
+  else null;
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     libmaxminddb


### PR DESCRIPTION


###### Motivation for this change
Fix build on OSX

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x ] macOS
   - [ x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
