### PR TITLE
gitAndTools.git-remote-codecommit: init at 1.15.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -132,6 +132,8 @@ let
     utillinux = if stdenv.isLinux then utillinuxMinimal else utillinux;
   };
 
+  git-remote-codecommit = python3Packages.callPackage ./git-remote-codecommit { };
+
   git-remote-gcrypt = callPackage ./git-remote-gcrypt { };
 
   git-remote-hg = callPackage ./git-remote-hg { };

--- a/pkgs/applications/version-management/git-and-tools/git-remote-codecommit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-codecommit/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonApplication, fetchFromGitHub, isPy3k, botocore, pytest, mock
+, flake8, tox, awscli }:
+
+buildPythonApplication rec {
+  pname = "git-remote-codecommit";
+  version = "1.15.1";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = pname;
+    rev = version;
+    sha256 = "1vvp7i8ghmq72v57f6smh441h35xnr5ar628q2mr40bzvcifwymw";
+  };
+
+  propagatedBuildInputs = [ botocore ];
+
+  checkInputs = [ pytest mock flake8 tox awscli ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = {
+    description =
+      "Git remote prefix to simplify pushing to and pulling from CodeCommit";
+    maintainers = [ lib.maintainers.zaninime ];
+    homepage = "https://github.com/awslabs/git-remote-codecommit";
+    license = lib.licenses.asl20;
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
