### PR TITLE
spirv-cross: 2020-06-29 -> 2020-09-17

### DIFF
--- a/pkgs/tools/graphics/spirv-cross/default.nix
+++ b/pkgs/tools/graphics/spirv-cross/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "spirv-cross";
-  version = "2020-06-29";
+  version = "2020-09-17";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Cross";
     rev = version;
-    sha256 = "0mnccmhlqmpdx92v495z39i07hbvjwdr5n4zbarlrr1d7rm99lx4";
+    sha256 = "03agx9f7klw96isfdz3xsw47308qxmgs24nsz7j9kx3f337fn435";
   };
 
   nativeBuildInputs = [ cmake python3 ];
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A tool designed for parsing and converting SPIR-V to other shader languages";
     homepage = "https://github.com/KhronosGroup/SPIRV-Cross";
+    changelog = "https://github.com/KhronosGroup/SPIRV-Cross/releases/tag/${version}";
     platforms = platforms.linux;
     license = licenses.asl20;
     maintainers = with maintainers; [ Flakebi ];


### PR DESCRIPTION
Add link to GitHub release as changelog.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
2020-09-17 was released: https://github.com/KhronosGroup/SPIRV-Cross/releases/tag/2020-09-17

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
