### PR TITLE
wxwidgets-kicad-macos init at 3.0.4

### DIFF
--- a/pkgs/development/libraries/wxwidgets/3.0/kicad.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/kicad.nix
@@ -1,0 +1,76 @@
+# kicad requires a special, patched version of wxwidgets on macOS. This is the
+# purpose of this package. Hopefully, this will eventually go away and KiCad
+# will use a stock wxwidgets on macOS, obviating the need for this packages.
+
+{ stdenv, fetchgit, fetchurl, pkgconfig
+, libXinerama, libSM, libXxf86vm, gtk3, xorgproto, gst_all_1
+, libGLU, libGL
+, compat24 ? false, compat26 ? true
+, setfile, AGL, Carbon, Cocoa, Kernel, QTKit, WebKit, AVFoundation, AVKit
+, ...
+}:
+
+with stdenv.lib;
+
+assert libGLU != null && libGL != null;
+
+stdenv.mkDerivation {
+  version = "kicad-macos-3.0.4";
+  pname = "wxwidgets";
+
+  src = fetchgit {
+    url = "https://gitlab.com/kicad/code/wxWidgets.git";
+    rev = "53e3765367870187718fc7809f27efc9b40420f8";
+    sha256 = "1yg02d47l4g57bhgn7n09s1k4rjal2mpj89vxiqg1k26zvs7cyc7";
+  };
+
+  buildInputs = [
+    libXinerama libSM libXxf86vm xorgproto gst_all_1.gstreamer gst_all_1.gst-plugins-base
+    gtk3 libGLU
+    setfile Kernel QTKit WebKit AVFoundation AVKit AGL
+  ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  propagatedBuildInputs = [ Carbon Cocoa ];
+
+  configureFlags =
+    [ "--disable-precomp-headers" "--enable-mediactrl"
+      (if compat24 then "--enable-compat24" else "--disable-compat24")
+      (if compat26 then "--enable-compat26" else "--disable-compat26")
+      "--with-cocoa" "--with-macosx-version-min=10.10"
+      "--enable-webview" "--enable-webview-webkit"
+      "--enable-unicode" "--with-opengl"
+    ];
+
+  SEARCH_LIB = "${libGLU.out}/lib ${libGL.out}/lib ";
+
+  preConfigure = ''
+    substituteInPlace configure --replace 'SEARCH_INCLUDE=' 'DUMMY_SEARCH_INCLUDE='
+    substituteInPlace configure --replace 'SEARCH_LIB=' 'DUMMY_SEARCH_LIB='
+    substituteInPlace configure --replace /usr /no-such-path
+    substituteInPlace configure --replace \
+      'ac_cv_prog_SETFILE="/Developer/Tools/SetFile"' \
+      'ac_cv_prog_SETFILE="${setfile}/bin/SetFile"'
+    substituteInPlace configure --replace "-framework System" -lSystem
+  '';
+
+  postInstall = "
+    (cd $out/include && ln -s wx-*/* .)
+  ";
+
+  passthru = {
+    inherit compat24 compat26;
+    unicode = true;
+    gtk = gtk3;
+  };
+
+  enableParallelBuilding = true;
+
+  meta = rec {
+    description = "Patched version of wxWidgets for KiCad on macOS";
+    homepage = "https://gitlab.com/kicad/code/wxWidgets";
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15794,6 +15794,11 @@ in
     inherit (darwin.stubs) setfile rez derez;
   };
 
+  wxGTK30-gtk3-kicad = callPackage ../development/libraries/wxwidgets/3.0/kicad.nix {
+    inherit (darwin.stubs) setfile;
+    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit WebKit AVFoundation AVKit;
+  };
+
   wxSVG = callPackage ../development/libraries/wxSVG {
     wxGTK = wxGTK30;
   };


### PR DESCRIPTION
###### Motivation for this change

KiCad uses a patched wxWidgets on macOS. KiCad maintains a branch of
wxWidgets with all patches already applied. This package provides wxWidgets
solely for KiCad on macOS.

See #98450
Possibly interesting here: #90654

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
