### PR TITLE
pythonPackages.{pure-python-adb,adb-shell,androidtv}: init

### DIFF
--- a/pkgs/development/python-modules/adb-shell/default.nix
+++ b/pkgs/development/python-modules/adb-shell/default.nix
@@ -1,0 +1,32 @@
+{ aiofiles, buildPythonPackage, cryptography, fetchFromGitHub, isPy3k, lib
+, libusb1, mock, pyasn1, python, pycryptodome, rsa }:
+
+buildPythonPackage rec {
+  pname = "adb-shell";
+  version = "0.2.3";
+
+  disabled = !isPy3k;
+
+  # pypi does not contain tests, using github sources instead
+  src = fetchFromGitHub {
+    owner = "JeffLIrion";
+    repo = "adb_shell";
+    rev = "v${version}";
+    sha256 = "1ay598avmg656cxnc9phdx43z1plsrfjf9png9jwjwyhyjjiqxil";
+  };
+
+  propagatedBuildInputs = [ aiofiles cryptography libusb1 pyasn1 rsa ];
+
+  checkInputs = [ mock pycryptodome ];
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover -s tests -t .
+  '';
+
+  meta = with lib; {
+    description =
+      "A Python implementation of ADB with shell and FileSync functionality.";
+    homepage = "https://github.com/JeffLIrion/adb_shell";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/development/python-modules/androidtv/default.nix
+++ b/pkgs/development/python-modules/androidtv/default.nix
@@ -1,0 +1,31 @@
+{ aiofiles, adb-shell, buildPythonPackage, fetchFromGitHub, isPy3k, lib, mock
+, pure-python-adb, python }:
+
+buildPythonPackage rec {
+  pname = "androidtv";
+  version = "0.0.50";
+
+  # pypi does not contain tests, using github sources instead
+  src = fetchFromGitHub {
+    owner = "JeffLIrion";
+    repo = "python-androidtv";
+    rev = "v${version}";
+    sha256 = "1iqw40szwgzvhv3fbnx2wwfnw0d3clcwk9vsq1xsn30fjil2vl7b";
+  };
+
+  propagatedBuildInputs = [ adb-shell pure-python-adb ]
+    ++ lib.optionals (isPy3k) [ aiofiles ];
+
+  checkInputs = [ mock ];
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover -s tests -t .
+  '';
+
+  meta = with lib; {
+    description =
+      "Communicate with an Android TV or Fire TV device via ADB over a network.";
+    homepage = "https://github.com/JeffLIrion/python-androidtv/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/development/python-modules/pure-python-adb/default.nix
+++ b/pkgs/development/python-modules/pure-python-adb/default.nix
@@ -1,0 +1,26 @@
+{ aiofiles, buildPythonPackage, fetchPypi, lib, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "pure-python-adb";
+  version = "0.3.0.dev0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0kdr7w2fhgjpcf1k3l6an9im583iqkr6v8hb4q1zw30nh3bqkk0f";
+  };
+
+  propagatedBuildInputs = [ aiofiles ];
+  # Disable tests as they require docker, docker-compose and a dedicated
+  # android emulator
+  doCheck = false;
+  pythonImportsCheck = [ "ppadb.client" "ppadb.client_async" ];
+
+  meta = with lib; {
+    description = "Pure python implementation of the adb client";
+    homepage = "https://github.com/Swind/pure-python-adb";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -29,7 +29,7 @@
     "amcrest" = ps: with ps; [ ha-ffmpeg ]; # missing inputs: amcrest
     "ampio" = ps: with ps; [ ]; # missing inputs: asmog
     "android_ip_webcam" = ps: with ps; [ ]; # missing inputs: pydroid-ipcam
-    "androidtv" = ps: with ps; [ ]; # missing inputs: adb-shell[async] androidtv[async] pure-python-adb[async]
+    "androidtv" = ps: with ps; [ adb-shell androidtv pure-python-adb ];
     "anel_pwrctrl" = ps: with ps; [ ]; # missing inputs: anel_pwrctrl-homeassistant
     "anthemav" = ps: with ps; [ ]; # missing inputs: anthemav
     "apache_kafka" = ps: with ps; [ aiokafka ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -164,6 +164,8 @@ in {
 
   adb-homeassistant = callPackage ../development/python-modules/adb-homeassistant { };
 
+  adb-shell = callPackage ../development/python-modules/adb-shell { };
+
   addic7ed-cli = callPackage ../development/python-modules/addic7ed-cli { };
 
   adguardhome= callPackage ../development/python-modules/adguardhome { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -282,6 +282,8 @@ in {
 
   amqplib = callPackage ../development/python-modules/amqplib { };
 
+  androidtv = callPackage ../development/python-modules/androidtv { };
+
   androguard = callPackage ../development/python-modules/androguard { };
 
   aniso8601 = callPackage ../development/python-modules/aniso8601 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4692,6 +4692,8 @@ in {
 
   purepng = callPackage ../development/python-modules/purepng { };
 
+  pure-python-adb = callPackage ../development/python-modules/pure-python-adb { };
+
   pure-python-adb-homeassistant = callPackage ../development/python-modules/pure-python-adb-homeassistant { };
 
   purl = callPackage ../development/python-modules/purl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Support `androidtv` in Home Assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
