### PR TITLE
skopeo: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/development/tools/skopeo/default.nix
+++ b/pkgs/development/tools/skopeo/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , buildGoModule
 , fetchFromGitHub
-, runCommand
 , gpgme
 , lvm2
 , btrfs-progs
@@ -10,18 +9,17 @@
 , installShellFiles
 , makeWrapper
 , fuse-overlayfs
-, nixosTests
 }:
 
 buildGoModule rec {
   pname = "skopeo";
-  version = "1.1.1";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "containers";
     repo = "skopeo";
-    sha256 = "0wkpw8fizxjpfypflp7rs1q128dg4hadwzdvn8k41h7f8cbcb39x";
+    sha256 = "1v7k3ki10i6082r7zswblyirx6zck674y6bw3plssw4p1l2611rd";
   };
 
   outputs = [ "out" "man" ];
@@ -37,12 +35,12 @@ buildGoModule rec {
 
   buildPhase = ''
     patchShebangs .
-    make binary-local
+    make bin/skopeo docs
   '';
 
   installPhase = ''
-    make install-binary PREFIX=$out
-    make install-docs MANINSTALLDIR="$man/share/man"
+    install -Dm755 bin/skopeo -t $out/bin
+    installManPage docs/*.[1-9]
     installShellCompletion --bash completions/bash/skopeo
   '';
 
@@ -50,8 +48,6 @@ buildGoModule rec {
     wrapProgram $out/bin/skopeo \
       --prefix PATH : ${stdenv.lib.makeBinPath [ fuse-overlayfs ]}
   '';
-
-  passthru.tests.docker-tools = nixosTests.docker-tools;
 
   meta = with stdenv.lib; {
     description = "A command line utility for various operations on container images and image repositories";


### PR DESCRIPTION
https://github.com/containers/skopeo/releases/tag/v1.2.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
