### PR TITLE
[20.09] Backport google resumable media

### DIFF
--- a/pkgs/development/libraries/crc32c/default.nix
+++ b/pkgs/development/libraries/crc32c/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, gflags }:
+{ stdenv, lib, fetchFromGitHub, cmake, gflags
+, staticOnly ? false }:
+
 stdenv.mkDerivation rec {
   pname = "crc32c";
   version = "1.1.0";
@@ -14,6 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ gflags ];
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isAarch64 "-march=armv8-a+crc";
+  cmakeFlags = lib.optionals (!staticOnly) [ "-DBUILD_SHARED_LIBS=1"  ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/google/crc32c";

--- a/pkgs/development/python-modules/google-crc32c/default.nix
+++ b/pkgs/development/python-modules/google-crc32c/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, isPy3k, fetchFromGitHub, cffi, crc32c, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "google-crc32c";
+  version = "1.0.0";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "googleapis";
+    repo = "python-crc32c";
+    rev = "v${version}";
+    sha256 = "0n3ggsxmk1fhq0kz6p5rcj4gypfb05i26fcn7lsawakgl7fzxqyl";
+  };
+
+  buildInputs = [ crc32c  ];
+  propagatedBuildInputs = [ cffi ];
+
+  LDFLAGS = "-L${crc32c}/lib";
+  CFLAGS = "-I${crc32c}/include";
+
+  checkInputs = [ pytestCheckHook crc32c ];
+  pythonImportsCheck = [ "google_crc32c" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/googleapis/python-crc32c";
+    description = "Wrapper the google/crc32c hardware-based implementation of the CRC32C hashing algorithm";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ freezeboy ];
+  };
+}

--- a/pkgs/development/python-modules/google_resumable_media/default.nix
+++ b/pkgs/development/python-modules/google_resumable_media/default.nix
@@ -1,30 +1,35 @@
-{ stdenv
+{ lib
 , buildPythonPackage
+, isPy3k
 , fetchPypi
 , six
 , requests
 , setuptools
 , pytest
 , mock
+, crcmod
+, google-crc32c
 }:
 
 buildPythonPackage rec {
   pname = "google-resumable-media";
-  version = "0.7.1";
+  version = "1.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "57841f5e65fb285c01071f439724745b2549a72eb75e5fd979198eb518608ed0";
+    sha256 = "FzrMa63hSApSn6KcbCcXVDri3AnULpRh/bhvOVAu/PI=";
   };
 
   checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ requests setuptools six ];
+  propagatedBuildInputs = [ requests setuptools six ]
+    ++ lib.optional isPy3k google-crc32c
+    ++ lib.optional (!isPy3k) crcmod;
 
   checkPhase = ''
     py.test tests/unit
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Utilities for Google Media Downloads and Resumable Uploads";
     homepage = "https://github.com/GoogleCloudPlatform/google-resumable-media-python";
     license = licenses.asl20;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2452,6 +2452,10 @@ in {
 
   google-compute-engine = callPackage ../tools/virtualization/google-compute-engine { };
 
+  google-crc32c = callPackage ../development/python-modules/google-crc32c {
+    inherit (pkgs) crc32c;
+  };
+
   google-i18n-address = callPackage ../development/python-modules/google-i18n-address { };
 
   google-music = callPackage ../development/python-modules/google-music { };

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -191,6 +191,9 @@ in {
   gsm = super.gsm.override {
     staticSupport = true;
   };
+  crc32c = super.crc32c.override {
+    staticOnly = true;
+  };
   parted = super.parted.override {
     enableStatic = true;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Initial PR: #97768
ZHF: #97479 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
