### PR TITLE
[20.03] Update SoftMaker Office/FreeOffice

### DIFF
--- a/pkgs/applications/office/softmaker/freeoffice.nix
+++ b/pkgs/applications/office/softmaker/freeoffice.nix
@@ -2,13 +2,13 @@
 
 callPackage ./generic.nix (args // rec {
   pname = "freeoffice";
-  version = "976";
+  version = "978";
   edition = "2018";
   suiteName = "FreeOffice";
 
   src = fetchurl {
     url = "https://www.softmaker.net/down/softmaker-freeoffice-${version}-amd64.tgz";
-    sha256 = "13yh4lyqakbdqf4r8vw8imy5gwpfva697iqfd85qmp3wimqvzskl";
+    sha256 = "1c5div1kbyyj48f89wkhc1i1759n70bsbp3w4a42cr0jmllyl60v";
   };
 
   archive = "freeoffice${edition}.tar.lzma";

--- a/pkgs/applications/office/softmaker/generic.nix
+++ b/pkgs/applications/office/softmaker/generic.nix
@@ -5,7 +5,7 @@
 
   # For fixing up execution of /bin/ls, which is necessary for
   # product unlocking.
-, coreutils, libredirect
+, coreutils
 
 , pname, version, edition, suiteName, src, archive
 
@@ -49,22 +49,7 @@ in stdenv.mkDerivation rec {
     runHook postUnpack
   '';
 
-  installPhase = let
-    # SoftMaker/FreeOffice collects some system information upon
-    # unlocking the product. But in doing so, it attempts to execute
-    # /bin/ls. If the execve syscall fails, the whole unlock
-    # procedure fails. This works around that by rewriting /bin/ls
-    # to the proper path.
-    #
-    # SoftMaker Office restarts itself upon some operations, such
-    # changing the theme and unlocking. Unfortunately, we do not
-    # have control over its environment then and it will fail
-    # with an error.
-    lsIntercept = ''
-      --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
-      --set NIX_REDIRECTS "/bin/ls=${coreutils}/bin/ls"
-    '';
-  in ''
+  installPhase = ''
     runHook preInstall
 
     mkdir -p $out/share
@@ -73,12 +58,9 @@ in stdenv.mkDerivation rec {
     # Wrap rather than symlinking, so that the programs can determine
     # their resource path.
     mkdir -p $out/bin
-    makeWrapper $out/share/${pname}${edition}/planmaker $out/bin/${pname}-planmaker \
-      ${lsIntercept}
-    makeWrapper $out/share/${pname}${edition}/presentations $out/bin/${pname}-presentations \
-      ${lsIntercept}
-    makeWrapper $out/share/${pname}${edition}/textmaker $out/bin/${pname}-textmaker \
-      ${lsIntercept}
+    makeWrapper $out/share/${pname}${edition}/planmaker $out/bin/${pname}-planmaker
+    makeWrapper $out/share/${pname}${edition}/presentations $out/bin/${pname}-presentations
+    makeWrapper $out/share/${pname}${edition}/textmaker $out/bin/${pname}-textmaker
 
     for size in 16 32 48 64 96 128 256 512 1024; do
       mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps

--- a/pkgs/applications/office/softmaker/softmaker_office.nix
+++ b/pkgs/applications/office/softmaker/softmaker_office.nix
@@ -2,13 +2,13 @@
 
 callPackage ./generic.nix (args // rec {
   pname = "softmaker-office";
-  version = "976";
+  version = "978";
   edition = "2018";
   suiteName = "SoftMaker Office";
 
   src = fetchurl {
     url = "https://www.softmaker.net/down/softmaker-office-${edition}-${version}-amd64.tgz";
-    sha256 = "0j6zm0cbxrcgm7glk84hvvbp4z0ys6v8bkwwhl5r7dbphyi72fw8";
+    sha256 = "14qnlbczq1zcz24vwy2yprdvhyn6bxv1nc1w6vjyq8w5jlwqsgbr";
   };
 
   archive = "office${edition}.tar.lzma";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Updating is necessary to have valid `sha256`s again. `libintercept` use is removed because it is not necessary anymore and breaks FreeOffice 978.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
