### PR TITLE
gifticlib: init at unstable-2020-07-07

### DIFF
--- a/pkgs/development/libraries/science/biology/gifticlib/default.nix
+++ b/pkgs/development/libraries/science/biology/gifticlib/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, cmake, expat, nifticlib, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "gifticlib";
+  version = "unstable-2020-07-07";
+
+  src = fetchFromGitHub {
+    owner = "NIFTI-Imaging";
+    repo = "gifti_clib";
+    rev = "5eae81ba1e87ef3553df3b6ba585f12dc81a0030";
+    sha256 = "0gcab06gm0irjnlrkpszzd4wr8z0fi7gx8f7966gywdp2jlxzw19";
+  };
+
+  cmakeFlags = [ "-DUSE_SYSTEM_NIFTI=ON" "-DDOWNLOAD_TEST_DATA=OFF" ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ expat nifticlib zlib ];
+
+  # without the test data, this is only a few basic tests
+  doCheck = !stdenv.isDarwin;
+  checkPhase = ''
+    runHook preCheck
+    ctest -LE 'NEEDS_DATA'
+    runHook postCheck
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.nitrc.org/projects/gifti";
+    description = "Medical imaging geometry format C API";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms = platforms.unix;
+    license = licenses.publicDomain;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12525,6 +12525,8 @@ in
 
   giblib = callPackage ../development/libraries/giblib { };
 
+  gifticlib = callPackage ../development/libraries/science/biology/gifticlib { };
+
   gio-sharp = callPackage ../development/libraries/gio-sharp { };
 
   givaro = callPackage ../development/libraries/givaro {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
