### PR TITLE
profiles: add HP Smart Array RAID scsi driver to all-hardware.nix

### DIFF
--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -29,7 +29,7 @@
       "pata_winbond"
 
       # SCSI support (incomplete).
-      "3w-9xxx" "3w-xxxx" "aic79xx" "aic7xxx" "arcmsr"
+      "3w-9xxx" "3w-xxxx" "aic79xx" "aic7xxx" "arcmsr" "hpsa"
 
       # USB support, especially for booting from USB CD-ROM
       # drives.


### PR DESCRIPTION
This adds support for HP Smart Array RAID controllers to all-hardware.nix

###### Motivation for this change
I couldn't boot hte nixos installer iso via the HP ILO interface of an HP server. Also flashing the ISO to one of it's internal SSDs and booting from there didn't work.
With other distros like debian this was not an issue.

###### Things done
Added the kernel module 'hpsa' to `boot.initrd.availableKernelModules` of all-hardware.nix

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
