### PR TITLE
kicad: use the same wxGTK version for KiCad and for wxPython

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -16,6 +16,7 @@
 }:
 
 assert ngspiceSupport -> libngspice != null;
+assert scriptingSupport -> stable;
 
 with lib;
 let
@@ -25,15 +26,18 @@ let
   versions =  import ./versions.nix;
   versionConfig = versions.${baseName};
 
-  wxGTK = if (stable)
+  python = python3;
+  wxPython = python.pkgs.wxPython_4_0;
+
+  wxGTK = if (scriptingSupport)
+    # build Kicad with same wxWidgets as wxPython, see #98634
+    then wxPython.wxGTK
+    else if (stable)
     # wxGTK3x may default to withGtk2 = false, see #73145
     then wxGTK30.override { withGtk2 = false; }
     # wxGTK31 currently introduces an issue with opening the python interpreter in pcbnew
     # but brings high DPI support?
     else wxGTK31.override { withGtk2 = false; };
-
-  python = python3;
-  wxPython = python.pkgs.wxPython_4_0;
 
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change

Since wxPython is used in KiCad to enable scripting via Python I think the
right thing to do is to use the same version of wxGTK for both KiCad and
wxPython.

This gets interesting on macOS, where KiCad requires a specially patched version of wxwidgets (#98538)
See also #98450 and possibly #86040.

In the end this is to get KiCad to work on macOS (but I think things work on other OS' by accident).

My local build is still in progess … but maybe someone can tell me if and why I might be wrong in the mean time.

Maybe the right to do would be `wxGTK = wxPython.wxGTK`, as wxPython passes wxGTK through.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
