### PR TITLE
tensorflow-bin_2: 2.1.0 -> 2.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9044,6 +9044,12 @@
     githubId = 1771332;
     name = "László Vaskó";
   };
+  vladmaraev = {
+    email = "vladislav.maraev@gu.se";
+    github = "vladmaraev";
+    githubId = 920783;
+    name = "Vladislav Maraev";
+  };
   vlstill = {
     email = "xstill@fi.muni.cz";
     github = "vlstill";

--- a/pkgs/development/python-modules/tensorboard-plugin-wit/default.nix
+++ b/pkgs/development/python-modules/tensorboard-plugin-wit/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  version = "1.7.0";
+  pname = "tensorboard_plugin_wit";
+  format = "wheel";
+
+  disabled = ! isPy3k;
+
+  src = fetchPypi {
+    inherit pname version format;
+    python = "py3";
+    abi = "none";
+    platform = "any";
+    sha256 = "0nv855qm2fav70lndsrv810pqgg41sbmd70fk86wk18ih825yxzf";
+  };
+
+  meta = {
+    homepage = https://github.com/tensorflow/addons;
+    description = "Useful extra functionality for TensorFlow 2.x maintained by SIG-addons";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ vladmaraev ];
+  };
+}

--- a/pkgs/development/python-modules/tensorflow-tensorboard/2/default.nix
+++ b/pkgs/development/python-modules/tensorflow-tensorboard/2/default.nix
@@ -8,6 +8,7 @@
 , futures
 , absl-py
 , google-auth-oauthlib
+, tensorboard-plugin-wit
 }:
 
 # tensorflow/tensorboard is built from a downloaded wheel, because
