### PR TITLE
[20.09] truvari: 1.3.4 -> 2.0.2, add new dependencies & fix build

### DIFF
--- a/pkgs/applications/science/biology/bwa/default.nix
+++ b/pkgs/applications/science/biology/bwa/default.nix
@@ -11,8 +11,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib ];
 
+  # it's unclear which headers are intended to be part of the public interface
+  # so we may find ourselves having to add more here over time
   installPhase = ''
-    install -vD bwa $out/bin/bwa
+    install -vD -t $out/bin bwa
+    install -vD -t $out/lib libbwa.a
+    install -vD -t $out/include bntseq.h
+    install -vD -t $out/include bwa.h
+    install -vD -t $out/include bwamem.h
+    install -vD -t $out/include bwt.h
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -25,13 +25,15 @@ python3Packages.buildPythonApplication rec {
 
   prePatch = ''
     substituteInPlace ./setup.py \
-      --replace '"progressbar2==3.41.0",' '"progressbar2==3.47.0",' \
-      --replace '"pysam==0.15.2",' '"pysam==0.15.4",' \
-      --replace '"pyfaidx==0.5.5.2",' '"pyfaidx==0.5.8",'
+      --replace '"progressbar2==3.41.0",' '"progressbar2",' \
+      --replace '"pysam==0.15.2",' '"pysam",' \
+      --replace '"pyfaidx==0.5.5.2",' '"pyfaidx",' \
+      --replace '"intervaltree==3.0.2",' '"intervaltree",'
   '';
 
   meta = with lib; {
     description = "Structural variant comparison tool for VCFs";
+    homepage = "https://github.com/spiralgenetics/truvari";
     license = licenses.mit;
     maintainers = with maintainers; [ scalavision ];
     longDescription = ''

--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -5,13 +5,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "truvari";
-  version = "1.3.4";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "spiralgenetics";
     repo = "truvari";
     rev = "v${version}";
-    sha256 = "1bph7v48s7pyfagz8a2fzl5fycjliqzn5lcbv3m2bp2ih1f1gd1v";
+    sha256 = "0lp1wnldjv92k4ncga1h0icb0dpjsrx427vggg40x04a7kp9lwx0";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -21,15 +21,16 @@ python3Packages.buildPythonApplication rec {
     pysam
     pyfaidx
     intervaltree
+    pytabix
+    acebinf
+    bwapy
+    joblib
+    pandas
   ];
 
-  prePatch = ''
-    substituteInPlace ./setup.py \
-      --replace '"progressbar2==3.41.0",' '"progressbar2",' \
-      --replace '"pysam==0.15.2",' '"pysam",' \
-      --replace '"pyfaidx==0.5.5.2",' '"pyfaidx",' \
-      --replace '"intervaltree==3.0.2",' '"intervaltree",'
-  '';
+  # no tests
+  doCheck = false;
+  pythonImportsCheck = [ "truvari" ];
 
   meta = with lib; {
     description = "Structural variant comparison tool for VCFs";

--- a/pkgs/development/python-modules/acebinf/default.nix
+++ b/pkgs/development/python-modules/acebinf/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pyvcf
+}:
+
+buildPythonPackage rec {
+  pname = "ACEBinf";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1168pny671l6zfm2vv1pwspnflmzi7f4v8yldjl7zlz0b9cm5zlz";
+  };
+
+  buildInputs = [ pyvcf ];
+
+  # no tests
+  doCheck = false;
+  pythonImportsCheck = [ "acebinf" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ACEnglish/acebinf";
+    description = "Collection of simple utilities used when building bioinformatics tools";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/development/python-modules/bwapy/default.nix
+++ b/pkgs/development/python-modules/bwapy/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, bwa
+, cffi
+, zlib
+}:
+
+buildPythonPackage rec {
+  pname = "bwapy";
+  version = "0.1.4";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "090qwx3vl729zn3a7sksbviyg04kc71gpbm3nd8dalqp673x1npw";
+  };
+  postPatch = ''
+    # replace bundled bwa
+    rm -r bwa/*
+    cp ${bwa}/lib/*.a ${bwa}/include/*.h bwa/
+
+    substituteInPlace setup.py \
+      --replace 'setuptools>=49.2.0' 'setuptools'
+  '';
+
+  buildInputs = [ zlib bwa ];
+
+  propagatedBuildInputs = [ cffi ];
+
+  # no tests
+  doCheck = false;
+  pythonImportsCheck = [ "bwapy" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ACEnglish/acebinf";
+    description = "Python bindings to bwa mem aligner";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/development/python-modules/pytabix/default.nix
+++ b/pkgs/development/python-modules/pytabix/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, isPy3k
+, fetchPypi
+, zlib
+}:
+
+buildPythonPackage rec {
+  pname = "pytabix";
+  version = "0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ldp5r4ggskji6qx4bp2qxy2vrvb3fam03ksn0gq2hdxgrlg2x07";
+  };
+
+  buildInputs = [ zlib ];
+
+  doCheck = !isPy3k;
+  preCheck = ''
+    substituteInPlace test/test.py \
+      --replace 'test_remote_file' 'dont_test_remote_file'
+  '';
+  pythonImportsCheck = [ "tabix" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/slowkow/pytabix";
+    description = "Python interface for tabix";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -150,6 +150,8 @@ in {
 
   accupy = callPackage ../development/python-modules/accupy { };
 
+  acebinf = callPackage ../development/python-modules/acebinf { };
+
   acme = callPackage ../development/python-modules/acme { };
 
   acme-tiny = callPackage ../development/python-modules/acme-tiny { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5408,6 +5408,8 @@ in {
 
   pysvn = callPackage ../development/python-modules/pysvn { };
 
+  pytabix = callPackage ../development/python-modules/pytabix { };
+
   pytado = callPackage ../development/python-modules/pytado { };
 
   pytaglib = callPackage ../development/python-modules/pytaglib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -979,6 +979,8 @@ in {
 
   bx-python = callPackage ../development/python-modules/bx-python { inherit (pkgs) zlib; };
 
+  bwapy = callPackage ../development/python-modules/bwapy { };
+
   bytecode = callPackage ../development/python-modules/bytecode { };
 
   bz2file = callPackage ../development/python-modules/bz2file { };


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Combined backport of  #98250 and  #98283

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
