### PR TITLE
cvc3: fix build against bison 3.7

### DIFF
--- a/pkgs/applications/science/logic/cvc3/default.nix
+++ b/pkgs/applications/science/logic/cvc3/default.nix
@@ -13,9 +13,14 @@ stdenv.mkDerivation rec {
 
   patches = [ ./cvc3-2.4.1-gccv6-fix.patch ];
 
-  preConfigure = ''
+  postPatch = ''
     sed -e "s@ /bin/bash@bash@g" -i Makefile.std
     find . -exec sed -e "s@/usr/bin/perl@${perl}/bin/perl@g" -i '{}' ';'
+
+    # bison 3.7 workaround
+    for f in parsePL parseLisp parsesmtlib parsesmtlib2 ; do
+      ln -s ../parser/''${f}_defs.h src/include/''${f}.hpp
+    done
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/logic/cvc3/default.nix
+++ b/pkgs/applications/science/logic/cvc3/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "A prover for satisfiability modulo theory (SMT)";
     maintainers = with maintainers;
       [ raskin ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.free;
     homepage = "http://www.cs.nyu.edu/acsys/cvc3/index.html";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26272,6 +26272,7 @@ in
 
   cvc3 = callPackage ../applications/science/logic/cvc3 {
     gmp = lib.overrideDerivation gmp (a: { dontDisableStatic = true; });
+    stdenv = gccStdenv;
   };
   cvc4 = callPackage ../applications/science/logic/cvc4 {
     jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

This was broken by the recent switch from bison 3.6 to 3.7. For some reason bison 3.7 output references `$x_defs.h` files under the name `$x.hpp`.

This sort-of-but-doesn't-really seem to correspond to changes documented in the changelog under "C++ file names" https://git.savannah.gnu.org/cgit/bison.git/tree/NEWS?h=v3.7.1#n169

Anyway, here we work around this by creating symlinks to make this happy.

Also enable for darwin while we're at it, because it works if switched to gcc. Tested macos 10.14.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