@@ -16,20 +17,18 @@
 
 buildPythonPackage rec {
   pname = "tensorflow-tensorboard";
-  version = "2.1.0";
+  version = "2.2.0";
   format = "wheel";
 
-  src = fetchPypi ({
+  disabled = ! isPy3k; # Python 2 not supported any more in version 2.2
+
+  src = fetchPypi {
     pname = "tensorboard";
     inherit version;
     format = "wheel";
-  } // (if isPy3k then {
     python = "py3";
-    sha256 = "1wpjdzhjpcdkyaahzd4bl71k4l30z5c55280ndiwj32hw70lxrp6";
-  } else {
-    python = "py2";
-    sha256 = "1f805839xa36wxb7xac9fyxzaww92vw4d50vs6g61wnlr4byp00w";
-  }));
+    sha256 = "1vdsgmr9i0nshcg884bfhr4rz5vnf90y8jdxdjx1319dmmsvqsxv";
+  };
 
   propagatedBuildInputs = [
     numpy
@@ -39,6 +38,7 @@ buildPythonPackage rec {
     grpcio
     absl-py
     google-auth-oauthlib
+    tensorboard-plugin-wit
     # not declared in install_requires, but used at runtime
     # https://github.com/NixOS/nixpkgs/issues/73840
     wheel

--- a/pkgs/development/python-modules/tensorflow-tensorboard/2/default.nix
+++ b/pkgs/development/python-modules/tensorflow-tensorboard/2/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "tensorflow-tensorboard";
-  version = "2.2.0";
+  version = "2.3.0";
   format = "wheel";
 
   disabled = ! isPy3k; # Python 2 not supported any more in version 2.2
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     inherit version;
     format = "wheel";
     python = "py3";
-    sha256 = "1vdsgmr9i0nshcg884bfhr4rz5vnf90y8jdxdjx1319dmmsvqsxv";
+    sha256 = "0pmfirgdy52g0abh3mmb1nx6n5lwzhf070gg95dxs0gzhgnhjink";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/tensorflow/2/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/2/bin.nix
@@ -9,6 +9,7 @@
 , wrapt
 , numpy
 , six
+, astunparse
 , termcolor
 , protobuf
 , absl-py
@@ -54,7 +55,7 @@ in buildPythonPackage {
   inherit (packages) version;
   format = "wheel";
 
-  disabled = isPy38;
+  disabled = ! isPy3k || isPy38;
 
   src = let
     pyVerNoDot = lib.strings.stringAsChars (x: if x == "." then "" else x) python.pythonVersion;
@@ -73,6 +74,7 @@ in buildPythonPackage {
     astor
     absl-py
     gast
+    astunparse
     opt-einsum
     google-pasta
     wrapt
@@ -96,10 +98,10 @@ in buildPythonPackage {
     # Unpack the wheel file.
     wheel unpack --dest unpacked ./*.whl
 
-    # Tensorflow has a hard dependency on gast==0.2.2, but we relax it to
-    # gast==0.3.2.
-    substituteInPlace ./unpacked/tensorflow*/tensorflow_core/tools/pip_package/setup.py --replace "gast == 0.2.2" "gast == 0.3.2"
-    substituteInPlace ./unpacked/tensorflow*/tensorflow_*.dist-info/METADATA --replace "gast (==0.2.2)" "gast (==0.3.2)"
+    # Tensorflow has a hard dependency on scipy, but it does not actually depend on it
+    # https://github.com/tensorflow/tensorflow/issues/40884
+    substituteInPlace ./unpacked/tensorflow*/tensorflow/tools/pip_package/setup.py --replace "scipy == 1.4.1" "scipy >= 1.4.1"
+    substituteInPlace ./unpacked/tensorflow*/tensorflow_*.dist-info/METADATA --replace "scipy (==1.4.1)" "scipy (>=1.4.1)"
 
     # Pack the wheel file back up.
     wheel pack ./unpacked/tensorflow*
@@ -134,14 +136,14 @@ in buildPythonPackage {
       # TODO: Create this list programmatically, and remove paths that aren't
       # actually needed.
       rrPathArr=(
-        "$out/${python.sitePackages}/tensorflow_core/"
-        "$out/${python.sitePackages}/tensorflow_core/compiler/tf2tensorrt/"
-        "$out/${python.sitePackages}/tensorflow_core/compiler/tf2xla/ops/"
-        "$out/${python.sitePackages}/tensorflow_core/lite/experimental/microfrontend/python/ops/"
-        "$out/${python.sitePackages}/tensorflow_core/lite/python/interpreter_wrapper/"
-        "$out/${python.sitePackages}/tensorflow_core/lite/python/optimize/"
-        "$out/${python.sitePackages}/tensorflow_core/python/"
-        "$out/${python.sitePackages}/tensorflow_core/python/framework/"
+        "$out/${python.sitePackages}/tensorflow/"
+        "$out/${python.sitePackages}/tensorflow/compiler/tf2tensorrt/"
+        "$out/${python.sitePackages}/tensorflow/compiler/tf2xla/ops/"
+        "$out/${python.sitePackages}/tensorflow/lite/experimental/microfrontend/python/ops/"
+        "$out/${python.sitePackages}/tensorflow/lite/python/interpreter_wrapper/"
+        "$out/${python.sitePackages}/tensorflow/lite/python/optimize/"
+        "$out/${python.sitePackages}/tensorflow/python/"
+        "$out/${python.sitePackages}/tensorflow/python/framework/"
         "${rpath}"
       )
 

--- a/pkgs/development/python-modules/tensorflow/2/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/2/bin.nix
@@ -55,7 +55,7 @@ in buildPythonPackage {
   inherit (packages) version;
   format = "wheel";
 
-  disabled = ! isPy3k || isPy38;
+  disabled = ! isPy3k;
 
   src = let
     pyVerNoDot = lib.strings.stringAsChars (x: if x == "." then "" else x) python.pythonVersion;
@@ -102,6 +102,11 @@ in buildPythonPackage {
     # https://github.com/tensorflow/tensorflow/issues/40884
     substituteInPlace ./unpacked/tensorflow*/tensorflow/tools/pip_package/setup.py --replace "scipy == 1.4.1" "scipy >= 1.4.1"
     substituteInPlace ./unpacked/tensorflow*/tensorflow_*.dist-info/METADATA --replace "scipy (==1.4.1)" "scipy (>=1.4.1)"
+
+    # Tensorflow has a hard dependency on gast==0.3.3, but we relax it to
+    # whatev gast version is avail
+    substituteInPlace ./unpacked/tensorflow*/tensorflow/tools/pip_package/setup.py --replace "gast == 0.3.3" "gast == ${gast.version}"
+    substituteInPlace ./unpacked/tensorflow*/tensorflow_*.dist-info/METADATA --replace "gast (==0.3.3)" "gast (==${gast.version})"
 
     # Pack the wheel file back up.
     wheel pack ./unpacked/tensorflow*

--- a/pkgs/development/python-modules/tensorflow/2/binary-hashes.nix
+++ b/pkgs/development/python-modules/tensorflow/2/binary-hashes.nix
@@ -1,51 +1,39 @@
 {
-version = "2.1.0";
-linux_py_27_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.1.0-cp27-cp27mu-manylinux2010_x86_64.whl";
-  sha256 = "17lnhr7vdrls68c79n3sah5rpd0q1x2v5m84azvlyxxh2wpypfmb";
-};
-linux_py_27_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.1.0-cp27-cp27mu-manylinux2010_x86_64.whl";
-  sha256 = "10lz3i4pcpgqrcbjmxm0n7k1gsqlpna3kdid902j2fy060cpi93z";
-};
+version = "2.2.0";
 linux_py_35_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.1.0-cp35-cp35m-manylinux2010_x86_64.whl";
-  sha256 = "09s081n08dpmflwgir3zwzfijfpmahbh2gy5fn5bv5ll86g1szsy";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.2.0-cp35-cp35m-manylinux2010_x86_64.whl";
+  sha256 = "1i091m4pwsvrjdqdqw3czpfqbp3c4lpnngd60hkr01d52cmzmlrw";
 };
 linux_py_35_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.1.0-cp35-cp35m-manylinux2010_x86_64.whl";
-  sha256 = "1aa7v9fnvx03hqvhl3x3xcn41qy6qxw5xybg54ifjvvicp455c8l";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp35-cp35m-manylinux2010_x86_64.whl";
+  sha256 = "11i3vysnx3rg8s2x1rzdd7n20l2vkfl04261a96c3ap536lhn5rz";
 };
 linux_py_36_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.1.0-cp36-cp36m-manylinux2010_x86_64.whl";
-  sha256 = "1dqp080ljbl9v3115vjp63ls0fimiwym6zxyanyhrlk8kwsq20zc";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.2.0-cp36-cp36m-manylinux2010_x86_64.whl";
+  sha256 = "0f7gbw4hqzi4cr7q0ski424jly4pfik76cj59z5c31vrhk2pzczh";
 };
 linux_py_36_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.1.0-cp36-cp36m-manylinux2010_x86_64.whl";
-  sha256 = "133z8anx7xm9rr5i9s9dwnp1wf06nr6s7q1lbs4lxpk6kn9nl480";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp36-cp36m-manylinux2010_x86_64.whl";
+  sha256 = "1dcc0c7wk9pdhf7gw1mx71n4anjmvnmdaj3lg04kphjc14xnbb18";
 };
 linux_py_37_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.1.0-cp37-cp37m-manylinux2010_x86_64.whl";
-  sha256 = "0yabl3xmcpr67w0zksqs3qc68nl9ax0vcd7w7b35nq8f65xl0ghy";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl";
+  sha256 = "0rh0cs54aczab8xxs8npggq66kzkyilidd3vzilslx5saz0qssac";
 };
 linux_py_37_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.1.0-cp37-cp37m-manylinux2010_x86_64.whl";
-  sha256 = "04gngbngyg7p1gwx1q89my0cl8j7lq4kknqh51s2ynrix71zvsy6";
-};
-mac_py_27_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.1.0-cp27-cp27m-macosx_10_9_x86_64.whl";
-  sha256 = "1mprp72w5kk0lyjm2mh4lf57827xk3wsg28c4gizwm00ydfgacg6";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl";
+  sha256 = "0ic6dp7ci15j0i7dlc36zqfjxkwl6dy6bzgnww7lwqmd3gbyl8hz";
 };
 mac_py_35_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.1.0-cp35-cp35m-macosx_10_6_intel.whl";
