### PR TITLE
reproc: init at 14.1.0

### DIFF
--- a/pkgs/development/libraries/reproc/default.nix
+++ b/pkgs/development/libraries/reproc/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "reproc";
+  version = "14.1.0";
+
+  src = fetchFromGitHub {
+    owner = "DaanDeMeyer";
+    repo = "reproc";
+    rev = "v${version}";
+    sha256 = "1n71wb50qv2dmhjgw7azx5gigbrp19l2n3d41g9p05l5l0y1qg0q";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DREPROC++=ON"
+    "-DREPROC_TEST=ON"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/DaanDeMeyer/reproc";
+    description = "A cross-platform (C99/C++11) process library";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22373,6 +22373,8 @@ in
 
   rep-gtk = callPackage ../development/libraries/rep-gtk { };
 
+  reproc = callPackage ../development/libraries/reproc { };
+
   sawfish = callPackage ../applications/window-managers/sawfish { };
 
   sidplayfp = callPackage ../applications/audio/sidplayfp { };


### PR DESCRIPTION
###### Motivation for this change

A part of #98871.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
