### PR TITLE
suitesparse: 5.7.2 -> 5.8.1

### DIFF
--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   # Use compatible indexing for lapack and blas used
-  buildInputs = [
+  buildInputs = assert (blas.isILP64 == lapack.isILP64); [
     blas lapack
     metis
     gfortran.cc.lib

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -4,14 +4,15 @@
 , blas, lapack
 , metis
 , fixDarwinDylibNames
-, gnum4
+, gmp
+, mpfr
 , enableCuda ? false
 , cudatoolkit
 }:
 
 stdenv.mkDerivation rec {
   pname = "suitesparse";
-  version = "5.7.2";
+  version = "5.8.1";
 
   outputs = [ "out" "dev" "doc" ];
 
@@ -19,17 +20,19 @@ stdenv.mkDerivation rec {
     owner = "DrTimothyAldenDavis";
     repo = "SuiteSparse";
     rev = "v${version}";
-    sha256 = "1imndff7yygjrbbrcscsmirdi8w0lkwj5dbhydxmf7lklwn4j3q6";
+    sha256 = "0qjlyfxs8s48rs63c2fzspisgq1kk4bwkgnhmh125hgkdhrq2w1c";
   };
 
   nativeBuildInputs = [
-    gnum4
   ] ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
+  # Use compatible indexing for lapack and blas used
   buildInputs = [
     blas lapack
     metis
     gfortran.cc.lib
+    gmp
+    mpfr
   ] ++ stdenv.lib.optional enableCuda cudatoolkit;
 
   preConfigure = ''
@@ -41,8 +44,6 @@ stdenv.mkDerivation rec {
     "INSTALL=${placeholder "out"}"
     "INSTALL_INCLUDE=${placeholder "dev"}/include"
     "JOBS=$(NIX_BUILD_CORES)"
-    "BLAS=-lblas"
-    "LAPACK=-llapack"
     "MY_METIS_LIB=-lmetis"
   ] ++ stdenv.lib.optionals blas.isILP64 [
     "CFLAGS=-DBLAS64"
@@ -50,7 +51,13 @@ stdenv.mkDerivation rec {
     "CUDA_PATH=${cudatoolkit}"
     "CUDART_LIB=${cudatoolkit.lib}/lib/libcudart.so"
     "CUBLAS_LIB=${cudatoolkit}/lib/libcublas.so"
-  ];
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    # Unless these are set, the build will attempt to use `Accelerate` on darwin, see:
+    # https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/v5.8.1/SuiteSparse_config/SuiteSparse_config.mk#L368
+    "BLAS=-lblas"
+    "LAPACK=-llapack"
+  ]
+  ;
 
   buildFlags = [
     # Build individual shared libraries, not demos


### PR DESCRIPTION
Assert that compatible lapack and blas implementations are used. Update dependencies. Remove now not needed `BLAS` and `LAPACK` makeFlags.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

Tested that Octave and Sundials build with this version, in a dirty branch, not with nixpkgs-review.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
