### PR TITLE
[20.09] tuxpaint: install desktop file

### DIFF
--- a/pkgs/games/tuxpaint/default.nix
+++ b/pkgs/games/tuxpaint/default.nix
@@ -30,6 +30,12 @@ stdenv.mkDerivation rec {
   };
 
   postInstall = ''
+    # Install desktop file
+    mkdir -p $out/share/applications
+    cp hildon/tuxpaint.xpm $out/share/pixmaps
+    sed -e "s+Exec=tuxpaint+Exec=$out/bin/tuxpaint+" < src/tuxpaint.desktop > $out/share/applications/tuxpaint.desktop
+ 
+    # Install stamps
     tar xzf $stamps
     cd tuxpaint-stamps-2014.08.23
     make install-all PREFIX=$out


### PR DESCRIPTION
(cherry picked from commit faec169f0d0beb660ec6a2cea452c38e5430cdf8)

###### Motivation for this change
backport #86829

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
