### PR TITLE
nixos/gnome3: don't enable modules for excludePackages

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -363,15 +363,6 @@ in
         /* gnome-boxes */
       ] config.environment.gnome3.excludePackages);
 
-      # Enable default programs
-      programs.evince.enable = mkDefault true;
-      programs.file-roller.enable = mkDefault true;
-      programs.geary.enable = mkDefault true;
-      programs.gnome-disks.enable = mkDefault true;
-      programs.gnome-terminal.enable = mkDefault true;
-      programs.seahorse.enable = mkDefault true;
-      services.gnome3.sushi.enable = mkDefault true;
-
       # Let nautilus find extensions
       # TODO: Create nautilus-with-extensions package
       environment.sessionVariables.NAUTILUS_EXTENSION_DIR = "${config.system.path}/lib/nautilus/extensions-3.0";
@@ -382,6 +373,25 @@ in
       environment.pathsToLink = [
         "/share/nautilus-python/extensions"
       ];
+    })
+
+    # Enable default program modules
+    # Since some of these have a corresponding package, we only
+    # enable that program module if the package hasn't been excluded
+    # through `environment.gnome3.excludePackages`
+    (
+    let
+      notExcluded = pkg: mkDefault (!(lib.elem pkg config.environment.gnome3.excludePackages));
+    in
+    with pkgs.gnome3;
+    {
+      programs.evince.enable = notExcluded evince;
+      programs.file-roller.enable = notExcluded file-roller;
+      programs.geary.enable = notExcluded geary;
+      programs.gnome-disks.enable = notExcluded gnome-disk-utility;
+      programs.gnome-terminal.enable = notExcluded gnome-terminal;
+      programs.seahorse.enable = notExcluded seahorse;
+      services.gnome3.sushi.enable = notExcluded sushi;
     })
 
     (mkIf serviceCfg.games.enable {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
#24667
some packages disabled through environment.gnome3.excludePackages end up enabled anyways by their program module.
example:
```
services.xserver.desktopManager.gnome3.enable = true;
environment.gnome3.excludePackages = [ pkgs.gnome3.sushi ];
```
```
$ which sushi
/run/current-system/sw/bin/sushi
```

###### Things done
Enable program module by default only if it's corresponding program is not listed in "excludedPackages"

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
