### PR TITLE
[20.09] cvc3: fix build against bison 3.7

### DIFF
--- a/pkgs/applications/science/logic/cvc3/default.nix
+++ b/pkgs/applications/science/logic/cvc3/default.nix
@@ -13,9 +13,14 @@ stdenv.mkDerivation rec {
 
   patches = [ ./cvc3-2.4.1-gccv6-fix.patch ];
 
-  preConfigure = ''
+  postPatch = ''
     sed -e "s@ /bin/bash@bash@g" -i Makefile.std
     find . -exec sed -e "s@/usr/bin/perl@${perl}/bin/perl@g" -i '{}' ';'
+
+    # bison 3.7 workaround
+    for f in parsePL parseLisp parsesmtlib parsesmtlib2 ; do
+      ln -s ../parser/''${f}_defs.h src/include/''${f}.hpp
+    done
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/logic/cvc3/default.nix
+++ b/pkgs/applications/science/logic/cvc3/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "A prover for satisfiability modulo theory (SMT)";
     maintainers = with maintainers;
       [ raskin ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.free;
     homepage = "http://www.cs.nyu.edu/acsys/cvc3/index.html";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26050,6 +26050,7 @@ in
 
   cvc3 = callPackage ../applications/science/logic/cvc3 {
     gmp = lib.overrideDerivation gmp (a: { dontDisableStatic = true; });
+    stdenv = gccStdenv;
   };
   cvc4 = callPackage ../applications/science/logic/cvc4 {};
 


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of #98498

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
