### PR TITLE
Allow specifying a `recursionLimit` for `toPretty`

### DIFF
--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -94,18 +94,7 @@ rec {
        trace: { a = { b = {…}; }; }
        => null
    */
-  traceSeqN = depth: x: y: with lib;
-    let snip = v: if      isList  v then noQuotes "[…]" v
-                  else if isAttrs v then noQuotes "{…}" v
-                  else v;
-        noQuotes = str: v: { __pretty = const str; val = v; };
-        modify = n: fn: v: if (n == 0) then fn v
-                      else if isList  v then map (modify (n - 1) fn) v
-                      else if isAttrs v then mapAttrs
-                        (const (modify (n - 1) fn)) v
-                      else v;
-    in trace (generators.toPretty { allowPrettyValues = true; }
-               (modify depth snip x)) y;
+  traceSeqN = depth: x: y: trace (lib.generators.toPretty { recursionLimit = depth; } x) y;
 
   /* A combination of `traceVal` and `traceSeq` that applies a
      provided function to the value to be traced after `deepSeq`ing

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -237,7 +237,10 @@ rec {
       if v == [] then "[ ]"
       else if recursionLimit != null && depth >= recursionLimit then "[ ... ]"
       else "[" + introSpace
-        + libStr.concatMapStringsSep introSpace (go (depth + 1)) v
+        + libStr.concatStringsSep introSpace (lib.imap0 (n: value:
+            builtins.addErrorContext "while lib.generators.toPretty descended into list index `${toString n}'"
+            (go (depth + 1) value)
+          ) v)
         + outroSpace + "]"
     else if isFunction v then
       let fna = lib.functionArgs v;
@@ -257,6 +260,7 @@ rec {
       else "{" + introSpace
           + libStr.concatStringsSep introSpace (libAttr.mapAttrsToList
               (name: value:
+                builtins.addErrorContext "while lib.generators.toPretty descended into the `${name}' attribute"
                 "${libStr.escapeNixIdentifier name} = ${go (depth + 1) value};") v)
         + outroSpace + "}"
     else abort "generators.toPretty: should never happen (v = ${v})";

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -486,7 +486,7 @@ runTests {
   };
 
   testToPrettyMultiline = {
-    expr = mapAttrs (const (generators.toPretty { })) rec {
+    expr = mapAttrs (const (generators.toPretty { recursionLimit = 3; })) rec {
       list = [ 3 4 [ false ] ];
       attrs = { foo = null; bar.foo = "baz"; };
       newlinestring = "\n";
@@ -499,6 +499,7 @@ runTests {
         hello
         there
         test'';
+      recursive = let x = { inherit x; }; in x;
     };
     expected = rec {
       list = ''
@@ -528,7 +529,14 @@ runTests {
           hello
           there
           test''''';
-
+      recursive = ''
+        {
+          x = {
+            x = {
+              x = { ... };
+            };
+          };
+        }'';
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
For being able to print infinitely-recursing values in https://github.com/NixOS/nixpkgs/pull/98155

Also, `toPretty` now adds relevant error context when recursing

See also #97133 which did other `toPretty` improvements

Ping @Profpatsch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
