### PR TITLE
[20.09] fix passing qt5 version to pythonInterpreters

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib }:
+{ pkgs }:
 
 with pkgs;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10117,10 +10117,10 @@ in
 
   pythonInterpreters = callPackage ./../development/interpreters/python {
     # Overrides that apply to all Python interpreters
-    pkgs = pkgs // {
-      qt5 = pkgs.qt514;
-      libsForQt5 = pkgs.libsForQt514;
-    };
+    pkgs = pkgs.extend (final: _: {
+      qt5 = final.qt514;
+      libsForQt5 = final.libsForQt514;
+    });
   };
   inherit (pythonInterpreters) python27 python36 python37 python38 python39 python3Minimal pypy27 pypy36;
 
@@ -22769,7 +22769,15 @@ in
 
   quodlibet-xine-full = quodlibet-full.override { xineBackend = true; tag = "-xine-full"; };
 
-  qutebrowser = libsForQt514.callPackage ../applications/networking/browsers/qutebrowser { };
+  qutebrowser = let
+    pkgs_ = pkgs.extend(_: prev: {
+      pythonInterpreters = prev.pythonInterpreters.override(oldAttrs: {
+        pkgs = oldAttrs.pkgs.extend(_: _: {
+          inherit (pkgs) qt5 libsForQt5;
+        });
+      });
+    });
+  in pkgs_.libsForQt5.callPackage ../applications/networking/browsers/qutebrowser { };
 
   rabbitvcs = callPackage ../applications/version-management/rabbitvcs {};
 


### PR DESCRIPTION
###### Motivation for this change

My `qutebrowser` stopped working on `nixos-20.09`:

```
$ qutebrowser 
13:27:27 INFO: Could not load the Qt platform plugin "xcb" in "" even though it was found.
13:27:27 CRITICAL: This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, xcb.

Fatal Python error: Aborted

Current thread 0x00007f3bbd085f40 (most recent call first):
  File "/nix/store/3fvywg6zzkbp1kcjy0zxkx4yllr9d9xk-qutebrowser-1.13.1/lib/python3.8/site-packages/qutebrowser/app.py", line 508 in __init__
  File "/nix/store/3fvywg6zzkbp1kcjy0zxkx4yllr9d9xk-qutebrowser-1.13.1/lib/python3.8/site-packages/qutebrowser/app.py", line 92 in run
  File "/nix/store/3fvywg6zzkbp1kcjy0zxkx4yllr9d9xk-qutebrowser-1.13.1/lib/python3.8/site-packages/qutebrowser/qutebrowser.py", line 202 in main
  File "/nix/store/3fvywg6zzkbp1kcjy0zxkx4yllr9d9xk-qutebrowser-1.13.1/bin/.qutebrowser-wrapped", line 9 in <module>
Aborted (core dumped)
```

###### Things done

This is a backport of #98197. I tested that this makes qutebrowser work again for me, but nothing more.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
