### PR TITLE
Build standalone libvlc

### DIFF
--- a/pkgs/applications/audio/cantata/default.nix
+++ b/pkgs/applications/audio/cantata/default.nix
@@ -16,7 +16,7 @@
 , withDevices ? true, udisks2
 , withDynamic ? true
 , withHttpServer ? true
-, withLibVlc ? false, vlc
+, withLibVlc ? false, libvlc
 , withStreams ? true
 }:
 
@@ -71,7 +71,7 @@ in mkDerivation {
     ++ lib.optional  withMtp libmtp
     ++ lib.optional  withMusicbrainz libmusicbrainz5
     ++ lib.optional  withUdisks udisks2
-    ++ lib.optional  withLibVlc vlc;
+    ++ lib.optional  withLibVlc libvlc;
 
   nativeBuildInputs = [ cmake pkgconfig qttools ];
 

--- a/pkgs/applications/audio/strawberry/default.nix
+++ b/pkgs/applications/audio/strawberry/default.nix
@@ -30,7 +30,7 @@
 , withGstreamer ? true
 , gst_all_1 ? null
 , withVlc ? true
-, vlc ? null
+, libvlc ? null
 }:
 
 mkDerivation rec {
@@ -75,7 +75,7 @@ mkDerivation rec {
     gst-plugins-good
     gst-plugins-ugly
   ])
-  ++ lib.optional withVlc vlc;
+  ++ lib.optional withVlc libvlc;
 
   nativeBuildInputs = [ cmake ninja pkgconfig qttools ];
 

--- a/pkgs/applications/kde/elisa.nix
+++ b/pkgs/applications/kde/elisa.nix
@@ -14,13 +14,13 @@
 , kinit
 , kirigami2
 , baloo
-, vlc
+, libvlc
 }:
 
 mkDerivation rec {
   name = "elisa";
 
-  buildInputs = [ vlc ];
+  buildInputs = [ libvlc ];
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
 

--- a/pkgs/applications/networking/p2p/tribler/default.nix
+++ b/pkgs/applications/networking/p2p/tribler/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgs, python3Packages, makeWrapper
-, enablePlayer ? true, vlc ? null, qt5, lib }:
+, enablePlayer ? true, libvlc ? null, qt5, lib }:
 
 stdenv.mkDerivation rec {
   pname = "tribler";
@@ -50,9 +50,9 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     ${stdenv.lib.optionalString enablePlayer ''
-      substituteInPlace "./TriblerGUI/vlc.py" --replace "ctypes.CDLL(p)" "ctypes.CDLL('${vlc}/lib/libvlc.so')"
+      substituteInPlace "./TriblerGUI/vlc.py" --replace "ctypes.CDLL(p)" "ctypes.CDLL('${libvlc}/lib/libvlc.so')"
       substituteInPlace "./TriblerGUI/widgets/videoplayerpage.py" --replace "if vlc and vlc.plugin_path" "if vlc"
-      substituteInPlace "./TriblerGUI/widgets/videoplayerpage.py" --replace "os.environ['VLC_PLUGIN_PATH'] = vlc.plugin_path" "os.environ['VLC_PLUGIN_PATH'] = '${vlc}/lib/vlc/plugins'"
+      substituteInPlace "./TriblerGUI/widgets/videoplayerpage.py" --replace "os.environ['VLC_PLUGIN_PATH'] = vlc.plugin_path" "os.environ['VLC_PLUGIN_PATH'] = '${libvlc}/lib/vlc/plugins'"
     ''}
   '';
 
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
         --run 'cd $_TRIBLERPATH' \
         --add-flags "-O $out/run_tribler.py" \
         ${stdenv.lib.optionalString enablePlayer ''
-          --prefix LD_LIBRARY_PATH : ${vlc}/lib
+          --prefix LD_LIBRARY_PATH : ${libvlc}/lib
         ''}
 
     mkdir -p $out/share/applications $out/share/icons $out/share/man/man1

--- a/pkgs/applications/video/hdhomerun-config-gui/default.nix
+++ b/pkgs/applications/video/hdhomerun-config-gui/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libhdhomerun, vlc, gcc, gnumake, pkg-config, gtk2 }:
+{ stdenv, fetchurl, libhdhomerun, gcc, gnumake, pkg-config, gtk2 }:
 
 stdenv.mkDerivation rec {
   pname = "hdhomerun-config-gui";

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -20,7 +20,7 @@
 , xorg
 , makeWrapper
 , pkgconfig
-, vlc
+, libvlc
 , mbedtls
 
 , scriptingSupport ? true
@@ -65,7 +65,7 @@ in mkDerivation rec {
     qtsvg
     speex
     x264
-    vlc
+    libvlc
     makeWrapper
     mbedtls
   ]
@@ -84,7 +84,7 @@ in mkDerivation rec {
 
   postInstall = ''
       wrapProgram $out/bin/obs \
-        --prefix "LD_LIBRARY_PATH" : "${xorg.libX11.out}/lib:${vlc}/lib"
+        --prefix "LD_LIBRARY_PATH" : "${xorg.libX11.out}/lib:${libvlc}/lib"
   '';
 
   postFixup = stdenv.lib.optionalString stdenv.isLinux ''

--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -99,6 +99,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.videolan.org/vlc/";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    broken = versionAtLeast qtbase.version "5.15";
+    broken = if qtbase != null then versionAtLeast qtbase.version "5.15" else false;
   };
 }

