### PR TITLE
pythonPackages.accuweather: init at 0.0.11

### DIFF
--- a/pkgs/development/python-modules/accuweather/default.nix
+++ b/pkgs/development/python-modules/accuweather/default.nix
@@ -1,0 +1,28 @@
+{ aiohttp, buildPythonPackage, fetchFromGitHub, lib, pytest, pytestCheckHook
+, pytestcov, pytestrunner, pytest-asyncio, python, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "accuweather";
+  version = "0.0.11";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "bieniu";
+    repo = pname;
+    rev = version;
+    sha256 = "1sgbw9yldf81phwx6pbvqg9sp767whxymyj0ca9pwx1r6ipr080h";
+  };
+
+  nativeBuildInputs = [ pytestrunner ];
+  propagatedBuildInputs = [ aiohttp ];
+  checkInputs = [ pytestCheckHook pytestcov pytest-asyncio ];
+
+  meta = with lib; {
+    description =
+      "Python wrapper for getting weather data from AccuWeather servers.";
+    homepage = "https://github.com/bieniu/accuweather";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -5,7 +5,7 @@
   version = "0.116.4";
   components = {
     "abode" = ps: with ps; [ abodepy ];
-    "accuweather" = ps: with ps; [ ]; # missing inputs: accuweather
+    "accuweather" = ps: with ps; [ accuweather ];
     "acer_projector" = ps: with ps; [ pyserial ];
     "acmeda" = ps: with ps; [ ]; # missing inputs: aiopulse
     "actiontec" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -150,6 +150,8 @@ in {
 
   absl-py = callPackage ../development/python-modules/absl-py { };
 
+  accuweather = callPackage ../development/python-modules/accuweather { };
+
   accupy = callPackage ../development/python-modules/accupy { };
 
   acebinf = callPackage ../development/python-modules/acebinf { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

support `accuweather` in home assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
