### PR TITLE
libical: fix cross-compilation

### DIFF
--- a/pkgs/development/libraries/libical/default.nix
+++ b/pkgs/development/libraries/libical/default.nix
@@ -1,17 +1,24 @@
-{ stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
+, fetchpatch
+, buildPackages
 , cmake
 , glib
-, gobject-introspection
 , icu
 , libxml2
 , ninja
 , perl
 , pkgconfig
+, libical
 , python3
 , tzdata
-, vala
+, introspectionSupport ? stdenv.buildPlatform == stdenv.hostPlatform
+, gobject-introspection ? null
+, vala ? null
 }:
+
+assert introspectionSupport -> gobject-introspection != null && vala != null;
 
 stdenv.mkDerivation rec {
   pname = "libical";
@@ -28,15 +35,19 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    gobject-introspection
     ninja
     perl
     pkgconfig
-    vala
     # Docs building fails:
     # https://github.com/NixOS/nixpkgs/pull/67204
     # previously with https://github.com/NixOS/nixpkgs/pull/61657#issuecomment-495579489
     # gtk-doc docbook_xsl docbook_xml_dtd_43 # for docs
+  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    # provides ical-glib-src-generator that runs during build
+    libical
+  ] ++ lib.optionals introspectionSupport [
+    gobject-introspection
+    vala
   ];
   installCheckInputs = [
     # running libical-glib tests
@@ -52,15 +63,24 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DGOBJECT_INTROSPECTION=True"
     "-DENABLE_GTK_DOC=False"
+  ] ++ lib.optionals introspectionSupport [
+    "-DGOBJECT_INTROSPECTION=True"
     "-DICAL_GLIB_VAPI=True"
+  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "-DIMPORT_GLIB_SRC_GENERATOR=${lib.getDev buildPackages.libical}/lib/cmake/LibIcal/GlibSrcGenerator.cmake"
   ];
 
   patches = [
     # Will appear in 3.1.0
     # https://github.com/libical/libical/issues/350
     ./respect-env-tzdir.patch
+    # Export src-generator binary for use while cross-compiling
+    # https://github.com/libical/libical/pull/439
+    (fetchpatch {
+      url = "https://github.com/libical/libical/commit/1197d84b63dce179b55a6293cfd6d0523607baf1.patch";
+      sha256 = "18i1khnwmw488s7g5a1kf05sladf8dbyhfc69mbcf6dkc4nnc3dg";
+    })
   ];
 
   # Using install check so we do not have to manually set


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

gobject-introspection cannot be cross-compiled, so disable it (and vala support, which depends on it) when cross-compiling.

cc @jtojnar @dtzWill 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
