### PR TITLE
minizinc: 2.4.3 -> unstable-2020-09-22

### DIFF
--- a/pkgs/development/tools/minizinc/default.nix
+++ b/pkgs/development/tools/minizinc/default.nix
@@ -1,28 +1,17 @@
 { stdenv, fetchFromGitHub, fetchpatch, cmake, flex, bison }:
-let
-  version = "2.4.3";
-in
-stdenv.mkDerivation {
-  pname = "minizinc";
-  inherit version;
 
-  buildInputs = [ cmake flex bison ];
+stdenv.mkDerivation rec {
+  pname = "minizinc";
+  version = "unstable-2020-09-22";
 
   src = fetchFromGitHub {
     owner = "MiniZinc";
     repo = "libminizinc";
-    rev = version;
-    sha256 = "0mahf621zwwywimly5nd6j39j7qr48k5p7zwpfqnjq4wn010mbf8";
+    rev = "d4a286f8c8dae2d9d4c3a3cd43f9252f54c586d3";
+    sha256 = "0nni772hw2g6m33ff0j5b5c57gvm6vsibcdv52sndy10897nay86";
   };
 
-  patches = [
-    # Fix build with newer Bison versions:
-    # https://github.com/MiniZinc/libminizinc/issues/389
-    (fetchpatch {
-      url = "https://github.com/MiniZinc/libminizinc/commit/d3136f6f198d3081943c17ac6890dbe14a81d112.diff";
-      sha256 = "1f4wxn9422ndgq6dd0vqdxm2313srm7gn9nh82aas2xijdxlmz2c";
-    })
-  ];
+  nativeBuildInputs = [ cmake flex bison ];
 
   meta = with stdenv.lib; {
     homepage = "https://www.minizinc.org/";


### PR DESCRIPTION
###### Motivation for this change
fixes regression in latest bison parser

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @sheenobu 