### PR TITLE
nixos/k3s: add ip_conntrack to kernel modules

### DIFF
--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -75,7 +75,7 @@ in
     virtualisation.docker = mkIf cfg.docker {
       enable = mkDefault true;
     };
-    
+
     boot.kernelModules = [ "ip_conntrack" ];
 
     systemd.services.k3s = {

--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -75,6 +75,8 @@ in
     virtualisation.docker = mkIf cfg.docker {
       enable = mkDefault true;
     };
+    
+    boot.kernelModules = [ "ip_conntrack" ];
 
     systemd.services.k3s = {
       description = "k3s service";


### PR DESCRIPTION
If `networking.firewall.enable = false`, the k3s service crashes, because the `ip_conntrack` kernel module is not loaded.

Things done:
add `ip_conntrack` too `boot.kernelModules`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
