### PR TITLE
config.users.ldap: do not include nss module if turned off

### DIFF
--- a/nixos/modules/config/ldap.nix
+++ b/nixos/modules/config/ldap.nix
@@ -240,9 +240,9 @@ in
       '';
     };
 
-    system.nssModules = singleton (
+    system.nssModules = mkIf cfg.nsswitch (singleton (
       if cfg.daemon.enable then nss_pam_ldapd else nss_ldap
-    );
+    ));
 
     system.nssDatabases.group = optional cfg.nsswitch "ldap";
     system.nssDatabases.passwd = optional cfg.nsswitch "ldap";


### PR DESCRIPTION
###### Motivation for this change
The option existed, but wasn't applied correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] In use at Mayflower since 2017
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
