### PR TITLE
pulumi: 2.6.1 -> 2.10.2

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,58 +1,178 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "2.6.1";
+  version = "2.10.2";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.6.1-linux-x64.tar.gz";
-        sha256 = "12f81wj8r3pmxj2l8qhcgnmy2m0a6bfzrvq9avl3444h2w29qpy2";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.10.2-linux-x64.tar.gz";
+        sha256 = "0pxm90vmha265zc4b1ip2f3iryslkwxznn4kb8l3ma6gibz1zav3";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.13.0-linux-amd64.tar.gz";
-        sha256 = "03l7ybc9ca63vdm7a2zsvgc8zz8ip973sfxsjqf3bb277r04mnpb";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v1.1.0-linux-amd64.tar.gz";
+        sha256 = "1l4kszzw1w862sfd4jnz66lwnp02p4kl1fwvj5ab81qfwzwg0cfx";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.13.0-linux-amd64.tar.gz";
-        sha256 = "0ivdiib3a1c1r2ppxmj6blgq26s05s3081969j0j9jlscpa79lap";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v3.4.0-linux-amd64.tar.gz";
+        sha256 = "1gzjdafx5zsqrb5r3amskak51ajcpqbbfw45939jdsdll8vclw7g";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.2.0-linux-amd64.tar.gz";
-        sha256 = "0w6ys5bmry1b8ndzj167cz3a8fc6mbl5v9v2almrmd3q6fycm4gj";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v2.6.0-linux-amd64.tar.gz";
+        sha256 = "0myvx2glqnx29l4wd5vx4gm773zrcmwcjvs2b1yv63fl10md9sv7";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.4.0-linux-amd64.tar.gz";
-        sha256 = "0id3mji08hk76kffz46dlbl2r11kgv5jvlmw869dssg2d0wliv82";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v2.5.0-linux-amd64.tar.gz";
+        sha256 = "12cajd8jiqy11s880vsv20gqfm44g160x7fxm93agjl7wng32ad6";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.2.2-linux-amd64.tar.gz";
-        sha256 = "07asdmmacxazg65d5hphjxzb5j5d2dcc95wjbxx3wwc1swqma4aq";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v2.8.0-linux-amd64.tar.gz";
+        sha256 = "0k429fh477f84kmnhyl5s9p0yym7d6sdq7hy7wqx6psxp4rf5h9x";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v2.8.0-linux-amd64.tar.gz";
+        sha256 = "045z7qj23bq71nxfjk1vvnfbjcnqfkcbxbpjz72q0hw4xn7dq6jz";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v2.3.0-linux-amd64.tar.gz";
+        sha256 = "16d0jd3429pr4vlrzrv32w2fa53j7gyqq5lc78gw9j4v3mc3scvz";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.25.0-linux-amd64.tar.gz";
+        sha256 = "0gz4kpddaf9p25lfnp70p6197wrfgsiys7s4vdy75z8dyd4sbiv0";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v2.0.0-linux-amd64.tar.gz";
+        sha256 = "0n2532gfb5i53raya07rn8wcp15rc07jfg8wsm2lfzj7a4mp2p6c";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v2.6.0-linux-amd64.tar.gz";
+        sha256 = "16l1a30rkg9l6yh68qv61dgm3h3gdgpsdacvnfg1ra0fvvfs9477";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v0.2.0-linux-amd64.tar.gz";
+        sha256 = "1m2w8gsksr36pprxr6v3v4y3n7x5ycbcdfywv67yxmbi4lxyy3ar";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.6.1-linux-amd64.tar.gz";
+        sha256 = "01vnbgck1ffj4jg8ghmkjp63xq3r9q3459vy03xpzm14l1i6agwv";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v2.2.0-linux-amd64.tar.gz";
+        sha256 = "1g05kqymbkrxf48iskn9w12kxy880allhqm9a7p4g7mx0174yfhm";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v2.2.1-linux-amd64.tar.gz";
+        sha256 = "1fa5i283nisa6cq02fcrsgwkw7bwnh2j3agjbqyvv2xiss34i7hw";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v2.6.0-linux-amd64.tar.gz";
+        sha256 = "0ihiag248c30dz4z2b559689zqwp52p0m7pv7jqpk86xwvimbsn1";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.1.0-linux-amd64.tar.gz";
+        sha256 = "0jwvdsb26bhsqcbrsw9ss54xgpccl830hhbwnbz8ql8yndd35srg";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.4.0-linux-amd64.tar.gz";
+        sha256 = "1wr4p312xwqi0icn153iv2j88rp37wkf8hc5y4pmdr61vd0kpw7w";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.3.1-linux-amd64.tar.gz";
+        sha256 = "0xq3as94i9ah9dv1cabgdqjg68yg7laksfzpf81s6kcv742cnnqi";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v2.4.0-linux-amd64.tar.gz";
+        sha256 = "1av7fj1jlhhqplqq60d6hzzidlhsvr41z9p1x3mvz5frwijxr1ab";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v2.10.0-linux-amd64.tar.gz";
+        sha256 = "1bgw5xw6f01whxlm5358xn6v9wqz9mxg3dvb5vi7rfs9wwxykr4g";
       }
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.6.1-darwin-x64.tar.gz";
-        sha256 = "17jf9xwpwpbqk5r20i14j1z4i4rbbx781k0zqyc9yskmv5q4mmwr";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v2.10.2-darwin-x64.tar.gz";
+        sha256 = "1fzqylx7pmrpvsxrmhlx56v9i9zkid96zrj9hsc26qhx5w7k600w";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v2.13.0-darwin-amd64.tar.gz";
-        sha256 = "18mjf9gm8siskg9jh65x4qp4w8p4wnp19bxxk4jfbq27icdk7ws9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v1.1.0-darwin-amd64.tar.gz";
+        sha256 = "05dxpdwdg8cd1a6d3xh8dkns5wkvpr0v11bb4zdzv38x6wxnqx0z";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.13.0-darwin-amd64.tar.gz";
-        sha256 = "14iwz1gm34irs9jlpwc4ig1wc8k4aaxq8mz3g22yrvwddrsc4rcw";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v3.4.0-darwin-amd64.tar.gz";
+        sha256 = "1jbnx1wpzh2k127ixh9j0ghlqhj3sc1s17cp3ax3q9gq3cadcl5i";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.2.0-darwin-amd64.tar.gz";
-        sha256 = "0zaxp2n1w5djwyq1afhd3v887dh0yj53jz449riqp19dpyfqf7h7";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v2.6.0-darwin-amd64.tar.gz";
+        sha256 = "0lpf3cqi3kss7hmr8a3y6gmwjl854vmva4f9p9q7147rxr8aw5f9";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.4.0-darwin-amd64.tar.gz";
-        sha256 = "1kzs7k7as9r1vbj746wqz9iph13zfzzw8nsk3waq8aq1hmgh2g1q";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v2.5.0-darwin-amd64.tar.gz";
+        sha256 = "0qwjrhmspibjr17kgswfcgbdhmkicqrjd1md6azingdr5wp7cwwm";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.2.2-darwin-amd64.tar.gz";
-        sha256 = "0hwdghij7g9h58nwimfmaz91lz38wibkrdzwqhi7d426m53g6f5c";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v2.8.0-darwin-amd64.tar.gz";
+        sha256 = "0rwgbpif7l3ayh363cz0k2dir36a87x0bszspq3nm3xbwmd190f0";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v2.8.0-darwin-amd64.tar.gz";
+        sha256 = "0943r8x70gxxkfn0rhcx2b9zya44k28j5s8z2m8jn2i1fvqvahq5";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v2.3.0-darwin-amd64.tar.gz";
+        sha256 = "1nvqjc1zrxfn2r1wdh2sdr2vimar5836bhscqsiaw4i6mjdsggfy";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v3.25.0-darwin-amd64.tar.gz";
+        sha256 = "05x0qlv3xkkvs71ixzmc21ck85w9f4a4dxrwmgkq6c0nhy3npbnj";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v2.0.0-darwin-amd64.tar.gz";
+        sha256 = "1m80l75r2w46m7191igjan4ipfkhc9ld1xlybncd628qlcf2jpqz";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v2.6.0-darwin-amd64.tar.gz";
+        sha256 = "0dan0qqvaxfh90db14s7adjjy670lz15bbm6a8fjfyj4fdhsbwyn";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v0.2.0-darwin-amd64.tar.gz";
+        sha256 = "1gznv5d10pxbkyl4hbd4c9skkgkypfs1xg0jjmszkwxcjzvhc4l3";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v2.6.1-darwin-amd64.tar.gz";
+        sha256 = "08w8by7h9nlgvyap2in6yy21dk46fxvl93h4ghaw7xxjjs2l3dfi";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v2.2.0-darwin-amd64.tar.gz";
+        sha256 = "0qjszd30r3094p5m7v5gynx2kxh9xf9878mxdc2wnswpkpw3v5pb";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v2.2.1-darwin-amd64.tar.gz";
+        sha256 = "1a19lmxi8r8h4yfll0k97kvq0lgkzwvrwf52ny4zl67bc9g4jr5p";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v2.6.0-darwin-amd64.tar.gz";
+        sha256 = "11vfjkmhrq7q4j6h5d2sdzan3ziyhl5qhc0fhfnsz2pxss549zab";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.1.0-darwin-amd64.tar.gz";
+        sha256 = "1ny1m6pb44k77gqf97km3gkb7dwhilkmqi2zy4hdl20js1ijsh7p";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v2.4.0-darwin-amd64.tar.gz";
+        sha256 = "1vm2pfj93wi6q7kcrqwy9190mx0jn2p96algcd5gms48a4m8bgpb";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v2.3.1-darwin-amd64.tar.gz";
+        sha256 = "0mnmlvyppfndq1rwy4k40j0syy590v2lg75kg0rnf16qlpffskn9";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v2.4.0-darwin-amd64.tar.gz";
+        sha256 = "0q9qbqalask628cbi3347pjbnm3304c8qhx7h8icqxxh59mjnhr7";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v2.10.0-darwin-amd64.tar.gz";
+        sha256 = "1gxiqq6hk77s1n3q3p92p0yykpihw2k8lv01dra015fjha6pyl19";
       }
     ];
   };

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -29,6 +29,7 @@ in stdenv.mkDerivation {
     license = with licenses; [ asl20 ];
     platforms = builtins.attrNames data.pulumiPkgs;
     maintainers = with maintainers; [
+      ghuntley
       peterromfeldhk
       jlesquembre
     ];

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -1,19 +1,34 @@
 #!/usr/bin/env bash
-
-VERSION="2.6.1"
-
 # Bash 3 compatible for Darwin
+
+# Version of Pulumi from
+# https://www.pulumi.com/docs/get-started/install/versions/
+VERSION="2.10.2"
+
+# Grab latest release ${VERSION} from
+# https://github.com/pulumi/pulumi-${NAME}/releases
 plugins=(
-    # https://github.com/pulumi/pulumi-aws/releases
-    "aws=2.13.0"
-    # https://github.com/pulumi/pulumi-gcp/releases
-    "gcp=3.13.0"
-    # https://github.com/pulumi/pulumi-random/releases
-    "random=2.2.0"
-    # https://github.com/pulumi/pulumi-kubernetes/releases
-    "kubernetes=2.4.0"
-    # https://github.com/pulumi/pulumi-postgresql/releases
-    "postgresql=2.2.2");
+    "auth0=1.1.0"
+    "aws=3.4.0"
+    "cloudflare=2.6.0"
+    "consul=2.5.0"
+    "datadog=2.8.0"
+    "digitalocean=2.8.0"
+    "docker=2.3.0"
+    "gcp=3.25.0"
+    "github=2.0.0"
+    "gitlab=2.6.0"
+    "hcloud=0.2.0"
+    "kubernetes=2.6.1"
+    "mailgun=2.2.0"
+    "mysql=2.2.1"
+    "openstack=2.6.0"
+    "packet=3.1.0"
+    "postgresql=2.4.0"
+    "random=2.3.1"
+    "vault=2.4.0"
+    "vsphere=2.10.0"
+    );
 
 function genMainSrc() {
     local url="https://get.pulumi.com/releases/sdk/pulumi-v${VERSION}-$1-x64.tar.gz"


### PR DESCRIPTION
###### Motivation for this change

- add more pulumi plugins
- bump to latest version
- demonstration to pulumi engineers how they could do this themselves (https://twitter.com/GeoffreyHuntley/status/1309131671854342150)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
