### PR TITLE
qrupdate: refactor, and assert blas && lapack compatibility

### DIFF
--- a/pkgs/development/libraries/qrupdate/default.nix
+++ b/pkgs/development/libraries/qrupdate/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation {
     description = "Library for fast updating of qr and cholesky decompositions";
     homepage = "https://sourceforge.net/projects/qrupdate/";
     license = licenses.gpl3;
+    maintainers = with maintainers; [ doronbehar ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/qrupdate/default.nix
+++ b/pkgs/development/libraries/qrupdate/default.nix
@@ -3,6 +3,7 @@
 , gfortran
 , blas
 , lapack
+, which
 }:
 stdenv.mkDerivation {
   name = "qrupdate-1.1.2";
@@ -32,6 +33,8 @@ stdenv.mkDerivation {
   installTargets = stdenv.lib.optionals stdenv.isDarwin [ "install-staticlib" "install-shlib" ];
 
   buildInputs = [ gfortran blas lapack ];
+
+  nativeBuildInputs = [ which ];
 
   meta = with stdenv.lib; {
     description = "Library for fast updating of qr and cholesky decompositions";

--- a/pkgs/development/libraries/qrupdate/default.nix
+++ b/pkgs/development/libraries/qrupdate/default.nix
@@ -5,24 +5,33 @@
 , lapack
 , which
 }:
-stdenv.mkDerivation {
-  name = "qrupdate-1.1.2";
+
+stdenv.mkDerivation rec {
+  pname = "qrupdate";
+  version = "1.1.2";
   src = fetchurl {
-    url = "mirror://sourceforge/qrupdate/qrupdate-1.1.2.tar.gz";
+    url = "mirror://sourceforge/qrupdate/${pname}-${version}.tar.gz";
     sha256 = "024f601685phcm1pg8lhif3lpy5j9j0k6n0r46743g4fvh8wg8g2";
   };
 
-  configurePhase =
-    ''
-      export PREFIX=$out
-      sed -i -e 's,^BLAS=.*,BLAS=-L${blas}/lib -lblas,' \
-          -e 's,^LAPACK=.*,LAPACK=-L${lapack}/lib -llapack,' \
-          Makeconf
-    ''
-    + stdenv.lib.optionalString blas.isILP64
-    ''
-      sed -i Makeconf -e '/^FFLAGS=.*/ s/$/-fdefault-integer-8/'
-    '';
+  preBuild =
+    # Check that blas and lapack are compatible
+    assert (blas.isILP64 == lapack.isILP64);
+  # We don't have structuredAttrs yet implemented, and we need to use space
+  # seprated values in makeFlags, so only this works.
+  ''
+    makeFlagsArray+=(
+      "LAPACK=-L${lapack}/lib -llapack"
+      "BLAS=-L${blas}/lib -lblas"
+      "PREFIX=${placeholder "out"}"
+      ${stdenv.lib.optionalString blas.isILP64
+      # Use their FFLAGS along with `-fdefault-integer-8`. If another
+      # application intends to use arpack, it should add this to it's FFLAGS as
+      # well. Otherwise (e.g): https://savannah.gnu.org/bugs/?50339
+      "FFLAGS=-fimplicit-none -O3 -funroll-loops -fdefault-integer-8"
+      }
+    )
+  '';
 
   doCheck = true;
 
@@ -32,14 +41,14 @@ stdenv.mkDerivation {
 
   installTargets = stdenv.lib.optionals stdenv.isDarwin [ "install-staticlib" "install-shlib" ];
 
-  buildInputs = [ gfortran blas lapack ];
+  buildInputs = [ gfortran ];
 
   nativeBuildInputs = [ which ];
 
   meta = with stdenv.lib; {
     description = "Library for fast updating of qr and cholesky decompositions";
     homepage = "https://sourceforge.net/projects/qrupdate/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ doronbehar ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change

Implement in Nix code stuff I learned at https://savannah.gnu.org/bugs/?57591 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
