### PR TITLE
ghc8102Binary: add numactl to libPath on aarch64

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -1,6 +1,6 @@
 { stdenv
 , fetchurl, perl, gcc
-, ncurses6, gmp, glibc, libiconv
+, ncurses6, gmp, glibc, libiconv, numactl
 , llvmPackages
 , ...
 }:
@@ -13,7 +13,8 @@ let
 
   libPath = stdenv.lib.makeLibraryPath ([
     ncurses6 gmp
-  ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv);
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv
+    ++ stdenv.lib.optional (stdenv.hostPlatform.isAarch64) numactl);
 
   libEnvVar = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin "DY"
     + "LD_LIBRARY_PATH";


### PR DESCRIPTION

###### Motivation for this change

Fixes:

```
utils/ghc-cabal/dist-install/build/tmp/ghc-cabal:
  error while loading shared libraries: libnuma.so.1:
    cannot open shared object file: No such file or directory
```

Found by @peti @ https://github.com/NixOS/nixpkgs/pull/98656#issuecomment-699127803

It seems to be affected by the same patchelf issue as GHC 8.6.5 (#97407) - it segfaults instantly on install tests:

```
running install tests
/nix/store/k832pghqg9z887j8py47ddhwzrn4yj1f-stdenv-linux/setup: line 1310:  3474 Segmentation fault      (core dumped) $out/bin/ghc --make main.hs
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
