### PR TITLE
geomyidae: init at 0.34

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7955,6 +7955,12 @@
     githubId = 2157287;
     name = "sohalt";
   };
+  solene = {
+    email = "solene@perso.pw";
+    github = "rapenne-s";
+    githubId = 248016;
+    name = "Solène Rapenne";
+  };
   solson = {
     email = "scott@solson.me";
     github = "solson";

--- a/pkgs/servers/gopher/geomyidae/default.nix
+++ b/pkgs/servers/gopher/geomyidae/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchgit, libressl }:
+
+stdenv.mkDerivation rec {
+
+  pname = "geomyidae";
+  version = "0.34";
+
+  src = fetchgit {
+    url = "git://bitreich.org/geomyidae";
+    rev = version;
+    sha256 = "0sbfc7s7575jgsgn6q9fn63j1k2vw0w52k6bixx4f7cyx0sj2p94";
+  };
+
+  buildInputs = [ libressl ];
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "A gopher daemon for Linux/BSD";
+    homepage = "gopher://bitreich.org/1/scm/geomyidae";
+    license = licenses.mit;
+    maintainers = [ maintainers.solene ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3913,6 +3913,8 @@ in
 
   genimage = callPackage ../tools/filesystems/genimage { };
 
+  geomyidae = callPackage ../servers/gopher/geomyidae {};
+
   geonkick = callPackage ../applications/audio/geonkick {};
 
   gerrit = callPackage ../applications/version-management/gerrit { };


### PR DESCRIPTION
###### Motivation for this change

This adds a simple gopher daemon.
I registered myself as maintainer

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
