### PR TITLE
zombietrackergps: init at 1.01

### DIFF
--- a/pkgs/applications/gis/zombietrackergps/default.nix
+++ b/pkgs/applications/gis/zombietrackergps/default.nix
@@ -1,0 +1,57 @@
+{ mkDerivation
+, lib
+, fetchFromGitLab
+, qmake
+, qtbase
+, qtcharts
+, qtsvg
+, marble
+, qtwebengine
+, ldutils
+}:
+
+mkDerivation rec {
+  pname = "zombietrackergps";
+  version = "1.01";
+
+  src = fetchFromGitLab {
+    owner = "ldutils-projects";
+    repo = pname;
+    rev = "v_${version}";
+    sha256 = "0h354ydbahy8rpkmzh5ym5bddbl6irjzklpcg6nbkv6apry84d48";
+  };
+
+  buildInputs = [
+    ldutils
+    qtbase
+    qtcharts
+    qtsvg
+    marble.dev
+    qtwebengine
+  ];
+
+  nativeBuildInputs = [
+    qmake
+  ];
+
+  prePatch = ''
+    sed -ie "s,INCLUDEPATH += /usr/include/libldutils,INCLUDEPATH += ${ldutils}," ZombieTrackerGPS.pro
+  '';
+
+  preConfigure = ''
+    export LANG=en_US.UTF-8
+    export INSTALL_ROOT=$out
+  '';
+
+  postConfigure = ''
+    substituteInPlace Makefile --replace '$(INSTALL_ROOT)' ""
+  '';
+
+  meta = with lib; {
+    description = "GPS track manager for Qt using KDE Marble maps";
+    homepage = "https://gitlab.com/ldutils-projects/zombietrackergps";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ sohalt ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/ldutils/default.nix
+++ b/pkgs/development/libraries/ldutils/default.nix
@@ -1,0 +1,41 @@
+{ mkDerivation
+, lib
+, fetchFromGitLab
+, qtbase
+, qtcharts
+, qtsvg
+, qmake
+}:
+
+mkDerivation rec {
+  pname = "ldutils";
+  version = "1.01";
+
+  src = fetchFromGitLab {
+    owner = "ldutils-projects";
+    repo = pname;
+    rev = "v_${version}";
+    sha256 = "09k2d5wj70xfr3sb4s9ajczq0lh65705pggs54zqqqjxazivbmgk";
+  };
+
+  buildInputs = [
+    qtbase
+    qtcharts
+    qtsvg
+  ];
+
+  nativeBuildInputs = [
+    qmake
+  ];
+
+  LDUTILS_LIB=placeholder "out";
+  LDUTILS_INCLUDE=placeholder "out";
+
+  meta = with lib; {
+    description = "Headers and link library for other ldutils projects";
+    homepage = "https://gitlab.com/ldutils-projects/ldutils";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ sohalt ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15069,6 +15069,8 @@ in
 
     kreport = callPackage ../development/libraries/kreport { };
 
+    ldutils = callPackage ../development/libraries/ldutils { };
+
     libcommuni = callPackage ../development/libraries/libcommuni { };
 
     libdbusmenu = callPackage ../development/libraries/libdbusmenu-qt/qt-5.5.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24604,6 +24604,8 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  zombietrackergps = libsForQt514.callPackage ../applications/gis/zombietrackergps { };
+
   zoom-us = libsForQt514.callPackage ../applications/networking/instant-messengers/zoom-us { };
 
   zotero = callPackage ../applications/office/zotero { };


### PR DESCRIPTION
###### Motivation for this change
Closes #97065

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
