### PR TITLE
ponyc: update 0.38.1

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, fetchurl, llvm, makeWrapper, pcre2, coreutils, which, libressl, libxml2, cmake, z3, substituteAll,
+{ stdenv, fetchFromGitHub, fetchurl, makeWrapper, pcre2, coreutils, which, libressl, libxml2, cmake, z3, substituteAll,
   cc ? stdenv.cc, lto ? !stdenv.isDarwin }:
 
-stdenv.mkDerivation ( rec {
+stdenv.mkDerivation (rec {
   pname = "ponyc";
   version = "0.38.1";
 
@@ -28,7 +28,6 @@ stdenv.mkDerivation ( rec {
     sha256 = "06i2cr4rj126m1zfz0x1rbxv1mw1l7a11mzal5kqk56cdrdicsiw";
     name = "v1.5.0.tar.gz";
   };
-
 
   buildInputs = [ makeWrapper which libxml2 cmake z3 ];
   propagatedBuildInputs = [ cc ];
@@ -76,8 +75,12 @@ stdenv.mkDerivation ( rec {
     make configure build_flags=-j$NIX_BUILD_CORES
   '';
 
-  makeFlags = [ "PONYC_VERSION=0.38.1" "prefix=${placeholder "out"}" ] ++ stdenv.lib.optionals stdenv.isDarwin [ "bits=64" ]
-             ++ stdenv.lib.optionals (stdenv.isDarwin && (!lto)) [ "lto=no" ];
+  makeFlags = [
+    "PONYC_VERSION=${version}"
+    "prefix=${placeholder "out"}"
+  ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ "bits=64" ]
+    ++ stdenv.lib.optionals (stdenv.isDarwin && (!lto)) [ "lto=no" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -1,64 +1,89 @@
-{ stdenv, fetchFromGitHub, llvm, makeWrapper, pcre2, coreutils, which, libressl, libxml2,
+{ stdenv, fetchFromGitHub, fetchurl, llvm, makeWrapper, pcre2, coreutils, which, libressl, libxml2, cmake, z3, substituteAll,
   cc ? stdenv.cc, lto ? !stdenv.isDarwin }:
 
 stdenv.mkDerivation ( rec {
   pname = "ponyc";
-  version = "0.33.2";
+  version = "0.38.1";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    sha256 = "0jcdr1r3g8sm3q9fcc87d6x98fg581n6hb90hz7r08mzn4bwvysw";
+    sha256 = "1hk810k9h3bl641pgw91y4x2qw67rvbapx6p2pk9qz5p7nfcn7qh";
+
+# Due to a bug in LLVM 9.x, ponyc has to include its own vendored patched
+# LLVM.  (The submodule is a specific tag in the LLVM source tree).
+#
+# The pony developers are currently working to get off 9.x as quickly
+# as possible so hopefully in a few revisions this package build will
+# become a lot simpler.
+#
+# https://reviews.llvm.org/rG9f4f237e29e7150dfcf04ae78fa287d2dc8d48e2
+
+    fetchSubmodules = true;
   };
 
-  buildInputs = [ llvm makeWrapper which libxml2 ];
+  ponygbenchmark = fetchurl {
+    url = https://github.com/google/benchmark/archive/v1.5.0.tar.gz;
+    sha256 = "06i2cr4rj126m1zfz0x1rbxv1mw1l7a11mzal5kqk56cdrdicsiw";
+    name = "v1.5.0.tar.gz";
+  };
+
+
+  buildInputs = [ makeWrapper which libxml2 cmake z3 ];
   propagatedBuildInputs = [ cc ];
 
-  # Disable problematic networking tests
-  patches = [ ./disable-tests.patch ];
+  # Sandbox disallows network access, so disabling problematic networking tests
+  patches = [
+    ./disable-tests.patch
+    (substituteAll {
+      src = ./make-safe-for-sandbox.patch;
+      googletest = fetchurl {
+        url = https://github.com/google/googletest/archive/release-1.8.1.tar.gz;
+        sha256 = "17147961i01fl099ygxjx4asvjanwdd446nwbq9v8156h98zxwcv";
+        name = "release-1.8.1.tar.gz";
+      };
+    })
+  ];
 
-  preBuild = ''
-    # Fix tests
+  postUnpack = ''
+    mkdir -p source/build/build_libs/gbenchmark-prefix/src
+    tar -C source/build/build_libs/gbenchmark-prefix/src -zxvf "$ponygbenchmark"
+    mv source/build/build_libs/gbenchmark-prefix/src/benchmark-1.5.0 \
+       source/build/build_libs/gbenchmark-prefix/src/benchmark
+  '';
+
+  dontConfigure = true;
+
+  postPatch = ''
+    # Patching Vendor LLVM
+    patchShebangs --host build/build_libs/gbenchmark-prefix/src/benchmark/tools/*.py
+    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2020-09-01-is-trivially-copyable.diff
+    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2020-01-07-01-c-exports.diff
+    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2019-12-23-01-jit-eh-frames.diff
+
     substituteInPlace packages/process/_test.pony \
-        --replace '"/bin/' '"${coreutils}/bin/'
-    substituteInPlace packages/process/_test.pony \
+        --replace '"/bin/' '"${coreutils}/bin/' \
         --replace '=/bin' "${coreutils}/bin"
-
-    # Disabling the stdlib tests
-    substituteInPlace Makefile-ponyc \
-        --replace 'test-ci: all check-version test-core test-stdlib-debug test-stdlib' 'test-ci: all check-version test-core'
-
-    # Remove impure system refs
     substituteInPlace src/libponyc/pkg/package.c \
         --replace "/usr/local/lib" "" \
         --replace "/opt/local/lib" ""
-
-    for file in `grep -irl '/usr/local/opt/libressl/lib' ./*`; do
-      substituteInPlace $file  --replace '/usr/local/opt/libressl/lib' "${stdenv.lib.getLib libressl}/lib"
-    done
-
-    export LLVM_CONFIG=${llvm}/bin/llvm-config
-  '' + stdenv.lib.optionalString ((!stdenv.isDarwin) && (!cc.isClang) && lto) ''
-    export LTO_PLUGIN=`find ${cc.cc}/ -name liblto_plugin.so`
-  '' + stdenv.lib.optionalString ((!stdenv.isDarwin) && (cc.isClang) && lto) ''
-    export LTO_PLUGIN=`find ${cc.cc}/ -name LLVMgold.so`
   '';
 
-  makeFlags = [ "config=release" ] ++ stdenv.lib.optionals stdenv.isDarwin [ "bits=64" ]
-              ++ stdenv.lib.optionals (stdenv.isDarwin && (!lto)) [ "lto=no" ];
+
+  preBuild = ''
+    make libs build_flags=-j$NIX_BUILD_CORES
+    make configure build_flags=-j$NIX_BUILD_CORES
+  '';
+
+  makeFlags = [ "PONYC_VERSION=0.38.1" "prefix=${placeholder "out"}" ] ++ stdenv.lib.optionals stdenv.isDarwin [ "bits=64" ]
+             ++ stdenv.lib.optionals (stdenv.isDarwin && (!lto)) [ "lto=no" ];
 
   enableParallelBuilding = true;
 
   doCheck = true;
 
-  checkTarget = "test-ci";
-
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=redundant-move" ];
-
-  preCheck = ''
-    export PONYPATH="$out/lib:${stdenv.lib.makeLibraryPath [ pcre2 libressl ]}"
-  '';
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=redundant-move" "-Wno-error=implicit-fallthrough" ];
 
   installPhase = ''
     make config=release prefix=$out ''
@@ -79,7 +104,7 @@ stdenv.mkDerivation ( rec {
     description = "Pony is an Object-oriented, actor-model, capabilities-secure, high performance programming language";
     homepage = "https://www.ponylang.org";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ doublec kamilchm patternspandemic ];
+    maintainers = with maintainers; [ doublec kamilchm patternspandemic redvers ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 })

--- a/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
+++ b/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
@@ -1,0 +1,93 @@
+--- a/lib/CMakeLists.txt	2020-09-27 02:39:12.862940179 +0000
++++ b/lib/CMakeLists.txt	2020-09-27 02:39:16.451957865 +0000
+@@ -10,12 +10,12 @@
+ endif()
+ 
+ ExternalProject_Add(gbenchmark
+-    URL https://github.com/google/benchmark/archive/v1.5.0.tar.gz
++    SOURCE_DIR gbenchmark-prefix/src/benchmark
+     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=-fpic --no-warn-unused-cli
+ )
+ 
+ ExternalProject_Add(googletest
+-    URL https://github.com/google/googletest/archive/release-1.8.1.tar.gz
++    URL @googletest@
+     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_CXX_FLAGS=-fpic -Dgtest_force_shared_crt=ON --no-warn-unused-cli
+ )
+ 
+@@ -28,75 +28,6 @@
+     COMPONENT library
+ )
+ 
+-find_package(Git)
+-
+-set(LLVM_DESIRED_HASH "c1a0a213378a458fbea1a5c77b315c7dce08fd05")
+-set(PATCHES_DESIRED_HASH "9063f83d727bf042a1232420e168c1ea192bf6a2960d35e57123245b630eb923")
+-
+-if(GIT_FOUND)
+-    if(EXISTS "${PROJECT_SOURCE_DIR}/../.git")
+-        # Update submodules as needed
+-        option(GIT_SUBMODULE "Check submodules during build" ON)
+-        if(GIT_SUBMODULE)
+-            message(STATUS "Updating submodules...")
+-            execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+-                            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-                            RESULT_VARIABLE git_submod_result)
+-            #message("git_submod_result ${git_submod_result}")
+-            if(NOT git_submod_result EQUAL "0")
+-                message(FATAL_ERROR "git submodule update --init --recursive failed with ${git_submod_result}, please checkout submodules")
+-            endif()
+-
+-            # we check to make sure the submodule hash matches
+-            # the reason the submodule hash is in this file is to be able to use this file as a key for caching the libs in CI
+-            execute_process(COMMAND ${GIT_EXECUTABLE} submodule status
+-                            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-                            OUTPUT_VARIABLE git_submod_output)
+-            #message("git_submod_output ${git_submod_output}")
+-            string(FIND "${git_submod_output}" "${LLVM_DESIRED_HASH}" LLVM_SUBMOD_POS)
+-            if(LLVM_SUBMOD_POS EQUAL "-1")
+-                message(FATAL_ERROR "Expecting the lib/llvm/src submodule to be at hash '${LLVM_DESIRED_HASH}'; found '${git_submod_output}'; update the LLVM_DESIRED_HASH variable in lib/CMakeLists.txt if you've updated the submodule.")
+-            endif()
+-        endif()
+-    endif()
+-
+-    # Apply patches
+-    message("Applying patches...")
+-    file(GLOB PONY_LLVM_PATCHES "${PROJECT_SOURCE_DIR}/llvm/patches/*.diff")
+-
+-    # check to see if the patch hashes match
+-    set(PATCHES_ACTUAL_HASH "")
+-    foreach (PATCH ${PONY_LLVM_PATCHES})
+-        file(SHA256 ${PATCH} patch_file_hash)
+-        string(CONCAT PATCHES_ACTUAL_HASH patch_file_hash)
+-    endforeach()
+-    string(SHA256 PATCHES_ACTUAL_HASH ${PATCHES_ACTUAL_HASH})
+-    if(NOT PATCHES_ACTUAL_HASH EQUAL "${PATCHES_DESIRED_HASH}")
+-        message(FATAL_ERROR "Patch hash actual ${PATCHES_ACTUAL_HASH} does not match desired ${PATCHES_DESIRED_HASH}")
+-    endif()
+-
+-    foreach (PATCH ${PONY_LLVM_PATCHES})
+-        message("  Checking ${PATCH}")
+-        execute_process(COMMAND ${GIT_EXECUTABLE} apply --check -p 1 --ignore-whitespace --whitespace=nowarn ${PATCH}
+-                        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/llvm/src"
+-                        ERROR_VARIABLE _err_out
+-                        RESULT_VARIABLE git_apply_check_result)
+-        if(git_apply_check_result EQUAL "0")
+-            message("    Applying ${PATCH}")
+-            execute_process(COMMAND ${GIT_EXECUTABLE} apply -p 1 --ignore-whitespace --whitespace=nowarn ${PATCH}
+-                            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/llvm/src"
+-                            RESULT_VARIABLE git_apply_result)
+-            if(NOT git_apply_result EQUAL "0")
+-                message(FATAL_ERROR "Unable to apply ${PATCH}")
+-            endif()
+-        else()
+-            message("    Already applied ${PATCH}")
+-        endif()
+-    endforeach()
+-else()
+-    message(FATAL_ERROR "Git not found!")
+-endif()
+-
+ if (NOT DEFINED LLVM_TARGETS_TO_BUILD)
+   set(LLVM_TARGETS_TO_BUILD X86)
+ endif()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9596,7 +9596,8 @@ in
   picat = callPackage ../development/compilers/picat { };
 
   ponyc = callPackage ../development/compilers/ponyc {
-    llvm = llvm_7;
+    # Upstream pony has dropped support for versions compiled with gcc.
+    stdenv = clangStdenv;
   };
 
   pony-stable = callPackage ../development/compilers/ponyc/pony-stable.nix { };


### PR DESCRIPTION
This addresses #98376 

###### Motivation for this change
ponyc had been stalled at v0.33.2 for a while for three reasons:

1. The buildsystem had been changed from make to cmake
2. A bug was discovered in LLVM 9.x which caused SIGSEGV in the test suite.  The fix has been applied to LLVM upstream but is in the 10.x and master branch.  Since ponyc currently uses 9.x, the build requires a patched+fixed llvm **for the build only**
3. The additional complexity of the (temporary) build-system in use was a real pain to integrate into a nix package.

I believe I have finally tamed this beast.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note - I do not own a Mac so I'm going to be reliant on hydra to test against that platform.

Thanks!

(This is a redo of #98568 after I squashed that commit into a mess of 7 commits I couldn't fix - my apologies).

cc: @evanjs 