### PR TITLE
mame: make the parallel build reliable

### DIFF
--- a/pkgs/misc/emulators/mame/default.nix
+++ b/pkgs/misc/emulators/mame/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivation, fetchFromGitHub, makeDesktopItem, makeWrapper
+{ stdenv, mkDerivation, fetchFromGitHub, fetchpatch, makeDesktopItem, makeWrapper
 , python, pkgconfig, SDL2, SDL2_ttf, alsaLib, which, qtbase, libXinerama
 , libpcap, CoreAudioKit, ForceFeedback
 , installShellFiles }:
@@ -51,7 +51,15 @@ in mkDerivation {
   # by default MAME assumes that paths with stock resources
   # are relative and that you run MAME changing to
   # install directory, so we add absolute paths here
-  patches = [ ./emuopts.patch ];
+  patches = [
+    ./emuopts.patch
+    # Make the parallel build reliable -- see https://github.com/mamedev/mame/pull/7279
+    (fetchpatch {
+      name = "fix-mame-parallel-build.patch";
+      url = "https://github.com/mamedev/mame/commit/13a54fd4e8b8b1a4aad77671562b2d9ef3d82e1f.patch";
+      sha256 = "1p4bszir9hcdjx6am58p48zh17rhjzlhx2baiacas7fnig61i02n";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace src/emu/emuopts.cpp \


### PR DESCRIPTION
##### Motivation for this change

The build sometimes fails: https://hydra.nixos.org/build/127855120/nixlog/1, and this is not fixed even on mame master.

Patch upstream: https://github.com/mamedev/mame/pull/7279.

To be backported -- ZHF: #97479

cc @gnidorah 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
