### PR TITLE
nixos/fontconfig: disable by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -59,7 +59,9 @@
 
   <itemizedlist>
    <listitem>
-    <para />
+    <para>
+      Fontconfig is no longer enabled by default. It is enabled by various modules that use fonts (xserver, sway, kmscon, cage, xrdp), but if you have services on a headless server which require fonts (e.g. for rendering images) or use an X server or Wayland compositor independently of the NixOS modules, you may need to set <xref linkend="opt-fonts.fontconfig.enable" /> to <literal>true</literal>.
+    </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -253,7 +253,7 @@ in
       fontconfig = {
         enable = mkOption {
           type = types.bool;
-          default = true;
+          default = false;
           description = ''
             If enabled, a Fontconfig configuration file will be built
             pointing to a set of default fonts.  If you don't care about

--- a/nixos/modules/programs/sway.nix
+++ b/nixos/modules/programs/sway.nix
@@ -126,6 +126,7 @@ in {
     };
     security.pam.services.swaylock = {};
     hardware.opengl.enable = mkDefault true;
+    fonts.fontconfig.enable = true;
     fonts.enableDefaultFonts = mkDefault true;
     programs.dconf.enable = mkDefault true;
     # To make a Sway session available if a display manager like SDDM is enabled:

--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -107,6 +107,7 @@ in
       icons.enable = true;
     };
 
+    fonts.fontconfig.enable = true;
     fonts.enableDefaultFonts = mkDefault true;
 
     systemd = {

--- a/nixos/modules/services/ttys/kmscon.nix
+++ b/nixos/modules/services/ttys/kmscon.nix
@@ -78,7 +78,6 @@ in {
       TTYReset=yes
       TTYVHangup=yes
       TTYVTDisallocate=yes
-
       X-RestartIfChanged=false
     '';
 
@@ -95,6 +94,8 @@ in {
       hwaccel
     '';
 
+    fonts.fontconfig.enable = true;
+    fonts.enableDefaultFonts = lib.mkDefault true;
     hardware.opengl.enable = mkIf cfg.hwRender true;
   };
 }

--- a/nixos/modules/services/wayland/cage.nix
+++ b/nixos/modules/services/wayland/cage.nix
@@ -88,6 +88,8 @@ in {
 
     hardware.opengl.enable = mkDefault true;
 
+    fonts.fontconfig.enable = true;
+
     systemd.targets.graphical.wants = [ "cage-tty1.service" ];
 
     systemd.defaultUnit = "graphical.target";

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -814,6 +814,7 @@ in
         ${cfg.extraConfig}
       '';
 
+    fonts.fontconfig.enable = true;
     fonts.enableDefaultFonts = mkDefault true;
 
   };

--- a/nixos/tests/fontconfig-default-fonts.nix
+++ b/nixos/tests/fontconfig-default-fonts.nix
@@ -8,6 +8,7 @@ import ./make-test-python.nix ({ lib, ... }:
   ];
 
   machine = { config, pkgs, ... }: {
+    fonts.fontconfig.enable = true;
     fonts.enableDefaultFonts = true; # Background fonts
     fonts.fonts = with pkgs; [
       noto-fonts-emoji


### PR DESCRIPTION
###### Motivation for this change
This can reduce the closure size of headless systems.

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@ofborg test xfce xrdp fontconfig-default-fonts cage chromium