### PR TITLE
perl-cross: fix . being included in INC

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -73,7 +73,7 @@ let
     # Miniperl needs -lm. perl needs -lrt.
     configureFlags =
       (if crossCompiling
-       then [ "-Dlibpth=\"\"" "-Dglibpth=\"\"" ]
+       then [ "-Dlibpth=\"\"" "-Dglibpth=\"\"" "-Ddefault_inc_excludes_dot" ]
        else [ "-de" "-Dcc=cc" ])
       ++ [
         "-Uinstallusrbinperl"


### PR DESCRIPTION
Perl build with perl-cross had `.` in `@INC`. This sets `-Ddefault_inc_excludes_dot` explicitly when cross compiling to avoid that.

```
$ $(nix-build -A pkgsCross.aarch64-multiplatform.perl)/bin/perl -V | grep -A10 \@INC
  @INC:
    /nix/store/ydwsg1alzk104qpvv7ayrkkbj1b7hyib-perl-5.32.0-aarch64-unknown-linux-gnu/lib/perl5/site_perl/5.32.0/aarch64-linux
    /nix/store/ydwsg1alzk104qpvv7ayrkkbj1b7hyib-perl-5.32.0-aarch64-unknown-linux-gnu/lib/perl5/site_perl/5.32.0
    /nix/store/ydwsg1alzk104qpvv7ayrkkbj1b7hyib-perl-5.32.0-aarch64-unknown-linux-gnu/lib/perl5/5.32.0/aarch64-linux
    /nix/store/ydwsg1alzk104qpvv7ayrkkbj1b7hyib-perl-5.32.0-aarch64-unknown-linux-gnu/lib/perl5/5.32.0
    .
```
This behaviour can be unsafe:
https://wiki.gentoo.org/wiki/Project:Perl/Dot-In-INC-Removal
https://metacpan.org/pod/release/XSAWYERX/perl-5.26.0-RC2/pod/perldelta.pod#Configuration-and-Compilation

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
