### PR TITLE
gem: 2020-03-26 -> 2020-09-22

### DIFF
--- a/pkgs/applications/audio/pd-plugins/gem/default.nix
+++ b/pkgs/applications/audio/pd-plugins/gem/default.nix
@@ -15,26 +15,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gem-unstable";
-  # The patch below applies to the latest release (v0.94), but then the build
-  # fails. I didn't track down what changed between that version and the
-  # current master that fixes the build on Nix
-  version = "2020-03-26";
+  version = "2020-09-22";
 
   src = fetchFromGitHub {
     owner = "umlaeute";
     repo = "Gem";
-    rev = "f38748d71bfca00e4d2b2f31d6c4e3759c03d599";
-    sha256 = "0bkky5fk0a836bapslrgzil272iq9y704y7hw254cfq5ffjd4qjy";
+    rev = "2edfde4f0587e72ef325e7f53681936dcc19655b";
+    sha256 = "0k5sq128wxi2qhaidspkw310pdgysxs47agv09pkjgvch2n4d5dq";
   };
-
-  patches = [
-    # Update autoconf OpenGL/GLU/GLUT detection scripts
-    # https://github.com/umlaeute/Gem/pull/251
-    (fetchpatch {
-      url = "https://github.com/umlaeute/Gem/commit/343a486c2b5c3427696f77aeabdff440e6590fc7.diff";
-      sha256 = "0gkzxv80rgg8lgp9av5qp6xng3ldhnbjz9d6r7ym784fw8yx41yj";
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
###### Motivation for this change

Removing the need for a patch, as that PR has now been merged.

Tested with a v4l video stream mapped onto a rotating cube

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