-  sha256 = "1as7brf5ai6r7v1di9646jfrbnirpk2b0d1g29mn3shavb62kw8w";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.2.0-cp35-cp35m-macosx_10_6_intel.whl";
+  sha256 = "0jc1rcb4fd8jz4laicxnp31fm4slb5ybbr9xb1wqlngnrm3ppmky";
 };
 mac_py_36_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.1.0-cp36-cp36m-macosx_10_9_x86_64.whl";
-  sha256 = "1v1rw9kjrskhcq1yas4ly2yfnzf2i1pjh6qg6zixfbkpkw7sw3wc";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.2.0-cp36-cp36m-macosx_10_9_x86_64.whl";
+  sha256 = "0kp5w5h36w3bwsbg9ar4rfbwbmjcgbpkcavf8w3hijy3x5p4hdb7";
 };
 mac_py_37_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.1.0-cp37-cp37m-macosx_10_9_x86_64.whl";
-  sha256 = "1hh4n0d97mrq35cmmsrnlmcv9vlswsyjy368lj3pda3y9dvck3rf";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.2.0-cp37-cp37m-macosx_10_9_x86_64.whl";
+  sha256 = "14wwlfaya7mpy56wb5w0hhjakqwkjry7i6fssn3cnm7xbkycfcn3";
 };
 }

