### PR TITLE
gammy: 0.9.58 -> 0.9.58a

### DIFF
--- a/pkgs/tools/misc/gammy/default.nix
+++ b/pkgs/tools/misc/gammy/default.nix
@@ -19,15 +19,6 @@ stdenv.mkDerivation {
 
   buildInputs = [ libXxf86vm ];
 
-  # FIXME remove when https://github.com/Fushko/gammy/issues/45 is fixed
-  installPhase = ''
-    runHook preInstall
-
-    install gammy -Dt $out/bin/
-
-    runHook postInstall
-  '';
-
   meta = with stdenv.lib; {
     description = "GUI tool for manual- of auto-adjusting of brightness/temperature";
     homepage = "https://github.com/Fushko/gammy";

--- a/pkgs/tools/misc/gammy/default.nix
+++ b/pkgs/tools/misc/gammy/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "gammy";
-  version = "0.9.58";
+  version = "0.9.58a";
 in
 
 stdenv.mkDerivation {
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     owner = "Fushko";
     repo = pname;
     rev = "v${version}";
-    sha256 = "02f19b7acrzip4kbfjgqk06xv1c257rq77khpdg5gz0ai6ayvwm8";
+    sha256 = "02kwfzh7h2dbsfb6b3qlsc7zga1hq21qvg45wf22vm03mahc28za";
   };
 
   nativeBuildInputs = [ qmake wrapQtAppsHook ];


### PR DESCRIPTION
Closes #98718

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/98718#pullrequestreview-496507279

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
