### PR TITLE
Streaming `toPretty`

### DIFF
--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -93,19 +93,12 @@ rec {
        traceSeqN 2 { a.b.c = 3; } null
        trace: { a = { b = {…}; }; }
        => null
-   */
-  traceSeqN = depth: x: y: with lib;
-    let snip = v: if      isList  v then noQuotes "[…]" v
-                  else if isAttrs v then noQuotes "{…}" v
-                  else v;
-        noQuotes = str: v: { __pretty = const str; val = v; };
-        modify = n: fn: v: if (n == 0) then fn v
-                      else if isList  v then map (modify (n - 1) fn) v
-                      else if isAttrs v then mapAttrs
-                        (const (modify (n - 1) fn)) v
-                      else v;
-    in trace (generators.toPretty { allowPrettyValues = true; }
-               (modify depth snip x)) y;
+  */
+  traceSeqN = depth: x: y: lib.generators.toPretty {
+    nextState = builtins.trace;
+    initialState = y;
+    recursionLimit = depth;
+  } x;
 
   /* A combination of `traceVal` and `traceSeq` that applies a
      provided function to the value to be traced after `deepSeq`ing

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -298,11 +298,17 @@ rec {
             result = if args == {} then "<function>" else "<function, args: {${allArgs}}>";
           in printLiteral result;
 
+        # This function evaluates the first argument and passes it to the
+        # function given in the second argument. If the evaluation of the first
+        # argument fails, it return a printer result signaling a failed evaluation
         eval = value: cont:
           let result = builtins.tryEval value; in
           if result.success then cont result.value
           else printLiteral "<failure>";
 
+        # We use `eval` every time we evaluate part of the input value, and for
+        # nothing else, making sure that only input value failures are shown as failures
+        # E.g. failures in the nextState function won't be caught (and they shouldn't)
         result = eval (builtins.typeOf value) (type: {
           null = printLiteral "null";
           bool = printLiteral (if value then "true" else "false");

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -195,67 +195,136 @@ rec {
     */
   toYAML = {}@args: toJSON args;
 
-
   /* Pretty print a value, akin to `builtins.trace`.
     * Should probably be a builtin as well.
     */
-  toPretty = {
-    /* If this option is true, attrsets like { __pretty = fn; val = …; }
-       will use fn to convert val to a pretty printed representation.
-       (This means fn is type Val -> String.) */
-    allowPrettyValues ? false,
-    /* If this option is true, the output is indented with newlines for attribute sets and lists */
-    multiline ? true
-  }@args: let
-    go = indent: v: with builtins;
-    let     isPath   = v: typeOf v == "path";
-            introSpace = if multiline then "\n${indent}  " else " ";
-            outroSpace = if multiline then "\n${indent}" else " ";
-    in if   isInt      v then toString v
-    else if isFloat    v then "~${toString v}"
-    else if isString   v then
-      let
-        # Separate a string into its lines
-        newlineSplits = filter (v: ! isList v) (builtins.split "\n" v);
-        # For a '' string terminated by a \n, which happens when the closing '' is on a new line
-        multilineResult = "''" + introSpace + concatStringsSep introSpace (lib.init newlineSplits) + outroSpace + "''";
-        # For a '' string not terminated by a \n, which happens when the closing '' is not on a new line
-        multilineResult' = "''" + introSpace + concatStringsSep introSpace newlineSplits + "''";
-        # For single lines, replace all newlines with their escaped representation
-        singlelineResult = "\"" + libStr.escape [ "\"" ] (concatStringsSep "\\n" newlineSplits) + "\"";
-      in if multiline && length newlineSplits > 1 then
-        if lib.last newlineSplits == "" then multilineResult else multilineResult'
-      else singlelineResult
-    else if true  ==   v then "true"
-    else if false ==   v then "false"
-    else if null  ==   v then "null"
-    else if isPath     v then toString v
-    else if isList     v then
-      if v == [] then "[ ]"
-      else "[" + introSpace
-        + libStr.concatMapStringsSep introSpace (go (indent + "  ")) v
-        + outroSpace + "]"
-    else if isFunction v then
-      let fna = lib.functionArgs v;
-          showFnas = concatStringsSep ", " (libAttr.mapAttrsToList
-                       (name: hasDefVal: if hasDefVal then name + "?" else name)
-                       fna);
-      in if fna == {}    then "<function>"
-                         else "<function, args: {${showFnas}}>"
-    else if isAttrs    v then
-      # apply pretty values if allowed
-      if attrNames v == [ "__pretty" "val" ] && allowPrettyValues
-         then v.__pretty v.val
-      else if v == {} then "{ }"
-      else if v ? type && v.type == "derivation" then
-        "<derivation ${v.drvPath}>"
-      else "{" + introSpace
-          + libStr.concatStringsSep introSpace (libAttr.mapAttrsToList
-              (name: value:
-                "${libStr.escapeNixIdentifier name} = ${go (indent + "  ") value};") v)
-        + outroSpace + "}"
-    else abort "generators.toPretty: should never happen (v = ${v})";
-  in go "";
+  toPretty =
+    { # The maximum depth of recursion into attribute sets and lists. No limit if null
+      recursionLimit ? null
+      # The state transition function to be called for every resulting line. It takes two arguments:
+      # - line: A string, this is the line that was generated and should be processed
+      # - state: The state as returned by the previous invocation of this function
+      #          (from the previous line, or initialState for invocation)
+      #
+      # The function should then return the new state, incorporating the given
+      # line into it. The function may also abort printing by returning an
+      # attribute set with a `return` attribute.
+      #
+      # The result of the toPretty call will be the state returned by the last
+      # call to this transition function
+      #
+      # Examples:
+      # - tracing lines:
+      #     nextState = builtins.trace;
+      # - tracing only 10 lines:
+      #     nextState = line: left:
+      #       if left == 0 then { return = null; }
+      #       else builtins.trace line (left - 1)
+      #     initialState = 10
+      # - collecting a list of lines:
+      #     nextState = line: list: list ++ [ line ]
+      #     initialState = []
+    , nextState ? line: state: if state == null then line else state + "\n" + line
+      # The initial state for the transition function
+    , initialState ? null
+    }: let
+
+      yield = line: state:
+        if state ? return then state
+        else nextState line state;
+
+      go = buildup: state: depth: value: let
+
+        indent = lib.concatStrings (lib.genList (_: "  ") depth);
+        canRecurse = recursionLimit == null || depth < recursionLimit;
+        printLiteral = lit: { buildup = buildup + lit; inherit state; };
+
+        # FIXME: Handle escaping better
+        printStr = str: let
+          # Separate a string into its lines
+          newlineSplits = lib.filter (r: ! lib.isList r) (builtins.split "\n" str);
+
+          multilineResult = {
+            state =
+              builtins.foldl' (acc: el:
+                yield (indent + "  " + el) acc
+              ) (yield (buildup + "''") state) (lib.init newlineSplits);
+            buildup =
+              if lib.last newlineSplits == ""
+              then "${indent}''"
+              else "${indent}  ${lib.last newlineSplits}''";
+          };
+          singlelineResult = printLiteral ("\"" + libStr.escape [ "\"" ] str + "\"");
+        in if lib.length newlineSplits > 1 then multilineResult else singlelineResult;
+
+        printList = list:
+          if list == [] then printLiteral "[ ]"
+          else if ! canRecurse then
+            if lib.length list == 1 then printLiteral "[ <1 element> ]"
+            else printLiteral ("[ <" + toString (lib.length list) + " elements> ]")
+          else {
+            state = builtins.foldl' (acc: el:
+                let start = go "${indent}  " acc (depth + 1) el;
+                in yield start.buildup start.state
+              ) (yield (buildup + "[") state) list;
+            buildup = "${indent}]";
+          };
+
+        printAttrs = attrs:
+          if attrs == {} then printLiteral "{ }"
+          else if ! canRecurse then
+            if lib.length (lib.attrNames attrs) == 1 then printLiteral "{ <1 attribute> }"
+            else printLiteral ("{ <" + toString (lib.length (lib.attrNames attrs)) + " attributes> }")
+          else {
+            state = builtins.foldl' (acc: el:
+                let start = go "${indent}  ${libStr.escapeNixIdentifier el} = " acc (depth + 1) attrs.${el};
+                in yield (start.buildup + ";") start.state
+              ) (yield (buildup + "{") state) (builtins.attrNames attrs);
+            buildup = "${indent}}";
+          };
+
+        printFun = args:
+          let
+            # Move non-default arguments to the front
+            argSort = a: b: if args.${a} == args.${b} then a < b else args.${b};
+            sortedArgs = lib.sort argSort (lib.attrNames args);
+            singleArg = name: if args.${name} then name + "?" else name;
+            allArgs = lib.concatStringsSep ", " (map singleArg sortedArgs);
+            result = if args == {} then "<function>" else "<function, args: {${allArgs}}>";
+          in printLiteral result;
+
+        eval = value: cont:
+          let result = builtins.tryEval value; in
+          if result.success then cont result.value
+          else printLiteral "<failure>";
+
+        result = eval (builtins.typeOf value) (type: {
+          null = printLiteral "null";
+          bool = printLiteral (if value then "true" else "false");
+          int = printLiteral (toString value);
+          float = printLiteral "~${toString value}";
+          path = printLiteral (toString value);
+          string = printStr value;
+          lambda = printFun (builtins.functionArgs value);
+          list = printList value;
+          set =
+            eval (value ? type && value.type == "derivation") (isDrv:
+            if isDrv then eval "<derivation ${value.drvPath}>" printLiteral
+
+            else eval (value ? __functor) (isFunctor:
+            if isFunctor then eval (value.__functionArgs or {}) printFun
+
+            else eval (value ? __toString || value ? outPath) (isStringCoercible:
+            if isStringCoercible then eval (toString value) printStr
+
+            else printAttrs value)));
+        }.${type} or (throw "Type not implemented: ${type}"));
+
+      in if state ? return then { inherit buildup state; } else result;
+
+    in v:
+      let res = go "" initialState 0 v;
+      in yield res.buildup res.state;
 
   # PLIST handling
   toPlist = {}: v: let

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -172,9 +172,9 @@ rec {
           if isAttrs value then
             lib.mapAttrsToList (name: value: recurse ([ name ] ++ path) value) value
           else if length path > 1 then {
-            ${concatStringsSep "." (lib.reverseList (tail path))}.${head path} = value;
+            "${concatStringsSep "." (lib.reverseList (tail path))}.${head path}" = value;
           } else {
-            ${head path} = value;
+            "${head path}" = value;
           };
       in attrs: lib.foldl lib.recursiveUpdate { } (lib.flatten (recurse [ ] attrs));
 


### PR DESCRIPTION
## Motivation for this change
This changes the implementation of `lib.generators.toPretty` significantly

### Output streaming

Adds the ability to stream its output in a generic way. This can be done using the new `initialState` and `nextState` arguments, which thread some arbitrary state through the execution. `nextState` is a function that takes two arguments:
- line: A string, this is the line that was generated and should be processed
- state: The state as returned by the previous invocation of this function (from the previous line, or `initialState` for the first invocation)

The function should then return the new state, incorporating the given line into it. The function may also abort execution by returning an attribute set with a `return` attribute.
  
The result of the `toPretty` call will be the last state.
  
Examples:
- tracing lines:
    ```nix
    {
      nextState = builtins.trace;
    }
    ```
- tracing only 10 lines:
    ```nix
    {
      nextState = line: left:
        if left == 0 then { return = null; }
        else builtins.trace line (left - 1);
      initialState = 10;
    }
- collecting a list of lines:
    ```nix
    {
      nextState = line: list: list ++ [ line ];
      initialState = [];
    }
    ```
- Tracing lines but trimmed to 80 chars wide
    ```nix
    {
      nextState = line: builtins.trace (builtins.substring 0 80 line);
    }
    ```

#### Limiting recursion depth

Allows the function to stop recursing at a certain depth using the `recursionLimit` argument. Attribute sets that aren't recursed into are shown as `{ <N attributes> }`, while lists are shown as `[ <N elements> ]`. The number of items is shown because that information is available without recursing.

#### Handling failing values

Values that fail to evaluate are shown as `<failure>`. This was a bit tricky to get right, but the implementation here should be very solid.

#### Printing of string-coercible attribute sets

Attribute sets that have an `outPath` or `__toString` attribute are now printed by using `toString` on it.

Ping @Profpatsch @edolstra 

## Things done

- [ ] Write tests