### PR TITLE
nixos/tor: allow onion only clients

### DIFF
--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -43,8 +43,8 @@ let
   ''
   # Client connection config
   + optionalString cfg.client.enable ''
-    SOCKSPort ${cfg.client.socksListenAddress} ${toString cfg.client.socksIsolationOptions}
-    SOCKSPort ${cfg.client.socksListenAddressFaster}
+    SOCKSPort ${cfg.client.socksListenAddress} ${optionalString cfg.client.onionOnly "OnionTrafficOnly"} ${toString cfg.client.socksIsolationOptions}
+    SOCKSPort ${cfg.client.socksListenAddressFaster} ${optionalString cfg.client.onionOnly "OnionTrafficOnly"}
     ${opt "SocksPolicy" cfg.client.socksPolicy}
 
     ${optionalString cfg.client.transparentProxy.enable ''
@@ -220,6 +220,12 @@ in
             is set, we accept all (and only) requests from
             <option>socksListenAddress</option>.
           '';
+        };
+
+        onionOnly = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Tell the tor client to only connect to .onion addresses in response to SOCKS5 requests";
         };
 
         socksIsolationOptions = mkOption (isolationOptions // {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This allows users to ensure that their tor client will only ever connect to onion services.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
