### PR TITLE
pythonPackages.requests-hawk: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -806,6 +806,12 @@
     githubId = 574938;
     name = "Jonathan Glines";
   };
+  austinbutler = {
+    email = "austinabutler@gmail.com";
+    github = "austinbutler";
+    githubId = 354741;
+    name = "Austin Butler";
+  };
   avaq = {
     email = "nixpkgs@account.avaq.it";
     github = "avaq";

--- a/pkgs/development/python-modules/requests-hawk/default.nix
+++ b/pkgs/development/python-modules/requests-hawk/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, python, mohawk, requests }:
+
+buildPythonPackage rec {
+  pname = "requests-hawk";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qcga289yr6qlkmc6fjk0ia6l5cg0galklpdzpslf1y8ky9zb7rl";
+  };
+
+  propagatedBuildInputs = [ mohawk requests ];
+
+  meta = with lib; {
+    description = "Hawk authentication strategy for the requests python library.";
+    homepage = "https://github.com/sam-washington/requests-hawk";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6077,6 +6077,8 @@ in {
 
   requests-cache = callPackage ../development/python-modules/requests-cache { };
 
+  requests-hawk = callPackage ../development/python-modules/requests-hawk { };
+
   requests = callPackage ../development/python-modules/requests { };
 
   requests_download = callPackage ../development/python-modules/requests_download { };


### PR DESCRIPTION
###### Motivation for this change

Step two of three for fixing the Alerta package for ZHF, as stated in https://github.com/NixOS/nixpkgs/pull/98336. I've tested that the Alerta failure is fixed when this package exists and is added to the Alerta package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).