### PR TITLE
mtr: 0.93 -> 0.94

### DIFF
--- a/pkgs/tools/networking/mtr/default.nix
+++ b/pkgs/tools/networking/mtr/default.nix
@@ -1,28 +1,20 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, autoreconfHook, pkgconfig
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig
 , libcap, ncurses
-, withGtk ? false, gtk2 ? null }:
+, withGtk ? false, gtk3 ? null }:
 
-assert withGtk -> gtk2 != null;
+assert withGtk -> gtk3 != null;
 
 stdenv.mkDerivation rec {
   pname = "mtr${lib.optionalString withGtk "-gui"}";
-  version = "0.93";
+  version = "0.94";
 
   src = fetchFromGitHub {
-    owner  = "traviscross";
-    repo   = "mtr";
-    rev    = "v${version}";
-    sha256 = "0n0zr9k61w7a9psnzgp7xnc7ll1ic2xzcvqsbbbyndg3v9rff6bw";
+    owner = "traviscross";
+    repo = "mtr";
+    rev = "v${version}";
+    sha256 = "sha256-5vdg2taIeaZHQh/MNO/4CpCoXk+4YyQXOZRRkdlB33I=";
   };
   
-  patches = [
-    # https://github.com/traviscross/mtr/pull/315
-    (fetchpatch {
-      url = "https://github.com/traviscross/mtr/pull/315.patch?full_index=1";
-      sha256 = "18qcsj9058snc2qhq6v6gdbqhz021gi5fgw9h7vfczv45gf0qasa";
-    })
-  ];
-
   # we need this before autoreconfHook does its thing
   postPatch = ''
     echo ${version} > .tarball-version
@@ -34,21 +26,21 @@ stdenv.mkDerivation rec {
       --replace ' install-exec-hook' ""
   '';
 
-  configureFlags = stdenv.lib.optional (!withGtk) "--without-gtk";
+  configureFlags = lib.optional (!withGtk) "--without-gtk";
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   buildInputs = [ ncurses ]
-    ++ stdenv.lib.optional withGtk gtk2
+    ++ stdenv.lib.optional withGtk gtk3
     ++ stdenv.lib.optional stdenv.isLinux libcap;
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A network diagnostics tool";
-    homepage    = "https://www.bitwizard.nl/mtr/";
-    license     = licenses.gpl2;
+    homepage = "https://www.bitwizard.nl/mtr/";
+    license = licenses.gpl2;
     maintainers = with maintainers; [ koral orivej raskin globin ];
-    platforms   = platforms.unix;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

gtk2 -> gtk3 as well

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).