### PR TITLE
ocamlPackages.fpath: 0.7.2 → 0.7.3

### DIFF
--- a/pkgs/development/ocaml-modules/fpath/default.nix
+++ b/pkgs/development/ocaml-modules/fpath/default.nix
@@ -1,10 +1,14 @@
 { stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, astring }:
 
+if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+then throw "fpath is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-fpath-0.7.2";
+  name = "ocaml${ocaml.version}-fpath-0.7.3";
   src = fetchurl {
-    url = "https://erratique.ch/software/fpath/releases/fpath-0.7.2.tbz";
-    sha256 = "1hr05d8bpqmqcfdavn4rjk9rxr7v2zl84866f5knjifrm60sxqic";
+    url = "https://erratique.ch/software/fpath/releases/fpath-0.7.3.tbz";
+    sha256 = "03z7mj0sqdz465rc4drj1gr88l9q3nfs374yssvdjdyhjbqqzc0j";
   };
 
   buildInputs = [ ocaml findlib ocamlbuild topkg ];


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.12: https://github.com/dbuenzli/fpath/blob/master/CHANGES.md#v073-2020-09-08-zagreb

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
