### PR TITLE
[20.09] nixosTests.magnetico: wait for open port and make curl actually fail

### DIFF
--- a/nixos/tests/magnetico.nix
+++ b/nixos/tests/magnetico.nix
@@ -27,12 +27,13 @@ in
       start_all()
       machine.wait_for_unit("magneticod")
       machine.wait_for_unit("magneticow")
+      machine.wait_for_open_port(${toString port})
       machine.succeed(
-          "${pkgs.curl}/bin/curl "
+          "${pkgs.curl}/bin/curl --fail "
           + "-u user:password http://localhost:${toString port}"
       )
-      assert "Unauthorised." in machine.succeed(
-          "${pkgs.curl}/bin/curl "
+      machine.fail(
+          "${pkgs.curl}/bin/curl --fail "
           + "-u user:wrongpwd http://localhost:${toString port}"
       )
       machine.shutdown()


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF #97479 
Backport #98244 

(cherry picked from commit 76aeb20d911b5d05085b41ee14d3e3ff40b29ba6)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
