### PR TITLE
sacc: 1.01 → 1.02

### DIFF
--- a/pkgs/applications/networking/gopher/sacc/default.nix
+++ b/pkgs/applications/networking/gopher/sacc/default.nix
@@ -1,15 +1,14 @@
-{ stdenv, fetchgit, ncurses
+{ stdenv, fetchurl, ncurses
 , patches ? [] # allow users to easily override config.def.h
 }:
 
 stdenv.mkDerivation rec {
   pname = "sacc";
-  version = "1.01";
+  version = "1.02";
 
-  src = fetchgit {
-    url = "git://bitreich.org/sacc";
-    rev = version;
-    sha256 = "0n6ghbi715m7hrxzqggx1bpqj8h7569s72b9bzk6m4gd29jaq9hz";
+  src = fetchurl {
+    url = "ftp://bitreich.org/releases/sacc/sacc-${version}.tgz";
+    sha512 = "18ja95cscgjaj1xqn70dj0482f76d0561bdcc47flqfsjh4mqckjqr65qv7awnw6rzm03i5cp45j1qx12y0y83skgsar4pplmy8q014";
   };
 
   inherit patches;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update `sacc` to 1.02.

cc @rapenne-s

Also switched download from `fetchgit` to `fetchurl` using the gopher protocol. Are there any objections to this? Fetching the tarball via gopher is faster than checking out the git repository so I think it's desireable, the question is if we want to support this protocol indefinitely (I guess if we continue using curl we will).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
