### PR TITLE
pythonPackages.{sseclient-py,python-nest}: init

### DIFF
--- a/pkgs/development/python-modules/python-nest/default.nix
+++ b/pkgs/development/python-modules/python-nest/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage, fetchPypi, lib, python, python-dateutil, requests
+, six, sseclient-py }:
+
+buildPythonPackage rec {
+  pname = "python-nest";
+  version = "4.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12iyypbl92ybh8w1bf4z0c2g0sb9id2c07c89vzvnlxgjylw3wbi";
+  };
+
+  propagatedBuildInputs = [ python-dateutil requests six sseclient-py ];
+  # has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "nest" ];
+
+  meta = with lib; {
+    description =
+      "Python API and command line tool for talking to the Nest™ Thermostat";
+    homepage = "https://github.com/jkoelker/python-nest";
+    license = licenses.cc-by-nc-sa-40;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/development/python-modules/sseclient-py/default.nix
+++ b/pkgs/development/python-modules/sseclient-py/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage, fetchFromGitHub, lib, python }:
+
+buildPythonPackage rec {
+  pname = "sseclient-py";
+  version = "1.7";
+
+  src = fetchFromGitHub {
+    owner = "mpetazzoni";
+    repo = "sseclient";
+    rev = "sseclient-py-${version}";
+    sha256 = "0iar4w8gryhjzqwy5k95q9gsv6xpmnwxkpz33418nw8hxlp86wfl";
+  };
+
+  # based on tox.ini
+  checkPhase = ''
+    ${python.interpreter} tests/unittests.py
+  '';
+
+  meta = with lib; {
+    description = "Pure-Python Server Side Events (SSE) client";
+    homepage = "https://github.com/mpetazzoni/sseclient";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -526,7 +526,7 @@
     "nederlandse_spoorwegen" = ps: with ps; [ ]; # missing inputs: nsapi
     "nello" = ps: with ps; [ ]; # missing inputs: pynello
     "ness_alarm" = ps: with ps; [ ]; # missing inputs: nessclient
-    "nest" = ps: with ps; [ ]; # missing inputs: python-nest
+    "nest" = ps: with ps; [ python-nest ];
     "netatmo" = ps: with ps; [ aiohttp-cors hass-nabucasa pyatmo ];
     "netdata" = ps: with ps; [ ]; # missing inputs: netdata
     "netgear" = ps: with ps; [ ]; # missing inputs: pynetgear

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6762,6 +6762,8 @@ in {
 
   sseclient = callPackage ../development/python-modules/sseclient { };
 
+  sseclient-py = callPackage ../development/python-modules/sseclient-py { };
+
   sshpubkeys = callPackage ../development/python-modules/sshpubkeys { };
 
   sshtunnel = callPackage ../development/python-modules/sshtunnel { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5756,6 +5756,8 @@ in {
 
   python-multipart = callPackage ../development/python-modules/python-multipart { };
 
+  python-nest = callPackage ../development/python-modules/python-nest { };
+
   pythonnet = callPackage
     ../development/python-modules/pythonnet { # `mono >= 4.6` required to prevent crashes encountered with earlier versions.
       mono = pkgs.mono4;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Support `nest` in home assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
