### PR TITLE
ocamlPackages.topkg: 1.0.0 → 1.0.3

### DIFF
--- a/pkgs/development/ocaml-modules/topkg/default.nix
+++ b/pkgs/development/ocaml-modules/topkg/default.nix
@@ -7,11 +7,17 @@ build system is required, the attribute `run` can be used.
 */
 { stdenv, fetchurl, ocaml, findlib, ocamlbuild, result, opaline }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.01"
-then throw "topkg is not available for OCaml ${ocaml.version}"
-else
-
 let
+  param =
+  if stdenv.lib.versionAtLeast ocaml.version "4.03" then {
+    version = "1.0.3";
+    sha256 = "0b77gsz9bqby8v77kfi4lans47x9p2lmzanzwins5r29maphb8y6";
+  } else {
+    version = "1.0.0";
+    sha256 = "1df61vw6v5bg2mys045682ggv058yqkqb67w7r2gz85crs04d5fw";
+    propagatedBuildInputs = [ result ];
+  };
+
 /* This command allows to run the “topkg” build system.
  * It is usually called with `build` or `test` as argument.
  * Packages that use `topkg` may call this command as part of
@@ -22,15 +28,15 @@ in
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-topkg-${version}";
-  version = "1.0.0";
+  inherit (param) version;
 
   src = fetchurl {
     url = "https://erratique.ch/software/topkg/releases/topkg-${version}.tbz";
-    sha256 = "1df61vw6v5bg2mys045682ggv058yqkqb67w7r2gz85crs04d5fw";
+    inherit (param) sha256;
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  propagatedBuildInputs = [ result ];
+  propagatedBuildInputs = param.propagatedBuildInputs or [];
 
   buildPhase = "${run} build";
   createFindlibDestdir = true;


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.12: https://github.com/dbuenzli/topkg/blob/master/CHANGES.md#v103-2020-09-19-zagreb

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
