### PR TITLE
tty-share: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -580,6 +580,12 @@
     githubId = 3808928;
     name = "Anders Sildnes";
   };
+  andys8 = {
+    email = "andys8@users.noreply.github.com";
+    github = "andys8";
+    githubId = 13085980;
+    name = "Andy";
+  };
   aneeshusa = {
     email = "aneeshusa@gmail.com";
     github = "aneeshusa";

--- a/pkgs/applications/misc/tty-share/default.nix
+++ b/pkgs/applications/misc/tty-share/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+# Upstream has a `./vendor` directory with all deps which we rely upon.
+buildGoPackage rec {
+  pname = "tty-share";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "elisescu";
+    repo = "tty-share";
+    rev = "v${version}";
+    sha256 = "1d2vd3d1lb4n0jq4s0p5mii1vz4r3z36hykr5mnx53srsni1wsj5";
+  };
+
+  goPackagePath = "github.com/elisescu/tty-share";
+
+  meta = with stdenv.lib; {
+    homepage = "https://tty-share.com";
+    description = "Share terminal via browser for remote work or shared sessions";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ andys8 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7882,6 +7882,8 @@ in
 
   tty-clock = callPackage ../tools/misc/tty-clock { };
 
+  tty-share = callPackage ../applications/misc/tty-share { };
+
   ttyplot = callPackage ../tools/misc/ttyplot { };
 
   ttyrec = callPackage ../tools/misc/ttyrec { };


### PR DESCRIPTION
Add `tty-share` - a tool to share tty sessions via webbrowser.


###### Motivation for this change

Add a missing tool

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
