### PR TITLE
wireshark: 3.2.5 -> 3.2.7

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -10,7 +10,7 @@ assert withQt  -> qt5  != null;
 with stdenv.lib;
 
 let
-  version = "3.2.5";
+  version = "3.2.7";
   variant = if withQt then "qt" else "cli";
   pcap = libpcap.override { withBluez = stdenv.isLinux; };
 
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.xz";
-    sha256 = "0h69m9maq6w5gik4gamv4kfqrr37hmi4kpwh225y1k36awm0b2dx";
+    sha256 = "1nkhglzxj05hwhgzrgan4glv0z67rmasf9djx1dmqicwdnw2z0xy";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
###### Motivation for this change
https://www.wireshark.org/docs/relnotes/wireshark-3.2.7.html
https://www.wireshark.org/docs/relnotes/wireshark-3.2.6.html

Fixes wnpa-sec-2020-10 (CVE-2020-17498), wnpa-sec-2020-11, wnpa-sec-2020-12, and wnpa-sec-2020-13.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
Tested wireshark-qt
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
