### PR TITLE
dust3d: init at 1.0.0-rc.6

### DIFF
--- a/pkgs/applications/misc/dust3d/default.nix
+++ b/pkgs/applications/misc/dust3d/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchurl
+, appimageTools
+}:
+
+let
+  pname = "dust3d";
+  version = "1.0.0-rc.6";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/huxingyi/dust3d/releases/download/${version}/dust3d-${version}.AppImage";
+    sha256 = "035mdm8dg6hknnadh5vc58hkwmzgvq5pp6ysib2n9a65sbgsg7xd";
+    name="${name}.AppImage";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/dust3d.desktop $out/share/applications/dust3d.desktop
+    install -m 444 -D ${appimageContents}/dust3d.png \
+      $out/share/icons/hicolor/250x250/apps/dust3d.png
+  '';
+
+  meta = with lib; {
+    description = "Cross-platform open-source modeling software";
+    homepage = "https://dust3d.org/";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20244,6 +20244,8 @@ in
 
   dunst = callPackage ../applications/misc/dunst { };
 
+  dust3d = callPackage ../applications/misc/dust3d { };
+
   du-dust = callPackage ../tools/misc/dust { };
 
   devede = callPackage ../applications/video/devede { };


### PR DESCRIPTION
###### Motivation for this change

Closes #90231

I'm using i3, so I cannot confirm if the `.desktop` file is working correctly. Also not sure about the license situation (see #90231 for discussion).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
