### PR TITLE
elm-format: 0.8.3 -> 0.8.4

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -30,18 +30,6 @@ let
             `package/nix/build.sh`
             */
             elm-format = justStaticExecutables (overrideCabal (self.callPackage ./packages/elm-format.nix {}) (drv: {
-              # GHC 8.8.3 support
-              # https://github.com/avh4/elm-format/pull/640
-              patches = [(
-                fetchpatch {
-                  url = "https://github.com/turboMaCk/elm-format/commit/4f4abdc7117ed6ce3335f6cf39b6495b48067b7c.patch";
-                  sha256 = "1zqk6q6w0ph12mnwffgwzf4h1hcgqg0v09ws9q2g5bg2riq4rvd9";
-                }
-              )];
-              # Tests are failing after upgrade to ghc881.
-              # Cause is probably just a minor change in stdout output
-              # see https://github.com/avh4/elm-format/pull/640
-              doCheck = false;
               jailbreak = true;
             }));
 

--- a/pkgs/development/compilers/elm/packages/elm-format.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchgit, ansi-terminal, ansi-wl-pprint, base, binary
+{ mkDerivation, fetchgit, ansi-terminal, ansi-wl-pprint, array, base, binary
 , bytestring, cmark, containers, directory, filepath, free, HUnit
 , indents, json, mtl, optparse-applicative, parsec, process
 , QuickCheck, quickcheck-io, split, stdenv, tasty, tasty-golden
@@ -6,11 +6,11 @@
 }:
 mkDerivation {
   pname = "elm-format";
-  version = "0.8.3";
+  version = "0.8.4";
   src = fetchgit {
     url = "https://github.com/avh4/elm-format";
-    sha256 = "0n6lrqj6mq044hdyraj3ss5cg74dn8k4z05xmwn2apjpm146iaw8";
-    rev = "b97e3593d564a1e069c0a022da8cbd98ca2c5a4b";
+    sha256 = "0cxlhhdjx4h9g03z83pxv91qrysbi0ab92rl52jb0yvkaix989ai";
+    rev = "5bd4fbe591fe8b456160c180cb875ef60bc57890";
   };
   postPatch = ''
     mkdir -p ./generated
@@ -18,15 +18,15 @@ mkDerivation {
     module Build_elm_format where
 
     gitDescribe :: String
-    gitDescribe = "0.8.3"
+    gitDescribe = "0.8.4"
     EOHS
   '';
   isLibrary = false;
   isExecutable = true;
   libraryHaskellDepends = [
-    ansi-terminal ansi-wl-pprint base binary bytestring containers
-    directory filepath free indents json mtl optparse-applicative
-    parsec process split text
+    ansi-terminal ansi-wl-pprint array base binary bytestring
+    containers directory filepath free indents json mtl
+    optparse-applicative parsec process split text
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New release of elm-format: https://github.com/avh4/elm-format/releases/tag/0.8.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @turboMaCk @domenkozar  