### PR TITLE
backblaze-b2: 1.3.8 -> 2.0.2

### DIFF
--- a/pkgs/development/python-modules/class-registry/default.nix
+++ b/pkgs/development/python-modules/class-registry/default.nix
@@ -1,0 +1,30 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  nose,
+  six,
+}:
+
+buildPythonPackage rec {
+  pname = "class-registry";
+  version = "2.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zjf9nczl1ifzj07bgs6mwxsfd5xck9l0lchv2j0fv2n481xp2v7";
+  };
+
+  propagatedBuildInputs = [ six ];
+  checkInputs = [ nose ];
+
+  # Tests currently failing.
+  doCheck = false;
+
+  meta = {
+    description = "Factory+Registry pattern for Python classes.";
+    homepage = "https://class-registry.readthedocs.io/en/latest/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kevincox ];
+  };
+}

--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -1,40 +1,39 @@
-{ lib, buildPythonApplication, fetchFromGitHub
-, arrow, futures, logfury, requests, six, tqdm
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
 }:
 
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "backblaze-b2";
-  version = "1.3.8";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "Backblaze";
     repo = "B2_Command_Line_Tool";
     rev = "v${version}";
-    sha256 = "1y4z4w6fj92rh9mrjsi0nmnzcmrj5jikarq2vs5qznvjdjm62igw";
+    sha256 = "00zs0a580vvfm2w4ja68mc46360p475wlgagjkq1hi4m8s4qwd75";
   };
 
-  propagatedBuildInputs = [ arrow futures logfury requests six tqdm ];
+  propagatedBuildInputs = with python3Packages; [
+    b2sdk
+    class-registry
+    setuptools
+  ];
 
+  checkInputs = with python3Packages; [
+    nose
+  ];
+
+  # doCheck = false;
   checkPhase = ''
-    python test_b2_command_line.py test
-  '';
-
-  postPatch = ''
-    # b2 uses an upper bound on arrow, because arrow 0.12.1 is not
-    # compatible with Python 2.6:
-    #
-    # https://github.com/crsmithdev/arrow/issues/517
-    #
-    # However, since we use Python 2.7, newer versions of arrow are fine.
-
-    sed -i 's/,<0.12.1//g' requirements.txt
+    nosetests
   '';
 
   postInstall = ''
     mv "$out/bin/b2" "$out/bin/backblaze-b2"
 
-    sed 's/^_have b2 \&\&$/_have backblaze-b2 \&\&/'  -i contrib/bash_completion/b2
-    sed 's/^\(complete -F _b2\) b2/\1 backblaze-b2/' -i contrib/bash_completion/b2
+    sed 's/b2/backblaze-b2/' -i contrib/bash_completion/b2
 
     mkdir -p "$out/etc/bash_completion.d"
     cp contrib/bash_completion/b2 "$out/etc/bash_completion.d/backblaze-b2"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1150,6 +1150,8 @@ in {
 
   ckcc-protocol = callPackage ../development/python-modules/ckcc-protocol { };
 
+  class-registry = callPackage ../development/python-modules/class-registry { };
+
   cld2-cffi = callPackage ../development/python-modules/cld2-cffi { };
 
   cleo = callPackage ../development/python-modules/cleo { };


### PR DESCRIPTION
###### Motivation for this change

Update.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
