### PR TITLE
notebook: fix tests on darwin, 6.1.3 -> 6.1.4

### DIFF
--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -28,12 +28,12 @@
 
 buildPythonPackage rec {
   pname = "notebook";
-  version = "6.1.3";
+  version = "6.1.4";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9990d51b9931a31e681635899aeb198b4c4b41586a9e87fbfaaed1a71d0a05b6";
+    sha256 = "0cnyi4zd3byh7zixdj2q71axm31xgjiyfklh1c63c87acgwh2zb8";
   };
 
   LC_ALL = "en_US.utf8";
@@ -67,6 +67,10 @@ buildPythonPackage rec {
     "TestInstallServerExtension"
     "launch_socket"
     "sock_server"
+  ]
+  ++ lib.optional stdenv.isDarwin [
+    "test_delete"
+    "test_checkpoints_follow_file" 
   ];
 
   # Some of the tests use localhost networking.

--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -67,10 +67,9 @@ buildPythonPackage rec {
     "TestInstallServerExtension"
     "launch_socket"
     "sock_server"
-  ]
-  ++ lib.optional stdenv.isDarwin [
+  ] ++ lib.optional stdenv.isDarwin [
     "test_delete"
-    "test_checkpoints_follow_file" 
+    "test_checkpoints_follow_file"
   ];
 
   # Some of the tests use localhost networking.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The last commit c379aa9f8e4d1d43b7cd1d549a49b8f09286fe91 removed two excluded tests on darwin. Unfortunately they still fail on darwin:
```bash
File "/nix/store/hzvpbjbpschymag875hjzpsy2vrvrd9l-python3.8-tornado-6.0.4/lib/python3.8/site-packages/tornado/web.py", line 1703, in _execute
    result = await result
  File "/nix/store/hzvpbjbpschymag875hjzpsy2vrvrd9l-python3.8-tornado-6.0.4/lib/python3.8/site-packages/tornado/gen.py", line 209, in wrapper
    yielded = next(result)
  File "/private/tmp/nix-build-python3.8-notebook-6.1.4.drv-0/notebook-6.1.4/notebook/services/contents/handlers.py", line 237, in delete
    yield maybe_future(cm.delete(path))
  File "/private/tmp/nix-build-python3.8-notebook-6.1.4.drv-0/notebook-6.1.4/notebook/services/contents/manager.py", line 279, in delete
    self.delete_file(path)
  File "/private/tmp/nix-build-python3.8-notebook-6.1.4.drv-0/notebook-6.1.4/notebook/services/contents/filemanager.py", line 546, in delete_file
    send2trash(os_path)
  File "/nix/store/jf45dbr7f1z7n01k1snqljlfbqw21sm8-python3.8-Send2Trash-1.5.0/lib/python3.8/site-packages/send2trash/plat_osx.py", line 48, in send2trash
    check_op_result(op_result)
  File "/nix/store/jf45dbr7f1z7n01k1snqljlfbqw21sm8-python3.8-Send2Trash-1.5.0/lib/python3.8/site-packages/send2trash/plat_osx.py", line 37, in check_op_result
    raise OSError(msg)
OSError: Insufficient access privileges for operation
```

I don't know what is causing it. It looks like nix cannot delete a file in `/private/tmp` on darwin due to permission issues. These permission issues seem to pop up since MacOs 10.15 Catalina.

@NixOS/nixos-release-managers For now I just excluded the tests again but if anyone has a better idea I am open for suggestions.

ZHF: #97479 


###### System info

```
- system: `"x86_64-darwin"`
 - host os: `Darwin 19.6.0, macOS 10.15.6`
 - multi-user?: `yes`
 - sandbox: `yes`
 - version: `nix-env (Nix) 2.3.6`
 - channels(tricktron): `""`
 - channels(root): `"nixpkgs-20.03pre197736.91d5b3f07d2"`
 - nixpkgs: `/Users/tricktron/github/my-forks/nixpkgs`
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
