### PR TITLE
[20.09] python3Packages.fluent-logger: relax version for msgpack

### DIFF
--- a/pkgs/development/python-modules/fluent-logger/default.nix
+++ b/pkgs/development/python-modules/fluent-logger/default.nix
@@ -9,10 +9,21 @@ buildPythonPackage rec {
     sha256 = "a7d47eae4d2a11c8cb0df10ae3d034d95b0b8cef9d060e59e7519ad1f82ffa73";
   };
 
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "msgpack<1.0.0" "msgpack"
+  '';
+
   propagatedBuildInputs = [ msgpack ];
 
   # Tests fail because absent in package
   doCheck = false;
+  pythonImportsCheck = [
+    "fluent"
+    "fluent.event"
+    "fluent.handler"
+    "fluent.sender"
+  ];
 
   meta = with lib; {
     description = "A structured logger for Fluentd (Python)";


### PR DESCRIPTION
Also add imports tests as we can't do more using the pip release

(cherry picked from commit e3c1b8782a24286f8778baa784d9fbfd061cd1d5)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Initial PR: #98211
ZHF: #97479 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
