### PR TITLE
nodePackages: init hsd, hs-airdrop, hs-client

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -69,6 +69,10 @@ let
       meta.broken = since "10";
     };
 
+    hsd = super.hsd.override {
+      buildInputs = [ self.node-gyp-build pkgs.unbound ];
+    };
+
     insect = super.insect.override (drv: {
       nativeBuildInputs = drv.nativeBuildInputs or [] ++ [ pkgs.psc-package self.pulp ];
     });

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -95,6 +95,7 @@
 , "htmlhint"
 , "http-server"
 , "hsd"
+, "hs-airdrop"
 , "hueadm"
 , "inliner"
 , "imapnotify"

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -96,6 +96,7 @@
 , "http-server"
 , "hsd"
 , "hs-airdrop"
+, "hs-client"
 , "hueadm"
 , "inliner"
 , "imapnotify"

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -94,6 +94,7 @@
 , "html-minifier"
 , "htmlhint"
 , "http-server"
+, "hsd"
 , "hueadm"
 , "inliner"
 , "imapnotify"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -22,40 +22,58 @@ let
         sha512 = "t4WmWoGV9gyzypwG3y3JlcK2t8fKLtvzBA7xEoFTj9SMPvOuLsf13uh4ikK0RRaaa9RPPWLgFUdOyIRaQvCpwQ==";
       };
     };
-    "@angular-devkit/architect-0.1002.0" = {
+    "@angular-devkit/architect-0.1100.1" = {
       name = "_at_angular-devkit_slash_architect";
       packageName = "@angular-devkit/architect";
-      version = "0.1002.0";
+      version = "0.1100.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1002.0.tgz";
-        sha512 = "twM8V03ujBIGVpgV1PBlSDodUdxtUb7WakutfWafAvEHUsgwzfvQz2VtKWvjNZ9AiYjnCuwkQaclqVv0VHNo9w==";
+        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1100.1.tgz";
+        sha512 = "DIAvTRRY+k7T2xHf4RVV06P16D0V7wSf1MSpGSDWVpfWcA3HNOSGfsk1F+COMlbFehXuKztwieXarv5rXbBCng==";
       };
     };
-    "@angular-devkit/core-10.2.0" = {
+    "@angular-devkit/core-11.0.0" = {
       name = "_at_angular-devkit_slash_core";
       packageName = "@angular-devkit/core";
-      version = "10.2.0";
+      version = "11.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-10.2.0.tgz";
-        sha512 = "XAszFhSF3mZw1VjoOsYGbArr5NJLcStjOvcCGjBPl1UBM2AKpuCQXHxI9XJGYKL3B93Vp5G58d8qkHvamT53OA==";
+        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-11.0.0.tgz";
+        sha512 = "fXZtSs3J4S12hboi3om1FA+QS0e8nuQMyzl2nkmtuhcELUFMmSrEl36dtCni5e7Svs46BUAZ5w8EazIkgGQDJg==";
       };
     };
-    "@angular-devkit/schematics-10.2.0" = {
+    "@angular-devkit/core-11.0.1" = {
+      name = "_at_angular-devkit_slash_core";
+      packageName = "@angular-devkit/core";
+      version = "11.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-11.0.1.tgz";
+        sha512 = "ui3g7w/0SpU9oq8uwN9upR8Y1eOXZ+P2p3NyDydBrR7ZEfEkRLS1mhozN/ib8farrwK5N3kIIJxMb5t3187Hng==";
+      };
+    };
+    "@angular-devkit/schematics-11.0.0" = {
       name = "_at_angular-devkit_slash_schematics";
       packageName = "@angular-devkit/schematics";
-      version = "10.2.0";
+      version = "11.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-10.2.0.tgz";
-        sha512 = "TQI5NnE6iM3ChF5gZQ9qb+lZgMWa7aLoF5ksOyT3zrmOuICiQYJhA6SsjV95q7J4M55qYymwBib8KTqU/xuQww==";
+        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.0.0.tgz";
+        sha512 = "oCz9E0thA5WdGDuv6biu3X5kw5/vNE4ZZOKT2sHBQMpAuuDYrDpfTYQJjXQtjfXWvmlr8L8aqDD9N4HXsE4Esw==";
       };
     };
-    "@angular-devkit/schematics-cli-0.1002.0" = {
+    "@angular-devkit/schematics-11.0.1" = {
+      name = "_at_angular-devkit_slash_schematics";
+      packageName = "@angular-devkit/schematics";
+      version = "11.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.0.1.tgz";
+        sha512 = "rAOnAndcybEH398xf5wzmcUPCoCi0dKiOo/+1dkKU5aTxynw1OUnANt5K6A+ZZTGnJmfjtP0ovkZGYun9IUDxQ==";
+      };
+    };
+    "@angular-devkit/schematics-cli-0.1100.1" = {
       name = "_at_angular-devkit_slash_schematics-cli";
       packageName = "@angular-devkit/schematics-cli";
-      version = "0.1002.0";
+      version = "0.1100.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-0.1002.0.tgz";
-        sha512 = "wV5YPdcolPAXo5oyMu9vM3fm3grb3ZT9amrTMC9oc3OWQUVFySPCIzvguHf8bVGMQ/AHfel2TaYxIQv/LurBrQ==";
+        url = "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-0.1100.1.tgz";
+        sha512 = "6iGauhYKSkgsqA8HK7sul7lrVzrkxXAghGd3FcTHtXsmjh/leBezi7R82MphzcoYAOQ36COLMcOJnYurVG1Y6g==";
       };
     };
     "@antora/asciidoc-loader-2.3.4" = {
@@ -1363,6 +1381,15 @@ let
         sha512 = "hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==";
       };
     };
+    "@braintree/sanitize-url-3.1.0" = {
+      name = "_at_braintree_slash_sanitize-url";
+      packageName = "@braintree/sanitize-url";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz";
+        sha512 = "GcIY79elgB+azP74j8vqkiXz8xLFfIzbQJdlwOPisgbKT00tviJQuEghOXSMVxJ00HoYJbGswr4kcllUc4xCcg==";
+      };
+    };
     "@bugsnag/browser-7.5.1" = {
       name = "_at_bugsnag_slash_browser";
       packageName = "@bugsnag/browser";
@@ -1417,13 +1444,13 @@ let
         sha512 = "htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==";
       };
     };
-    "@chemzqm/neovim-5.2.8" = {
+    "@chemzqm/neovim-5.2.10" = {
       name = "_at_chemzqm_slash_neovim";
       packageName = "@chemzqm/neovim";
-      version = "5.2.8";
+      version = "5.2.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@chemzqm/neovim/-/neovim-5.2.8.tgz";
-        sha512 = "687yDuEK7A+aZ8PcJVD7xLWkbC1WMp41FcCg1SCHuBroEGn2cbIMl7zwM7LeHsPCDMSDyWfYPMqEgUiVgGfrsQ==";
+        url = "https://registry.npmjs.org/@chemzqm/neovim/-/neovim-5.2.10.tgz";
+        sha512 = "IeXAS7yFgsz0EyZrQguX1/Rbbe5EYMZOm2OxosY1oht+LjxQj2vv0u91tvX/Qu67SIWCFoaudJZuDcgK88anyg==";
       };
     };
     "@cliqz-oss/firefox-client-0.3.1" = {
@@ -1561,24 +1588,6 @@ let
         sha512 = "HilPrVrCosYWqSyjfpDtaaN1kJwdlBpS+IAflP3z+e7nsEgk3JGJf1Vg0NgHJooTf5HDfXSyZqMVg+5jvXCK0g==";
       };
     };
-    "@emmetio/abbreviation-2.0.2" = {
-      name = "_at_emmetio_slash_abbreviation";
-      packageName = "@emmetio/abbreviation";
-      version = "2.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.0.2.tgz";
-        sha512 = "kpWg6jyR1YEj/yWceruvDj/fe1BhXqA0tGH3Z2ZiPFo8SDMH4JHg6FChqon5x0CCfLf4zVswrQa0gcZ4XtdRBQ==";
-      };
-    };
-    "@emmetio/css-abbreviation-2.1.2" = {
-      name = "_at_emmetio_slash_css-abbreviation";
-      packageName = "@emmetio/css-abbreviation";
-      version = "2.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.2.tgz";
-        sha512 = "CvYTzJltVpLqJaCZ1Qn97LVAKsl2Uwl2fzir1EX/WuMY3xWxgc3BWRCheL6k65km6GyDrLVl6RhrrNb/pxOiAQ==";
-      };
-    };
     "@emmetio/extract-abbreviation-0.1.6" = {
       name = "_at_emmetio_slash_extract-abbreviation";
       packageName = "@emmetio/extract-abbreviation";
@@ -1586,15 +1595,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@emmetio/extract-abbreviation/-/extract-abbreviation-0.1.6.tgz";
         sha512 = "Ce3xE2JvTSEbASFbRbA1gAIcMcZWdS2yUYRaQbeM0nbOzaZrUYfa3ePtcriYRZOZmr+CkKA+zbjhvTpIOAYVcw==";
-      };
-    };
-    "@emmetio/scanner-1.0.0" = {
-      name = "_at_emmetio_slash_scanner";
-      packageName = "@emmetio/scanner";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.0.tgz";
-        sha512 = "8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA==";
       };
     };
     "@emotion/is-prop-valid-0.8.8" = {
@@ -2047,13 +2047,13 @@ let
         sha512 = "t3yIbbPKJubb22vQ/FIWwS9vFAzaPYzFxKWPHVWLtxs/P+5yL+LD3B16DRtYreWAdl9CZvEbos58ChLZ0KHwSQ==";
       };
     };
-    "@fluentui/react-7.149.4" = {
+    "@fluentui/react-7.150.0" = {
       name = "_at_fluentui_slash_react";
       packageName = "@fluentui/react";
-      version = "7.149.4";
+      version = "7.150.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@fluentui/react/-/react-7.149.4.tgz";
-        sha512 = "yZqU5EFYDlXZQfFLIm085/A/nYW9SL/YccPT6E+r51vwn4NlfRSQ6K0IFD5cGnMPOhA+mwyT79uFgxb3/I281A==";
+        url = "https://registry.npmjs.org/@fluentui/react/-/react-7.150.0.tgz";
+        sha512 = "G/JohcQ6ZxxtoWTr5YwTQbV3pfKf7KkEVKF2ScJJ/rspNJRHFx7w4pzmb1jvNm78rAKiHA6sVlXeJmlTiivn1g==";
       };
     };
     "@fluentui/react-focus-7.16.17" = {
@@ -2110,13 +2110,13 @@ let
         sha512 = "+ywPfK6N2Ddna6oOa5Qb1Mv7EA8LOwRNOAPP9dL37FEhksJM9pYqPSceUcqMqg7S9b0+Cgr78s408rgvurV3/Q==";
       };
     };
-    "@graphql-tools/delegate-7.0.4" = {
+    "@graphql-tools/delegate-7.0.5" = {
       name = "_at_graphql-tools_slash_delegate";
       packageName = "@graphql-tools/delegate";
-      version = "7.0.4";
+      version = "7.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-7.0.4.tgz";
-        sha512 = "6/qL9V31FgECNPwc5As1359hpsAt4ASWsiYBSYWL+Iq9/K0YRcNeEmSseXIyCP4oh8k/9HS/w/m2lkMk/YSUpQ==";
+        url = "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-7.0.5.tgz";
+        sha512 = "wkB/L9cRxlPB4m9k9WQJZYPbnRxfEu2bkxvI9pVGHMsmoQxMZiM2GkhCBHDTBYJb7cxCS6Wv3LJb1w0iEqw24w==";
       };
     };
     "@graphql-tools/graphql-file-loader-6.2.5" = {
@@ -2767,6 +2767,42 @@ let
         sha512 = "UK0Fu0eevQlpRXq5ff4o/71HJlpX9wJMddJjMYg9vUqCCl8ZnumRAljfShHFhGyO+Vc9IzN6dd8Y5JZZTp1KOw==";
       };
     };
+    "@joplinapp/fork-htmlparser2-4.1.8" = {
+      name = "_at_joplinapp_slash_fork-htmlparser2";
+      packageName = "@joplinapp/fork-htmlparser2";
+      version = "4.1.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@joplinapp/fork-htmlparser2/-/fork-htmlparser2-4.1.8.tgz";
+        sha512 = "EZUzKlV6K8KV8DMm9PJW8fToBStA6GvoNKzn/zso8xmwFtMFsyAj/N8++0q7ZyzxJ+7N15GJNgELhxE5f9JY/g==";
+      };
+    };
+    "@joplinapp/fork-sax-1.2.12" = {
+      name = "_at_joplinapp_slash_fork-sax";
+      packageName = "@joplinapp/fork-sax";
+      version = "1.2.12";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@joplinapp/fork-sax/-/fork-sax-1.2.12.tgz";
+        sha512 = "TDdIKTv/THRusbN6cRIIGDrVWAp1JC7lS7faaaQtrJlKLFYAM2oeBIGHmDmxkC0MBFN/XPMiZl5bWBdSuy+C9g==";
+      };
+    };
+    "@joplinapp/lib-1.0.9" = {
+      name = "_at_joplinapp_slash_lib";
+      packageName = "@joplinapp/lib";
+      version = "1.0.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@joplinapp/lib/-/lib-1.0.9.tgz";
+        sha512 = "fXRs/nKJNL36kZX/rfm4F3zaNse12cpXXZQNg+8txUcGTSFx7DBBu2r3x3QV33y6DxsjK9dW/CUM4NJUcXKMFQ==";
+      };
+    };
+    "@joplinapp/renderer-1.0.17" = {
+      name = "_at_joplinapp_slash_renderer";
+      packageName = "@joplinapp/renderer";
+      version = "1.0.17";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@joplinapp/renderer/-/renderer-1.0.17.tgz";
+        sha512 = "uX7V8peMH+OHwmceEw6u0bgVuKNhNhnFaZWqyhnH0aCoemOCnjZ45VQSJfTM/2ljL8xFo1VTA9MoWUmLdU/QCg==";
+      };
+    };
     "@kwsites/file-exists-1.1.1" = {
       name = "_at_kwsites_slash_file-exists";
       packageName = "@kwsites/file-exists";
@@ -3325,13 +3361,13 @@ let
         sha512 = "/NdX1Ql8hKNM0vHFJnEr/bcw6BG0ULHD3HhInpniZw5ixpl+n/QIRfMEEmLCn7acedbM1zGdZvU5ZMbn9kcF5Q==";
       };
     };
-    "@microsoft/load-themed-styles-1.10.126" = {
+    "@microsoft/load-themed-styles-1.10.133" = {
       name = "_at_microsoft_slash_load-themed-styles";
       packageName = "@microsoft/load-themed-styles";
-      version = "1.10.126";
+      version = "1.10.133";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.126.tgz";
-        sha512 = "6GoapdGJPmWq6WChTaImAZ6UjuPb2FWHeP/pTEHw6Dz+d4/4TnyWcVR9uDLx+8n6xn3ZpU6OtW0FEGzNNa+TUw==";
+        url = "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.133.tgz";
+        sha512 = "jiGxZDBXmjD0uQPtZ+C/UPEdGwp5C50x1fYLy84dpkooZ8nT0jeWlXS3JJjWpHAL9URY37OIrBWzHu/FcBWFGQ==";
       };
     };
     "@mozilla/readability-0.3.0" = {
@@ -3361,13 +3397,13 @@ let
         sha512 = "Vwhc3ObxmDZmA5hY8mfsau2rJ4vGPvzbj20QSZ2/E1GDPF61QVyjLfNHak9xmel6pW4heRt3v1fHa6np9Ehfeg==";
       };
     };
-    "@nestjs/schematics-7.2.1" = {
+    "@nestjs/schematics-7.2.2" = {
       name = "_at_nestjs_slash_schematics";
       packageName = "@nestjs/schematics";
-      version = "7.2.1";
+      version = "7.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@nestjs/schematics/-/schematics-7.2.1.tgz";
-        sha512 = "yTIwiclX65HYIeemJ/ih3SVlj3BhUHS5eeGy/6uFy1EiIujNadsgi/RZxFSwlCIDkSrGUykqoZdvzfdnsD1Itw==";
+        url = "https://registry.npmjs.org/@nestjs/schematics/-/schematics-7.2.2.tgz";
+        sha512 = "3y0LE1z50CEzXr5rFlOpaJ+0ctkyQWtREkMuvQd/SUILF75+6cNTqmfjjnUJw12vdkdkc+zsksgXFWEPkns4Pg==";
       };
     };
     "@netflix/nerror-1.1.3" = {
@@ -3379,13 +3415,13 @@ let
         sha512 = "b+MGNyP9/LXkapreJzNUzcvuzZslj/RGgdVVJ16P2wSlYatfLycPObImqVJSmNAdyeShvNeM/pl3sVZsObFueg==";
       };
     };
-    "@netlify/build-5.2.1" = {
+    "@netlify/build-5.3.1" = {
       name = "_at_netlify_slash_build";
       packageName = "@netlify/build";
-      version = "5.2.1";
+      version = "5.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/build/-/build-5.2.1.tgz";
-        sha512 = "o08VdNJmJvsxGvFkFScpgznrk+lkG72Rv7VHW+K4WkFXsYjbcitM5zjoQizSZwxgQ8/iee9EZn+8zWwjf/K1tw==";
+        url = "https://registry.npmjs.org/@netlify/build/-/build-5.3.1.tgz";
+        sha512 = "4Qb4TuqOoRP2fopebyAonjNu0Ay3GVjOQSqzJUcENPg7MNIwzqd/V7nY+OtQJyA8/1Xjd4cwdPP20SIoGoBvMQ==";
       };
     };
     "@netlify/cache-utils-1.0.6" = {
@@ -3406,13 +3442,13 @@ let
         sha512 = "Z7yzbx5qCX2I5RLlNyo0MMQ6GKJc8o5Nej9yspCavjqgYlUS7VJfbeE67WNxC26FXwDUqq00zJ0MrCS0Un1YOw==";
       };
     };
-    "@netlify/config-2.3.6" = {
+    "@netlify/config-2.4.0" = {
       name = "_at_netlify_slash_config";
       packageName = "@netlify/config";
-      version = "2.3.6";
+      version = "2.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/config/-/config-2.3.6.tgz";
-        sha512 = "50cK+lEnmZdN1Es1jeiiBV8kT5tKbRK9yp4qlUo1CYp3MJxw4RY/duoYnCAy/D1wbdV5poDM5gZpHS+dxF7nmQ==";
+        url = "https://registry.npmjs.org/@netlify/config/-/config-2.4.0.tgz";
+        sha512 = "MDp7A7AMHVOHpvX+o69t+c8nZjVtkxNcepxsSqE+9wuPVlSHWCqzkHVxKQU0ozuk74z/xHBRUpp/OMCXkiEugg==";
       };
     };
     "@netlify/functions-utils-1.3.2" = {
@@ -3649,13 +3685,13 @@ let
         sha512 = "QyAGYo/Fbj4MXeGdJcFzZ+FkDkomfRBrPM+9QYJSg+PxgAUL+LU3FneQk37rKR2/zjqkCV1BLHccX98wRXG3Sg==";
       };
     };
-    "@npmcli/run-script-1.7.4" = {
+    "@npmcli/run-script-1.7.5" = {
       name = "_at_npmcli_slash_run-script";
       packageName = "@npmcli/run-script";
-      version = "1.7.4";
+      version = "1.7.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.7.4.tgz";
-        sha512 = "GAeOB6P4/aYyvEbROVHXuSGPgy4wwQN/fGfXP993o9btyuCAOaz0T2cr5Y1y4nSeaBPfhk5W/E/AfFKDt6yG7w==";
+        url = "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.7.5.tgz";
+        sha512 = "G8taZCc0HExiLadB3Nv0/h1TWjQ9HhkqW/waaH9MNqMX26rPRyNORst1LlNXOO8QnxQF4tNdJfc/Z3TuEtiyww==";
       };
     };
     "@oclif/color-0.1.2" = {
@@ -3719,6 +3755,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.3.tgz";
         sha512 = "EJR6AIOEkt/NnARNIVAskPDVtdhtO5TTNXmhDrGqMoWVsr0R6DkkLrMyq95BmHvlVWM1nduoq4fQPuCyuF2jaA==";
+      };
+    };
+    "@oclif/errors-1.3.4" = {
+      name = "_at_oclif_slash_errors";
+      packageName = "@oclif/errors";
+      version = "1.3.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.4.tgz";
+        sha512 = "pJKXyEqwdfRTUdM8n5FIHiQQHg5ETM0Wlso8bF9GodczO40mF5Z3HufnYWJE7z8sGKxOeJCdbAVZbS8Y+d5GCw==";
       };
     };
     "@oclif/linewrap-1.0.0" = {
@@ -3964,310 +4009,310 @@ let
         sha512 = "PffXX2AL8Sh0VHQ52jJC4u3T0H6wDK6N/4bg7xh4ngMYOIi13aR1kzVvX1sVDBgfGwDOkMbl4c54Xm3tlPx/+A==";
       };
     };
-    "@ot-builder/bin-composite-types-0.10.31" = {
+    "@ot-builder/bin-composite-types-0.10.33" = {
       name = "_at_ot-builder_slash_bin-composite-types";
       packageName = "@ot-builder/bin-composite-types";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/bin-composite-types/-/bin-composite-types-0.10.31.tgz";
-        sha512 = "SbyWNIMJZEqPdbJW6P1KaHnLTvTqinm3J9MiNmdOhrEuw1k4jLpatQCYT4jLMDHuD1bRLmzgRshcfbm5Rtb+Kg==";
+        url = "https://registry.npmjs.org/@ot-builder/bin-composite-types/-/bin-composite-types-0.10.33.tgz";
+        sha512 = "6Ls0hv6JRVzyeT3By9wl34B1d2exTKp6eilU7z4MZzGR78MU73H6nVDp9NTlwhA545K1dqAk6lAN2ApUo60UaQ==";
       };
     };
-    "@ot-builder/bin-util-0.10.31" = {
+    "@ot-builder/bin-util-0.10.33" = {
       name = "_at_ot-builder_slash_bin-util";
       packageName = "@ot-builder/bin-util";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/bin-util/-/bin-util-0.10.31.tgz";
-        sha512 = "bbYcQ582m2uNcJajhPB7St2lXvN4hekaNrMVgQREfaDmHcQycV7NaqM3Q333IYbKNSHehSLBcJ3whVyN1oAOvw==";
+        url = "https://registry.npmjs.org/@ot-builder/bin-util/-/bin-util-0.10.33.tgz";
+        sha512 = "ijm6023Wlv4l6jt04Zq/Ts2GJDtDN++NDD70VQ0PsKcX0N5/Ebzbn2v+2cNaTFirGY1O+H1tGtLcPFVR32aDLw==";
       };
     };
-    "@ot-builder/cli-help-shower-0.10.31" = {
+    "@ot-builder/cli-help-shower-0.10.33" = {
       name = "_at_ot-builder_slash_cli-help-shower";
       packageName = "@ot-builder/cli-help-shower";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/cli-help-shower/-/cli-help-shower-0.10.31.tgz";
-        sha512 = "96SdquA87vuHHuwPuTDKrFoKD7g89SddDsmowjdR57N+9tinbwGxNiz3jCK4DycMIebSRwWIq0ls20Veq0uT3g==";
+        url = "https://registry.npmjs.org/@ot-builder/cli-help-shower/-/cli-help-shower-0.10.33.tgz";
+        sha512 = "720ibT7AxqrTfcYdOuPC4/RTQV8HgOt3W5yz1Z7tF0Dtj7Oka5X3qiLHlBiaNQYfRlmvap84NG1JXI9KedYtQA==";
       };
     };
-    "@ot-builder/cli-proc-0.10.31" = {
+    "@ot-builder/cli-proc-0.10.33" = {
       name = "_at_ot-builder_slash_cli-proc";
       packageName = "@ot-builder/cli-proc";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/cli-proc/-/cli-proc-0.10.31.tgz";
-        sha512 = "5rt5zCn681qoz8CwwB8HBrSdHv/axOtmtjOAkFuTm1HEOZeAmJt2nRVQwP+08lQLlPhZyiBM57XDqNgohGu+3A==";
+        url = "https://registry.npmjs.org/@ot-builder/cli-proc/-/cli-proc-0.10.33.tgz";
+        sha512 = "ou8I9QUwwttYreAmeTsdRHSJeudclIEQdDitKXTDJFB3qombH2n1509BHN+lod5TbDEO/L/Nhyz82xQxmEnvUw==";
       };
     };
-    "@ot-builder/cli-shared-0.10.31" = {
+    "@ot-builder/cli-shared-0.10.33" = {
       name = "_at_ot-builder_slash_cli-shared";
       packageName = "@ot-builder/cli-shared";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/cli-shared/-/cli-shared-0.10.31.tgz";
-        sha512 = "54dJvtBCZ2ELNI38F98blPUURwD/cu09sOC68u7WghDrkmcql9UOjCgVsujoLDS52KdpD7DzOxhTu2j6upAZ2w==";
+        url = "https://registry.npmjs.org/@ot-builder/cli-shared/-/cli-shared-0.10.33.tgz";
+        sha512 = "pZXxdWoIj/XntJ2+NbpW+N5IdRJzTRMa+0SQdKr/xqrLq9qIKkcBhaqeY8HzqKF8CXPDdwEsgtXrAvmrStE1VA==";
       };
     };
-    "@ot-builder/common-impl-0.10.31" = {
+    "@ot-builder/common-impl-0.10.33" = {
       name = "_at_ot-builder_slash_common-impl";
       packageName = "@ot-builder/common-impl";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/common-impl/-/common-impl-0.10.31.tgz";
-        sha512 = "9cGRXS45fPR9tau81G+zo6J8toEP9ouuE0gTTAL8ZHz84mAeUE3ybTL0pyiBO0fu01LtMgeLxl1w0rBze8T4jw==";
+        url = "https://registry.npmjs.org/@ot-builder/common-impl/-/common-impl-0.10.33.tgz";
+        sha512 = "5lZxnaoP2qQ5/57BDhdtY3y5qdUScUi9AOBb0xIEG2MbzSEqruoY01AbxhNG47oJGeVCTrgRP9u0xPOhWY+4+A==";
       };
     };
-    "@ot-builder/errors-0.10.31" = {
+    "@ot-builder/errors-0.10.33" = {
       name = "_at_ot-builder_slash_errors";
       packageName = "@ot-builder/errors";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/errors/-/errors-0.10.31.tgz";
-        sha512 = "6UvEpFqukndJ2d9T5gvdtMUliK6H8j8g1JrLyG9WNNPMY9NZ7MAHz1vAzR3ZNN9cBZPMy/mYjUf7q1mjs8fiow==";
+        url = "https://registry.npmjs.org/@ot-builder/errors/-/errors-0.10.33.tgz";
+        sha512 = "Eq3ghzkxLIZasfh2Sc49MDoaCwmW6c4xaqq9yZSmY1txd6s8WrzWisDBYdt7qwCHVW2EcbsJMNpSKECzAfegpA==";
       };
     };
-    "@ot-builder/io-bin-cff-0.10.31" = {
+    "@ot-builder/io-bin-cff-0.10.33" = {
       name = "_at_ot-builder_slash_io-bin-cff";
       packageName = "@ot-builder/io-bin-cff";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/io-bin-cff/-/io-bin-cff-0.10.31.tgz";
-        sha512 = "ypaCkzW/hDvItKwJ6i5JVsG4YxhLP9M3CNUxSOD5FNH8Ld/AvS2Mt8i1fJdj37O2tAJgFLUj3dET0bWL8Czlvg==";
+        url = "https://registry.npmjs.org/@ot-builder/io-bin-cff/-/io-bin-cff-0.10.33.tgz";
+        sha512 = "QffGC05YocTrzNDhNa2gF64/iZqarERvRM8EnGRyZM4THHE/LwWHVMtirDl/DI8V1Ex00XTpxfCPwRerhQWBvw==";
       };
     };
-    "@ot-builder/io-bin-encoding-0.10.31" = {
+    "@ot-builder/io-bin-encoding-0.10.33" = {
       name = "_at_ot-builder_slash_io-bin-encoding";
       packageName = "@ot-builder/io-bin-encoding";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/io-bin-encoding/-/io-bin-encoding-0.10.31.tgz";
-        sha512 = "BsU7+eeG+G7TaE1zdmqP2QqQk97KXYpaY08eAwrZBVoOWbOKClg+GKup4+Cbcy+2ckNZtviYnty18iwzfVNXSQ==";
+        url = "https://registry.npmjs.org/@ot-builder/io-bin-encoding/-/io-bin-encoding-0.10.33.tgz";
+        sha512 = "WUFSdfpv55uuiPTOepAPrcXqRLDeyLb3dY9OjUeX2bPbWTHoNH0n6SaKAf0PAKhCMeELoPibd6tXMe1BRtpVag==";
       };
     };
-    "@ot-builder/io-bin-ext-private-0.10.31" = {
+    "@ot-builder/io-bin-ext-private-0.10.33" = {
       name = "_at_ot-builder_slash_io-bin-ext-private";
       packageName = "@ot-builder/io-bin-ext-private";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/io-bin-ext-private/-/io-bin-ext-private-0.10.31.tgz";
-        sha512 = "xI/UUgCEfbulXwawyNtPpCNS2cIkDzz81sIK/u83sK7BVUIfrLQmsxX7Qfcnz3fbskbhY0oM2qIbJ5StfbOVHA==";
+        url = "https://registry.npmjs.org/@ot-builder/io-bin-ext-private/-/io-bin-ext-private-0.10.33.tgz";
+        sha512 = "fq97OoqCT+sdZ0tfwpPeWHXbji5a3dxZLNw4WkRRJ1Ih8/IwL8NNZPpwv4MbgWvl18Bwsfeu0VHXkwiZKmlo6Q==";
       };
     };
-    "@ot-builder/io-bin-font-0.10.31" = {
+    "@ot-builder/io-bin-font-0.10.33" = {
       name = "_at_ot-builder_slash_io-bin-font";
       packageName = "@ot-builder/io-bin-font";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/io-bin-font/-/io-bin-font-0.10.31.tgz";
-        sha512 = "lcXfk5enFMKNd8tGO5aZFVWDqqaHVDl3q6nSNlcrrYGcAxvuoMfwRExgqxT7WSrEn9RNc4GueKfR3CMz0B0dtg==";
+        url = "https://registry.npmjs.org/@ot-builder/io-bin-font/-/io-bin-font-0.10.33.tgz";
+        sha512 = "Kyf0e5g1ovpCX3ndbvyRUpdpNK227WWxr+KFRZzuy0vV+IJS+vbJ6TnLeYBCblIgrUGtGn12XJi7VL5wLN6eWg==";
       };
     };
-    "@ot-builder/io-bin-glyph-store-0.10.31" = {
+    "@ot-builder/io-bin-glyph-store-0.10.33" = {
       name = "_at_ot-builder_slash_io-bin-glyph-store";
       packageName = "@ot-builder/io-bin-glyph-store";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/io-bin-glyph-store/-/io-bin-glyph-store-0.10.31.tgz";
-        sha512 = "7uL/j0AE+eRE+gdUKVILmRL1lKlBofUk1WQ6JV/HMFI7WcKQNRguifXMUlKARYJLdVJE2XB85q7TejJ8ycPVSA==";
+        url = "https://registry.npmjs.org/@ot-builder/io-bin-glyph-store/-/io-bin-glyph-store-0.10.33.tgz";
+        sha512 = "0pMS9l8Ip+IWokPV90VC2x1Xqvm3oAmVxK+FUgY9kogbZAwnQXmMzkXSvNk+HDHv6yVXq73c/v9AzztPVzW3DQ==";
       };
     };
-    "@ot-builder/io-bin-layout-0.10.31" = {
+    "@ot-builder/io-bin-layout-0.10.33" = {
       name = "_at_ot-builder_slash_io-bin-layout";
       packageName = "@ot-builder/io-bin-layout";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/io-bin-layout/-/io-bin-layout-0.10.31.tgz";
-        sha512 = "gLrHGKulldU6G5kMlNyMAofBOz/9/Om0RBvkXvt2djp6ndVFvTXGiWqeS0SdU5CJZxAZWGvKARETWQ4d0foz2g==";
+        url = "https://registry.npmjs.org/@ot-builder/io-bin-layout/-/io-bin-layout-0.10.33.tgz";
+        sha512 = "GjGUw00uuPIownm+gQoF9ntBJuaInqofYtb43ScjS1gvQX+qcjg7ZMHoaOcF0N9MmbgQRoQYde0JFXuagHdlVg==";
       };
     };
-    "@ot-builder/io-bin-metadata-0.10.31" = {
+    "@ot-builder/io-bin-metadata-0.10.33" = {
       name = "_at_ot-builder_slash_io-bin-metadata";
       packageName = "@ot-builder/io-bin-metadata";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/io-bin-metadata/-/io-bin-metadata-0.10.31.tgz";
-        sha512 = "fYJlzf7gTGMntv+/OmIS2KlyGJuFwWQX69L1IH4swV1VJXYC9KlA4GojFyZ1oAZLWBORZ0kuUuvjD/4nox4QCA==";
+        url = "https://registry.npmjs.org/@ot-builder/io-bin-metadata/-/io-bin-metadata-0.10.33.tgz";
+        sha512 = "0Wf5CVkJH3e6imQSsqMKuGV3xX//Vj8Mf3dRkuxCj9EC7C1W1dZoVwrBwKg8DS25uYyERQCHrjuJ4+hbArnfcQ==";
       };
     };
-    "@ot-builder/io-bin-metric-0.10.31" = {
+    "@ot-builder/io-bin-metric-0.10.33" = {
       name = "_at_ot-builder_slash_io-bin-metric";
       packageName = "@ot-builder/io-bin-metric";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/io-bin-metric/-/io-bin-metric-0.10.31.tgz";
-        sha512 = "6RueaPhQ2r2dTQ4/vncM1TCYjPpJ+N5vyFT4w0SJP30C46g1kn0bryyrhdpG0jvl+pLkty7MbwKOpBxOQ0RtdA==";
+        url = "https://registry.npmjs.org/@ot-builder/io-bin-metric/-/io-bin-metric-0.10.33.tgz";
+        sha512 = "lJQWWJl5fZaB1/u+s8xp/5bOrG6WKdz6HV9C669HhiUF29RbeYVgHqUz7Mf4tlcXqulTUddDwDGS552GuyJEfw==";
       };
     };
-    "@ot-builder/io-bin-name-0.10.31" = {
+    "@ot-builder/io-bin-name-0.10.33" = {
       name = "_at_ot-builder_slash_io-bin-name";
       packageName = "@ot-builder/io-bin-name";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/io-bin-name/-/io-bin-name-0.10.31.tgz";
-        sha512 = "x7aI+idbaNwJf2Ty9RaEOS/E0aEh33QihM2EhrcT20ui67hnx+99aAUXjVwp7puY0zXARy/u0k99r91SATrLqw==";
+        url = "https://registry.npmjs.org/@ot-builder/io-bin-name/-/io-bin-name-0.10.33.tgz";
+        sha512 = "rCuiBuln5t7e8CGHAFJqa8duCVFlPbhSXGb7TsOyrqyNbEwZPrCDx40grMVB46xjKdAj8ZeE1Y1jikxSNlPW7g==";
       };
     };
-    "@ot-builder/io-bin-sfnt-0.10.31" = {
+    "@ot-builder/io-bin-sfnt-0.10.33" = {
       name = "_at_ot-builder_slash_io-bin-sfnt";
       packageName = "@ot-builder/io-bin-sfnt";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/io-bin-sfnt/-/io-bin-sfnt-0.10.31.tgz";
-        sha512 = "ssmHoGAuxMe1QkS24+GlxcgjpHoxQDsBQrdTSfh4pkmRP9aSfOrMWLksBgSQCTzRmOwf3lEJH2gz2r3NbsZldw==";
+        url = "https://registry.npmjs.org/@ot-builder/io-bin-sfnt/-/io-bin-sfnt-0.10.33.tgz";
+        sha512 = "vLRxvsh8LYOwLPqPEGdedG9/KqVpfeR6ceHa0zYc0Y/5FwOYjwbscIdr3SlyKJsPBFVvbOuzvmIBkKC7rASc8w==";
       };
     };
-    "@ot-builder/io-bin-ttf-0.10.31" = {
+    "@ot-builder/io-bin-ttf-0.10.33" = {
       name = "_at_ot-builder_slash_io-bin-ttf";
       packageName = "@ot-builder/io-bin-ttf";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/io-bin-ttf/-/io-bin-ttf-0.10.31.tgz";
-        sha512 = "pDWFXlUvguvygBDFpeliDMSKOg/rFprhiyCz6wPokRYwJg8fDS5EDtJOQ6p9/Y0C1V12PWA1O+fucYBfqUmSQw==";
+        url = "https://registry.npmjs.org/@ot-builder/io-bin-ttf/-/io-bin-ttf-0.10.33.tgz";
+        sha512 = "8yJoOjvwpRPyRMs45/uNNS9kBS3iQFLCSdLRlikH9cqxCHDpVH0vr74XHf0LCWwhnG/DJzcbB6L8LRnhl+QH2A==";
       };
     };
-    "@ot-builder/ot-0.10.31" = {
+    "@ot-builder/ot-0.10.33" = {
       name = "_at_ot-builder_slash_ot";
       packageName = "@ot-builder/ot";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/ot/-/ot-0.10.31.tgz";
-        sha512 = "5Cit1J+bxKOgLsB+6jey90eOXLPHiUzJbdNmHrIwUyM5C5ZRXRLg5VRnrYPYZoRCLPaVjG6AXFP+WvALdaLp8A==";
+        url = "https://registry.npmjs.org/@ot-builder/ot/-/ot-0.10.33.tgz";
+        sha512 = "fFR3y7oFFmdOHSPQV0yU5hYj9Ahg+M0Y46rvcI8JaUDywIWeuDV0p0YBZ83x4p4wX5k571aiY5lxQtZrDAHSRA==";
       };
     };
-    "@ot-builder/ot-encoding-0.10.31" = {
+    "@ot-builder/ot-encoding-0.10.33" = {
       name = "_at_ot-builder_slash_ot-encoding";
       packageName = "@ot-builder/ot-encoding";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/ot-encoding/-/ot-encoding-0.10.31.tgz";
-        sha512 = "cVQZu7ZxOb/Fq2Ilh6ka7vzHXCVyZYOATFthrsV3uZFF3Iz+xefrrK0eh38UEoRopmbqMiPC9U3IHr6A86h+JA==";
+        url = "https://registry.npmjs.org/@ot-builder/ot-encoding/-/ot-encoding-0.10.33.tgz";
+        sha512 = "rAt3lLA3sWtQCfGB1IPfkEzDpSjE4xom/qR7+xT38FXKu5SUqWQYLIqmtLmXX9oSo6oQ3z1Urx4rbdGYdwHpwQ==";
       };
     };
-    "@ot-builder/ot-ext-private-0.10.31" = {
+    "@ot-builder/ot-ext-private-0.10.33" = {
       name = "_at_ot-builder_slash_ot-ext-private";
       packageName = "@ot-builder/ot-ext-private";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/ot-ext-private/-/ot-ext-private-0.10.31.tgz";
-        sha512 = "G+TV59TNTa2tKrQ2/wy55dVoOP5uSVv6LfUcM2al5aM6pAjeWMV84BtBzDWH0nPTjlovyEmmiqDoUFgrm2TqYw==";
+        url = "https://registry.npmjs.org/@ot-builder/ot-ext-private/-/ot-ext-private-0.10.33.tgz";
+        sha512 = "+cQV1aTbCFXX+OyEIvRohlLbHpXTlzPJ8E4PICOyfqe41fw1DHbDEdilyQRvdLQ6TJqvvxktBD4xt+IOluviPw==";
       };
     };
-    "@ot-builder/ot-glyphs-0.10.31" = {
+    "@ot-builder/ot-glyphs-0.10.33" = {
       name = "_at_ot-builder_slash_ot-glyphs";
       packageName = "@ot-builder/ot-glyphs";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/ot-glyphs/-/ot-glyphs-0.10.31.tgz";
-        sha512 = "qY+O9RIXFalVg707swyfRK9beGDHEAKCGd74Rt9HdZIaWWPYfb+CH22zbwI+gVJEV/NRCTMGpZB1WrdLRm4q4w==";
+        url = "https://registry.npmjs.org/@ot-builder/ot-glyphs/-/ot-glyphs-0.10.33.tgz";
+        sha512 = "jpPxTDct01TTpJptMFDIuKzXYxhiNXpQIfikydKXQU+M7jDQJJLjIjAnz33MVzeMxR6+8og0F2qgG/OFcDMpTQ==";
       };
     };
-    "@ot-builder/ot-layout-0.10.31" = {
+    "@ot-builder/ot-layout-0.10.33" = {
       name = "_at_ot-builder_slash_ot-layout";
       packageName = "@ot-builder/ot-layout";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/ot-layout/-/ot-layout-0.10.31.tgz";
-        sha512 = "j1WZRr6V48jIvl0VROBbzI1MPNYJUbrjwwiPdzMpi/Moj/k0tMAO5d/3FKhvVMcvpgXtN/Pe2V3yxz9yXD37pw==";
+        url = "https://registry.npmjs.org/@ot-builder/ot-layout/-/ot-layout-0.10.33.tgz";
+        sha512 = "aa2b4Oa5B2YFZ//A+MAEEVBcLv0XEKTjtUARAj3bTthHNnPWJHjGjHUpNPMccBJNWysKwlz37cxAItpMXgpgOg==";
       };
     };
-    "@ot-builder/ot-metadata-0.10.31" = {
+    "@ot-builder/ot-metadata-0.10.33" = {
       name = "_at_ot-builder_slash_ot-metadata";
       packageName = "@ot-builder/ot-metadata";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/ot-metadata/-/ot-metadata-0.10.31.tgz";
-        sha512 = "H/Pdmf667+hLQkx7zpBecvwOW8VppxRSLSvKIopd0+TSdiXo9iZrmkkqnIHxA9/KPdvVLh6a/gzfxj5KwMMeDw==";
+        url = "https://registry.npmjs.org/@ot-builder/ot-metadata/-/ot-metadata-0.10.33.tgz";
+        sha512 = "pwwf49hCU3mjWkUUT4mIN7dtJr7fBtXozcOQ70vVAzTPE3kUOD/eun4Vs2UqHGkPRvOU89eEQQgQ+5941aH8rg==";
       };
     };
-    "@ot-builder/ot-name-0.10.31" = {
+    "@ot-builder/ot-name-0.10.33" = {
       name = "_at_ot-builder_slash_ot-name";
       packageName = "@ot-builder/ot-name";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/ot-name/-/ot-name-0.10.31.tgz";
-        sha512 = "38oV/H2n9x9DKl44XDdMWf8fY5lsgIlykxMUXT+2XlBS0Fw1u/S4THLXGhRG8nwcM6eJRzF+diL6/yGPCtpYfQ==";
+        url = "https://registry.npmjs.org/@ot-builder/ot-name/-/ot-name-0.10.33.tgz";
+        sha512 = "32jR7zRnkMLWmkdiQzXryRaPycbiJNJiPY016/efcv4hYuHvrq/tpXA5P6bEV205njy7n5KA7txrkSWZP9+0JA==";
       };
     };
-    "@ot-builder/ot-sfnt-0.10.31" = {
+    "@ot-builder/ot-sfnt-0.10.33" = {
       name = "_at_ot-builder_slash_ot-sfnt";
       packageName = "@ot-builder/ot-sfnt";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/ot-sfnt/-/ot-sfnt-0.10.31.tgz";
-        sha512 = "hkTeDmNMZqeWq5OwBPy5zpy6cFecfkT/zO6ZiPyqbo8ND6Qp6WoLvkhIST6Bwesh2mApffTKyePbGnHrfWdnkw==";
+        url = "https://registry.npmjs.org/@ot-builder/ot-sfnt/-/ot-sfnt-0.10.33.tgz";
+        sha512 = "/T4TfeimVDhLMRXInKhz2EGKzzWLAgijNaQpc7OO+Cxy3z43g0B6d7EzlsAD8W9lauYpuMnXEItvznY0wBgi7A==";
       };
     };
-    "@ot-builder/ot-standard-glyph-namer-0.10.31" = {
+    "@ot-builder/ot-standard-glyph-namer-0.10.33" = {
       name = "_at_ot-builder_slash_ot-standard-glyph-namer";
       packageName = "@ot-builder/ot-standard-glyph-namer";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/ot-standard-glyph-namer/-/ot-standard-glyph-namer-0.10.31.tgz";
-        sha512 = "at6KH+5XDfi+7buSy1AayHp0C8N8iEql5PO8ZeTry22uE9mI80spqBShdTbYjI4m7S4rgKxK+Mtx5+Iq1pku1Q==";
+        url = "https://registry.npmjs.org/@ot-builder/ot-standard-glyph-namer/-/ot-standard-glyph-namer-0.10.33.tgz";
+        sha512 = "PDz2ZupCN7DmIRSOvJWrv/uCUwUqEmWZSSrzu9vaSpIglbjSzKtQ9axi/SZIAMughky9YMxME8yiKFpHzI/FGw==";
       };
     };
-    "@ot-builder/prelude-0.10.31" = {
+    "@ot-builder/prelude-0.10.33" = {
       name = "_at_ot-builder_slash_prelude";
       packageName = "@ot-builder/prelude";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/prelude/-/prelude-0.10.31.tgz";
-        sha512 = "0GhgWpPaCetCvzJfpC5o11WqEQ0O6ZE5BLyiCC1cLCd2i/4zsyOlXvAUZ2FLvvR8Oz3Q/EtF1uZ12iuIxR75Hw==";
+        url = "https://registry.npmjs.org/@ot-builder/prelude/-/prelude-0.10.33.tgz";
+        sha512 = "3dUiOB4e4BUT4u6YssK1pe/W8wSMw2+XG9TqtW9ZRrnFAaVxmEnrh7okde5Y26Rq/TtMiMmd7zUaP+ut9x9VYg==";
       };
     };
-    "@ot-builder/primitive-0.10.31" = {
+    "@ot-builder/primitive-0.10.33" = {
       name = "_at_ot-builder_slash_primitive";
       packageName = "@ot-builder/primitive";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/primitive/-/primitive-0.10.31.tgz";
-        sha512 = "1woeCUkc1BxsBNVGw9ALcR4P0Lk3iTK7LkRnMM2VCP+NhoF6aYM81FK1TYMZbmf21nS6OQtyZaT/+10oaZ1Y2A==";
+        url = "https://registry.npmjs.org/@ot-builder/primitive/-/primitive-0.10.33.tgz";
+        sha512 = "0wNZRIgJ9j2fqF8m3ldGmqlRrR7JJesBJe1841pD/yY756A0aY0/mkqBB2SKo58YYZA+HZicUT8dlD1EgNCbXw==";
       };
     };
-    "@ot-builder/rectify-0.10.31" = {
+    "@ot-builder/rectify-0.10.33" = {
       name = "_at_ot-builder_slash_rectify";
       packageName = "@ot-builder/rectify";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/rectify/-/rectify-0.10.31.tgz";
-        sha512 = "QpHhRMGu0Hj1eN3nBKm2BYNHb2UOGi+2ZJP/QmH2GXMdE4LFOWmSN9Mvvubfxr23cjt3VtHK1X/5OBmhcEVfyA==";
+        url = "https://registry.npmjs.org/@ot-builder/rectify/-/rectify-0.10.33.tgz";
+        sha512 = "JqAcAgy2feCstg++bgeH9JofhOSc++Sx/ZjIGRNgtu8qiGRxRGP2MTZdn4zEy4etQYpRSgiuJbCx1K9XmwNXHA==";
       };
     };
-    "@ot-builder/stat-glyphs-0.10.31" = {
+    "@ot-builder/stat-glyphs-0.10.33" = {
       name = "_at_ot-builder_slash_stat-glyphs";
       packageName = "@ot-builder/stat-glyphs";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/stat-glyphs/-/stat-glyphs-0.10.31.tgz";
-        sha512 = "GxSEEaRstSZV40FkF3SDTZceZN9UboBx3f9Kx2mSW2wfmQk14cCvQszLehXJsXnZ2+h9oVgJ8fpzSU0jY5Ip8g==";
+        url = "https://registry.npmjs.org/@ot-builder/stat-glyphs/-/stat-glyphs-0.10.33.tgz";
+        sha512 = "fwvn4vnmQGKHVHOVrNUA56I++k8bbxyYrMh/ifdZhn7FrlCldeM5UvQfPbjsVoU1aIKGkr+WM6BBF1WkbXPsxg==";
       };
     };
-    "@ot-builder/trace-0.10.31" = {
+    "@ot-builder/trace-0.10.33" = {
       name = "_at_ot-builder_slash_trace";
       packageName = "@ot-builder/trace";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/trace/-/trace-0.10.31.tgz";
-        sha512 = "hCeRQp1FusNIU3B5gWL+0E5Ionr8RNF3nFk9wIuqYbgQqeaYpJaEcD4brlGp5BrgCqQA6n9pOTpogPMZOffdFw==";
+        url = "https://registry.npmjs.org/@ot-builder/trace/-/trace-0.10.33.tgz";
+        sha512 = "8AKK0zw3z90ozZI/V2vByGc2QPTN3fJol/MwEsyY1wART7s0YIo2/Q4gFq72T2sTw10aBNH3CQ5cP8DPRFqCwg==";
       };
     };
-    "@ot-builder/var-store-0.10.31" = {
+    "@ot-builder/var-store-0.10.33" = {
       name = "_at_ot-builder_slash_var-store";
       packageName = "@ot-builder/var-store";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/var-store/-/var-store-0.10.31.tgz";
-        sha512 = "adpNdlPmVCrBZBbDTPITLGe/EJpdfgoZJ7vTiR6tQ0gfwkD88r/i9I/YovWYi1v0VonXEIH9IyGlH3iU13zXuw==";
+        url = "https://registry.npmjs.org/@ot-builder/var-store/-/var-store-0.10.33.tgz";
+        sha512 = "3+9BBDVQ3FmG10XWsJwsVTh6ViNdiVej2Zw5h0aXtUkS9InaFkE4aRGSaqfm9zVhunTaxZ/cFNwZAXXLAJKSrQ==";
       };
     };
-    "@ot-builder/variance-0.10.31" = {
+    "@ot-builder/variance-0.10.33" = {
       name = "_at_ot-builder_slash_variance";
       packageName = "@ot-builder/variance";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ot-builder/variance/-/variance-0.10.31.tgz";
-        sha512 = "3M2HFcPQs2YGsNdx5XuW+s1fwTnWYW2d/FpdLN9VtVa5THeI3GfUtWHlWgHIrYWycakM9+XPTbueQDTCEf26Cg==";
+        url = "https://registry.npmjs.org/@ot-builder/variance/-/variance-0.10.33.tgz";
+        sha512 = "Fk4yLjEK1lcvfbUgLFfyepWyYToHtAPYjh/A7KgDPhnq1MYc5kNx8w3r9Pq9vHXr5csl36kyP7+iJC6z1HHPsQ==";
       };
     };
     "@parcel/fs-1.11.0" = {
@@ -4342,13 +4387,13 @@ let
         sha512 = "CY/a6Nw72vrlp/FPx38l4jfEHp4gNEbo8i+WlSJ2cnWO6VE6CKmnC1zb4yQLvdP8f3EuzzoOBZVq6aGN20M82Q==";
       };
     };
-    "@pm2/js-api-0.6.0" = {
+    "@pm2/js-api-0.6.1" = {
       name = "_at_pm2_slash_js-api";
       packageName = "@pm2/js-api";
-      version = "0.6.0";
+      version = "0.6.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.6.0.tgz";
-        sha512 = "ZgM/0yI8s3FRyxP01wI5UzDrVTecS/SmD98z25C9fsHo2Wz3JB1DtS4uIBlPopq2/R5HIQynTUJPDNn4qo1d/Q==";
+        url = "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.6.1.tgz";
+        sha512 = "LImZWHEzcpIrLZ7kt4z3Gllkoz+CChHk2waDretOWeinSItyTMrNpzcXcZd2QikP/57qPolLfHGFipHJmOKkwQ==";
       };
     };
     "@pm2/pm2-version-check-1.0.3" = {
@@ -4367,15 +4412,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.3.3.tgz";
         sha512 = "uc6FmPEegAZawSHjUMFQwU7EjaDn7zy1iD/KD/wBROL9F4378OES8MKMYHoRAKT61Fk7LxVKZSDR5VespMQiqw==";
-      };
-    };
-    "@prettier/plugin-pug-1.10.1" = {
-      name = "_at_prettier_slash_plugin-pug";
-      packageName = "@prettier/plugin-pug";
-      version = "1.10.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@prettier/plugin-pug/-/plugin-pug-1.10.1.tgz";
-        sha512 = "HyX0FN8pGdumKS1eiVJ8jbYh8bx2DdbvBOpuKf4+SNP1Z8OFDZorl/q4ShH7oCqMAnFj2kFCpZkuIOkD6gZv7Q==";
       };
     };
     "@primer/octicons-11.0.0" = {
@@ -4621,31 +4657,31 @@ let
         sha512 = "c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==";
       };
     };
-    "@schematics/angular-10.2.0" = {
+    "@schematics/angular-11.0.1" = {
       name = "_at_schematics_slash_angular";
       packageName = "@schematics/angular";
-      version = "10.2.0";
+      version = "11.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/angular/-/angular-10.2.0.tgz";
-        sha512 = "rJRTTTL8CMMFb3ebCvAVHKHxuNzRqy/HtbXhJ82l5Xo/jXcm74eV2Q0RBUrNo1yBKWFIR+FIwiXLJaGcC/R9Pw==";
+        url = "https://registry.npmjs.org/@schematics/angular/-/angular-11.0.1.tgz";
+        sha512 = "cYq3NhFn4DLSXXtbYYU2w0sginkMfN1w7pXjZLT/+etXXbtANQAXSPrPrDQql004ZNMbuDKuC0aoXjv8hgXOfw==";
       };
     };
-    "@schematics/schematics-0.1002.0" = {
+    "@schematics/schematics-0.1100.1" = {
       name = "_at_schematics_slash_schematics";
       packageName = "@schematics/schematics";
-      version = "0.1002.0";
+      version = "0.1100.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/schematics/-/schematics-0.1002.0.tgz";
-        sha512 = "A6z0j+GCgj3NPAJ3+OZPgU/8KYLHcVWN+ZELuQTFXZgN6mpgbxCmM3yymfo7+riaF0xx1mXlt8G+tO7xDsLVvQ==";
+        url = "https://registry.npmjs.org/@schematics/schematics/-/schematics-0.1100.1.tgz";
+        sha512 = "Y5J/qafyZtsu6spEFywGLjYMqEgONSDx9m8c8KL4c45+KqqerQeh2QQHims3G0brKUFIK3nCw95zqw+RMsGcsA==";
       };
     };
-    "@schematics/update-0.1002.0" = {
+    "@schematics/update-0.1100.1" = {
       name = "_at_schematics_slash_update";
       packageName = "@schematics/update";
-      version = "0.1002.0";
+      version = "0.1100.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/update/-/update-0.1002.0.tgz";
-        sha512 = "g2bfJSAj3x/YL0GNhnHsDSQmO6DoxSnLxoFLqNN5+ukxK5jq7OZNDwMJGxZ3X6RcSMWKEkIKL/wlq9yhj2T/kw==";
+        url = "https://registry.npmjs.org/@schematics/update/-/update-0.1100.1.tgz";
+        sha512 = "EVcqdM/d5rC5L1UYnwhFMk/TjHlNgL5LGfroE13C38A+WpKKJquAjgOQLj4nPvJ5csdEZqn3Sui9yeEWc3hklQ==";
       };
     };
     "@segment/loosely-validate-event-2.0.0" = {
@@ -4720,13 +4756,13 @@ let
         sha512 = "zTJBhzjWtDBogLFnzoz6NYiQ6CThsxuvHQxSbBLcNK4+VQPIkrZOxaQ+dNCNLeLN1Tb3NnZDPNGkoThvgGwq3Q==";
       };
     };
-    "@serverless/platform-client-china-2.0.8" = {
+    "@serverless/platform-client-china-2.0.9" = {
       name = "_at_serverless_slash_platform-client-china";
       packageName = "@serverless/platform-client-china";
-      version = "2.0.8";
+      version = "2.0.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-2.0.8.tgz";
-        sha512 = "20sceKHkGP56HnwMgrdHwD963bxew63+hE2aNrcu1DtLuUqcRvP5evaWO/CwMDTajJJDhEwi3wQDxPpxtKlJ7A==";
+        url = "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-2.0.9.tgz";
+        sha512 = "qec3a5lVaMH0nccgjVgvcEF8M+M95BXZbbYDGypVHEieJQxrKqj057+VVKsiHBeHYXzr4B3v6pIyQHst40vpIw==";
       };
     };
     "@serverless/platform-sdk-2.3.2" = {
@@ -4765,13 +4801,31 @@ let
         sha512 = "yZQT2f8LIZZlH2ibAIvK4C/Ks72Y8CIWmGz04XGCLPHa/ANA6KqlXTKV6zWg/n1PDy2yj2zgX+m509VpIZuDeQ==";
       };
     };
-    "@serverless/utils-china-1.0.10" = {
+    "@serverless/utils-china-1.0.11" = {
       name = "_at_serverless_slash_utils-china";
       packageName = "@serverless/utils-china";
-      version = "1.0.10";
+      version = "1.0.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-1.0.10.tgz";
-        sha512 = "pMl6uW672Tll5rjFAYILxu1EwxSaWBE7r/Tr38sCgDOh0t36sRXiI3oCBHIu/C0tqKFfU1s+coRZbZYKkirCiw==";
+        url = "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-1.0.11.tgz";
+        sha512 = "raOPIoPSTrkWKBDuozkYWvLXP2W65K9Uk4ud+lPcbhhBSamO3uVW40nuAkC19MdIoAsFi5oTGYpcc9UDx8b+lg==";
+      };
+    };
+    "@shiftkey/node-abi-2.19.2-pre" = {
+      name = "_at_shiftkey_slash_node-abi";
+      packageName = "@shiftkey/node-abi";
+      version = "2.19.2-pre";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@shiftkey/node-abi/-/node-abi-2.19.2-pre.tgz";
+        sha512 = "+LfXo6nd2uZ8cGSJ66zL3OuddvG2oMWMc9GzpDoX2ZNMLmYpu+ReoEKXtmoKVwd6JSavDymldebCxSJh9NQ9cg==";
+      };
+    };
+    "@shiftkey/prebuild-install-6.0.1-pre2" = {
+      name = "_at_shiftkey_slash_prebuild-install";
+      packageName = "@shiftkey/prebuild-install";
+      version = "6.0.1-pre2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@shiftkey/prebuild-install/-/prebuild-install-6.0.1-pre2.tgz";
+        sha512 = "wDV1DgFxi0F+kTpyGNdnDctdw3Rb9aP8RBAGFE2wXr1+pXSCJRRA+Qh5ko5dKc0LeNIBZzjEECjmtAykajv+Xw==";
       };
     };
     "@sindresorhus/is-0.14.0" = {
@@ -4900,13 +4954,13 @@ let
         sha512 = "/TOzXGh+JFgAu8pWdo1oLFKDNfFk99TnSQG2lbEu+vKLI2ZrGAk9oGO0geNogAN7Ib4EDQOEhgb7YwqwL7aA7w==";
       };
     };
-    "@snyk/docker-registry-v2-client-1.13.6" = {
+    "@snyk/docker-registry-v2-client-1.13.8" = {
       name = "_at_snyk_slash_docker-registry-v2-client";
       packageName = "@snyk/docker-registry-v2-client";
-      version = "1.13.6";
+      version = "1.13.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-1.13.6.tgz";
-        sha512 = "upbnvJOIDuoRgDhG9xBVM3QmyE/NRwlTTHMj1T5Tlfr1nrasVWTVqKmgXEc9RSfL1zlLmyUudGK2fVNgi2wdEg==";
+        url = "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-1.13.8.tgz";
+        sha512 = "3PYCDWQ79HDsdUs964H3mSmdbMEdC8pGNeuMirM7rxKOkNzF6CYijfNyYLPbjS9YvmF5e7jdvUNnaP8miV7n9w==";
       };
     };
     "@snyk/gemfile-1.2.0" = {
@@ -4918,22 +4972,13 @@ let
         sha512 = "nI7ELxukf7pT4/VraL4iabtNNMz8mUo7EXlqCFld8O5z6mIMLX9llps24iPpaIZOwArkY3FWA+4t+ixyvtTSIA==";
       };
     };
-    "@snyk/java-call-graph-builder-1.16.0" = {
+    "@snyk/java-call-graph-builder-1.16.2" = {
       name = "_at_snyk_slash_java-call-graph-builder";
       packageName = "@snyk/java-call-graph-builder";
-      version = "1.16.0";
+      version = "1.16.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.16.0.tgz";
-        sha512 = "bHbBR7NKCxLPxlsSdJ2pn2gBSfguBr9SAdo/2re9bEvHO/0hTefQiS0h/EJ4OpMCJbPyUN1BW4eaFq00MzgMtA==";
-      };
-    };
-    "@snyk/java-call-graph-builder-1.16.1" = {
-      name = "_at_snyk_slash_java-call-graph-builder";
-      packageName = "@snyk/java-call-graph-builder";
-      version = "1.16.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.16.1.tgz";
-        sha512 = "rxvSS9sz5h6fNjvUG6NhqYpUI8eok+xLTzLShfnSuDllI3JLxPMc/f7EKv5mv3GLlh1sVCCVXYeyIw3RAg5xQg==";
+        url = "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.16.2.tgz";
+        sha512 = "tJF+dY/wTfexwYuCgFB3RpWl4RGcf2H9RT9yurkTVi5wwKfvcNwZMUMwSlTDEFOqwmAsJ7e0uNVRlkPQHekCcQ==";
       };
     };
     "@snyk/rpm-parser-2.2.1" = {
@@ -4954,22 +4999,13 @@ let
         sha512 = "A+1xHD+SpmXQa0p+dWmiApFZtz/y37qAW9aWmFx2B1j7fwRBf9Qr89/6RbJOznf1a4nEitjzE3fa98yNZk/MNg==";
       };
     };
-    "@snyk/snyk-docker-pull-3.2.0" = {
+    "@snyk/snyk-docker-pull-3.2.2" = {
       name = "_at_snyk_slash_snyk-docker-pull";
       packageName = "@snyk/snyk-docker-pull";
-      version = "3.2.0";
+      version = "3.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/snyk-docker-pull/-/snyk-docker-pull-3.2.0.tgz";
-        sha512 = "uWKtjh29I/d0mfmfBN7w6RwwNBQxQVKrauF5ND/gqb0PVsKV22GIpkI+viWjI7KNKso6/B0tMmsv7TX2tsNcLQ==";
-      };
-    };
-    "@sorg/log-2.2.1" = {
-      name = "_at_sorg_slash_log";
-      packageName = "@sorg/log";
-      version = "2.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@sorg/log/-/log-2.2.1.tgz";
-        sha512 = "GGtgReHuH7M+FS0pGy6tb3QPNVipjUl5+RWvG8yMP3Hb+Lq0AqsFYgBUz+FVECQ9J3otvsAzgOfz+8BIqRUr0Q==";
+        url = "https://registry.npmjs.org/@snyk/snyk-docker-pull/-/snyk-docker-pull-3.2.2.tgz";
+        sha512 = "EL7LegIJJDpXCOENEUu8ljI5sy9anE/RuXM/JdK+i8sEiUdybiSOCJOw43EOdMqYP+tK7l2JIaxYBzcDIxi3+g==";
       };
     };
     "@starptech/expression-parser-0.10.0" = {
@@ -5296,13 +5332,13 @@ let
         sha512 = "MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==";
       };
     };
-    "@types/babel__template-7.0.3" = {
+    "@types/babel__template-7.4.0" = {
       name = "_at_types_slash_babel__template";
       packageName = "@types/babel__template";
-      version = "7.0.3";
+      version = "7.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz";
-        sha512 = "uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==";
+        url = "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz";
+        sha512 = "NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==";
       };
     };
     "@types/babel__traverse-7.0.15" = {
@@ -5485,13 +5521,13 @@ let
         sha512 = "98rXVukLD6/ozrQ2O80NAlWDGA4INg+tqsEReWJldqyi2fulC9V7Use/n28SWgROXKm6003ycWV4gZHoF8GA6w==";
       };
     };
-    "@types/eslint-7.2.4" = {
+    "@types/eslint-7.2.5" = {
       name = "_at_types_slash_eslint";
       packageName = "@types/eslint";
-      version = "7.2.4";
+      version = "7.2.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.4.tgz";
-        sha512 = "YCY4kzHMsHoyKspQH+nwSe+70Kep7Vjt2X+dZe5Vs2vkRudqtoFoUIv1RlJmZB8Hbp7McneupoZij4PadxsK5Q==";
+        url = "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.5.tgz";
+        sha512 = "Dc6ar9x16BdaR3NSxSF7T4IjL9gxxViJq8RmFd+2UAyA+K6ck2W+gUwfgpG/y9TPyUuBL35109bbULpEynvltA==";
       };
     };
     "@types/eslint-scope-3.7.0" = {
@@ -5917,6 +5953,15 @@ let
         sha1 = "69a23a3ad29caf0097f06eda59b361ee2f0639f6";
       };
     };
+    "@types/minimist-1.2.1" = {
+      name = "_at_types_slash_minimist";
+      packageName = "@types/minimist";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz";
+        sha512 = "fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==";
+      };
+    };
     "@types/mithril-2.0.3" = {
       name = "_at_types_slash_mithril";
       packageName = "@types/mithril";
@@ -6007,13 +6052,13 @@ let
         sha512 = "oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw==";
       };
     };
-    "@types/node-14.14.6" = {
+    "@types/node-14.14.7" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "14.14.6";
+      version = "14.14.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz";
-        sha512 = "6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==";
+        url = "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz";
+        sha512 = "Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==";
       };
     };
     "@types/node-6.14.13" = {
@@ -6196,13 +6241,13 @@ let
         sha512 = "41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==";
       };
     };
-    "@types/serve-static-1.13.6" = {
+    "@types/serve-static-1.13.7" = {
       name = "_at_types_slash_serve-static";
       packageName = "@types/serve-static";
-      version = "1.13.6";
+      version = "1.13.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.6.tgz";
-        sha512 = "nuRJmv7jW7VmCVTn+IgYDkkbbDGyIINOeu/G0d74X3lm6E5KfMeQPJhxIt1ayQeQB3cSxvYs1RA/wipYoFB4EA==";
+        url = "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.7.tgz";
+        sha512 = "3diZWucbR+xTmbDlU+FRRxBf+31OhFew7cJXML/zh9NmvSPTNoFecAwHB66BUqFgENJtqMiyl7JAwUE/siqdLw==";
       };
     };
     "@types/sizzle-2.3.2" = {
@@ -6358,13 +6403,13 @@ let
         sha512 = "C/jZ35OT5k/rsJyAK8mS1kM++vMcm89oSWegkzxRCvHllIq0cToZAkIDs6eCY4SKrvik3nrhELizyLcM0onbQA==";
       };
     };
-    "@types/webpack-4.41.24" = {
+    "@types/webpack-4.41.25" = {
       name = "_at_types_slash_webpack";
       packageName = "@types/webpack";
-      version = "4.41.24";
+      version = "4.41.25";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.24.tgz";
-        sha512 = "1A0MXPwZiMOD3DPMuOKUKcpkdPo8Lq33UGggZ7xio6wJ/jV1dAu5cXDrOfGDnldUroPIRLsr/DT43/GqOA4RFQ==";
+        url = "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.25.tgz";
+        sha512 = "cr6kZ+4m9lp86ytQc1jPOJXgINQyz3kLLunZ57jznW+WIAL0JqZbGubQk4GlD42MuQL5JGOABrxdpqqWeovlVQ==";
       };
     };
     "@types/webpack-sources-2.0.0" = {
@@ -6385,13 +6430,13 @@ let
         sha512 = "f5WLMpezwVxCLm1xQe/kdPpQIOmL0TXYx2O15VYfYzc7hTIdxiOoOvez+McSIw3b7z/1zGovew9YSL7+h4h7/Q==";
       };
     };
-    "@types/ws-7.2.9" = {
+    "@types/ws-7.4.0" = {
       name = "_at_types_slash_ws";
       packageName = "@types/ws";
-      version = "7.2.9";
+      version = "7.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/ws/-/ws-7.2.9.tgz";
-        sha512 = "gmXYAXr7G4BrRMnkGQGkGonc3ArVro9VZd//C1uns/qqsJyl2dxaJdlPMhZbcq5MTxFFC+ttFWtHSfVW5+hlRA==";
+        url = "https://registry.npmjs.org/@types/ws/-/ws-7.4.0.tgz";
+        sha512 = "Y29uQ3Uy+58bZrFLhX36hcI3Np37nqWE7ky5tjiDoy1GDZnIwVxS0CgF+s+1bXMzjKBFy+fqaRfb708iNzdinw==";
       };
     };
     "@types/yargs-13.0.11" = {
@@ -7807,15 +7852,6 @@ let
         sha1 = "73b5eeca3fab653e3d3f9422b341ad42205dc965";
       };
     };
-    "ajv-6.12.4" = {
-      name = "ajv";
-      packageName = "ajv";
-      version = "6.12.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz";
-        sha512 = "eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==";
-      };
-    };
     "ajv-6.12.6" = {
       name = "ajv";
       packageName = "ajv";
@@ -7879,13 +7915,13 @@ let
         sha512 = "0mAYXMSauA8RZ7r+B4+EAOYcZEcO9OK5EiQCR7W7Cv4E44pJj56ZnkKLJ9/PAcOc0dT+LlV9fdDcq2TxVJfOYw==";
       };
     };
-    "alex-9.0.1" = {
+    "alex-9.1.0" = {
       name = "alex";
       packageName = "alex";
-      version = "9.0.1";
+      version = "9.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/alex/-/alex-9.0.1.tgz";
-        sha512 = "q560b+fVMXvu3WVkvoYBUGRHRXo9K9P/Fnt6Xcq1VhZow9MNqoQ5x7OJTYzSStAElaGxaJ7djTef9pJrM3GBXg==";
+        url = "https://registry.npmjs.org/alex/-/alex-9.1.0.tgz";
+        sha512 = "mlNQ0CBGinzZj1pjiXaSLsihjZ4Kzq0U0EjR+DrZ3IQQfM4pf4OtxHI1agBIiEwv0tQUzimjgTk+5t9iHeT7Vw==";
       };
     };
     "align-text-0.1.4" = {
@@ -8642,15 +8678,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz";
         sha512 = "pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==";
-      };
-    };
-    "app-module-path-2.2.0" = {
-      name = "app-module-path";
-      packageName = "app-module-path";
-      version = "2.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz";
-        sha1 = "641aa55dfb7d6a6f0a8141c4b9c0aa50b6c24dd5";
       };
     };
     "append-0.1.1" = {
@@ -9697,6 +9724,15 @@ let
         sha1 = "125dd09de95d3ea30a378adbed021092179b03c9";
       };
     };
+    "async-write-2.1.0" = {
+      name = "async-write";
+      packageName = "async-write";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async-write/-/async-write-2.1.0.tgz";
+        sha1 = "1e762817d849ce44bfac07925a42036787061b15";
+      };
+    };
     "asynckit-0.4.0" = {
       name = "asynckit";
       packageName = "asynckit";
@@ -9778,13 +9814,13 @@ let
         sha512 = "kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==";
       };
     };
-    "atomically-1.6.0" = {
+    "atomically-1.7.0" = {
       name = "atomically";
       packageName = "atomically";
-      version = "1.6.0";
+      version = "1.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/atomically/-/atomically-1.6.0.tgz";
-        sha512 = "mu394MH+yY2TSKMyH+978PcGMZ8sRNks2PuVeH6c2ED4mimR2LEE039MVcIGVhtmG54cKEMh4gKhxKL/CLaX/w==";
+        url = "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz";
+        sha512 = "Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==";
       };
     };
     "attach-ware-1.1.1" = {
@@ -9868,13 +9904,13 @@ let
         sha1 = "00f35b2d27ac91b1f0d3ef2084c98cf1d1f0adc3";
       };
     };
-    "aws-sdk-2.786.0" = {
+    "aws-sdk-2.792.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.786.0";
+      version = "2.792.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.786.0.tgz";
-        sha512 = "oL+rDkoBdn0Q3AxiEzSemCE3WqW6kBf0A72SIjDQZJb4/NDvA2mL2rpNQGaxaFX3zMHEwfUGcMu7T3q7I6Q0lw==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.792.0.tgz";
+        sha512 = "h7oSlrCDtZkW5qNw/idKmMjjNJaaPlXFY+NbqtaTjejpCyVuIonUmFvm8GW16V58Avj/hujJfhpX9q0BMCg+VQ==";
       };
     };
     "aws-sign2-0.6.0" = {
@@ -9994,6 +10030,15 @@ let
         sha512 = "z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==";
       };
     };
+    "babel-eslint-10.1.0" = {
+      name = "babel-eslint";
+      packageName = "babel-eslint";
+      version = "10.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz";
+        sha512 = "ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==";
+      };
+    };
     "babel-extract-comments-1.0.0" = {
       name = "babel-extract-comments";
       packageName = "babel-extract-comments";
@@ -10082,6 +10127,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz";
         sha512 = "7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==";
+      };
+    };
+    "babel-loader-8.2.1" = {
+      name = "babel-loader";
+      packageName = "babel-loader";
+      version = "8.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.1.tgz";
+        sha512 = "dMF8sb2KQ8kJl21GUjkW1HWmcsL39GOV5vnzjqrCzEPNY0S0UfMLnumidiwIajDSBmKhYf5iRW+HXaM4cvCKBw==";
       };
     };
     "babel-plugin-dynamic-import-node-2.3.3" = {
@@ -10615,6 +10669,15 @@ let
         sha512 = "mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==";
       };
     };
+    "base64-js-1.5.1" = {
+      name = "base64-js";
+      packageName = "base64-js";
+      version = "1.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz";
+        sha512 = "AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==";
+      };
+    };
     "base64-stream-1.0.0" = {
       name = "base64-stream";
       packageName = "base64-stream";
@@ -10696,6 +10759,15 @@ let
         sha1 = "dc34314f4e679318093fc760272525f94bf25c16";
       };
     };
+    "bcfg-0.1.6" = {
+      name = "bcfg";
+      packageName = "bcfg";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bcfg/-/bcfg-0.1.6.tgz";
+        sha512 = "BR2vwQZwu24aRm588XHOnPVjjQtbK8sF0RopRFgMuke63/REJMWnePTa2YHKDBefuBYiVdgkowuB1/e4K7Ue3g==";
+      };
+    };
     "bcrypt-3.0.6" = {
       name = "bcrypt";
       packageName = "bcrypt";
@@ -10739,6 +10811,42 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz";
         sha1 = "9ab5627b93e60621ff7cdac5da9733027df1d0cb";
+      };
+    };
+    "bcrypto-5.3.0" = {
+      name = "bcrypto";
+      packageName = "bcrypto";
+      version = "5.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bcrypto/-/bcrypto-5.3.0.tgz";
+        sha512 = "SP48cpoc4BkEPNOErdsZ1VjbtdXY/C0f5wAywWniLne/Fd/5oOBqLbC6ZavngLvk4oik76g4I7PO5KduJoqECQ==";
+      };
+    };
+    "bcurl-0.1.9" = {
+      name = "bcurl";
+      packageName = "bcurl";
+      version = "0.1.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bcurl/-/bcurl-0.1.9.tgz";
+        sha512 = "WV9LKCqFPtmGwIOqHexJx3Mm/9H/G5bwSCZxJXq9WRrnVQmd58L+Ltxgp/2QicveDG6AgTfepP6JtNiYWbbeHQ==";
+      };
+    };
+    "bdb-1.3.0" = {
+      name = "bdb";
+      packageName = "bdb";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bdb/-/bdb-1.3.0.tgz";
+        sha512 = "oJnWnHOTcnJhazwpEzQvPFtSR1IdHtS3PczuLY3klgZTTtRUbARX7tdphQS8iNUUwEVMfuO93eHDWwTICoeJlg==";
+      };
+    };
+    "bdns-0.1.5" = {
+      name = "bdns";
+      packageName = "bdns";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bdns/-/bdns-0.1.5.tgz";
+        sha512 = "LNVkfM7ynlAD0CvPvO9cKxW8YXt1KOCRQZlRsGZWeMyymUWVdHQpZudAzH9chaFAz6HiwAnQxwDemCKDPy6Mag==";
       };
     };
     "beeper-1.1.1" = {
@@ -10820,6 +10928,42 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz";
         sha1 = "40866b9e1b9e0b55b481894311e68faffaebc522";
+      };
+    };
+    "bevent-0.1.5" = {
+      name = "bevent";
+      packageName = "bevent";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bevent/-/bevent-0.1.5.tgz";
+        sha512 = "hs6T3BjndibrAmPSoKTHmKa3tz/c6Qgjv9iZw+tAoxuP6izfTCkzfltBQrW7SuK5xnY22gv9jCEf51+mRH+Qvg==";
+      };
+    };
+    "bfile-0.2.2" = {
+      name = "bfile";
+      packageName = "bfile";
+      version = "0.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bfile/-/bfile-0.2.2.tgz";
+        sha512 = "X205SsJ7zFAnjeJ/pBLqDqF10x/4Su3pBy8UdVKw4hdGJk7t5pLoRi+uG4rPaDAClGbrEfT/06PGUbYiMYKzTg==";
+      };
+    };
+    "bfilter-1.0.5" = {
+      name = "bfilter";
+      packageName = "bfilter";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bfilter/-/bfilter-1.0.5.tgz";
+        sha512 = "GupIidtCvLbKhXnA1sxvrwa+gh95qbjafy7P1U1x/2DHxNabXq4nGW0x3rmgzlJMYlVl+c8fMxoMRIwpKYlgcQ==";
+      };
+    };
+    "bheep-0.1.5" = {
+      name = "bheep";
+      packageName = "bheep";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bheep/-/bheep-0.1.5.tgz";
+        sha512 = "0KR5Zi8hgJBKL35+aYzndCTtgSGakOMxrYw2uszd5UmXTIfx3+drPGoETlVbQ6arTdAzSoQYA1j35vbaWpQXBg==";
       };
     };
     "biased-opener-0.2.8" = {
@@ -10957,6 +11101,15 @@ let
         sha512 = "p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==";
       };
     };
+    "binet-0.3.6" = {
+      name = "binet";
+      packageName = "binet";
+      version = "0.3.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/binet/-/binet-0.3.6.tgz";
+        sha512 = "6pm+Gc3uNiiJZEv0k8JDWqQlo9ki/o9UNAkLmr0EGm7hI5MboOJVIOlO1nw3YuDkLHWN78OPsaC4JhRkn2jMLw==";
+      };
+    };
     "bitfield-0.1.0" = {
       name = "bitfield";
       packageName = "bitfield";
@@ -11020,13 +11173,13 @@ let
         sha512 = "fvb6M58Ceiv/S94nu6zeaiMoJvUYOeIqRbgaClm+kJTzCAqJPtAR/31pXNYB5iEReOoKqQB5zY33gY0W6ZRWQQ==";
       };
     };
-    "bittorrent-lsd-1.0.0" = {
+    "bittorrent-lsd-1.1.0" = {
       name = "bittorrent-lsd";
       packageName = "bittorrent-lsd";
-      version = "1.0.0";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bittorrent-lsd/-/bittorrent-lsd-1.0.0.tgz";
-        sha512 = "rM3ECQrtEiE1ef5TTdQbWJgbpd4NQur3bxrNs0r5VPcYfnFhXT85m75+whkyV5NIwNsndS7M/D+Uf/Mi/BUrWg==";
+        url = "https://registry.npmjs.org/bittorrent-lsd/-/bittorrent-lsd-1.1.0.tgz";
+        sha512 = "j9F+bDt1R//+kLfeSgkmc1A3x0u70gjb/FXaRgTtw+V3wIeYjOekiIlmsXf1SNKuxU5YHDkNL8CFNHx+MfSPSw==";
       };
     };
     "bittorrent-peerid-1.3.3" = {
@@ -11146,6 +11299,15 @@ let
         sha512 = "jLLXR9pjjm/T2jY0Q8OCCpuDquWiMULkPyT8YNaiLUR0j1MchTQK/Q7SiuD63jn9ekn9BrohwP1Kom/FylmeHQ==";
       };
     };
+    "blgr-0.1.8" = {
+      name = "blgr";
+      packageName = "blgr";
+      version = "0.1.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/blgr/-/blgr-0.1.8.tgz";
+        sha512 = "9AvDK+lc92q//63S8cHtkaB060YOZqoqd0DkMwn35mR1SrcY0FXnCHePHZFx6Oe1d/6wj8Lw7mKEGoShCUf3Yw==";
+      };
+    };
     "blob-0.0.2" = {
       name = "blob";
       packageName = "blob";
@@ -11189,6 +11351,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/block-stream2/-/block-stream2-2.0.0.tgz";
         sha512 = "1oI+RHHUEo64xomy1ozLgVJetFlHkIfQfJzTBQrj6xWnEMEPooeo2fZoqFjp0yzfHMBrgxwgh70tKp6T17+i3g==";
+      };
+    };
+    "blru-0.1.6" = {
+      name = "blru";
+      packageName = "blru";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/blru/-/blru-0.1.6.tgz";
+        sha512 = "34+xZ2u4ys/aUzWCU9m6Eee4nVuN1ywdxbi8b3Z2WULU6qvnfeHvCWEdGzlVfRbbhimG2xxJX6R77GD2cuVO6w==";
+      };
+    };
+    "blst-0.1.5" = {
+      name = "blst";
+      packageName = "blst";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/blst/-/blst-0.1.5.tgz";
+        sha512 = "TPl04Cx3CHdPFAJ2x9Xx1Z1FOfpAzmNPfHkfo+pGAaNH4uLhS58ExvamVkZh3jadF+B7V5sMtqvrqdf9mHINYA==";
       };
     };
     "bluebird-1.1.1" = {
@@ -11254,6 +11434,15 @@ let
         sha1 = "e05a63f796a6c1ff25f4771ec7adadc148c07233";
       };
     };
+    "bmutex-0.1.6" = {
+      name = "bmutex";
+      packageName = "bmutex";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bmutex/-/bmutex-0.1.6.tgz";
+        sha512 = "nXWOXtQHbfPaMl6jyEF/rmRMrcemj2qn+OCAI/uZYurjfx7Dg3baoXdPzHOL0U8Cfvn8CWxKcnM/rgxL7DR4zw==";
+      };
+    };
     "bn.js-4.11.9" = {
       name = "bn.js";
       packageName = "bn.js";
@@ -11288,6 +11477,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bncode/-/bncode-0.5.3.tgz";
         sha1 = "e16661697452d436bf9886238cc791b08d66a61a";
+      };
+    };
+    "bns-0.13.0" = {
+      name = "bns";
+      packageName = "bns";
+      version = "0.13.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bns/-/bns-0.13.0.tgz";
+        sha512 = "2aRg/m7+fvXsf+CpR30f0iXTgAFdf2UdhreZNhxbgMpVTo83rnlGhb6QuMznGIiqDxj6akDnONVg50M8wADoIw==";
       };
     };
     "body-0.1.0" = {
@@ -11704,13 +11902,13 @@ let
         sha1 = "98dde8aa5c561fd6d3fe49bbaa102b74b396fdea";
       };
     };
-    "browserify-rsa-4.0.1" = {
+    "browserify-rsa-4.1.0" = {
       name = "browserify-rsa";
       packageName = "browserify-rsa";
-      version = "4.0.1";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz";
-        sha1 = "21e0abfaf6f2029cf2fafb133567a701d4135524";
+        url = "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz";
+        sha512 = "AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==";
       };
     };
     "browserify-sign-4.2.1" = {
@@ -11758,13 +11956,31 @@ let
         sha512 = "TpfK0TDgv71dzuTsEAlQiHeWQ/tiPqgNZVdv046fvNtBZrjbv2O3TsWCDU0AWGJJKCF/KsjNdLzR9hXOsh/CfA==";
       };
     };
-    "browserslist-4.14.6" = {
+    "browserslist-4.14.7" = {
       name = "browserslist";
       packageName = "browserslist";
-      version = "4.14.6";
+      version = "4.14.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.14.6.tgz";
-        sha512 = "zeFYcUo85ENhc/zxHbiIp0LGzzTrE2Pv2JhxvS7kpUb9Q9D38kUX6Bie7pGutJ/5iF5rOxE7CepAuWD56xJ33A==";
+        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz";
+        sha512 = "BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==";
+      };
+    };
+    "brq-0.1.8" = {
+      name = "brq";
+      packageName = "brq";
+      version = "0.1.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/brq/-/brq-0.1.8.tgz";
+        sha512 = "6SDY1lJMKXgt5TZ6voJQMH2zV1XPWWtm203PSkx3DSg9AYNYuRfOPFSBDkNemabzgpzFW9/neR4YhTvyJml8rQ==";
+      };
+    };
+    "bs32-0.1.6" = {
+      name = "bs32";
+      packageName = "bs32";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bs32/-/bs32-0.1.6.tgz";
+        sha512 = "usjDesQqZ8ihHXOnOEQuAdymBHnJEfSd+aELFSg1jN/V3iAf12HrylHlRJwIt6DTMmXpBDQ+YBg3Q3DIYdhRgQ==";
       };
     };
     "bser-2.1.1" = {
@@ -11774,6 +11990,42 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz";
         sha512 = "gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==";
+      };
+    };
+    "bsert-0.0.10" = {
+      name = "bsert";
+      packageName = "bsert";
+      version = "0.0.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz";
+        sha512 = "NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q==";
+      };
+    };
+    "bsock-0.1.9" = {
+      name = "bsock";
+      packageName = "bsock";
+      version = "0.1.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bsock/-/bsock-0.1.9.tgz";
+        sha512 = "/l9Kg/c5o+n/0AqreMxh2jpzDMl1ikl4gUxT7RFNe3A3YRIyZkiREhwcjmqxiymJSRI/Qhew357xGn1SLw/xEw==";
+      };
+    };
+    "bsocks-0.2.5" = {
+      name = "bsocks";
+      packageName = "bsocks";
+      version = "0.2.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bsocks/-/bsocks-0.2.5.tgz";
+        sha512 = "w1yG8JmfKPIaTDLuR9TIxJM2Ma6nAiInRpLNZ43g3qPnPHjawCC4SV6Bdy84bEJQX1zJWYTgdod/BnQlDhq4Gg==";
+      };
+    };
+    "btcp-0.1.5" = {
+      name = "btcp";
+      packageName = "btcp";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/btcp/-/btcp-0.1.5.tgz";
+        sha512 = "tkrtMDxeJorn5p0KxaLXELneT8AbfZMpOFeoKYZ5qCCMMSluNuwut7pGccLC5YOJqmuk0DR774vNVQLC9sNq/A==";
       };
     };
     "btoa-lite-1.0.0" = {
@@ -11801,6 +12053,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bubble-stream-error/-/bubble-stream-error-1.0.0.tgz";
         sha1 = "7dad97f17128da396169bf37ada4acb195361e30";
+      };
+    };
+    "budp-0.1.6" = {
+      name = "budp";
+      packageName = "budp";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/budp/-/budp-0.1.6.tgz";
+        sha512 = "o+a8NPq3DhV91j4nInjht2md6mbU1XL+7ciPltP66rw5uD3KP1m5r8lA94LZVaPKcFdJ0l2HVVzRNxnY26Pefg==";
       };
     };
     "buefy-helper-json-1.0.3" = {
@@ -11837,6 +12098,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz";
         sha512 = "EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==";
+      };
+    };
+    "buffer-6.0.2" = {
+      name = "buffer";
+      packageName = "buffer";
+      version = "6.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer/-/buffer-6.0.2.tgz";
+        sha512 = "XeXCUm+F7uY7fIzq4pKy+BLbZk4SgYS5xwlZOFYD3UEcAD+PwOoTaFr/SaXvhR1yRa8SKyPSZ7LNX4N65w7h8A==";
       };
     };
     "buffer-alloc-1.2.0" = {
@@ -11965,6 +12235,15 @@ let
         sha512 = "I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==";
       };
     };
+    "buffer-map-0.0.7" = {
+      name = "buffer-map";
+      packageName = "buffer-map";
+      version = "0.0.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-map/-/buffer-map-0.0.7.tgz";
+        sha512 = "95try3p/vMRkIAAnJDaGkFhGpT/65NoeW6XelEPjAomWYR58RQtW4khn0SwKj34kZoE7uxL7w2koZSwbnszvQQ==";
+      };
+    };
     "buffer-queue-1.0.0" = {
       name = "buffer-queue";
       packageName = "buffer-queue";
@@ -12053,6 +12332,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bufferview/-/bufferview-1.0.1.tgz";
         sha1 = "7afd74a45f937fa422a1d338c08bbfdc76cd725d";
+      };
+    };
+    "bufio-1.0.7" = {
+      name = "bufio";
+      packageName = "bufio";
+      version = "1.0.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz";
+        sha512 = "bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A==";
       };
     };
     "bufrw-1.3.0" = {
@@ -12145,6 +12433,15 @@ let
         sha512 = "tY6iaw+iYbCjlsAgAyO4CeA7Usnj5VndygMfd2PcHK++626oMoHANcdsH5tq5VxRPsbk9M1fbuk0a5pX9axV2w==";
       };
     };
+    "bupnp-0.2.6" = {
+      name = "bupnp";
+      packageName = "bupnp";
+      version = "0.2.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bupnp/-/bupnp-0.2.6.tgz";
+        sha512 = "J6ykzJhZMxXKN78K+1NzFi3v/51X2Mvzp2hW42BWwmxIVfau6PaN99gyABZ8x05e8MObWbsAis23gShhj9qpbw==";
+      };
+    };
     "busboy-0.2.14" = {
       name = "busboy";
       packageName = "busboy";
@@ -12161,6 +12458,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz";
         sha512 = "y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==";
+      };
+    };
+    "bval-0.1.6" = {
+      name = "bval";
+      packageName = "bval";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bval/-/bval-0.1.6.tgz";
+        sha512 = "jxNH9gSx7g749hQtS+nTxXYz/bLxwr4We1RHFkCYalNYcj12RfbW6qYWsKu0RYiKAdFcbNoZRHmWrIuXIyhiQQ==";
+      };
+    };
+    "bweb-0.1.10" = {
+      name = "bweb";
+      packageName = "bweb";
+      version = "0.1.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bweb/-/bweb-0.1.10.tgz";
+        sha512 = "3Kkz/rfsyAWUS+8DV5XYhwcgVN4DfDewrP+iFTcpQfdZzcF6+OypAq7dHOtXV0sW7U/3msA/sEEqz0MHZ9ERWg==";
       };
     };
     "byline-5.0.0" = {
@@ -12559,13 +12874,13 @@ let
         sha512 = "bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==";
       };
     };
-    "caniuse-lite-1.0.30001156" = {
+    "caniuse-lite-1.0.30001158" = {
       name = "caniuse-lite";
       packageName = "caniuse-lite";
-      version = "1.0.30001156";
+      version = "1.0.30001158";
       src = fetchurl {
-        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001156.tgz";
-        sha512 = "z7qztybA2eFZTB6Z3yvaQBIoJpQtsewRD74adw2UbRWwsRq3jIPvgrQGawBMbfafekQaD21FWuXNcywtTDGGCw==";
+        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001158.tgz";
+        sha512 = "s5loVYY+yKpuVA3HyW8BarzrtJvwHReuzugQXlv1iR3LKSReoFXRm86mT6hT7PEF5RxW+XQZg+6nYjlywYzQ+g==";
       };
     };
     "canvas-2.6.1" = {
@@ -12782,15 +13097,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz";
         sha512 = "4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==";
-      };
-    };
-    "chalk-4.0.0" = {
-      name = "chalk";
-      packageName = "chalk";
-      version = "4.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz";
-        sha512 = "N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==";
       };
     };
     "chalk-4.1.0" = {
@@ -13765,13 +14071,13 @@ let
         sha512 = "t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==";
       };
     };
-    "cliui-7.0.3" = {
+    "cliui-7.0.4" = {
       name = "cliui";
       packageName = "cliui";
-      version = "7.0.3";
+      version = "7.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cliui/-/cliui-7.0.3.tgz";
-        sha512 = "Gj3QHTkVMPKqwP3f7B4KPkBZRMR9r4rfi5bXFpg1a+Svvj8l7q5CnkBkVQzfxT5DFSsGk2+PascOgL0JYkL2kw==";
+        url = "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz";
+        sha512 = "OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==";
       };
     };
     "clivas-0.1.4" = {
@@ -14143,6 +14449,15 @@ let
         sha512 = "jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==";
       };
     };
+    "color-3.1.2" = {
+      name = "color";
+      packageName = "color";
+      version = "3.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/color/-/color-3.1.2.tgz";
+        sha512 = "vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==";
+      };
+    };
     "color-3.1.3" = {
       name = "color";
       packageName = "color";
@@ -14377,13 +14692,13 @@ let
         sha512 = "MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==";
       };
     };
-    "command-line-usage-6.1.0" = {
+    "command-line-usage-6.1.1" = {
       name = "command-line-usage";
       packageName = "command-line-usage";
-      version = "6.1.0";
+      version = "6.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz";
-        sha512 = "Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==";
+        url = "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz";
+        sha512 = "F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==";
       };
     };
     "commander-0.6.1" = {
@@ -15935,6 +16250,15 @@ let
         sha512 = "oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==";
       };
     };
+    "css-b64-images-0.2.5" = {
+      name = "css-b64-images";
+      packageName = "css-b64-images";
+      version = "0.2.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/css-b64-images/-/css-b64-images-0.2.5.tgz";
+        sha1 = "42005d83204b2b4a5d93b6b1a5644133b5927a02";
+      };
+    };
     "css-color-keywords-1.0.0" = {
       name = "css-color-keywords";
       packageName = "css-color-keywords";
@@ -16061,15 +16385,6 @@ let
         sha512 = "Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==";
       };
     };
-    "css-tree-1.0.0" = {
-      name = "css-tree";
-      packageName = "css-tree";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0.tgz";
-        sha512 = "CdVYz/Yuqw0VdKhXPBIgi8DO3NicJVYZNWeX9XcIuSp9ZoFT5IcleVRW07O5rMjdcx1mb+MEJPknTTEW7DdsYw==";
-      };
-    };
     "css-tree-1.0.0-alpha.37" = {
       name = "css-tree";
       packageName = "css-tree";
@@ -16077,6 +16392,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz";
         sha512 = "DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==";
+      };
+    };
+    "css-tree-1.0.1" = {
+      name = "css-tree";
+      packageName = "css-tree";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/css-tree/-/css-tree-1.0.1.tgz";
+        sha512 = "WroX+2MvsYcRGP8QA0p+rxzOniT/zpAoQ/DTKDSJzh5T3IQKUkFHeIIfgIapm2uaP178GWY3Mime1qbk8GO/tA==";
       };
     };
     "css-what-1.0.0" = {
@@ -16196,13 +16520,13 @@ let
         sha1 = "178b43a44621221c27756086f531e02f42900ee8";
       };
     };
-    "csso-4.1.0" = {
+    "csso-4.1.1" = {
       name = "csso";
       packageName = "csso";
-      version = "4.1.0";
+      version = "4.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/csso/-/csso-4.1.0.tgz";
-        sha512 = "h+6w/W1WqXaJA4tb1dk7r5tVbOm97MsKxzwnvOR04UQ6GILroryjMWu3pmCCtL2mLaEStQ0fZgeGiy99mo7iyg==";
+        url = "https://registry.npmjs.org/csso/-/csso-4.1.1.tgz";
+        sha512 = "Rvq+e1e0TFB8E8X+8MQjHSY6vtol45s5gxtLI/018UsAn2IBMmwNEZRM/h+HVnAJRHjasLIKKUO3uvoMM28LvA==";
       };
     };
     "cssom-0.3.8" = {
@@ -16250,13 +16574,13 @@ let
         sha512 = "AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==";
       };
     };
-    "csstype-2.6.13" = {
+    "csstype-2.6.14" = {
       name = "csstype";
       packageName = "csstype";
-      version = "2.6.13";
+      version = "2.6.14";
       src = fetchurl {
-        url = "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz";
-        sha512 = "ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==";
+        url = "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz";
+        sha512 = "2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A==";
       };
     };
     "csurf-1.11.0" = {
@@ -16412,6 +16736,24 @@ let
         sha512 = "m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==";
       };
     };
+    "d3-5.16.0" = {
+      name = "d3";
+      packageName = "d3";
+      version = "5.16.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3/-/d3-5.16.0.tgz";
+        sha512 = "4PL5hHaHwX4m7Zr1UapXW23apo6pexCgdetdJ5kTmADpG/7T9Gkxw0M0tf/pjoB63ezCCm0u5UaFYy2aMt0Mcw==";
+      };
+    };
+    "d3-array-1.2.4" = {
+      name = "d3-array";
+      packageName = "d3-array";
+      version = "1.2.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz";
+        sha512 = "KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==";
+      };
+    };
     "d3-array-2.8.0" = {
       name = "d3-array";
       packageName = "d3-array";
@@ -16419,6 +16761,51 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz";
         sha512 = "6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw==";
+      };
+    };
+    "d3-axis-1.0.12" = {
+      name = "d3-axis";
+      packageName = "d3-axis";
+      version = "1.0.12";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.12.tgz";
+        sha512 = "ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==";
+      };
+    };
+    "d3-brush-1.1.6" = {
+      name = "d3-brush";
+      packageName = "d3-brush";
+      version = "1.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.6.tgz";
+        sha512 = "7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==";
+      };
+    };
+    "d3-chord-1.0.6" = {
+      name = "d3-chord";
+      packageName = "d3-chord";
+      version = "1.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.6.tgz";
+        sha512 = "JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==";
+      };
+    };
+    "d3-collection-1.0.7" = {
+      name = "d3-collection";
+      packageName = "d3-collection";
+      version = "1.0.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz";
+        sha512 = "ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==";
+      };
+    };
+    "d3-color-1.4.1" = {
+      name = "d3-color";
+      packageName = "d3-color";
+      version = "1.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz";
+        sha512 = "p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==";
       };
     };
     "d3-color-2.0.0" = {
@@ -16430,6 +16817,15 @@ let
         sha512 = "SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==";
       };
     };
+    "d3-contour-1.3.2" = {
+      name = "d3-contour";
+      packageName = "d3-contour";
+      version = "1.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-contour/-/d3-contour-1.3.2.tgz";
+        sha512 = "hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==";
+      };
+    };
     "d3-delaunay-5.3.0" = {
       name = "d3-delaunay";
       packageName = "d3-delaunay";
@@ -16437,6 +16833,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz";
         sha512 = "amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==";
+      };
+    };
+    "d3-dispatch-1.0.6" = {
+      name = "d3-dispatch";
+      packageName = "d3-dispatch";
+      version = "1.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz";
+        sha512 = "fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==";
       };
     };
     "d3-dispatch-2.0.0" = {
@@ -16448,6 +16853,24 @@ let
         sha512 = "S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==";
       };
     };
+    "d3-drag-1.2.5" = {
+      name = "d3-drag";
+      packageName = "d3-drag";
+      version = "1.2.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz";
+        sha512 = "rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==";
+      };
+    };
+    "d3-dsv-1.2.0" = {
+      name = "d3-dsv";
+      packageName = "d3-dsv";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.2.0.tgz";
+        sha512 = "9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==";
+      };
+    };
     "d3-dsv-2.0.0" = {
       name = "d3-dsv";
       packageName = "d3-dsv";
@@ -16455,6 +16878,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz";
         sha512 = "E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==";
+      };
+    };
+    "d3-ease-1.0.7" = {
+      name = "d3-ease";
+      packageName = "d3-ease";
+      version = "1.0.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz";
+        sha512 = "lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==";
+      };
+    };
+    "d3-fetch-1.2.0" = {
+      name = "d3-fetch";
+      packageName = "d3-fetch";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-fetch/-/d3-fetch-1.2.0.tgz";
+        sha512 = "yC78NBVcd2zFAyR/HnUiBS7Lf6inSCoWcSxFfw8FYL7ydiqe80SazNwoffcqOfs95XaLo7yebsmQqDKSsXUtvA==";
+      };
+    };
+    "d3-force-1.2.1" = {
+      name = "d3-force";
+      packageName = "d3-force";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz";
+        sha512 = "HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==";
       };
     };
     "d3-force-2.1.1" = {
@@ -16466,6 +16916,15 @@ let
         sha512 = "nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==";
       };
     };
+    "d3-format-1.4.5" = {
+      name = "d3-format";
+      packageName = "d3-format";
+      version = "1.4.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz";
+        sha512 = "J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==";
+      };
+    };
     "d3-format-2.0.0" = {
       name = "d3-format";
       packageName = "d3-format";
@@ -16473,6 +16932,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz";
         sha512 = "Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==";
+      };
+    };
+    "d3-geo-1.12.1" = {
+      name = "d3-geo";
+      packageName = "d3-geo";
+      version = "1.12.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz";
+        sha512 = "XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==";
       };
     };
     "d3-geo-2.0.1" = {
@@ -16493,6 +16961,15 @@ let
         sha512 = "1JE+filVbkEX2bT25dJdQ05iA4QHvUwev6o0nIQHOSrNlHCAKfVss/U10vEM3pA4j5v7uQoFdQ4KLbx9BlEbWA==";
       };
     };
+    "d3-hierarchy-1.1.9" = {
+      name = "d3-hierarchy";
+      packageName = "d3-hierarchy";
+      version = "1.1.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz";
+        sha512 = "j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==";
+      };
+    };
     "d3-hierarchy-2.0.0" = {
       name = "d3-hierarchy";
       packageName = "d3-hierarchy";
@@ -16500,6 +16977,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz";
         sha512 = "SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw==";
+      };
+    };
+    "d3-interpolate-1.4.0" = {
+      name = "d3-interpolate";
+      packageName = "d3-interpolate";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz";
+        sha512 = "V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==";
       };
     };
     "d3-interpolate-2.0.1" = {
@@ -16511,6 +16997,15 @@ let
         sha512 = "c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==";
       };
     };
+    "d3-path-1.0.9" = {
+      name = "d3-path";
+      packageName = "d3-path";
+      version = "1.0.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz";
+        sha512 = "VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==";
+      };
+    };
     "d3-path-2.0.0" = {
       name = "d3-path";
       packageName = "d3-path";
@@ -16518,6 +17013,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz";
         sha512 = "ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==";
+      };
+    };
+    "d3-polygon-1.0.6" = {
+      name = "d3-polygon";
+      packageName = "d3-polygon";
+      version = "1.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.6.tgz";
+        sha512 = "k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ==";
+      };
+    };
+    "d3-quadtree-1.0.7" = {
+      name = "d3-quadtree";
+      packageName = "d3-quadtree";
+      version = "1.0.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz";
+        sha512 = "RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==";
       };
     };
     "d3-quadtree-2.0.0" = {
@@ -16529,6 +17042,24 @@ let
         sha512 = "b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw==";
       };
     };
+    "d3-random-1.1.2" = {
+      name = "d3-random";
+      packageName = "d3-random";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-random/-/d3-random-1.1.2.tgz";
+        sha512 = "6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ==";
+      };
+    };
+    "d3-scale-2.2.2" = {
+      name = "d3-scale";
+      packageName = "d3-scale";
+      version = "2.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz";
+        sha512 = "LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==";
+      };
+    };
     "d3-scale-3.2.3" = {
       name = "d3-scale";
       packageName = "d3-scale";
@@ -16536,6 +17067,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz";
         sha512 = "8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==";
+      };
+    };
+    "d3-scale-chromatic-1.5.0" = {
+      name = "d3-scale-chromatic";
+      packageName = "d3-scale-chromatic";
+      version = "1.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz";
+        sha512 = "ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==";
+      };
+    };
+    "d3-selection-1.4.2" = {
+      name = "d3-selection";
+      packageName = "d3-selection";
+      version = "1.4.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz";
+        sha512 = "SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==";
+      };
+    };
+    "d3-shape-1.3.7" = {
+      name = "d3-shape";
+      packageName = "d3-shape";
+      version = "1.3.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz";
+        sha512 = "EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==";
       };
     };
     "d3-shape-2.0.0" = {
@@ -16547,6 +17105,15 @@ let
         sha512 = "djpGlA779ua+rImicYyyjnOjeubyhql1Jyn1HK0bTyawuH76UQRWXd+pftr67H6Fa8hSwetkgb/0id3agKWykw==";
       };
     };
+    "d3-time-1.1.0" = {
+      name = "d3-time";
+      packageName = "d3-time";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz";
+        sha512 = "Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==";
+      };
+    };
     "d3-time-2.0.0" = {
       name = "d3-time";
       packageName = "d3-time";
@@ -16554,6 +17121,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/d3-time/-/d3-time-2.0.0.tgz";
         sha512 = "2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q==";
+      };
+    };
+    "d3-time-format-2.3.0" = {
+      name = "d3-time-format";
+      packageName = "d3-time-format";
+      version = "2.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz";
+        sha512 = "guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==";
       };
     };
     "d3-time-format-3.0.0" = {
@@ -16565,6 +17141,15 @@ let
         sha512 = "UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==";
       };
     };
+    "d3-timer-1.0.10" = {
+      name = "d3-timer";
+      packageName = "d3-timer";
+      version = "1.0.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz";
+        sha512 = "B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==";
+      };
+    };
     "d3-timer-2.0.0" = {
       name = "d3-timer";
       packageName = "d3-timer";
@@ -16574,6 +17159,33 @@ let
         sha512 = "TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==";
       };
     };
+    "d3-transition-1.3.2" = {
+      name = "d3-transition";
+      packageName = "d3-transition";
+      version = "1.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-transition/-/d3-transition-1.3.2.tgz";
+        sha512 = "sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==";
+      };
+    };
+    "d3-voronoi-1.1.4" = {
+      name = "d3-voronoi";
+      packageName = "d3-voronoi";
+      version = "1.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz";
+        sha512 = "dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==";
+      };
+    };
+    "d3-zoom-1.8.3" = {
+      name = "d3-zoom";
+      packageName = "d3-zoom";
+      version = "1.8.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.8.3.tgz";
+        sha512 = "VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==";
+      };
+    };
     "dag-map-1.0.2" = {
       name = "dag-map";
       packageName = "dag-map";
@@ -16581,6 +17193,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz";
         sha1 = "e8379f041000ed561fc515475c1ed2c85eece8d7";
+      };
+    };
+    "dagre-0.8.5" = {
+      name = "dagre";
+      packageName = "dagre";
+      version = "0.8.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz";
+        sha512 = "/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==";
+      };
+    };
+    "dagre-d3-0.6.4" = {
+      name = "dagre-d3";
+      packageName = "dagre-d3";
+      version = "0.6.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dagre-d3/-/dagre-d3-0.6.4.tgz";
+        sha512 = "e/6jXeCP7/ptlAM48clmX4xTZc5Ek6T6kagS7Oz2HrYSdqcLZFLqpAfh7ldbZRFfxCZVyh61NEPR08UQRVxJzQ==";
       };
     };
     "dargs-4.1.0" = {
@@ -16862,13 +17492,13 @@ let
         sha512 = "3VmRXEtw7RZKAf+4Tv1Ym9AGeo8r8+CjDi26x+7SYQil1UqtqdaokhzoEJohqlzt0m5kacJSDhJQkG/LWhpRBw==";
       };
     };
-    "dayjs-1.9.5" = {
+    "dayjs-1.9.6" = {
       name = "dayjs";
       packageName = "dayjs";
-      version = "1.9.5";
+      version = "1.9.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dayjs/-/dayjs-1.9.5.tgz";
-        sha512 = "WULIw7UpW/E0y6VywewpbXAMH3d5cZijEhoHLwM+OMVbk/NtchKS/W+57H/0P1rqU7gHrAArjiRLHCUhgMQl6w==";
+        url = "https://registry.npmjs.org/dayjs/-/dayjs-1.9.6.tgz";
+        sha512 = "HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw==";
       };
     };
     "deasync-0.1.15" = {
@@ -16880,13 +17510,13 @@ let
         sha512 = "pxMaCYu8cQIbGkA4Y1R0PLSooPIpH1WgFBLeJ+zLxQgHfkZG86ViJSmZmONSjZJ/R3NjwkMcIWZAzpLB2G9/CA==";
       };
     };
-    "deasync-0.1.20" = {
+    "deasync-0.1.21" = {
       name = "deasync";
       packageName = "deasync";
-      version = "0.1.20";
+      version = "0.1.21";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deasync/-/deasync-0.1.20.tgz";
-        sha512 = "E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==";
+        url = "https://registry.npmjs.org/deasync/-/deasync-0.1.21.tgz";
+        sha512 = "kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==";
       };
     };
     "death-1.1.0" = {
@@ -17555,15 +18185,6 @@ let
         sha512 = "1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==";
       };
     };
-    "del-cli-3.0.1" = {
-      name = "del-cli";
-      packageName = "del-cli";
-      version = "3.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/del-cli/-/del-cli-3.0.1.tgz";
-        sha512 = "BLHItGr82rUbHhjMu41d+vw9Md49i81jmZSV00HdTq4t+RTHywmEht/23mNFpUl2YeLYJZJyGz4rdlMAyOxNeg==";
-      };
-    };
     "delaunator-4.0.1" = {
       name = "delaunator";
       packageName = "delaunator";
@@ -17924,13 +18545,13 @@ let
         sha512 = "7/nIzKdQ8y2K0imjIP7dyg2GJ2h38Ps6VOMXWZHIarNDV3p6mTXyEugKFnkmsZ2DD58JEG34ILyVb3qdOMmP9w==";
       };
     };
-    "devtools-protocol-0.0.809251" = {
+    "devtools-protocol-0.0.818844" = {
       name = "devtools-protocol";
       packageName = "devtools-protocol";
-      version = "0.0.809251";
+      version = "0.0.818844";
       src = fetchurl {
-        url = "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.809251.tgz";
-        sha512 = "pf+2OY6ghMDPjKkzSWxHMq+McD+9Ojmq5XVRYpv/kPd9sTMQxzEt21592a31API8qRjro0iYYOc3ag46qF/1FA==";
+        url = "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz";
+        sha512 = "AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==";
       };
     };
     "dezalgo-1.0.3" = {
@@ -18896,13 +19517,13 @@ let
         sha512 = "vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==";
       };
     };
-    "easy-stack-1.0.0" = {
+    "easy-stack-1.0.1" = {
       name = "easy-stack";
       packageName = "easy-stack";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.0.tgz";
-        sha1 = "12c91b3085a37f0baa336e9486eac4bf94e3e788";
+        url = "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.1.tgz";
+        sha512 = "wK2sCs4feiiJeFXn3zvY0p41mdU5VUgbgs1rNsc/y5ngFUijdWd+iIN8eoyuZHKB8xN6BL4PdWmzqFmxNg6V2w==";
       };
     };
     "ecc-jsbn-0.1.2" = {
@@ -19031,13 +19652,13 @@ let
         sha512 = "dldq3ZfFtgVTJMLjOe+/3sROTzALlL9E34V4/sDtUd/KlBSS0s6U1/+WPE1B4sj9CXHJpL1M6rhNJnc9Wbal9w==";
       };
     };
-    "electron-to-chromium-1.3.589" = {
+    "electron-to-chromium-1.3.596" = {
       name = "electron-to-chromium";
       packageName = "electron-to-chromium";
-      version = "1.3.589";
+      version = "1.3.596";
       src = fetchurl {
-        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.589.tgz";
-        sha512 = "rQItBTFnol20HaaLm26UgSUduX7iGerwW7pEYX17MB1tI6LzFajiLV7iZ7LVcUcsN/7HrZUoCLrBauChy/IqEg==";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.596.tgz";
+        sha512 = "nLO2Wd2yU42eSoNJVQKNf89CcEGqeFZd++QsnN2XIgje1s/19AgctfjLIbPORlvcCO8sYjLwX4iUgDdusOY8Sg==";
       };
     };
     "elegant-spinner-1.0.1" = {
@@ -19111,15 +19732,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz";
         sha512 = "Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==";
-      };
-    };
-    "emmet-2.1.6" = {
-      name = "emmet";
-      packageName = "emmet";
-      version = "2.1.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/emmet/-/emmet-2.1.6.tgz";
-        sha512 = "kfJMlze+k8jpX5CUx7xPYS83DxRNXuh8rQ98rQKnnf+wfo/KD+BG6pmpnEp5a7a1DWM9xmllKuOPfC7MeRmepQ==";
       };
     };
     "emoji-named-characters-1.0.2" = {
@@ -19347,13 +19959,13 @@ let
         sha512 = "b4Q85dFkGw+TqgytGPrGgACRUhsdKc9S9ErRAXpPGy/CXKs4tYoHDkvIRdsseAF7NjfVwjRFIn6KTnbw7LwJZg==";
       };
     };
-    "engine.io-4.0.1" = {
+    "engine.io-4.0.2" = {
       name = "engine.io";
       packageName = "engine.io";
-      version = "4.0.1";
+      version = "4.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/engine.io/-/engine.io-4.0.1.tgz";
-        sha512 = "6EaSBxasBUwxRdf6B68SEYpD3tcrG80J4YTzHl/D+9Q+vM0AMHZabfYcc2WdnvEaQxZjX/UZsa+UdGoM0qQQkQ==";
+        url = "https://registry.npmjs.org/engine.io/-/engine.io-4.0.2.tgz";
+        sha512 = "sumdttqWLNjbuSMOSgDdL2xiEld9s5QZDk9VLyr4e28o+lzNNADhU3qpQDAY7cm2VZH0Otw/U0fL8mEjZ6kBMg==";
       };
     };
     "engine.io-client-1.3.1" = {
@@ -19489,6 +20101,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz";
         sha512 = "hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==";
+      };
+    };
+    "entity-decode-2.0.2" = {
+      name = "entity-decode";
+      packageName = "entity-decode";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/entity-decode/-/entity-decode-2.0.2.tgz";
+        sha512 = "5CCY/3ci4MC1m2jlumNjWd7VBFt4VfFnmSqSNmVcXq4gxM3Vmarxtt+SvmBnzwLS669MWdVuXboNVj1qN2esVg==";
       };
     };
     "env-ci-3.2.2" = {
@@ -19671,13 +20292,13 @@ let
         sha512 = "I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==";
       };
     };
-    "es-get-iterator-1.1.0" = {
+    "es-get-iterator-1.1.1" = {
       name = "es-get-iterator";
       packageName = "es-get-iterator";
-      version = "1.1.0";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz";
-        sha512 = "UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==";
+        url = "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.1.tgz";
+        sha512 = "qorBw8Y7B15DVLaJWy6WdEV/ZkieBcu6QCq/xzWzGOKJqgG1j754vXRfZ3NY7HSShneqU43mPB4OkQBTkvHhFw==";
       };
     };
     "es-to-primitive-1.2.1" = {
@@ -20013,13 +20634,13 @@ let
         sha512 = "G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==";
       };
     };
-    "eslint-7.12.1" = {
+    "eslint-7.13.0" = {
       name = "eslint";
       packageName = "eslint";
-      version = "7.12.1";
+      version = "7.13.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eslint/-/eslint-7.12.1.tgz";
-        sha512 = "HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==";
+        url = "https://registry.npmjs.org/eslint/-/eslint-7.13.0.tgz";
+        sha512 = "uCORMuOO8tUzJmsdRtrvcGq5qposf7Rw0LwkTJkoDbOycVQtQjmnhZSuLQnozLE4TmAzlMVV45eCHmQ1OpDKUQ==";
       };
     };
     "eslint-plugin-no-unsanitized-3.1.4" = {
@@ -22101,13 +22722,13 @@ let
         sha512 = "LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==";
       };
     };
-    "flat-tree-1.6.0" = {
+    "flat-tree-1.7.0" = {
       name = "flat-tree";
       packageName = "flat-tree";
-      version = "1.6.0";
+      version = "1.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flat-tree/-/flat-tree-1.6.0.tgz";
-        sha1 = "fca30cddb9006fb656eb5ebc79aeb274e7fde9ed";
+        url = "https://registry.npmjs.org/flat-tree/-/flat-tree-1.7.0.tgz";
+        sha512 = "dh9Dnlb5NLKDnJEtU6zP57FCDwusVoGhFAq3Uz1p/szjiuSlPdb3A3aoV31v4tlQMb3c8aDEUbqOpi+8DLDy7Q==";
       };
     };
     "flatiron-0.4.3" = {
@@ -22173,13 +22794,13 @@ let
         sha512 = "jlbUu0XkbpXeXhan5xyTqVK1jmEKNxE8hpzznI3TThHTr76GiFwK0iRzhDo4KNy+S9h/KxHaqVhTP86vA6wHCg==";
       };
     };
-    "flow-parser-0.137.0" = {
+    "flow-parser-0.138.0" = {
       name = "flow-parser";
       packageName = "flow-parser";
-      version = "0.137.0";
+      version = "0.138.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.137.0.tgz";
-        sha512 = "i3KXJZ8lhlQI0n+BoZzIeH/rv+fNvAiu1i9/s64MklBV+HuhFbycUML7367J2eng0gapLnwvYPFNaPZys8POsA==";
+        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.138.0.tgz";
+        sha512 = "LFnTyjrv39UvCWl8NOcpByr/amj8a5k5z7isO2wv4T43nNrUnHQwX3rarTz9zcpHXkDAQv6X4MfQ4ZzJUptpbw==";
       };
     };
     "fluent-ffmpeg-2.1.2" = {
@@ -22218,13 +22839,13 @@ let
         sha1 = "ae049a714386bb83e342657a82924b70364a90d6";
       };
     };
-    "flumedb-2.1.8" = {
+    "flumedb-1.1.0" = {
       name = "flumedb";
       packageName = "flumedb";
-      version = "2.1.8";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flumedb/-/flumedb-2.1.8.tgz";
-        sha512 = "MtBCZFjj9GuqOQP8Ld87FbXm8ztQyLkLeuiHuB5+aACFuVn1kunnCis75R03ujFZTqCFmkBwFz7E016b3DB0zA==";
+        url = "https://registry.npmjs.org/flumedb/-/flumedb-1.1.0.tgz";
+        sha512 = "Bwol+72GU5z2DxZlnaxUA9A8qaRcQcdTprmRcgfqn2ldn147ByVh9Zyp90hVGPlo/oEN/yjOBUXcNkK3SYjbgA==";
       };
     };
     "flumelog-offset-3.4.4" = {
@@ -22470,13 +23091,13 @@ let
         sha512 = "DuVkPNrM12jR41KM2e+N+styka0EgLkTnXmNcXdgOM37vtGeY+oCBK/Jx0hzSeEU6memFCtWb4htrHPMDfwwUQ==";
       };
     };
-    "fork-ts-checker-webpack-plugin-5.2.1" = {
+    "fork-ts-checker-webpack-plugin-6.0.2" = {
       name = "fork-ts-checker-webpack-plugin";
       packageName = "fork-ts-checker-webpack-plugin";
-      version = "5.2.1";
+      version = "6.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz";
-        sha512 = "SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==";
+        url = "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.0.2.tgz";
+        sha512 = "3WrR/gNMcOAJ+macFpYTXxbt/xZDF9MLCYsPU3j9IUmS8LAvi8WoTiI001z1A8qkgmDtkoh6MTytTQqf8/7aOA==";
       };
     };
     "form-data-1.0.0-rc3" = {
@@ -22596,13 +23217,13 @@ let
         sha1 = "98c23dab1175657b8c0573e8ceccd91b0ff18c84";
       };
     };
-    "fp-ts-2.8.5" = {
+    "fp-ts-2.8.6" = {
       name = "fp-ts";
       packageName = "fp-ts";
-      version = "2.8.5";
+      version = "2.8.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fp-ts/-/fp-ts-2.8.5.tgz";
-        sha512 = "g6do+Q/IQsxgsd2qU6+QnAbZaPR533seIbFyLGqWSxhNX4+F+cY37QdaYmMUOzekLOv/yg/2f15tc26tzDatgw==";
+        url = "https://registry.npmjs.org/fp-ts/-/fp-ts-2.8.6.tgz";
+        sha512 = "fGGpKf/Jy3UT4s16oM+hr/8F5QXFcZ+20NAvaZXH5Y5jsiLPMDCaNqffXq0z1Kr6ZUJj0346cH9tq+cI2SoJ4w==";
       };
     };
     "fragment-cache-0.2.1" = {
@@ -24136,6 +24757,15 @@ let
         sha512 = "Vric7QFWxzHFxITZ10bmlG1H/5rhODb7hJuWyKWMD8GflpQzRmbMVqkFp3fKvN+U9tPwZItGVhkiOR+84PX3ew==";
       };
     };
+    "goosig-0.9.0" = {
+      name = "goosig";
+      packageName = "goosig";
+      version = "0.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/goosig/-/goosig-0.9.0.tgz";
+        sha512 = "RaCpYN0eStJQszrudhwf42hd8j/Nod6iRiUU81cnHjI0f3s4vhmVkvpPE7QktF/EUA9tkoG2hrYYr9NJXvgefg==";
+      };
+    };
     "gossip-query-2.0.2" = {
       name = "gossip-query";
       packageName = "gossip-query";
@@ -25261,13 +25891,13 @@ let
         sha1 = "b86ce808598e8a9d1892c571f3cedd86fc9f0653";
       };
     };
-    "highlight.js-10.1.1" = {
+    "highlight.js-10.3.2" = {
       name = "highlight.js";
       packageName = "highlight.js";
-      version = "10.1.1";
+      version = "10.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.1.tgz";
-        sha512 = "b4L09127uVa+9vkMgPpdUQP78ickGbHEQTWeBrQFTJZ4/n2aihWOGS0ZoUqAwjVmfjhq/C76HRzkqwZhK4sBbg==";
+        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-10.3.2.tgz";
+        sha512 = "3jRT7OUYsVsKvukNKZCtnvRcFyCJqSEIuIMsEybAXRiFSwpt65qjPd/Pr+UOdYt7WJlt+lj3+ypUsHiySBp/Jw==";
       };
     };
     "highlight.js-8.2.0" = {
@@ -25423,6 +26053,15 @@ let
         sha1 = "87774c0949e513f42e84575b3c45681fade2a0b2";
       };
     };
+    "hs-client-0.0.9" = {
+      name = "hs-client";
+      packageName = "hs-client";
+      version = "0.0.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hs-client/-/hs-client-0.0.9.tgz";
+        sha512 = "TAsexmpPhSVdCQ1iiX4bBnuqlThTSdGz/YKq+vjLSS1TZ2TwKxERJ8vZh1Wd6GGaMGLZl99uQR+2wUyk4HLSbg==";
+      };
+    };
     "hsl-regex-1.0.0" = {
       name = "hsl-regex";
       packageName = "hsl-regex";
@@ -25493,6 +26132,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz";
         sha512 = "LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==";
+      };
+    };
+    "html-minifier-4.0.0" = {
+      name = "html-minifier";
+      packageName = "html-minifier";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz";
+        sha512 = "aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==";
       };
     };
     "html-minifier-terser-5.1.1" = {
@@ -25567,13 +26215,13 @@ let
         sha1 = "3a03edc2214bca3b66424a3e7959349509cb0351";
       };
     };
-    "htmlnano-0.2.7" = {
+    "htmlnano-0.2.8" = {
       name = "htmlnano";
       packageName = "htmlnano";
-      version = "0.2.7";
+      version = "0.2.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/htmlnano/-/htmlnano-0.2.7.tgz";
-        sha512 = "ozbK3npguK3MTn77WCKngBtCDhc94fmEptPQsn+dO+uIWoEghIMKsjzCMnDJuu403M01ePg9GA5MpXhRBQ3PVg==";
+        url = "https://registry.npmjs.org/htmlnano/-/htmlnano-0.2.8.tgz";
+        sha512 = "q5gbo4SIDAE5sfJ5V0UD6uu+n1dcO/Mpr0B6SlDlJBoV7xKPne4uG4UwrT8vUWjdjIPJl95TY8EDuEbBW2TG0A==";
       };
     };
     "htmlparser2-3.10.1" = {
@@ -25610,15 +26258,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz";
         sha512 = "4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==";
-      };
-    };
-    "htmlparser2-5.0.1" = {
-      name = "htmlparser2";
-      packageName = "htmlparser2";
-      version = "5.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz";
-        sha512 = "vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==";
       };
     };
     "http-auth-2.0.7" = {
@@ -25838,13 +26477,13 @@ let
         sha512 = "NwoTQYSJoFt34jSBbwzDHDofoA61NGXzu6wXh95o1Ry62EnmKjXb/nR/RknLeZ3G/uGwrlKNY2z7uPt+Cdl7Tw==";
       };
     };
-    "http-status-1.4.2" = {
+    "http-status-1.5.0" = {
       name = "http-status";
       packageName = "http-status";
-      version = "1.4.2";
+      version = "1.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/http-status/-/http-status-1.4.2.tgz";
-        sha512 = "mBnIohUwRw9NyXMEMMv8/GANnzEYUj0Y8d3uL01zDWFkxUjYyZ6rgCaAI2zZ1Wb34Oqtbx/nFZolPRDc8Xlm5A==";
+        url = "https://registry.npmjs.org/http-status/-/http-status-1.5.0.tgz";
+        sha512 = "wcGvY31MpFNHIkUcXHHnvrE4IKYlpvitJw5P/1u892gMBAM46muQ+RH7UN1d+Ntnfx5apnOnVY6vcLmrWHOLwg==";
       };
     };
     "http2-client-1.3.3" = {
@@ -27449,15 +28088,6 @@ let
         sha1 = "39acaa6be7fd1f3471dc42c7416e61c24317ac9f";
       };
     };
-    "is-expression-4.0.0" = {
-      name = "is-expression";
-      packageName = "is-expression";
-      version = "4.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz";
-        sha512 = "zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==";
-      };
-    };
     "is-extendable-0.1.1" = {
       name = "is-extendable";
       packageName = "is-extendable";
@@ -28943,22 +29573,22 @@ let
         sha512 = "/Tbp1OVzZjbwzwJQFIlYLm9eWQ+3aYbBXLSaqb1mEJzhcQAfrqMMQYtjb6io+U6KpD0ID4F+Id3/xcjH3l/sqA==";
       };
     };
-    "js-message-1.0.5" = {
+    "js-message-1.0.7" = {
       name = "js-message";
       packageName = "js-message";
-      version = "1.0.5";
+      version = "1.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz";
-        sha1 = "2300d24b1af08e89dd095bc1a4c9c9cfcb892d15";
+        url = "https://registry.npmjs.org/js-message/-/js-message-1.0.7.tgz";
+        sha512 = "efJLHhLjIyKRewNS9EGZ4UpI8NguuL6fKkhRxVuMmrGV2xN/0APGdQYwLFky5w9naebSZ0OwAGp0G6/2Cg90rA==";
       };
     };
-    "js-queue-2.0.0" = {
+    "js-queue-2.0.2" = {
       name = "js-queue";
       packageName = "js-queue";
-      version = "2.0.0";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/js-queue/-/js-queue-2.0.0.tgz";
-        sha1 = "362213cf860f468f0125fc6c96abc1742531f948";
+        url = "https://registry.npmjs.org/js-queue/-/js-queue-2.0.2.tgz";
+        sha512 = "pbKLsbCfi7kriM3s1J4DDCo7jQkI58zPLHi0heXPzPlj0hjUsm+FesPUbE0DSbIVIK503A36aUBoCN7eMFedkA==";
       };
     };
     "js-select-0.6.0" = {
@@ -29456,15 +30086,6 @@ let
         sha512 = "hk/69oAeaIzchq/v3lS50PXuzn5O2ynldopMC+SWBql7J2WtdptfB9dy8Y7+Og5rPkTCpn83zTiO8FMcqlXJ/g==";
       };
     };
-    "jsonc-parser-2.3.0" = {
-      name = "jsonc-parser";
-      packageName = "jsonc-parser";
-      version = "2.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.0.tgz";
-        sha512 = "b0EBt8SWFNnixVdvoR2ZtEGa9ZqLhbJnOjezn+WP+8kspFm+PFYDN8Z4Bc7pRlDjvuVcADSUkroIuTWWn/YiIA==";
-      };
-    };
     "jsonc-parser-2.3.1" = {
       name = "jsonc-parser";
       packageName = "jsonc-parser";
@@ -29618,15 +30239,6 @@ let
         sha1 = "313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2";
       };
     };
-    "jssha-2.4.2" = {
-      name = "jssha";
-      packageName = "jssha";
-      version = "2.4.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/jssha/-/jssha-2.4.2.tgz";
-        sha512 = "/jsi/9C0S70zfkT/4UlKQa5E1xKurDnXcQizcww9JSR/Fv+uIbWM2btG+bFcL3iNoK9jIGS0ls9HWLr1iw0kFg==";
-      };
-    };
     "jstransform-10.1.0" = {
       name = "jstransform";
       packageName = "jstransform";
@@ -29744,13 +30356,13 @@ let
         sha1 = "7d86bd56679f58ce6a84704a657dd392bba81a79";
       };
     };
-    "jwt-decode-3.1.1" = {
+    "jwt-decode-3.1.2" = {
       name = "jwt-decode";
       packageName = "jwt-decode";
-      version = "3.1.1";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.1.tgz";
-        sha512 = "EaH9dTD9ogCmxZRdiTsIUIJslqjoFfk8nEAi+Bq8u/aUjrVuhZ6eZjhWRH6SC9NBA0Lwr3K35H2zDnWvK/n4vQ==";
+        url = "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz";
+        sha512 = "UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==";
       };
     };
     "k-bucket-0.6.0" = {
@@ -29961,13 +30573,13 @@ let
         sha1 = "1e80454250018dbad4c3fe94497d6e67b6269c77";
       };
     };
-    "keytar-5.6.0" = {
+    "keytar-7.1.0" = {
       name = "keytar";
       packageName = "keytar";
-      version = "5.6.0";
+      version = "7.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/keytar/-/keytar-5.6.0.tgz";
-        sha512 = "ueulhshHSGoryfRXaIvTj0BV1yB0KddBGhGoqCxSN9LR1Ks1GKuuCdVhF+2/YOs5fMl6MlTI9On1a4DHDXoTow==";
+        url = "https://registry.npmjs.org/keytar/-/keytar-7.1.0.tgz";
+        sha512 = "ciDrtCcvhKpmVfPMVAiKSeKKQd+8S2VWOIcJP0Rdwz/ezSxHxYrycpwufDGpEHJqLyi/F7C7iwoz0eKGllzcMw==";
       };
     };
     "keyv-3.0.0" = {
@@ -29995,6 +30607,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz";
         sha512 = "zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==";
+      };
+    };
+    "khroma-1.1.0" = {
+      name = "khroma";
+      packageName = "khroma";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/khroma/-/khroma-1.1.0.tgz";
+        sha512 = "aTO+YX22tYOLEQJYFiatAj1lc5QZ+H5sHWFRBWNCiKwc5NWNUJZyeSeiHEPeURJ2a1GEVYcmyMUwGjjLe5ec5A==";
       };
     };
     "killable-1.0.1" = {
@@ -30958,6 +31579,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz";
         sha512 = "rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==";
+      };
+    };
+    "loady-0.0.5" = {
+      name = "loady";
+      packageName = "loady";
+      version = "0.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz";
+        sha512 = "uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ==";
       };
     };
     "locate-java-home-1.1.2" = {
@@ -32805,13 +33435,13 @@ let
         sha512 = "ZpqciThlbvE6KkyT5oxAup/6CwjePw1hdtR8NU5+vq2hn9Sp5b7w3bRiJRvo9fMHUj2dWSuVCdkqt9p4ed1V9Q==";
       };
     };
-    "magnet-uri-6.0.0" = {
+    "magnet-uri-6.1.0" = {
       name = "magnet-uri";
       packageName = "magnet-uri";
-      version = "6.0.0";
+      version = "6.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/magnet-uri/-/magnet-uri-6.0.0.tgz";
-        sha512 = "p9wst4k4u0seE7yPonAPKIUTaiC+fm706o2D8FrNoBalK5CcQdU4hB+RHQTqfIISYkFp0nZzsgyKPacPa6Yg/g==";
+        url = "https://registry.npmjs.org/magnet-uri/-/magnet-uri-6.1.0.tgz";
+        sha512 = "731qLviHaqN/Ni96wm6gNKuvoip+QHWTznjHNz/4qDlsHh3/CWJoL8fZ18IIRhGJgnWoKJp8RVE5lZvQ60Khhw==";
       };
     };
     "make-dir-1.3.0" = {
@@ -33246,13 +33876,13 @@ let
         sha512 = "EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==";
       };
     };
-    "marked-1.2.3" = {
+    "marked-1.2.4" = {
       name = "marked";
       packageName = "marked";
-      version = "1.2.3";
+      version = "1.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/marked/-/marked-1.2.3.tgz";
-        sha512 = "RQuL2i6I6Gn+9n81IDNGbL0VHnta4a+8ZhqvryXEniTb/hQNtf3i26hi1XWUhzb9BgVyWHKR3UO8MaHtKoYibw==";
+        url = "https://registry.npmjs.org/marked/-/marked-1.2.4.tgz";
+        sha512 = "6x5TFGCTKSQBLTZtOburGxCxFEBJEGYVLwCMTBCxzvyuisGcC20UNzDSJhCr/cJ/Kmh6ulfJm10g6WWEAJ3kvg==";
       };
     };
     "marked-terminal-4.1.0" = {
@@ -33903,6 +34533,15 @@ let
         sha1 = "f8a064760d37e7978ad5f9f6d3c119a494f57081";
       };
     };
+    "mermaid-8.8.3" = {
+      name = "mermaid";
+      packageName = "mermaid";
+      version = "8.8.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mermaid/-/mermaid-8.8.3.tgz";
+        sha512 = "+SK/kofUw9Y4u08hU5KhLuoMy3If6DMdZEmaWeNnq368FUHQBBZbe+Pr0hjuGbz81rbOkFqar1O1DJjXopjM+g==";
+      };
+    };
     "mersenne-0.0.4" = {
       name = "mersenne";
       packageName = "mersenne";
@@ -33912,13 +34551,13 @@ let
         sha1 = "401fdec7ec21cdb9e03cd3d3021398da21b27085";
       };
     };
-    "metals-languageclient-0.3.2" = {
+    "metals-languageclient-0.3.3" = {
       name = "metals-languageclient";
       packageName = "metals-languageclient";
-      version = "0.3.2";
+      version = "0.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/metals-languageclient/-/metals-languageclient-0.3.2.tgz";
-        sha512 = "qpog+/luf+h3i6zvgDu05SMmDqEsPMYbcamy+odlysA9iT31k8j0mknR2uGAQ1ZLL4oWYCSct+2/zpxrYLiDng==";
+        url = "https://registry.npmjs.org/metals-languageclient/-/metals-languageclient-0.3.3.tgz";
+        sha512 = "lcYMlelg5pHFxFR1oz6vqZA9M6bi2IcCcPdkc/OAOg1KTkS5fGBrW8RXGnbKx/j+w0hQ3sUJsg16x5U/ikXVVA==";
       };
     };
     "metalsmith-2.3.0" = {
@@ -34299,6 +34938,15 @@ let
         sha512 = "LfHUYIA047rrqIZEn0gwbqbzarU5bmZ8yZ9SizeoiPwVq5cemE3foJTJZ3pCktUq/IPkKNGghFHJk1O8149mOA==";
       };
     };
+    "minify-4.1.3" = {
+      name = "minify";
+      packageName = "minify";
+      version = "4.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/minify/-/minify-4.1.3.tgz";
+        sha512 = "ykuscavxivSmVpcCzsXmsVTukWYLUUtPhHj0w2ILvHDGqC+hsuTCihBn9+PJBd58JNvWTNg9132J9nrrI2anzA==";
+      };
+    };
     "minilog-3.1.0" = {
       name = "minilog";
       packageName = "minilog";
@@ -34659,13 +35307,13 @@ let
         sha1 = "ebb3a977e7af1c683ae6fda12b545a6ba6c5853d";
       };
     };
-    "mobx-6.0.3" = {
+    "mobx-6.0.4" = {
       name = "mobx";
       packageName = "mobx";
-      version = "6.0.3";
+      version = "6.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mobx/-/mobx-6.0.3.tgz";
-        sha512 = "DBMd0NXsMn25HJMUAWBndgJ2wRjOJPbpn6wdzUvZW0PVsyTnrw028XwQfzsjnxnKG+bAXGVNb38rvd+1o0G9uQ==";
+        url = "https://registry.npmjs.org/mobx/-/mobx-6.0.4.tgz";
+        sha512 = "wT2QJT9tW19VSHo9x7RPKU3z/I2Ps6wUS8Kb1OO+kzmg7UY3n4AkcaYG6jq95Lp1R9ohjC/NGYuT2PtuvBjhFg==";
       };
     };
     "mobx-react-6.3.1" = {
@@ -34812,13 +35460,22 @@ let
         sha1 = "359a19ec634cda3c706c8709adda54c0329aaec4";
       };
     };
-    "moment-timezone-0.5.31" = {
+    "moment-mini-2.24.0" = {
+      name = "moment-mini";
+      packageName = "moment-mini";
+      version = "2.24.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/moment-mini/-/moment-mini-2.24.0.tgz";
+        sha512 = "9ARkWHBs+6YJIvrIp0Ik5tyTTtP9PoV0Ssu2Ocq5y9v8+NOOpWiRshAp8c4rZVWTOe+157on/5G+zj5pwIQFEQ==";
+      };
+    };
+    "moment-timezone-0.5.32" = {
       name = "moment-timezone";
       packageName = "moment-timezone";
-      version = "0.5.31";
+      version = "0.5.32";
       src = fetchurl {
-        url = "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz";
-        sha512 = "+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==";
+        url = "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz";
+        sha512 = "Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==";
       };
     };
     "monotonic-timestamp-0.0.9" = {
@@ -34927,6 +35584,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.6.0.tgz";
         sha512 = "LvghnKMFC70hKWMVykmhJarlO5e7lT3t9s9A2qPCUx+lazL3Mq55U+eCV0eLi7/nRRQYvEUWo/2tTo89EjnCJQ==";
+      };
+    };
+    "mrmr-0.1.10" = {
+      name = "mrmr";
+      packageName = "mrmr";
+      version = "0.1.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mrmr/-/mrmr-0.1.10.tgz";
+        sha512 = "NJRJs+yJyRWwcTqLRf7O32n56UP1+UQoTrGVEoB3LMj0h2jlon790drDbxKvi5mK5k4HfC0cpNkxqHcrJK/evg==";
       };
     };
     "ms-0.7.1" = {
@@ -35352,6 +36018,15 @@ let
         sha512 = "z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==";
       };
     };
+    "n64-0.2.10" = {
+      name = "n64";
+      packageName = "n64";
+      version = "0.2.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/n64/-/n64-0.2.10.tgz";
+        sha512 = "uH9geV4+roR1tohsrrqSOLCJ9Mh1iFcDI+9vUuydDlDxUS1UCAWUfuGb06p3dj3flzywquJNrGsQ7lHP8+4RVQ==";
+      };
+    };
     "nan-0.3.2" = {
       name = "nan";
       packageName = "nan";
@@ -35377,15 +36052,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz";
         sha512 = "INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==";
-      };
-    };
-    "nan-2.14.1" = {
-      name = "nan";
-      packageName = "nan";
-      version = "2.14.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz";
-        sha512 = "isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==";
       };
     };
     "nan-2.14.2" = {
@@ -35857,13 +36523,13 @@ let
         sha512 = "pF8BiOr3Pa4kQLLiOu53I0d30EIUDM0DYqYvCQmKD96cMX2qLh/QsxT0Zh18IrL5a0IWQ236/o76lTe0yEEw6w==";
       };
     };
-    "netlify-redirector-0.2.0" = {
+    "netlify-redirector-0.2.1" = {
       name = "netlify-redirector";
       packageName = "netlify-redirector";
-      version = "0.2.0";
+      version = "0.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/netlify-redirector/-/netlify-redirector-0.2.0.tgz";
-        sha512 = "5SSUu++MXvE/tik90Hx7lzISBHCl5k4TqpVeTuBEoHp5K7uWitY7c3MjPNiY3kB83GSZiTNLbuIY7bo6mpyU3Q==";
+        url = "https://registry.npmjs.org/netlify-redirector/-/netlify-redirector-0.2.1.tgz";
+        sha512 = "17vDR9p1Loanp+vd57y+b6WlKb5X+qb0LZ44oTYsKJbdonz4Md+Ybv1lzH1w1aKm5YWWXHR8LMpWyY9bjlAJKw==";
       };
     };
     "netmask-1.0.6" = {
@@ -36071,6 +36737,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz";
         sha512 = "ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA==";
+      };
+    };
+    "node-addon-api-3.0.2" = {
+      name = "node-addon-api";
+      packageName = "node-addon-api";
+      version = "3.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz";
+        sha512 = "+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg==";
       };
     };
     "node-appc-1.1.2" = {
@@ -36299,13 +36974,13 @@ let
         sha512 = "MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==";
       };
     };
-    "node-html-parser-1.4.8" = {
+    "node-html-parser-1.4.9" = {
       name = "node-html-parser";
       packageName = "node-html-parser";
-      version = "1.4.8";
+      version = "1.4.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.4.8.tgz";
-        sha512 = "goyDL2T1qnepirf64Qu1ttJ2UZmNGp1CPbG3pkh2VYc1yqzgPX0rjKN7vqThFcZmEIzC+ratLIod1O/MNXwgzg==";
+        url = "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.4.9.tgz";
+        sha512 = "UVcirFD1Bn0O+TSmloHeHqZZCxHjvtIeGdVdGMhyZ8/PWlEiZaZ5iJzR189yKZr8p0FXN58BUeC7RHRkf/KYGw==";
       };
     };
     "node-int64-0.4.0" = {
@@ -36317,13 +36992,13 @@ let
         sha1 = "87a9065cdb355d3182d8f94ce11188b825c68a3b";
       };
     };
-    "node-ipc-9.1.1" = {
+    "node-ipc-9.1.3" = {
       name = "node-ipc";
       packageName = "node-ipc";
-      version = "9.1.1";
+      version = "9.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-ipc/-/node-ipc-9.1.1.tgz";
-        sha512 = "FAyICv0sIRJxVp3GW5fzgaf9jwwRQxAKDJlmNFUL5hOy+W4X/I5AypyHoq0DXXbo9o/gt79gj++4cMr4jVWE/w==";
+        url = "https://registry.npmjs.org/node-ipc/-/node-ipc-9.1.3.tgz";
+        sha512 = "8RS4RZyS/KMKKYG8mrje+cLxwATe9dBCuOiqKFSWND4oOuKytfuKCiR9yinvhoXF/nGdX/WnbywaUee+9U87zA==";
       };
     };
     "node-libs-browser-2.2.1" = {
@@ -36461,13 +37136,13 @@ let
         sha512 = "j1g/VtSCI2tBrBnCD+u8iSo9tH0nvn70k1O1SxkHk3+qx7tHUyOKQc7wNc4rUs9J1PkGngUC3qEDd5cL7Z/klg==";
       };
     };
-    "node-releases-1.1.65" = {
+    "node-releases-1.1.66" = {
       name = "node-releases";
       packageName = "node-releases";
-      version = "1.1.65";
+      version = "1.1.66";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-releases/-/node-releases-1.1.65.tgz";
-        sha512 = "YpzJOe2WFIW0V4ZkJQd/DGR/zdVwc/pI4Nl1CZrBO19FdRcSTmsuhdttw9rsTzzJLrNcSloLiBbEYx1C4f6gpA==";
+        url = "https://registry.npmjs.org/node-releases/-/node-releases-1.1.66.tgz";
+        sha512 = "JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg==";
       };
     };
     "node-source-walk-4.2.0" = {
@@ -36864,15 +37539,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-7.0.0.tgz";
         sha512 = "xXxr8y5U0kl8dVkz2oK7yZjPBvqM2fwaO5l3Yg13p03v8+E3qQcD0JNhHzjL1vyGgxcKkD0cco+NLR72iuPk3g==";
-      };
-    };
-    "npm-package-arg-8.0.1" = {
-      name = "npm-package-arg";
-      packageName = "npm-package-arg";
-      version = "8.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.0.1.tgz";
-        sha512 = "/h5Fm6a/exByzFSTm7jAyHbgOqErl9qSNJDQF32Si/ZzgwT2TERVxRxn3Jurw1wflgyVVAxnFR4fRHPM7y1ClQ==";
       };
     };
     "npm-package-arg-8.1.0" = {
@@ -37578,13 +38244,13 @@ let
         sha512 = "fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==";
       };
     };
-    "office-ui-fabric-react-7.149.4" = {
+    "office-ui-fabric-react-7.150.0" = {
       name = "office-ui-fabric-react";
       packageName = "office-ui-fabric-react";
-      version = "7.149.4";
+      version = "7.150.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.149.4.tgz";
-        sha512 = "9gfzIGlQr9tijkR10S+chRkNhxtyf2bonPFwTvJh/vrJ3R2/CHanHEWh+k4KUjsz2+4bf/+aRY5mjKCpEG65qA==";
+        url = "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.150.0.tgz";
+        sha512 = "2g617g8jp9eav54Qy9mRJzIqkF5Ugg0D7hUVgxCuQyxXMqSDCuuas6C+Fv+5pYi/AyTejbVp9EcT/bJ78oCf8A==";
       };
     };
     "omggif-1.0.10" = {
@@ -37801,15 +38467,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/open/-/open-7.1.0.tgz";
         sha512 = "lLPI5KgOwEYCDKXf4np7y1PBEkj7HYIyP2DY8mVDRnx0VIIu6bNrRB0R66TuO7Mack6EnTNLm4uvcl1UoklTpA==";
-      };
-    };
-    "open-7.2.0" = {
-      name = "open";
-      packageName = "open";
-      version = "7.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/open/-/open-7.2.0.tgz";
-        sha512 = "4HeyhxCvBTI5uBePsAdi55C5fmqnWZ2e2MlmvWi5KW5tdH5rxoiv/aMtbeVxKZc3eWkT1GymMnLG8XC4Rq4TDQ==";
       };
     };
     "open-7.3.0" = {
@@ -38253,15 +38910,6 @@ let
         sha512 = "sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==";
       };
     };
-    "ora-5.0.0" = {
-      name = "ora";
-      packageName = "ora";
-      version = "5.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ora/-/ora-5.0.0.tgz";
-        sha512 = "s26qdWqke2kjN/wC4dy+IQPBIMWBJlSU/0JZhk30ZDBLelW25rv66yutUWARMigpGPzcXHb+Nac5pNhN/WsARw==";
-      };
-    };
     "ora-5.1.0" = {
       name = "ora";
       packageName = "ora";
@@ -38397,22 +39045,22 @@ let
         sha512 = "0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==";
       };
     };
-    "ot-builder-0.10.31" = {
+    "ot-builder-0.10.33" = {
       name = "ot-builder";
       packageName = "ot-builder";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ot-builder/-/ot-builder-0.10.31.tgz";
-        sha512 = "Cj/EsGzPQ4h59OWJJoXi5JEj94ULlxHB0ZwLvaRt6O3kmJ6PvZdp7MyEvi6fF0/BMcjFJOMOkcggbjAOCl/E3g==";
+        url = "https://registry.npmjs.org/ot-builder/-/ot-builder-0.10.33.tgz";
+        sha512 = "Xs2G7yDDlNcMOUTgBDHdtT4iLMs90uqwylB5T4l96+o9ePXSsa0TwtzrI7D5eFpiZY+u2PjXUNRcfvfh/HvQvw==";
       };
     };
-    "otb-ttc-bundle-0.10.31" = {
+    "otb-ttc-bundle-0.10.33" = {
       name = "otb-ttc-bundle";
       packageName = "otb-ttc-bundle";
-      version = "0.10.31";
+      version = "0.10.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/otb-ttc-bundle/-/otb-ttc-bundle-0.10.31.tgz";
-        sha512 = "PHT2rzKRD8QkwD7CrPDuh7tmtnaAVecK6JjALw7d4CajmNBvYbFlnb7fdpF1melyizJgnhigeN3hjHllEuqdMQ==";
+        url = "https://registry.npmjs.org/otb-ttc-bundle/-/otb-ttc-bundle-0.10.33.tgz";
+        sha512 = "xt7ZOSlNWN6DcWzH/2kYUVoB37FQjhe7ZZJ9JO7RysRQxlJWBciHpOK6oYHOm9rA1RGDbUYbVj9411yV5dqmXg==";
       };
     };
     "p-all-2.1.0" = {
@@ -39333,13 +39981,13 @@ let
         sha512 = "to8zT7+o6bVTyP35r2QgG1svuFGMFO1mE6ri1oWHgL9tlgnOtfjmfHmA3mOuP9HTIU/8OiZw0NG5zbyqVLxhvA==";
       };
     };
-    "parse-torrent-9.0.0" = {
+    "parse-torrent-9.1.0" = {
       name = "parse-torrent";
       packageName = "parse-torrent";
-      version = "9.0.0";
+      version = "9.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/parse-torrent/-/parse-torrent-9.0.0.tgz";
-        sha512 = "Er+VA8XwlGbuwEwss7LYIbWZRYvttS1c+0Td6FMxZhIog/0HDlU3A3qbRfL+1aOSM+L+kGL544yRoGbpTRWPsQ==";
+        url = "https://registry.npmjs.org/parse-torrent/-/parse-torrent-9.1.0.tgz";
+        sha512 = "TVht2kv44bTHEd55KgmfEHyDh5djIBZMhaD6uFWnxLhJWUXy8lrIOsjPSs4Tfzs9PTGIgGM0k+UG6CFphHgOZQ==";
       };
     };
     "parse-torrent-file-2.1.4" = {
@@ -39639,15 +40287,6 @@ let
         sha512 = "nxl9nrnLQmh64iTzMfyylSlRozL7kAXIaxw1fVcLYdyhNkJCRUzirRZTikXGJsg+hc4fqpneTK6iU2H1Q8THSA==";
       };
     };
-    "patch-package-6.2.2" = {
-      name = "patch-package";
-      packageName = "patch-package";
-      version = "6.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/patch-package/-/patch-package-6.2.2.tgz";
-        sha512 = "YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==";
-      };
-    };
     "patel-0.33.1" = {
       name = "patel";
       packageName = "patel";
@@ -39873,13 +40512,13 @@ let
         sha1 = "b942e6d4bde653005ef6b71361def8727d0645e0";
       };
     };
-    "patrisika-0.22.0" = {
+    "patrisika-0.22.2" = {
       name = "patrisika";
       packageName = "patrisika";
-      version = "0.22.0";
+      version = "0.22.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/patrisika/-/patrisika-0.22.0.tgz";
-        sha512 = "2ug3pMunBT5js9S6+6cpt7KkfQA+nQ35nZi6aiiS6S0GdqvXhcsaSvOnczJosEZK9Xrar4j8t9J1VpNnVMrHWw==";
+        url = "https://registry.npmjs.org/patrisika/-/patrisika-0.22.2.tgz";
+        sha512 = "8L6zlp+F4InnoFv0jjGdar948yEzP30bE96f6RHnECaUsU9BWRiTBhkAuhIobG4Lrr8CBscUcar7UWe0Bm1lqA==";
       };
     };
     "patrisika-scopes-0.11.1" = {
@@ -40044,13 +40683,13 @@ let
         sha512 = "ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA==";
       };
     };
-    "pg-protocol-1.3.0" = {
+    "pg-protocol-1.4.0" = {
       name = "pg-protocol";
       packageName = "pg-protocol";
-      version = "1.3.0";
+      version = "1.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.3.0.tgz";
-        sha512 = "64/bYByMrhWULUaCd+6/72c9PMWhiVFs3EVxl9Ct6a3v/U8+rKgqP2w+kKg/BIGgMJyB+Bk/eNivT32Al+Jghw==";
+        url = "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.4.0.tgz";
+        sha512 = "El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA==";
       };
     };
     "pg-types-2.2.0" = {
@@ -41251,22 +41890,22 @@ let
         sha512 = "BUIorsYJTvS9UhXxPTzupIztOMVNPa/HtAm9KHni9z6qEfiJ1bpOBL5DfUOL9XAc3XkLIEzBzpph+Zbm4AdRAg==";
       };
     };
-    "posthtml-parser-0.5.2" = {
+    "posthtml-parser-0.5.3" = {
       name = "posthtml-parser";
       packageName = "posthtml-parser";
-      version = "0.5.2";
+      version = "0.5.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.5.2.tgz";
-        sha512 = "rwRA0TyUTivQN6NAG8CLhi8KEdqjWQMZSAJQedxkuH1c8/hme99WDVOW+z8Ony+YLmoaH0sJRUk6RCWVFQ6Rkw==";
+        url = "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.5.3.tgz";
+        sha512 = "uHosRn0y+1wbnlYKrqMjBPoo/kK5LPYImLtiETszNFYfFwAD3cQdD1R2E13Mh5icBxkHj+yKtlIHozCsmVWD/Q==";
       };
     };
-    "posthtml-render-1.2.3" = {
+    "posthtml-render-1.3.0" = {
       name = "posthtml-render";
       packageName = "posthtml-render";
-      version = "1.2.3";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.2.3.tgz";
-        sha512 = "rGGayND//VwTlsYKNqdILsA7U/XP0WJa6SMcdAEoqc2WRM5QExplGg/h9qbTuHz7mc2PvaXU+6iNxItvr5aHMg==";
+        url = "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.3.0.tgz";
+        sha512 = "km+kuwydlc2lnx4FnHmTwejGtgmfjBT2fOqu9mDTJUoNecwwMnx4soRxngfJ1Qvpa/OLu1YIqZ+/0OiJDOnCzg==";
       };
     };
     "prebuild-install-5.3.0" = {
@@ -41278,13 +41917,13 @@ let
         sha512 = "aaLVANlj4HgZweKttFNUVNRxDukytuIuxeK2boIMHjagNJCiVKWFsKF4tCE3ql3GbrD2tExPQ7/pwtEJcHNZeg==";
       };
     };
-    "prebuild-install-5.3.3" = {
+    "prebuild-install-5.3.6" = {
       name = "prebuild-install";
       packageName = "prebuild-install";
-      version = "5.3.3";
+      version = "5.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz";
-        sha512 = "GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==";
+        url = "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz";
+        sha512 = "s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==";
       };
     };
     "precinct-6.3.1" = {
@@ -41366,15 +42005,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz";
         sha512 = "s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==";
-      };
-    };
-    "prettier-2.0.5" = {
-      name = "prettier";
-      packageName = "prettier";
-      version = "2.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz";
-        sha512 = "7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==";
       };
     };
     "prettier-2.1.2" = {
@@ -42133,15 +42763,6 @@ let
         sha512 = "qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ==";
       };
     };
-    "pug-error-2.0.0" = {
-      name = "pug-error";
-      packageName = "pug-error";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz";
-        sha512 = "sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ==";
-      };
-    };
     "pug-filters-3.1.1" = {
       name = "pug-filters";
       packageName = "pug-filters";
@@ -42158,15 +42779,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.1.0.tgz";
         sha512 = "i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==";
-      };
-    };
-    "pug-lexer-5.0.0" = {
-      name = "pug-lexer";
-      packageName = "pug-lexer";
-      version = "5.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.0.tgz";
-        sha512 = "52xMk8nNpuyQ/M2wjZBN5gXQLIylaGkAoTk5Y1pBhVqaopaoj8Z0iVzpbFZAqitL4RHNVDZRnJDsqEYe99Ti0A==";
       };
     };
     "pug-linker-3.0.6" = {
@@ -42230,15 +42842,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.0.0.tgz";
         sha1 = "7017a984c3b834de77bac38c10b776f22dfc1843";
-      };
-    };
-    "pull-abortable-4.1.1" = {
-      name = "pull-abortable";
-      packageName = "pull-abortable";
-      version = "4.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.1.1.tgz";
-        sha1 = "b3ad5aefb4116b25916d26db89393ac98d0dcea1";
       };
     };
     "pull-block-filter-1.0.0" = {
@@ -42817,13 +43420,13 @@ let
         sha512 = "l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==";
       };
     };
-    "puppeteer-5.4.1" = {
+    "puppeteer-5.5.0" = {
       name = "puppeteer";
       packageName = "puppeteer";
-      version = "5.4.1";
+      version = "5.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/puppeteer/-/puppeteer-5.4.1.tgz";
-        sha512 = "8u6r9tFm3gtMylU4uCry1W/CeAA8uczKMONvGvivkTsGqKA7iB7DWO2CBFYlB9GY6/IEoq9vkI5slJWzUBkwNw==";
+        url = "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz";
+        sha512 = "OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==";
       };
     };
     "purgecss-2.3.0" = {
@@ -43465,13 +44068,13 @@ let
         sha512 = "XxTbgJnYZmxuPtY3y/UV0D8/65NKkmaia4rXzViknVnZeVlklSh8u6TnaEYPfAi/Gh1TP4mEOXHI6jQOPbeakQ==";
       };
     };
-    "react-devtools-core-4.9.0" = {
+    "react-devtools-core-4.10.0" = {
       name = "react-devtools-core";
       packageName = "react-devtools-core";
-      version = "4.9.0";
+      version = "4.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.9.0.tgz";
-        sha512 = "3NyHXW1ClqxEXdHunawAytDxiIxs620oP3wB8DHsbx1fkGgqjMkwlyHVf0zmES/b4ffqzJySowRwSYds/uAHzw==";
+        url = "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.10.0.tgz";
+        sha512 = "5m5VBtpjuHI7odyk3GAR3BJq3/IHQ0fVZ0+h8zUvoHulSj7Z9hp9d9n4Y1HmSZZxv7NUKfBtsnH+NfLNFDtfog==";
       };
     };
     "react-dom-16.14.0" = {
@@ -44185,13 +44788,13 @@ let
         sha512 = "4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==";
       };
     };
-    "registry-auth-token-4.2.0" = {
+    "registry-auth-token-4.2.1" = {
       name = "registry-auth-token";
       packageName = "registry-auth-token";
-      version = "4.2.0";
+      version = "4.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz";
-        sha512 = "P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==";
+        url = "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz";
+        sha512 = "6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==";
       };
     };
     "registry-url-3.1.0" = {
@@ -44329,15 +44932,6 @@ let
         sha1 = "802a38c3aa98c9e1e3ea015eeba211d27cb65e1f";
       };
     };
-    "remark-5.1.0" = {
-      name = "remark";
-      packageName = "remark";
-      version = "5.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/remark/-/remark-5.1.0.tgz";
-        sha1 = "cb463bd3dbcb4b99794935eee1cf71d7a8e3068c";
-      };
-    };
     "remark-8.0.0" = {
       name = "remark";
       packageName = "remark";
@@ -44392,15 +44986,6 @@ let
         sha512 = "k9bt7BYc3G7YBdmeAhvd3VavrPa/XlKWR3CyHjr4sLO9xJyly8WHHT3Sp+8HPR8lEUv+/sZaffL7IjMLV0f6BA==";
       };
     };
-    "remark-parse-1.1.0" = {
-      name = "remark-parse";
-      packageName = "remark-parse";
-      version = "1.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/remark-parse/-/remark-parse-1.1.0.tgz";
-        sha1 = "c3ca10f9a8da04615c28f09aa4e304510526ec21";
-      };
-    };
     "remark-parse-4.0.0" = {
       name = "remark-parse";
       packageName = "remark-parse";
@@ -44435,15 +45020,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/remark-retext/-/remark-retext-4.0.0.tgz";
         sha512 = "cYCchalpf25bTtfXF24ribYvqytPKq0TiEhqQDBHvVEEsApebwruPWP1cTcvTFBidmpXyqzycm+y8ng7Kmvc8Q==";
-      };
-    };
-    "remark-stringify-1.1.0" = {
-      name = "remark-stringify";
-      packageName = "remark-stringify";
-      version = "1.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/remark-stringify/-/remark-stringify-1.1.0.tgz";
-        sha1 = "a7105e25b9ee2bf9a49b75d2c423f11b06ae2092";
       };
     };
     "remark-stringify-4.0.0" = {
@@ -44725,13 +45301,13 @@ let
         sha512 = "wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==";
       };
     };
-    "requestretry-4.1.1" = {
+    "requestretry-4.1.2" = {
       name = "requestretry";
       packageName = "requestretry";
-      version = "4.1.1";
+      version = "4.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/requestretry/-/requestretry-4.1.1.tgz";
-        sha512 = "sV2lkWitASDXpIK+m0scC7dHBkW42EKj5iao6Cp8GCXsXY7qS4Q/min6PP5YBuqgV9W38lsA7LUhEkOezl1/Og==";
+        url = "https://registry.npmjs.org/requestretry/-/requestretry-4.1.2.tgz";
+        sha512 = "N1WAp+8eOy8NfsVBChcSxNCKvPY1azOpliQ4Sby4WDe0HFEhdKywlNZeROMBQ+BI3Jpc0eNOT1KVFGREawtahA==";
       };
     };
     "require-directory-2.1.1" = {
@@ -44858,6 +45434,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz";
         sha512 = "lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==";
+      };
+    };
+    "resolve-1.19.0" = {
+      name = "resolve";
+      packageName = "resolve";
+      version = "1.19.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz";
+        sha512 = "rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==";
       };
     };
     "resolve-2.0.0-next.2" = {
@@ -45085,13 +45670,13 @@ let
         sha512 = "yr1PgaBDde+25aJXrnt3p1jvT8FVLVat2Bx8XeAWX13KXo8OT+3nWGU3HWxM4YFJvmfqvJYJZG2d7xxaO774gw==";
       };
     };
-    "retext-equality-5.2.0" = {
+    "retext-equality-5.5.0" = {
       name = "retext-equality";
       packageName = "retext-equality";
-      version = "5.2.0";
+      version = "5.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/retext-equality/-/retext-equality-5.2.0.tgz";
-        sha512 = "qfyDsVvwI6RsbyBi5GDRnutDbRMQj5zzK5oVg6ddKhONle2ZmQ/DBg9mz9QLKdnGhp8aW5xoVskXgwHufSQa3g==";
+        url = "https://registry.npmjs.org/retext-equality/-/retext-equality-5.5.0.tgz";
+        sha512 = "ha7zrQ+Bq4xWifm21IcAzc9xhMWCJYfePUjRRNE2mXi8cFhaq1F8+cD78YA2nd6W2mxd11VGTVKY9O0DmzEywQ==";
       };
     };
     "retext-profanities-6.1.0" = {
@@ -45346,13 +45931,13 @@ let
         sha512 = "/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==";
       };
     };
-    "rollup-2.33.1" = {
+    "rollup-2.33.2" = {
       name = "rollup";
       packageName = "rollup";
-      version = "2.33.1";
+      version = "2.33.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/rollup/-/rollup-2.33.1.tgz";
-        sha512 = "uY4O/IoL9oNW8MMcbA5hcOaz6tZTMIh7qJHx/tzIJm+n1wLoY38BLn6fuy7DhR57oNFLMbDQtDeJoFURt5933w==";
+        url = "https://registry.npmjs.org/rollup/-/rollup-2.33.2.tgz";
+        sha512 = "QPQ6/fWCrzHtSXkI269rhKaC7qXGghYBwXU04b1JsDZ6ibZa3DJ9D1SFAYRMgx1inDg0DaTbb3N4Z1NK/r3fhw==";
       };
     };
     "rollup-plugin-babel-4.4.0" = {
@@ -45652,15 +46237,6 @@ let
         sha512 = "xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==";
       };
     };
-    "rxjs-6.6.2" = {
-      name = "rxjs";
-      packageName = "rxjs";
-      version = "6.6.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz";
-        sha512 = "BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==";
-      };
-    };
     "rxjs-6.6.3" = {
       name = "rxjs";
       packageName = "rxjs";
@@ -45668,15 +46244,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz";
         sha512 = "trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==";
-      };
-    };
-    "s.color-0.0.15" = {
-      name = "s.color";
-      packageName = "s.color";
-      version = "0.0.15";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz";
-        sha512 = "AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==";
       };
     };
     "s3-stream-upload-2.0.2" = {
@@ -45830,15 +46397,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sass/-/sass-1.29.0.tgz";
         sha512 = "ZpwAUFgnvAUCdkjwPREny+17BpUj8nh5Yr6zKPGtLNTLrmtoRYIjm7njP24COhjJldjwW1dcv52Lpf4tNZVVRA==";
-      };
-    };
-    "sass-formatter-0.5.1" = {
-      name = "sass-formatter";
-      packageName = "sass-formatter";
-      version = "0.5.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.5.1.tgz";
-        sha512 = "hRIyMsN9eKQCx+tQec78EtbRs+Be7vamEh+B+JCdIyIc4t2Ku84FIZHC+qjeu+Q5LDtXcHoMxS61AijNA+SZvA==";
       };
     };
     "sax-0.5.8" = {
@@ -46615,13 +47173,13 @@ let
         sha512 = "y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==";
       };
     };
-    "sharp-0.23.4" = {
+    "sharp-0.26.2" = {
       name = "sharp";
       packageName = "sharp";
-      version = "0.23.4";
+      version = "0.26.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sharp/-/sharp-0.23.4.tgz";
-        sha512 = "fJMagt6cT0UDy9XCsgyLi0eiwWWhQRxbwGmqQT6sY8Av4s0SVsT/deg8fobBQCTDU5iXRgz0rAeXoE2LBZ8g+Q==";
+        url = "https://registry.npmjs.org/sharp/-/sharp-0.26.2.tgz";
+        sha512 = "bGBPCxRAvdK9bX5HokqEYma4j/Q5+w8Nrmb2/sfgQCLEUx/HblcpmOfp59obL3+knIKnOhyKmDb4tEOhvFlp6Q==";
       };
     };
     "shasum-1.0.2" = {
@@ -46939,6 +47497,15 @@ let
         sha512 = "rohCHmEjD/ESXFLxF4bVeqgdb4Awc65ZyyuCKl3f7BvgMbZOBa/Ye3HN/GFnvruiUOAWWNupxhz3Rz5/3vJLTg==";
       };
     };
+    "simple-git-2.22.0" = {
+      name = "simple-git";
+      packageName = "simple-git";
+      version = "2.22.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/simple-git/-/simple-git-2.22.0.tgz";
+        sha512 = "/8WMNrQ5slYl05jYOpeh4BIyMQc84PkEvk9YAcBHVJaPoAgoxzLzdRzUzWDZJ9U6Z2pUjLxkGcQC0kU4pbRN5Q==";
+      };
+    };
     "simple-markdown-0.4.4" = {
       name = "simple-markdown";
       packageName = "simple-markdown";
@@ -46957,13 +47524,13 @@ let
         sha1 = "4e421f485ac7b13b08077a4476934d52c5ba3bb3";
       };
     };
-    "simple-peer-9.8.0" = {
+    "simple-peer-9.9.3" = {
       name = "simple-peer";
       packageName = "simple-peer";
-      version = "9.8.0";
+      version = "9.9.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-peer/-/simple-peer-9.8.0.tgz";
-        sha512 = "GK1KhJvEwtZILr6zWvQR3AnBNpLrxwr6b5wcduFxOrQNGLg9Hn92eFsHD7RYPnnWsapxGXFMJcBjNuicqBDRIQ==";
+        url = "https://registry.npmjs.org/simple-peer/-/simple-peer-9.9.3.tgz";
+        sha512 = "T3wuv0UqBpDTV0x0pJPPsz4thy0tC0fTOHE4g9+AF43RUxxT+MWeXVtdQcK5Xuzv/XTVrB2NrGzdfO1IFBqOkw==";
       };
     };
     "simple-plist-1.1.1" = {
@@ -47326,31 +47893,31 @@ let
         sha1 = "6541184cc90aeea6c6e7b35e2659082443c66198";
       };
     };
-    "snyk-config-3.1.1" = {
+    "snyk-config-4.0.0-rc.2" = {
       name = "snyk-config";
       packageName = "snyk-config";
-      version = "3.1.1";
+      version = "4.0.0-rc.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-config/-/snyk-config-3.1.1.tgz";
-        sha512 = "wwrMIEDozfLJ8LmakCsCC1FQ0siIX5icCQPCbUKKgRbeVsZ27NjPJs37BpTXX4rcHkaWpe8TbH3yOtp23qmszg==";
+        url = "https://registry.npmjs.org/snyk-config/-/snyk-config-4.0.0-rc.2.tgz";
+        sha512 = "HIXpMCRp5IdQDFH/CY6WqOUt5X5Ec55KC9dFVjlMLe/2zeqsImJn1vbjpE5uBoLYIdYi1SteTqtsJhyJZWRK8g==";
       };
     };
-    "snyk-cpp-plugin-2.0.0" = {
+    "snyk-cpp-plugin-2.1.0" = {
       name = "snyk-cpp-plugin";
       packageName = "snyk-cpp-plugin";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.0.0.tgz";
-        sha512 = "/xcDy8H5wxhk+4E9e8zDDGfcNo5g+zpwy585sCDkH5KpHdZHmguPi0GmZ9ZCBTuGIodeTIqsDqkBiA1WXSH7+w==";
+        url = "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.1.0.tgz";
+        sha512 = "TcAlIkHtTvKdPIORxFRr/Ur//ucWK7eFBwlMR4gPeIhKbmEE/PZedBXW2IM8ZUdPIhG53lAP/Eq++1bVFSmZ9g==";
       };
     };
-    "snyk-docker-plugin-4.7.0" = {
+    "snyk-docker-plugin-4.7.2" = {
       name = "snyk-docker-plugin";
       packageName = "snyk-docker-plugin";
-      version = "4.7.0";
+      version = "4.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.7.0.tgz";
-        sha512 = "u8IFJfOBswBMGYMGalY2XrMr+uMBrNCDxRld8wNJJmGtM2yW7tQXKkCqtF266rFrYJnuqIgHHJb+NQiPBK2Ypw==";
+        url = "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.7.2.tgz";
+        sha512 = "x9KT0EmWjdmQoooWmN0jToLmyWBXW+2rCb1yF5Tv8bPQzWtb2SNDOx/wxJl9rqureXjAFvGsUYFGDld5BXJwJQ==";
       };
     };
     "snyk-go-parser-1.4.1" = {
@@ -47371,13 +47938,13 @@ let
         sha512 = "FAM56z3bl1iuxeqkCEA/jyZ2hpwkQK8xQxQbhR+QppEK5lole7w1PQyWYgZAJ9oRY/BU32zdRAJwGuZbhk7G2Q==";
       };
     };
-    "snyk-gradle-plugin-3.10.1" = {
+    "snyk-gradle-plugin-3.10.2" = {
       name = "snyk-gradle-plugin";
       packageName = "snyk-gradle-plugin";
-      version = "3.10.1";
+      version = "3.10.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.10.1.tgz";
-        sha512 = "kChphbd9OHdUadkPbYILGeNozwm1QISeEYgAX0Lfth6Gi1ViB71vAErbzzY6MnErImo8m+9rQRuWsqEFv8CvAw==";
+        url = "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.10.2.tgz";
+        sha512 = "gTFKL0BLUN54asUQ4OIoa4lATGn27VZwWDJGQ0VuqSaaoy8I5W16Cbn/KN95oIKa7tgwrmasPLd5uviFWzo/Qw==";
       };
     };
     "snyk-module-1.9.1" = {
@@ -47407,40 +47974,31 @@ let
         sha512 = "HHuOYEAACpUpkFgU8HT57mmxmonaJ4O3YADoSkVhnhkmJ+AowqZyJOau703dYHNrq2DvQ7qYw81H7yyxS1Nfjw==";
       };
     };
-    "snyk-mvn-plugin-2.23.0" = {
+    "snyk-mvn-plugin-2.23.1" = {
       name = "snyk-mvn-plugin";
       packageName = "snyk-mvn-plugin";
-      version = "2.23.0";
+      version = "2.23.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.23.0.tgz";
-        sha512 = "aCmXPRvK89bcRNKjtU6mCqe6tnKaSR++/Co3V1XjqfJSRDiZ+c7A0LdtpTkRF/HbVdzZVHJ8glOn67yO/VGKhQ==";
+        url = "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.23.1.tgz";
+        sha512 = "WPEZxCoUyZUs/vvsI3OF9nVQLbED8FlhrLG1HHtSM2JPZs4ashB2HqgM93zG0Vk5kxns3aiZcWL4q6vnZReyFA==";
       };
     };
-    "snyk-nodejs-lockfile-parser-1.28.1" = {
+    "snyk-nodejs-lockfile-parser-1.30.1" = {
       name = "snyk-nodejs-lockfile-parser";
       packageName = "snyk-nodejs-lockfile-parser";
-      version = "1.28.1";
+      version = "1.30.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.28.1.tgz";
-        sha512 = "0zbmtidYLI2ia/DQD4rZm2YKrhfHLvHlVBdF2cMAGPwhOoKW5ovG9eBO4wNQdvjxNi7b4VeUyAj8SfuhjDraDQ==";
+        url = "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.30.1.tgz";
+        sha512 = "QyhE4pmy7GI7fQrVmZ+qrQB8GGSbxN7OoYueS4BEP9nDxIyH4dJAz8dME5zOUeUxh3frcgBWoWgZoSzE4VOYpg==";
       };
     };
-    "snyk-nodejs-lockfile-parser-1.30.0" = {
-      name = "snyk-nodejs-lockfile-parser";
-      packageName = "snyk-nodejs-lockfile-parser";
-      version = "1.30.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.30.0.tgz";
-        sha512 = "OmrLyV9oZ2ItH0oNoRs5BjTlvS+lSsYuBw8PryvsdmcNK6VzfMoJ7RuevTau201gVvMz1imTi7LlTxcSoCCzJg==";
-      };
-    };
-    "snyk-nuget-plugin-1.19.3" = {
+    "snyk-nuget-plugin-1.19.4" = {
       name = "snyk-nuget-plugin";
       packageName = "snyk-nuget-plugin";
-      version = "1.19.3";
+      version = "1.19.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.19.3.tgz";
-        sha512 = "KwKoMumwcXVz/DQH80ifXfX7CTnm29bmHJ2fczjCGohxLGb4EKBGQtA3t7K98O7lTISQGgXDxnWIaM9ZXkxPdw==";
+        url = "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.19.4.tgz";
+        sha512 = "6BvLJc7gpNdfPJSnvpmTL4BrbaOVbXh/9q1FNMs5OVp8NbnZ3l97iM+bpQXWTJHOa3BJBZz7iEg+3suH4AWoWw==";
       };
     };
     "snyk-paket-parser-1.6.0" = {
@@ -47461,13 +48019,13 @@ let
         sha512 = "IQcdsQBqqXVRY5DatlI7ASy4flbhtU2V7cr4P2rK9rkFnVHO6LHcitwKXVZa9ocdOmpZDzk7U6iwHJkVFcR6OA==";
       };
     };
-    "snyk-poetry-lockfile-parser-1.1.0" = {
+    "snyk-poetry-lockfile-parser-1.1.1" = {
       name = "snyk-poetry-lockfile-parser";
       packageName = "snyk-poetry-lockfile-parser";
-      version = "1.1.0";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-poetry-lockfile-parser/-/snyk-poetry-lockfile-parser-1.1.0.tgz";
-        sha512 = "FTMF6dVl9xOsDBcQT6k4gyoIurO7oZ2i78+rfb4X0W0XH4XYwSXeFw02vQLcWza2eNBvCcFmI0DtXRvQS880SA==";
+        url = "https://registry.npmjs.org/snyk-poetry-lockfile-parser/-/snyk-poetry-lockfile-parser-1.1.1.tgz";
+        sha512 = "G3LX27V2KUsKObwVN4vDDjrYr5BERad9pXHAf+SST5+vZsdPUUZjd1ZUIrHgCv7IQhwq+7mZrtqedY5x7+LIGA==";
       };
     };
     "snyk-policy-1.14.1" = {
@@ -47479,13 +48037,13 @@ let
         sha512 = "C5vSkoBYxPnaqb218sm4m6N5s1BhIXlldpIX5xRNnZ0QkDwVj3dy/PfgwxRgVQh7QFGa1ajbvKmsGmm4RRsN8g==";
       };
     };
-    "snyk-python-plugin-1.18.0" = {
+    "snyk-python-plugin-1.19.1" = {
       name = "snyk-python-plugin";
       packageName = "snyk-python-plugin";
-      version = "1.18.0";
+      version = "1.19.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.18.0.tgz";
-        sha512 = "vt07qsO1rHRAjO7wKwaLUJ0uZyvh6Aceafokc88N9mDyRbY2sf4ptIKEZ718wlbSQDLu17uRXiIQ+9jSWwH6Ng==";
+        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.19.1.tgz";
+        sha512 = "JoOUHnA76L3pekCblSuE9jQ9CuA5jt+GqXpsLQbEIZ0FQQTBa+0F7vfolg3Q7+s1it4ZdtgSbSWrlxCngIJt8g==";
       };
     };
     "snyk-resolve-1.0.1" = {
@@ -48046,13 +48604,13 @@ let
         sha1 = "ff4ae6e68656056ba4b3e792ab3334d38273ca11";
       };
     };
-    "spawn-please-0.4.1" = {
+    "spawn-please-1.0.0" = {
       name = "spawn-please";
       packageName = "spawn-please";
-      version = "0.4.1";
+      version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/spawn-please/-/spawn-please-0.4.1.tgz";
-        sha512 = "YJwFL/shPyY5fddOU1XXkShCDNVkMDGKsGlpB91FKOkRGa+pVAe+A5/CUUwLrZ3e89prqbTXaGapCzTlmc3HaA==";
+        url = "https://registry.npmjs.org/spawn-please/-/spawn-please-1.0.0.tgz";
+        sha512 = "Kz33ip6NRNKuyTRo3aDWyWxeGeM0ORDO552Fs6E1nj4pLWPkl37SrRtTnq+MEopVaqgmaO6bAvVS+v64BJ5M/A==";
       };
     };
     "spawn-sync-1.0.15" = {
@@ -48379,6 +48937,15 @@ let
         sha1 = "475393ff9e91479aea62dcaf0ca3d14983a7fb40";
       };
     };
+    "srcset-3.0.0" = {
+      name = "srcset";
+      packageName = "srcset";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/srcset/-/srcset-3.0.0.tgz";
+        sha512 = "D59vF08Qzu/C4GAOXVgMTLfgryt5fyWo93FZyhEWANo0PokFz/iWdDe13mX3O5TRf6l8vMTqckAfR4zPiaH0yQ==";
+      };
+    };
     "srt2vtt-1.3.1" = {
       name = "srt2vtt";
       packageName = "srt2vtt";
@@ -48442,13 +49009,13 @@ let
         sha512 = "DyCrGIsl01GkdHreAkkaDUorV7SAgRSqKn/htg4ZwbvH6g0NAdOi84x/8ehzDuojPev78hbkWjZXgIqi+/Jo0g==";
       };
     };
-    "ssb-db-20.3.0" = {
+    "ssb-db-19.2.0" = {
       name = "ssb-db";
       packageName = "ssb-db";
-      version = "20.3.0";
+      version = "19.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-db/-/ssb-db-20.3.0.tgz";
-        sha512 = "JOXCrS6k3+/kuOcFmZwc9vxPN55Czb7McFs5KEYA+/phykPwQ6e3hwjMT5YrVzSirCf8ptPS/mpOsCDog5Z2dg==";
+        url = "https://registry.npmjs.org/ssb-db/-/ssb-db-19.2.0.tgz";
+        sha512 = "pJAFizB6OcuJLX4RJJuU9HWyPwM2CqLi/vs08lhVIR3TGxacxpavvK5LzbxT+Y3iWkBchOTKS5hHCigA5aaung==";
       };
     };
     "ssb-ebt-5.6.7" = {
@@ -48460,13 +49027,13 @@ let
         sha512 = "ifPgPNmDE8EKuuoqtXibwgYNtDZNry7sJL1epSUb3XgQr62bUV31N9R5LHKDsI2kx96OgWRwWY2PfZ7vf/hU8Q==";
       };
     };
-    "ssb-friends-4.2.1" = {
+    "ssb-friends-4.3.0" = {
       name = "ssb-friends";
       packageName = "ssb-friends";
-      version = "4.2.1";
+      version = "4.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-friends/-/ssb-friends-4.2.1.tgz";
-        sha512 = "DgArf97p2MQxOKn9jWmyxA/6HUiyZkk5QFYohS/qo7CAFJzBJobgoJuvEGjzCgszJAZ/WmGwjYTrKTqFHwMEuQ==";
+        url = "https://registry.npmjs.org/ssb-friends/-/ssb-friends-4.3.0.tgz";
+        sha512 = "5NgtiuYM8M2g8crzQF2nCpenM70zhsb6PNeL6B0iXalAl/IN2wwEWSUhU8++2gTh9dZ7icZJ8nC/kCzIoUdmgA==";
       };
     };
     "ssb-git-0.5.0" = {
@@ -48631,22 +49198,13 @@ let
         sha512 = "6yI5XBpBHkwFdAELpKwlf1C1V32Z0/AKEJYsoU7lk+Eh88blv8LKydo4a1DnjMiPy4ywn4lRU5oayQaPE5MRtQ==";
       };
     };
-    "ssb-plugins-1.0.4" = {
+    "ssb-plugins-1.0.0" = {
       name = "ssb-plugins";
       packageName = "ssb-plugins";
-      version = "1.0.4";
+      version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-plugins/-/ssb-plugins-1.0.4.tgz";
-        sha512 = "D48CcHdlkQwkFnaBmEQFt/rPDqHZ252JJ/dqAuFvdpFTnZ5ujYmdbIldOdBGcTm3Bn7GrRGmAGctOKwH/3X0dQ==";
-      };
-    };
-    "ssb-private1-1.0.1" = {
-      name = "ssb-private1";
-      packageName = "ssb-private1";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-private1/-/ssb-private1-1.0.1.tgz";
-        sha512 = "x69YHNhjxCrknkK7XbEJyk2P0P3p52t6NF74I8ObHIrBdWnyRrO6iUH8K5b8CkaHawM4giXdZG5cyrOPzPN/Fg==";
+        url = "https://registry.npmjs.org/ssb-plugins/-/ssb-plugins-1.0.0.tgz";
+        sha512 = "eM8vid+K8MhwZwzk/CDUhSNhUoS6wYgq9clJrrKaP0/Otdd3zZzcBQw54Xvm0olMcOgpTSlY3m2rT4iqjZPIBw==";
       };
     };
     "ssb-pull-requests-1.0.0" = {
@@ -48856,13 +49414,13 @@ let
         sha1 = "a8f6eaeca90674c333e7c43953f275b451510695";
       };
     };
-    "stack-utils-2.0.2" = {
+    "stack-utils-2.0.3" = {
       name = "stack-utils";
       packageName = "stack-utils";
-      version = "2.0.2";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz";
-        sha512 = "0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==";
+        url = "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz";
+        sha512 = "gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==";
       };
     };
     "stackframe-1.2.0" = {
@@ -49981,6 +50539,15 @@ let
         sha512 = "luHn2OAMGJouOnadm6Fim6WXodQ2AWDkWjYq0rMdyEwzO5PdE4LzoXAEn9LL2snmBAlwUp1URVOTF7lZR3KU+Q==";
       };
     };
+    "stylis-3.5.4" = {
+      name = "stylis";
+      packageName = "stylis";
+      version = "3.5.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz";
+        sha512 = "8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==";
+      };
+    };
     "stylus-0.54.8" = {
       name = "stylus";
       packageName = "stylus";
@@ -50060,15 +50627,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.1.1.tgz";
         sha512 = "es33J1g2HjMpyAhz8lOR+ICmXXAqTuKbuXuUWLhOLew20oN9oUCgCJx615U/v7aioZg7IX5lIh9x34vwneu4pA==";
-      };
-    };
-    "suf-regex-0.0.25" = {
-      name = "suf-regex";
-      packageName = "suf-regex";
-      version = "0.0.25";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/suf-regex/-/suf-regex-0.0.25.tgz";
-        sha512 = "0hd6oSzoeqwFgFLtXRoA6lMndzTpgPZCSU+/sCoin0HyKnqni/GX/BkUe9Qgs4uRIV1pxsZzE2pEIbaiFX61AQ==";
       };
     };
     "sugarss-1.0.1" = {
@@ -50350,13 +50908,13 @@ let
         sha512 = "xk5CMbwoQVI53rTq9o/iMojAqXP5NT4/+TMeTP4uXWDIH18pB9AXgO5Olqt0RXuf3jH032DA4DS4qzem6XdXAw==";
       };
     };
-    "swagger-ui-dist-3.36.1" = {
+    "swagger-ui-dist-3.36.2" = {
       name = "swagger-ui-dist";
       packageName = "swagger-ui-dist";
-      version = "3.36.1";
+      version = "3.36.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.36.1.tgz";
-        sha512 = "p7lx/OubaaCzOfSYDuMbkRvf/a+rTnQAOySN/NhL+k6D5o9WXEEeKZwj/6fRHRoLSHKZq28jc1xQcz8HuYcgwQ==";
+        url = "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.36.2.tgz";
+        sha512 = "jbxorhRC/FKk8yMx5zEbg1A1sXc/vsW2vrDTJ3clmaMr9F12zsy161kwnxjVt/vVkMglDOz+BC8ZMY01toxHwA==";
       };
     };
     "swagger2openapi-6.2.3" = {
@@ -50467,13 +51025,13 @@ let
         sha512 = "YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==";
       };
     };
-    "systeminformation-4.28.1" = {
+    "systeminformation-4.30.1" = {
       name = "systeminformation";
       packageName = "systeminformation";
-      version = "4.28.1";
+      version = "4.30.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.28.1.tgz";
-        sha512 = "g9WQy+Igsf0efbbTlXzDkV7iYeUerFJeqI/zh07F9sWHxclejmXn5hrGdgHf2ok+1DuRmC9t4mEh7XS0b8Zk9w==";
+        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.30.1.tgz";
+        sha512 = "FrZISqs8G/oZfnzodPU/zCk41JIfa0os2WY6CJKuk9FwIVc9UWMJfRlgP307AkFu8IRjuVI/HiCNiP4dAnURTA==";
       };
     };
     "syswide-cas-5.3.0" = {
@@ -50630,13 +51188,13 @@ let
         sha512 = "4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==";
       };
     };
-    "tapable-2.0.0" = {
+    "tapable-2.1.1" = {
       name = "tapable";
       packageName = "tapable";
-      version = "2.0.0";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tapable/-/tapable-2.0.0.tgz";
-        sha512 = "bjzn0C0RWoffnNdTzNi7rNDhs1Zlwk2tRXgk8EiHKAOX1Mag3d6T0Y5zNa7l9CJ+EoUne/0UHdwS8tMbkh9zDg==";
+        url = "https://registry.npmjs.org/tapable/-/tapable-2.1.1.tgz";
+        sha512 = "Wib1S8m2wdpLbmQz0RBEVosIyvb/ykfKXf3ZIDqvWoMg/zTNm6G/tDSuUM61J1kNCDXWJrLHGSFeMhAG+gAGpQ==";
       };
     };
     "tape-2.3.3" = {
@@ -50693,15 +51251,6 @@ let
         sha512 = "tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==";
       };
     };
-    "tar-5.0.5" = {
-      name = "tar";
-      packageName = "tar";
-      version = "5.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tar/-/tar-5.0.5.tgz";
-        sha512 = "MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==";
-      };
-    };
     "tar-6.0.5" = {
       name = "tar";
       packageName = "tar";
@@ -50720,13 +51269,13 @@ let
         sha512 = "NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==";
       };
     };
-    "tar-fs-2.1.0" = {
+    "tar-fs-2.1.1" = {
       name = "tar-fs";
       packageName = "tar-fs";
-      version = "2.1.0";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz";
-        sha512 = "9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==";
+        url = "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz";
+        sha512 = "V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==";
       };
     };
     "tar-pack-3.4.1" = {
@@ -50837,13 +51386,13 @@ let
         sha512 = "WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==";
       };
     };
-    "temp-0.9.2" = {
+    "temp-0.9.4" = {
       name = "temp";
       packageName = "temp";
-      version = "0.9.2";
+      version = "0.9.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/temp/-/temp-0.9.2.tgz";
-        sha512 = "KLVd6CXeUYsqmI/LBWDLg3bFkdZPg0Xr/Gn79GUuPNiISzp6v/EKUaCOrxqeH1w/wVNmrljyDRgKxhZV9JzyJA==";
+        url = "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz";
+        sha512 = "yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==";
       };
     };
     "temp-dir-1.0.0" = {
@@ -50972,13 +51521,13 @@ let
         sha512 = "EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==";
       };
     };
-    "terser-5.3.8" = {
+    "terser-5.4.0" = {
       name = "terser";
       packageName = "terser";
-      version = "5.3.8";
+      version = "5.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/terser/-/terser-5.3.8.tgz";
-        sha512 = "zVotuHoIfnYjtlurOouTazciEfL7V38QMAOhGqpXDEg6yT13cF4+fEP9b0rrCEQTn+tT46uxgFsTZzhygk+CzQ==";
+        url = "https://registry.npmjs.org/terser/-/terser-5.4.0.tgz";
+        sha512 = "3dZunFLbCJis9TAF2VnX+VrQLctRUmt1p3W2kCsJuZE4ZgWqh//+1MZ62EanewrqKoUf4zIaDGZAvml4UDc0OQ==";
       };
     };
     "terser-webpack-plugin-1.4.5" = {
@@ -52151,6 +52700,15 @@ let
         sha1 = "405923909592d56f78a5818434b0b78489ca5f2b";
       };
     };
+    "try-catch-2.0.1" = {
+      name = "try-catch";
+      packageName = "try-catch";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/try-catch/-/try-catch-2.0.1.tgz";
+        sha512 = "LsOrmObN/2WdM+y2xG+t16vhYrQsnV8wftXIcIOWZhQcBJvKGYuamJGwnU98A7Jxs2oZNkJztXlphEOoA0DWqg==";
+      };
+    };
     "try-resolve-1.0.1" = {
       name = "try-resolve";
       packageName = "try-resolve";
@@ -52158,6 +52716,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz";
         sha1 = "cfde6fabd72d63e5797cfaab873abbe8e700e912";
+      };
+    };
+    "try-to-catch-1.1.1" = {
+      name = "try-to-catch";
+      packageName = "try-to-catch";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/try-to-catch/-/try-to-catch-1.1.1.tgz";
+        sha512 = "ikUlS+/BcImLhNYyIgZcEmq4byc31QpC+46/6Jm5ECWkVFhf8SM2Fp/0pMVXPX6vk45SMCwrP4Taxucne8I0VA==";
       };
     };
     "ts-invariant-0.3.3" = {
@@ -52484,13 +53051,13 @@ let
         sha1 = "b75bc2df15649bb84e8b9aa3c0669c6c4bce0d25";
       };
     };
-    "twig-1.15.2" = {
+    "twig-1.15.3" = {
       name = "twig";
       packageName = "twig";
-      version = "1.15.2";
+      version = "1.15.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/twig/-/twig-1.15.2.tgz";
-        sha512 = "n7w76E8gzguhcLyKcjlT3sYWGdBTgZY2DO/frcbZ5Fk7LwMRoTathvWMFxZyJ2HYRJ+rEzccw6nu3fsy7ceGGQ==";
+        url = "https://registry.npmjs.org/twig/-/twig-1.15.3.tgz";
+        sha512 = "ePfzzS7vzzn/Kb8vs/IkCvCNZltBPeBW8B/1blN/Bxh5ubxnZEGI5ysgr8t1Dr0/We9ahLDfqC78fNzDvCMkpw==";
       };
     };
     "twitter-1.7.1" = {
@@ -52601,13 +53168,13 @@ let
         sha512 = "eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==";
       };
     };
-    "type-fest-0.18.0" = {
+    "type-fest-0.18.1" = {
       name = "type-fest";
       packageName = "type-fest";
-      version = "0.18.0";
+      version = "0.18.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/type-fest/-/type-fest-0.18.0.tgz";
-        sha512 = "fbDukFPnJBdn2eZ3RR+5mK2slHLFd6gYHY7jna1KWWy4Yr4XysHuCdXRzy+RiG/HwG4WJat00vdC2UHky5eKiQ==";
+        url = "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz";
+        sha512 = "OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==";
       };
     };
     "type-fest-0.3.1" = {
@@ -52844,13 +53411,13 @@ let
         sha512 = "FyYnoxVL1D6+jDGQpbK5jW6y/2JlVfRfEeQ67BPCUg5wfCjaKOpr2XeceE4QL+MkhxliLtf5EbrMDZgzpt2CNw==";
       };
     };
-    "uglify-js-3.11.5" = {
+    "uglify-js-3.11.6" = {
       name = "uglify-js";
       packageName = "uglify-js";
-      version = "3.11.5";
+      version = "3.11.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.5.tgz";
-        sha512 = "btvv/baMqe7HxP7zJSF7Uc16h1mSfuuSplT0/qdjxseesDU+yYzH33eHBH+eMdeRXwujXspaCTooWHQVVBh09w==";
+        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.6.tgz";
+        sha512 = "oASI1FOJ7BBFkSCNDZ446EgkSuHkOZBuqRFrwXIKWCoXw8ZXQETooTQjkAcBS03Acab7ubCKsXnwuV2svy061g==";
       };
     };
     "uglify-js-3.4.10" = {
@@ -52869,6 +53436,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz";
         sha1 = "6e0924d6bda6b5afe349e39a6d632850a0f882b7";
+      };
+    };
+    "uglifycss-0.0.29" = {
+      name = "uglifycss";
+      packageName = "uglifycss";
+      version = "0.0.29";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uglifycss/-/uglifycss-0.0.29.tgz";
+        sha512 = "J2SQ2QLjiknNGbNdScaNZsXgmMGI0kYNrXaDlr4obnPW9ni1jljb1NeEVWAiTgZ8z+EBWP2ozfT9vpy03rjlMQ==";
       };
     };
     "uid-0.0.2" = {
@@ -52968,6 +53544,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz";
         sha512 = "4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==";
+      };
+    };
+    "unbound-0.4.3" = {
+      name = "unbound";
+      packageName = "unbound";
+      version = "0.4.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unbound/-/unbound-0.4.3.tgz";
+        sha512 = "2ISqZLXtzp1l9f1V8Yr6S+zuhXxEwE1CjKHjXULFDHJcfhc9Gm3mn19hdPp4rlNGEdCivKYGKjYe3WRGnafYdA==";
       };
     };
     "unbzip2-stream-1.4.3" = {
@@ -53186,15 +53771,6 @@ let
         sha1 = "14bc6cd40d98ffff75b405506bad873ecbbac3ba";
       };
     };
-    "unified-4.2.1" = {
-      name = "unified";
-      packageName = "unified";
-      version = "4.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/unified/-/unified-4.2.1.tgz";
-        sha1 = "76ff43aa8da430f6e7e4a55c84ebac2ad2cfcd2e";
-      };
-    };
     "unified-6.2.0" = {
       name = "unified";
       packageName = "unified";
@@ -53357,13 +53933,13 @@ let
         sha1 = "e2f7876828903a6a9308e362051f86b14f35b545";
       };
     };
-    "unist-util-find-1.0.1" = {
+    "unist-util-find-1.0.2" = {
       name = "unist-util-find";
       packageName = "unist-util-find";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/unist-util-find/-/unist-util-find-1.0.1.tgz";
-        sha1 = "1062bbb6928c7a97c6adc89b53745d4c46c222a2";
+        url = "https://registry.npmjs.org/unist-util-find/-/unist-util-find-1.0.2.tgz";
+        sha512 = "ft06UDYzqi9o9RmGP0sZWI/zvLLQiBW2/MD+rW6mDqbOWDcmknGX9orQPspfuGRYWr8eSJAmfsBcvOpfGRJseA==";
       };
     };
     "unist-util-find-all-after-1.0.5" = {
@@ -53949,6 +54525,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz";
         sha1 = "da937f7a62e21fec1fd18d49b35c2935067a6c72";
+      };
+    };
+    "urkel-0.6.3" = {
+      name = "urkel";
+      packageName = "urkel";
+      version = "0.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/urkel/-/urkel-0.6.3.tgz";
+        sha512 = "aY/u3cpCRRwa3XjUGG8DcLcQJSNmQ0+qXDeT0igDytKhrK+yiusZ7mYdPRzmtbQ2CPozHhwsmVxCVBkPBp9jDQ==";
       };
     };
     "url-0.10.3" = {
@@ -55131,13 +55716,13 @@ let
         sha512 = "lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA==";
       };
     };
-    "videostream-3.2.1" = {
+    "videostream-3.2.2" = {
       name = "videostream";
       packageName = "videostream";
-      version = "3.2.1";
+      version = "3.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/videostream/-/videostream-3.2.1.tgz";
-        sha512 = "Z4EcsX9aYNJZD1M+0jCeQ0t+5ETlHE88B2SF1fCuVxfn+XxHGJVec6tbHGqpULk4esOOLJEipAScOCDGHk+teQ==";
+        url = "https://registry.npmjs.org/videostream/-/videostream-3.2.2.tgz";
+        sha512 = "4tz23yGGeATmbzj/ZnUm6wgQ4E1lzmMXu2mUA/c0G6adtWKxm1Di5YejdZdRsK6SdkLjKjhplFFYT7r+UUDKvA==";
       };
     };
     "vinyl-0.5.3" = {
@@ -55230,13 +55815,13 @@ let
         sha512 = "gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==";
       };
     };
-    "vls-0.5.5" = {
+    "vls-0.5.9" = {
       name = "vls";
       packageName = "vls";
-      version = "0.5.5";
+      version = "0.5.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vls/-/vls-0.5.5.tgz";
-        sha512 = "DDfnr83S2jAXWA0TLOy3t2g+wgTzo+hUNz8aYcF4WQrCTlNVyDsZ3wtcCa5koZVYWbfDitfBAlbqkqIpjeaDng==";
+        url = "https://registry.npmjs.org/vls/-/vls-0.5.9.tgz";
+        sha512 = "9IGH1YFto0XvLHRKzdOQmkzqnIQOO/yTe77ieaOTJM4Zrr5dDqZKEBwboJyEpx5jy4R1TNUh7HTI+DwhWUtiLQ==";
       };
     };
     "vm-browserify-1.1.2" = {
@@ -55320,15 +55905,6 @@ let
         sha512 = "X4pzcrJ8dE7M3ArFuySF5fgipKDd/EauXkiJwtjBIVRWpVNq0tF9+lNCyuC7iDUwP3Oq7ow/TGssD3GdG96Jow==";
       };
     };
-    "vscode-emmet-helper-2.1.1" = {
-      name = "vscode-emmet-helper";
-      packageName = "vscode-emmet-helper";
-      version = "2.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-emmet-helper/-/vscode-emmet-helper-2.1.1.tgz";
-        sha512 = "598eqXynvHDBdjgZqjTTg3XNb0SIvlVIc22/DwqxKjTKJLqe4LDCWi0H1yYBvU0Eb1FAJSh/l04InFxuI/mDVg==";
-      };
-    };
     "vscode-html-languageservice-2.1.12" = {
       name = "vscode-html-languageservice";
       packageName = "vscode-html-languageservice";
@@ -55345,6 +55921,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.10.0.tgz";
         sha512 = "8IvuRSQnjznu+obqy6Dy4S4H68Ke7a3Kb+A0FcdctyAMAWEnrORpCpMOMqEYiPLm/OTYLVWJ7ql3qToDTozu4w==";
+      };
+    };
+    "vscode-json-languageservice-3.8.4" = {
+      name = "vscode-json-languageservice";
+      packageName = "vscode-json-languageservice";
+      version = "3.8.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.8.4.tgz";
+        sha512 = "njDG0+YJvYNKXH+6plQGZMxgbifATFrRpC6Qnm/SAn4IW8bMHxsYunsxrjtpqK42CVSz6Lr7bpbTEZbVuOmFLw==";
       };
     };
     "vscode-jsonrpc-3.5.0" = {
@@ -55390,15 +55975,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.1.0-next.1.tgz";
         sha512 = "mwLDojZkbmpizSJSmp690oa9FB9jig18SIDGZeBCvFc2/LYSRvMm/WwWtMBJuJ1MfFh7rZXfQige4Uje5Z9NzA==";
-      };
-    };
-    "vscode-jsonrpc-6.0.0-next.5" = {
-      name = "vscode-jsonrpc";
-      packageName = "vscode-jsonrpc";
-      version = "6.0.0-next.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.5.tgz";
-        sha512 = "IAgsltQPwg/pXOPsdXgbUTCaO9VSKZwirZN5SGtkdYQ/R3VjeC4v00WTVvoNayWMZpoC3O9u0ogqmsKzKhVasQ==";
       };
     };
     "vscode-jsonrpc-6.0.0-next.7" = {
@@ -55491,15 +56067,6 @@ let
         sha512 = "UCXULa/RmT2zxcb6auNezl9ZIPwYHS15+a0XzybrpT2+xA0RbHEYQCsIQkTRYjGv8cm3yS9iPJMmxLilP+y1Xw==";
       };
     };
-    "vscode-languageserver-7.0.0-next.7" = {
-      name = "vscode-languageserver";
-      packageName = "vscode-languageserver";
-      version = "7.0.0-next.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0-next.7.tgz";
-        sha512 = "6La+usoCF0OnCYIbOLBTmqgzaZSAyIBpnsLjS/g7AnI8Pv9v6yzC38VhTvBoip4/ZBwf1U8vpdwatD/qCSKeWA==";
-      };
-    };
     "vscode-languageserver-protocol-3.14.1" = {
       name = "vscode-languageserver-protocol";
       packageName = "vscode-languageserver-protocol";
@@ -55534,15 +56101,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.2.tgz";
         sha512 = "atmkGT/W6tF0cx4SaWFYtFs2UeSeC28RPiap9myv2YZTaTCFvTBEPNWrU5QRKfkyM0tbgtGo6T3UCQ8tkDpjzA==";
-      };
-    };
-    "vscode-languageserver-protocol-3.16.0-next.7" = {
-      name = "vscode-languageserver-protocol";
-      packageName = "vscode-languageserver-protocol";
-      version = "3.16.0-next.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.7.tgz";
-        sha512 = "tOjrg+K3RddJ547zpC9/LAgTbzadkPuHlqJFFWIcKjVhiJOh73XyY+Ngcu9wukGaTsuSGjJ0W8rlmwanixa0FQ==";
       };
     };
     "vscode-languageserver-protocol-3.5.1" = {
@@ -55615,15 +56173,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz";
         sha512 = "QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==";
-      };
-    };
-    "vscode-languageserver-types-3.16.0-next.3" = {
-      name = "vscode-languageserver-types";
-      packageName = "vscode-languageserver-types";
-      version = "3.16.0-next.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.3.tgz";
-        sha512 = "s/z5ZqSe7VpoXJ6JQcvwRiPPA3nG0nAcJ/HH03zoU6QaFfnkcgPK+HshC3WKPPnC2G08xA0iRB6h7kmyBB5Adg==";
       };
     };
     "vscode-languageserver-types-3.16.0-next.4" = {
@@ -55732,15 +56281,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz";
         sha512 = "8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==";
-      };
-    };
-    "vscode-web-custom-data-0.3.1" = {
-      name = "vscode-web-custom-data";
-      packageName = "vscode-web-custom-data";
-      version = "0.3.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-web-custom-data/-/vscode-web-custom-data-0.3.1.tgz";
-        sha512 = "pFWfUyoJoROfzk7l8+QK1aHsAcfb8fJP8iaEghMbASbYieaGOOnfovNjPIrJmhNf84RGn36R6r2030i9Eld7vA==";
       };
     };
     "vstream-0.1.0" = {
@@ -55914,6 +56454,15 @@ let
         sha512 = "aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==";
       };
     };
+    "watchpack-1.7.5" = {
+      name = "watchpack";
+      packageName = "watchpack";
+      version = "1.7.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz";
+        sha512 = "9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==";
+      };
+    };
     "watchpack-2.0.1" = {
       name = "watchpack";
       packageName = "watchpack";
@@ -55923,13 +56472,13 @@ let
         sha512 = "vO8AKGX22ZRo6PiOFM9dC0re8IcKh8Kd/aH2zeqUc6w4/jBGlTy2P7fTC6ekT0NjVeGjgU2dGC5rNstKkeLEQg==";
       };
     };
-    "watchpack-chokidar2-2.0.0" = {
+    "watchpack-chokidar2-2.0.1" = {
       name = "watchpack-chokidar2";
       packageName = "watchpack-chokidar2";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz";
-        sha512 = "9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==";
+        url = "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz";
+        sha512 = "nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==";
       };
     };
     "watershed-0.3.4" = {
@@ -57102,6 +57651,15 @@ let
         sha512 = "D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==";
       };
     };
+    "ws-7.4.0" = {
+      name = "ws";
+      packageName = "ws";
+      version = "7.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz";
+        sha512 = "kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==";
+      };
+    };
     "x-default-browser-0.3.1" = {
       name = "x-default-browser";
       packageName = "x-default-browser";
@@ -57679,15 +58237,6 @@ let
         sha512 = "2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==";
       };
     };
-    "yaml-ast-parser-custom-tags-0.0.43" = {
-      name = "yaml-ast-parser-custom-tags";
-      packageName = "yaml-ast-parser-custom-tags";
-      version = "0.0.43";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/yaml-ast-parser-custom-tags/-/yaml-ast-parser-custom-tags-0.0.43.tgz";
-        sha512 = "R5063FF/JSAN6qXCmylwjt9PcDH6M0ExEme/nJBzLspc6FJDmHHIqM7xh2WfEmsTJqClF79A9VkXjkAqmZw9SQ==";
-      };
-    };
     "yaml-front-matter-3.4.1" = {
       name = "yaml-front-matter";
       packageName = "yaml-front-matter";
@@ -57706,13 +58255,13 @@ let
         sha1 = "87cfa5a9613f48e26005420d6a8ee0da6fe8daec";
       };
     };
-    "yaml-language-server-0.11.1" = {
+    "yaml-language-server-0.12.0" = {
       name = "yaml-language-server";
       packageName = "yaml-language-server";
-      version = "0.11.1";
+      version = "0.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.11.1.tgz";
-        sha512 = "N3Tu3g4O6ZWV7W0LVsNk62DtKJDQkbnPZRDd7ntaAeEl8QkxL1vnMunI26uzDU4PwwG4tPJ8g/VRS6U+fVp/6A==";
+        url = "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.12.0.tgz";
+        sha512 = "EAr9fJi05wVWsFVgc4s0AI74nT6D2oN7xcy7W+7JCkvirbm0L7aPDRAjSz6z/dXVyYyFlEAgRWVThXzqguFyTw==";
       };
     };
     "yaml-language-server-parser-0.1.1" = {
@@ -57805,13 +58354,13 @@ let
         sha512 = "6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==";
       };
     };
-    "yargs-16.1.0" = {
+    "yargs-16.1.1" = {
       name = "yargs";
       packageName = "yargs";
-      version = "16.1.0";
+      version = "16.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs/-/yargs-16.1.0.tgz";
-        sha512 = "upWFJOmDdHN0syLuESuvXDmrRcWd1QafJolHskzaw79uZa7/x53gxQKiR07W59GWY1tFhhU/Th9DrtSfpS782g==";
+        url = "https://registry.npmjs.org/yargs/-/yargs-16.1.1.tgz";
+        sha512 = "hAD1RcFP/wfgfxgMVswPE+z3tlPFtxG8/yWUrG2i17sTWGCGqWnxKcLTF4cUKDUK8fzokwsmO9H0TDkRbMHy8w==";
       };
     };
     "yargs-3.10.0" = {
@@ -57913,13 +58462,13 @@ let
         sha1 = "85568de3cf150ff49fa51825f03a8c880ddcc5c4";
       };
     };
-    "yargs-parser-20.2.3" = {
+    "yargs-parser-20.2.4" = {
       name = "yargs-parser";
       packageName = "yargs-parser";
-      version = "20.2.3";
+      version = "20.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz";
-        sha512 = "emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==";
+        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz";
+        sha512 = "WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==";
       };
     };
     "yargs-parser-4.2.1" = {
@@ -58189,28 +58738,27 @@ in
   "@angular/cli" = nodeEnv.buildNodePackage {
     name = "_at_angular_slash_cli";
     packageName = "@angular/cli";
-    version = "10.2.0";
+    version = "11.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@angular/cli/-/cli-10.2.0.tgz";
-      sha512 = "YBzwkFBmG6CdUJk8onsPXxHX/ByU5MERBQgYhLC873e2nZlXMUu+Ttq2Wai6apyskGvsXKxZNPOQSFZTGKXzXg==";
+      url = "https://registry.npmjs.org/@angular/cli/-/cli-11.0.1.tgz";
+      sha512 = "zB20jTLQxLpkJjhbYelhRyMcgGsjwbD8pSYYAO6QX656Tx1tCtJ2UskEtf4ePQvgzu0Ds2dnAEfco+tekIMRTA==";
     };
     dependencies = [
-      sources."@angular-devkit/architect-0.1002.0"
-      sources."@angular-devkit/core-10.2.0"
-      sources."@angular-devkit/schematics-10.2.0"
-      sources."@schematics/angular-10.2.0"
-      sources."@schematics/update-0.1002.0"
+      sources."@angular-devkit/architect-0.1100.1"
+      sources."@angular-devkit/core-11.0.1"
+      sources."@angular-devkit/schematics-11.0.1"
+      sources."@schematics/angular-11.0.1"
+      sources."@schematics/update-0.1100.1"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."JSONStream-1.3.5"
       sources."agent-base-4.3.0"
       sources."agentkeepalive-3.5.2"
-      sources."ajv-6.12.4"
+      sources."ajv-6.12.6"
       sources."ansi-colors-4.1.1"
       sources."ansi-escapes-4.3.1"
       sources."ansi-regex-5.0.0"
       sources."ansi-styles-4.3.0"
       sources."aproba-1.2.0"
-      sources."asap-2.0.6"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."asynckit-0.4.0"
@@ -58229,7 +58777,6 @@ in
           sources."yallist-3.1.1"
         ];
       })
-      sources."call-bind-1.0.0"
       sources."caseless-0.12.0"
       sources."chalk-4.1.0"
       sources."chardet-0.7.0"
@@ -58251,12 +58798,9 @@ in
       sources."core-util-is-1.0.2"
       sources."cyclist-1.0.1"
       sources."dashdash-1.14.1"
-      sources."debug-4.1.1"
-      sources."debuglog-1.0.1"
+      sources."debug-4.2.0"
       sources."defaults-1.0.3"
-      sources."define-properties-1.1.3"
       sources."delayed-stream-1.0.0"
-      sources."dezalgo-1.0.3"
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
       sources."emoji-regex-8.0.0"
@@ -58267,8 +58811,6 @@ in
       })
       sources."end-of-stream-1.4.4"
       sources."err-code-1.1.2"
-      sources."es-abstract-1.17.7"
-      sources."es-to-primitive-1.2.1"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
@@ -58288,7 +58830,6 @@ in
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."genfun-5.0.0"
-      sources."get-intrinsic-1.0.1"
       sources."get-stream-4.1.0"
       sources."getpass-0.1.7"
       sources."glob-7.1.6"
@@ -58297,7 +58838,6 @@ in
       sources."har-validator-5.1.5"
       sources."has-1.0.3"
       sources."has-flag-4.0.0"
-      sources."has-symbols-1.0.1"
       sources."hosted-git-info-3.0.7"
       sources."http-cache-semantics-3.8.1"
       (sources."http-proxy-agent-2.1.0" // {
@@ -58323,15 +58863,10 @@ in
       sources."ini-1.3.5"
       sources."inquirer-7.3.3"
       sources."ip-1.1.5"
-      sources."is-callable-1.2.2"
       sources."is-core-module-2.1.0"
-      sources."is-date-object-1.0.2"
       sources."is-docker-2.1.1"
       sources."is-fullwidth-code-point-3.0.0"
       sources."is-interactive-1.0.0"
-      sources."is-negative-zero-2.0.0"
-      sources."is-regex-1.1.1"
-      sources."is-symbol-1.0.3"
       sources."is-typedarray-1.0.0"
       sources."is-wsl-2.2.0"
       sources."isarray-1.0.0"
@@ -58339,11 +58874,10 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-parse-better-errors-1.0.2"
-      sources."json-parse-even-better-errors-2.3.1"
       sources."json-schema-0.2.3"
       sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
-      sources."jsonc-parser-2.3.0"
+      sources."jsonc-parser-2.3.1"
       sources."jsonparse-1.3.1"
       sources."jsprim-1.4.1"
       sources."lodash-4.17.20"
@@ -58386,7 +58920,7 @@ in
       sources."npm-bundled-1.1.1"
       sources."npm-install-checks-4.0.0"
       sources."npm-normalize-package-bin-1.0.1"
-      sources."npm-package-arg-8.0.1"
+      sources."npm-package-arg-8.1.0"
       sources."npm-packlist-1.4.8"
       sources."npm-pick-manifest-6.1.0"
       (sources."npm-registry-fetch-4.0.7" // {
@@ -58399,14 +58933,10 @@ in
         ];
       })
       sources."oauth-sign-0.9.0"
-      sources."object-inspect-1.8.0"
-      sources."object-keys-1.1.1"
-      sources."object.assign-4.1.2"
-      sources."object.getownpropertydescriptors-2.1.0"
       sources."once-1.4.0"
       sources."onetime-5.1.2"
-      sources."open-7.2.0"
-      sources."ora-5.0.0"
+      sources."open-7.3.0"
+      sources."ora-5.1.0"
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
       sources."osenv-0.1.5"
@@ -58438,14 +58968,11 @@ in
       })
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
-      sources."read-package-json-2.1.2"
-      sources."read-package-tree-5.3.1"
       (sources."readable-stream-2.3.7" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
         ];
       })
-      sources."readdir-scoped-modules-1.1.0"
       (sources."request-2.88.2" // {
         dependencies = [
           sources."uuid-3.4.0"
@@ -58457,7 +58984,7 @@ in
       sources."rimraf-3.0.2"
       sources."run-async-2.4.1"
       sources."run-queue-1.0.3"
-      sources."rxjs-6.6.2"
+      sources."rxjs-6.6.3"
       sources."safe-buffer-5.2.1"
       sources."safer-buffer-2.1.2"
       sources."semver-7.3.2"
@@ -58485,16 +59012,6 @@ in
       sources."stream-each-1.2.3"
       sources."stream-shift-1.0.1"
       sources."string-width-4.2.0"
-      (sources."string.prototype.trimend-1.0.2" // {
-        dependencies = [
-          sources."es-abstract-1.18.0-next.1"
-        ];
-      })
-      (sources."string.prototype.trimstart-1.0.2" // {
-        dependencies = [
-          sources."es-abstract-1.18.0-next.1"
-        ];
-      })
       (sources."string_decoder-1.1.1" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
@@ -58502,7 +59019,7 @@ in
       })
       sources."strip-ansi-6.0.0"
       sources."supports-color-7.2.0"
-      sources."symbol-observable-1.2.0"
+      sources."symbol-observable-2.0.3"
       (sources."tar-4.4.13" // {
         dependencies = [
           sources."yallist-3.1.1"
@@ -58526,8 +59043,7 @@ in
       })
       sources."uri-js-4.4.0"
       sources."util-deprecate-1.0.2"
-      sources."util-promisify-2.1.0"
-      sources."uuid-8.3.0"
+      sources."uuid-8.3.1"
       sources."validate-npm-package-license-3.0.4"
       sources."validate-npm-package-name-3.0.0"
       sources."verror-1.10.0"
@@ -58621,7 +59137,7 @@ in
       sources."braces-3.0.2"
       (sources."buffer-5.7.1" // {
         dependencies = [
-          sources."base64-js-1.3.1"
+          sources."base64-js-1.5.1"
         ];
       })
       sources."buffer-crc32-0.2.13"
@@ -58864,7 +59380,7 @@ in
         ];
       })
       sources."to-utf8-0.0.1"
-      sources."uglify-js-3.11.5"
+      sources."uglify-js-3.11.6"
       sources."unc-path-regex-0.1.2"
       sources."unique-stream-2.3.1"
       sources."universalify-0.1.2"
@@ -58904,10 +59420,10 @@ in
   "@bitwarden/cli" = nodeEnv.buildNodePackage {
     name = "_at_bitwarden_slash_cli";
     packageName = "@bitwarden/cli";
-    version = "1.12.1";
+    version = "1.13.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@bitwarden/cli/-/cli-1.12.1.tgz";
-      sha512 = "H1KuRpjyqNTzqQZZg3tTVmm+cDDDm23AcLvbA59A4EqfxMkVZ6gT+FqUtWEuQ7AFO28W56wdilYGSf9tQ6ySgA==";
+      url = "https://registry.npmjs.org/@bitwarden/cli/-/cli-1.13.2.tgz";
+      sha512 = "DqNFJ3OgwJweYGc8pxYUW6mJGLSAMN3QH8mtXOwiy3I/SR5QY+ebbEd5XhCdibjHk5nIyLAiP8Erkdevhjuozw==";
     };
     dependencies = [
       sources."abab-2.0.5"
@@ -59070,20 +59586,15 @@ in
   "@nestjs/cli" = nodeEnv.buildNodePackage {
     name = "_at_nestjs_slash_cli";
     packageName = "@nestjs/cli";
-    version = "7.5.2";
+    version = "7.5.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@nestjs/cli/-/cli-7.5.2.tgz";
-      sha512 = "qxh5aqQbxzQe8Tuc3CF8nLb1KsWCjLabSAZm+hlxrWYSJzbffbn947MPmsIwZdXgAXZ6AprmJV5KeB2U6DoM+w==";
+      url = "https://registry.npmjs.org/@nestjs/cli/-/cli-7.5.3.tgz";
+      sha512 = "PgpdXaNNtWMRAnDzMEXjbCXDiJWoNcmnKa6HhJ9iLJaqdXkIILiLthJx64sZxB6GiE4UYWjbX/KuPH3N2dx/6Q==";
     };
     dependencies = [
-      sources."@angular-devkit/core-10.2.0"
-      (sources."@angular-devkit/schematics-10.2.0" // {
-        dependencies = [
-          sources."chalk-4.1.0"
-          sources."ora-5.0.0"
-        ];
-      })
-      sources."@angular-devkit/schematics-cli-0.1002.0"
+      sources."@angular-devkit/core-11.0.1"
+      sources."@angular-devkit/schematics-11.0.1"
+      sources."@angular-devkit/schematics-cli-0.1100.1"
       sources."@babel/code-frame-7.10.4"
       sources."@babel/helper-validator-identifier-7.10.4"
       (sources."@babel/highlight-7.10.4" // {
@@ -59096,15 +59607,20 @@ in
           sources."supports-color-5.5.0"
         ];
       })
-      sources."@nestjs/schematics-7.2.1"
-      sources."@schematics/schematics-0.1002.0"
+      (sources."@nestjs/schematics-7.2.2" // {
+        dependencies = [
+          sources."@angular-devkit/core-11.0.0"
+          sources."@angular-devkit/schematics-11.0.0"
+        ];
+      })
+      sources."@schematics/schematics-0.1100.1"
       sources."@types/anymatch-1.3.1"
-      sources."@types/eslint-7.2.4"
+      sources."@types/eslint-7.2.5"
       sources."@types/eslint-scope-3.7.0"
       sources."@types/estree-0.0.45"
       sources."@types/json-schema-7.0.6"
       sources."@types/json5-0.0.29"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."@types/parse-json-4.0.0"
       sources."@types/source-list-map-0.1.2"
       sources."@types/tapable-1.0.6"
@@ -59113,7 +59629,7 @@ in
           sources."source-map-0.6.1"
         ];
       })
-      (sources."@types/webpack-4.41.24" // {
+      (sources."@types/webpack-4.41.25" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -59140,10 +59656,11 @@ in
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.2"
       sources."acorn-8.0.4"
-      sources."ajv-6.12.4"
+      sources."ajv-6.12.6"
       sources."ajv-keywords-3.5.2"
+      sources."ansi-colors-4.1.1"
       sources."ansi-escapes-4.3.1"
-      sources."ansi-regex-5.0.0"
+      sources."ansi-regex-3.0.0"
       sources."ansi-styles-4.3.0"
       sources."anymatch-3.1.1"
       sources."at-least-node-1.0.0"
@@ -59151,10 +59668,10 @@ in
       sources."binary-extensions-2.1.0"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
-      sources."browserslist-4.14.6"
+      sources."browserslist-4.14.7"
       sources."buffer-from-1.1.1"
       sources."callsites-3.1.0"
-      sources."caniuse-lite-1.0.30001156"
+      sources."caniuse-lite-1.0.30001158"
       sources."chalk-3.0.0"
       sources."chardet-0.7.0"
       sources."chokidar-3.4.3"
@@ -59166,6 +59683,7 @@ in
       sources."clone-1.0.4"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
+      sources."colorette-1.2.1"
       sources."colors-1.4.0"
       sources."commander-4.1.1"
       sources."concat-map-0.0.1"
@@ -59174,7 +59692,7 @@ in
       sources."cross-spawn-7.0.3"
       sources."deepmerge-4.2.2"
       sources."defaults-1.0.3"
-      sources."electron-to-chromium-1.3.589"
+      sources."electron-to-chromium-1.3.596"
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
       sources."enhanced-resolve-4.3.0"
@@ -59197,7 +59715,7 @@ in
       sources."figures-3.2.0"
       sources."fill-range-7.0.1"
       sources."find-up-4.1.0"
-      (sources."fork-ts-checker-webpack-plugin-5.2.1" // {
+      (sources."fork-ts-checker-webpack-plugin-6.0.2" // {
         dependencies = [
           sources."chalk-4.1.0"
         ];
@@ -59221,9 +59739,11 @@ in
       sources."inherits-2.0.4"
       (sources."inquirer-7.3.3" // {
         dependencies = [
+          sources."ansi-regex-5.0.0"
           sources."chalk-4.1.0"
           sources."is-fullwidth-code-point-3.0.0"
           sources."string-width-4.2.0"
+          sources."strip-ansi-6.0.0"
         ];
       })
       sources."interpret-1.4.0"
@@ -59272,7 +59792,7 @@ in
       sources."mute-stream-0.0.8"
       sources."neo-async-2.6.2"
       sources."node-emoji-1.10.0"
-      sources."node-releases-1.1.65"
+      sources."node-releases-1.1.66"
       sources."normalize-path-3.0.0"
       sources."npm-run-path-4.0.1"
       sources."object-assign-4.1.1"
@@ -59280,7 +59800,9 @@ in
       sources."onetime-5.1.2"
       (sources."ora-5.1.0" // {
         dependencies = [
+          sources."ansi-regex-5.0.0"
           sources."chalk-4.1.0"
+          sources."strip-ansi-6.0.0"
         ];
       })
       sources."os-name-4.0.0"
@@ -59306,12 +59828,12 @@ in
       sources."readable-stream-2.3.7"
       sources."readdirp-3.5.0"
       sources."rechoir-0.6.2"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-from-4.0.0"
       sources."restore-cursor-3.1.0"
       sources."rimraf-3.0.2"
       sources."run-async-2.4.1"
-      sources."rxjs-6.6.2"
+      sources."rxjs-6.6.3"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."schema-utils-2.7.0"
@@ -59329,27 +59851,21 @@ in
         ];
       })
       sources."sourcemap-codec-1.4.8"
-      (sources."string-width-2.1.1" // {
-        dependencies = [
-          sources."ansi-regex-3.0.0"
-          sources."strip-ansi-4.0.0"
-        ];
-      })
+      sources."string-width-2.1.1"
       sources."string_decoder-1.1.1"
-      sources."strip-ansi-6.0.0"
+      sources."strip-ansi-4.0.0"
       sources."strip-bom-3.0.0"
       sources."strip-final-newline-2.0.0"
       sources."supports-color-7.2.0"
-      sources."symbol-observable-1.2.0"
+      sources."symbol-observable-2.0.3"
       sources."tapable-1.1.3"
-      (sources."terser-5.3.8" // {
+      (sources."terser-5.4.0" // {
         dependencies = [
           sources."commander-2.20.3"
         ];
       })
       (sources."terser-webpack-plugin-5.0.3" // {
         dependencies = [
-          sources."ajv-6.12.6"
           sources."p-limit-3.0.2"
           sources."schema-utils-3.0.0"
           sources."source-map-0.6.1"
@@ -59380,10 +59896,9 @@ in
       sources."wcwidth-1.0.1"
       (sources."webpack-5.4.0" // {
         dependencies = [
-          sources."ajv-6.12.6"
           sources."enhanced-resolve-5.3.1"
           sources."schema-utils-3.0.0"
-          sources."tapable-2.0.0"
+          sources."tapable-2.1.1"
         ];
       })
       sources."webpack-node-externals-2.5.2"
@@ -59736,7 +60251,7 @@ in
       sources."@types/long-4.0.1"
       sources."@types/mime-2.0.3"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       (sources."@types/node-fetch-2.5.7" // {
         dependencies = [
           sources."form-data-3.0.0"
@@ -59745,9 +60260,9 @@ in
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/qs-6.9.5"
       sources."@types/range-parser-1.2.3"
-      sources."@types/serve-static-1.13.6"
+      sources."@types/serve-static-1.13.7"
       sources."@types/through-0.0.30"
-      sources."@types/ws-7.2.9"
+      sources."@types/ws-7.4.0"
       sources."@types/zen-observable-0.8.1"
       sources."@vue/cli-shared-utils-4.5.8"
       (sources."@vue/cli-ui-4.5.8" // {
@@ -59909,7 +60424,7 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."big.js-5.2.2"
       sources."binary-extensions-1.13.1"
@@ -59949,7 +60464,7 @@ in
       })
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
-      sources."browserslist-4.14.6"
+      sources."browserslist-4.14.7"
       sources."buffer-5.7.1"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
@@ -59977,7 +60492,7 @@ in
       sources."callsites-2.0.0"
       sources."camel-case-4.1.1"
       sources."camelcase-4.1.0"
-      sources."caniuse-lite-1.0.30001156"
+      sources."caniuse-lite-1.0.30001158"
       sources."capital-case-1.0.3"
       sources."capture-stack-trace-1.0.1"
       sources."cardinal-2.1.1"
@@ -60068,6 +60583,7 @@ in
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
+      sources."colorette-1.2.1"
       sources."colors-1.4.0"
       sources."combined-stream-1.0.8"
       sources."commander-2.20.3"
@@ -60115,7 +60631,7 @@ in
       sources."crypto-random-string-1.0.0"
       sources."cssesc-3.0.0"
       sources."cssfilter-0.0.10"
-      sources."csstype-2.6.13"
+      sources."csstype-2.6.14"
       sources."csv-parser-1.12.1"
       sources."dashdash-1.14.1"
       sources."date-fns-1.30.1"
@@ -60181,11 +60697,11 @@ in
       })
       sources."download-git-repo-3.0.2"
       sources."duplexer3-0.1.4"
-      sources."easy-stack-1.0.0"
+      sources."easy-stack-1.0.1"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."ejs-2.7.4"
-      sources."electron-to-chromium-1.3.589"
+      sources."electron-to-chromium-1.3.596"
       sources."elegant-spinner-1.0.1"
       sources."emoji-regex-8.0.0"
       sources."emojis-list-3.0.0"
@@ -60276,7 +60792,7 @@ in
       })
       sources."find-up-3.0.0"
       sources."fkill-6.2.0"
-      sources."flow-parser-0.137.0"
+      sources."flow-parser-0.138.0"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -60500,8 +61016,8 @@ in
       sources."iterall-1.3.0"
       sources."java-properties-1.0.2"
       sources."javascript-stringify-1.6.0"
-      sources."js-message-1.0.5"
-      sources."js-queue-2.0.0"
+      sources."js-message-1.0.7"
+      sources."js-queue-2.0.2"
       sources."js-tokens-4.0.0"
       sources."js-yaml-3.14.0"
       sources."jsbn-0.1.1"
@@ -60664,14 +61180,14 @@ in
       sources."no-case-3.0.3"
       sources."node-dir-0.1.17"
       sources."node-fetch-2.6.1"
-      sources."node-ipc-9.1.1"
+      sources."node-ipc-9.1.3"
       sources."node-modules-regexp-1.0.0"
       (sources."node-notifier-6.0.0" // {
         dependencies = [
           sources."is-wsl-2.2.0"
         ];
       })
-      sources."node-releases-1.1.65"
+      sources."node-releases-1.1.66"
       (sources."nodemon-1.19.4" // {
         dependencies = [
           sources."debug-3.2.6"
@@ -60877,7 +61393,7 @@ in
       sources."request-2.88.2"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-from-3.0.0"
       sources."resolve-url-0.2.1"
       sources."responselike-1.0.2"
@@ -61561,7 +62077,7 @@ in
       sources."parse-passwd-1.0.0"
       sources."path-parse-1.0.6"
       sources."pkginfo-0.4.1"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."safe-buffer-5.1.2"
       sources."sax-0.5.8"
       sources."semver-5.7.1"
@@ -61598,7 +62114,7 @@ in
     dependencies = [
       sources."@types/glob-7.1.3"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
       sources."chromium-pickle-js-0.2.0"
@@ -61878,7 +62394,7 @@ in
       sources."read-pkg-up-1.0.1"
       sources."redent-1.0.0"
       sources."repeating-2.0.1"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       (sources."rimraf-2.7.1" // {
         dependencies = [
           sources."glob-7.1.6"
@@ -61941,7 +62457,7 @@ in
       })
       sources."available-typed-arrays-1.0.2"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bn.js-5.1.3"
       sources."brace-expansion-1.1.11"
       sources."brorand-1.1.0"
@@ -61950,11 +62466,7 @@ in
       sources."browserify-aes-1.2.0"
       sources."browserify-cipher-1.0.1"
       sources."browserify-des-1.0.2"
-      (sources."browserify-rsa-4.0.1" // {
-        dependencies = [
-          sources."bn.js-4.11.9"
-        ];
-      })
+      sources."browserify-rsa-4.1.0"
       (sources."browserify-sign-4.2.1" // {
         dependencies = [
           sources."readable-stream-3.6.0"
@@ -62087,7 +62599,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."ripemd160-2.0.2"
       sources."safe-buffer-5.2.1"
       sources."safer-buffer-2.1.2"
@@ -62187,7 +62699,7 @@ in
       sources."aws-sign2-0.7.0"
       sources."aws4-1.11.0"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."bencode-2.0.1"
       sources."bep53-range-1.0.0"
@@ -62455,7 +62967,7 @@ in
       sources."redent-1.0.0"
       sources."repeating-2.0.1"
       sources."request-2.88.2"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."rimraf-2.7.1"
       sources."router-0.6.2"
       sources."run-parallel-1.1.10"
@@ -62712,10 +63224,10 @@ in
   coc-diagnostic = nodeEnv.buildNodePackage {
     name = "coc-diagnostic";
     packageName = "coc-diagnostic";
-    version = "0.12.0";
+    version = "0.13.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-diagnostic/-/coc-diagnostic-0.12.0.tgz";
-      sha512 = "onUfHm8s/nisp/VtrtPwjXvljhdnYUmQwc/VmB/MsZfaJW3hDLhl4gDbBHISR+CHDHANpkItHw/dpU53V/YC6g==";
+      url = "https://registry.npmjs.org/coc-diagnostic/-/coc-diagnostic-0.13.0.tgz";
+      sha512 = "09jUr50HgKBPxlK88p6CrJXGdu5owMT5c951Ajxwp2lhmFlo26NYn5eVo69shEaZvkpFvlskQWn5lqvrDox0Vw==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -62770,10 +63282,10 @@ in
   coc-git = nodeEnv.buildNodePackage {
     name = "coc-git";
     packageName = "coc-git";
-    version = "2.0.2";
+    version = "2.0.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-git/-/coc-git-2.0.2.tgz";
-      sha512 = "j7Hs+NHSk6nMEVobAi6NCGLuU8ME7FAbjaOWSszbsYidkXKQ/pwKoNl459YWRjePC/uDZKBbLERPYqX+Y0xAQw==";
+      url = "https://registry.npmjs.org/coc-git/-/coc-git-2.0.4.tgz";
+      sha512 = "Ej4dq5XOkMfnJkHIgUj2FlARz3sU3ACsrSq4YmLD3zj11uf/1nkPf5or89GOngQ1/KyCa1Llj1ai8+oTHyJAQw==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -62885,10 +63397,10 @@ in
   coc-jest = nodeEnv.buildNodePackage {
     name = "coc-jest";
     packageName = "coc-jest";
-    version = "1.1.2";
+    version = "1.1.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-jest/-/coc-jest-1.1.2.tgz";
-      sha512 = "vQKfTnF+LMEJEDR/+oTWowOUylr2+3pkOHGUr+OgNMhdjQPy+K1/Kcuqkm4qTpmhQFwg7OzF7GYDfoQojEEmBQ==";
+      url = "https://registry.npmjs.org/coc-jest/-/coc-jest-1.1.3.tgz";
+      sha512 = "iE9zECMZPRdN/HUu1FqjNQ2bkBYePtFpwXOfLQSkb7C+8g3PB3ne3GpS7eLaqVnjgRz9mXzQ6xMBvFIp++7PFA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -62938,13 +63450,13 @@ in
   coc-metals = nodeEnv.buildNodePackage {
     name = "coc-metals";
     packageName = "coc-metals";
-    version = "0.9.5";
+    version = "0.9.6";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-metals/-/coc-metals-0.9.5.tgz";
-      sha512 = "KZVd2kmQjUQVLEHM9c2aXxP4AbM8sRybPtdAR6lWfIK3VGj67O2PIoG30Ro17d7BgcASVBp2Ad86azK9Op8uDw==";
+      url = "https://registry.npmjs.org/coc-metals/-/coc-metals-0.9.6.tgz";
+      sha512 = "5NSCyYUbOployL6Vfanw7LeIYAi9+8LTqXjKqmVCSRql/YpscZJj7Y3KnhUc4P6WYuORXTl7r9Wwau6T/McyQw==";
     };
     dependencies = [
-      sources."@chemzqm/neovim-5.2.8"
+      sources."@chemzqm/neovim-5.2.10"
       sources."@tootallnate/once-1.1.2"
       sources."agent-base-6.0.2"
       sources."arch-2.2.0"
@@ -62988,7 +63500,7 @@ in
       sources."fb-watchman-2.0.1"
       sources."flatted-2.0.2"
       sources."follow-redirects-1.13.0"
-      sources."fp-ts-2.8.5"
+      sources."fp-ts-2.8.6"
       sources."fs-extra-8.1.0"
       sources."fs-minipass-2.1.0"
       sources."fs.realpath-1.0.0"
@@ -63033,7 +63545,7 @@ in
       })
       sources."lodash-4.17.20"
       sources."log4js-6.3.0"
-      sources."metals-languageclient-0.3.2"
+      sources."metals-languageclient-0.3.3"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
       sources."minipass-3.1.3"
@@ -63220,7 +63732,7 @@ in
       sources."callsites-3.1.0"
       sources."camelcase-2.1.1"
       sources."camelcase-keys-2.1.0"
-      sources."caniuse-lite-1.0.30001156"
+      sources."caniuse-lite-1.0.30001158"
       sources."capture-stack-trace-1.0.1"
       sources."ccount-1.1.0"
       sources."chalk-2.4.2"
@@ -63317,7 +63829,7 @@ in
       sources."domutils-1.7.0"
       sources."dot-prop-5.3.0"
       sources."duplexer3-0.1.4"
-      sources."electron-to-chromium-1.3.589"
+      sources."electron-to-chromium-1.3.596"
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
       sources."entities-1.1.2"
@@ -63824,7 +64336,7 @@ in
       sources."require-from-string-2.0.2"
       sources."require-main-filename-1.0.1"
       sources."require-relative-0.8.7"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       (sources."resolve-cwd-2.0.0" // {
         dependencies = [
           sources."resolve-from-3.0.0"
@@ -64156,10 +64668,10 @@ in
   coc-rust-analyzer = nodeEnv.buildNodePackage {
     name = "coc-rust-analyzer";
     packageName = "coc-rust-analyzer";
-    version = "0.14.0";
+    version = "0.15.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-rust-analyzer/-/coc-rust-analyzer-0.14.0.tgz";
-      sha512 = "2s1VTk/IgwO82Vf/YhywNUbijpdgAmUBa6+R9f8xPzl2MyYw9lKVqasxJPa3qA4CB6sqSAG5r3egP6LzqqDxbA==";
+      url = "https://registry.npmjs.org/coc-rust-analyzer/-/coc-rust-analyzer-0.15.0.tgz";
+      sha512 = "0hSwXiDZTOVskAlCM7T5HqEixWw5FnSRnc1Uweq8slqxwBnGa6x68akVqa674MEM0KhbJi/H6TDE6q8LzUR58g==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -64192,10 +64704,10 @@ in
   coc-snippets = nodeEnv.buildNodePackage {
     name = "coc-snippets";
     packageName = "coc-snippets";
-    version = "2.2.5";
+    version = "2.2.9";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-snippets/-/coc-snippets-2.2.5.tgz";
-      sha512 = "YtWw6yFdKxgIxjoUyEgzmT3YVtp3JX7AZUOYDbbnPbneyck5poZyOpjwL+3Wu2TzohDtg2H4ivTDyttv2wXvRQ==";
+      url = "https://registry.npmjs.org/coc-snippets/-/coc-snippets-2.2.9.tgz";
+      sha512 = "SjVr0CSmF97LS5e/qz2Lac5JYpx9F6U9MPLzbB3WfGSIBwlrbevgw47DJSIxCr1ZWNb1Um/esRWDGfkhrMjbmA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -64260,7 +64772,7 @@ in
       sources."@nodelib/fs.walk-1.2.4"
       sources."@stylelint/postcss-css-in-js-0.37.2"
       sources."@stylelint/postcss-markdown-0.36.1"
-      sources."@types/minimist-1.2.0"
+      sources."@types/minimist-1.2.1"
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/parse-json-4.0.0"
       sources."@types/unist-2.0.3"
@@ -64275,11 +64787,11 @@ in
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
-      sources."browserslist-4.14.6"
+      sources."browserslist-4.14.7"
       sources."callsites-3.1.0"
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.2.2"
-      sources."caniuse-lite-1.0.30001156"
+      sources."caniuse-lite-1.0.30001158"
       sources."ccount-1.1.0"
       (sources."chalk-4.1.0" // {
         dependencies = [
@@ -64320,7 +64832,7 @@ in
       sources."domelementtype-1.3.1"
       sources."domhandler-2.4.2"
       sources."domutils-1.7.0"
-      sources."electron-to-chromium-1.3.589"
+      sources."electron-to-chromium-1.3.596"
       sources."emoji-regex-8.0.0"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
@@ -64418,7 +64930,7 @@ in
       })
       sources."mkdirp-0.5.5"
       sources."ms-2.1.2"
-      sources."node-releases-1.1.65"
+      sources."node-releases-1.1.66"
       sources."normalize-package-data-2.5.0"
       sources."normalize-range-0.1.2"
       sources."normalize-selector-0.2.0"
@@ -64476,7 +64988,7 @@ in
       sources."remark-stringify-8.1.1"
       sources."repeat-string-1.6.1"
       sources."replace-ext-1.0.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-from-5.0.0"
       sources."reusify-1.0.4"
       sources."rimraf-2.6.3"
@@ -64623,7 +65135,7 @@ in
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."path-parse-1.0.6"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."semver-5.7.1"
       sources."sprintf-js-1.0.3"
       sources."supports-color-5.5.0"
@@ -64700,320 +65212,52 @@ in
   coc-vetur = nodeEnv.buildNodePackage {
     name = "coc-vetur";
     packageName = "coc-vetur";
-    version = "1.2.1";
+    version = "1.2.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-vetur/-/coc-vetur-1.2.1.tgz";
-      sha512 = "ji3UHWxiAnEwEcAxedGMxZbwKffTB+7t0zT2mKozv9wYZGgc3Rexp0Nvl3J05Cfvz+FCrSEDSaxpo+JSfdYLIQ==";
+      url = "https://registry.npmjs.org/coc-vetur/-/coc-vetur-1.2.2.tgz";
+      sha512 = "nqfCmf1pAQnVFNkGni5Isw9ISX4jVt7qTDXZmr//eY1IFCbNXjq4+xJyHoJyeAq3SSVWPKoKoELfQevnwdBxOA==";
     };
     dependencies = [
       sources."@babel/code-frame-7.10.4"
       sources."@babel/helper-validator-identifier-7.10.4"
-      sources."@babel/highlight-7.10.4"
-      sources."@emmetio/abbreviation-2.0.2"
-      sources."@emmetio/css-abbreviation-2.1.2"
-      sources."@emmetio/scanner-1.0.0"
-      (sources."@eslint/eslintrc-0.2.1" // {
+      (sources."@babel/highlight-7.10.4" // {
         dependencies = [
-          sources."debug-4.3.0"
-          sources."ignore-4.0.6"
-          sources."strip-json-comments-3.1.1"
+          sources."chalk-2.4.2"
         ];
       })
-      sources."@mrmlnc/readdir-enhanced-2.2.1"
-      (sources."@nodelib/fs.scandir-2.1.3" // {
-        dependencies = [
-          sources."@nodelib/fs.stat-2.0.3"
-        ];
-      })
-      sources."@nodelib/fs.stat-1.1.3"
-      sources."@nodelib/fs.walk-1.2.4"
-      sources."@prettier/plugin-pug-1.10.1"
-      sources."@sindresorhus/is-0.14.0"
-      sources."@sorg/log-2.2.1"
-      sources."@starptech/expression-parser-0.10.0"
-      sources."@starptech/hast-util-from-webparser-0.10.0"
-      (sources."@starptech/prettyhtml-0.10.0" // {
-        dependencies = [
-          sources."prettier-1.19.1"
-        ];
-      })
-      (sources."@starptech/prettyhtml-formatter-0.10.0" // {
-        dependencies = [
-          sources."prettier-1.19.1"
-        ];
-      })
-      sources."@starptech/prettyhtml-hast-to-html-0.10.0"
-      sources."@starptech/prettyhtml-hastscript-0.10.0"
-      sources."@starptech/prettyhtml-sort-attributes-0.10.0"
-      sources."@starptech/rehype-minify-whitespace-0.10.0"
-      sources."@starptech/rehype-webparser-0.10.0"
-      sources."@starptech/webparser-0.10.0"
-      sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/eslint-visitor-keys-1.0.0"
-      sources."@types/glob-7.1.3"
-      sources."@types/json-schema-7.0.6"
-      sources."@types/minimatch-3.0.3"
-      sources."@types/minimist-1.2.0"
-      sources."@types/node-14.14.6"
-      sources."@types/normalize-package-data-2.4.0"
-      sources."@types/unist-2.0.3"
-      sources."@types/vfile-3.0.2"
-      sources."@types/vfile-message-2.0.0"
-      sources."@typescript-eslint/experimental-utils-3.10.1"
-      (sources."@typescript-eslint/parser-3.10.1" // {
-        dependencies = [
-          sources."eslint-visitor-keys-1.3.0"
-        ];
-      })
-      sources."@typescript-eslint/types-3.10.1"
-      (sources."@typescript-eslint/typescript-estree-3.10.1" // {
-        dependencies = [
-          sources."debug-4.3.0"
-          sources."semver-7.3.2"
-        ];
-      })
-      (sources."@typescript-eslint/visitor-keys-3.10.1" // {
-        dependencies = [
-          sources."eslint-visitor-keys-1.3.0"
-        ];
-      })
-      sources."abbrev-1.1.1"
+      sources."@eslint/eslintrc-0.2.1"
       sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
-      (sources."aggregate-error-3.1.0" // {
-        dependencies = [
-          sources."indent-string-4.0.0"
-        ];
-      })
       sources."ajv-6.12.6"
-      (sources."ansi-align-3.0.0" // {
-        dependencies = [
-          sources."ansi-regex-4.1.0"
-          sources."string-width-3.1.0"
-          sources."strip-ansi-5.2.0"
-        ];
-      })
       sources."ansi-colors-4.1.1"
-      (sources."ansi-escapes-4.3.1" // {
-        dependencies = [
-          sources."type-fest-0.11.0"
-        ];
-      })
-      sources."ansi-regex-3.0.0"
+      sources."ansi-regex-5.0.0"
       sources."ansi-styles-3.2.1"
-      sources."anymatch-3.1.1"
       sources."argparse-1.0.10"
-      sources."arr-diff-4.0.0"
-      sources."arr-flatten-1.1.0"
-      sources."arr-union-3.1.0"
-      sources."array-find-index-1.0.2"
-      sources."array-iterate-1.1.4"
-      sources."array-union-1.0.2"
-      sources."array-uniq-1.0.3"
-      sources."array-unique-0.3.2"
-      sources."arrify-1.0.1"
-      sources."assign-symbols-1.0.0"
       sources."astral-regex-1.0.0"
-      sources."async-1.5.2"
-      sources."atob-2.1.2"
-      sources."bail-1.0.5"
       sources."balanced-match-1.0.0"
-      (sources."base-0.11.2" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-        ];
-      })
-      sources."binary-extensions-2.1.0"
-      sources."bootstrap-vue-helper-json-1.1.1"
-      (sources."boxen-3.2.0" // {
-        dependencies = [
-          sources."ansi-regex-4.1.0"
-          sources."camelcase-5.3.1"
-          sources."string-width-3.1.0"
-          sources."strip-ansi-5.2.0"
-        ];
-      })
       sources."brace-expansion-1.1.11"
-      (sources."braces-2.3.2" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
-      sources."buffer-from-1.1.1"
-      sources."builtin-modules-1.1.1"
-      sources."cache-base-1.0.1"
-      (sources."cacheable-request-6.1.0" // {
-        dependencies = [
-          sources."get-stream-5.2.0"
-          sources."lowercase-keys-2.0.0"
-        ];
-      })
-      sources."call-me-maybe-1.0.1"
       sources."callsites-3.1.0"
-      sources."camelcase-4.1.0"
-      sources."camelcase-keys-4.2.0"
-      sources."ccount-1.1.0"
-      sources."chalk-2.4.2"
-      sources."character-entities-1.2.4"
-      sources."character-entities-html4-1.1.4"
-      sources."character-entities-legacy-1.1.4"
-      sources."character-parser-2.2.0"
-      sources."character-reference-invalid-1.1.4"
-      sources."chardet-0.7.0"
-      (sources."chokidar-3.0.2" // {
+      (sources."chalk-4.1.0" // {
         dependencies = [
-          sources."braces-3.0.2"
-          sources."fill-range-7.0.1"
-          sources."is-number-7.0.0"
-          sources."to-regex-range-5.0.1"
-        ];
-      })
-      sources."ci-info-2.0.0"
-      (sources."class-utils-0.3.6" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-buffer-1.1.6"
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
-      sources."clean-stack-2.2.0"
-      sources."cli-boxes-2.2.1"
-      sources."cli-cursor-3.1.0"
-      sources."cli-width-3.0.0"
-      sources."cliui-4.1.0"
-      sources."clone-1.0.4"
-      sources."clone-response-1.0.2"
-      sources."code-point-at-1.1.0"
-      sources."collapse-white-space-1.0.6"
-      sources."collection-visit-1.0.0"
-      sources."color-convert-1.9.3"
-      sources."color-name-1.1.3"
-      (sources."columnify-1.5.4" // {
-        dependencies = [
-          sources."ansi-regex-2.1.1"
-          sources."strip-ansi-3.0.1"
-        ];
-      })
-      sources."comma-separated-tokens-1.0.8"
-      sources."commander-2.20.3"
-      sources."common-tags-1.8.0"
-      sources."component-emitter-1.3.0"
-      sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.2"
-      sources."config-chain-1.1.12"
-      sources."configstore-4.0.0"
-      sources."copy-descriptor-0.1.1"
-      sources."core-js-3.7.0"
-      sources."core-util-is-1.0.2"
-      sources."cross-spawn-5.1.0"
-      sources."crypto-random-string-1.0.0"
-      (sources."css-2.2.4" // {
-        dependencies = [
-          sources."source-map-0.6.1"
-        ];
-      })
-      sources."css-parse-2.0.0"
-      sources."currently-unhandled-0.4.1"
-      sources."debug-3.2.6"
-      sources."decamelize-1.2.0"
-      (sources."decamelize-keys-1.1.0" // {
-        dependencies = [
-          sources."map-obj-1.0.1"
-        ];
-      })
-      sources."decode-uri-component-0.2.0"
-      sources."decompress-response-3.3.0"
-      sources."deep-extend-0.6.0"
-      sources."deep-is-0.1.3"
-      sources."defaults-1.0.3"
-      sources."defer-to-connect-1.1.3"
-      sources."define-property-2.0.2"
-      (sources."del-5.1.0" // {
-        dependencies = [
-          sources."@nodelib/fs.stat-2.0.3"
-          sources."array-union-2.1.0"
-          sources."braces-3.0.2"
-          sources."dir-glob-3.0.1"
-          sources."fast-glob-3.2.4"
-          sources."fill-range-7.0.1"
-          sources."globby-10.0.2"
-          sources."ignore-5.1.8"
-          sources."is-number-7.0.0"
-          sources."is-path-inside-3.0.2"
-          sources."micromatch-4.0.2"
-          sources."path-type-4.0.0"
-          sources."rimraf-3.0.2"
-          sources."slash-3.0.0"
-          sources."to-regex-range-5.0.1"
-        ];
-      })
-      (sources."del-cli-3.0.1" // {
-        dependencies = [
-          sources."camelcase-5.3.1"
-          sources."camelcase-keys-6.2.2"
-          sources."indent-string-4.0.0"
-          sources."map-obj-4.1.0"
-          sources."meow-6.1.1"
-          sources."minimist-options-4.1.0"
-          sources."quick-lru-4.0.1"
-          sources."redent-3.0.0"
-          sources."strip-indent-3.0.0"
-          sources."trim-newlines-3.0.0"
-          sources."type-fest-0.13.1"
-          sources."yargs-parser-18.1.3"
-        ];
-      })
-      sources."diff-4.0.2"
-      sources."dir-glob-2.0.0"
-      sources."dlv-1.1.3"
-      sources."doctrine-3.0.0"
-      sources."dot-prop-4.2.1"
-      sources."duplexer3-0.1.4"
-      sources."editorconfig-0.15.3"
-      sources."element-helper-json-2.0.6"
-      sources."emmet-2.1.6"
-      sources."emoji-regex-7.0.3"
-      sources."end-of-stream-1.4.4"
-      sources."enquirer-2.3.6"
-      sources."error-ex-1.3.2"
-      sources."escape-string-regexp-1.0.5"
-      (sources."eslint-7.12.1" // {
-        dependencies = [
-          sources."ansi-regex-5.0.0"
           sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
-          sources."cross-spawn-7.0.3"
-          sources."debug-4.3.0"
           sources."has-flag-4.0.0"
-          sources."ignore-4.0.6"
-          sources."path-key-3.1.1"
-          sources."semver-7.3.2"
-          sources."shebang-command-2.0.0"
-          sources."shebang-regex-3.0.0"
-          sources."strip-ansi-6.0.0"
-          sources."strip-json-comments-3.1.1"
           sources."supports-color-7.2.0"
-          sources."which-2.0.2"
         ];
       })
-      (sources."eslint-plugin-vue-7.1.0" // {
-        dependencies = [
-          sources."semver-7.3.2"
-        ];
-      })
+      sources."color-convert-1.9.3"
+      sources."color-name-1.1.3"
+      sources."concat-map-0.0.1"
+      sources."cross-spawn-7.0.3"
+      sources."debug-4.3.0"
+      sources."deep-is-0.1.3"
+      sources."doctrine-3.0.0"
+      sources."emoji-regex-7.0.3"
+      sources."enquirer-2.3.6"
+      sources."escape-string-regexp-1.0.5"
+      sources."eslint-7.13.0"
+      sources."eslint-plugin-vue-7.1.0"
       sources."eslint-scope-5.1.1"
       (sources."eslint-utils-2.1.0" // {
         dependencies = [
@@ -65039,733 +65283,80 @@ in
       })
       sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
-      sources."execa-0.7.0"
-      (sources."expand-brackets-2.1.4" // {
-        dependencies = [
-          sources."debug-2.6.9"
-          sources."define-property-0.2.5"
-          sources."extend-shallow-2.0.1"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-buffer-1.1.6"
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-          sources."ms-2.0.0"
-        ];
-      })
-      sources."extend-3.0.2"
-      (sources."extend-shallow-3.0.2" // {
-        dependencies = [
-          sources."is-extendable-1.0.1"
-        ];
-      })
-      sources."external-editor-3.1.0"
-      (sources."extglob-2.0.4" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-          sources."extend-shallow-2.0.1"
-        ];
-      })
       sources."fast-deep-equal-3.1.3"
-      (sources."fast-glob-2.2.7" // {
-        dependencies = [
-          (sources."glob-parent-3.1.0" // {
-            dependencies = [
-              sources."is-glob-3.1.0"
-            ];
-          })
-        ];
-      })
       sources."fast-json-stable-stringify-2.1.0"
       sources."fast-levenshtein-2.0.6"
-      sources."fastq-1.9.0"
-      sources."fault-1.0.4"
-      sources."figures-3.2.0"
       sources."file-entry-cache-5.0.1"
-      (sources."fill-range-4.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
-      sources."find-up-2.1.0"
       sources."flat-cache-2.0.1"
       sources."flatted-2.0.2"
-      sources."fn-name-2.0.1"
-      sources."for-in-1.0.2"
-      sources."format-0.2.2"
-      sources."fragment-cache-0.2.1"
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.2.1"
-      sources."function-bind-1.1.1"
       sources."functional-red-black-tree-1.0.1"
-      sources."get-caller-file-1.0.3"
-      sources."get-stream-3.0.0"
-      sources."get-value-2.0.6"
       sources."glob-7.1.6"
       sources."glob-parent-5.1.1"
-      sources."glob-to-regexp-0.3.0"
-      sources."global-dirs-0.1.1"
-      (sources."globals-12.4.0" // {
-        dependencies = [
-          sources."type-fest-0.8.1"
-        ];
-      })
-      sources."globby-8.0.2"
-      (sources."got-9.6.0" // {
-        dependencies = [
-          sources."get-stream-4.1.0"
-        ];
-      })
-      sources."graceful-fs-4.2.4"
-      sources."gridsome-helper-json-1.0.3"
-      sources."hard-rejection-2.1.0"
-      sources."has-1.0.3"
-      (sources."has-ansi-2.0.0" // {
-        dependencies = [
-          sources."ansi-regex-2.1.1"
-        ];
-      })
+      sources."globals-12.4.0"
       sources."has-flag-3.0.0"
-      sources."has-symbols-1.0.1"
-      sources."has-value-1.0.0"
-      (sources."has-values-1.0.0" // {
-        dependencies = [
-          sources."is-buffer-1.1.6"
-          sources."kind-of-4.0.0"
-        ];
-      })
-      sources."has-yarn-2.1.0"
-      sources."hast-util-embedded-1.0.5"
-      sources."hast-util-has-property-1.0.4"
-      sources."hast-util-is-body-ok-link-1.0.4"
-      sources."hast-util-is-element-1.1.0"
-      sources."hast-util-parse-selector-2.2.5"
-      sources."hast-util-to-string-1.0.4"
-      sources."hast-util-whitespace-1.0.4"
-      sources."hosted-git-info-2.8.8"
-      sources."html-void-elements-1.0.5"
-      sources."html-whitespace-sensitive-tag-names-1.0.3"
-      sources."http-cache-semantics-4.1.0"
-      sources."iconv-lite-0.4.24"
-      sources."ignore-3.3.10"
-      (sources."import-fresh-3.2.2" // {
-        dependencies = [
-          sources."resolve-from-4.0.0"
-        ];
-      })
-      sources."import-lazy-2.1.0"
+      sources."ignore-4.0.6"
+      sources."import-fresh-3.2.2"
       sources."imurmurhash-0.1.4"
-      sources."indent-string-3.2.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."ini-1.3.5"
-      (sources."inquirer-7.3.3" // {
-        dependencies = [
-          sources."ansi-regex-5.0.0"
-          sources."ansi-styles-4.3.0"
-          sources."chalk-4.1.0"
-          sources."color-convert-2.0.1"
-          sources."color-name-1.1.4"
-          sources."emoji-regex-8.0.0"
-          sources."has-flag-4.0.0"
-          sources."is-fullwidth-code-point-3.0.0"
-          sources."string-width-4.2.0"
-          sources."strip-ansi-6.0.0"
-          sources."supports-color-7.2.0"
-        ];
-      })
-      sources."invert-kv-2.0.0"
-      sources."is-accessor-descriptor-1.0.0"
-      sources."is-alphabetical-1.0.4"
-      sources."is-alphanumerical-1.0.4"
-      sources."is-arrayish-0.2.1"
-      sources."is-binary-path-2.1.0"
-      sources."is-buffer-2.0.5"
-      sources."is-ci-2.0.0"
-      sources."is-core-module-2.1.0"
-      sources."is-data-descriptor-1.0.0"
-      sources."is-decimal-1.0.4"
-      sources."is-descriptor-1.0.2"
-      sources."is-empty-1.2.0"
-      sources."is-expression-4.0.0"
-      sources."is-extendable-0.1.1"
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
-      sources."is-hexadecimal-1.0.4"
-      sources."is-hidden-1.1.3"
-      sources."is-installed-globally-0.1.0"
-      sources."is-npm-3.0.0"
-      (sources."is-number-3.0.0" // {
-        dependencies = [
-          sources."is-buffer-1.1.6"
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."is-obj-1.0.1"
-      sources."is-object-1.0.1"
-      sources."is-path-cwd-2.2.0"
-      sources."is-path-inside-1.0.1"
-      sources."is-plain-obj-1.1.0"
-      sources."is-plain-object-2.0.4"
-      sources."is-regex-1.1.1"
-      sources."is-stream-1.1.0"
-      sources."is-utf8-0.2.1"
-      sources."is-windows-1.0.2"
-      sources."is-yarn-global-0.3.0"
-      sources."isarray-1.0.0"
       sources."isexe-2.0.0"
-      sources."isobject-3.0.1"
-      (sources."js-beautify-1.13.0" // {
-        dependencies = [
-          sources."mkdirp-1.0.4"
-        ];
-      })
       sources."js-tokens-4.0.0"
       sources."js-yaml-3.14.0"
-      sources."json-buffer-3.0.0"
-      sources."json-parse-better-errors-1.0.2"
-      sources."json-parse-even-better-errors-2.3.1"
       sources."json-schema-traverse-0.4.1"
       sources."json-stable-stringify-without-jsonify-1.0.1"
-      sources."json5-2.1.3"
-      sources."jsonc-parser-2.3.1"
-      sources."keyv-3.1.0"
-      sources."kind-of-6.0.3"
-      sources."latest-version-5.1.0"
-      sources."lcid-2.0.0"
       sources."levn-0.4.1"
-      sources."lines-and-columns-1.1.6"
-      sources."load-json-file-4.0.0"
-      sources."load-plugin-2.3.1"
-      sources."locate-path-2.0.0"
       sources."lodash-4.17.20"
-      sources."lodash.assign-4.2.0"
-      sources."lodash.defaults-4.2.0"
-      sources."lodash.iteratee-4.7.0"
-      sources."lodash.merge-4.6.2"
-      sources."loglevel-1.7.0"
-      (sources."loglevel-colored-level-prefix-1.0.0" // {
-        dependencies = [
-          sources."ansi-regex-2.1.1"
-          sources."ansi-styles-2.2.1"
-          sources."chalk-1.1.3"
-          sources."strip-ansi-3.0.1"
-          sources."supports-color-2.0.0"
-        ];
-      })
-      sources."longest-streak-1.0.0"
-      sources."loud-rejection-1.6.0"
-      sources."lowercase-keys-1.0.1"
-      sources."lru-cache-4.1.5"
-      sources."make-dir-1.3.0"
-      sources."map-age-cleaner-0.1.3"
-      sources."map-cache-0.2.2"
-      sources."map-obj-2.0.0"
-      sources."map-visit-1.0.0"
-      sources."markdown-table-0.4.0"
-      sources."mem-4.3.0"
-      (sources."meow-5.0.0" // {
-        dependencies = [
-          sources."read-pkg-up-3.0.0"
-        ];
-      })
-      sources."merge2-1.4.1"
-      sources."micromatch-3.1.10"
-      sources."mimic-fn-2.1.0"
-      sources."mimic-response-1.0.1"
-      sources."min-indent-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
-      sources."minimist-options-3.0.2"
-      (sources."mixin-deep-1.3.2" // {
-        dependencies = [
-          sources."is-extendable-1.0.1"
-        ];
-      })
       sources."mkdirp-0.5.5"
-      sources."mout-0.5.0"
       sources."ms-2.1.2"
-      sources."mute-stream-0.0.8"
-      sources."nanomatch-1.2.13"
       sources."natural-compare-1.4.0"
-      sources."nice-try-1.0.5"
-      sources."nopt-5.0.0"
-      sources."normalize-package-data-2.5.0"
-      sources."normalize-path-3.0.0"
-      sources."normalize-url-4.5.0"
-      sources."npm-prefix-1.2.0"
-      sources."npm-run-path-2.0.2"
-      sources."number-is-nan-1.0.1"
-      sources."nuxt-helper-json-1.0.0"
-      sources."object-assign-4.1.1"
-      (sources."object-copy-0.1.0" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."is-accessor-descriptor-0.1.6"
-          sources."is-buffer-1.1.6"
-          sources."is-data-descriptor-0.1.4"
-          (sources."is-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-5.1.0"
-            ];
-          })
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."object-visit-1.0.1"
-      sources."object.pick-1.3.0"
       sources."once-1.4.0"
-      sources."onetime-5.1.2"
       sources."optionator-0.9.1"
-      sources."os-homedir-1.0.2"
-      (sources."os-locale-3.1.0" // {
-        dependencies = [
-          sources."cross-spawn-6.0.5"
-          sources."execa-1.0.0"
-          sources."get-stream-4.1.0"
-        ];
-      })
-      sources."os-tmpdir-1.0.2"
-      sources."p-cancelable-1.1.0"
-      sources."p-defer-1.0.0"
-      sources."p-finally-1.0.0"
-      sources."p-is-promise-2.1.0"
-      sources."p-limit-1.3.0"
-      sources."p-locate-2.0.0"
-      sources."p-map-3.0.0"
-      sources."p-try-1.0.0"
-      (sources."package-json-6.5.0" // {
-        dependencies = [
-          sources."semver-6.3.0"
-        ];
-      })
       sources."parent-module-1.0.1"
-      sources."parse-entities-1.2.2"
-      sources."parse-gitignore-1.0.1"
-      sources."parse-json-4.0.0"
-      sources."pascalcase-0.1.1"
-      sources."path-dirname-1.0.2"
-      sources."path-exists-3.0.0"
       sources."path-is-absolute-1.0.1"
-      sources."path-is-inside-1.0.2"
-      sources."path-key-2.0.1"
-      sources."path-parse-1.0.6"
-      sources."path-type-3.0.0"
-      sources."picomatch-2.2.2"
-      sources."pify-3.0.0"
-      sources."pinkie-2.0.4"
-      sources."pinkie-promise-2.0.1"
-      (sources."pkg-conf-1.1.3" // {
-        dependencies = [
-          sources."find-up-1.1.2"
-          sources."load-json-file-1.1.0"
-          sources."parse-json-2.2.0"
-          sources."path-exists-2.1.0"
-          sources."pify-2.3.0"
-          sources."strip-bom-2.0.0"
-        ];
-      })
-      sources."posix-character-classes-0.1.1"
+      sources."path-key-3.1.1"
       sources."prelude-ls-1.2.1"
-      sources."prepend-http-2.0.0"
-      sources."prettier-2.1.2"
-      (sources."prettier-eslint-11.0.0" // {
-        dependencies = [
-          sources."ansi-regex-4.1.0"
-          (sources."cross-spawn-6.0.5" // {
-            dependencies = [
-              sources."semver-5.7.1"
-            ];
-          })
-          sources."debug-4.3.0"
-          sources."eslint-6.8.0"
-          sources."eslint-utils-1.4.3"
-          sources."eslint-visitor-keys-1.3.0"
-          sources."espree-6.2.1"
-          sources."ignore-4.0.6"
-          sources."indent-string-4.0.0"
-          sources."levn-0.3.0"
-          sources."optionator-0.8.3"
-          sources."prelude-ls-1.1.2"
-          sources."regexpp-2.0.1"
-          sources."semver-6.3.0"
-          sources."strip-ansi-5.2.0"
-          sources."strip-json-comments-3.1.1"
-          sources."type-check-0.3.2"
-          sources."typescript-3.9.7"
-        ];
-      })
-      sources."prettier-tslint-0.4.2"
-      sources."pretty-format-23.6.0"
-      sources."process-nextick-args-2.0.1"
       sources."progress-2.0.3"
-      sources."property-information-5.6.0"
-      sources."proto-list-1.2.4"
-      sources."pseudomap-1.0.2"
-      sources."pug-error-2.0.0"
-      sources."pug-lexer-5.0.0"
-      sources."pump-3.0.0"
       sources."punycode-2.1.1"
-      sources."quick-lru-1.1.0"
-      sources."rc-1.2.8"
-      sources."read-pkg-3.0.0"
-      (sources."read-pkg-up-7.0.1" // {
-        dependencies = [
-          sources."find-up-4.1.0"
-          sources."locate-path-5.0.0"
-          sources."p-limit-2.3.0"
-          sources."p-locate-4.1.0"
-          sources."p-try-2.2.0"
-          sources."parse-json-5.1.0"
-          sources."path-exists-4.0.0"
-          (sources."read-pkg-5.2.0" // {
-            dependencies = [
-              sources."type-fest-0.6.0"
-            ];
-          })
-          sources."type-fest-0.8.1"
-        ];
-      })
-      sources."readable-stream-2.3.7"
-      sources."readdirp-3.5.0"
-      sources."redent-2.0.0"
-      sources."regex-not-1.0.2"
       sources."regexpp-3.1.0"
-      sources."registry-auth-token-4.2.0"
-      sources."registry-url-5.1.0"
-      sources."rehype-sort-attribute-values-2.0.1"
-      (sources."remark-5.1.0" // {
-        dependencies = [
-          sources."unified-4.2.1"
-          sources."vfile-1.4.0"
-        ];
-      })
-      sources."remark-parse-1.1.0"
-      (sources."remark-stringify-1.1.0" // {
-        dependencies = [
-          sources."stringify-entities-1.3.2"
-        ];
-      })
-      sources."repeat-element-1.1.3"
-      sources."repeat-string-1.6.1"
-      sources."replace-ext-1.0.0"
-      sources."require-directory-2.1.1"
-      sources."require-main-filename-1.0.1"
-      sources."require-relative-0.8.7"
-      sources."resolve-1.18.1"
-      sources."resolve-from-5.0.0"
-      sources."resolve-url-0.2.1"
-      sources."responselike-1.0.2"
-      sources."restore-cursor-3.1.0"
-      sources."ret-0.1.15"
-      sources."reusify-1.0.4"
+      sources."resolve-from-4.0.0"
       sources."rimraf-2.6.3"
-      sources."run-async-2.4.1"
-      sources."run-parallel-1.1.10"
-      sources."rxjs-6.6.3"
-      sources."s.color-0.0.15"
-      sources."safe-buffer-5.1.2"
-      sources."safe-regex-1.1.0"
-      sources."safer-buffer-2.1.2"
-      sources."sass-formatter-0.5.1"
-      sources."sax-1.2.4"
-      sources."semver-5.7.1"
-      sources."semver-diff-2.1.0"
-      sources."set-blocking-2.0.0"
-      (sources."set-value-2.0.1" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
-      sources."shebang-command-1.2.0"
-      sources."shebang-regex-1.0.0"
-      sources."shellsubstitute-1.2.0"
-      sources."sigmund-1.0.1"
-      sources."signal-exit-3.0.3"
-      sources."slash-1.0.0"
+      sources."semver-7.3.2"
+      sources."shebang-command-2.0.0"
+      sources."shebang-regex-3.0.0"
       sources."slice-ansi-2.1.0"
-      (sources."snapdragon-0.8.2" // {
-        dependencies = [
-          sources."debug-2.6.9"
-          sources."define-property-0.2.5"
-          sources."extend-shallow-2.0.1"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-buffer-1.1.6"
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-          sources."ms-2.0.0"
-        ];
-      })
-      (sources."snapdragon-node-2.1.1" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-        ];
-      })
-      (sources."snapdragon-util-3.0.1" // {
-        dependencies = [
-          sources."is-buffer-1.1.6"
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."source-map-0.5.7"
-      sources."source-map-resolve-0.5.3"
-      sources."source-map-url-0.4.0"
-      sources."space-separated-tokens-1.1.5"
-      sources."spdx-correct-3.1.1"
-      sources."spdx-exceptions-2.3.0"
-      sources."spdx-expression-parse-3.0.1"
-      sources."spdx-license-ids-3.0.6"
-      sources."split-string-3.1.0"
       sources."sprintf-js-1.0.3"
-      sources."stampit-1.2.0"
-      (sources."static-extend-0.1.2" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-buffer-1.1.6"
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
-      sources."string-width-2.1.1"
-      sources."string_decoder-1.1.1"
-      sources."stringify-entities-2.0.0"
-      sources."strip-ansi-4.0.0"
-      sources."strip-bom-3.0.0"
-      sources."strip-eof-1.0.0"
-      sources."strip-indent-2.0.0"
-      sources."strip-json-comments-2.0.1"
-      (sources."stylint-2.0.0" // {
-        dependencies = [
-          sources."ansi-regex-2.1.1"
-          sources."ansi-styles-2.2.1"
-          sources."camelcase-3.0.0"
-          sources."chalk-1.1.3"
-          sources."cliui-3.2.0"
-          sources."find-up-1.1.2"
-          sources."glob-7.0.4"
-          sources."invert-kv-1.0.0"
-          sources."is-fullwidth-code-point-1.0.0"
-          sources."lcid-1.0.0"
-          sources."load-json-file-1.1.0"
-          sources."os-locale-1.4.0"
-          sources."parse-json-2.2.0"
-          sources."path-exists-2.1.0"
-          sources."path-type-1.1.0"
-          sources."pify-2.3.0"
-          sources."read-pkg-1.1.0"
-          sources."read-pkg-up-1.0.1"
-          sources."set-blocking-1.0.0"
-          sources."string-width-1.0.2"
-          sources."strip-ansi-3.0.1"
-          sources."strip-bom-2.0.0"
-          sources."supports-color-2.0.0"
-          sources."yargs-4.7.1"
-          sources."yargs-parser-2.4.1"
-        ];
-      })
-      (sources."stylus-0.54.8" // {
-        dependencies = [
-          sources."debug-3.1.0"
-          sources."mkdirp-1.0.4"
-          sources."ms-2.0.0"
-          sources."semver-6.3.0"
-          sources."source-map-0.7.3"
-        ];
-      })
-      sources."stylus-supremacy-2.14.5"
-      sources."suf-regex-0.0.25"
-      sources."supports-color-5.5.0"
-      sources."symbol-0.2.3"
-      (sources."table-5.4.6" // {
+      (sources."string-width-3.1.0" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
-          sources."string-width-3.1.0"
           sources."strip-ansi-5.2.0"
         ];
       })
-      sources."term-size-1.2.0"
+      sources."strip-ansi-6.0.0"
+      sources."strip-json-comments-3.1.1"
+      sources."supports-color-5.5.0"
+      sources."table-5.4.6"
       sources."text-table-0.2.0"
-      sources."through-2.3.8"
-      sources."tmp-0.0.33"
-      (sources."to-object-path-0.3.0" // {
-        dependencies = [
-          sources."is-buffer-1.1.6"
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."to-readable-stream-1.0.0"
-      sources."to-regex-3.0.2"
-      sources."to-regex-range-2.1.1"
-      sources."to-vfile-6.1.0"
-      sources."trim-0.0.1"
-      sources."trim-newlines-2.0.0"
-      sources."trim-trailing-lines-1.1.4"
-      sources."trough-1.0.5"
-      sources."tslib-1.14.1"
-      (sources."tslint-5.20.1" // {
-        dependencies = [
-          sources."tsutils-2.29.0"
-        ];
-      })
-      sources."tsutils-3.17.1"
       sources."type-check-0.4.0"
-      sources."type-fest-0.3.1"
-      sources."typedarray-0.0.6"
-      sources."typescript-4.0.5"
-      sources."unherit-1.1.3"
-      (sources."unified-7.1.0" // {
-        dependencies = [
-          sources."unist-util-stringify-position-1.1.2"
-          sources."vfile-3.0.1"
-          sources."vfile-message-1.1.1"
-        ];
-      })
-      (sources."unified-engine-6.0.1" // {
-        dependencies = [
-          sources."to-vfile-4.0.0"
-          sources."unist-util-stringify-position-1.1.2"
-          sources."vfile-3.0.1"
-          sources."vfile-message-1.1.1"
-          (sources."vfile-reporter-5.1.2" // {
-            dependencies = [
-              sources."unist-util-stringify-position-2.0.3"
-            ];
-          })
-        ];
-      })
-      sources."union-value-1.0.1"
-      sources."unique-string-1.0.0"
-      sources."unist-util-find-1.0.1"
-      sources."unist-util-inspect-4.1.4"
-      sources."unist-util-is-2.1.3"
-      sources."unist-util-modify-children-1.1.6"
-      sources."unist-util-remove-position-1.1.4"
-      sources."unist-util-stringify-position-2.0.3"
-      sources."unist-util-visit-1.4.1"
-      (sources."unist-util-visit-parents-2.1.2" // {
-        dependencies = [
-          sources."unist-util-is-3.0.0"
-        ];
-      })
-      (sources."unset-value-1.0.0" // {
-        dependencies = [
-          (sources."has-value-0.3.1" // {
-            dependencies = [
-              sources."isobject-2.1.0"
-            ];
-          })
-          sources."has-values-0.1.4"
-        ];
-      })
-      sources."untildify-2.1.0"
-      sources."update-notifier-3.0.1"
+      sources."type-fest-0.8.1"
       sources."uri-js-4.4.0"
-      sources."urix-0.1.0"
-      sources."url-parse-lax-3.0.0"
-      sources."use-3.1.1"
-      sources."user-home-2.0.0"
-      sources."util-deprecate-1.0.2"
       sources."v8-compile-cache-2.2.0"
-      sources."validate-npm-package-license-3.0.4"
-      sources."vfile-4.2.0"
-      sources."vfile-location-2.0.6"
-      sources."vfile-message-2.0.4"
-      (sources."vfile-reporter-6.0.1" // {
-        dependencies = [
-          sources."ansi-regex-5.0.0"
-          sources."emoji-regex-8.0.0"
-          sources."is-fullwidth-code-point-3.0.0"
-          sources."string-width-4.2.0"
-          sources."strip-ansi-6.0.0"
-          sources."supports-color-6.1.0"
-        ];
-      })
-      sources."vfile-sort-2.2.2"
-      sources."vfile-statistics-1.1.4"
-      sources."vls-0.5.5"
-      (sources."vscode-css-languageservice-4.3.5" // {
-        dependencies = [
-          sources."vscode-languageserver-types-3.16.0-next.2"
-        ];
-      })
-      (sources."vscode-emmet-helper-2.1.1" // {
-        dependencies = [
-          sources."vscode-languageserver-types-3.15.1"
-        ];
-      })
-      sources."vscode-jsonrpc-6.0.0-next.5"
-      sources."vscode-languageserver-7.0.0-next.7"
-      sources."vscode-languageserver-protocol-3.16.0-next.7"
-      sources."vscode-languageserver-textdocument-1.0.1"
-      sources."vscode-languageserver-types-3.16.0-next.3"
-      sources."vscode-nls-5.0.0"
-      sources."vscode-uri-2.1.2"
-      sources."vscode-web-custom-data-0.3.1"
+      sources."vls-0.5.9"
       (sources."vue-eslint-parser-7.1.1" // {
         dependencies = [
-          sources."debug-4.3.0"
           sources."eslint-visitor-keys-1.3.0"
           sources."espree-6.2.1"
         ];
       })
-      sources."vue-onsenui-helper-json-1.0.2"
-      sources."wcwidth-1.0.1"
-      sources."which-1.3.1"
-      sources."which-module-2.0.0"
-      sources."widest-line-2.0.1"
-      sources."window-size-0.2.0"
+      sources."which-2.0.2"
       sources."word-wrap-1.2.3"
-      (sources."wrap-ansi-2.1.0" // {
-        dependencies = [
-          sources."ansi-regex-2.1.1"
-          sources."is-fullwidth-code-point-1.0.0"
-          sources."string-width-1.0.2"
-          sources."strip-ansi-3.0.1"
-        ];
-      })
       sources."wrappy-1.0.2"
       sources."write-1.0.3"
-      sources."write-file-atomic-2.4.3"
-      sources."x-is-array-0.1.0"
-      sources."x-is-string-0.1.0"
-      sources."xdg-basedir-3.0.0"
-      sources."xtend-4.0.2"
-      sources."y18n-3.2.1"
-      sources."yallist-2.1.2"
-      (sources."yargs-11.1.1" // {
-        dependencies = [
-          sources."yargs-parser-9.0.2"
-        ];
-      })
-      sources."yargs-parser-10.1.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -65814,10 +65405,10 @@ in
   coc-yaml = nodeEnv.buildNodePackage {
     name = "coc-yaml";
     packageName = "coc-yaml";
-    version = "1.1.0";
+    version = "1.1.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-yaml/-/coc-yaml-1.1.0.tgz";
-      sha512 = "z35izd8vv80UcyoIs2Yw6Q/8qoe9U321StT76JKIDSLRXLqY27Q6wS8RpVCWsPb6aXxmPRMt2sjnjF8DExpaMQ==";
+      url = "https://registry.npmjs.org/coc-yaml/-/coc-yaml-1.1.2.tgz";
+      sha512 = "schv9IuNXZIGJqoSUQf/zDTgtSG1Kqht5s9yrlWGPhByHofheyffW3jrXrI/yMY9CT/5/Mg37udFrAbx8WCpCg==";
     };
     dependencies = [
       sources."agent-base-4.3.0"
@@ -65831,15 +65422,13 @@ in
       sources."js-yaml-3.14.0"
       sources."jsonc-parser-2.3.1"
       sources."ms-2.0.0"
-      sources."prettier-2.0.5"
-      sources."request-light-0.2.5"
-      sources."sprintf-js-1.0.3"
-      (sources."vscode-json-languageservice-3.10.0" // {
+      (sources."request-light-0.2.5" // {
         dependencies = [
-          sources."vscode-languageserver-types-3.16.0-next.2"
-          sources."vscode-nls-5.0.0"
+          sources."vscode-nls-4.1.2"
         ];
       })
+      sources."sprintf-js-1.0.3"
+      sources."vscode-json-languageservice-3.8.4"
       sources."vscode-jsonrpc-4.0.0"
       (sources."vscode-languageserver-5.2.1" // {
         dependencies = [
@@ -65852,11 +65441,16 @@ in
         ];
       })
       sources."vscode-languageserver-textdocument-1.0.1"
-      sources."vscode-languageserver-types-3.15.1"
-      sources."vscode-nls-4.1.2"
+      sources."vscode-languageserver-types-3.16.0-next.2"
+      sources."vscode-nls-5.0.0"
       sources."vscode-uri-2.1.2"
-      sources."yaml-ast-parser-custom-tags-0.0.43"
-      sources."yaml-language-server-0.11.1"
+      (sources."yaml-language-server-0.12.0" // {
+        dependencies = [
+          sources."vscode-languageserver-types-3.15.1"
+          sources."vscode-nls-4.1.2"
+        ];
+      })
+      sources."yaml-language-server-parser-0.1.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -65870,10 +65464,10 @@ in
   coc-yank = nodeEnv.buildNodePackage {
     name = "coc-yank";
     packageName = "coc-yank";
-    version = "1.1.8";
+    version = "1.1.11";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-yank/-/coc-yank-1.1.8.tgz";
-      sha512 = "jDBtzTnFb3TnwmsqQt5b6KFRcXB7J5pdsebzdovqroaKwKT9YH19CG4qPeuJleT3dJ/AwfUw3WP3yZWkwvLbFg==";
+      url = "https://registry.npmjs.org/coc-yank/-/coc-yank-1.1.11.tgz";
+      sha512 = "pWJbOo12PmigwYTCk8ghckDlPE5K0qO4VxEZeLJ7ck4v6jhRaKi0lVlYfhBauPuCDv3Yqd0DoKyVLvrQXoRg1A==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -66055,7 +65649,7 @@ in
       sources."aws-sign2-0.7.0"
       sources."aws4-1.11.0"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."big-integer-1.6.48"
       (sources."body-parser-1.19.0" // {
@@ -66386,7 +65980,7 @@ in
       sources."read-1.0.7"
       sources."read-chunk-3.2.0"
       sources."read-package-json-2.1.2"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       (sources."request-2.88.2" // {
         dependencies = [
@@ -66394,7 +65988,7 @@ in
           sources."tough-cookie-2.5.0"
         ];
       })
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-from-4.0.0"
       sources."responselike-1.0.2"
       (sources."restore-cursor-2.0.0" // {
@@ -66450,7 +66044,7 @@ in
       sources."strip-final-newline-2.0.0"
       sources."strip-json-comments-2.0.1"
       sources."supports-color-7.2.0"
-      sources."systeminformation-4.28.1"
+      sources."systeminformation-4.30.1"
       sources."term-size-2.2.1"
       sources."through-2.3.8"
       sources."tmp-0.2.1"
@@ -66536,8 +66130,8 @@ in
       sources."@nodelib/fs.stat-1.1.3"
       sources."@types/glob-7.1.3"
       sources."@types/minimatch-3.0.3"
-      sources."@types/minimist-1.2.0"
-      sources."@types/node-14.14.6"
+      sources."@types/minimist-1.2.1"
+      sources."@types/node-14.14.7"
       sources."@types/normalize-package-data-2.4.0"
       sources."aggregate-error-3.1.0"
       sources."ansi-styles-3.2.1"
@@ -66787,7 +66381,7 @@ in
       sources."regex-not-1.0.2"
       sources."repeat-element-1.1.3"
       sources."repeat-string-1.6.1"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-url-0.2.1"
       sources."ret-0.1.15"
       sources."safe-regex-1.1.0"
@@ -66908,7 +66502,7 @@ in
       sources."@cycle/run-3.4.0"
       sources."@cycle/time-0.10.1"
       sources."@types/cookiejar-2.1.2"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."@types/superagent-3.8.2"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-2.1.1"
@@ -67444,7 +67038,7 @@ in
           sources."extend-shallow-2.0.1"
         ];
       })
-      sources."flat-tree-1.6.0"
+      sources."flat-tree-1.7.0"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -68010,10 +67604,10 @@ in
   elasticdump = nodeEnv.buildNodePackage {
     name = "elasticdump";
     packageName = "elasticdump";
-    version = "6.34.0";
+    version = "6.39.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-6.34.0.tgz";
-      sha512 = "YpMFwMv6BhUg4xC1eJRkBzqonsOFf/gsSjOP3Dr6S89USW3DNrY4UTZn0D7rrfpCkSZPDDcEwqy5rpcfSNYN9Q==";
+      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-6.39.0.tgz";
+      sha512 = "BSjkKIOZRkaqXkotVO/0HILZ+mqc8PrRatspvcNFajHgXiIJYk3dU4PDfbU26Y8DkxlofZfEpbw0QWKh+pu4AQ==";
     };
     dependencies = [
       sources."JSONStream-1.3.5"
@@ -68022,10 +67616,10 @@ in
       sources."assert-plus-1.0.0"
       sources."async-2.6.3"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.786.0"
+      sources."aws-sdk-2.792.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.11.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."big.js-5.2.2"
       sources."buffer-4.9.2"
@@ -68050,7 +67644,7 @@ in
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."http-signature-1.2.0"
-      sources."http-status-1.4.2"
+      sources."http-status-1.5.0"
       sources."ieee754-1.1.13"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
@@ -68090,13 +67684,14 @@ in
         ];
       })
       sources."request-2.88.2"
-      sources."requestretry-4.1.1"
+      sources."requestretry-4.1.2"
       sources."s3-stream-upload-2.0.2"
       sources."s3signed-0.1.0"
       sources."s3urls-1.5.2"
       sources."safe-buffer-5.2.1"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.1"
+      sources."semver-5.7.1"
       sources."socks5-client-1.2.8"
       sources."socks5-http-client-1.0.4"
       sources."socks5-https-client-1.2.1"
@@ -68199,8 +67794,8 @@ in
       sources."@types/cacheable-request-6.0.1"
       sources."@types/http-cache-semantics-4.0.0"
       sources."@types/keyv-3.1.1"
-      sources."@types/minimist-1.2.0"
-      sources."@types/node-14.14.6"
+      sources."@types/minimist-1.2.1"
+      sources."@types/node-14.14.7"
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/responselike-1.0.0"
       sources."@types/yoga-layout-1.9.2"
@@ -68215,7 +67810,7 @@ in
       sources."arch-2.2.0"
       sources."arrify-1.0.1"
       sources."astral-regex-2.0.0"
-      sources."atomically-1.6.0"
+      sources."atomically-1.7.0"
       sources."auto-bind-4.0.0"
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
@@ -68399,7 +67994,7 @@ in
       sources."punycode-2.1.1"
       sources."quick-lru-5.1.1"
       sources."react-16.14.0"
-      sources."react-devtools-core-4.9.0"
+      sources."react-devtools-core-4.10.0"
       sources."react-is-16.13.1"
       sources."react-reconciler-0.24.0"
       (sources."read-pkg-5.2.0" // {
@@ -68417,7 +68012,7 @@ in
         ];
       })
       sources."redent-3.0.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-alpn-1.0.0"
       sources."resolve-from-3.0.0"
       sources."responselike-2.0.0"
@@ -68443,7 +68038,7 @@ in
       sources."spdx-exceptions-2.3.0"
       sources."spdx-expression-parse-3.0.1"
       sources."spdx-license-ids-3.0.6"
-      (sources."stack-utils-2.0.2" // {
+      (sources."stack-utils-2.0.3" // {
         dependencies = [
           sources."escape-string-regexp-2.0.0"
         ];
@@ -68476,7 +68071,7 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."yargs-parser-18.1.3"
       sources."yoga-layout-prebuilt-1.10.0"
     ];
@@ -68525,7 +68120,7 @@ in
       sources."@fluentui/date-time-utilities-7.9.0"
       sources."@fluentui/dom-utilities-1.1.1"
       sources."@fluentui/keyboard-key-0.2.12"
-      sources."@fluentui/react-7.149.4"
+      sources."@fluentui/react-7.150.0"
       sources."@fluentui/react-focus-7.16.17"
       sources."@fluentui/react-window-provider-1.0.1"
       sources."@fluentui/theme-1.6.0"
@@ -68539,7 +68134,7 @@ in
           sources."normalize-path-2.1.1"
         ];
       })
-      sources."@microsoft/load-themed-styles-1.10.126"
+      sources."@microsoft/load-themed-styles-1.10.133"
       sources."@nodelib/fs.scandir-2.1.3"
       sources."@nodelib/fs.stat-2.0.3"
       sources."@nodelib/fs.walk-1.2.4"
@@ -68578,7 +68173,7 @@ in
           sources."form-data-2.5.1"
         ];
       })
-      sources."@types/serve-static-1.13.6"
+      sources."@types/serve-static-1.13.7"
       sources."@types/socket.io-2.1.11"
       sources."@types/socket.io-client-1.4.33"
       sources."@types/sqlite3-3.1.6"
@@ -68727,7 +68322,7 @@ in
         ];
       })
       sources."base64-arraybuffer-0.1.4"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."base64id-2.0.0"
       sources."basic-auth-2.0.1"
       sources."bcrypt-pbkdf-1.0.2"
@@ -68747,11 +68342,7 @@ in
       sources."browserify-aes-1.2.0"
       sources."browserify-cipher-1.0.1"
       sources."browserify-des-1.0.2"
-      (sources."browserify-rsa-4.0.1" // {
-        dependencies = [
-          sources."bn.js-4.11.9"
-        ];
-      })
+      sources."browserify-rsa-4.1.0"
       (sources."browserify-sign-4.2.1" // {
         dependencies = [
           sources."inherits-2.0.4"
@@ -69561,7 +69152,7 @@ in
       sources."object.map-1.0.1"
       sources."object.pick-1.3.0"
       sources."object.reduce-1.0.1"
-      sources."office-ui-fabric-react-7.149.4"
+      sources."office-ui-fabric-react-7.150.0"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
@@ -69645,7 +69236,7 @@ in
       sources."pg-connection-string-2.4.0"
       sources."pg-int8-1.0.1"
       sources."pg-pool-3.2.2"
-      sources."pg-protocol-1.3.0"
+      sources."pg-protocol-1.4.0"
       sources."pg-types-2.2.0"
       sources."pgpass-1.0.4"
       sources."picomatch-2.2.2"
@@ -69721,7 +69312,7 @@ in
       sources."rechoir-0.6.2"
       sources."regenerator-runtime-0.10.5"
       sources."regex-not-1.0.2"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."remove-bom-buffer-3.0.0"
       sources."remove-bom-stream-1.2.0"
@@ -69737,7 +69328,7 @@ in
       })
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-dir-1.0.1"
       sources."resolve-options-1.1.0"
       sources."resolve-url-0.2.1"
@@ -69931,7 +69522,7 @@ in
           sources."mkdirp-0.5.5"
         ];
       })
-      (sources."terser-5.3.8" // {
+      (sources."terser-5.4.0" // {
         dependencies = [
           sources."source-map-0.7.3"
         ];
@@ -70051,7 +69642,7 @@ in
         ];
       })
       sources."vm-browserify-1.1.2"
-      (sources."watchpack-1.7.4" // {
+      (sources."watchpack-1.7.5" // {
         dependencies = [
           sources."anymatch-3.1.1"
           sources."binary-extensions-2.1.0"
@@ -70061,7 +69652,7 @@ in
           sources."readdirp-3.5.0"
         ];
       })
-      sources."watchpack-chokidar2-2.0.0"
+      sources."watchpack-chokidar2-2.0.1"
       (sources."webpack-4.44.2" // {
         dependencies = [
           sources."acorn-6.4.2"
@@ -70115,7 +69706,7 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."xtend-4.0.2"
       sources."y18n-3.2.1"
@@ -70160,10 +69751,10 @@ in
   eslint = nodeEnv.buildNodePackage {
     name = "eslint";
     packageName = "eslint";
-    version = "7.12.1";
+    version = "7.13.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/eslint/-/eslint-7.12.1.tgz";
-      sha512 = "HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==";
+      url = "https://registry.npmjs.org/eslint/-/eslint-7.13.0.tgz";
+      sha512 = "uCORMuOO8tUzJmsdRtrvcGq5qposf7Rw0LwkTJkoDbOycVQtQjmnhZSuLQnozLE4TmAzlMVV45eCHmQ1OpDKUQ==";
     };
     dependencies = [
       sources."@babel/code-frame-7.10.4"
@@ -70355,7 +69946,7 @@ in
       sources."emoji-regex-7.0.3"
       sources."enquirer-2.3.6"
       sources."escape-string-regexp-1.0.5"
-      sources."eslint-7.12.1"
+      sources."eslint-7.13.0"
       sources."eslint-scope-5.1.1"
       (sources."eslint-utils-2.1.0" // {
         dependencies = [
@@ -70826,7 +70417,7 @@ in
       })
       sources."@npmcli/node-gyp-1.0.1"
       sources."@npmcli/promise-spawn-1.3.2"
-      sources."@npmcli/run-script-1.7.4"
+      sources."@npmcli/run-script-1.7.5"
       sources."@pmmmwh/react-refresh-webpack-plugin-0.3.3"
       sources."@react-native-community/cli-debugger-ui-4.9.0"
       (sources."@react-native-community/cli-platform-android-4.13.0" // {
@@ -70904,7 +70495,7 @@ in
           sources."source-map-0.6.1"
         ];
       })
-      (sources."@types/webpack-4.41.24" // {
+      (sources."@types/webpack-4.41.25" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -71066,7 +70657,7 @@ in
         ];
       })
       sources."base32.js-0.1.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."base64url-3.0.1"
       sources."batch-0.6.1"
       sources."bcrypt-pbkdf-1.0.2"
@@ -71104,11 +70695,7 @@ in
       sources."browserify-aes-1.2.0"
       sources."browserify-cipher-1.0.1"
       sources."browserify-des-1.0.2"
-      (sources."browserify-rsa-4.0.1" // {
-        dependencies = [
-          sources."bn.js-4.11.9"
-        ];
-      })
+      sources."browserify-rsa-4.1.0"
       (sources."browserify-sign-4.2.1" // {
         dependencies = [
           sources."readable-stream-3.6.0"
@@ -71116,7 +70703,7 @@ in
         ];
       })
       sources."browserify-zlib-0.2.0"
-      sources."browserslist-4.14.6"
+      sources."browserslist-4.14.7"
       sources."buffer-5.7.1"
       sources."buffer-equal-0.0.1"
       sources."buffer-from-1.1.1"
@@ -71155,7 +70742,7 @@ in
       })
       sources."camelcase-5.3.1"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30001156"
+      sources."caniuse-lite-1.0.30001158"
       sources."capture-stack-trace-1.0.1"
       sources."caseless-0.12.0"
       (sources."chalk-4.1.0" // {
@@ -71330,9 +70917,9 @@ in
       sources."cssnano-util-get-match-4.0.0"
       sources."cssnano-util-raw-cache-4.0.1"
       sources."cssnano-util-same-parent-4.0.1"
-      (sources."csso-4.1.0" // {
+      (sources."csso-4.1.1" // {
         dependencies = [
-          sources."css-tree-1.0.0"
+          sources."css-tree-1.0.1"
           sources."mdn-data-2.0.12"
           sources."source-map-0.6.1"
         ];
@@ -71341,7 +70928,7 @@ in
       sources."dag-map-1.0.2"
       sources."dashdash-1.14.1"
       sources."dateformat-3.0.3"
-      sources."dayjs-1.9.5"
+      sources."dayjs-1.9.6"
       sources."debug-4.3.0"
       sources."debuglog-1.0.1"
       sources."decache-4.4.0"
@@ -71414,7 +71001,7 @@ in
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.589"
+      sources."electron-to-chromium-1.3.596"
       (sources."elliptic-6.5.3" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -71449,11 +71036,7 @@ in
       sources."error-stack-parser-2.0.6"
       sources."errorhandler-1.5.1"
       sources."es-abstract-1.18.0-next.1"
-      (sources."es-get-iterator-1.1.0" // {
-        dependencies = [
-          sources."es-abstract-1.17.7"
-        ];
-      })
+      sources."es-get-iterator-1.1.1"
       sources."es-to-primitive-1.2.1"
       sources."es6-error-3.2.0"
       sources."escalade-3.1.1"
@@ -72058,7 +71641,7 @@ in
           sources."which-2.0.2"
         ];
       })
-      sources."node-html-parser-1.4.8"
+      sources."node-html-parser-1.4.9"
       (sources."node-libs-browser-2.2.1" // {
         dependencies = [
           sources."buffer-4.9.2"
@@ -72067,7 +71650,7 @@ in
           sources."punycode-1.4.1"
         ];
       })
-      sources."node-releases-1.1.65"
+      sources."node-releases-1.1.66"
       sources."nopt-5.0.0"
       sources."normalize-path-3.0.0"
       sources."normalize-url-3.3.0"
@@ -72570,7 +72153,7 @@ in
       sources."require-from-string-2.0.2"
       sources."require-main-filename-2.0.0"
       sources."requires-port-1.0.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-alpn-1.0.0"
       (sources."resolve-cwd-2.0.0" // {
         dependencies = [
@@ -72957,8 +72540,8 @@ in
       sources."verror-1.10.0"
       sources."vlq-1.0.1"
       sources."vm-browserify-1.1.2"
-      sources."watchpack-1.7.4"
-      (sources."watchpack-chokidar2-2.0.0" // {
+      sources."watchpack-1.7.5"
+      (sources."watchpack-chokidar2-2.0.1" // {
         dependencies = [
           sources."anymatch-2.0.0"
           sources."binary-extensions-1.13.1"
@@ -73358,7 +72941,7 @@ in
       sources."repeating-2.0.1"
       sources."request-2.88.2"
       sources."request-progress-2.0.1"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."restore-cursor-1.0.1"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
@@ -73441,15 +73024,13 @@ in
           sources."tslib-2.0.3"
         ];
       })
-      sources."@oclif/errors-1.3.3"
+      sources."@oclif/errors-1.3.4"
       sources."@oclif/linewrap-1.0.0"
       sources."@oclif/parser-3.8.5"
       (sources."@oclif/plugin-autocomplete-0.1.5" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."fs-extra-6.0.1"
-          sources."jsonfile-4.0.0"
-          sources."universalify-0.1.2"
         ];
       })
       (sources."@oclif/plugin-help-1.2.11" // {
@@ -73481,7 +73062,6 @@ in
       sources."assert-plus-1.0.0"
       sources."assign-symbols-1.0.0"
       sources."asynckit-0.4.0"
-      sources."at-least-node-1.0.0"
       sources."atob-2.1.2"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.11.0"
@@ -73491,7 +73071,7 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."bluebird-3.7.2"
       sources."brace-expansion-1.1.11"
@@ -73543,10 +73123,8 @@ in
           sources."fs-extra-7.0.1"
           sources."indent-string-3.2.0"
           sources."is-wsl-1.1.0"
-          sources."jsonfile-4.0.0"
           sources."semver-5.7.1"
           sources."strip-ansi-5.2.0"
-          sources."universalify-0.1.2"
         ];
       })
       sources."clone-response-1.0.2"
@@ -73631,7 +73209,7 @@ in
       sources."form-data-2.3.3"
       sources."fragment-cache-0.2.1"
       sources."from2-2.3.0"
-      sources."fs-extra-9.0.1"
+      sources."fs-extra-8.1.0"
       sources."fs.realpath-1.0.0"
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
@@ -73734,11 +73312,7 @@ in
       sources."json-schema-0.2.3"
       sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
-      (sources."jsonfile-6.1.0" // {
-        dependencies = [
-          sources."universalify-2.0.0"
-        ];
-      })
+      sources."jsonfile-4.0.0"
       sources."jsprim-1.4.1"
       sources."keyv-3.0.0"
       sources."kind-of-6.0.3"
@@ -73931,7 +73505,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."type-check-0.3.2"
       sources."union-value-1.0.1"
-      sources."universalify-1.0.0"
+      sources."universalify-0.1.2"
       (sources."unset-value-1.0.0" // {
         dependencies = [
           (sources."has-value-0.3.1" // {
@@ -73988,7 +73562,7 @@ in
           sources."supports-color-5.5.0"
         ];
       })
-      sources."@types/minimist-1.2.0"
+      sources."@types/minimist-1.2.1"
       sources."@types/normalize-package-data-2.4.0"
       sources."aggregate-error-3.1.0"
       sources."ansi-escapes-4.3.1"
@@ -74118,7 +73692,7 @@ in
         ];
       })
       sources."redent-3.0.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."restore-cursor-3.1.0"
       sources."run-async-2.4.1"
       sources."rxjs-6.6.3"
@@ -74886,7 +74460,7 @@ in
       })
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/minimist-1.2.0"
+      sources."@types/minimist-1.2.1"
       sources."@types/normalize-package-data-2.4.0"
       sources."ajv-6.12.6"
       (sources."ansi-align-3.0.0" // {
@@ -74902,7 +74476,7 @@ in
       sources."ansi-regex-5.0.0"
       sources."ansi-styles-4.3.0"
       sources."arrify-1.0.1"
-      sources."atomically-1.6.0"
+      sources."atomically-1.7.0"
       (sources."boxen-4.2.0" // {
         dependencies = [
           sources."chalk-3.0.0"
@@ -75079,9 +74653,9 @@ in
         ];
       })
       sources."redent-3.0.0"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."responselike-1.0.2"
       sources."restore-cursor-3.1.0"
       sources."run-async-2.4.1"
@@ -75171,7 +74745,7 @@ in
           sources."@graphql-tools/utils-7.0.2"
         ];
       })
-      (sources."@graphql-tools/delegate-7.0.4" // {
+      (sources."@graphql-tools/delegate-7.0.5" // {
         dependencies = [
           sources."@graphql-tools/utils-7.0.2"
         ];
@@ -75216,7 +74790,7 @@ in
       sources."@nodelib/fs.walk-1.2.4"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."@types/parse-json-4.0.0"
       sources."@types/websocket-1.0.1"
       sources."aggregate-error-3.1.0"
@@ -75241,7 +74815,7 @@ in
       sources."aws4-1.11.0"
       sources."backo2-1.0.2"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
@@ -75316,11 +74890,7 @@ in
       sources."end-of-stream-1.4.4"
       sources."error-ex-1.3.2"
       sources."es-abstract-1.18.0-next.1"
-      (sources."es-get-iterator-1.1.0" // {
-        dependencies = [
-          sources."es-abstract-1.17.7"
-        ];
-      })
+      sources."es-get-iterator-1.1.1"
       sources."es-to-primitive-1.2.1"
       sources."es5-ext-0.10.53"
       sources."es6-iterator-2.0.3"
@@ -75596,7 +75166,7 @@ in
           sources."es-abstract-1.17.7"
         ];
       })
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."remove-trailing-separator-1.1.0"
       sources."request-2.88.2"
@@ -75704,11 +75274,11 @@ in
       (sources."yargs-16.0.3" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
-          sources."cliui-7.0.3"
+          sources."cliui-7.0.4"
           sources."strip-ansi-6.0.0"
           sources."wrap-ansi-7.0.0"
           sources."y18n-5.0.5"
-          sources."yargs-parser-20.2.3"
+          sources."yargs-parser-20.2.4"
         ];
       })
       sources."yargs-parser-18.1.3"
@@ -75899,7 +75469,7 @@ in
       sources."regex-not-1.0.2"
       sources."repeat-element-1.1.3"
       sources."repeat-string-1.6.1"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-dir-1.0.1"
       sources."resolve-url-0.2.1"
       sources."ret-0.1.15"
@@ -76082,7 +75652,7 @@ in
           sources."supports-color-7.2.0"
         ];
       })
-      sources."systeminformation-4.28.1"
+      sources."systeminformation-4.30.1"
       sources."term-canvas-0.0.5"
       sources."type-fest-0.11.0"
       sources."wordwrap-0.0.3"
@@ -76430,7 +76000,7 @@ in
       sources."replace-homedir-1.0.0"
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-dir-1.0.1"
       sources."resolve-options-1.1.0"
       sources."resolve-url-0.2.1"
@@ -76821,7 +76391,7 @@ in
       sources."replace-homedir-1.0.0"
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-dir-1.0.1"
       sources."resolve-url-0.2.1"
       sources."ret-0.1.15"
@@ -76959,7 +76529,7 @@ in
       sources."param-case-2.1.1"
       sources."relateurl-0.2.7"
       sources."source-map-0.6.1"
-      sources."uglify-js-3.11.5"
+      sources."uglify-js-3.11.6"
       sources."upper-case-1.1.3"
     ];
     buildInputs = globalBuildInputs;
@@ -76975,10 +76545,10 @@ in
   htmlhint = nodeEnv.buildNodePackage {
     name = "htmlhint";
     packageName = "htmlhint";
-    version = "0.14.1";
+    version = "0.14.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/htmlhint/-/htmlhint-0.14.1.tgz";
-      sha512 = "VWKrljlwF8tEKH48YPfC30zYKhrsMqm70d7vXswivEqd3DSva8ZlIzfeCa3YWFEFRIIhiXKgKurlqEpCtYMCAA==";
+      url = "https://registry.npmjs.org/htmlhint/-/htmlhint-0.14.2.tgz";
+      sha512 = "lUCgGVZ/oyCkpgDkIa5IfClwX8Ppy11Dk7XdeVboAGSmKjIuOKx6yy86WS0W08KFtCRuxftzNy+KdQjM4UjqCA==";
     };
     dependencies = [
       sources."ajv-6.12.6"
@@ -76993,7 +76563,7 @@ in
       sources."bcrypt-pbkdf-1.0.2"
       sources."brace-expansion-1.1.11"
       sources."caseless-0.12.0"
-      sources."chalk-4.0.0"
+      sources."chalk-4.1.0"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
       sources."combined-stream-1.0.8"
@@ -77102,6 +76672,112 @@ in
     meta = {
       description = "A simple zero-configuration command-line http server";
       homepage = "https://github.com/http-party/http-server#readme";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
+  hsd = nodeEnv.buildNodePackage {
+    name = "hsd";
+    packageName = "hsd";
+    version = "2.2.0";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/hsd/-/hsd-2.2.0.tgz";
+      sha512 = "9U6ylEa3WPEb5AHb/TuwYDOJaXmR6mfKky8uJml3Y0xUAvO/yg/b4GfBXnMQ2wPQME5fG5Vkx0OLK7MyidtmAw==";
+    };
+    dependencies = [
+      sources."bcfg-0.1.6"
+      sources."bcrypto-5.3.0"
+      sources."bcurl-0.1.9"
+      sources."bdb-1.3.0"
+      sources."bdns-0.1.5"
+      sources."bevent-0.1.5"
+      sources."bfile-0.2.2"
+      sources."bfilter-1.0.5"
+      sources."bheep-0.1.5"
+      sources."binet-0.3.6"
+      sources."blgr-0.1.8"
+      sources."blru-0.1.6"
+      sources."blst-0.1.5"
+      sources."bmutex-0.1.6"
+      sources."bns-0.13.0"
+      sources."brq-0.1.8"
+      sources."bs32-0.1.6"
+      sources."bsert-0.0.10"
+      sources."bsock-0.1.9"
+      sources."bsocks-0.2.5"
+      sources."btcp-0.1.5"
+      sources."budp-0.1.6"
+      sources."buffer-map-0.0.7"
+      sources."bufio-1.0.7"
+      sources."bupnp-0.2.6"
+      sources."bval-0.1.6"
+      sources."bweb-0.1.10"
+      sources."goosig-0.9.0"
+      sources."hs-client-0.0.9"
+      sources."loady-0.0.5"
+      sources."mrmr-0.1.10"
+      sources."n64-0.2.10"
+      sources."unbound-0.4.3"
+      sources."urkel-0.6.3"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Cryptocurrency bike-shed";
+      homepage = https://github.com/handshake-org/hsd;
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
+  hs-airdrop = nodeEnv.buildNodePackage {
+    name = "hs-airdrop";
+    packageName = "hs-airdrop";
+    version = "0.9.0";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/hs-airdrop/-/hs-airdrop-0.9.0.tgz";
+      sha512 = "eqN7mbITsdiBFdRlFHd91Vgudu5rajvIfPhZ8juWLFBZhxhuXzu1POMy4uHK+02jxNjX+upMMRyDxo4xS/ZudQ==";
+    };
+    dependencies = [
+      sources."bcrypto-5.3.0"
+      sources."bfile-0.2.2"
+      sources."brq-0.1.8"
+      sources."bsert-0.0.10"
+      sources."bufio-1.0.7"
+      sources."goosig-0.9.0"
+      sources."loady-0.0.5"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Handshake airdrop redemption";
+      homepage = https://github.com/handshake-org/hs-airdrop;
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
+  hs-client = nodeEnv.buildNodePackage {
+    name = "hs-client";
+    packageName = "hs-client";
+    version = "0.0.9";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/hs-client/-/hs-client-0.0.9.tgz";
+      sha512 = "TAsexmpPhSVdCQ1iiX4bBnuqlThTSdGz/YKq+vjLSS1TZ2TwKxERJ8vZh1Wd6GGaMGLZl99uQR+2wUyk4HLSbg==";
+    };
+    dependencies = [
+      sources."bcfg-0.1.6"
+      sources."bcurl-0.1.9"
+      sources."brq-0.1.8"
+      sources."bsert-0.0.10"
+      sources."bsock-0.1.9"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "HSD node and wallet client";
+      homepage = https://github.com/handshake-org/hs-client;
       license = "MIT";
     };
     production = true;
@@ -77829,7 +77505,7 @@ in
       })
       sources."wrappy-1.0.2"
       sources."write-file-atomic-3.0.3"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."xregexp-2.0.0"
       sources."yallist-3.1.1"
     ];
@@ -77854,9 +77530,9 @@ in
     };
     dependencies = [
       sources."@iarna/toml-2.2.5"
-      sources."@ot-builder/bin-composite-types-0.10.31"
-      sources."@ot-builder/bin-util-0.10.31"
-      (sources."@ot-builder/cli-help-shower-0.10.31" // {
+      sources."@ot-builder/bin-composite-types-0.10.33"
+      sources."@ot-builder/bin-util-0.10.33"
+      (sources."@ot-builder/cli-help-shower-0.10.33" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
@@ -77866,7 +77542,7 @@ in
           sources."supports-color-7.2.0"
         ];
       })
-      (sources."@ot-builder/cli-proc-0.10.31" // {
+      (sources."@ot-builder/cli-proc-0.10.33" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
@@ -77876,7 +77552,7 @@ in
           sources."supports-color-7.2.0"
         ];
       })
-      (sources."@ot-builder/cli-shared-0.10.31" // {
+      (sources."@ot-builder/cli-shared-0.10.33" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
@@ -77886,35 +77562,35 @@ in
           sources."supports-color-7.2.0"
         ];
       })
-      sources."@ot-builder/common-impl-0.10.31"
-      sources."@ot-builder/errors-0.10.31"
-      sources."@ot-builder/io-bin-cff-0.10.31"
-      sources."@ot-builder/io-bin-encoding-0.10.31"
-      sources."@ot-builder/io-bin-ext-private-0.10.31"
-      sources."@ot-builder/io-bin-font-0.10.31"
-      sources."@ot-builder/io-bin-glyph-store-0.10.31"
-      sources."@ot-builder/io-bin-layout-0.10.31"
-      sources."@ot-builder/io-bin-metadata-0.10.31"
-      sources."@ot-builder/io-bin-metric-0.10.31"
-      sources."@ot-builder/io-bin-name-0.10.31"
-      sources."@ot-builder/io-bin-sfnt-0.10.31"
-      sources."@ot-builder/io-bin-ttf-0.10.31"
-      sources."@ot-builder/ot-0.10.31"
-      sources."@ot-builder/ot-encoding-0.10.31"
-      sources."@ot-builder/ot-ext-private-0.10.31"
-      sources."@ot-builder/ot-glyphs-0.10.31"
-      sources."@ot-builder/ot-layout-0.10.31"
-      sources."@ot-builder/ot-metadata-0.10.31"
-      sources."@ot-builder/ot-name-0.10.31"
-      sources."@ot-builder/ot-sfnt-0.10.31"
-      sources."@ot-builder/ot-standard-glyph-namer-0.10.31"
-      sources."@ot-builder/prelude-0.10.31"
-      sources."@ot-builder/primitive-0.10.31"
-      sources."@ot-builder/rectify-0.10.31"
-      sources."@ot-builder/stat-glyphs-0.10.31"
-      sources."@ot-builder/trace-0.10.31"
-      sources."@ot-builder/var-store-0.10.31"
-      sources."@ot-builder/variance-0.10.31"
+      sources."@ot-builder/common-impl-0.10.33"
+      sources."@ot-builder/errors-0.10.33"
+      sources."@ot-builder/io-bin-cff-0.10.33"
+      sources."@ot-builder/io-bin-encoding-0.10.33"
+      sources."@ot-builder/io-bin-ext-private-0.10.33"
+      sources."@ot-builder/io-bin-font-0.10.33"
+      sources."@ot-builder/io-bin-glyph-store-0.10.33"
+      sources."@ot-builder/io-bin-layout-0.10.33"
+      sources."@ot-builder/io-bin-metadata-0.10.33"
+      sources."@ot-builder/io-bin-metric-0.10.33"
+      sources."@ot-builder/io-bin-name-0.10.33"
+      sources."@ot-builder/io-bin-sfnt-0.10.33"
+      sources."@ot-builder/io-bin-ttf-0.10.33"
+      sources."@ot-builder/ot-0.10.33"
+      sources."@ot-builder/ot-encoding-0.10.33"
+      sources."@ot-builder/ot-ext-private-0.10.33"
+      sources."@ot-builder/ot-glyphs-0.10.33"
+      sources."@ot-builder/ot-layout-0.10.33"
+      sources."@ot-builder/ot-metadata-0.10.33"
+      sources."@ot-builder/ot-name-0.10.33"
+      sources."@ot-builder/ot-sfnt-0.10.33"
+      sources."@ot-builder/ot-standard-glyph-namer-0.10.33"
+      sources."@ot-builder/prelude-0.10.33"
+      sources."@ot-builder/primitive-0.10.33"
+      sources."@ot-builder/rectify-0.10.33"
+      sources."@ot-builder/stat-glyphs-0.10.33"
+      sources."@ot-builder/trace-0.10.33"
+      sources."@ot-builder/var-store-0.10.33"
+      sources."@ot-builder/variance-0.10.33"
       sources."@unicode/unicode-13.0.0-1.0.2"
       sources."abbrev-1.1.1"
       sources."ajv-6.12.6"
@@ -78085,8 +77761,8 @@ in
       sources."os-locale-1.4.0"
       sources."os-tmpdir-1.0.2"
       sources."osenv-0.1.5"
-      sources."ot-builder-0.10.31"
-      (sources."otb-ttc-bundle-0.10.31" // {
+      sources."ot-builder-0.10.33"
+      (sources."otb-ttc-bundle-0.10.33" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
@@ -78107,7 +77783,7 @@ in
       sources."path-is-absolute-1.0.1"
       sources."path-parse-1.0.6"
       sources."path-type-1.1.0"
-      sources."patrisika-0.22.0"
+      sources."patrisika-0.22.2"
       sources."patrisika-scopes-0.11.1"
       sources."pegjs-0.10.0"
       sources."performance-now-2.1.0"
@@ -78125,7 +77801,7 @@ in
       sources."request-2.88.2"
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-url-0.2.1"
       sources."restore-cursor-3.1.0"
       sources."resumer-0.0.0"
@@ -78358,14 +78034,53 @@ in
   joplin = nodeEnv.buildNodePackage {
     name = "joplin";
     packageName = "joplin";
-    version = "1.3.3";
+    version = "1.4.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/joplin/-/joplin-1.3.3.tgz";
-      sha512 = "6QhCBf0amMaVX6u90Uy84hEdHLPthTrQIbgUBFccFpBC1bowdj85C3tSYEfrSCf72OtjwwT26OaHuRJgzCmb8A==";
+      url = "https://registry.npmjs.org/joplin/-/joplin-1.4.3.tgz";
+      sha512 = "29r23EaeUT0HupQVr5xNN1WuUpT+vn9agxrjbSwVJCYhV++kpkf2zvmuFe7fcTI3oAVu5yXLiK388DlJ7vaFPQ==";
     };
     dependencies = [
+      sources."@babel/code-frame-7.10.4"
+      (sources."@babel/generator-7.12.5" // {
+        dependencies = [
+          sources."source-map-0.5.7"
+        ];
+      })
+      sources."@babel/helper-function-name-7.10.4"
+      sources."@babel/helper-get-function-arity-7.10.4"
+      sources."@babel/helper-split-export-declaration-7.11.0"
+      sources."@babel/helper-validator-identifier-7.10.4"
+      (sources."@babel/highlight-7.10.4" // {
+        dependencies = [
+          sources."chalk-2.4.2"
+        ];
+      })
+      sources."@babel/parser-7.12.5"
+      sources."@babel/template-7.10.4"
+      (sources."@babel/traverse-7.12.5" // {
+        dependencies = [
+          sources."debug-4.3.0"
+        ];
+      })
+      sources."@babel/types-7.12.6"
+      sources."@braintree/sanitize-url-3.1.0"
       sources."@cronvel/get-pixels-3.4.0"
-      sources."@yarnpkg/lockfile-1.1.0"
+      sources."@joplinapp/fork-htmlparser2-4.1.8"
+      sources."@joplinapp/fork-sax-1.2.12"
+      sources."@joplinapp/lib-1.0.9"
+      (sources."@joplinapp/renderer-1.0.17" // {
+        dependencies = [
+          sources."fs-extra-8.1.0"
+          sources."jsonfile-4.0.0"
+          sources."uslug-git+https://github.com/laurent22/uslug.git#emoji-support"
+        ];
+      })
+      (sources."@shiftkey/node-abi-2.19.2-pre" // {
+        dependencies = [
+          sources."semver-5.7.1"
+        ];
+      })
+      sources."@shiftkey/prebuild-install-6.0.1-pre2"
       sources."abab-2.0.5"
       sources."abbrev-1.1.1"
       sources."acorn-7.4.1"
@@ -78383,102 +78098,72 @@ in
       })
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-3.2.1"
-      sources."app-module-path-2.2.0"
+      sources."anymatch-3.1.1"
       sources."aproba-1.2.0"
-      (sources."are-we-there-yet-1.1.5" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-          sources."string_decoder-1.1.1"
-        ];
-      })
+      sources."are-we-there-yet-1.1.5"
       (sources."argparse-1.0.10" // {
         dependencies = [
           sources."sprintf-js-1.0.3"
         ];
       })
-      sources."arr-diff-4.0.0"
-      sources."arr-flatten-1.1.0"
-      sources."arr-union-3.1.0"
       sources."array-back-2.0.0"
       sources."array-equal-1.0.0"
-      sources."array-unique-0.3.2"
       sources."asap-2.0.6"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
-      sources."assign-symbols-1.0.0"
       sources."async-mutex-0.1.4"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
-      (sources."aws-sdk-2.786.0" // {
+      (sources."aws-sdk-2.792.0" // {
         dependencies = [
           sources."sax-1.2.1"
           sources."uuid-3.3.2"
           sources."xml2js-0.4.19"
+          sources."xmlbuilder-9.0.7"
         ];
       })
       sources."aws-sign2-0.7.0"
       sources."aws4-1.11.0"
+      sources."babel-eslint-10.1.0"
       sources."balanced-match-1.0.0"
-      (sources."base-0.11.2" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-        ];
-      })
       sources."base-64-0.1.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."base64-stream-1.0.0"
       sources."bcrypt-pbkdf-1.0.2"
+      sources."binary-extensions-2.1.0"
       (sources."bl-4.0.3" // {
         dependencies = [
           sources."buffer-5.7.1"
+          sources."readable-stream-3.6.0"
         ];
       })
       sources."brace-expansion-1.1.11"
-      (sources."braces-2.3.2" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
+      sources."braces-3.0.2"
       sources."browser-process-hrtime-1.0.0"
       sources."buffer-4.9.2"
+      sources."buffer-from-1.1.1"
       sources."builtin-modules-3.1.0"
-      sources."cache-base-1.0.1"
       sources."camel-case-3.0.0"
       sources."camelcase-4.1.0"
       sources."caseless-0.12.0"
-      sources."chalk-2.4.2"
+      (sources."chalk-4.1.0" // {
+        dependencies = [
+          sources."ansi-styles-4.3.0"
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+          sources."has-flag-4.0.0"
+          sources."supports-color-7.2.0"
+        ];
+      })
       sources."charenc-0.0.2"
+      sources."chokidar-3.4.3"
       sources."chownr-1.1.4"
       sources."chroma-js-2.1.0"
-      sources."ci-info-2.0.0"
-      (sources."class-utils-0.3.6" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
       sources."clean-css-4.2.3"
-      (sources."clean-html-1.5.0" // {
-        dependencies = [
-          sources."htmlparser2-3.10.1"
-        ];
-      })
+      sources."clean-html-1.5.0"
       sources."cliss-0.0.2"
       sources."code-point-at-1.1.0"
-      sources."collection-visit-1.0.0"
-      sources."color-3.1.3"
+      sources."color-3.1.2"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."color-string-1.5.4"
@@ -78486,23 +78171,14 @@ in
       sources."command-line-usage-4.1.0"
       sources."commander-2.17.1"
       sources."compare-version-0.1.2"
-      sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
       sources."console-control-strings-1.1.0"
-      sources."copy-descriptor-0.1.1"
       sources."core-util-is-1.0.2"
-      (sources."cross-env-6.0.3" // {
-        dependencies = [
-          sources."cross-spawn-7.0.3"
-          sources."path-key-3.1.1"
-          sources."shebang-command-2.0.0"
-          sources."shebang-regex-3.0.0"
-          sources."which-2.0.2"
-        ];
-      })
-      sources."cross-spawn-6.0.5"
+      sources."cross-env-6.0.3"
+      sources."cross-spawn-7.0.3"
       sources."crypt-0.0.2"
       sources."css-2.2.4"
+      sources."css-b64-images-0.2.5"
       sources."cssom-0.4.4"
       (sources."cssstyle-2.3.0" // {
         dependencies = [
@@ -78510,31 +78186,59 @@ in
         ];
       })
       sources."cwise-compiler-1.1.3"
+      sources."d3-5.16.0"
+      sources."d3-array-1.2.4"
+      sources."d3-axis-1.0.12"
+      sources."d3-brush-1.1.6"
+      sources."d3-chord-1.0.6"
+      sources."d3-collection-1.0.7"
+      sources."d3-color-1.4.1"
+      sources."d3-contour-1.3.2"
+      sources."d3-dispatch-1.0.6"
+      sources."d3-drag-1.2.5"
+      sources."d3-dsv-1.2.0"
+      sources."d3-ease-1.0.7"
+      sources."d3-fetch-1.2.0"
+      sources."d3-force-1.2.1"
+      sources."d3-format-1.4.5"
+      sources."d3-geo-1.12.1"
+      sources."d3-hierarchy-1.1.9"
+      sources."d3-interpolate-1.4.0"
+      sources."d3-path-1.0.9"
+      sources."d3-polygon-1.0.6"
+      sources."d3-quadtree-1.0.7"
+      sources."d3-random-1.1.2"
+      sources."d3-scale-2.2.2"
+      sources."d3-scale-chromatic-1.5.0"
+      sources."d3-selection-1.4.2"
+      sources."d3-shape-1.3.7"
+      sources."d3-time-1.1.0"
+      sources."d3-time-format-2.3.0"
+      sources."d3-timer-1.0.10"
+      sources."d3-transition-1.3.2"
+      sources."d3-voronoi-1.1.4"
+      sources."d3-zoom-1.8.3"
+      sources."dagre-0.8.5"
+      sources."dagre-d3-0.6.4"
       sources."dashdash-1.14.1"
       sources."data-urls-1.1.0"
-      sources."debug-2.6.9"
+      sources."debug-3.2.6"
       sources."decode-uri-component-0.2.0"
       sources."decompress-response-4.2.1"
       sources."deep-extend-0.6.0"
       sources."deep-is-0.1.3"
       sources."deepmerge-2.2.1"
-      sources."define-property-2.0.2"
       sources."delayed-stream-1.0.0"
       sources."delegates-1.0.0"
       sources."depd-1.1.2"
       sources."detect-libc-1.0.3"
       sources."diacritics-1.3.0"
       sources."diff-match-patch-1.0.5"
-      (sources."dom-serializer-0.2.2" // {
-        dependencies = [
-          sources."domelementtype-2.0.2"
-          sources."entities-2.1.0"
-        ];
-      })
-      sources."domelementtype-1.3.1"
+      sources."dom-serializer-1.1.0"
+      sources."domelementtype-2.0.2"
       sources."domexception-1.0.1"
-      sources."domhandler-2.4.2"
-      sources."domutils-1.7.0"
+      sources."domhandler-3.3.0"
+      sources."domutils-2.4.2"
       sources."ecc-jsbn-0.1.2"
       (sources."emphasize-1.5.0" // {
         dependencies = [
@@ -78551,45 +78255,18 @@ in
         ];
       })
       sources."end-of-stream-1.4.4"
-      sources."entities-1.1.2"
+      sources."entities-2.1.0"
+      sources."entity-decode-2.0.2"
       sources."es6-promise-pool-2.5.0"
       sources."escape-string-regexp-1.0.5"
       sources."escodegen-1.14.3"
+      sources."eslint-visitor-keys-1.3.0"
       sources."esprima-4.0.1"
       sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."events-1.1.1"
-      (sources."expand-brackets-2.1.4" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."extend-shallow-2.0.1"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
       sources."expand-template-2.0.3"
       sources."extend-3.0.2"
-      (sources."extend-shallow-3.0.2" // {
-        dependencies = [
-          sources."is-extendable-1.0.1"
-        ];
-      })
-      (sources."extglob-2.0.4" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-          sources."extend-shallow-2.0.1"
-        ];
-      })
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-3.1.3"
       sources."fast-json-stable-stringify-2.1.0"
@@ -78597,30 +78274,25 @@ in
       sources."fault-1.0.4"
       sources."file-type-10.11.0"
       sources."file-uri-to-path-1.0.0"
-      (sources."fill-range-4.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
+      sources."fill-range-7.0.1"
       sources."find-up-2.1.0"
-      (sources."find-yarn-workspace-root-1.2.1" // {
-        dependencies = [
-          sources."fs-extra-4.0.3"
-        ];
-      })
       sources."follow-redirects-1.13.0"
       sources."font-awesome-filetypes-2.1.0"
       sources."for-each-property-0.0.4"
       sources."for-each-property-deep-0.0.3"
-      sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.5.1"
       sources."format-0.2.2"
-      sources."fragment-cache-0.2.1"
       sources."fs-constants-1.0.0"
-      sources."fs-extra-5.0.0"
-      sources."fs-minipass-2.1.0"
+      (sources."fs-extra-5.0.0" // {
+        dependencies = [
+          sources."jsonfile-4.0.0"
+        ];
+      })
+      sources."fs-minipass-1.2.7"
       sources."fs.realpath-1.0.0"
+      sources."fsevents-2.1.3"
+      sources."function-bind-1.1.1"
       (sources."gauge-2.7.4" // {
         dependencies = [
           sources."strip-ansi-3.0.1"
@@ -78628,34 +78300,38 @@ in
       })
       sources."get-prototype-chain-1.0.1"
       sources."get-stdin-5.0.1"
-      sources."get-value-2.0.6"
       sources."getpass-0.1.7"
       sources."github-from-package-0.0.0"
       sources."glob-7.1.6"
+      sources."glob-parent-5.1.1"
+      sources."globals-11.12.0"
       sources."graceful-fs-4.2.4"
+      sources."graphlib-2.1.8"
+      sources."growly-1.3.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
+      sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."has-unicode-2.0.1"
-      sources."has-value-1.0.0"
-      (sources."has-values-1.0.0" // {
-        dependencies = [
-          sources."kind-of-4.0.0"
-        ];
-      })
       sources."he-1.2.0"
-      sources."highlight.js-10.1.1"
+      sources."highlight.js-10.3.2"
       sources."html-encoding-sniffer-1.0.2"
       sources."html-entities-1.3.1"
       sources."html-minifier-3.5.21"
-      (sources."htmlparser2-4.1.0" // {
+      (sources."htmlparser2-3.10.1" // {
         dependencies = [
-          sources."dom-serializer-1.1.0"
-          sources."domelementtype-2.0.2"
-          sources."domhandler-3.3.0"
-          sources."domutils-2.4.2"
-          sources."entities-2.1.0"
+          (sources."dom-serializer-0.2.2" // {
+            dependencies = [
+              sources."domelementtype-2.0.2"
+              sources."entities-2.1.0"
+            ];
+          })
+          sources."domelementtype-1.3.1"
+          sources."domhandler-2.4.2"
+          sources."domutils-1.7.0"
+          sources."entities-1.1.2"
+          sources."readable-stream-3.6.0"
         ];
       })
       sources."http-errors-1.8.0"
@@ -78666,7 +78342,6 @@ in
       (sources."image-data-uri-2.0.1" // {
         dependencies = [
           sources."fs-extra-0.26.7"
-          sources."jsonfile-2.4.0"
         ];
       })
       sources."image-type-3.1.0"
@@ -78703,21 +78378,15 @@ in
       sources."iota-array-1.0.0"
       sources."ip-regex-2.1.0"
       sources."is-absolute-0.2.6"
-      sources."is-accessor-descriptor-1.0.0"
       sources."is-arrayish-0.3.2"
+      sources."is-binary-path-2.1.0"
       sources."is-buffer-1.1.6"
-      sources."is-ci-2.0.0"
-      sources."is-data-descriptor-1.0.0"
-      sources."is-descriptor-1.0.2"
+      sources."is-core-module-2.1.0"
       sources."is-docker-2.1.1"
-      sources."is-extendable-0.1.1"
+      sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-1.0.0"
-      (sources."is-number-3.0.0" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."is-plain-object-2.0.4"
+      sources."is-glob-4.0.1"
+      sources."is-number-7.0.0"
       sources."is-relative-0.2.1"
       sources."is-stream-1.1.0"
       sources."is-typedarray-1.0.0"
@@ -78731,7 +78400,7 @@ in
       })
       sources."isarray-1.0.0"
       sources."isexe-2.0.0"
-      sources."isobject-3.0.1"
+      sources."isobject-2.1.0"
       sources."isstream-0.1.2"
       sources."jmespath-0.15.0"
       sources."joplin-turndown-4.0.30"
@@ -78739,22 +78408,25 @@ in
       sources."jpeg-js-0.4.2"
       sources."js-tokens-4.0.0"
       sources."jsbn-0.1.1"
-      sources."jsdom-15.2.1"
+      (sources."jsdom-15.2.1" // {
+        dependencies = [
+          sources."tough-cookie-3.0.1"
+        ];
+      })
+      sources."jsesc-2.5.2"
       sources."json-schema-0.2.3"
       sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
-      sources."jsonfile-4.0.0"
+      sources."jsonfile-2.4.0"
       sources."jsprim-1.4.1"
-      sources."jssha-2.4.2"
       (sources."katex-0.12.0" // {
         dependencies = [
           sources."commander-2.20.3"
         ];
       })
-      sources."keytar-5.6.0"
-      sources."kind-of-6.0.3"
+      sources."keytar-7.1.0"
+      sources."khroma-1.1.0"
       sources."klaw-1.3.1"
-      sources."klaw-sync-6.0.0"
       sources."lazyness-1.2.0"
       sources."levenshtein-1.0.5"
       sources."levn-0.3.0"
@@ -78774,8 +78446,6 @@ in
         ];
       })
       sources."magicli-0.0.8"
-      sources."map-cache-0.2.2"
-      sources."map-visit-1.0.0"
       (sources."markdown-it-10.0.0" // {
         dependencies = [
           sources."entities-2.0.3"
@@ -78802,52 +78472,60 @@ in
       sources."md5-2.3.0"
       sources."md5-file-4.0.0"
       sources."mdurl-1.0.1"
-      sources."micromatch-3.1.10"
-      sources."mime-2.4.6"
+      sources."mermaid-8.8.3"
       sources."mime-db-1.44.0"
       sources."mime-types-2.1.27"
       sources."mimic-response-2.1.0"
-      sources."minimatch-3.0.4"
-      sources."minimist-1.2.5"
-      sources."minipass-3.1.3"
-      sources."minizlib-2.1.2"
-      (sources."mixin-deep-1.3.2" // {
+      (sources."minify-4.1.3" // {
         dependencies = [
-          sources."is-extendable-1.0.1"
+          sources."commander-2.20.3"
+          sources."debug-4.3.0"
+          sources."html-minifier-4.0.0"
+          sources."uglify-js-3.11.6"
         ];
       })
+      sources."minimatch-3.0.4"
+      sources."minimist-1.2.5"
+      sources."minipass-2.9.0"
+      sources."minizlib-1.3.3"
       sources."mkdirp-0.5.5"
       sources."mkdirp-classic-0.5.3"
       sources."moment-2.29.1"
-      sources."ms-2.0.0"
+      sources."moment-mini-2.24.0"
+      sources."ms-2.1.2"
       sources."multiparty-4.2.2"
-      sources."nan-2.14.1"
+      sources."mustache-4.0.1"
+      sources."nan-2.14.2"
       sources."nanoid-3.1.16"
-      (sources."nanomatch-1.2.13" // {
-        dependencies = [
-          sources."is-windows-1.0.2"
-        ];
-      })
       sources."napi-build-utils-1.0.2"
       sources."ndarray-1.0.19"
       sources."ndarray-pack-1.2.1"
-      (sources."needle-2.5.2" // {
+      sources."needle-2.5.2"
+      sources."nextgen-events-1.3.3"
+      sources."no-case-2.3.2"
+      (sources."node-abi-2.19.1" // {
         dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
+          sources."semver-5.7.1"
         ];
       })
-      sources."nextgen-events-1.3.3"
-      sources."nice-try-1.0.5"
-      sources."no-case-2.3.2"
-      sources."node-abi-2.19.1"
+      sources."node-addon-api-3.0.2"
       sources."node-bitmap-0.0.1"
       sources."node-emoji-1.10.0"
       sources."node-fetch-1.7.3"
+      (sources."node-notifier-8.0.0" // {
+        dependencies = [
+          sources."uuid-8.3.1"
+        ];
+      })
       sources."node-persist-2.1.0"
-      sources."node-pre-gyp-0.11.0"
+      (sources."node-pre-gyp-0.11.0" // {
+        dependencies = [
+          sources."semver-5.7.1"
+        ];
+      })
       sources."noop-logger-0.1.1"
       sources."nopt-4.0.3"
+      sources."normalize-path-3.0.0"
       sources."npm-bundled-1.1.1"
       sources."npm-normalize-package-bin-1.0.1"
       sources."npm-packlist-1.4.8"
@@ -78856,27 +78534,12 @@ in
       sources."nwsapi-2.2.0"
       sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
-      (sources."object-copy-0.1.0" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."is-accessor-descriptor-0.1.6"
-          sources."is-data-descriptor-0.1.4"
-          (sources."is-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-5.1.0"
-            ];
-          })
-          sources."kind-of-3.2.2"
-        ];
-      })
       (sources."object-to-arguments-0.0.8" // {
         dependencies = [
           sources."inspect-parameters-declaration-0.0.10"
           sources."magicli-0.0.5"
         ];
       })
-      sources."object-visit-1.0.1"
-      sources."object.pick-1.3.0"
       sources."omggif-1.0.10"
       sources."once-1.4.0"
       sources."open-7.3.0"
@@ -78889,29 +78552,24 @@ in
       sources."p-try-1.0.0"
       sources."param-case-2.1.1"
       sources."parse5-5.1.0"
-      sources."pascalcase-0.1.1"
-      (sources."patch-package-6.2.2" // {
-        dependencies = [
-          sources."fs-extra-7.0.1"
-        ];
-      })
       sources."path-exists-3.0.0"
       sources."path-is-absolute-1.0.1"
-      sources."path-key-2.0.1"
+      sources."path-key-3.1.1"
+      sources."path-parse-1.0.6"
       sources."performance-now-2.1.0"
+      sources."picomatch-2.2.2"
       sources."pify-3.0.0"
       sources."pipe-functions-1.3.0"
       sources."pn-1.1.0"
       sources."pngjs-5.0.0"
-      sources."posix-character-classes-0.1.1"
-      sources."prebuild-install-5.3.3"
+      sources."prebuild-install-5.3.6"
       sources."prelude-ls-1.1.2"
       sources."process-nextick-args-2.0.1"
       sources."promise-7.3.1"
       sources."proper-lockfile-2.0.1"
       sources."psl-1.8.0"
       sources."pump-3.0.0"
-      sources."punycode-1.3.2"
+      sources."punycode-2.1.1"
       sources."q-1.1.2"
       sources."qs-6.5.2"
       sources."query-string-4.3.4"
@@ -78921,144 +78579,83 @@ in
       sources."rc-1.2.8"
       sources."re-reselect-4.0.0"
       sources."read-chunk-2.1.0"
-      sources."readable-stream-3.6.0"
-      sources."reduce-flatten-1.0.1"
-      sources."redux-3.7.2"
-      sources."regex-not-1.0.2"
-      sources."relateurl-0.2.7"
-      (sources."relative-3.0.2" // {
+      (sources."readable-stream-2.3.7" // {
         dependencies = [
-          sources."isobject-2.1.0"
+          sources."safe-buffer-5.1.2"
         ];
       })
-      sources."repeat-element-1.1.3"
-      sources."repeat-string-1.6.1"
+      sources."readdirp-3.5.0"
+      sources."reduce-flatten-1.0.1"
+      sources."redux-3.7.2"
+      sources."relateurl-0.2.7"
+      sources."relative-3.0.2"
       (sources."request-2.88.2" // {
         dependencies = [
           sources."form-data-2.3.3"
-          sources."punycode-2.1.1"
-          sources."tough-cookie-2.5.0"
         ];
       })
       sources."request-promise-core-1.1.4"
-      (sources."request-promise-native-1.0.9" // {
-        dependencies = [
-          sources."punycode-2.1.1"
-          sources."tough-cookie-2.5.0"
-        ];
-      })
+      sources."request-promise-native-1.0.9"
       sources."requires-port-1.0.0"
       sources."reselect-4.0.0"
+      sources."resolve-1.19.0"
       sources."resolve-url-0.2.1"
-      sources."ret-0.1.15"
       sources."retry-0.10.1"
       sources."rimraf-2.7.1"
+      sources."rw-1.3.3"
       sources."safe-buffer-5.2.1"
-      sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
       sources."saxes-3.1.11"
-      sources."semver-5.7.1"
+      sources."semver-7.3.2"
       sources."server-destroy-1.0.1"
       sources."set-blocking-2.0.0"
-      (sources."set-value-2.0.1" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
       sources."setimmediate-1.0.5"
       sources."setprototypeof-1.2.0"
       sources."seventh-0.7.36"
-      (sources."sharp-0.23.4" // {
+      (sources."sharp-0.26.2" // {
         dependencies = [
-          sources."semver-6.3.0"
-          sources."tar-5.0.5"
+          sources."decompress-response-6.0.0"
+          sources."mimic-response-3.1.0"
+          sources."simple-get-4.0.0"
         ];
       })
-      sources."shebang-command-1.2.0"
-      sources."shebang-regex-1.0.0"
+      sources."shebang-command-2.0.0"
+      sources."shebang-regex-3.0.0"
+      sources."shellwords-0.1.1"
       sources."signal-exit-3.0.3"
       sources."simple-concat-1.0.1"
       sources."simple-get-3.1.0"
       sources."simple-swizzle-0.2.2"
-      sources."slash-2.0.0"
       (sources."slice-ansi-1.0.0" // {
         dependencies = [
           sources."is-fullwidth-code-point-2.0.0"
         ];
       })
-      (sources."snapdragon-0.8.2" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."extend-shallow-2.0.1"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-          sources."source-map-0.5.7"
-        ];
-      })
-      (sources."snapdragon-node-2.1.1" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-        ];
-      })
-      (sources."snapdragon-util-3.0.1" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
       sources."source-map-0.6.1"
       sources."source-map-resolve-0.5.3"
+      sources."source-map-support-0.5.19"
       sources."source-map-url-0.4.0"
       sources."split-skip-0.0.2"
-      sources."split-string-3.1.0"
       sources."sprintf-js-1.1.2"
       sources."sqlite3-4.2.0"
       sources."sshpk-1.16.1"
-      (sources."static-extend-0.1.2" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
       sources."statuses-1.5.0"
       sources."stealthy-require-1.1.1"
       sources."strict-uri-encode-1.1.0"
       sources."string-kit-0.11.8"
       sources."string-padding-1.0.2"
-      (sources."string-to-stream-1.1.1" // {
-        dependencies = [
-          sources."readable-stream-2.3.7"
-          sources."safe-buffer-5.1.2"
-          sources."string_decoder-1.1.1"
-        ];
-      })
+      sources."string-to-stream-1.1.1"
       (sources."string-width-1.0.2" // {
         dependencies = [
           sources."strip-ansi-3.0.1"
         ];
       })
-      sources."string_decoder-1.3.0"
+      (sources."string_decoder-1.1.1" // {
+        dependencies = [
+          sources."safe-buffer-5.1.2"
+        ];
+      })
       (sources."stringify-parameters-0.0.4" // {
         dependencies = [
           sources."magicli-0.0.5"
@@ -79070,21 +78667,19 @@ in
         ];
       })
       sources."strip-json-comments-2.0.1"
+      sources."stylis-3.5.4"
       sources."supports-color-5.5.0"
       sources."symbol-observable-1.2.0"
       sources."symbol-tree-3.2.4"
       sources."syswide-cas-5.3.0"
       sources."table-layout-0.4.5"
-      (sources."tar-4.4.13" // {
+      sources."tar-4.4.13"
+      sources."tar-fs-2.1.1"
+      (sources."tar-stream-2.1.4" // {
         dependencies = [
-          sources."fs-minipass-1.2.7"
-          sources."minipass-2.9.0"
-          sources."minizlib-1.3.3"
-          sources."yallist-3.1.1"
+          sources."readable-stream-3.6.0"
         ];
       })
-      sources."tar-fs-2.1.0"
-      sources."tar-stream-2.1.4"
       (sources."tcp-port-used-0.1.2" // {
         dependencies = [
           sources."debug-0.7.4"
@@ -79092,33 +78687,27 @@ in
         ];
       })
       sources."terminal-kit-1.44.0"
+      (sources."terser-4.8.0" // {
+        dependencies = [
+          sources."commander-2.20.3"
+        ];
+      })
       (sources."tkwidgets-0.5.26" // {
         dependencies = [
+          sources."chalk-2.4.2"
           sources."is-fullwidth-code-point-2.0.0"
           sources."node-emoji-git+https://github.com/laurent22/node-emoji.git"
           sources."string-width-2.1.1"
         ];
       })
-      sources."tmp-0.0.33"
-      (sources."to-object-path-0.3.0" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."to-regex-3.0.2"
-      sources."to-regex-range-2.1.1"
+      sources."to-fast-properties-2.0.0"
+      sources."to-regex-range-5.0.1"
       sources."toidentifier-1.0.0"
-      (sources."tough-cookie-3.0.1" // {
-        dependencies = [
-          sources."punycode-2.1.1"
-        ];
-      })
-      (sources."tr46-1.0.1" // {
-        dependencies = [
-          sources."punycode-2.1.1"
-        ];
-      })
+      sources."tough-cookie-2.5.0"
+      sources."tr46-1.0.1"
       sources."tree-kit-0.6.2"
+      sources."try-catch-2.0.1"
+      sources."try-to-catch-1.1.1"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-check-0.3.2"
@@ -79129,33 +78718,22 @@ in
           sources."commander-2.19.0"
         ];
       })
+      sources."uglifycss-0.0.29"
       sources."uid-safe-2.1.5"
       sources."unc-path-regex-0.1.2"
-      sources."union-value-1.0.1"
       sources."uniq-1.0.1"
       sources."universalify-0.1.2"
       sources."unorm-1.6.0"
       sources."unpack-string-0.0.2"
-      (sources."unset-value-1.0.0" // {
-        dependencies = [
-          (sources."has-value-0.3.1" // {
-            dependencies = [
-              sources."isobject-2.1.0"
-            ];
-          })
-          sources."has-values-0.1.4"
-        ];
-      })
       sources."upper-case-1.1.3"
-      (sources."uri-js-4.4.0" // {
+      sources."uri-js-4.4.0"
+      sources."urix-0.1.0"
+      (sources."url-0.10.3" // {
         dependencies = [
-          sources."punycode-2.1.1"
+          sources."punycode-1.3.2"
         ];
       })
-      sources."urix-0.1.0"
-      sources."url-0.10.3"
       sources."url-parse-1.4.7"
-      sources."use-3.1.1"
       sources."uslug-git+https://github.com/laurent22/uslug.git#emoji-support"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.4.0"
@@ -79167,7 +78745,7 @@ in
       sources."whatwg-encoding-1.0.5"
       sources."whatwg-mimetype-2.3.0"
       sources."whatwg-url-7.1.0"
-      sources."which-1.3.1"
+      sources."which-2.0.2"
       sources."which-pm-runs-1.0.0"
       sources."wide-align-1.1.3"
       sources."word-wrap-1.2.3"
@@ -79179,16 +78757,12 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."xml-name-validator-3.0.0"
-      (sources."xml2js-0.4.23" // {
-        dependencies = [
-          sources."xmlbuilder-11.0.1"
-        ];
-      })
-      sources."xmlbuilder-9.0.7"
+      sources."xml2js-0.4.23"
+      sources."xmlbuilder-11.0.1"
       sources."xmlchars-2.2.0"
-      sources."yallist-4.0.0"
+      sources."yallist-3.1.1"
       sources."yargs-parser-7.0.0"
     ];
     buildInputs = globalBuildInputs;
@@ -79465,10 +79039,10 @@ in
   json-server = nodeEnv.buildNodePackage {
     name = "json-server";
     packageName = "json-server";
-    version = "0.16.2";
+    version = "0.16.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/json-server/-/json-server-0.16.2.tgz";
-      sha512 = "USmSODvmBvt9Z7M3e4AHGHzLBcFlNkQMVOOqtB/h/k79JQI4saPcWniYvD5zf0kE3oGNR9VJzcHKzT8fZ9kEtw==";
+      url = "https://registry.npmjs.org/json-server/-/json-server-0.16.3.tgz";
+      sha512 = "tbsBONiefH7SR5EhSmK4EzwP3kCHuOduUq5hWAQjCwXTva4OBeKVcPrciHNWOK/+12ygtUnjuWcAxuHgqTuBLA==";
     };
     dependencies = [
       sources."@sindresorhus/is-0.14.0"
@@ -79484,7 +79058,11 @@ in
       sources."array-flatten-1.1.1"
       sources."basic-auth-2.0.1"
       sources."body-parser-1.19.0"
-      sources."boxen-4.2.0"
+      (sources."boxen-4.2.0" // {
+        dependencies = [
+          sources."chalk-3.0.0"
+        ];
+      })
       sources."bytes-3.1.0"
       (sources."cacheable-request-6.1.0" // {
         dependencies = [
@@ -79493,10 +79071,10 @@ in
         ];
       })
       sources."camelcase-5.3.1"
-      sources."chalk-3.0.0"
+      sources."chalk-4.1.0"
       sources."ci-info-2.0.0"
       sources."cli-boxes-2.2.1"
-      (sources."cliui-6.0.0" // {
+      (sources."cliui-7.0.4" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
           sources."strip-ansi-6.0.0"
@@ -79520,7 +79098,6 @@ in
       sources."cors-2.8.5"
       sources."crypto-random-string-2.0.0"
       sources."debug-2.6.9"
-      sources."decamelize-1.2.0"
       sources."decompress-response-3.3.0"
       sources."deep-extend-0.6.0"
       sources."defer-to-connect-1.1.3"
@@ -79533,6 +79110,7 @@ in
       sources."encodeurl-1.0.2"
       sources."end-of-stream-1.4.4"
       sources."errorhandler-1.5.1"
+      sources."escalade-3.1.1"
       sources."escape-goat-2.1.1"
       sources."escape-html-1.0.3"
       sources."etag-1.8.1"
@@ -79543,7 +79121,6 @@ in
         ];
       })
       sources."finalhandler-1.1.2"
-      sources."find-up-4.1.0"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
       sources."get-caller-file-2.0.5"
@@ -79564,7 +79141,7 @@ in
       sources."is-ci-2.0.0"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-installed-globally-0.3.2"
-      sources."is-npm-4.0.0"
+      sources."is-npm-5.0.0"
       sources."is-obj-2.0.0"
       sources."is-path-inside-3.0.2"
       sources."is-promise-2.2.2"
@@ -79576,12 +79153,15 @@ in
       sources."json-parse-helpfulerror-1.0.3"
       sources."keyv-3.1.0"
       sources."latest-version-5.1.0"
-      sources."locate-path-5.0.0"
       sources."lodash-4.17.20"
       sources."lodash-id-0.14.0"
       sources."lowdb-1.0.0"
       sources."lowercase-keys-1.0.1"
-      sources."make-dir-3.1.0"
+      (sources."make-dir-3.1.0" // {
+        dependencies = [
+          sources."semver-6.3.0"
+        ];
+      })
       sources."media-typer-0.3.0"
       sources."merge-descriptors-1.0.1"
       (sources."method-override-3.0.0" // {
@@ -79601,7 +79181,7 @@ in
         ];
       })
       sources."ms-2.0.0"
-      sources."nanoid-2.1.11"
+      sources."nanoid-3.1.16"
       sources."negotiator-0.6.2"
       sources."normalize-url-4.5.0"
       sources."object-assign-4.1.1"
@@ -79609,12 +79189,12 @@ in
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
       sources."p-cancelable-1.1.0"
-      sources."p-limit-2.3.0"
-      sources."p-locate-4.1.0"
-      sources."p-try-2.2.0"
-      sources."package-json-6.5.0"
+      (sources."package-json-6.5.0" // {
+        dependencies = [
+          sources."semver-6.3.0"
+        ];
+      })
       sources."parseurl-1.3.3"
-      sources."path-exists-4.0.0"
       sources."path-to-regexp-0.1.7"
       sources."pify-3.0.0"
       sources."please-upgrade-node-3.2.0"
@@ -79627,16 +79207,19 @@ in
       sources."range-parser-1.2.1"
       sources."raw-body-2.4.0"
       sources."rc-1.2.8"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."require-directory-2.1.1"
-      sources."require-main-filename-2.0.0"
       sources."responselike-1.0.2"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
-      sources."semver-6.3.0"
+      sources."semver-7.3.2"
       sources."semver-compare-1.0.0"
-      sources."semver-diff-3.1.1"
+      (sources."semver-diff-3.1.1" // {
+        dependencies = [
+          sources."semver-6.3.0"
+        ];
+      })
       (sources."send-0.17.1" // {
         dependencies = [
           sources."ms-2.1.1"
@@ -79644,7 +79227,6 @@ in
       })
       sources."serve-static-1.14.1"
       sources."server-destroy-1.0.1"
-      sources."set-blocking-2.0.0"
       sources."setprototypeof-1.1.1"
       sources."signal-exit-3.0.3"
       sources."statuses-1.5.0"
@@ -79668,13 +79250,12 @@ in
       sources."typedarray-to-buffer-3.1.5"
       sources."unique-string-2.0.0"
       sources."unpipe-1.0.0"
-      sources."update-notifier-4.1.3"
+      sources."update-notifier-5.0.1"
       sources."url-parse-lax-3.0.0"
       sources."utils-merge-1.0.1"
       sources."vary-1.1.2"
-      sources."which-module-2.0.0"
       sources."widest-line-3.1.0"
-      (sources."wrap-ansi-6.2.0" // {
+      (sources."wrap-ansi-7.0.0" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
           sources."strip-ansi-6.0.0"
@@ -79683,9 +79264,9 @@ in
       sources."wrappy-1.0.2"
       sources."write-file-atomic-3.0.3"
       sources."xdg-basedir-4.0.0"
-      sources."y18n-4.0.0"
-      sources."yargs-15.4.1"
-      sources."yargs-parser-18.1.3"
+      sources."y18n-5.0.5"
+      sources."yargs-16.1.1"
+      sources."yargs-parser-20.2.4"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -79914,7 +79495,7 @@ in
       sources."which-module-2.0.0"
       sources."wrap-ansi-6.2.0"
       sources."wrappy-1.0.2"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."y18n-4.0.0"
       sources."yargs-15.4.1"
@@ -80426,8 +80007,8 @@ in
       sources."@octokit/types-5.5.0"
       sources."@types/glob-7.1.3"
       sources."@types/minimatch-3.0.3"
-      sources."@types/minimist-1.2.0"
-      sources."@types/node-14.14.6"
+      sources."@types/minimist-1.2.1"
+      sources."@types/node-14.14.7"
       sources."@types/normalize-package-data-2.4.0"
       sources."@zkochan/cmd-shim-3.1.0"
       sources."JSONStream-1.3.5"
@@ -80929,9 +80510,9 @@ in
             ];
           })
           sources."semver-7.3.2"
-          sources."type-fest-0.18.0"
+          sources."type-fest-0.18.1"
           sources."yallist-4.0.0"
-          sources."yargs-parser-20.2.3"
+          sources."yargs-parser-20.2.4"
         ];
       })
       sources."merge2-1.4.1"
@@ -81099,7 +80680,7 @@ in
       sources."request-2.88.2"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       (sources."resolve-cwd-2.0.0" // {
         dependencies = [
           sources."resolve-from-3.0.0"
@@ -81252,7 +80833,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."type-fest-0.3.1"
       sources."typedarray-0.0.6"
-      sources."uglify-js-3.11.5"
+      sources."uglify-js-3.11.6"
       sources."uid-number-0.0.6"
       sources."umask-1.1.0"
       sources."union-value-1.0.1"
@@ -82216,7 +81797,7 @@ in
       sources."uuid-3.4.0"
       sources."vary-1.1.2"
       sources."verror-1.10.0"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."yeast-0.1.2"
     ];
@@ -82351,7 +81932,7 @@ in
       sources."@jest/types-25.5.0"
       sources."@types/babel__core-7.1.12"
       sources."@types/babel__generator-7.6.2"
-      sources."@types/babel__template-7.0.3"
+      sources."@types/babel__template-7.4.0"
       sources."@types/babel__traverse-7.0.15"
       sources."@types/estree-0.0.45"
       sources."@types/graceful-fs-4.1.4"
@@ -82359,7 +81940,7 @@ in
       sources."@types/istanbul-lib-report-3.0.0"
       sources."@types/istanbul-reports-1.1.2"
       sources."@types/json-schema-7.0.6"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/resolve-0.0.8"
       sources."@types/yargs-15.0.9"
@@ -82433,9 +82014,9 @@ in
       sources."babel-helper-remove-or-void-0.4.3"
       sources."babel-helper-to-multiple-sequence-expressions-0.5.0"
       sources."babel-jest-25.5.1"
-      (sources."babel-loader-8.1.0" // {
+      (sources."babel-loader-8.2.1" // {
         dependencies = [
-          sources."mkdirp-0.5.5"
+          sources."make-dir-2.1.0"
         ];
       })
       sources."babel-plugin-dynamic-import-node-2.3.3"
@@ -82479,7 +82060,7 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."big.js-5.2.2"
       sources."binary-extensions-2.1.0"
@@ -82509,11 +82090,7 @@ in
       sources."browserify-aes-1.2.0"
       sources."browserify-cipher-1.0.1"
       sources."browserify-des-1.0.2"
-      (sources."browserify-rsa-4.0.1" // {
-        dependencies = [
-          sources."bn.js-4.11.9"
-        ];
-      })
+      sources."browserify-rsa-4.1.0"
       (sources."browserify-sign-4.2.1" // {
         dependencies = [
           sources."readable-stream-3.6.0"
@@ -82521,7 +82098,7 @@ in
         ];
       })
       sources."browserify-zlib-0.2.0"
-      sources."browserslist-4.14.6"
+      sources."browserslist-4.14.7"
       sources."bser-2.1.1"
       sources."buffer-5.2.1"
       sources."buffer-from-1.1.1"
@@ -82537,7 +82114,7 @@ in
       sources."cached-path-relative-1.0.2"
       sources."call-bind-1.0.0"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30001156"
+      sources."caniuse-lite-1.0.30001158"
       sources."capture-exit-2.0.0"
       sources."caseless-0.12.0"
       (sources."chalk-3.0.0" // {
@@ -82587,6 +82164,7 @@ in
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
+      sources."colorette-1.2.1"
       sources."colors-1.4.0"
       (sources."combine-source-map-0.8.0" // {
         dependencies = [
@@ -82660,7 +82238,7 @@ in
       sources."duplexer2-0.1.4"
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
-      sources."electron-to-chromium-1.3.589"
+      sources."electron-to-chromium-1.3.596"
       (sources."elliptic-6.5.3" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -82966,7 +82544,7 @@ in
         ];
       })
       sources."node-modules-regexp-1.0.0"
-      sources."node-releases-1.1.65"
+      sources."node-releases-1.1.66"
       sources."normalize-package-data-2.5.0"
       sources."normalize-path-3.0.0"
       sources."npm-run-path-2.0.2"
@@ -83080,7 +82658,7 @@ in
       sources."request-2.88.2"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       (sources."resolve-cwd-2.0.0" // {
         dependencies = [
           sources."resolve-from-3.0.0"
@@ -83301,8 +82879,8 @@ in
       sources."vinyl-2.2.1"
       sources."vm-browserify-1.1.2"
       sources."walker-1.0.7"
-      sources."watchpack-1.7.4"
-      (sources."watchpack-chokidar2-2.0.0" // {
+      sources."watchpack-1.7.5"
+      (sources."watchpack-chokidar2-2.0.1" // {
         dependencies = [
           sources."anymatch-2.0.0"
           sources."binary-extensions-1.13.1"
@@ -83463,7 +83041,7 @@ in
       sources."link-check-4.5.2"
       sources."lodash-4.17.20"
       sources."markdown-link-extractor-1.2.6"
-      sources."marked-1.2.3"
+      sources."marked-1.2.4"
       sources."mime-db-1.44.0"
       sources."mime-types-2.1.27"
       sources."ms-2.1.2"
@@ -83721,7 +83299,7 @@ in
       sources."replace-ext-0.0.1"
       sources."request-2.88.0"
       sources."require-uncached-1.0.3"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-from-1.0.1"
       sources."restore-cursor-1.0.1"
       sources."rimraf-2.6.3"
@@ -83853,12 +83431,12 @@ in
       sha512 = "X9I7gwvqKVdqVvqi9AVfUWXnHQQYjssWJ2asKfhBDAkQn0vPagKkx6EjzKcRgyIroWGXN6ZpwkQ/gMvTPFlx7g==";
     };
     dependencies = [
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."@types/yauzl-2.9.1"
       sources."agent-base-5.1.1"
       sources."ansi-styles-4.3.0"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bl-4.0.3"
       sources."brace-expansion-1.1.11"
       sources."buffer-5.7.1"
@@ -83870,7 +83448,7 @@ in
       sources."commander-6.2.0"
       sources."concat-map-0.0.1"
       sources."debug-4.3.0"
-      sources."devtools-protocol-0.0.809251"
+      sources."devtools-protocol-0.0.818844"
       sources."end-of-stream-1.4.4"
       sources."extract-zip-2.0.1"
       sources."fd-slicer-1.1.0"
@@ -83900,19 +83478,19 @@ in
       sources."progress-2.0.3"
       sources."proxy-from-env-1.1.0"
       sources."pump-3.0.0"
-      sources."puppeteer-5.4.1"
+      sources."puppeteer-5.5.0"
       sources."readable-stream-3.6.0"
       sources."rimraf-3.0.2"
       sources."safe-buffer-5.2.1"
       sources."string_decoder-1.3.0"
       sources."supports-color-7.2.0"
-      sources."tar-fs-2.1.0"
+      sources."tar-fs-2.1.1"
       sources."tar-stream-2.1.4"
       sources."through-2.3.8"
       sources."unbzip2-stream-1.4.3"
       sources."util-deprecate-1.0.2"
       sources."wrappy-1.0.2"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."yauzl-2.10.0"
     ];
     buildInputs = globalBuildInputs;
@@ -83937,11 +83515,11 @@ in
       sources."@fluentui/date-time-utilities-7.9.0"
       sources."@fluentui/dom-utilities-1.1.1"
       sources."@fluentui/keyboard-key-0.2.12"
-      sources."@fluentui/react-7.149.4"
+      sources."@fluentui/react-7.150.0"
       sources."@fluentui/react-focus-7.16.17"
       sources."@fluentui/react-window-provider-1.0.1"
       sources."@fluentui/theme-1.6.0"
-      sources."@microsoft/load-themed-styles-1.10.126"
+      sources."@microsoft/load-themed-styles-1.10.133"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@uifabric/foundation-7.9.19"
@@ -83966,7 +83544,7 @@ in
         ];
       })
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."basic-auth-2.0.1"
       sources."body-parser-1.19.0"
       sources."brace-expansion-1.1.11"
@@ -84076,7 +83654,7 @@ in
       sources."node-fetch-1.6.3"
       sources."normalize-url-4.5.0"
       sources."object-assign-4.1.1"
-      sources."office-ui-fabric-react-7.149.4"
+      sources."office-ui-fabric-react-7.150.0"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
@@ -84132,7 +83710,7 @@ in
       sources."react-is-16.13.1"
       sources."readable-stream-3.6.0"
       sources."regenerator-runtime-0.10.5"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."responselike-1.0.2"
       sources."restore-cursor-2.0.0"
@@ -84175,7 +83753,7 @@ in
       sources."strip-json-comments-2.0.1"
       sources."supports-color-2.0.0"
       sources."swagger-schema-official-2.0.0-bab6bed"
-      sources."swagger-ui-dist-3.36.1"
+      sources."swagger-ui-dist-3.36.2"
       sources."tail-2.0.4"
       sources."through-2.3.8"
       sources."tmp-0.0.33"
@@ -84462,10 +84040,10 @@ in
   netlify-cli = nodeEnv.buildNodePackage {
     name = "netlify-cli";
     packageName = "netlify-cli";
-    version = "2.68.0";
+    version = "2.68.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/netlify-cli/-/netlify-cli-2.68.0.tgz";
-      sha512 = "nrdMstEiFYtwLmPF+UsMxnOekeKIayUwRpEMzaLtK+i9Yf/IjCPxKwMF7Z+yc3wjYIjxjlWSBqq0I8bcwxUDnQ==";
+      url = "https://registry.npmjs.org/netlify-cli/-/netlify-cli-2.68.5.tgz";
+      sha512 = "QEvYSfvIvMMN1are5UdbkSD95w6UAnyvC6EavB5nvdgCF65SzyOTPhe8zTmGzAspfzFP5/GnHrDlAsWOEM9IVg==";
     };
     dependencies = [
       sources."@babel/code-frame-7.10.4"
@@ -84583,14 +84161,14 @@ in
       sources."@dabh/diagnostics-2.0.2"
       sources."@jest/types-24.9.0"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
-      (sources."@netlify/build-5.2.1" // {
+      (sources."@netlify/build-5.3.1" // {
         dependencies = [
           sources."chalk-3.0.0"
           sources."resolve-2.0.0-next.2"
         ];
       })
       sources."@netlify/cache-utils-1.0.6"
-      (sources."@netlify/config-2.3.6" // {
+      (sources."@netlify/config-2.4.0" // {
         dependencies = [
           sources."chalk-3.0.0"
         ];
@@ -84778,7 +84356,7 @@ in
       sources."@types/istanbul-reports-1.1.2"
       sources."@types/minimatch-3.0.3"
       sources."@types/mkdirp-0.5.2"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."@types/node-fetch-2.5.7"
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/parse5-5.0.3"
@@ -84848,7 +84426,7 @@ in
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
       sources."atob-lite-2.0.0"
-      (sources."aws-sdk-2.786.0" // {
+      (sources."aws-sdk-2.792.0" // {
         dependencies = [
           sources."buffer-4.9.2"
           sources."ieee754-1.1.13"
@@ -84864,7 +84442,7 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."before-after-hook-2.1.0"
       sources."binary-extensions-2.1.0"
       (sources."bl-0.8.2" // {
@@ -84897,17 +84475,13 @@ in
       sources."browserify-cipher-1.0.1"
       sources."browserify-des-1.0.2"
       sources."browserify-fs-1.0.0"
-      (sources."browserify-rsa-4.0.1" // {
-        dependencies = [
-          sources."bn.js-4.11.9"
-        ];
-      })
+      sources."browserify-rsa-4.1.0"
       (sources."browserify-sign-4.2.1" // {
         dependencies = [
           sources."readable-stream-3.6.0"
         ];
       })
-      sources."browserslist-4.14.6"
+      sources."browserslist-4.14.7"
       sources."btoa-lite-1.0.0"
       sources."buffer-5.7.1"
       sources."buffer-alloc-1.2.0"
@@ -84931,7 +84505,7 @@ in
       sources."call-bind-1.0.0"
       sources."call-me-maybe-1.0.1"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30001156"
+      sources."caniuse-lite-1.0.30001158"
       sources."cardinal-2.1.1"
       sources."caw-2.0.1"
       sources."ccount-1.1.0"
@@ -85002,6 +84576,7 @@ in
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."color-string-1.5.4"
+      sources."colorette-1.2.1"
       sources."colors-1.4.0"
       sources."colorspace-1.1.2"
       sources."combined-stream-1.0.8"
@@ -85182,7 +84757,7 @@ in
       })
       sources."duplexer3-0.1.4"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.589"
+      sources."electron-to-chromium-1.3.596"
       sources."elf-tools-1.1.2"
       (sources."elliptic-6.5.3" // {
         dependencies = [
@@ -85557,7 +85132,7 @@ in
       sources."json5-2.1.3"
       sources."jsonfile-4.0.0"
       sources."junk-3.1.0"
-      sources."jwt-decode-3.1.1"
+      sources."jwt-decode-3.1.2"
       sources."keep-func-props-3.0.1"
       sources."keyv-3.1.0"
       sources."kind-of-6.0.3"
@@ -85744,10 +85319,10 @@ in
           sources."chalk-3.0.0"
         ];
       })
-      sources."netlify-redirector-0.2.0"
+      sources."netlify-redirector-0.2.1"
       sources."nice-try-1.0.5"
       sources."node-fetch-2.6.1"
-      sources."node-releases-1.1.65"
+      sources."node-releases-1.1.66"
       sources."node-source-walk-4.2.0"
       sources."noop2-2.0.0"
       (sources."normalize-package-data-2.5.0" // {
@@ -85932,7 +85507,7 @@ in
       sources."regenerator-transform-0.14.5"
       sources."regex-not-1.0.2"
       sources."regexpu-core-4.7.1"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."regjsgen-0.5.2"
       (sources."regjsparser-0.6.4" // {
@@ -85950,7 +85525,7 @@ in
       sources."require-main-filename-2.0.0"
       sources."require-package-name-2.0.1"
       sources."requires-port-1.0.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-url-0.2.1"
       sources."responselike-1.0.2"
       (sources."restore-cursor-2.0.0" // {
@@ -85963,7 +85538,7 @@ in
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
       sources."ripemd160-2.0.2"
-      sources."rollup-2.33.1"
+      sources."rollup-2.33.2"
       sources."rollup-plugin-node-builtins-2.1.2"
       sources."rollup-plugin-terser-7.0.2"
       sources."run-async-2.4.1"
@@ -86156,7 +85731,7 @@ in
         ];
       })
       sources."term-size-2.2.1"
-      (sources."terser-5.3.8" // {
+      (sources."terser-5.4.0" // {
         dependencies = [
           sources."source-map-0.7.3"
         ];
@@ -86669,7 +86244,7 @@ in
           sources."qs-6.4.0"
         ];
       })
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."rimraf-2.2.8"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
@@ -86916,7 +86491,7 @@ in
       sources."aws4-1.11.0"
       sources."axios-0.19.2"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       (sources."basic-auth-2.0.1" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
@@ -87146,7 +86721,7 @@ in
       })
       sources."mkdirp-0.5.5"
       sources."moment-2.29.1"
-      sources."moment-timezone-0.5.31"
+      sources."moment-timezone-0.5.32"
       (sources."mqtt-4.2.4" // {
         dependencies = [
           sources."concat-stream-2.0.0"
@@ -87154,7 +86729,7 @@ in
           sources."ms-2.1.2"
           sources."readable-stream-3.6.0"
           sources."string_decoder-1.3.0"
-          sources."ws-7.3.1"
+          sources."ws-7.4.0"
         ];
       })
       (sources."mqtt-packet-6.6.0" // {
@@ -87483,7 +87058,7 @@ in
         ];
       })
       sources."request-2.88.2"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."retry-0.10.1"
       sources."rimraf-2.6.3"
       sources."safe-buffer-5.2.1"
@@ -87511,7 +87086,7 @@ in
           sources."mkdirp-1.0.4"
         ];
       })
-      sources."temp-0.9.2"
+      sources."temp-0.9.4"
       sources."tough-cookie-2.5.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
@@ -87650,7 +87225,7 @@ in
       sources."pupa-2.1.1"
       sources."rc-1.2.8"
       sources."readdirp-3.5.0"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."responselike-1.0.2"
       sources."semver-5.7.1"
@@ -87722,10 +87297,10 @@ in
   npm-check-updates = nodeEnv.buildNodePackage {
     name = "npm-check-updates";
     packageName = "npm-check-updates";
-    version = "9.2.4";
+    version = "10.1.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-9.2.4.tgz";
-      sha512 = "YXEIqKXzxOhtPWg670+JAp/jPtjfTdaBJVGSlWL3eHbUDY4O80ELQNGO/qDy8oxh3pOrxSdII7vNglDf4FDw4w==";
+      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-10.1.1.tgz";
+      sha512 = "d1lwJqv0sRKJwXwaAUSZTNqBzvJJOQfTiEqkM674tThNmtPd5WU0Mqar//0BpDdSIRs2fEQkvKvg57+2Kbosaw==";
     };
     dependencies = [
       sources."@npmcli/ci-detect-1.3.0"
@@ -87734,7 +87309,7 @@ in
       sources."@npmcli/move-file-1.0.1"
       sources."@npmcli/node-gyp-1.0.1"
       sources."@npmcli/promise-spawn-1.3.2"
-      sources."@npmcli/run-script-1.7.4"
+      sources."@npmcli/run-script-1.7.5"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@tootallnate/once-1.1.2"
@@ -87971,7 +87546,7 @@ in
       sources."read-package-json-fast-1.2.1"
       sources."readable-stream-2.3.7"
       sources."readdir-scoped-modules-1.1.0"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."remote-git-tags-3.0.0"
       sources."request-2.88.2"
@@ -87994,7 +87569,7 @@ in
       sources."smart-buffer-4.1.0"
       sources."socks-2.5.0"
       sources."socks-proxy-agent-5.0.0"
-      sources."spawn-please-0.4.1"
+      sources."spawn-please-1.0.0"
       sources."sprintf-js-1.0.3"
       sources."sshpk-1.16.1"
       sources."ssri-8.0.0"
@@ -88451,7 +88026,7 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."binary-extensions-1.13.1"
       sources."bindings-1.5.0"
@@ -88465,11 +88040,7 @@ in
       sources."browserify-aes-1.2.0"
       sources."browserify-cipher-1.0.1"
       sources."browserify-des-1.0.2"
-      (sources."browserify-rsa-4.0.1" // {
-        dependencies = [
-          sources."bn.js-4.11.9"
-        ];
-      })
+      sources."browserify-rsa-4.1.0"
       (sources."browserify-sign-4.2.1" // {
         dependencies = [
           sources."readable-stream-3.6.0"
@@ -88481,7 +88052,7 @@ in
           sources."pako-1.0.11"
         ];
       })
-      sources."browserslist-4.14.6"
+      sources."browserslist-4.14.7"
       (sources."buffer-4.9.2" // {
         dependencies = [
           sources."isarray-1.0.0"
@@ -88498,7 +88069,7 @@ in
       sources."caller-path-2.0.0"
       sources."callsites-2.0.0"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30001156"
+      sources."caniuse-lite-1.0.30001158"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chokidar-2.1.8"
@@ -88513,6 +88084,7 @@ in
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."color-string-1.5.4"
+      sources."colorette-1.2.1"
       sources."combined-stream-1.0.8"
       sources."command-exists-1.2.9"
       sources."commander-2.20.3"
@@ -88570,9 +88142,9 @@ in
       sources."cssnano-util-get-match-4.0.0"
       sources."cssnano-util-raw-cache-4.0.1"
       sources."cssnano-util-same-parent-4.0.1"
-      (sources."csso-4.1.0" // {
+      (sources."csso-4.1.1" // {
         dependencies = [
-          sources."css-tree-1.0.0"
+          sources."css-tree-1.0.1"
           sources."mdn-data-2.0.12"
         ];
       })
@@ -88580,7 +88152,7 @@ in
       sources."cssstyle-1.4.0"
       sources."dashdash-1.14.1"
       sources."data-urls-1.1.0"
-      sources."deasync-0.1.20"
+      sources."deasync-0.1.21"
       sources."debug-4.3.0"
       sources."decode-uri-component-0.2.0"
       sources."deep-is-0.1.3"
@@ -88624,11 +88196,7 @@ in
       sources."domain-browser-1.2.0"
       sources."domelementtype-1.3.1"
       sources."domexception-1.0.1"
-      (sources."domhandler-3.3.0" // {
-        dependencies = [
-          sources."domelementtype-2.0.2"
-        ];
-      })
+      sources."domhandler-2.4.2"
       sources."domutils-1.7.0"
       sources."dot-prop-5.3.0"
       sources."dotenv-5.0.1"
@@ -88636,7 +88204,7 @@ in
       sources."duplexer2-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.589"
+      sources."electron-to-chromium-1.3.596"
       (sources."elliptic-6.5.3" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -88739,19 +88307,16 @@ in
       sources."html-comment-regex-1.1.2"
       sources."html-encoding-sniffer-1.0.2"
       sources."html-tags-1.2.0"
-      (sources."htmlnano-0.2.7" // {
+      (sources."htmlnano-0.2.8" // {
         dependencies = [
           sources."posthtml-0.13.4"
-          sources."posthtml-parser-0.5.2"
+          sources."posthtml-parser-0.5.3"
           sources."terser-4.8.0"
         ];
       })
-      (sources."htmlparser2-5.0.1" // {
+      (sources."htmlparser2-3.10.1" // {
         dependencies = [
-          sources."dom-serializer-1.1.0"
-          sources."domelementtype-2.0.2"
-          sources."domutils-2.4.2"
-          sources."entities-2.1.0"
+          sources."readable-stream-3.6.0"
         ];
       })
       sources."http-errors-1.7.3"
@@ -88894,7 +88459,7 @@ in
           sources."punycode-1.4.1"
         ];
       })
-      sources."node-releases-1.1.65"
+      sources."node-releases-1.1.66"
       sources."normalize-path-3.0.0"
       sources."normalize-url-3.3.0"
       sources."nth-check-1.0.2"
@@ -88999,14 +88564,8 @@ in
       sources."postcss-unique-selectors-4.0.1"
       sources."postcss-value-parser-3.3.1"
       sources."posthtml-0.11.6"
-      (sources."posthtml-parser-0.4.2" // {
-        dependencies = [
-          sources."domhandler-2.4.2"
-          sources."htmlparser2-3.10.1"
-          sources."readable-stream-3.6.0"
-        ];
-      })
-      sources."posthtml-render-1.2.3"
+      sources."posthtml-parser-0.4.2"
+      sources."posthtml-render-1.3.0"
       sources."prelude-ls-1.1.2"
       sources."process-0.11.10"
       sources."process-nextick-args-2.0.1"
@@ -89062,7 +88621,7 @@ in
       sources."request-2.88.2"
       sources."request-promise-core-1.1.4"
       sources."request-promise-native-1.0.9"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-from-3.0.0"
       sources."resolve-url-0.2.1"
       sources."restore-cursor-2.0.0"
@@ -89126,6 +88685,7 @@ in
         ];
       })
       sources."sprintf-js-1.0.3"
+      sources."srcset-3.0.0"
       sources."sshpk-1.16.1"
       sources."stable-0.1.8"
       (sources."static-eval-2.1.0" // {
@@ -89505,7 +89065,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.18"
-      sources."uglify-js-3.11.5"
+      sources."uglify-js-3.11.6"
       sources."unix-dgram-2.0.4"
       sources."unpipe-1.0.0"
       sources."uri-js-4.4.0"
@@ -90046,7 +89606,7 @@ in
         ];
       })
       sources."repeating-2.0.1"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."restore-cursor-2.0.0"
       sources."reverse-http-1.3.0"
       sources."rimraf-2.7.1"
@@ -90167,7 +89727,7 @@ in
       sources."backo2-1.0.2"
       sources."balanced-match-1.0.0"
       sources."base64-arraybuffer-0.1.4"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."base64id-2.0.0"
       sources."basic-auth-2.0.1"
       sources."bcrypt-pbkdf-1.0.2"
@@ -90499,7 +90059,7 @@ in
       sources."verror-1.10.0"
       sources."which-1.3.1"
       sources."wrappy-1.0.2"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."xtend-4.0.2"
       sources."yeast-0.1.2"
@@ -90566,7 +90126,7 @@ in
           sources."tslib-1.9.3"
         ];
       })
-      (sources."@pm2/js-api-0.6.0" // {
+      (sources."@pm2/js-api-0.6.1" // {
         dependencies = [
           sources."async-2.6.3"
           sources."debug-3.2.6"
@@ -90694,7 +90254,7 @@ in
       sources."mkdirp-1.0.4"
       sources."module-details-from-path-1.0.3"
       sources."moment-2.29.1"
-      sources."moment-timezone-0.5.31"
+      sources."moment-timezone-0.5.32"
       sources."ms-2.1.2"
       sources."mute-stream-0.0.8"
       (sources."needle-2.4.0" // {
@@ -90745,7 +90305,7 @@ in
       })
       sources."readdirp-3.5.0"
       sources."require-in-the-middle-5.0.3"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."run-series-1.1.9"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
@@ -90767,7 +90327,7 @@ in
       sources."statuses-1.5.0"
       sources."string_decoder-0.10.31"
       sources."supports-color-7.2.0"
-      sources."systeminformation-4.28.1"
+      sources."systeminformation-4.30.1"
       sources."thunkify-2.1.2"
       sources."to-regex-range-5.0.1"
       sources."toidentifier-1.0.0"
@@ -90802,10 +90362,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "5.10.4";
+    version = "5.12.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-5.10.4.tgz";
-      sha512 = "HWtg7vrXpNNCeroOc0IhsoNdwPmga/N7Nci/Mc9SadHrkMXPNpkFXCHT3g9e4HqtGlbDX2K30WKvYQu2umdM+w==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-5.12.0.tgz";
+      sha512 = "ag+ar3N2DgYM2Tx5XMr0rCnuFteAokiEUZQRNJjuWNt091i3m68FDLxxfBTqM14ZnI6Z55S70XYWkesPo232BQ==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -90852,7 +90412,7 @@ in
       sources."callsites-3.1.0"
       sources."chalk-4.1.0"
       sources."chokidar-3.4.3"
-      sources."cliui-7.0.3"
+      sources."cliui-7.0.4"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
       sources."colorette-1.2.1"
@@ -90928,8 +90488,8 @@ in
       sources."wrap-ansi-7.0.0"
       sources."y18n-5.0.5"
       sources."yaml-1.10.0"
-      sources."yargs-16.1.0"
-      sources."yargs-parser-20.2.3"
+      sources."yargs-16.1.1"
+      sources."yargs-parser-20.2.4"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -91022,7 +90582,7 @@ in
       })
       sources."async-1.5.2"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bn.js-5.1.3"
       sources."brace-expansion-1.1.11"
       sources."brorand-1.1.0"
@@ -91043,11 +90603,7 @@ in
           sources."jsonparse-0.0.5"
         ];
       })
-      (sources."browserify-rsa-4.0.1" // {
-        dependencies = [
-          sources."bn.js-4.11.9"
-        ];
-      })
+      sources."browserify-rsa-4.1.0"
       (sources."browserify-sign-4.2.1" // {
         dependencies = [
           sources."readable-stream-3.6.0"
@@ -91200,7 +90756,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."rimraf-2.7.1"
       sources."ripemd160-2.0.2"
       sources."safe-buffer-5.2.1"
@@ -91225,7 +90781,7 @@ in
       sources."string_decoder-1.3.0"
       sources."subarg-1.0.0"
       sources."syntax-error-1.4.0"
-      (sources."temp-0.9.2" // {
+      (sources."temp-0.9.4" // {
         dependencies = [
           sources."rimraf-2.6.3"
         ];
@@ -91316,10 +90872,10 @@ in
   purty = nodeEnv.buildNodePackage {
     name = "purty";
     packageName = "purty";
-    version = "6.2.0";
+    version = "6.2.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/purty/-/purty-6.2.0.tgz";
-      sha512 = "JfT8kJHSyxuOFQtRiH2x55SiPxXZsSdedQlZap8JehQ7KzB49B5C9cWwVybtSB36BdADQcxPvtw8D52z4EPnBw==";
+      url = "https://registry.npmjs.org/purty/-/purty-6.2.1.tgz";
+      sha512 = "7VkL+WEp0wCpzy4DWMSEHvNbylMWKGYHycwJ90ZjvdX90lI8akp2JM4hhyL/JOAkIP9DDd996PaW+x/Nre0IDA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -91334,10 +90890,10 @@ in
   pyright = nodeEnv.buildNodePackage {
     name = "pyright";
     packageName = "pyright";
-    version = "1.1.83";
+    version = "1.1.85";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pyright/-/pyright-1.1.83.tgz";
-      sha512 = "uwaqJsuGxtY94lA8PL3Akp1xkUqUYWEFDLrIdW3FQY6JgFngkAZ51rPyUsuXQjoObm056OZ68wtzUMhDX5P5UA==";
+      url = "https://registry.npmjs.org/pyright/-/pyright-1.1.85.tgz";
+      sha512 = "G27ke+PtyAyhoFwCpPwu1MgksAp4h3b2nQ3UAQ/A6GhLtYXr49TwP48bfuAZD89N9PaX1QFCaud3kchb89ktGA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -91373,11 +90929,7 @@ in
       sources."deep-equal-2.0.4"
       sources."define-properties-1.1.3"
       sources."es-abstract-1.18.0-next.1"
-      (sources."es-get-iterator-1.1.0" // {
-        dependencies = [
-          sources."es-abstract-1.17.7"
-        ];
-      })
+      sources."es-get-iterator-1.1.1"
       sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."eyes-0.1.8"
@@ -91523,10 +91075,10 @@ in
   readability-cli = nodeEnv.buildNodePackage {
     name = "readability-cli";
     packageName = "readability-cli";
-    version = "1.1.5";
+    version = "1.2.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/readability-cli/-/readability-cli-1.1.5.tgz";
-      sha512 = "xMbRC9qGezXO4dqRlTpSfC/o4XuUpsRq0yLGEumtulcNVz1RJyOEbovgnqmOhulZYSgsLbRCm8gZ0nQ5n0up6w==";
+      url = "https://registry.npmjs.org/readability-cli/-/readability-cli-1.2.1.tgz";
+      sha512 = "oS0m68Y02lcMnrCYh3loRj3o8pGjhBAk8petnaJuvvE6eif3bjj60mTByFhZTlYRWNLuQaq/Yqe8Wk0yFI2wdQ==";
     };
     dependencies = [
       sources."@mozilla/readability-0.3.0"
@@ -91637,7 +91189,7 @@ in
       sources."whatwg-mimetype-2.3.0"
       sources."whatwg-url-8.4.0"
       sources."word-wrap-1.2.3"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."xml-name-validator-3.0.0"
       sources."xmlchars-2.2.0"
     ];
@@ -91702,7 +91254,7 @@ in
       })
       sources."babel-plugin-styled-components-1.11.1"
       sources."babel-plugin-syntax-jsx-6.18.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."better-ajv-errors-0.6.7"
       sources."binary-extensions-2.1.0"
       sources."bn.js-5.1.3"
@@ -91711,11 +91263,7 @@ in
       sources."browserify-aes-1.2.0"
       sources."browserify-cipher-1.0.1"
       sources."browserify-des-1.0.2"
-      (sources."browserify-rsa-4.0.1" // {
-        dependencies = [
-          sources."bn.js-4.11.9"
-        ];
-      })
+      sources."browserify-rsa-4.1.0"
       (sources."browserify-sign-4.2.1" // {
         dependencies = [
           sources."inherits-2.0.4"
@@ -91846,7 +91394,7 @@ in
       sources."minimalistic-crypto-utils-1.0.1"
       sources."minimist-1.2.5"
       sources."mkdirp-1.0.4"
-      sources."mobx-6.0.3"
+      sources."mobx-6.0.4"
       sources."mobx-react-6.3.1"
       sources."mobx-react-lite-2.2.2"
       sources."ms-2.1.2"
@@ -91942,7 +91490,7 @@ in
       sources."to-regex-range-5.0.1"
       sources."tslib-2.0.3"
       sources."tty-browserify-0.0.0"
-      sources."uglify-js-3.11.5"
+      sources."uglify-js-3.11.6"
       (sources."url-0.11.0" // {
         dependencies = [
           sources."punycode-1.3.2"
@@ -92002,10 +91550,10 @@ in
   rollup = nodeEnv.buildNodePackage {
     name = "rollup";
     packageName = "rollup";
-    version = "2.33.1";
+    version = "2.33.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/rollup/-/rollup-2.33.1.tgz";
-      sha512 = "uY4O/IoL9oNW8MMcbA5hcOaz6tZTMIh7qJHx/tzIJm+n1wLoY38BLn6fuy7DhR57oNFLMbDQtDeJoFURt5933w==";
+      url = "https://registry.npmjs.org/rollup/-/rollup-2.33.2.tgz";
+      sha512 = "QPQ6/fWCrzHtSXkI269rhKaC7qXGghYBwXU04b1JsDZ6ibZa3DJ9D1SFAYRMgx1inDg0DaTbb3N4Z1NK/r3fhw==";
     };
     dependencies = [
       sources."fsevents-2.1.3"
@@ -92135,7 +91683,7 @@ in
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
-      (sources."eslint-7.12.1" // {
+      (sources."eslint-7.13.0" // {
         dependencies = [
           sources."eslint-visitor-keys-2.0.0"
           sources."semver-7.3.2"
@@ -92281,10 +91829,10 @@ in
       sources."regexpp-3.1.0"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-from-4.0.0"
       sources."rimraf-2.6.3"
-      sources."rollup-2.33.1"
+      sources."rollup-2.33.2"
       sources."safe-buffer-5.2.1"
       sources."semver-6.3.0"
       sources."serialize-javascript-5.0.1"
@@ -92680,10 +92228,10 @@ in
   serverless = nodeEnv.buildNodePackage {
     name = "serverless";
     packageName = "serverless";
-    version = "2.11.0";
+    version = "2.11.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/serverless/-/serverless-2.11.0.tgz";
-      sha512 = "xR6ntWPdLA2gMauiuXAXUImUEFEVe8vmPbIZ4pbc34VwbztyeAnhUf4JyOL9wfDHStdJC2vqZ/zDngTJbM0DxQ==";
+      url = "https://registry.npmjs.org/serverless/-/serverless-2.11.1.tgz";
+      sha512 = "BQN53zkm/HWh+QtzaR/uXHRAxAcabHkstyRMo4+9JJc+DM7cQM9cyRBm15BW9PKMO9c3aCKYNTJSb5cegn7qmw==";
     };
     dependencies = [
       sources."2-thenable-1.0.0"
@@ -92731,7 +92279,7 @@ in
       sources."@serverless/enterprise-plugin-4.1.2"
       sources."@serverless/event-mocks-1.1.1"
       sources."@serverless/platform-client-3.1.2"
-      sources."@serverless/platform-client-china-2.0.8"
+      sources."@serverless/platform-client-china-2.0.9"
       (sources."@serverless/platform-sdk-2.3.2" // {
         dependencies = [
           sources."chalk-2.4.2"
@@ -92750,7 +92298,7 @@ in
           sources."write-file-atomic-3.0.3"
         ];
       })
-      sources."@serverless/utils-china-1.0.10"
+      sources."@serverless/utils-china-1.0.11"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@tencent-sdk/capi-1.1.6"
@@ -92760,7 +92308,7 @@ in
       sources."@types/keyv-3.1.1"
       sources."@types/lodash-4.14.165"
       sources."@types/long-4.0.1"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."@types/request-2.48.5"
       sources."@types/request-promise-native-1.0.17"
       sources."@types/responselike-1.0.0"
@@ -92817,7 +92365,7 @@ in
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."at-least-node-1.0.0"
-      (sources."aws-sdk-2.786.0" // {
+      (sources."aws-sdk-2.792.0" // {
         dependencies = [
           sources."buffer-4.9.2"
           sources."ieee754-1.1.13"
@@ -92830,7 +92378,7 @@ in
       sources."backo2-1.0.2"
       sources."balanced-match-1.0.0"
       sources."base64-arraybuffer-0.1.4"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."binary-0.3.0"
       sources."binary-extensions-2.1.0"
@@ -92950,7 +92498,7 @@ in
         ];
       })
       sources."dashdash-1.14.1"
-      sources."dayjs-1.9.5"
+      sources."dayjs-1.9.6"
       sources."debug-3.1.0"
       sources."decode-uri-component-0.2.0"
       sources."decompress-4.2.1"
@@ -93348,7 +92896,7 @@ in
       sources."readdir-glob-1.1.1"
       sources."readdirp-3.5.0"
       sources."regenerator-runtime-0.13.7"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."replaceall-0.1.6"
       (sources."request-2.88.2" // {
@@ -93380,7 +92928,7 @@ in
       sources."signal-exit-3.0.3"
       sources."simple-concat-1.0.1"
       sources."simple-get-2.8.1"
-      (sources."simple-git-2.21.0" // {
+      (sources."simple-git-2.22.0" // {
         dependencies = [
           sources."debug-4.3.0"
           sources."ms-2.1.2"
@@ -93523,7 +93071,7 @@ in
       })
       sources."wrappy-1.0.2"
       sources."write-file-atomic-2.4.3"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."xml2js-0.4.19"
       sources."xmlbuilder-9.0.7"
       sources."xmlhttprequest-ssl-1.5.5"
@@ -93531,7 +93079,7 @@ in
       sources."yallist-4.0.0"
       sources."yaml-ast-parser-0.0.43"
       sources."yamljs-0.3.0"
-      sources."yargs-parser-20.2.3"
+      sources."yargs-parser-20.2.4"
       sources."yauzl-2.10.0"
       sources."yeast-0.1.2"
       sources."zip-stream-4.0.2"
@@ -94173,10 +93721,10 @@ in
   snyk = nodeEnv.buildNodePackage {
     name = "snyk";
     packageName = "snyk";
-    version = "1.424.4";
+    version = "1.427.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/snyk/-/snyk-1.424.4.tgz";
-      sha512 = "l+p0PgYx7+xmAYNGy4hvd8hXtDIcQzYM1SrI7uM4CtlxR0Hjze93p0TcE3GYxSuia3IUDub95DIVtWmxLCeCMw==";
+      url = "https://registry.npmjs.org/snyk/-/snyk-1.427.0.tgz";
+      sha512 = "0T0pvkP7FSzvNdf8E/us1bB/aUWf2gr+ClsKexfVoKPcJYPuStFDaolmDMN0nvXD5yrYaLneYbQieuZrGtdlJQ==";
     };
     dependencies = [
       sources."@sindresorhus/is-2.1.1"
@@ -94184,16 +93732,16 @@ in
       sources."@snyk/cocoapods-lockfile-parser-3.5.2"
       sources."@snyk/composer-lockfile-parser-1.4.1"
       sources."@snyk/dep-graph-1.19.4"
-      sources."@snyk/docker-registry-v2-client-1.13.6"
+      sources."@snyk/docker-registry-v2-client-1.13.8"
       sources."@snyk/gemfile-1.2.0"
-      sources."@snyk/java-call-graph-builder-1.16.0"
+      sources."@snyk/java-call-graph-builder-1.16.2"
       sources."@snyk/rpm-parser-2.2.1"
       (sources."@snyk/snyk-cocoapods-plugin-2.5.1" // {
         dependencies = [
           sources."tslib-2.0.3"
         ];
       })
-      (sources."@snyk/snyk-docker-pull-3.2.0" // {
+      (sources."@snyk/snyk-docker-pull-3.2.2" // {
         dependencies = [
           sources."tmp-0.1.0"
         ];
@@ -94206,7 +93754,7 @@ in
       sources."@types/http-cache-semantics-4.0.0"
       sources."@types/js-yaml-3.12.5"
       sources."@types/keyv-3.1.1"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."@types/responselike-1.0.0"
       sources."@types/semver-5.5.0"
       sources."@yarnpkg/lockfile-1.1.0"
@@ -94232,9 +93780,9 @@ in
           sources."tslib-2.0.3"
         ];
       })
-      sources."async-1.5.2"
+      sources."async-3.2.0"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       (sources."bl-4.0.3" // {
         dependencies = [
@@ -94246,7 +93794,6 @@ in
       (sources."boxen-4.2.0" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
-          sources."camelcase-5.3.1"
           sources."chalk-3.0.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
@@ -94267,7 +93814,7 @@ in
           sources."get-stream-5.2.0"
         ];
       })
-      sources."camelcase-2.1.1"
+      sources."camelcase-5.3.1"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
       sources."child-process-1.0.2"
@@ -94276,18 +93823,8 @@ in
       sources."cli-cursor-3.1.0"
       sources."cli-spinner-0.2.10"
       sources."cli-width-3.0.0"
-      (sources."cliui-3.2.0" // {
-        dependencies = [
-          sources."ansi-regex-2.1.1"
-          sources."is-fullwidth-code-point-1.0.0"
-          sources."string-width-1.0.2"
-          sources."strip-ansi-3.0.1"
-          sources."wrap-ansi-2.1.0"
-        ];
-      })
       sources."clone-response-1.0.2"
       sources."co-4.6.0"
-      sources."code-point-at-1.1.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."concat-map-0.0.1"
@@ -94301,7 +93838,6 @@ in
       sources."crypto-random-string-2.0.0"
       sources."data-uri-to-buffer-1.2.0"
       sources."debug-4.3.0"
-      sources."decamelize-1.2.0"
       (sources."decompress-response-6.0.0" // {
         dependencies = [
           sources."mimic-response-3.1.0"
@@ -94410,7 +93946,6 @@ in
           sources."supports-color-7.2.0"
         ];
       })
-      sources."invert-kv-1.0.0"
       sources."ip-1.1.5"
       sources."is-ci-2.0.0"
       sources."is-deflate-1.0.0"
@@ -94437,7 +93972,6 @@ in
       })
       sources."keyv-4.0.3"
       sources."latest-version-5.1.0"
-      sources."lcid-1.0.0"
       sources."levn-0.3.0"
       sources."lie-3.3.0"
       sources."lodash-4.17.20"
@@ -94468,7 +94002,6 @@ in
       sources."mkdirp-1.0.4"
       sources."ms-2.1.2"
       sources."mute-stream-0.0.8"
-      sources."nconf-0.10.0"
       (sources."needle-2.5.0" // {
         dependencies = [
           sources."debug-3.2.6"
@@ -94478,13 +94011,11 @@ in
       sources."nice-try-1.0.5"
       sources."normalize-url-4.5.0"
       sources."npm-run-path-2.0.2"
-      sources."number-is-nan-1.0.1"
       sources."object-hash-2.0.3"
       sources."once-1.4.0"
       sources."onetime-5.1.2"
       sources."open-7.3.0"
       sources."optionator-0.8.3"
-      sources."os-locale-1.4.0"
       sources."os-name-3.1.0"
       sources."os-tmpdir-1.0.2"
       sources."p-cancelable-2.0.0"
@@ -94542,7 +94073,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."resolve-alpn-1.0.0"
       sources."responselike-2.0.0"
@@ -94553,7 +94084,6 @@ in
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."secure-keys-1.0.0"
       sources."semver-6.3.0"
       sources."semver-diff-3.1.1"
       sources."set-immediate-shim-1.0.1"
@@ -94562,8 +94092,8 @@ in
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.3"
       sources."smart-buffer-4.1.0"
-      sources."snyk-config-3.1.1"
-      (sources."snyk-cpp-plugin-2.0.0" // {
+      sources."snyk-config-4.0.0-rc.2"
+      (sources."snyk-cpp-plugin-2.1.0" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."chalk-4.1.0"
@@ -94574,10 +94104,9 @@ in
           sources."tslib-2.0.3"
         ];
       })
-      (sources."snyk-docker-plugin-4.7.0" // {
+      (sources."snyk-docker-plugin-4.7.2" // {
         dependencies = [
           sources."rimraf-3.0.2"
-          sources."snyk-nodejs-lockfile-parser-1.30.0"
           sources."tmp-0.2.1"
           sources."uuid-8.3.1"
         ];
@@ -94589,7 +94118,7 @@ in
           sources."tmp-0.2.1"
         ];
       })
-      (sources."snyk-gradle-plugin-3.10.1" // {
+      (sources."snyk-gradle-plugin-3.10.2" // {
         dependencies = [
           (sources."@snyk/cli-interface-2.9.1" // {
             dependencies = [
@@ -94608,16 +94137,19 @@ in
         ];
       })
       sources."snyk-module-3.1.0"
-      (sources."snyk-mvn-plugin-2.23.0" // {
+      (sources."snyk-mvn-plugin-2.23.1" // {
         dependencies = [
           sources."@snyk/cli-interface-2.9.1"
-          sources."@snyk/java-call-graph-builder-1.16.1"
           sources."tmp-0.1.0"
           sources."tslib-1.11.1"
         ];
       })
-      sources."snyk-nodejs-lockfile-parser-1.28.1"
-      (sources."snyk-nuget-plugin-1.19.3" // {
+      (sources."snyk-nodejs-lockfile-parser-1.30.1" // {
+        dependencies = [
+          sources."uuid-8.3.1"
+        ];
+      })
+      (sources."snyk-nuget-plugin-1.19.4" // {
         dependencies = [
           sources."jszip-3.4.0"
           sources."pako-1.0.11"
@@ -94629,7 +94161,7 @@ in
           sources."tslib-1.11.1"
         ];
       })
-      (sources."snyk-poetry-lockfile-parser-1.1.0" // {
+      (sources."snyk-poetry-lockfile-parser-1.1.1" // {
         dependencies = [
           (sources."@snyk/dep-graph-1.20.0" // {
             dependencies = [
@@ -94650,7 +94182,7 @@ in
           })
         ];
       })
-      sources."snyk-python-plugin-1.18.0"
+      sources."snyk-python-plugin-1.19.1"
       (sources."snyk-resolve-1.0.1" // {
         dependencies = [
           sources."debug-3.2.6"
@@ -94756,7 +94288,6 @@ in
       sources."vscode-languageserver-types-3.15.1"
       sources."which-1.3.1"
       sources."widest-line-3.1.0"
-      sources."window-size-0.1.4"
       sources."windows-release-3.3.3"
       sources."word-wrap-1.2.3"
       (sources."wrap-ansi-5.1.0" // {
@@ -94773,17 +94304,8 @@ in
       sources."xmlbuilder-11.0.1"
       sources."xregexp-2.0.0"
       sources."xtend-4.0.2"
-      sources."y18n-3.2.1"
       sources."yallist-3.1.1"
       sources."yaml-1.10.0"
-      (sources."yargs-3.32.0" // {
-        dependencies = [
-          sources."ansi-regex-2.1.1"
-          sources."is-fullwidth-code-point-1.0.0"
-          sources."string-width-1.0.2"
-          sources."strip-ansi-3.0.1"
-        ];
-      })
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -94798,10 +94320,10 @@ in
   "socket.io" = nodeEnv.buildNodePackage {
     name = "socket.io";
     packageName = "socket.io";
-    version = "3.0.0";
+    version = "3.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/socket.io/-/socket.io-3.0.0.tgz";
-      sha512 = "arLQtd+UoJ08NXBRBGUJDyQ9B+cc9WwD67hc5s1WQcs2DyAkYzI5HWg4U0CrFtK00kjyAWxBGhLwVbfOeMqz1A==";
+      url = "https://registry.npmjs.org/socket.io/-/socket.io-3.0.1.tgz";
+      sha512 = "oVYbCQ4sCwm4wVi+f1bsE3YFXcvd6b4JjVP8D7IZnQqBeJOKX9XrdgJWSbXqBEqUXPY3jdTqb1M3s4KFTa/IHg==";
     };
     dependencies = [
       sources."accepts-1.3.7"
@@ -94810,7 +94332,7 @@ in
       sources."cookie-0.4.1"
       sources."cors-2.8.5"
       sources."debug-4.1.1"
-      sources."engine.io-4.0.1"
+      sources."engine.io-4.0.2"
       sources."engine.io-parser-4.0.1"
       sources."mime-db-1.44.0"
       sources."mime-types-2.1.27"
@@ -94820,7 +94342,7 @@ in
       sources."socket.io-adapter-2.0.3"
       sources."socket.io-parser-4.0.1"
       sources."vary-1.1.2"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -94956,7 +94478,7 @@ in
       sources."redent-2.0.0"
       sources."registry-auth-token-3.4.0"
       sources."registry-url-3.1.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."restore-cursor-2.0.0"
       sources."round-to-3.0.0"
       sources."safe-buffer-5.2.1"
@@ -95010,10 +94532,10 @@ in
   ssb-server = nodeEnv.buildNodePackage {
     name = "ssb-server";
     packageName = "ssb-server";
-    version = "16.0.1";
+    version = "15.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ssb-server/-/ssb-server-16.0.1.tgz";
-      sha512 = "cast7wQRxqUSiRVyFoaTtymeukwSh5nlfDj5ShHmdnh0qmfi4uQnvPuBA5BBgC3WEtI/ozgNjAc1/vqJFgILig==";
+      url = "https://registry.npmjs.org/ssb-server/-/ssb-server-15.3.0.tgz";
+      sha512 = "+KXfMBecoFFAo0C4FTfSsH2ZXtrL2aQDXgVlQ0NrYdNLHW2TEnibV0hG3yq3hOlAEUQmrwVHZATfVToO825gxA==";
     };
     dependencies = [
       sources."abstract-leveldown-6.0.3"
@@ -95034,13 +94556,9 @@ in
       sources."assign-symbols-1.0.0"
       sources."async-each-1.0.3"
       sources."async-single-1.0.5"
+      sources."async-write-2.1.0"
       sources."atob-2.1.2"
-      (sources."atomic-file-2.1.1" // {
-        dependencies = [
-          sources."flumecodec-0.0.1"
-          sources."level-codec-6.2.0"
-        ];
-      })
+      sources."atomic-file-1.1.5"
       sources."attach-ware-1.1.1"
       sources."available-typed-arrays-1.0.2"
       sources."bail-1.0.5"
@@ -95051,7 +94569,7 @@ in
           sources."isobject-3.0.1"
         ];
       })
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."base64-url-2.3.3"
       sources."bash-color-0.0.4"
       sources."binary-extensions-1.13.1"
@@ -95157,9 +94675,8 @@ in
       sources."epidemic-broadcast-trees-7.0.0"
       sources."errno-0.1.7"
       sources."es-abstract-1.18.0-next.1"
-      (sources."es-get-iterator-1.1.0" // {
+      (sources."es-get-iterator-1.1.1" // {
         dependencies = [
-          sources."es-abstract-1.17.7"
           sources."isarray-2.0.5"
         ];
       })
@@ -95185,39 +94702,37 @@ in
           sources."level-codec-6.2.0"
         ];
       })
-      (sources."flumedb-2.1.8" // {
-        dependencies = [
-          sources."pull-abortable-4.1.1"
-        ];
-      })
+      sources."flumedb-1.1.0"
       sources."flumelog-offset-3.4.4"
-      (sources."flumeview-hashtable-1.1.1" // {
-        dependencies = [
-          sources."atomic-file-1.1.5"
-        ];
-      })
-      (sources."flumeview-level-4.0.4" // {
-        dependencies = [
-          sources."abstract-leveldown-6.2.3"
-          sources."level-6.0.1"
-          sources."level-js-5.0.2"
-          sources."mkdirp-1.0.4"
-        ];
-      })
+      sources."flumeview-hashtable-1.1.1"
+      sources."flumeview-level-3.0.14"
       (sources."flumeview-links-1.0.1" // {
         dependencies = [
           sources."deep-equal-2.0.4"
-          sources."flumeview-level-3.0.14"
           sources."isarray-2.0.5"
           sources."map-filter-reduce-3.2.2"
         ];
       })
       (sources."flumeview-query-8.0.0" // {
         dependencies = [
+          sources."abstract-leveldown-6.2.3"
+          sources."flumeview-level-4.0.4"
+          sources."level-6.0.1"
+          sources."level-js-5.0.2"
           sources."map-filter-reduce-3.2.2"
+          sources."mkdirp-1.0.4"
         ];
       })
-      sources."flumeview-reduce-1.3.17"
+      (sources."flumeview-reduce-1.3.17" // {
+        dependencies = [
+          (sources."atomic-file-2.1.1" // {
+            dependencies = [
+              sources."flumecodec-0.0.1"
+            ];
+          })
+          sources."level-codec-6.2.0"
+        ];
+      })
       sources."for-each-0.3.3"
       sources."for-in-1.0.2"
       sources."for-own-0.1.5"
@@ -95355,7 +94870,6 @@ in
       sources."libnested-1.5.0"
       sources."libsodium-0.7.8"
       sources."libsodium-wrappers-0.7.8"
-      sources."lodash.clonedeep-4.5.0"
       sources."lodash.get-4.4.2"
       sources."log-symbols-1.0.2"
       sources."log-update-1.0.2"
@@ -95688,20 +95202,10 @@ in
       sources."ssb-caps-1.1.0"
       sources."ssb-client-4.9.0"
       sources."ssb-config-3.4.5"
-      (sources."ssb-db-20.3.0" // {
-        dependencies = [
-          sources."glob-7.1.6"
-          sources."mkdirp-1.0.4"
-          sources."rimraf-3.0.2"
-        ];
-      })
+      sources."ssb-db-19.2.0"
       sources."ssb-ebt-5.6.7"
-      sources."ssb-friends-4.2.1"
-      (sources."ssb-gossip-1.1.1" // {
-        dependencies = [
-          sources."atomic-file-1.1.5"
-        ];
-      })
+      sources."ssb-friends-4.3.0"
+      sources."ssb-gossip-1.1.1"
       (sources."ssb-invite-2.1.6" // {
         dependencies = [
           sources."abstract-leveldown-6.2.3"
@@ -95723,8 +95227,7 @@ in
           sources."level-codec-6.2.0"
         ];
       })
-      sources."ssb-plugins-1.0.4"
-      sources."ssb-private1-1.0.1"
+      sources."ssb-plugins-1.0.0"
       sources."ssb-query-2.4.5"
       sources."ssb-ref-2.14.2"
       sources."ssb-replicate-1.3.2"
@@ -95933,7 +95436,7 @@ in
       sources."async-1.5.2"
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
-      (sources."aws-sdk-2.786.0" // {
+      (sources."aws-sdk-2.792.0" // {
         dependencies = [
           sources."uuid-3.3.2"
         ];
@@ -95952,7 +95455,7 @@ in
       })
       sources."balanced-match-1.0.0"
       sources."base64-arraybuffer-0.1.4"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."base64id-2.0.0"
       sources."base64url-3.0.1"
       sources."basic-auth-1.1.0"
@@ -96073,7 +95576,7 @@ in
         dependencies = [
           sources."cookie-0.3.1"
           sources."debug-4.1.1"
-          sources."ws-7.3.1"
+          sources."ws-7.4.0"
         ];
       })
       (sources."engine.io-client-3.4.4" // {
@@ -96429,7 +95932,7 @@ in
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
       sources."requires-port-1.0.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."ret-0.2.2"
       sources."rethinkdb-2.4.2"
       sources."retry-0.9.0"
@@ -96729,9 +96232,9 @@ in
       sources."css-select-base-adapter-0.1.1"
       sources."css-tree-1.0.0-alpha.37"
       sources."css-what-3.4.2"
-      (sources."csso-4.1.0" // {
+      (sources."csso-4.1.1" // {
         dependencies = [
-          sources."css-tree-1.0.0"
+          sources."css-tree-1.0.1"
           sources."mdn-data-2.0.12"
         ];
       })
@@ -97369,7 +96872,7 @@ in
       sources."truncate-utf8-bytes-1.0.2"
       sources."type-is-1.6.18"
       sources."typedarray-0.0.6"
-      sources."uglify-js-3.11.5"
+      sources."uglify-js-3.11.6"
       sources."undefsafe-2.0.3"
       (sources."union-value-1.0.1" // {
         dependencies = [
@@ -97764,7 +97267,7 @@ in
       sources."repeat-string-1.6.1"
       sources."replace-ext-1.0.0"
       sources."require-from-string-2.0.2"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."rimraf-2.6.3"
       sources."safe-buffer-5.1.2"
       sources."semver-5.7.1"
@@ -97924,11 +97427,11 @@ in
       sources."@textlint/ast-node-types-4.3.4"
       sources."@textlint/types-1.4.5"
       sources."@types/hast-2.3.1"
-      sources."@types/minimist-1.2.0"
+      sources."@types/minimist-1.2.1"
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/parse5-5.0.3"
       sources."@types/unist-2.0.3"
-      sources."alex-9.0.1"
+      sources."alex-9.1.0"
       (sources."ansi-align-3.0.0" // {
         dependencies = [
           sources."string-width-3.1.0"
@@ -98164,7 +97667,7 @@ in
       })
       sources."readable-stream-1.0.34"
       sources."redent-3.0.0"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."rehype-parse-7.0.1"
       sources."rehype-retext-2.0.4"
@@ -98176,11 +97679,11 @@ in
       sources."remark-stringify-8.1.1"
       sources."repeat-string-1.6.1"
       sources."replace-ext-1.0.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-from-5.0.0"
       sources."responselike-1.0.2"
       sources."retext-english-3.0.4"
-      sources."retext-equality-5.2.0"
+      sources."retext-equality-5.5.0"
       sources."retext-profanities-6.1.0"
       sources."safe-buffer-5.2.1"
       sources."semver-5.7.1"
@@ -98723,7 +98226,7 @@ in
       sources."@types/debug-4.1.5"
       sources."@types/http-cache-semantics-4.0.0"
       sources."@types/keyv-3.1.1"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."@types/responselike-1.0.0"
       sources."abbrev-1.1.1"
       sources."abstract-logging-2.0.1"
@@ -99042,7 +98545,7 @@ in
       sources."readable-stream-3.6.0"
       sources."readable-web-to-node-stream-2.0.0"
       sources."regenerator-runtime-0.13.7"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       (sources."request-2.88.2" // {
         dependencies = [
@@ -99138,7 +98641,7 @@ in
       sources."wide-align-1.1.3"
       sources."with-open-file-0.1.7"
       sources."wrappy-1.0.2"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."yallist-3.1.1"
       sources."yarn-1.22.4"
@@ -99641,10 +99144,10 @@ in
   uglify-js = nodeEnv.buildNodePackage {
     name = "uglify-js";
     packageName = "uglify-js";
-    version = "3.11.5";
+    version = "3.11.6";
     src = fetchurl {
-      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.5.tgz";
-      sha512 = "btvv/baMqe7HxP7zJSF7Uc16h1mSfuuSplT0/qdjxseesDU+yYzH33eHBH+eMdeRXwujXspaCTooWHQVVBh09w==";
+      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.6.tgz";
+      sha512 = "oASI1FOJ7BBFkSCNDZ446EgkSuHkOZBuqRFrwXIKWCoXw8ZXQETooTQjkAcBS03Acab7ubCKsXnwuV2svy061g==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -99687,7 +99190,7 @@ in
       sources."@primer/octicons-11.0.0"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
       sources."after-0.8.2"
@@ -99720,7 +99223,7 @@ in
         ];
       })
       sources."callsite-1.0.0"
-      sources."cliui-7.0.3"
+      sources."cliui-7.0.4"
       sources."clone-2.1.2"
       sources."clone-response-1.0.2"
       sources."color-3.0.0"
@@ -99892,7 +99395,7 @@ in
       sources."raw-body-2.4.0"
       sources."rc-1.2.8"
       sources."readable-stream-3.6.0"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."require-directory-2.1.1"
       sources."responselike-1.0.2"
@@ -99947,7 +99450,7 @@ in
       })
       sources."strip-ansi-6.0.0"
       sources."strip-json-comments-2.0.1"
-      (sources."temp-0.9.2" // {
+      (sources."temp-0.9.4" // {
         dependencies = [
           sources."mkdirp-0.5.5"
           sources."rimraf-2.6.3"
@@ -99975,12 +99478,12 @@ in
       })
       sources."wrap-ansi-7.0.0"
       sources."wrappy-1.0.2"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."y18n-5.0.5"
       sources."yallist-2.1.2"
-      sources."yargs-16.1.0"
-      sources."yargs-parser-20.2.3"
+      sources."yargs-16.1.1"
+      sources."yargs-parser-20.2.4"
       sources."yeast-0.1.2"
     ];
     buildInputs = globalBuildInputs;
@@ -100011,7 +99514,7 @@ in
       sources."brace-expansion-1.1.11"
       sources."canvas-2.6.1"
       sources."chownr-1.1.4"
-      (sources."cliui-7.0.3" // {
+      (sources."cliui-7.0.4" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
           sources."is-fullwidth-code-point-3.0.0"
@@ -100096,7 +99599,7 @@ in
       sources."rc-1.2.8"
       sources."readable-stream-2.3.7"
       sources."require-directory-2.1.1"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."rimraf-2.7.1"
       sources."rw-1.3.3"
       sources."safe-buffer-5.1.2"
@@ -100156,7 +99659,7 @@ in
       sources."wrappy-1.0.2"
       sources."y18n-5.0.5"
       sources."yallist-3.1.1"
-      (sources."yargs-16.1.0" // {
+      (sources."yargs-16.1.1" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
           sources."is-fullwidth-code-point-3.0.0"
@@ -100164,7 +99667,7 @@ in
           sources."strip-ansi-6.0.0"
         ];
       })
-      sources."yargs-parser-20.2.3"
+      sources."yargs-parser-20.2.4"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -100190,7 +99693,7 @@ in
       sources."ansi-regex-5.0.0"
       sources."ansi-styles-4.3.0"
       sources."array-flat-polyfill-1.0.1"
-      sources."cliui-7.0.3"
+      sources."cliui-7.0.4"
       sources."clone-2.1.2"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
@@ -100211,7 +99714,7 @@ in
       sources."wrap-ansi-7.0.0"
       sources."y18n-5.0.5"
       sources."yargs-16.0.3"
-      sources."yargs-parser-20.2.3"
+      sources."yargs-parser-20.2.4"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -100424,7 +99927,7 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."big.js-5.2.2"
       sources."binary-extensions-2.1.0"
       sources."bindings-1.5.0"
@@ -100438,11 +99941,7 @@ in
       sources."browserify-aes-1.2.0"
       sources."browserify-cipher-1.0.1"
       sources."browserify-des-1.0.2"
-      (sources."browserify-rsa-4.0.1" // {
-        dependencies = [
-          sources."bn.js-4.11.9"
-        ];
-      })
+      sources."browserify-rsa-4.1.0"
       (sources."browserify-sign-4.2.1" // {
         dependencies = [
           sources."readable-stream-3.6.0"
@@ -101093,13 +100592,13 @@ in
       sources."vsce-1.81.1"
       sources."vscode-debugadapter-testsupport-1.42.0"
       sources."vscode-debugprotocol-1.42.0"
-      (sources."watchpack-1.7.4" // {
+      (sources."watchpack-1.7.5" // {
         dependencies = [
           sources."chokidar-3.4.3"
           sources."readdirp-3.5.0"
         ];
       })
-      (sources."watchpack-chokidar2-2.0.0" // {
+      (sources."watchpack-chokidar2-2.0.1" // {
         dependencies = [
           sources."anymatch-2.0.0"
           sources."binary-extensions-1.13.1"
@@ -101217,7 +100716,7 @@ in
       sources."aws-sign2-0.7.0"
       sources."aws4-1.11.0"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."bl-1.2.3"
       sources."bluebird-3.7.2"
@@ -101442,7 +100941,7 @@ in
       sources."tslib-1.14.1"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
-      sources."uglify-js-3.11.5"
+      sources."uglify-js-3.11.6"
       sources."uid-0.0.2"
       sources."unbzip2-stream-1.4.3"
       sources."unyield-0.0.1"
@@ -101501,7 +101000,7 @@ in
       sources."@starptech/rehype-webparser-0.10.0"
       sources."@starptech/webparser-0.10.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."@types/unist-2.0.3"
       sources."@types/vfile-3.0.2"
       sources."@types/vfile-message-2.0.0"
@@ -101590,10 +101089,8 @@ in
       sources."camelcase-keys-4.2.0"
       sources."ccount-1.1.0"
       sources."chalk-2.4.2"
-      sources."character-entities-1.2.4"
       sources."character-entities-html4-1.1.4"
       sources."character-entities-legacy-1.1.4"
-      sources."character-reference-invalid-1.1.4"
       sources."chardet-0.7.0"
       (sources."chokidar-3.0.2" // {
         dependencies = [
@@ -101921,7 +101418,6 @@ in
           sources."supports-color-2.0.0"
         ];
       })
-      sources."longest-streak-1.0.0"
       sources."loud-rejection-1.6.0"
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.5"
@@ -101930,7 +101426,6 @@ in
       sources."map-cache-0.2.2"
       sources."map-obj-2.0.0"
       sources."map-visit-1.0.0"
-      sources."markdown-table-0.4.0"
       (sources."mem-4.3.0" // {
         dependencies = [
           sources."mimic-fn-2.1.0"
@@ -102010,7 +101505,6 @@ in
         ];
       })
       sources."parent-module-1.0.1"
-      sources."parse-entities-1.2.2"
       sources."parse-gitignore-1.0.1"
       sources."parse-json-4.0.0"
       sources."pascalcase-0.1.1"
@@ -102095,21 +101589,9 @@ in
       sources."regenerator-runtime-0.11.1"
       sources."regex-not-1.0.2"
       sources."regexpp-2.0.1"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."rehype-sort-attribute-values-2.0.1"
-      (sources."remark-5.1.0" // {
-        dependencies = [
-          sources."unified-4.2.1"
-          sources."vfile-1.4.0"
-        ];
-      })
-      sources."remark-parse-1.1.0"
-      (sources."remark-stringify-1.1.0" // {
-        dependencies = [
-          sources."stringify-entities-1.3.2"
-        ];
-      })
       sources."repeat-element-1.1.3"
       sources."repeat-string-1.6.1"
       sources."replace-ext-1.0.0"
@@ -102121,7 +101603,7 @@ in
           sources."resolve-from-1.0.1"
         ];
       })
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-from-5.0.0"
       sources."resolve-url-0.2.1"
       sources."responselike-1.0.2"
@@ -102282,9 +101764,7 @@ in
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
       sources."to-vfile-6.1.0"
-      sources."trim-0.0.1"
       sources."trim-newlines-2.0.0"
-      sources."trim-trailing-lines-1.1.4"
       sources."trough-1.0.5"
       sources."tslib-1.14.1"
       sources."tslint-5.20.1"
@@ -102298,7 +101778,6 @@ in
           sources."semver-5.5.0"
         ];
       })
-      sources."unherit-1.1.3"
       (sources."unified-7.1.0" // {
         dependencies = [
           sources."unist-util-stringify-position-1.1.2"
@@ -102321,11 +101800,10 @@ in
       })
       sources."union-value-1.0.1"
       sources."unique-string-1.0.0"
-      sources."unist-util-find-1.0.1"
+      sources."unist-util-find-1.0.2"
       sources."unist-util-inspect-4.1.4"
       sources."unist-util-is-2.1.3"
       sources."unist-util-modify-children-1.1.6"
-      sources."unist-util-remove-position-1.1.4"
       sources."unist-util-stringify-position-2.0.3"
       sources."unist-util-visit-1.4.1"
       (sources."unist-util-visit-parents-2.1.2" // {
@@ -102353,7 +101831,6 @@ in
       sources."util-deprecate-1.0.2"
       sources."validate-npm-package-license-3.0.4"
       sources."vfile-4.2.0"
-      sources."vfile-location-2.0.6"
       sources."vfile-message-2.0.4"
       (sources."vfile-reporter-6.0.1" // {
         dependencies = [
@@ -102465,7 +101942,7 @@ in
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."JSONSelect-0.2.1"
       sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
@@ -102521,7 +101998,7 @@ in
           sources."isobject-3.0.1"
         ];
       })
-      sources."base64-js-1.3.1"
+      sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."binary-extensions-2.1.0"
       sources."bindings-1.5.0"
@@ -103110,7 +102587,7 @@ in
         ];
       })
       sources."regexpp-3.1.0"
-      sources."registry-auth-token-4.2.0"
+      sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       (sources."relaxed-json-1.0.3" // {
         dependencies = [
@@ -103304,7 +102781,7 @@ in
       sources."v8-compile-cache-2.2.0"
       sources."verror-1.10.0"
       sources."watchpack-1.7.4"
-      (sources."watchpack-chokidar2-2.0.0" // {
+      (sources."watchpack-chokidar2-2.0.1" // {
         dependencies = [
           sources."anymatch-2.0.0"
           sources."binary-extensions-1.13.1"
@@ -103409,11 +102886,11 @@ in
       sha512 = "udpYTyqz8toTTdaOsL2QKPLeZLt2IEm9qY7yTXuFEQhKu5bk0yQD9BtAdVQksmz4jFbbWOiWmm3NHarO0zr/ng==";
     };
     dependencies = [
-      sources."@types/eslint-7.2.4"
+      sources."@types/eslint-7.2.5"
       sources."@types/eslint-scope-3.7.0"
       sources."@types/estree-0.0.45"
       sources."@types/json-schema-7.0.6"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."@webassemblyjs/ast-1.9.0"
       sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
       sources."@webassemblyjs/helper-api-error-1.9.0"
@@ -103437,12 +102914,13 @@ in
       sources."acorn-8.0.4"
       sources."ajv-6.12.6"
       sources."ajv-keywords-3.5.2"
-      sources."browserslist-4.14.6"
+      sources."browserslist-4.14.7"
       sources."buffer-from-1.1.1"
-      sources."caniuse-lite-1.0.30001156"
+      sources."caniuse-lite-1.0.30001158"
       sources."chrome-trace-event-1.0.2"
+      sources."colorette-1.2.1"
       sources."commander-2.20.3"
-      sources."electron-to-chromium-1.3.589"
+      sources."electron-to-chromium-1.3.596"
       sources."enhanced-resolve-5.3.1"
       sources."escalade-3.1.1"
       sources."eslint-scope-5.1.1"
@@ -103468,7 +102946,7 @@ in
       sources."mime-db-1.44.0"
       sources."mime-types-2.1.27"
       sources."neo-async-2.6.2"
-      sources."node-releases-1.1.65"
+      sources."node-releases-1.1.66"
       sources."p-limit-2.3.0"
       sources."p-locate-4.1.0"
       sources."p-try-2.2.0"
@@ -103483,8 +102961,8 @@ in
       sources."source-map-0.6.1"
       sources."source-map-support-0.5.19"
       sources."supports-color-7.2.0"
-      sources."tapable-2.0.0"
-      (sources."terser-5.3.8" // {
+      sources."tapable-2.1.1"
+      (sources."terser-5.4.0" // {
         dependencies = [
           sources."source-map-0.7.3"
         ];
@@ -103527,7 +103005,7 @@ in
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."colorette-1.2.1"
-      sources."command-line-usage-6.1.0"
+      sources."command-line-usage-6.1.1"
       sources."commander-6.2.0"
       sources."cross-spawn-7.0.3"
       sources."deep-extend-0.6.0"
@@ -103565,7 +103043,7 @@ in
       sources."pump-3.0.0"
       sources."rechoir-0.7.0"
       sources."reduce-flatten-2.0.0"
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-cwd-3.0.0"
       sources."resolve-from-5.0.0"
       sources."shebang-command-2.0.0"
@@ -103602,7 +103080,7 @@ in
     dependencies = [
       sources."@types/glob-7.1.3"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."accepts-1.3.7"
       sources."ajv-6.12.6"
       sources."ajv-errors-1.0.1"
@@ -104188,10 +103666,10 @@ in
   copy-webpack-plugin = nodeEnv.buildNodePackage {
     name = "copy-webpack-plugin";
     packageName = "copy-webpack-plugin";
-    version = "6.3.0";
+    version = "6.3.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.3.0.tgz";
-      sha512 = "kQ2cGGQLO6Ov2fe7rEGVxObI17dPeFkv8bRGnUAGZehOcrrObyAR9yWYlFGlJsyWM4EeuC/ytQNQkXxjYotMzg==";
+      url = "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.3.1.tgz";
+      sha512 = "SyIMdP6H3v+zPU+VIhKRsK0ZEF82KZ93JBlKOoIW8SkkuI84FSrHxG+aMTE1u4csbi9PLRqqWTIK+bfJ2xsFuQ==";
     };
     dependencies = [
       sources."@nodelib/fs.scandir-2.1.3"
@@ -104302,10 +103780,10 @@ in
   webtorrent-cli = nodeEnv.buildNodePackage {
     name = "webtorrent-cli";
     packageName = "webtorrent-cli";
-    version = "3.0.7";
+    version = "3.2.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webtorrent-cli/-/webtorrent-cli-3.0.7.tgz";
-      sha512 = "7psSgPvy+nL4hQ8zIv1RW1pdFZVrxB6jHnIEwmDU6xP6zst/t5pgerrdnZerzgQBzlGjpRQQ9fQtZoHxK7zgtw==";
+      url = "https://registry.npmjs.org/webtorrent-cli/-/webtorrent-cli-3.2.0.tgz";
+      sha512 = "7XNNVzaGIoUuPouqLYNji+59kmNZSqeN0uqla4Z/i0x5XqlhocRGcm7gfhvBLXShyVcxyveUNjTOz3Z5NTTQTg==";
     };
     dependencies = [
       sources."@protobufjs/aspromise-1.1.2"
@@ -104323,6 +103801,7 @@ in
       sources."addr-to-ip-port-1.5.1"
       sources."airplay-js-0.3.0"
       sources."balanced-match-1.0.0"
+      sources."base64-js-1.5.1"
       sources."bencode-2.0.1"
       sources."bep53-range-1.0.0"
       sources."binary-search-1.3.6"
@@ -104333,7 +103812,7 @@ in
           sources."ms-2.1.2"
         ];
       })
-      (sources."bittorrent-lsd-1.0.0" // {
+      (sources."bittorrent-lsd-1.1.0" // {
         dependencies = [
           sources."debug-4.3.0"
           sources."ms-2.1.2"
@@ -104361,6 +103840,7 @@ in
       sources."bn.js-5.1.3"
       sources."brace-expansion-1.1.11"
       sources."browserify-package-json-1.0.1"
+      sources."buffer-6.0.2"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
       sources."buffer-fill-1.0.0"
@@ -104427,6 +103907,7 @@ in
       sources."he-1.2.0"
       sources."http-node-git://github.com/feross/http-node#webtorrent"
       sources."http-parser-js-0.4.13"
+      sources."ieee754-1.2.1"
       sources."immediate-chunk-store-2.1.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -104529,7 +104010,7 @@ in
       sources."semver-5.1.1"
       sources."simple-concat-1.0.1"
       sources."simple-get-2.8.1"
-      (sources."simple-peer-9.8.0" // {
+      (sources."simple-peer-9.9.3" // {
         dependencies = [
           sources."debug-4.3.0"
           sources."ms-2.1.2"
@@ -104584,23 +104065,23 @@ in
       sources."utf-8-validate-5.0.3"
       sources."util-deprecate-1.0.2"
       sources."utp-native-2.2.1"
-      sources."videostream-3.2.1"
+      sources."videostream-3.2.2"
       sources."vlc-command-1.2.0"
       (sources."webtorrent-0.110.1" // {
         dependencies = [
           sources."debug-4.3.0"
           sources."decompress-response-6.0.0"
           sources."get-stdin-8.0.0"
-          sources."magnet-uri-6.0.0"
+          sources."magnet-uri-6.1.0"
           sources."mimic-response-3.1.0"
           sources."ms-2.1.2"
-          sources."parse-torrent-9.0.0"
+          sources."parse-torrent-9.1.0"
           sources."simple-get-4.0.0"
         ];
       })
       sources."winreg-1.2.4"
       sources."wrappy-1.0.2"
-      sources."ws-7.3.1"
+      sources."ws-7.4.0"
       sources."xml2js-0.4.23"
       sources."xmlbuilder-11.0.1"
       sources."xmldom-0.1.31"
@@ -104750,7 +104231,7 @@ in
       sources."@sindresorhus/is-0.7.0"
       sources."@types/glob-7.1.3"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-14.14.6"
+      sources."@types/node-14.14.7"
       sources."@types/normalize-package-data-2.4.0"
       sources."JSONStream-1.3.5"
       sources."aggregate-error-3.1.0"
@@ -105342,7 +104823,7 @@ in
           sources."tough-cookie-2.5.0"
         ];
       })
-      sources."resolve-1.18.1"
+      sources."resolve-1.19.0"
       sources."resolve-url-0.2.1"
       sources."responselike-1.0.2"
       sources."restore-cursor-2.0.0"
@@ -105524,7 +105005,7 @@ in
       sources."tunnel-0.0.6"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
-      sources."twig-1.15.2"
+      sources."twig-1.15.3"
       sources."type-fest-0.3.1"
       sources."typedarray-0.0.6"
       sources."union-value-1.0.1"


### PR DESCRIPTION

##### Motivation for this change

This adds a few tools related to the [`handshake`](https://handshake.org) decentralized naming system.

The following tools are added:

- [`hsd`](https://github.com/handshake-org/hsd)
- [`hs-client`](https://github.com/handshake-org/hs-client)
- [`hs-airdrop`](https://github.com/handshake-org/hs-airdrop)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
