### PR TITLE
pythonPackages.accupy: remove perfplot from checkInputs, fixing build

### DIFF
--- a/pkgs/development/python-modules/accupy/default.nix
+++ b/pkgs/development/python-modules/accupy/default.nix
@@ -7,9 +7,8 @@
 , pybind11
 , pyfma
 , eigen
-, pytest
+, pytestCheckHook
 , matplotlib
-, perfplot
 , isPy27
 }:
 
@@ -35,9 +34,8 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
     matplotlib
-    perfplot
   ];
 
   postConfigure = ''
@@ -49,9 +47,15 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d)
   '';
 
-  checkPhase = ''
-    pytest test
+  # performance tests aren't useful to us and disabling them allows us to
+  # decouple ourselves from an unnecessary build dep
+  preCheck = ''
+    for f in test/test*.py ; do
+      substituteInPlace $f --replace 'import perfplot' ""
+    done
   '';
+  disabledTests = [ "test_speed_comparison1" "test_speed_comparison2" ];
+  pythonImportsCheck = [ "accupy" ];
 
   meta = with lib; {
     description = "Accurate sums and dot products for Python";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

`perfplot` was only used for performance tests that aren't useful to us - disabling these tests allows us to decouple from an unnecessary build dependency. `perfplot` is likely fixable, but it probably needs updating and that will involve packaging some new dependencies - so I'm deprioritizing that for now.

Also convert to `pytestCheckHook`.

One test is still failing on darwin and I'm looking at whether this is an upstream issue @ https://github.com/nschloe/accupy/issues/17. Still, this fix re-enables `accupy` for non-darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
