### PR TITLE
purple-slack: 2019-08-19 - 2020-09-22

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-slack/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "purple-slack-unstable";
-  version = "2019-08-18";
+  version = "2020-09-22";
 
   src = fetchFromGitHub {
     owner = "dylex";
     repo = "slack-libpurple";
-    rev = "be97802c7fd0b611722d2f551756e2a2672f6084";
-    sha256 = "0l6hwnnv6zzszxkk0a3nli88w5gijvlc9qgkkai0sb4v4c504y5v";
+    rev = "2e9fa028224b02e29473b1b998fc1e5f487e79ec";
+    sha256 = "1sksqshiwldd32k8jmiflp2pcax31ym6rypr4qa4v5vdn907g80m";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x[ Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
