### PR TITLE
pyvips: init at 2.1.12

### DIFF
--- a/pkgs/development/python-modules/pyvips/default.nix
+++ b/pkgs/development/python-modules/pyvips/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonPackage, fetchPypi, pytestrunner, pytestCheckHook, glib, vips, cffi
+, pkg-config, pkgconfig, lib }:
+
+buildPythonPackage rec {
+  pname = "pyvips";
+  version = "2.1.12";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0pg0dxhxgi2m7bb5bi5wpx9hgnbi8ws1bz6w2dldbhi52pizghl4";
+  };
+
+  nativeBuildInputs = [ pytestrunner pkgconfig pkg-config ];
+
+  buildInputs = [ glib vips ];
+
+  propagatedBuildInputs = [ cffi ];
+
+  # tests are not included in pypi tarball
+  doCheck = false;
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pyvips" ];
+
+  meta = with lib; {
+    description = "A python wrapper for libvips";
+    homepage = "https://github.com/libvips/pyvips";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ccellado ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5892,6 +5892,10 @@ in {
 
   pyviz-comms = callPackage ../development/python-modules/pyviz-comms { };
 
+  pyvips = callPackage ../development/python-modules/pyvips {
+    inherit (pkgs) pkg-config vips glib;
+  };
+
   pyvmomi = callPackage ../development/python-modules/pyvmomi { };
 
   pyvoro = callPackage ../development/python-modules/pyvoro { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add python bindings for libvips in API mode to nixpkgs rep.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
