### PR TITLE
megapixels: init at 0.14.0

### DIFF
--- a/pkgs/applications/graphics/megapixels/default.nix
+++ b/pkgs/applications/graphics/megapixels/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, fetchgit
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook
+, gtk3
+, gnome3
+, tiffSupport ? true
+, libraw
+, jpgSupport ? true
+, imagemagick
+, exiftool
+}:
+
+assert jpgSupport -> tiffSupport;
+
+let
+  inherit (lib) makeBinPath optional optionals optionalString;
+  runtimePath = makeBinPath (
+    optional tiffSupport libraw
+    ++ optionals jpgSupport [ imagemagick exiftool ]
+  );
+in
+stdenv.mkDerivation rec {
+  pname = "megapixels";
+  version = "0.14.0";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~martijnbraam/megapixels";
+    rev = version;
+    sha256 = "136rv9sx0kgfkpqn5s90j7j4qhb8h04p14g5qhqshb89kmmsmxiw";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config wrapGAppsHook ];
+
+  buildInputs = [ gtk3 gnome3.adwaita-icon-theme ]
+  ++ optional tiffSupport libraw
+  ++ optional jpgSupport imagemagick;
+
+  preFixup = optionalString (tiffSupport || jpgSupport) ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${runtimePath}
+    )
+  '';
+
+  meta = with lib; {
+    description = "GTK3 camera application using raw v4l2 and media-requests";
+    homepage = "https://sr.ht/~martijnbraam/Megapixels";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23120,6 +23120,8 @@ in
 
   mediathekview = callPackage ../applications/video/mediathekview { };
 
+  megapixels = callPackage ../applications/graphics/megapixels { };
+
   meteo = callPackage ../applications/networking/weather/meteo { };
 
   meld = callPackage ../applications/version-management/meld { };


### PR DESCRIPTION
###### Motivation for this change
Packaging a well-behaving camera app that can use both of the PinePhone's cameras without any kernel hacks.

<details>
  <summary>(Big) photo of the working app</summary>

![image.jpg](https://cdn.discordapp.com/attachments/519164281518948372/756514517009170442/IMG_20200918_155640.jpg)

</details>

Unsure where to put the package. It queries `/proc/device-tree/compatible` to figure out the device & available camera hardware, but configuration files in various locations may be used to override the detection - is that too `os-specific`? I don't know what else is *can* run on. Would `pkgs/applications/video` be better? Support for other devices may follow in the future, the shipped configuration files only describe the various PinePhone models right now.

Reviewers with a PinePhone running NixOS would be highly appreciated if possible! I tested this on the pre-installed postmarketOS distro of my Community Edition 3GB model. Compiles on my desktop, but no configuration to describe a usable camera here so it won't exactly do much.

I'm considering writing a NixOS module to configure `/etc/megapixels.ini` in case the user would like to override the camera settings on a system-level, would that make sense?

cc @samueldr for mobile-nixos, @TilCreator for recently having worked on better PinePhone support

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (postmarketOS)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
