### PR TITLE
[20.09] rsibreak: 0.12.8 -> 0.12.13

### DIFF
--- a/pkgs/applications/misc/rsibreak/default.nix
+++ b/pkgs/applications/misc/rsibreak/default.nix
@@ -7,13 +7,13 @@
 let
   pname = "rsibreak";
   version = "0.12";
-  revision = ".8";
+  revision = ".13";
 in mkDerivation rec {
   name = "rsibreak-${version}${revision}";
 
   src = fetchurl {
     url = "https://download.kde.org/stable/${pname}/${version}/${name}.tar.xz";
-    sha256 = "1qn9xdjx9zzw47jsj7f4nkqmrangfhdgafm2jxm7cm6z6kcvzr28";
+    sha256 = "N0C+f788fq5yotSC54H2K4WDc6PnGi8Nh/vXL4v0fxo=";
   };
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];


### PR DESCRIPTION
(cherry picked from commit 88c8a3c69f97b1dda4f1b8f4c47f07b11bd9f6d1)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Initial PR: #98747 
ZHF: #97479 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
