### PR TITLE
plexamp: 3.1.1 -> 3.2.0

### DIFF
--- a/pkgs/applications/audio/plexamp/default.nix
+++ b/pkgs/applications/audio/plexamp/default.nix
@@ -2,12 +2,12 @@
 
 let
   pname = "plexamp";
-  version = "3.1.1";
+  version = "3.2.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}.AppImage";
-    sha256 = "11hgcysa1x9yqvha6ri4vl1zk8gf8vhcpnh3j38wg9ncd7nz5k2v";
+    sha256 = "R1BhobnwoU7oJ7bNes8kH2neXqHlMPbRCNjcHyzUPqo=";
     name="${pname}-${version}.AppImage";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Adds remote control support for other plex players, as well as other
changes.

Release notes: https://forums.plex.tv/t/plexamp-release-notes/221280/16

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
