### PR TITLE
doc: rename guide to 'Nixpkgs Manual'

### DIFF
--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -1,7 +1,7 @@
 <book xmlns="http://docbook.org/ns/docbook"
       xmlns:xi="http://www.w3.org/2001/XInclude">
  <info>
-  <title>Nixpkgs Users and Contributors Guide</title>
+  <title>Nixpkgs Manual</title>
   <subtitle>Version <xi:include href=".version" parse="text" />
   </subtitle>
  </info>


### PR DESCRIPTION
For consistency with 'NixOS Manual' and 'Nix Manual', to better match what it's
often called in practice, and to match its URL and HTML title.

/cc @garbas