### PR TITLE
linux-next: new function to ease testing the newest kernels

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-next.nix
+++ b/pkgs/os-specific/linux/kernel/linux-next.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPackages, fetchurl, perl, buildLinux, modDirVersionArg ? null, lib, date, version, sha256, ... } @ args:
+
+with stdenv.lib;
+
+buildLinux (args // rec {
+  inherit version;
+
+  modDirVersion = if modDirVersionArg == null
+    then lib.strings.concatStringsSep "-" [ version date ]
+    else modDirVersionArg;
+
+  src = fetchurl {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/snapshot/linux-next-next-${date}.tar.gz";
+    inherit sha256;
+  };
+
+} // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19306,6 +19306,25 @@ in
 
   # Intentionally lacks recurseIntoAttrs, as -rc kernels will quite likely break out-of-tree modules and cause failed Hydra builds.
   linuxPackages_testing = linuxPackagesFor pkgs.linux_testing;
+
+  # linuxPackages_next - as well as linux_next itself - takes a set with 2 required and 2 optional key-value pairs as an argument:
+  #   1. date: REQUIRED - The daily tarball of the kernel sources you would like to use.
+  #   2. sha256: REQUIRED - You don't have to know this before starting. When left undefined, it will fail and promt the hash to use.
+  #   3. extraMeta.branch: OPTIONAL - If linux_testing is too far behind upstream, you may need to set this manually.
+  #   4. extraMeta.rc: OPTIONAL - If linux_testing is too far behind upstream, you may need to set this manually.
+  #
+  # In general, the error message of a failed kernel build will tell you what the optional arguments should be. In the example below
+  # the error was:
+  #   Error: modDirVersion 5.11.0-rc5-next-20210118 specified in the Nix expression is wrong, it should be: 5.11.0-rc3-next-20210118
+  #
+  # Usage:
+  #
+  # boot.kernelPackages = pkgs.linuxPackages_next {
+  #   date = "20210118"                                               # required
+  #   sha256 = "1nqlpqnqkx263yrrvy2xyyx9yr3s0nap3vrf4lfzz7saav2jmf9r" # required
+  #   extraMeta.branch = "5.11"                                       # optional, if linux_testing is too far off.
+  #   extraMeta.branch = "rc3"                                        # optional, if linux_testing is too far off.
+  # }
   linuxPackages_next = args: linuxPackagesFor (pkgs.linux_next args);
 
   linuxPackages_custom = { version, src, configfile, allowImportFromDerivation ? true }:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19040,6 +19040,27 @@ in
     ];
   };
 
+  # Needs a `date` and a `sha256` argument. If version differs from `linux_testing` it also needs
+  # `extraMeta.branch` and `extraMeta.rc`.
+  linux_next = args: with lib;
+    let
+      defaultArgs = {
+        extraMeta.branch = linux_testing.meta.branch;
+        extraMeta.rc = last (splitString "-" linux_testing.version);
+        kernelPatches = linux_testing.kernelPatches;
+        sha256 = fakeSha256;
+      };
+      combined = recursiveUpdate defaultArgs args;
+      realArgs = { inherit version; } // combined;
+      version =
+        let branch = combined.extraMeta.branch + ".0";
+            rc = combined.extraMeta.rc;
+        in concatStringsSep "-" (
+          # X.Y.0-rcZ-next
+          [branch] ++ optional (rc != "") rc ++ ["next"]
+        );
+    in callPackage ../os-specific/linux/kernel/linux-next.nix realArgs;
+
   /* Linux kernel modules are inherently tied to a specific kernel.  So
      rather than provide specific instances of those packages for a
      specific kernel, we have a function that builds those packages
@@ -19285,6 +19306,7 @@ in
 
   # Intentionally lacks recurseIntoAttrs, as -rc kernels will quite likely break out-of-tree modules and cause failed Hydra builds.
   linuxPackages_testing = linuxPackagesFor pkgs.linux_testing;
+  linuxPackages_next = args: linuxPackagesFor (pkgs.linux_next args);
 
   linuxPackages_custom = { version, src, configfile, allowImportFromDerivation ? true }:
     recurseIntoAttrs (linuxPackagesFor (pkgs.linuxManualConfig {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Getting some tests done with the newest upstream patches without a lot of fiddling around.

###### Things done
Added a new function `linux_next` and a corresponding `linuxPackages_next`. These take a as an argument a set containing a date, a hash and maybe a version string (if `linux_testing` and the upstream RC version differ).

usage:

```
  boot.kernelPackages = pkgs.linuxPackages_next {
#   date = "20200924";
#   sha256 = "0r0vpa7k7pw6kq5200p9bf0xnmlya14lirdlbf6zmb9l04lcxxd3";
    date = "20200925";
    sha256 = "08kna2qn32ds8fs45gh74i0n9l8nx7ng3gj8rk58v4sip69snzgh";
#  version = "5.9.0-rc6-next";
  };
```

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
