### PR TITLE
cmake: classify libraries in /usr/lib as system libraries

### DIFF
--- a/pkgs/development/libraries/cimg/default.nix
+++ b/pkgs/development/libraries/cimg/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "dtschump";
     repo = "CImg";
     rev = "v.${version}";
-    sha256 = "1sb0z5ryh34y80ghlr2agsl64gayjmxpl96l9fjaylf5k2m3fg2b";
+    sha256 = "sha256-7v8651yDkxTdRMoGhEl4d/k7mxYwfIwW/rkuyjqVGwY=";
   };
 
   installPhase = ''

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -70,6 +70,12 @@ stdenv.mkDerivation rec {
   # CC_FOR_BUILD and CXX_FOR_BUILD are used to bootstrap cmake
   + ''
     configureFlags="--parallel=''${NIX_BUILD_CORES:-1} CC=$CC_FOR_BUILD CXX=$CXX_FOR_BUILD $configureFlags"
+  ''
+  # Detect dylibs in /usr/lib as system libraries on Darwin to correctly build App bundles
+  + stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Modules/GetPrerequisites.cmake --replace \
+      "if(resolved_file MATCHES \"^(/System/Library/|/var/empty/lib/)\")" \
+      "if(resolved_file MATCHES \"^(/System/Library/|/usr/lib/)\")"
   '';
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

This change is only relevant for App Bundle builds on macOS. For an App Bundle
every non-system runtime dependency gets copied recursively into the App Bundle
to make a standalone distributable package.
The replacement of every occurence of '/usr' by '/var/empty' by Nix thwarts App
Bundle builds, because libraries in /usr/lib do not get correctly classified as
system libraries.
This patch reverts this single path name back to '/usr/lib', so that packaging
App Bundles on macOS works. FYI: within CMake the occurence is also guarded by
an 'if(APPLE)' statement.

The substituteInPlace matches only a single line: https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/GetPrerequisites.cmake#L522
Let me know, if a proper patch is preferred instead.

~~Draft, because I'm still building ;)~~
**Edit:** Building the world succeeded

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
