### PR TITLE
why3: 1.3.1 → 1.3.3

### DIFF
--- a/pkgs/applications/science/logic/why3/default.nix
+++ b/pkgs/applications/science/logic/why3/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation {
   pname = "why3";
-  version = "1.3.1";
+  version = "1.3.3";
 
   src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/38291/why3-1.3.1.tar.gz";
-    sha256 = "16zcrc60zz2j3gd3ww93z2z9x2jkxb3kr57y8i5rcgmacy7mw3bv";
+    url = "https://gforge.inria.fr/frs/download.php/file/38367/why3-1.3.3.tar.gz";
+    sha256 = "1n0a2nn1gnk0zg339lh698g4wpk7m8m1vyi2yvifd5adqvk4milw";
   };
 
   buildInputs = with ocamlPackages; [


### PR DESCRIPTION
###### Motivation for this change

Bug fixes: [1.3.2](https://lists.gforge.inria.fr/pipermail/why3-club/2020-September/002248.html) [1.3.3](https://lists.gforge.inria.fr/pipermail/why3-club/2020-September/002251.html)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
