### PR TITLE
chromium: 85.0.4183.102 -> 85.0.4183.121

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -1,17 +1,17 @@
 {
   "stable": {
-    "version": "85.0.4183.102",
-    "sha256": "032yh1mfwins7a62zw8kwwq8xw1n52a0a93lqz7qlyjaf9sd8s4a",
-    "sha256bin64": "1i8xaxxnmg80vsia8hxnq58qi9k5nnbrl80d6d23g9lb7dbc9cpm"
+    "version": "85.0.4183.121",
+    "sha256": "0a1xn39kmvyfpal6pgnylpy30z0322p3v7sx6vxi0r2naiz58670",
+    "sha256bin64": "08vqf1v91703aik47344bl409rsl4myar9bsd2lsvzqncncwsaca"
   },
   "beta": {
-    "version": "86.0.4240.30",
-    "sha256": "1isj0zngb72k1hhn3h0s8mccg1cdmppz1mjmg19f2h306farzmzl",
-    "sha256bin64": "10d8im2adqqnkd6265gngv6xlm5qsz6r13z6cbbchsss0ssr8fxa"
+    "version": "86.0.4240.42",
+    "sha256": "06cfhiym9xmz2q86v6b6xcicrrp2pmr7karavylzz4fqvwd2v6fa",
+    "sha256bin64": "1z5zmdc2i31iimps7p5z43vv4qi83c8ljb7x68zc1rvf8x62p7xj"
   },
   "dev": {
-    "version": "87.0.4252.0",
-    "sha256": "1lxlsdni63zh79hxvpwgmnfn67kgfzhz3yg9bkxghqchqykkz92y",
-    "sha256bin64": "130hf7b35wcxpw05ddbqq89x10c0kays1vb9qg6xhq3zx2mk6ijw"
+    "version": "87.0.4263.3",
+    "sha256": "1ybfrlm4417lpbg5qcwhq5p6nnxrw68wzyy5zvb1sg1ma8s9hhkk",
+    "sha256bin64": "1f7a272kalglmdwmrrzb4iw3crvvpv3mhxca5jh75qpldn4gby6m"
   }
 }


### PR DESCRIPTION
https://chromereleases.googleblog.com/2020/09/stable-channel-update-for-desktop_21.html

This update includes 10 security fixes.

CVEs:
CVE-2020-15960 CVE-2020-15961 CVE-2020-15962 CVE-2020-15963
CVE-2020-15965 CVE-2020-15966 CVE-2020-15964

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Testing status

| platform | attribute | status | tester |
| --- | --- | --- | --- |
| x86_64 | chromium | | @danielfullmer |
| x86_64 | nixosTests.chromium | | @danielfullmer  |
| x86_64 | google-chrome | | |
| aarch64 | chromium | | @thefloweringash |


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
