### PR TITLE
ponyc: update to 0.37.0

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -1,85 +1,113 @@
-{ stdenv, fetchFromGitHub, llvm, makeWrapper, pcre2, coreutils, which, libressl, libxml2,
-  cc ? stdenv.cc, lto ? !stdenv.isDarwin }:
+{ clangStdenv, fetchFromGitHub, fetchurl, llvm, makeWrapper, pcre2, coreutils, which, libressl, libxml2, cmake, z3,
+  cc ? clangStdenv.cc, lto ? !clangStdenv.isDarwin }:
 
-stdenv.mkDerivation ( rec {
+clangStdenv.mkDerivation ( rec {
   pname = "ponyc";
-  version = "0.33.2";
+  version = "0.37.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    sha256 = "0jcdr1r3g8sm3q9fcc87d6x98fg581n6hb90hz7r08mzn4bwvysw";
+    sha256 = "0pdvxyp11p4xskzcp0ps811xd3js51yh6hjs33w69kkh5bnipmyr";
+
+# Due to a bug in LLVM 9.x, ponyc has to include its own vendored patched
+# LLVM.  (The submodule is a specific tag in the LLVM source tree).
+#
+# The pony developers are currently working to get off 9.x as quickly
+# as possible so hopefully in a few revisions this package build will
+# become a lot simpler.
+#
+# https://reviews.llvm.org/rG9f4f237e29e7150dfcf04ae78fa287d2dc8d48e2
+
+    fetchSubmodules = true;
   };
 
-  buildInputs = [ llvm makeWrapper which libxml2 ];
+# build time dependencies for the patched LLVM also need patches
+  googletest = fetchurl {
+    url = https://github.com/google/googletest/archive/release-1.8.1.tar.gz;
+    sha256 = "17147961i01fl099ygxjx4asvjanwdd446nwbq9v8156h98zxwcv";
+    name = "release-1.8.1.tar.gz";
+  };
+  ponygbenchmark = fetchurl {
+    url = https://github.com/google/benchmark/archive/v1.5.0.tar.gz;
+    sha256 = "06i2cr4rj126m1zfz0x1rbxv1mw1l7a11mzal5kqk56cdrdicsiw";
+    name = "v1.5.0.tar.gz";
+  };
+
+  buildInputs = [ llvm makeWrapper which libxml2 cmake z3 ];
   propagatedBuildInputs = [ cc ];
 
-  # Disable problematic networking tests
+  # Sandbox disallows network access, so disabling problematic networking tests
   patches = [ ./disable-tests.patch ];
 
-  preBuild = ''
-    # Fix tests
+  postUnpack = ''
+    mkdir -p source/build/build_libs/gbenchmark-prefix/src
+    tar -C source/build/build_libs/gbenchmark-prefix/src -zxvf '${ponygbenchmark}'
+    mv source/build/build_libs/gbenchmark-prefix/src/benchmark-1.5.0 \
+       source/build/build_libs/gbenchmark-prefix/src/benchmark
+  '';
+
+  dontConfigure = true;
+
+  postPatch = ''
+    # Patching Vendor LLVM
+    patchShebangs --host build/build_libs/gbenchmark-prefix/src/benchmark/tools/*.py
+    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2020-01-07-01-c-exports.diff
+    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2019-12-23-01-jit-eh-frames.diff
+
+    # Patching CMakeList to remove all the download code which will fail inside
+    # the sandbox.
+    sed -i -e '31,86d' lib/CMakeLists.txt
+    substituteInPlace lib/CMakeLists.txt \
+        --replace 'URL https://github.com/google/benchmark/archive/v1.5.0.tar.gz' \
+                  'SOURCE_DIR gbenchmark-prefix/src/benchmark' \
+        --replace 'https://github.com/google/googletest/archive/release-1.8.1.tar.gz' '${googletest}'
+
     substituteInPlace packages/process/_test.pony \
-        --replace '"/bin/' '"${coreutils}/bin/'
-    substituteInPlace packages/process/_test.pony \
+        --replace '"/bin/' '"${coreutils}/bin/' \
         --replace '=/bin' "${coreutils}/bin"
-
-    # Disabling the stdlib tests
-    substituteInPlace Makefile-ponyc \
-        --replace 'test-ci: all check-version test-core test-stdlib-debug test-stdlib' 'test-ci: all check-version test-core'
-
-    # Remove impure system refs
     substituteInPlace src/libponyc/pkg/package.c \
         --replace "/usr/local/lib" "" \
         --replace "/opt/local/lib" ""
 
-    for file in `grep -irl '/usr/local/opt/libressl/lib' ./*`; do
-      substituteInPlace $file  --replace '/usr/local/opt/libressl/lib' "${stdenv.lib.getLib libressl}/lib"
-    done
-
-    export LLVM_CONFIG=${llvm}/bin/llvm-config
-  '' + stdenv.lib.optionalString ((!stdenv.isDarwin) && (!cc.isClang) && lto) ''
-    export LTO_PLUGIN=`find ${cc.cc}/ -name liblto_plugin.so`
-  '' + stdenv.lib.optionalString ((!stdenv.isDarwin) && (cc.isClang) && lto) ''
-    export LTO_PLUGIN=`find ${cc.cc}/ -name LLVMgold.so`
   '';
 
-  makeFlags = [ "config=release" ] ++ stdenv.lib.optionals stdenv.isDarwin [ "bits=64" ]
-              ++ stdenv.lib.optionals (stdenv.isDarwin && (!lto)) [ "lto=no" ];
 
-  enableParallelBuilding = true;
+  preBuild = ''
+    make libs
+    make configure
+  '';
+
+  makeFlags = [ "PONYC_VERSION=0.37.0" "prefix=${placeholder "out"}" ] ++ clangStdenv.lib.optionals clangStdenv.isDarwin [ "bits=64" ]
+             ++ clangStdenv.lib.optionals (clangStdenv.isDarwin && (!lto)) [ "lto=no" ];
+
+  enableParallelBuilding = false;
 
   doCheck = true;
 
-  checkTarget = "test-ci";
-
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=redundant-move" ];
-
-  preCheck = ''
-    export PONYPATH="$out/lib:${stdenv.lib.makeLibraryPath [ pcre2 libressl ]}"
-  '';
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=redundant-move" "-Wno-error=implicit-fallthrough" ];
 
   installPhase = ''
     make config=release prefix=$out ''
-    + stdenv.lib.optionalString stdenv.isDarwin '' bits=64 ''
-    + stdenv.lib.optionalString (stdenv.isDarwin && (!lto)) '' lto=no ''
+    + clangStdenv.lib.optionalString clangStdenv.isDarwin '' bits=64 ''
+    + clangStdenv.lib.optionalString (clangStdenv.isDarwin && (!lto)) '' lto=no ''
     + '' install
 
     wrapProgram $out/bin/ponyc \
-      --prefix PATH ":" "${stdenv.cc}/bin" \
+      --prefix PATH ":" "${clangStdenv.cc}/bin" \
       --set-default CC "$CC" \
-      --prefix PONYPATH : "${stdenv.lib.makeLibraryPath [ pcre2 libressl (placeholder "out") ]}"
+      --prefix PONYPATH : "${clangStdenv.lib.makeLibraryPath [ pcre2 libressl (placeholder "out") ]}"
   '';
 
   # Stripping breaks linking for ponyc
   dontStrip = true;
 
-  meta = with stdenv.lib; {
+  meta = with clangStdenv.lib; {
     description = "Pony is an Object-oriented, actor-model, capabilities-secure, high performance programming language";
     homepage = "https://www.ponylang.org";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ doublec kamilchm patternspandemic ];
+    maintainers = with maintainers; [ doublec kamilchm patternspandemic redvers ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 })

--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -75,8 +75,8 @@ clangStdenv.mkDerivation ( rec {
 
 
   preBuild = ''
-    make libs '$makeFlags'
-    make configure '$makeFlags'
+    make libs 
+    make configure 
   '';
 
   makeFlags = [ "PONYC_VERSION=0.37.0" "prefix=${placeholder "out"}" ] ++ clangStdenv.lib.optionals clangStdenv.isDarwin [ "bits=64" ]

--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -75,8 +75,8 @@ clangStdenv.mkDerivation ( rec {
 
 
   preBuild = ''
-    make libs 
-    make configure 
+    make libs
+    make configure
   '';
 
   makeFlags = [ "PONYC_VERSION=0.37.0" "prefix=${placeholder "out"}" ] ++ clangStdenv.lib.optionals clangStdenv.isDarwin [ "bits=64" ]

--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -1,85 +1,113 @@
-{ stdenv, fetchFromGitHub, llvm, makeWrapper, pcre2, coreutils, which, libressl, libxml2,
-  cc ? stdenv.cc, lto ? !stdenv.isDarwin }:
+{ clangStdenv, fetchFromGitHub, fetchurl, llvm, makeWrapper, pcre2, coreutils, which, libressl, libxml2, cmake, z3,
+  cc ? clangStdenv.cc, lto ? !clangStdenv.isDarwin }:
 
-stdenv.mkDerivation ( rec {
+clangStdenv.mkDerivation ( rec {
   pname = "ponyc";
-  version = "0.33.2";
+  version = "0.37.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    sha256 = "0jcdr1r3g8sm3q9fcc87d6x98fg581n6hb90hz7r08mzn4bwvysw";
+    sha256 = "0pdvxyp11p4xskzcp0ps811xd3js51yh6hjs33w69kkh5bnipmyr";
+
+# Due to a bug in LLVM 9.x, ponyc has to include its own vendored patched
+# LLVM.  (The submodule is a specific tag in the LLVM source tree).
+#
+# The pony developers are currently working to get off 9.x as quickly
+# as possible so hopefully in a few revisions this package build will
+# become a lot simpler.
+#
+# https://reviews.llvm.org/rG9f4f237e29e7150dfcf04ae78fa287d2dc8d48e2 
+
+    fetchSubmodules = true;
   };
 
-  buildInputs = [ llvm makeWrapper which libxml2 ];
+# build time dependencies for the patched LLVM also need patches 
+  googletest = fetchurl {
+    url = https://github.com/google/googletest/archive/release-1.8.1.tar.gz;
+    sha256 = "17147961i01fl099ygxjx4asvjanwdd446nwbq9v8156h98zxwcv";
+    name = "release-1.8.1.tar.gz";
+  };
+  ponygbenchmark = fetchurl {
+    url = https://github.com/google/benchmark/archive/v1.5.0.tar.gz;
+    sha256 = "06i2cr4rj126m1zfz0x1rbxv1mw1l7a11mzal5kqk56cdrdicsiw";
+    name = "v1.5.0.tar.gz";
+  };
+
+  buildInputs = [ llvm makeWrapper which libxml2 cmake z3 ];
   propagatedBuildInputs = [ cc ];
 
-  # Disable problematic networking tests
+  # Sandbox disallows network access, so disabling problematic networking tests
   patches = [ ./disable-tests.patch ];
 
-  preBuild = ''
-    # Fix tests
+  postUnpack = ''
+    mkdir -p source/build/build_libs/gbenchmark-prefix/src
+    tar -C source/build/build_libs/gbenchmark-prefix/src -zxvf '${ponygbenchmark}'
+    mv source/build/build_libs/gbenchmark-prefix/src/benchmark-1.5.0 \
+       source/build/build_libs/gbenchmark-prefix/src/benchmark
+  '';
+
+  dontConfigure = true;
+
+  postPatch = ''
+    # Patching Vendor LLVM
+    patchShebangs --host build/build_libs/gbenchmark-prefix/src/benchmark/tools/*.py
+    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2020-01-07-01-c-exports.diff 
+    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2019-12-23-01-jit-eh-frames.diff 
+
+    # Patching CMakeList to remove all the download code which will fail inside
+    # the sandbox.
+    sed -i -e '31,86d' lib/CMakeLists.txt
+    substituteInPlace lib/CMakeLists.txt \
+        --replace 'URL https://github.com/google/benchmark/archive/v1.5.0.tar.gz' \
+                  'SOURCE_DIR gbenchmark-prefix/src/benchmark' \
+        --replace 'https://github.com/google/googletest/archive/release-1.8.1.tar.gz' '${googletest}'
+
     substituteInPlace packages/process/_test.pony \
-        --replace '"/bin/' '"${coreutils}/bin/'
-    substituteInPlace packages/process/_test.pony \
+        --replace '"/bin/' '"${coreutils}/bin/' \
         --replace '=/bin' "${coreutils}/bin"
-
-    # Disabling the stdlib tests
-    substituteInPlace Makefile-ponyc \
-        --replace 'test-ci: all check-version test-core test-stdlib-debug test-stdlib' 'test-ci: all check-version test-core'
-
-    # Remove impure system refs
     substituteInPlace src/libponyc/pkg/package.c \
         --replace "/usr/local/lib" "" \
         --replace "/opt/local/lib" ""
 
-    for file in `grep -irl '/usr/local/opt/libressl/lib' ./*`; do
-      substituteInPlace $file  --replace '/usr/local/opt/libressl/lib' "${stdenv.lib.getLib libressl}/lib"
-    done
-
-    export LLVM_CONFIG=${llvm}/bin/llvm-config
-  '' + stdenv.lib.optionalString ((!stdenv.isDarwin) && (!cc.isClang) && lto) ''
-    export LTO_PLUGIN=`find ${cc.cc}/ -name liblto_plugin.so`
-  '' + stdenv.lib.optionalString ((!stdenv.isDarwin) && (cc.isClang) && lto) ''
-    export LTO_PLUGIN=`find ${cc.cc}/ -name LLVMgold.so`
   '';
 
-  makeFlags = [ "config=release" ] ++ stdenv.lib.optionals stdenv.isDarwin [ "bits=64" ]
-              ++ stdenv.lib.optionals (stdenv.isDarwin && (!lto)) [ "lto=no" ];
 
-  enableParallelBuilding = true;
+  preBuild = ''
+    make libs '$makeFlags'
+    make configure '$makeFlags'
+  '';
+
+  makeFlags = [ "PONYC_VERSION=0.37.0" "prefix=${placeholder "out"}" ] ++ clangStdenv.lib.optionals clangStdenv.isDarwin [ "bits=64" ]
+             ++ clangStdenv.lib.optionals (clangStdenv.isDarwin && (!lto)) [ "lto=no" ];
+
+  enableParallelBuilding = false;
 
   doCheck = true;
 
-  checkTarget = "test-ci";
-
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=redundant-move" ];
-
-  preCheck = ''
-    export PONYPATH="$out/lib:${stdenv.lib.makeLibraryPath [ pcre2 libressl ]}"
-  '';
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=redundant-move" "-Wno-error=implicit-fallthrough" ];
 
   installPhase = ''
     make config=release prefix=$out ''
-    + stdenv.lib.optionalString stdenv.isDarwin '' bits=64 ''
-    + stdenv.lib.optionalString (stdenv.isDarwin && (!lto)) '' lto=no ''
+    + clangStdenv.lib.optionalString clangStdenv.isDarwin '' bits=64 ''
+    + clangStdenv.lib.optionalString (clangStdenv.isDarwin && (!lto)) '' lto=no ''
     + '' install
 
     wrapProgram $out/bin/ponyc \
-      --prefix PATH ":" "${stdenv.cc}/bin" \
+      --prefix PATH ":" "${clangStdenv.cc}/bin" \
       --set-default CC "$CC" \
-      --prefix PONYPATH : "${stdenv.lib.makeLibraryPath [ pcre2 libressl (placeholder "out") ]}"
+      --prefix PONYPATH : "${clangStdenv.lib.makeLibraryPath [ pcre2 libressl (placeholder "out") ]}"
   '';
 
   # Stripping breaks linking for ponyc
   dontStrip = true;
 
-  meta = with stdenv.lib; {
+  meta = with clangStdenv.lib; {
     description = "Pony is an Object-oriented, actor-model, capabilities-secure, high performance programming language";
     homepage = "https://www.ponylang.org";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ doublec kamilchm patternspandemic ];
+    maintainers = with maintainers; [ doublec kamilchm patternspandemic redvers ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 })

--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -18,12 +18,12 @@ clangStdenv.mkDerivation ( rec {
 # as possible so hopefully in a few revisions this package build will
 # become a lot simpler.
 #
-# https://reviews.llvm.org/rG9f4f237e29e7150dfcf04ae78fa287d2dc8d48e2 
+# https://reviews.llvm.org/rG9f4f237e29e7150dfcf04ae78fa287d2dc8d48e2
 
     fetchSubmodules = true;
   };
 
-# build time dependencies for the patched LLVM also need patches 
+# build time dependencies for the patched LLVM also need patches
   googletest = fetchurl {
     url = https://github.com/google/googletest/archive/release-1.8.1.tar.gz;
     sha256 = "17147961i01fl099ygxjx4asvjanwdd446nwbq9v8156h98zxwcv";
@@ -53,8 +53,8 @@ clangStdenv.mkDerivation ( rec {
   postPatch = ''
     # Patching Vendor LLVM
     patchShebangs --host build/build_libs/gbenchmark-prefix/src/benchmark/tools/*.py
-    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2020-01-07-01-c-exports.diff 
-    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2019-12-23-01-jit-eh-frames.diff 
+    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2020-01-07-01-c-exports.diff
+    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2019-12-23-01-jit-eh-frames.diff
 
     # Patching CMakeList to remove all the download code which will fail inside
     # the sandbox.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
ponyc had been stalled at v0.33.2 for a while for three reasons:

1. The buildsystem had been changed from make to cmake
2. A bug was discovered in LLVM 9.x which caused SIGSEGV in the test suite.  The fix has been applied to LLVM upstream but is in the 10.x and master branch.  Since ponyc currently uses 9.x, the build requires a patched+fixed llvm **for the build only**
3. The additional complexity of the (temporary) build-system in use was a real pain to integrate into a nix package.

I believe I have finally tamed this beast.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note - I do not own a Mac so I'm going to be reliant on hydra to test against that platform.

Thanks!