### PR TITLE
[20.09] youtube-viewer: 3.7.5 -> 3.7.9

### DIFF
--- a/pkgs/development/perl-modules/WWW-YoutubeViewer/default.nix
+++ b/pkgs/development/perl-modules/WWW-YoutubeViewer/default.nix
@@ -2,13 +2,13 @@
 
 buildPerlPackage rec {
   pname = "WWW-YoutubeViewer";
-  version = "3.7.5";
+  version = "3.7.9";
 
   src = fetchFromGitHub {
     owner  = "trizen";
     repo   = "youtube-viewer";
     rev    = version;
-    sha256 = "1caz56sxy554avz2vdv9gm7gyqcq0gyixzrh5v9ixmg6vxif5d4f";
+    sha256 = "16p0sa91h0zpqdpqmy348g6b9qj5f6qrbzrljn157vk00cg6mx18";
   };
 
   nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin shortenPerlShebang;


### PR DESCRIPTION
backport #98763 
(cherry picked from commit 2ab6756314b6df55030c6a43535299fb060c5ba3)

###### Motivation for this change
make it work with youtube api v3. Works. Lists and plays videos (if you provide an API key).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
