### PR TITLE
libqtav: 1.12.0 -> git-2020-09-10

### DIFF
--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -32,6 +32,7 @@
 , libkipi
 , libksane
 , liblqr1
+, libqtav
 , libusb1
 , marble
 , libGL
@@ -72,6 +73,7 @@ mkDerivation rec {
     libkipi
     libksane
     liblqr1
+    libqtav
     libusb1
     libGL
     libGLU

--- a/pkgs/development/libraries/libqtav/default.nix
+++ b/pkgs/development/libraries/libqtav/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, fetchFromGitHub, extra-cmake-modules
 , qtbase, qtmultimedia, qtquick1, qttools
 , libGL, libX11
-, libass, openal, ffmpeg_3, libuchardet
+, libass, openal, ffmpeg, libuchardet
 , alsaLib, libpulseaudio, libva
 }:
 
@@ -9,19 +9,19 @@ with lib;
 
 mkDerivation rec {
   pname = "libqtav";
-  version = "1.12.0";
+  version = "git-2020-09-10";
 
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   buildInputs = [
     qtbase qtmultimedia qtquick1
     libGL libX11
-    libass openal ffmpeg_3 libuchardet
+    libass openal ffmpeg libuchardet
     alsaLib libpulseaudio libva
   ];
 
   src = fetchFromGitHub {
-    sha256 = "03ii9l38l3fsr27g42fx4151ipzkip2kr4akdr8x28sx5r9rr5m2";
-    rev = "v${version}";
+    sha256 = "0qwrk40dihkbwmm7krz6qaqyn9v3qdjnd2k9b4s3a67x4403pib3";
+    rev = "2a470d2a8d2fe22fae969bee5d594909a07b350a";
     repo = "QtAV";
     owner = "wang-bin";
     fetchSubmodules = true;
@@ -46,6 +46,5 @@ mkDerivation rec {
     homepage = "http://www.qtav.org/";
     maintainers = [ maintainers.jraygauthier ];
     platforms = platforms.linux;
-    broken = !(lib.versionOlder qtbase.version "5.13");
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This un-breaks libqtav by upgrading it to the current upstream HEAD.
Previously, Qtav was broken by the Qt 5.12 -> 5.14 migration (#84232).
See commit 819bb63d5c1ff038f7cd39bb0fa7a4f9564ce000

This patch also re-adds libqtav to digikam's list of dependencies,
restoring support for video playback.
This effectively reverts commit 5194e7c0cbb4601df1a57531bf5955c35bbf4314

As digikam is currently the only derivation that references libqtav,
upgrading to an pre-release revision poses minimal risk.

Lastly, this un-pins ffmpeg_3; libqtav works fine with current ffmpeg.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