--- a/pkgs/development/python-modules/tensorflow/2/binary-hashes.nix
+++ b/pkgs/development/python-modules/tensorflow/2/binary-hashes.nix
@@ -1,39 +1,51 @@
 {
-version = "2.2.0";
+version = "2.3.1";
 linux_py_35_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.2.0-cp35-cp35m-manylinux2010_x86_64.whl";
-  sha256 = "1i091m4pwsvrjdqdqw3czpfqbp3c4lpnngd60hkr01d52cmzmlrw";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.3.0-cp35-cp35m-manylinux2010_x86_64.whl";
+  sha256 = "1dl88c7626ivrbxvy04d30shfay0dn357czy83d5x0531adlx5cv";
 };
 linux_py_35_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp35-cp35m-manylinux2010_x86_64.whl";
-  sha256 = "11i3vysnx3rg8s2x1rzdd7n20l2vkfl04261a96c3ap536lhn5rz";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.3.0-cp35-cp35m-manylinux2010_x86_64.whl";
+  sha256 = "1sjzayigf0k2qyli4m7fyzinxx83r0xbc660yc1c1qd59bq2vpc2";
 };
 linux_py_36_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.2.0-cp36-cp36m-manylinux2010_x86_64.whl";
-  sha256 = "0f7gbw4hqzi4cr7q0ski424jly4pfik76cj59z5c31vrhk2pzczh";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.3.0-cp36-cp36m-manylinux2010_x86_64.whl";
+  sha256 = "0rwahkmz1wxh9xjn3zvbfvnmvi6n1z9jlimab0y0apar7fgh5b7q";
 };
 linux_py_36_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp36-cp36m-manylinux2010_x86_64.whl";
-  sha256 = "1dcc0c7wk9pdhf7gw1mx71n4anjmvnmdaj3lg04kphjc14xnbb18";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.3.0-cp36-cp36m-manylinux2010_x86_64.whl";
+  sha256 = "1nxn23bk0cl8pcnz1xs4yrc3nvihh9rvr6cwxmwyvzs6x6l8dgw4";
 };
 linux_py_37_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl";
-  sha256 = "0rh0cs54aczab8xxs8npggq66kzkyilidd3vzilslx5saz0qssac";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.3.0-cp37-cp37m-manylinux2010_x86_64.whl";
+  sha256 = "1gv0c59n5agrr8b1wq39kkp88pbhxiw5qg226qfcb6pyjmi5a8fd";
 };
 linux_py_37_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl";
-  sha256 = "0ic6dp7ci15j0i7dlc36zqfjxkwl6dy6bzgnww7lwqmd3gbyl8hz";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.3.0-cp37-cp37m-manylinux2010_x86_64.whl";
+  sha256 = "1yhvmk2kja1cq1b8b0ay78pgnrkjpkxq0bh1rijl64v15hnvi9yz";
+};
+linux_py_38_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.3.0-cp38-cp38-manylinux2010_x86_64.whl";
+  sha256 = "0q9hcv5pjf6995ygmwhghrp5nb9dh3bvhlxczw29aq0yz2gzq8pk";
+};
+linux_py_38_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.3.0-cp38-cp38-manylinux2010_x86_64.whl";
+  sha256 = "1f05p9x15v42dpyxq642v8778k8jdvmry5xd39kmbp2yc57sbh73";
 };
 mac_py_35_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.2.0-cp35-cp35m-macosx_10_6_intel.whl";