--- a/pkgs/development/libraries/phonon/backends/vlc.nix
+++ b/pkgs/development/libraries/phonon/backends/vlc.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, cmake, phonon, pkgconfig, vlc
+{ stdenv, lib, fetchurl, cmake, phonon, pkgconfig, libvlc
 , extra-cmake-modules, qttools, qtbase, qtx11extras
 , debug ? false
 }:
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     phonon
-    vlc
+    libvlc
     qtbase
     qtx11extras
   ];

--- a/pkgs/development/python-modules/python-vlc/default.nix
+++ b/pkgs/development/python-modules/python-vlc/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , setuptools
-, vlc
+, libvlc
 , substituteAll
 }:
 
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./vlc-paths.patch;
-      libvlcPath="${vlc}/lib/libvlc.so.5";
+      libvlcPath="${libvlc}/lib/libvlc.so.5";
     })
   ];
 

--- a/pkgs/games/megaglest/default.nix
+++ b/pkgs/games/megaglest/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, pkgconfig, git, curl, SDL2, xercesc, openal, lua, vlc
+{ stdenv, cmake, pkgconfig, git, curl, SDL2, xercesc, openal, lua, libvlc
 , libjpeg, wxGTK, cppunit, ftgl, glew, libogg, libvorbis, buildEnv, libpng
 , fontconfig, freetype, xorg, makeWrapper, bash, which, gnome3, libGLU, glib
 , fetchFromGitHub
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake git curl SDL2 xercesc openal lua libpng libjpeg vlc wxGTK
+  buildInputs = [ cmake git curl SDL2 xercesc openal lua libpng libjpeg libvlc wxGTK
     glib cppunit fontconfig freetype ftgl glew libogg libvorbis makeWrapper libGLU ];
 
   configurePhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2634,9 +2634,7 @@ in
 
   davix = callPackage ../tools/networking/davix { };
 
-  cantata = libsForQt5.callPackage ../applications/audio/cantata {
-    inherit vlc;
-  };
+  cantata = libsForQt5.callPackage ../applications/audio/cantata { };
 
   can-utils = callPackage ../os-specific/linux/can-utils { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23930,6 +23930,15 @@ in
 
   vlc_qt5 = vlc;
 
+  libvlc = vlc.override {
+    withQt5 = false;
+    qtbase = null;
+    qtsvg = null;
+    qtx11extras = null;
+    wrapQtAppsHook = null;
+    onlyLibVLC = true;
+  };
+
   vmpk = callPackage ../applications/audio/vmpk { };
 
   vocproc = callPackage ../applications/audio/vocproc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15144,8 +15144,6 @@ in
 
     telepathy = callPackage ../development/libraries/telepathy/qt { };
 
-    vlc = callPackage ../applications/video/vlc {};
-
     qtwebkit-plugins = callPackage ../development/libraries/qtwebkit-plugins { };
 
   };
@@ -23926,7 +23924,7 @@ in
 
   vkeybd = callPackage ../applications/audio/vkeybd {};
 
-  vlc = libsForQt514.vlc;
+  vlc = libsForQt514.callPackage ../applications/video/vlc {};
 
   vlc_qt5 = vlc;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Use standalone libvlc instead of full VLC to reduce dependence on Qt and unnecessary rebuilds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
