### PR TITLE
i3nator: init at 1.2.0

### DIFF
--- a/pkgs/tools/misc/i3nator/default.nix
+++ b/pkgs/tools/misc/i3nator/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "i3nator";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "pitkley";
+    repo = pname;
+    rev = version;
+    sha256 = "10rxvxq48dhzlw5p9fsj6x0ci4pap85s9b192zakgvk4h97ifp2p";
+  };
+
+  cargoSha256 = "1i58ix414klm72562scqhb0lmy4wgpiksriz5qs4ss7lzvqdsizy";
+
+  meta = with lib; {
+    description = "Tmuxinator for the i3 window manager";
+    homepage = "https://github.com/pitkley/i3nator";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ mpoquet ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21255,6 +21255,8 @@ in
 
   i3minator = callPackage ../tools/misc/i3minator { };
 
+  i3nator = callPackage ../tools/misc/i3nator { };
+
   i3pystatus = callPackage ../applications/window-managers/i3/pystatus.nix { };
 
   i3status = callPackage ../applications/window-managers/i3/status.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Add [i3nator](https://github.com/pitkley/i3nator) to nixpkgs.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Tested manually that the built package worked to *start* an existing i3 layout