### PR TITLE
pythonPackages.cozy: fix build

### DIFF
--- a/pkgs/development/python-modules/cozy/default.nix
+++ b/pkgs/development/python-modules/cozy/default.nix
@@ -4,6 +4,7 @@
 buildPythonPackage {
   pname = "cozy";
   version = "2.0a1";
+  disabled = !isPy3k;
 
   propagatedBuildInputs = [
     z3 ply python-igraph oset ordered-set dictionaries
@@ -18,18 +19,18 @@ buildPythonPackage {
 
   # Yoink the Z3 dependency name, because our Z3 package doesn't provide it.
   postPatch = ''
-    sed -i -e '/z3-solver/d' requirements.txt
+    sed -i -e '/z3-solver/d' -e 's/^dictionaries.*$/dictionaries/' requirements.txt
   '';
 
   # Tests are not correctly set up in the source tree.
   doCheck = false;
+  pythonImportsCheck = [ "cozy" ];
 
   # There is some first-time-run codegen that we will force to happen.
   postInstall = ''
     $out/bin/cozy --help
   '';
 
-  disabled = !isPy3k;
 
   meta = {
     description = "The collection synthesizer";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Allow building with `dictionaries` 0.0.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
