### PR TITLE
arpack: assert that blas and lapack are compatible

### DIFF
--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -13,12 +13,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ gfortran blas lapack eigen ];
+  buildInputs = assert (blas.isILP64 == lapack.isILP64); [
+    gfortran
+    blas
+    lapack
+    eigen
+  ];
 
   doCheck = true;
-
-  BLAS_LIBS = "-L${blas}/lib -lblas";
-  LAPACK_LIBS = "-L${lapack}/lib -llapack";
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"

--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -1,14 +1,9 @@
 { stdenv, fetchFromGitHub, cmake
 , gfortran, blas, lapack, eigen }:
 
-with stdenv.lib;
-
-let
-  version = "3.7.0";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "arpack";
-  inherit version;
+  version = "3.7.0";
 
   src = fetchFromGitHub {
     owner = "opencollab";
@@ -27,7 +22,7 @@ stdenv.mkDerivation {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
-    "-DINTERFACE64=${optionalString blas.isILP64 "1"}"
+    "-DINTERFACE64=${stdenv.lib.optionalString blas.isILP64 "1"}"
   ];
 
   preCheck = if stdenv.isDarwin then ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Implement stuff I learned at https://savannah.gnu.org/bugs/?57591#comment112 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
