### PR TITLE
libaudec: init at 0.2.4

### DIFF
--- a/pkgs/development/libraries/libaudec/default.nix
+++ b/pkgs/development/libraries/libaudec/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub
+, libsndfile, libsamplerate
+, meson, ninja, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libaudec";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "zrythm";
+    repo = "libaudec";
+    rev = "v${version}";
+    sha256 = "1570m2dfia17dbkhd2qhx8jjihrpm7g8nnyg6n4wif4vv229s7dz";
+  };
+
+  buildInputs = [ libsndfile libsamplerate ];
+  nativeBuildInputs = [ meson ninja pkg-config ];
+
+  meta = with lib; {
+    homepage = "https://www.zrythm.org";
+    description = "A library for reading and resampling audio files";
+    license = licenses.agpl3Plus;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13290,6 +13290,8 @@ in
 
   libaudclient = callPackage ../development/libraries/libaudclient { };
 
+  libaudec = callPackage ../development/libraries/libaudec { };
+
   libav = libav_11; # branch 11 is API-compatible with branch 10
   libav_all = callPackages ../development/libraries/libav { };
   inherit (libav_all) libav_0_8 libav_11 libav_12;


### PR DESCRIPTION
###### Motivation for this change

A part of https://github.com/NixOS/nixpkgs/issues/98871.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
