### PR TITLE
turbo-geth: init at 2020.09.04

### DIFF
--- a/pkgs/applications/blockchains/turbo-geth.nix
+++ b/pkgs/applications/blockchains/turbo-geth.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "turbo-geth";
+  version = "2020.11.01";
+
+  src = fetchFromGitHub {
+    owner = "ledgerwatch";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0hm8kqd0w231mlclsmsghf15r8pbrs5g064mkpx59qpqzk37lgss";
+  };
+
+  vendorSha256 = "0b7ldrnwkz3r1d4fw95hvvpi3bz56d9v8p2mjzdvlpk5zhl2a37p";
+  runVend = true;
+
+  subPackages = [
+    "cmd/tg"
+    "cmd/restapi"
+    "cmd/rpcdaemon"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ledgerwatch/turbo-geth/";
+    description = "Ethereum node and geth fork focused on scalability and modularity";
+    license = with licenses; [ lgpl3 gpl3 ];
+    maintainers = with maintainers; [ xwvvvvwx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24986,6 +24986,8 @@ in
 
   tessera = callPackage ../applications/blockchains/tessera.nix { };
 
+  turbo-geth = callPackage ../applications/blockchains/turbo-geth.nix { };
+
   vertcoin  = libsForQt514.callPackage ../applications/blockchains/vertcoin.nix { boost = boost165; withGui = true; };
   vertcoind = callPackage ../applications/blockchains/vertcoin.nix { boost = boost165; withGui = false; };
 


### PR DESCRIPTION
###### Motivation for this change

Adds a package for the [`turbo-geth`](https://github.com/ledgerwatch/turbo-geth/) ethereum blockchain node.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
