### PR TITLE
libcyaml: init at 1.1.0

### DIFF
--- a/pkgs/development/libraries/libcyaml/default.nix
+++ b/pkgs/development/libraries/libcyaml/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub
+, libyaml
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libcyaml";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "tlsa";
+    repo = "libcyaml";
+    rev = "v${version}";
+    sha256 = "0428p0rwq71nhh5nzcbapsbrjxa0x5l6h6ns32nxv7j624f0zd93";
+  };
+
+  buildInputs = [ libyaml ];
+
+  makeFlags = [ "VARIANT=release" "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/tlsa/libcyaml";
+    description = "C library for reading and writing YAML";
+    license = licenses.isc;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14341,6 +14341,8 @@ in
 
   libyamlcpp = callPackage ../development/libraries/libyaml-cpp { };
 
+  libcyaml = callPackage ../development/libraries/libcyaml { };
+
   rang = callPackage ../development/libraries/rang { };
 
   libyamlcpp_0_3 = pkgs.libyamlcpp.overrideAttrs (oldAttrs: {


### PR DESCRIPTION
###### Motivation for this change

A part of https://github.com/NixOS/nixpkgs/issues/98871.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
