### PR TITLE
mpd: 0.21.25 -> 0.22

### DIFF
--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -14,24 +14,32 @@ stdenv.mkDerivation rec {
 
   separateDebugInfo = true;
   enableParallelBuilding = true;
-
-  outputs = [ "out" "lib" "dev" "man" ];
-
-  configurePhase = ''
-    ./configure \
-      --prefix=$out \
-      --includedir=$dev/include \
-      --libdir=$lib/lib \
-      --mandir=$man/share/man \
+  # Upstream's configure script is not autoconf generated, but a hand written one.
+  setOutputFlags = false;
+  preConfigure =
+    # We cannot use configureFlags or configureFlagsArray directly, since we
+    # don't have structuredAttrs yet and using placeholder causes permissions
+    # denied errors. Using $dev / $man in configureFlags causes bash evaluation
+    # errors
+  ''
+    configureFlagsArray+=(
+      "--includedir=$dev/include"
+      "--mandir=$man/share/man"
+    )
   '';
 
-  # Copy the examples into $out.
-  postInstall = ''
-    mkdir -p $out/bin
-    cp ./examples/io_uring-cp examples/io_uring-test $out/bin
-    cp ./examples/link-cp $out/bin/io_uring-link-cp
-    cp ./examples/ucontext-cp $out/bin/io_uring-ucontext-cp
-  '';
+  outputs = [ "out" "bin" "dev" "man" ];
+
+  postInstall =
+  # Copy the examples into $bin. Most reverse dependency of this package should
+  # reference only the $out output
+  ''
+    mkdir -p $bin/bin
+    cp ./examples/io_uring-cp examples/io_uring-test $bin/bin
+    cp ./examples/link-cp $bin/bin/io_uring-link-cp
+    cp ./examples/ucontext-cp $bin/bin/io_uring-ucontext-cp
+  ''
+  ;
 
   meta = with stdenv.lib; {
     description = "Userspace library for the Linux io_uring API";

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, meson, ninja, pkg-config, glib, systemd, boost, darwin
 # Inputs
-, curl, libmms, libnfs, samba
+, curl, libmms, libnfs, liburing, samba
 # Archive support
 , bzip2, zziplib
 # Codecs
@@ -30,6 +30,7 @@
 
 let
   lib = stdenv.lib;
+  concatAttrVals = nameList: set: lib.concatMap (x: set.${x} or []) nameList;
 
   featureDependencies = {
     # Storage plugins
@@ -37,6 +38,7 @@ let
     webdav        = [ curl expat ];
     # Input plugins
     curl          = [ curl ];
+    io_uring      = [ liburing ];
     mms           = [ libmms ];
     nfs           = [ libnfs ];
     smbclient     = [ samba ];
@@ -85,15 +87,19 @@ let
     zeroconf      = [ avahi dbus ];
   };
 
+  nativeFeatureDependencies = {
+    documentation = [ doxygen python3Packages.sphinx ];
+  };
+
   run = { features ? null }:
     let
       # Disable platform specific features if needed
       # using libmad to decode mp3 files on darwin is causing a segfault -- there
       # is probably a solution, but I'm disabling it for now
       platformMask = lib.optionals stdenv.isDarwin [ "mad" "pulse" "jack" "nfs" "smbclient" ]
-                  ++ lib.optionals (!stdenv.isLinux) [ "alsa" "systemd" "syslog" ];
+                  ++ lib.optionals (!stdenv.isLinux) [ "alsa" "io_uring" "systemd" "syslog" ];
 
-      knownFeatures = builtins.attrNames featureDependencies;
+      knownFeatures = builtins.attrNames featureDependencies ++ builtins.attrNames nativeFeatureDependencies;
       platformFeatures = lib.subtractLists platformMask knownFeatures;
 
       features_ = if (features == null )
@@ -110,13 +116,13 @@ let
 
     in stdenv.mkDerivation rec {
       pname = "mpd";
-      version = "0.21.25";
+      version = "0.22";
 
       src = fetchFromGitHub {
         owner  = "MusicPlayerDaemon";
         repo   = "MPD";
         rev    = "v${version}";
-        sha256 = "1yjp8pwr2zn0mp39ls1w0pl37zrjn5m9ycgjmcsw2wpa4709r356";
+        sha256 = "1lsi4fgrarabkahfhf5zbmppg7jba7m362gxyqhv54hmqprl1qff";
       };
 
       buildInputs = [
@@ -128,16 +134,15 @@ let
         #    Run-time dependency GTest found: YES 1.10.0
         gtest
       ]
-        ++ (lib.concatLists (lib.attrVals features_ featureDependencies))
+        ++ concatAttrVals features_ featureDependencies
         ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.AudioToolbox darwin.apple_sdk.frameworks.AudioUnit ];
 
       nativeBuildInputs = [
         meson
         ninja
         pkg-config
-        python3Packages.sphinx
-        doxygen
-      ];
+      ]
+        ++ concatAttrVals features_ nativeFeatureDependencies;
 
       # Otherwise, the meson log says:
       #
@@ -153,10 +158,9 @@ let
       outputs = [ "out" "doc" "man" ];
 
       mesonFlags = [
-        # Documentation is enabled unconditionally but it's not installed
-        # unconditionally thanks to the outputs being split
-        "-Ddocumentation=true"
         "-Dtest=true"
+        "-Dmanpages=true"
+        "-Dhtml_manual=true"
       ]
         ++ map (x: "-D${x}=enabled") features_
         ++ map (x: "-D${x}=disabled") (lib.subtractLists features_ knownFeatures)
@@ -193,7 +197,7 @@ in
     "yajl" "sqlite"
     "soundcloud" "qobuz" "tidal"
   ] ++ lib.optionals stdenv.isLinux [
-    "alsa" "systemd" "syslog"
+    "alsa" "systemd" "syslog" "io_uring"
   ] ++ lib.optionals (!stdenv.isDarwin) [
     "mad" "jack" "nfs"
   ]; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
New version: https://raw.githubusercontent.com/MusicPlayerDaemon/MPD/v0.22/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Closure size grows from 483.1 to 483.2 Mb.