### PR TITLE
[20.09] python3Packages.parse: 1.16.0 -> 1.18.0, python-docx: run behave tests

### DIFF
--- a/pkgs/development/python-modules/behave/default.nix
+++ b/pkgs/development/python-modules/behave/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , buildPythonApplication, python
-, mock, pathpy, pyhamcrest, pytest, pytest-html
+, pytestCheckHook, mock, pathpy, pyhamcrest, pytest-html
 , glibcLocales
 , colorama, cucumber-tag-expressions, parse, parse-type, six
 }:
@@ -16,7 +16,7 @@ buildPythonApplication rec {
     sha256 = "1ssgixmqlg8sxsyalr83a1970njc2wg3zl8idsmxnsljwacv7qwv";
   };
 
-  checkInputs = [ mock pathpy pyhamcrest pytest pytest-html ];
+  checkInputs = [ pytestCheckHook mock pathpy pyhamcrest pytest-html ];
   buildInputs = [ glibcLocales ];
   propagatedBuildInputs = [ colorama cucumber-tag-expressions parse parse-type six ];
 
@@ -24,13 +24,13 @@ buildPythonApplication rec {
     patchShebangs bin
   '';
 
-  doCheck = true;
+  # timing-based test flaky on Darwin
+  # https://github.com/NixOS/nixpkgs/pull/97737#issuecomment-691489824
+  disabledTests = stdenv.lib.optionals stdenv.isDarwin [ "test_step_decorator_async_run_until_complete" ];
 
-  checkPhase = ''
+  postCheck = ''
     export LANG="en_US.UTF-8"
     export LC_ALL="en_US.UTF-8"
-
-    pytest tests
 
     ${python.interpreter} bin/behave -f progress3 --stop --tags='~@xfail' features/
     ${python.interpreter} bin/behave -f progress3 --stop --tags='~@xfail' tools/test-features/

--- a/pkgs/development/python-modules/parse/default.nix
+++ b/pkgs/development/python-modules/parse/default.nix
@@ -3,11 +3,11 @@
 }:
 buildPythonPackage rec {
   pname = "parse";
-  version = "1.16.0";
+  version = "1.18.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "cd89e57aed38dcf3e0ff8253f53121a3b23e6181758993323658bffc048a5c19";
+    sha256 = "91666032d6723dc5905248417ef0dc9e4c51df9526aaeef271eacad6491f06a4";
   };
 
   checkPhase = ''

--- a/pkgs/development/python-modules/python-docx/default.nix
+++ b/pkgs/development/python-modules/python-docx/default.nix
@@ -22,6 +22,7 @@ buildPythonPackage rec {
 
   checkPhase = ''
     py.test tests
+    behave --format progress --stop --tags=-wip
   '';
 
   meta = {


### PR DESCRIPTION
Backport of #97737 
ZHF: #97479
cc @NixOS/nixos-release-managers

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

nixpkgs-review results:
```
2 packages failed to build:
python38Packages.pytest-bdd terraform-compliance

18 packages built:
nrfutil python27Packages.parse python27Packages.parse-type python27Packages.pyparser python27Packages.pytest-bdd python37Packages.behave python37Packages.parse python37Packages.parse-type python37Packages.pyparser python37Packages.pytest-bdd python37Packages.python-docx python37Packages.radish-bdd python38Packages.behave python38Packages.parse python38Packages.parse-type python38Packages.pyparser python38Packages.python-docx python38Packages.radish-bdd
```