-  sha256 = "0jc1rcb4fd8jz4laicxnp31fm4slb5ybbr9xb1wqlngnrm3ppmky";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.3.0-cp35-cp35m-macosx_10_6_intel.whl";
+  sha256 = "179vdlx1jmjlbxjp3jm4bs34kqsjcdigwn71cglrj0g28klx9yn6";
 };
 mac_py_36_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.2.0-cp36-cp36m-macosx_10_9_x86_64.whl";
-  sha256 = "0kp5w5h36w3bwsbg9ar4rfbwbmjcgbpkcavf8w3hijy3x5p4hdb7";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.3.0-cp36-cp36m-macosx_10_9_x86_64.whl";
+  sha256 = "1bifgv1pypkvdmj72mp0nxqs01m2g4idm6npg71l37rsrw1rjsdi";
 };
 mac_py_37_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.2.0-cp37-cp37m-macosx_10_9_x86_64.whl";
-  sha256 = "14wwlfaya7mpy56wb5w0hhjakqwkjry7i6fssn3cnm7xbkycfcn3";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.3.0-cp37-cp37m-macosx_10_9_x86_64.whl";
+  sha256 = "19v2jb10wi80665mcpwcdlz6yr931fm14zv7qyzws22lhyz0zyqc";
+};
+mac_py_38_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.3.0-cp38-cp38-macosx_10_14_x86_64.whl";
+  sha256 = "1pwsbq89133mg8zc907xb2517mhnfvwaw0vbprnxb7nin9wxkj24";
 };
 }

--- a/pkgs/development/python-modules/tensorflow/2/prefetcher.sh
+++ b/pkgs/development/python-modules/tensorflow/2/prefetcher.sh
@@ -1,20 +1,17 @@
 #!/usr/bin/env bash
 
-version=2.1.0
+version=2.2.0
 
 # List of binary wheels for Tensorflow.  The most recent versions can be found
 # on the following page:
 # https://www.tensorflow.org/install/pip?lang=python3#package-location
 url_and_key_list=(
-  "linux_py_27_gpu https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-${version}-cp27-cp27mu-manylinux2010_x86_64.whl"
-  "linux_py_27_cpu https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-${version}-cp27-cp27mu-manylinux2010_x86_64.whl"
   "linux_py_35_gpu https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-${version}-cp35-cp35m-manylinux2010_x86_64.whl"
   "linux_py_35_cpu https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-${version}-cp35-cp35m-manylinux2010_x86_64.whl"
   "linux_py_36_gpu https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-${version}-cp36-cp36m-manylinux2010_x86_64.whl"
   "linux_py_36_cpu https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-${version}-cp36-cp36m-manylinux2010_x86_64.whl"
   "linux_py_37_gpu https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-${version}-cp37-cp37m-manylinux2010_x86_64.whl"
   "linux_py_37_cpu https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-${version}-cp37-cp37m-manylinux2010_x86_64.whl"
-  "mac_py_27_cpu https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-${version}-cp27-cp27m-macosx_10_9_x86_64.whl"
   "mac_py_35_cpu https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-${version}-cp35-cp35m-macosx_10_6_intel.whl"
   "mac_py_36_cpu https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-${version}-cp36-cp36m-macosx_10_9_x86_64.whl"
   "mac_py_37_cpu https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-${version}-cp37-cp37m-macosx_10_9_x86_64.whl"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6906,6 +6906,8 @@ in {
 
   tensorboardx = callPackage ../development/python-modules/tensorboardx { };
 
+  tensorboard-plugin-wit = callPackage ../development/python-modules/tensorboard-plugin-wit { };
+
   tensorflow-bin_1 = callPackage ../development/python-modules/tensorflow/1/bin.nix {
     cudaSupport = pkgs.config.cudaSupport or false;
     inherit (pkgs.linuxPackages) nvidia_x11;
@@ -6942,6 +6944,8 @@ in {
   };
 
   tensorflow-build = self.tensorflow-build_1;
+
+
 
   tensorflow-estimator_1 = callPackage ../development/python-modules/tensorflow-estimator/1 { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

After #95824 (tensorflow-build_2 upgrade) tensorflow-bin_2 should be upgraded aswell


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
