### PR TITLE
ocamlPackages.merlin: 3.3.9 -> 3.4.0

### DIFF
--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -1,17 +1,22 @@
-{ lib, fetchurl, buildDunePackage, yojson }:
+{ lib, fetchurl, buildDunePackage, substituteAll
+, dot-merlin-reader, dune_2, yojson, csexp, result }:
 
 buildDunePackage rec {
   pname = "merlin";
-  version = "3.3.9";
 
-  minimumOCamlVersion = "4.02.1";
+  inherit (dot-merlin-reader) src version;
 
-  src = fetchurl {
-    url = "https://github.com/ocaml/merlin/releases/download/v${version}/merlin-v${version}.tbz";
-    sha256 = "00ng8299l5rzpak8ljxzr6dgxw6z52ivm91159ahv09xk4d0y5x3";
-  };
+  minimumOCamlVersion = "4.02.3";
 
-  buildInputs = [ yojson ];
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      dot_merlin_reader = "${dot-merlin-reader}/bin/dot-merlin-reader";
+      dune = "${dune_2}/bin/dune";
+    })
+  ];
+
+  buildInputs = [ dot-merlin-reader yojson csexp result ];
 
   meta = with lib; {
     description = "An editor-independent tool to ease the development of programs in OCaml";

--- a/pkgs/development/tools/ocaml/merlin/fix-paths.patch
+++ b/pkgs/development/tools/ocaml/merlin/fix-paths.patch
@@ -1,0 +1,15 @@
+--- a/src/kernel/mconfig_dot.ml
++++ b/src/kernel/mconfig_dot.ml
+@@ -126,10 +126,10 @@ module Configurator = struct
+       let prog, args =
+         match cfg with
+         | Dot_merlin ->
+-          let prog = "dot-merlin-reader" in
++          let prog = "@dot_merlin_reader@" in
+           prog, [| prog |]
+         | Dune ->
+-          let prog = "dune" in
++          let prog = "@dune@" in
+           prog, [| prog; "ocaml-merlin"; "--no-print-directory" |]
+       in
+       log ~title:"get_config" "Using %s configuration provider." (to_string cfg);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://discuss.ocaml.org/t/ann-merlin-3-4-0-introducing-external-configuration-readers/6446

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions: Ubuntu
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): 407972720 -> 419151640
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
