### PR TITLE
bazel: Fix bazel query and provide a default java toolchain

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
@@ -143,7 +143,7 @@ let
       build --override_repository=${remote_java_tools.name}=${remote_java_tools}
       fetch --override_repository=${remote_java_tools.name}=${remote_java_tools}
       query --override_repository=${remote_java_tools.name}=${remote_java_tools}
-      
+
       # Provide a default java toolchain, this will be the same as ${runJdk}
       build --host_javabase='@local_jdk//:jdk'
 

--- a/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
@@ -48,9 +48,10 @@ let
       srcs.bazel_skylib
       srcs.io_bazel_rules_sass
       srcs.platforms
-      (if stdenv.hostPlatform.isDarwin
-       then srcs."java_tools_javac11_darwin-v8.0.zip"
-       else srcs."java_tools_javac11_linux-v8.0.zip")
+      # `bazel query` wants all of these to be available regardless of platform.
+      srcs."java_tools_javac11_darwin-v8.0.zip"
+      srcs."java_tools_javac11_linux-v8.0.zip"
+      srcs."java_tools_javac11_windows-v8.0.zip"
       srcs."coverage_output_generator-v2.1.zip"
       srcs.build_bazel_rules_nodejs
       srcs."android_tools_pkg-0.19.0rc1.tar.gz"
@@ -131,9 +132,20 @@ let
   bazelRC = writeTextFile {
     name = "bazel-rc";
     text = ''
-      build --override_repository=${remote_java_tools.name}=${remote_java_tools}
-      build --distdir=${distDir}
       startup --server_javabase=${runJdk}
+
+      # Can't use 'common'; https://github.com/bazelbuild/bazel/issues/3054
+      # Most commands inherit from 'build' anyway.
+      build --distdir=${distDir}
+      fetch --distdir=${distDir}
+      query --distdir=${distDir}
+
+      build --override_repository=${remote_java_tools.name}=${remote_java_tools}
+      fetch --override_repository=${remote_java_tools.name}=${remote_java_tools}
+      query --override_repository=${remote_java_tools.name}=${remote_java_tools}
+      
+      # Provide a default java toolchain, this will be the same as ${runJdk}
+      build --host_javabase='@local_jdk//:jdk'
 
       # load default location for the system wide configuration
       try-import /etc/bazel.bazelrc
@@ -534,7 +546,7 @@ stdenv.mkDerivation rec {
     export TEST_TMPDIR=$(pwd)
 
     hello_test () {
-      $out/bin/bazel test --distdir=${distDir} \
+      $out/bin/bazel test \
         --test_output=errors \
         --java_toolchain='${javaToolchain}' \
         examples/cpp:hello-success_test \


### PR DESCRIPTION
###### Motivation for this change

These are fixes for problems I ran into with:
- `bazel test //example:cpp-test`
This needed `build --host_javabase='@local_jdk//:jdk'`

- `bazel query 'deps(//example:cpp-test)'`
This needed the same flags as `build`. (Trying to get a sense of why the cpp-test needs java!)

Is it contentious to (partially?) configure the default java toolchain? I don't see it as much different than providing the bazel server's java.
It would continue to be configurable/overridable by overriding the flags. 
https://github.com/NixOS/nixpkgs/issues/86410 is related.

(will rewrite commit later, web ui is tricky :))

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

And a random notes from this escapade, but https://github.com/bazelbuild/bazel/blob/master/WORKSPACE#L144-L308 looks a little different from https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/build-managers/bazel/bazel_3/src-deps.json so one of them is probably wrong :)
