### PR TITLE
python3Packages.transformers: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/transformers/default.nix
+++ b/pkgs/development/python-modules/transformers/default.nix
@@ -6,6 +6,7 @@
 , regex
 , requests
 , numpy
+, parameterized
 , sacremoses
 , sentencepiece
 , timeout-decorator
@@ -16,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "transformers";
-  version = "3.1.0";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0wg36qrcljmpsyhjaxpqw3s1r6276yg8cq0bjrf52l4zlc5k4xzk";
+    sha256 = "0jj94153kgdyklra30xcszxv11hwzfigzy82fgvgzvbwlxv3a1j5";
   };
 
   propagatedBuildInputs = [
@@ -38,6 +39,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    parameterized
     pytestCheckHook
     timeout-decorator
   ];
@@ -49,13 +51,16 @@ buildPythonPackage rec {
 
   preCheck = ''
     export HOME="$TMPDIR"
-    cd tests
 
     # This test requires the nlp module, which we haven't
     # packaged yet. However, nlp is optional for transformers
     # itself
-    rm test_trainer.py
+    rm tests/test_trainer.py
   '';
+
+  # We have to run from the main directory for the tests. However,
+  # letting pytest discover tests leads to errors.
+  pytestFlagsArray = [ "tests" ];
 
   # Disable tests that require network access.
   disabledTests = [
@@ -76,6 +81,7 @@ buildPythonPackage rec {
     "test_tokenizer_from_model_type"
     "test_tokenizer_from_model_type"
     "test_tokenizer_from_pretrained"
+    "test_tokenizer_from_tokenizer_class"
     "test_tokenizer_identifier_with_correct_config"
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Changes:
https://github.com/huggingface/transformers/releases/tag/v3.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
