### PR TITLE
bind: 9.14.12 -> 9.16.7

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -1,6 +1,6 @@
 { config, stdenv, lib, fetchurl, fetchpatch
-, perl
-, libcap, libtool, libxml2, openssl
+, perl, pkg-config
+, libcap, libtool, libxml2, openssl, libuv
 , enablePython ? config.bind.enablePython or false, python3 ? null
 , enableSeccomp ? false, libseccomp ? null, buildPackages
 }:
@@ -10,11 +10,11 @@ assert enablePython -> python3 != null;
 
 stdenv.mkDerivation rec {
   pname = "bind";
-  version = "9.14.12";
+  version = "9.16.7";
 
   src = fetchurl {
-    url = "https://ftp.isc.org/isc/bind9/${version}/${pname}-${version}.tar.gz";
-    sha256 = "1j7ldvdschmvzxrbajjhmdsl2iqxc1lm64vk0a5sdykxpy9y8kcw";
+    url = "https://downloads.isc.org/isc/bind9/${version}/${pname}-${version}.tar.xz";
+    sha256 = "1l8lhgnkj3fnl1101bs3pzj5gv2x5m9ahvrbyscsc9mxxc91hzcz";
   };
 
   outputs = [ "out" "lib" "dev" "man" "dnsutils" "host" ];
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
     ./remove-mkdir-var.patch
   ];
 
-  nativeBuildInputs = [ perl ];
-  buildInputs = [ libtool libxml2 openssl ]
+  nativeBuildInputs = [ perl pkg-config ];
+  buildInputs = [ libtool libxml2 openssl libuv ]
     ++ lib.optional stdenv.isLinux libcap
     ++ lib.optional enableSeccomp libseccomp
     ++ lib.optional enablePython (python3.withPackages (ps: with ps; [ ply ]));
@@ -35,8 +35,6 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--localstatedir=/var"
     "--with-libtool"
-    "--with-libxml2=${libxml2.dev}"
-    "--with-openssl=${openssl.dev}"
     (if enablePython then "--with-python" else "--without-python")
     "--without-atf"
     "--without-dlopen"
@@ -59,7 +57,6 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     moveToOutput bin/bind9-config $dev
-    moveToOutput bin/isc-config.sh $dev
 
     moveToOutput bin/host $host
 
@@ -68,7 +65,7 @@ stdenv.mkDerivation rec {
     moveToOutput bin/nslookup $dnsutils
     moveToOutput bin/nsupdate $dnsutils
 
-    for f in "$lib/lib/"*.la "$dev/bin/"{isc-config.sh,bind*-config}; do
+    for f in "$lib/lib/"*.la "$dev/bin/"bind*-config; do
       sed -i "$f" -e 's|-L${openssl.dev}|-L${openssl.out}|g'
     done
   '';

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -2,7 +2,7 @@
 , perl, pkg-config
 , libcap, libtool, libxml2, openssl, libuv
 , enablePython ? config.bind.enablePython or false, python3 ? null
-, enableSeccomp ? false, libseccomp ? null, buildPackages
+, enableSeccomp ? false, libseccomp ? null, buildPackages, nixosTests
 }:
 
 assert enableSeccomp -> libseccomp != null;
