### PR TITLE
certbot: 1.7.0 -> 1.9.0

### DIFF
--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "certbot";
-  version = "1.7.0";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "1fx29gsa3glwh0ik5k2gynwdz6i3ckq9aakf6ip92n3qyh6l08a8";
+    sha256 = "1y04mchxybmy197lgj2rz53fx29s248hirsmb3zk2vdzlbbbs1b6";
   };
 
   sourceRoot = "source/${pname}";


### PR DESCRIPTION
###### Motivation for this change
https://github.com/certbot/certbot/releases/tag/v1.8.0
https://github.com/certbot/certbot/releases/tag/v1.9.0

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).