### PR TITLE
WIP: ocaml: Export mkOcamlPackages again (and a question)

### DIFF
--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1224,6 +1224,7 @@ let
 
 in let inherit (pkgs) callPackage; in rec
 {
+  inherit mkOcamlPackages;
 
   ocamlPackages_4_00_1 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.00.1.nix { });
 


### PR DESCRIPTION
This change is motivated by my wish to create a development environment for OCaml with a version of the OCaml compiler with additional features enabled (like the Flambda optimization engine, or support for American Fuzzy Lop).

If I understand correctly, `mkOcamlPackages` was previously exported, but then that change was reverted. See the commit message for more details.

Before this PR is considered for merging, I have a question which I think needs to be addressed.

I have a file `shell.nix` in my project directory that I would have assumed to accomplish my goals, but I get the following error about a missing `version` attribute and I'm not sure why:

```
$ nix-shell
error: attribute 'version' missing, at /home/jhaberku/src/nixpkgs/pkgs/top-level/ocaml-packages.nix:1020:32
(use '--show-trace' to show detailed location information)
```

(In the "real" `shell.nix` I'm using a separate clone of nixkgs under the `hakuch` name, but that's not important here.)

I don't understand why the `ocaml` record doesn't have the `version` attribute in this context.

Here's the `shell.nix` file:

```nix
let
  pkgs = import <nixpkgs> {};
  
  ocaml = pkgs.callPackage <nixpkgs/pkgs/development/compilers/ocaml/4.11.nix> {
    flambdaSupport = true;
  };
  
   ocamlPackages = pkgs.ocaml-ng.mkOcamlPackages { inherit ocaml; };
in

pkgs.mkShell {
  buildInputs = [
    ocaml
    pkgs.ocamlformat
  ] ++ (with ocamlPackages; [
    dune_2
    findlib
    ppx_expect
    odoc
    utop
  ]);
}
```