### PR TITLE
libvorbis: 1.3.6 -> 1.3.7

### DIFF
--- a/pkgs/development/libraries/libvorbis/default.nix
+++ b/pkgs/development/libraries/libvorbis/default.nix
@@ -1,27 +1,14 @@
-{ stdenv, fetchurl, libogg, pkgconfig, fetchpatch }:
+{ stdenv, fetchurl, libogg, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "libvorbis-1.3.6";
+  name = "libvorbis-1.3.7";
 
   src = fetchurl {
     url = "http://downloads.xiph.org/releases/vorbis/${name}.tar.xz";
-    sha256 = "05dlzjkdpv46zb837wysxqyn8l636x3dw8v8ymlrwz2fg1dbn05g";
+    sha256 = "0jwmf87x5sdis64rbv0l87mdpah1rbilkkxszipbzg128f9w8g5k";
   };
 
   outputs = [ "out" "dev" "doc" ];
-
-  patches = [
-    (fetchpatch {
-      url = "https://gitlab.xiph.org/xiph/vorbis/commit/018ca26dece618457dd13585cad52941193c4a25.patch";
-      sha256 = "18k4vp0nmrxxpis641ylnw6dgwxrymh5bf74njr6v8dizmmz1bkj";
-      name = "CVE-2017-14160+CVE-2018-10393.patch";
-    })
-    (fetchpatch {
-      url = "https://gitlab.xiph.org/xiph/vorbis/commit/112d3bd0aaacad51305e1464d4b381dabad0e88b.diff";
-      sha256 = "1k77y3q36npy8mkkz40f6cb46l2ldrwyrd191m29s8rnbhnafdf7";
-      name = "CVE-2018-10392.patch";
-    })
-  ];
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ libogg ];


### PR DESCRIPTION
New release contains various security fixes. Among others for:
* CVE-2017-14160
* CVE-2018-10392
* CVE-2018-10393

@ehmry please review

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions *Ubuntu*
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of *some* pkgs that depend on this change: mkvtoolnix, ogmtools, easytag
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
