### PR TITLE
perldevel: 5.33.1 -> 5.33.2, perl-cross: 15ca535 -> f59d2b6

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -175,11 +175,11 @@ let
       priority = 6; # in `buildEnv' (including the one inside `perl.withPackages') the library files will have priority over files in `perl`
     };
   } // optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) rec {
-    crossVersion = "15ca5359f99698ef0a199bc307b7956c08907abc"; # Aug 27, 2020
+    crossVersion = "f59d2b6a179760230d925550db78b93c410433e4"; # Sept 22, 2020
 
     perl-cross-src = fetchurl {
       url = "https://github.com/arsv/perl-cross/archive/${crossVersion}.tar.gz";
-      sha256 = "0pcwv2ac02i2l0fjc8drdw70q6gwbypj2c5a53x2449m919v37h9";
+      sha256 = "1r07waq4ik4gf32c046f27pglwcy5rv9b6whj6497xbxfmaa5562";
     };
 
     depsBuildBuild = [ buildPackages.stdenv.cc makeWrapper ];
@@ -215,7 +215,7 @@ in {
   perldevel = common {
     perl = pkgs.perldevel;
     buildPerl = buildPackages.perldevel;
-    version = "5.33.1";
-    sha256 = "1rlnqqqzyhal79ys5dv7fwm3mg81s43dwks28b74x2gcmsngjnw9";
+    version = "5.33.2";
+    sha256 = "0zrb3d744argzy5idmafk92iprq9qbhzqbg4xj5w2i80sgg41212";
   };
 }


### PR DESCRIPTION
Updates `perldevel` to `5.33.2`

https://metacpan.org/release/XSAWYERX/perl-5.33.2/
https://metacpan.org/pod/release/XSAWYERX/perl-5.33.2/pod/perldelta.pod

dependencies:
perl-cross: https://github.com/arsv/perl-cross/commit/15ca5359f99698ef0a199bc307b7956c08907abc -> https://github.com/arsv/perl-cross/commit/f59d2b6a179760230d925550db78b93c410433e4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
