### PR TITLE
generate-expr-from-tarballs.pl: quote URLs per RFC 0045

### DIFF
--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -307,7 +307,7 @@ foreach my $pkg (sort (keys %pkgURLs)) {
     name = "$pkgNames{$pkg}";
     builder = ./builder.sh;
     src = fetchurl {
-      url = $pkgURLs{$pkg};
+      url = "$pkgURLs{$pkg}";
       sha256 = "$pkgHashes{$pkg}";
     };
     hardeningDisable = [ "bindnow" "relro" ];


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/rfcs/pull/45

###### Things done
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
