### PR TITLE
programs.neovim: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -139,6 +139,7 @@
   ./programs/mininet.nix
   ./programs/mtr.nix
   ./programs/nano.nix
+  ./programs/neovim.nix
   ./programs/nm-applet.nix
   ./programs/npm.nix
   ./programs/oblogout.nix

--- a/nixos/modules/programs/neovim.nix
+++ b/nixos/modules/programs/neovim.nix
@@ -72,8 +72,8 @@ in {
           };
       '';
       description = ''
-        Generate your init file from your list of plugins and custom commands,
-        Neovim will then be wrapped to load <command>nvim -u /nix/store/hash-vimrc</command>
+        Generate your init file from your list of plugins and custom commands.
+        Neovim will then be wrapped to load <command>nvim -u /nix/store/<hash>-vimrc</command>
       '';
     };
 
@@ -94,9 +94,7 @@ in {
     runtime = mkOption {
       default = {};
       example = literalExample ''
-        {
         runtime."ftplugin/c.vim".text = "setlocal omnifunc=v:lua.vim.lsp.omnifunc";
-        }
       '';
       description = ''
         Set of files that have to be linked in <filename>runtime</filename>.

--- a/nixos/modules/programs/neovim.nix
+++ b/nixos/modules/programs/neovim.nix
@@ -1,0 +1,167 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.neovim;
+
+  runtime' = filter (f: f.enable) (attrValues cfg.runtime);
+
+  # taken from the etc module
+  runtime = pkgs.stdenvNoCC.mkDerivation {
+    name = "runtime";
+
+    builder = ../system/etc/make-etc.sh;
+
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+
+    sources = map (x: x.source) runtime';
+    targets = map (x: x.target) runtime';
+  };
+
+in {
+  options.programs.neovim = {
+    enable = mkEnableOption "Neovim";
+
+    defaultEditor = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        When enabled, installs neovim and configures neovim to be the default editor
+        using the EDITOR environment variable.
+      '';
+    };
+
+    viAlias = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Symlink <command>vi</command> to <command>nvim</command> binary.
+      '';
+    };
+
+    vimAlias = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Symlink <command>vim</command> to <command>nvim</command> binary.
+      '';
+    };
+
+    withRuby = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable ruby provider.";
+    };
+
+    configure = mkOption {
+      type = types.attrs;
+      default = {};
+      example = literalExample ''
+        configure = {
+            customRC = $''''
+            " here your custom configuration goes!
+            $'''';
+            packages.myVimPackage = with pkgs.vimPlugins; {
+              # loaded on launch
+              start = [ fugitive ];
+              # manually loadable by calling `:packadd $plugin-name`
+              opt = [ ];
+            };
+          };
+      '';
+      description = ''
+        Generate your init file from your list of plugins and custom commands,
+        Neovim will then be wrapped to load <command>nvim -u /nix/store/hash-vimrc</command>
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.neovim-unwrapped;
+      defaultText = literalExample "pkgs.neovim-unwrapped";
+      description = "The package to use for the neovim binary.";
+    };
+
+    finalPackage = mkOption {
+      type = types.package;
+      visible = false;
+      readOnly = true;
+      description = "Resulting customized neovim package.";
+    };
+
+    runtime = mkOption {
+      default = {};
+      example = literalExample ''
+        {
+        runtime."ftplugin/c.vim".text = "setlocal omnifunc=v:lua.vim.lsp.omnifunc";
+        }
+      '';
+      description = ''
+        Set of files that have to be linked in <filename>runtime</filename>.
+      '';
+
+      type = with types; attrsOf (submodule (
+        { name, config, ... }:
+        { options = {
+
+            enable = mkOption {
+              type = types.bool;
+              default = true;
+              description = ''
+                Whether this /etc file should be generated.  This
+                option allows specific /etc files to be disabled.
+              '';
+            };
+
+            target = mkOption {
+              type = types.str;
+              description = ''
+                Name of symlink.  Defaults to the attribute
+                name.
+              '';
+            };
+
+            text = mkOption {
+              default = null;
+              type = types.nullOr types.lines;
+              description = "Text of the file.";
+            };
+
+            source = mkOption {
+              type = types.path;
+              description = "Path of the source file.";
+            };
+
+          };
+
+          config = {
+            target = mkDefault name;
+            source = mkIf (config.text != null) (
+              let name' = "neovim-runtime" + baseNameOf name;
+              in mkDefault (pkgs.writeText name' config.text));
+          };
+
+        }));
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.finalPackage
+    ];
+    environment.variables = { EDITOR = mkOverride 900 "nvim"; };
+
+    programs.neovim.finalPackage = pkgs.wrapNeovim cfg.package {
+      inherit (cfg) viAlias vimAlias;
+      configure = cfg.configure // {
+
+        customRC = (cfg.configure.customRC or "") + ''
+          set runtimepath^=${runtime}/etc
+        '';
+      };
+    };
+  };
+}


### PR DESCRIPTION
Allows to build a proper runtime folder with after/ ftplugin/ parser/ subfolders etc.
(neo)vim expects a few different folders, for instance to load
treesitter parsers.

This PR reuses the builder from the etc module, notwithstanding the
different modes/uid/gid.

This allows to get rid of some autocmd in customRC (via proper use of
the folder hierarchy) which is a win in my opinion.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I find strange to use a systemwide module for an editor but https://github.com/NixOS/nixpkgs/pull/55635 was too ambitious this I prefer to do it step by step. The (neo)vim configuration is not trivial and the module system with the typecheck is quite useful. The ability to reproduce a proper runtime folder is quite useful to alleviate the customrc writing but also to install treesitter parsers alongside neovim. I plan to improve the module later but right now I use it with
```
{ config, lib, pkgs,  ... }:
{
  programs.neovim = {
    enable = true;
    package = pkgs.neovim-unwrapped-master;

    configure = pkgs.neovimConfigure // {
      customRC = (pkgs.neovimConfigure.customRC  or "") + ''
        let g:fzf_command_prefix = 'Fzf' " prefix commands :Files become :FzfFiles, etc.
        let g:fzf_nvim_statusline = 0 " disable statusline overwriting
        source ~/.config/nvim/init.vim
      '';

    };

    runtime."ftplugin/bzl.vim".text = ''
      setlocal expandtab
    '';

    runtime."ftplugin/c.vim".text = ''
      " otherwise vim defaults to ccomplete#Complete
      setlocal omnifunc=v:lua.vim.lsp.omnifunc

    '';


    # cp $(nix-build -A tree-sitter.builtGrammars."$lang" ~/nixpkgs)/parser config/nvim/parser/${lang}.so
    runtime."parser/c.so".source = "${pkgs.tree-sitter.builtGrammars.c}/parser";
    runtime."parser/bash.so".source = "${pkgs.tree-sitter.builtGrammars.bash}/parser";
  };

}
```

@timokau 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
