### PR TITLE
elixir_1_6: remove

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -39,27 +39,22 @@ let
         elixir = elixir_1_10;
 
         elixir_1_10 = lib.callElixir ../interpreters/elixir/1.10.nix {
-          inherit rebar erlang;
+          inherit erlang;
           debugInfo = true;
         };
 
         elixir_1_9 = lib.callElixir ../interpreters/elixir/1.9.nix {
-          inherit rebar erlang;
+          inherit erlang;
           debugInfo = true;
         };
 
         elixir_1_8 = lib.callElixir ../interpreters/elixir/1.8.nix {
-          inherit rebar erlang;
+          inherit erlang;
           debugInfo = true;
         };
 
         elixir_1_7 = lib.callElixir ../interpreters/elixir/1.7.nix {
-          inherit rebar erlang;
-          debugInfo = true;
-        };
-
-        elixir_1_6 = lib.callElixir ../interpreters/elixir/1.6.nix {
-          inherit rebar erlang;
+          inherit erlang;
           debugInfo = true;
         };
 

--- a/pkgs/development/interpreters/elixir/1.6.nix
+++ b/pkgs/development/interpreters/elixir/1.6.nix
@@ -1,7 +1,0 @@
-{ mkDerivation }:
-
-mkDerivation {
-  version = "1.6.6";
-  sha256 = "1wl8rfpw0dxacq4f7xf6wjr8v2ww5691d0cfw9pzw7phd19vazgl";
-  minimumOTPVersion = "19";
-}

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, fetchFromGitHub, erlang, rebar, makeWrapper,
+{ pkgs, stdenv, fetchFromGitHub, erlang, makeWrapper,
   coreutils, curl, bash, debugInfo ? false }:
 
 { baseName ? "elixir"
@@ -20,7 +20,7 @@ in
 
     inherit src version;
 
-    buildInputs = [ erlang rebar makeWrapper ];
+    buildInputs = [ erlang makeWrapper ];
 
     LANG = "C.UTF-8";
     LC_TYPE = "C.UTF-8";
@@ -32,10 +32,6 @@ in
     buildFlags = optional debugInfo "ERL_COMPILER_OPTIONS=debug_info";
 
     preBuild = ''
-      # The build process uses ./rebar. Link it to the nixpkgs rebar
-      rm -vf rebar
-      ln -s ${rebar}/bin/rebar rebar
-
       patchShebangs lib/elixir/generate_app.escript || true
 
       substituteInPlace Makefile \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9627,7 +9627,7 @@ in
   inherit (beam.interpreters)
     erlang erlangR23 erlangR22 erlangR21 erlangR20 erlangR19 erlangR18
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
-    elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6;
+    elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7;
 
   inherit (beam.packages.erlang)
     rebar rebar3

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -97,7 +97,7 @@ rec {
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR22.elixir`.
-    inherit (packages.erlang) elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6;
+    inherit (packages.erlang) elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7;
 
     inherit (packages.erlang) lfe lfe_1_2 lfe_1_3;
   };


### PR DESCRIPTION
Additionally removed the now obsolete `rebar` build dependency for elixir.
Was only necessary till v1.6.

###### Motivation for this change

As Elixir v1.11 will be released soon - Elixir v1.6 will then be deprecated.
But my main motivation to do it now is to get rid of the `rebar` build dependency.
It seems that rebar won't build with Erlang v23 anymore.
Erlang v23.1 is already released and in my opinion should get soon the default Erlang version within nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
