### PR TITLE
stockfish: 11 -> 12

### DIFF
--- a/pkgs/games/stockfish/default.nix
+++ b/pkgs/games/stockfish/default.nix
@@ -4,20 +4,31 @@ let arch = if stdenv.isx86_64 then "x86-64" else
            if stdenv.isi686 then "x86-32" else
            "unknown";
 
-    version = "11";
+    version = "12";
+
+    nnueFile = "nn-82215d0fd0df.nnue";
+    nnue = fetchurl {
+      name = nnueFile;
+        url = "https://tests.stockfishchess.org/api/nn/${nnueFile}";
+      sha256 = "1r4yqrh4di05syyhl84hqcz84djpbd605b27zhbxwg6zs07ms8c2";
+    };
 in
 
 stdenv.mkDerivation {
-
   pname = "stockfish";
   inherit version;
 
   src = fetchurl {
     url = "https://github.com/official-stockfish/Stockfish/archive/sf_${version}.tar.gz";
-    sha256 = "16di83s79gf9kzdhcal5y0q9d59544gd5xqf1k8bwrqvc36628l0";
+    sha256 = "16980aicm5i6i9252239q4f9bcxg1gnqkv6nphrmpz4drg8i3v6i";
   };
 
-  postUnpack = "sourceRoot+=/src";
+  postUnpack = ''
+    sourceRoot+=/src
+    echo ${nnue}
+    cp "${nnue}" "$sourceRoot/${nnueFile}"
+  '';
+
   makeFlags = [ "PREFIX=$(out)" "ARCH=${arch}" ];
   buildFlags = [ "build" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
- New version
- Improved performance

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Ran the engine with `scid` and evaluations seem to work correctly.