### PR TITLE
tests.haskell-shellFor: get compiling again [backport to 20.09]

### DIFF
--- a/pkgs/test/haskell-shellFor/default.nix
+++ b/pkgs/test/haskell-shellFor/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, haskellPackages, cabal-install }:
+{ lib, stdenv, haskellPackages, cabal-install }:
 
-haskellPackages.shellFor {
-  packages = p: [ p.database-id-class p.constraints-extras ];
+(haskellPackages.shellFor {
+  packages = p: [ p.database-id-class p.constraints ];
   nativeBuildInputs = [ cabal-install ];
   phases = [ "unpackPhase" "buildPhase" "installPhase" ];
   unpackPhase = ''
@@ -9,16 +9,25 @@ haskellPackages.shellFor {
     mkdir -p "$sourceRoot"
     cd "$sourceRoot"
     tar -xf ${haskellPackages.database-id-class.src}
-    tar -xf ${haskellPackages.constraints-extras.src}
-    cp ${builtins.toFile "cabal.project" "packages: database-id-class* constraints-extras*"} cabal.project
+    tar -xf ${haskellPackages.constraints.src}
+    cp ${builtins.toFile "cabal.project" "packages: database-id-class* constraints*"} cabal.project
   '';
   buildPhase = ''
     export HOME=$(mktemp -d)
     mkdir -p $HOME/.cabal
     touch $HOME/.cabal/config
-    cabal v2-build --offline --verbose database-id-class constraints-extras --ghc-options="-O0 -j$NIX_BUILD_CORES"
+    cabal v2-build --offline --verbose database-id-class constraints --ghc-options="-O0 -j$NIX_BUILD_CORES"
   '';
   installPhase = ''
     touch $out
   '';
-}
+}).overrideAttrs (oldAttrs: {
+  meta =
+    let
+      oldMeta = oldAttrs.meta or {};
+      oldMaintainers = oldMeta.maintainers or [];
+      additionalMaintainers = with lib.maintainers; [ cdepillabout ];
+      allMaintainers = oldMaintainers ++ additionalMaintainers;
+    in
+    oldMeta // { maintainers = allMaintainers; };
+})


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/98459 to the 20.09 release branch.

(cherry picked from commit bdc7deed613290588c2f77a4e0e65f98fa1562ff)

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
