### PR TITLE
nixos-container: re-enable `nixpkgs` option

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -529,12 +529,16 @@ in
 
             pkgs = mkOption {
               type = types.nullOr types.attrs;
-              default = pkgs;
-              defaultText = "pkgs";
-              example = literalExample "null";
+              default = null;
+              example = literalExample "pkgs";
               description = ''
                 The nixpkgs to use for the container.
-                When <literal>null</literal>, the pkgs are set by the container <option>config</option>.
+                When <literal>null</literal>, the pkgs are set by the container <option>config</option>
+                through the <option>nixpkgs</option> option.
+                Otherwise, option <option>nixpkgs</option> from the container config is ignored.
+
+                Set this option to <literal>pkgs</literal> to speed up container evaluation by reusing
+                the system pkgs.
               '';
             };
 


### PR DESCRIPTION
#### This PR is superseded by #106767.

Since the introduction (https://github.com/NixOS/nixpkgs/pull/85570) of option `containers.<name>.pkgs`, the option `nixpkgs` (including `nixpkgs.pkgs`, `nixpkgs.config`, ...) was always ignored in container configs.

This option is now honored again if `pkgs == null`.

The default behavior (including its performance benefits by re-using `pkgs`) is unchanged.
**Edit:** The fixup commit reverts to the default behavior of 20.03/20.09 to fix existing container configs broken by https://github.com/NixOS/nixpkgs/pull/85570.

Also, remove the redundant definition of `baseModules`, which is identical to the [one in `eval-config.nix`](https://github.com/NixOS/nixpkgs/blob/f5061117b2b1b4df42190238d8d496337d8d9fd3/nixos/lib/eval-config.nix#L17).

### Reproduce

The following config was broken before and is fixed by this PR:
```bash
nix-build --no-out-link - <<'EOF'
let
  configuration = {
    containers.mycontainer = {
      pkgs = null;
      config = { pkgs, ... }: {
        nixpkgs.overlays = [ (self: super: {
          myval = "hello";
        }) ];
        networking.hostName = pkgs.myval;
      };
    };
  };
in
(import <nixpkgs/nixos> { inherit configuration; }).vm
EOF

# error: attribute 'myval' missing, at (string):9:31
```

Fixes #88621.
cc @adisbladis