### PR TITLE
sacc: 1.01 -> 1.02

### DIFF
--- a/pkgs/applications/networking/gopher/sacc/default.nix
+++ b/pkgs/applications/networking/gopher/sacc/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "sacc";
-  version = "1.01";
+  version = "1.02";
 
   src = fetchgit {
     url = "git://bitreich.org/sacc";


### PR DESCRIPTION
###### Motivation for this change

Software update

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
