### PR TITLE
weather: cleanups, enable on all Unix platforms

### DIFF
--- a/pkgs/applications/misc/weather/default.nix
+++ b/pkgs/applications/misc/weather/default.nix
@@ -1,41 +1,41 @@
 { stdenv, fetchurl, pythonPackages }:
 
 stdenv.mkDerivation rec {
-    version = "2.4.1";
-    pname = "weather";
+  version = "2.4.1";
+  pname = "weather";
 
-    src = fetchurl {
-        url = "http://fungi.yuggoth.org/weather/src/${pname}-${version}.tar.xz";
-        sha256 = "0nf680dl7a2vlgavdhj6ljq8a7lkhvr6zghkpzad53vmilxsndys";
-    };
+  src = fetchurl {
+    url = "http://fungi.yuggoth.org/weather/src/${pname}-${version}.tar.xz";
+    sha256 = "0nf680dl7a2vlgavdhj6ljq8a7lkhvr6zghkpzad53vmilxsndys";
+  };
 
-    nativeBuildInputs = [ pythonPackages.wrapPython ];
+  nativeBuildInputs = [ pythonPackages.wrapPython ];
 
-    buildInputs = [ pythonPackages.python ];
+  buildInputs = [ pythonPackages.python ];
 
-    phases = [ "unpackPhase" "installPhase" ];
+  phases = [ "unpackPhase" "installPhase" ];
 
-    installPhase = ''
-        site_packages=$out/${pythonPackages.python.sitePackages}
-        mkdir -p $out/{share/{man,weather-util},bin,etc} $site_packages
-        cp weather $out/bin/
-        cp weather.py $site_packages/
-        chmod +x $out/bin/weather
-        cp airports overrides.{conf,log} places slist stations zctas zlist zones $out/share/weather-util/
-        cp weatherrc $out/etc
-        cp weather.1 weatherrc.5 $out/share/man/
-        sed -i \
-          -e "s|/etc|$out/etc|g" \
-          -e "s|else: default_setpath = \".:~/.weather|&:$out/share/weather-util|" \
-          $site_packages/weather.py
-        wrapPythonPrograms
-    '';
+  installPhase = ''
+    site_packages=$out/${pythonPackages.python.sitePackages}
+    mkdir -p $out/{share/{man,weather-util},bin,etc} $site_packages
+    cp weather $out/bin/
+    cp weather.py $site_packages/
+    chmod +x $out/bin/weather
+    cp airports overrides.{conf,log} places slist stations zctas zlist zones $out/share/weather-util/
+    cp weatherrc $out/etc
+    cp weather.1 weatherrc.5 $out/share/man/
+    sed -i \
+      -e "s|/etc|$out/etc|g" \
+      -e "s|else: default_setpath = \".:~/.weather|&:$out/share/weather-util|" \
+      $site_packages/weather.py
+    wrapPythonPrograms
+  '';
 
-    meta = with stdenv.lib; {
-        homepage = "http://fungi.yuggoth.org/weather";
-        description = "Quick access to current weather conditions and forecasts";
-        license = licenses.isc;
-        maintainers = [ maintainers.matthiasbeyer ];
-        platforms = platforms.linux ++ platforms.darwin;
-    };
+  meta = with stdenv.lib; {
+    homepage = "http://fungi.yuggoth.org/weather";
+    description = "Quick access to current weather conditions and forecasts";
+    license = licenses.isc;
+    maintainers = [ maintainers.matthiasbeyer ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
 }

--- a/pkgs/applications/misc/weather/default.nix
+++ b/pkgs/applications/misc/weather/default.nix
@@ -43,6 +43,6 @@ stdenv.mkDerivation rec {
     description = "Quick access to current weather conditions and forecasts";
     license = licenses.isc;
     maintainers = [ maintainers.matthiasbeyer ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

* Run `nixpkgs-fmt` to fix non-standard indentation.
* Simplify `installPhase`.
* Enable on all Unix platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc: @matthiasbeyer