### PR TITLE
nixos-manual: link to sources

### DIFF
--- a/nixos/doc/manual/manual-contrib/manual-contrib.xml
+++ b/nixos/doc/manual/manual-contrib/manual-contrib.xml
@@ -1,0 +1,13 @@
+<appendix xmlns="http://docbook.org/ns/docbook"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns:xi="http://www.w3.org/2001/XInclude"
+          version="5.0"
+          xml:id="ch-manual-contrib">
+ <title>Contributing to this manual</title>
+ <para>
+  The NixOS manual is maintained as part of the
+  <link xlink:href="https://github.com/nixos/nixpkgs">nixpkgs</link> collection.
+  You can find the sources and documentation on how to build them in
+  the <link xlink:href="https://github.com/nixos/nixpkgs/tree/master/nixos/doc/manual">nixos/doc/manual</link> directory.
+ </para>
+</appendix>

--- a/nixos/doc/manual/manual.xml
+++ b/nixos/doc/manual/manual.xml
@@ -20,4 +20,5 @@
                 xpointer="configuration-variable-list" />
  </appendix>
  <xi:include href="release-notes/release-notes.xml" />
+ <xi:include href="manual-contrib/manual-contrib.xml" />
 </book>


### PR DESCRIPTION
###### Motivation for this change

I wanted to contribute to the nixos-manual but it took me a while to figure out
where it sources were. This should make that easier ;).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).