### PR TITLE
pciutils: fix build on darwin

### DIFF
--- a/pkgs/tools/system/pciutils/default.nix
+++ b/pkgs/tools/system/pciutils/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, pkgconfig, zlib, kmod, which
 , static ? stdenv.targetPlatform.isStatic
+, darwin ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ zlib kmod which ];
+  buildInputs = [ zlib kmod which ] ++
+    stdenv.lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.IOKit;
+
+  preConfigure = if stdenv.cc.isGNU then null else ''
+    substituteInPlace Makefile --replace 'CC=$(CROSS_COMPILE)gcc' ""
+  '';
 
   makeFlags = [
     "SHARED=${if static then "no" else "yes"}"


### PR DESCRIPTION
Makefile assumes CC=gcc, so we should use our own CC. To avoid affecting currently working derivations, this is only done when `!stdenv.cc.isGNU`.
Darwin also requires IOKit framework.
~~I'm adding preConfigure via optionalAttrs to avoid affecting any non-darwin derivations. Let me know if there's a clearer way to achieve this.~~

###### Motivation for this change
ZHF 20.09 https://github.com/NixOS/nixpkgs/issues/97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions (Ubuntu x86_64)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
