### PR TITLE
thc-ipv6: init at 3.6

### DIFF
--- a/pkgs/tools/security/thc-ipv6/default.nix
+++ b/pkgs/tools/security/thc-ipv6/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, libpcap, openssl, libnetfilter_queue, libnfnetlink }:
+stdenv.mkDerivation rec {
+  pname = "thc-ipv6";
+  version = "3.6";
+
+  src = fetchFromGitHub {
+    owner = "vanhauser-thc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1xjg30z0wzm3xvccv9cgh000i1m79p3m8f0b3s741k0mzyrk8lln";
+  };
+
+  buildInputs = [
+    libpcap
+    openssl
+    libnetfilter_queue
+    libnfnetlink
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "IPv6 attack toolkit";
+    homepage = "https://github.com/vanhauser-thc/thc-ipv6";
+    maintainers = with maintainers; [ ajs124 ];
+    platforms = platforms.linux;
+    license = licenses.agpl3Only;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7329,6 +7329,8 @@ in
 
   thc-hydra = callPackage ../tools/security/thc-hydra { };
 
+  thc-ipv6 = callPackage ../tools/security/thc-ipv6 { };
+
   theharvester = callPackage ../tools/security/theharvester { };
 
   inherit (nodePackages) thelounge;


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


related: #81418