### PR TITLE
Fix Openfortivpn on Darwin Part 2

### DIFF
--- a/pkgs/tools/networking/openfortivpn/default.nix
+++ b/pkgs/tools/networking/openfortivpn/default.nix
@@ -16,11 +16,13 @@ in stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ openssl ppp ];
+
+  buildInputs = (if pkgs.stdenv.isDarwin then [ openssl ] else [ openssl ppp ]);
 
   NIX_CFLAGS_COMPILE = "-Wno-error=unused-function";
 
-  configureFlags = [ "--with-pppd=${ppp}/bin/pppd" ];
+  configureFlags = (if pkgs.stdenv.isDarwin then [ "--with-pppd=/usr/sbin/pppd" ]
+                    else [ "--with-pppd=${ppp}/bin/pppd" ] );
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Nix/pppd in not allowed on Darwin. In fact I used openfortivpn on my
Darwin machine using the system pppd with success (this is how
openfortivpn is designed how to work). This PR changes the pppd used
on Darwin to be the system pppd and sets up the configure arguments
accordingly.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
