### PR TITLE
joplin-desktop: 1.0.245 -> 1.1.4

### DIFF
--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -1,39 +1,31 @@
-{ appimageTools, fetchurl, lib, gsettings-desktop-schemas, gtk3, makeDesktopItem }:
+{ stdenv, appimageTools, fetchurl, gsettings-desktop-schemas, gtk3, undmg }:
 
 let
   pname = "joplin-desktop";
-  version = "1.0.245";
+  version = "1.1.4";
   name = "${pname}-${version}";
 
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  suffix = {
+    x86_64-linux = "AppImage";
+    x86_64-darwin = "dmg";
+  }.${system} or throwSystem;
+
   src = fetchurl {
-    url = "https://github.com/laurent22/joplin/releases/download/v${version}/Joplin-${version}.AppImage";
-    sha256 = "1xybzjixqmp95b2a97kbbygn0jwndws9115cd7mbw8czl7nshdq6";
+    url = "https://github.com/laurent22/joplin/releases/download/v${version}/Joplin-${version}.${suffix}";
+    sha256 = {
+      x86_64-linux = "1jgmjwjl2y3nrywnwidpk6p31sypy3gjghmzzqkrgjpf77ccbssm";
+      x86_64-darwin = "1v06k4qrk3n1ncgpmnqp4axmn7gvs3mgbvf8n6ldhgjhj3hq9day";
+    }.${system} or throwSystem;
   };
 
   appimageContents = appimageTools.extractType2 {
     inherit name src;
   };
-in appimageTools.wrapType2 rec {
-  inherit name src;
 
-  profile = ''
-    export LC_ALL=C.UTF-8
-    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
-  '';
-
-  multiPkgs = null; # no 32bit needed
-  extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
-  extraInstallCommands = ''
-    mv $out/bin/{${name},${pname}}
-    install -m 444 -D ${appimageContents}/joplin.desktop $out/share/applications/joplin.desktop
-    install -m 444 -D ${appimageContents}/joplin.png \
-      $out/share/pixmaps/joplin.png
-    substituteInPlace $out/share/applications/joplin.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
-  '';
-
-
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "An open source note taking and to-do application with synchronisation capabilities";
     longDescription = ''
       Joplin is a free, open source note taking and to-do application, which can
@@ -45,6 +37,41 @@ in appimageTools.wrapType2 rec {
     homepage = "https://joplinapp.org";
     license = licenses.mit;
     maintainers = with maintainers; [ hugoreeves ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
-}
+
+  linux = appimageTools.wrapType2 rec {
+    inherit name src meta;
+
+    profile = ''
+      export LC_ALL=C.UTF-8
+      export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+    '';
+
+    multiPkgs = null; # no 32bit needed
+    extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
+    extraInstallCommands = ''
+      mv $out/bin/{${name},${pname}}
+      install -Dm444 ${appimageContents}/joplin.desktop -t $out/share/applications
+      install -Dm444 ${appimageContents}/joplin.png -t $out/share/pixmaps
+      substituteInPlace $out/share/applications/joplin.desktop \
+        --replace 'Exec=AppRun' 'Exec=${pname}'
+    '';
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit name src meta;
+
+    nativeBuildInputs = [ undmg ];
+
+    sourceRoot = "Joplin.app";
+
+    installPhase = ''
+      mkdir -p $out/Applications/Joplin.app
+      cp -R . $out/Applications/Joplin.app
+    '';
+  };
+in
+if stdenv.isDarwin
+then darwin
+else linux


### PR DESCRIPTION
###### Motivation for this change
* update to 1.1.4 ([changelog](https://github.com/laurent22/joplin/releases/tag/v1.1.4))
* enable on darwin

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
