### PR TITLE
omnisharp-roslyn: fix outdated built-in msbuild for unity

### DIFF
--- a/pkgs/development/tools/omnisharp-roslyn/default.nix
+++ b/pkgs/development/tools/omnisharp-roslyn/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cd ..
     cp -r src $out/
-    rm -rf $out/src/.msbuild
+    rm -r $out/src/.msbuild
     cp -r ${msbuild}/lib/mono/msbuild $out/src/.msbuild
 
     chmod -R u+w $out/src

--- a/pkgs/development/tools/omnisharp-roslyn/default.nix
+++ b/pkgs/development/tools/omnisharp-roslyn/default.nix
@@ -1,7 +1,10 @@
 { stdenv
 , fetchurl
-, mono5
+, mono6
+, msbuild
+, dotnet-sdk
 , makeWrapper
+, dotnetPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "0pknphydf194n7rjyax4mh8n7j8679j0jflw63gfgh37daxry0r2";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper dotnet-sdk dotnetPackages.Nuget ];
 
   preUnpack = ''
     mkdir src
@@ -26,8 +29,13 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cd ..
     cp -r src $out/
-    ls -al $out/src
-    makeWrapper ${mono5}/bin/mono $out/bin/omnisharp \
+    rm -rf $out/src/.msbuild
+    cp -r ${msbuild}/lib/mono/msbuild $out/src/.msbuild
+
+    chmod -R u+w $out/src
+    mv $out/src/.msbuild/Current/{bin,Bin}
+
+    makeWrapper ${mono6}/bin/mono $out/bin/omnisharp \
     --add-flags "$out/src/OmniSharp.exe"
   '';
 
@@ -36,7 +44,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/OmniSharp/omnisharp-roslyn";
     platforms = platforms.linux;
     license = licenses.mit;
-    maintainers = with maintainers; [ tesq0 ];
+    maintainers = with maintainers; [ tesq0 ericdallo ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
The `msbuild` inside `omnisharp-roslyn` is outdated, so libs like Unity doesn't work because of that.
Also the minimum mono version for omnisharp-roslyn is now `mono6`

###### Things done
* Changed `omnisharp-roslyn` to use mono6 instead of mono5
* Changed `omnisharp-roslyn` to use nix derivation of `msbuild` instead of built-in msbuild

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
