### PR TITLE
dot-merlin-reader: init at 3.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3467,6 +3467,12 @@
     githubId = 896431;
     name = "Chris Hodapp";
   };
+  hongchangwu = {
+    email = "wuhc85@gmail.com";
+    github = "hongchangwu";
+    githubId = 362833;
+    name = "Hongchang Wu";
+  };
   hrdinka = {
     email = "c.nix@hrdinka.at";
     github = "hrdinka";

--- a/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
+++ b/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
@@ -1,0 +1,24 @@
+{ lib, fetchurl, ocamlPackages }:
+
+with ocamlPackages;
+
+buildDunePackage rec {
+  pname = "dot-merlin-reader";
+  version = "3.4.0";
+
+  minimumOCamlVersion = "4.02.1";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml/merlin/releases/download/v${version}/merlin-v${version}.tbz";
+    sha256 = "048rkpbvayksv8mgmkgi17vv0y9xplv7v2ww4d1hs7bkm5zzsvg2";
+  };
+
+  buildInputs = [ yojson csexp result ];
+
+  meta = with lib; {
+    description = "Reads config files for merlin";
+    homepage = "https://github.com/ocaml/merlin";
+    license = licenses.mit;
+    maintainers = [ maintainers.hongchangwu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1842,6 +1842,8 @@ in
 
   dosage = callPackage ../applications/graphics/dosage { };
 
+  dot-merlin-reader = callPackage ../development/tools/ocaml/merlin/dot-merlin-reader.nix { };
+
   dozenal = callPackage ../applications/misc/dozenal { };
 
   dpic = callPackage ../tools/graphics/dpic { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`dot-merlin-reader` is a new dependency for `merlin` 3.4.0 (which I plan to do in a separate PR). It serves as an external config provider for `merlin`. The intention is that future versions of `merlin` will be able to source config from different providers (e.g., `dune`).

Reference PRs:
- [Merlin change](https://github.com/ocaml/merlin/pull/1123)
- [Dune change](https://github.com/ocaml/dune/pull/3395)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions: Ubuntu
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
