### PR TITLE
nixos/codimd: add option `environmentFile` for injecting secrets

### DIFF
--- a/nixos/tests/codimd.nix
+++ b/nixos/tests/codimd.nix
@@ -21,7 +21,15 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
       services = {
         codimd = {
           enable = true;
-          configuration.dbURL = "postgres://codimd:snakeoilpassword@localhost:5432/codimddb";
+          configuration.dbURL = "postgres://codimd:\${DB_PASSWORD}@localhost:5432/codimddb";
+
+          /*
+           * Do not use pkgs.writeText for secrets as
+           * they will end up in the world-readable Nix store.
+           */
+          environmentFile = pkgs.writeText "codimd-env" ''
+            DB_PASSWORD=snakeoilpassword
+          '';
         };
         postgresql = {
           enable = true;


### PR DESCRIPTION
###### Motivation for this change
Currently the upstream module is missing a way to pass secrets to the service without adding them to the Nix store.

###### Things done
Secrets are injected from the environment into the rendered
configuration before each startup using envsubst.
The test now makes use of this feature for the db password.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
