### PR TITLE
[20.09] chez-modules: Fix path to csv-site.

### DIFF
--- a/pkgs/development/chez-modules/chez-mit/default.nix
+++ b/pkgs/development/chez-modules/chez-mit/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   buildInputs = [ chez chez-srfi ];
 
   buildPhase = ''
-    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv9.5-site
+    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv-site
     make PREFIX=$out CHEZ=${chez}/bin/scheme
   '';
 

--- a/pkgs/development/chez-modules/chez-mit/default.nix
+++ b/pkgs/development/chez-modules/chez-mit/default.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation {
   buildInputs = [ chez chez-srfi ];
 
   buildPhase = ''
-    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv-site
     make PREFIX=$out CHEZ=${chez}/bin/scheme
   '';
 

--- a/pkgs/development/chez-modules/chez-scmutils/default.nix
+++ b/pkgs/development/chez-modules/chez-scmutils/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   buildInputs = [ chez chez-srfi chez-mit ];
 
   buildPhase = ''
-    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv9.5-site:${chez-mit}/lib/csv9.5-site
+    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv-site:${chez-mit}/lib/csv-site
     make PREFIX=$out CHEZ=${chez}/bin/scheme
   '';
 

--- a/pkgs/development/chez-modules/chez-scmutils/default.nix
+++ b/pkgs/development/chez-modules/chez-scmutils/default.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation {
   buildInputs = [ chez chez-srfi chez-mit ];
 
   buildPhase = ''
-    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv-site:${chez-mit}/lib/csv-site
     make PREFIX=$out CHEZ=${chez}/bin/scheme
   '';
 

--- a/pkgs/development/compilers/chez/default.nix
+++ b/pkgs/development/compilers/chez/default.nix
@@ -65,6 +65,8 @@ stdenv.mkDerivation rec {
     rm -rf $out/lib/csv${version}/examples
   '';
 
+  setupHook = ./setup-hook.sh;
+
   meta = {
     description  = "A powerful and incredibly fast R6RS Scheme compiler";
     homepage     = "https://cisco.github.io/ChezScheme/";

--- a/pkgs/development/compilers/chez/setup-hook.sh
+++ b/pkgs/development/compilers/chez/setup-hook.sh
@@ -1,0 +1,5 @@
+addChezLibraryPath() {
+  addToSearchPath CHEZSCHEMELIBDIRS "$1/lib/csv-site"
+}
+
+addEnvHooks "$targetOffset" addChezLibraryPath


### PR DESCRIPTION
###### Motivation for this change

backport of #97927 and #98128
ZHF: #97479

cc @NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - `nixpkgs-review` seems to want to merge my branch with master before building the diffs. The changes were tested before backporting, though
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