@@ -71,6 +71,8 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = false; # requires root and the net
+
+  passthru.tests = { inherit (nixosTests) bind; };
 
   meta = with stdenv.lib; {
     homepage = "https://www.isc.org/downloads/bind/";

--- a/pkgs/servers/dns/bind/dont-keep-configure-flags.patch
+++ b/pkgs/servers/dns/bind/dont-keep-configure-flags.patch
@@ -1,40 +1,37 @@
-diff --git a/bin/named/include/named/globals.h b/bin/named/include/named/globals.h
-index b8e356b..cbe6c94 100644
---- a/bin/named/include/named/globals.h
-+++ b/bin/named/include/named/globals.h
-@@ -68,7 +68,9 @@ EXTERN const char *		named_g_version		INIT(VERSION);
- EXTERN const char *		named_g_product		INIT(PRODUCT);
- EXTERN const char *		named_g_description	INIT(DESCRIPTION);
- EXTERN const char *		named_g_srcid		INIT(SRCID);
+diff -ru a/bin/named/include/named/globals.h b/bin/named/include/named/globals.h
+--- a/bin/named/include/named/globals.h	2020-09-24 17:43:49.398977491 +0200
++++ b/bin/named/include/named/globals.h	2020-09-24 17:44:36.826590553 +0200
+@@ -69,7 +69,9 @@
+ EXTERN const char *named_g_product     INIT(PRODUCT);
+ EXTERN const char *named_g_description INIT(DESCRIPTION);
+ EXTERN const char *named_g_srcid       INIT(SRCID);
 +#if 0
- EXTERN const char *		named_g_configargs	INIT(CONFIGARGS);
+ EXTERN const char *named_g_configargs  INIT(CONFIGARGS);
 +#endif
- EXTERN const char *		named_g_builder		INIT(BUILDER);
- EXTERN in_port_t		named_g_port		INIT(0);
- EXTERN isc_dscp_t		named_g_dscp		INIT(-1);
-diff --git a/bin/named/main.c b/bin/named/main.c
-index 62d9ce3..342abdc 100644
---- a/bin/named/main.c
-+++ b/bin/named/main.c
-@@ -459,8 +459,10 @@ printversion(bool verbose) {
+ EXTERN const char *named_g_builder     INIT(BUILDER);
+ EXTERN in_port_t named_g_port	       INIT(0);
+ EXTERN isc_dscp_t named_g_dscp	       INIT(-1);
+diff -ru a/bin/named/main.c b/bin/named/main.c
+--- a/bin/named/main.c	2020-09-24 17:43:49.399977504 +0200
++++ b/bin/named/main.c	2020-09-24 17:44:24.102426273 +0200
+@@ -506,7 +506,9 @@
  	}
  
  	printf("running on %s\n", named_os_uname());
 +#if 0
- 	printf("built by %s with %s\n",
- 	       named_g_builder, named_g_configargs);
+ 	printf("built by %s with %s\n", named_g_builder, named_g_configargs);
 +#endif
  #ifdef __clang__
  	printf("compiled by CLANG %s\n", __VERSION__);
- #else
-@@ -1001,9 +1003,11 @@ setup(void) {
- 		      NAMED_LOGMODULE_MAIN, ISC_LOG_NOTICE,
- 		      "running on %s", named_os_uname());
+ #else /* ifdef __clang__ */
+@@ -1102,9 +1104,11 @@
+ 		      NAMED_LOGMODULE_MAIN, ISC_LOG_NOTICE, "running on %s",
+ 		      named_os_uname());
  
 +#if 0
  	isc_log_write(named_g_lctx, NAMED_LOGCATEGORY_GENERAL,
- 		      NAMED_LOGMODULE_MAIN, ISC_LOG_NOTICE,
- 		      "built with %s", named_g_configargs);
+ 		      NAMED_LOGMODULE_MAIN, ISC_LOG_NOTICE, "built with %s",
+ 		      named_g_configargs);
 +#endif
  
  	isc_log_write(named_g_lctx, NAMED_LOGCATEGORY_GENERAL,

--- a/pkgs/tools/networking/dnsperf/default.nix
+++ b/pkgs/tools/networking/dnsperf/default.nix
@@ -4,14 +4,14 @@
 
 stdenv.mkDerivation rec {
   pname = "dnsperf";
-  version = "2.3.1";
+  version = "2.3.4";
 
   # The same as the initial commit of the new GitHub repo (only readme changed).
   src = fetchFromGitHub {
     owner = "DNS-OARC";
     repo = "dnsperf";
     rev = "v${version}";
-    sha256 = "0yxwm5xi9ry154ayzn2h27bnwwc202bsna8h6i4a65pn76nrn81w";
+    sha256 = "1lyci2vdl6g0s5pqs7dkq7pxdahcpkzh614wmy5fwi2f3334y0d1";
   };
 
   outputs = [ "out" "man" "doc" ];


### PR DESCRIPTION
###### Motivation for this change

bind 9.14.12 was released 5 months ago and is the last release on the EOL 9.14 branch. 9.16 is pretty stable at this point, and most distros have already upgraded long ago.

Also bump dnsperf at the same time since the old version currently packaged cannot deal with Bind 9.16.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
