### PR TITLE
pythonPackages.blessed: 1.15.0 -> 1.17.10

### DIFF
--- a/pkgs/development/python-modules/blessed/default.nix
+++ b/pkgs/development/python-modules/blessed/default.nix
@@ -2,35 +2,21 @@
 , wcwidth, pytest, mock, glibcLocales
 }:
 
-let
-
-  fixTestSuiteFailure_1 = fetchpatch {
-    url = "https://github.com/jquast/blessed/pull/108/commits/76a54d39b0f58bfc71af04ee143459eefb0e1e7b.patch";
-    sha256 = "1higmv4c03ly7ywac1d7s71f3hrl531vj16nsfl9xh6zh9c47qcg";
-  };
-
-  fixTestSuiteFailure_2 = fetchpatch {
-    url = "https://github.com/jquast/blessed/pull/108/commits/aa94e01aed745715e667601fb674844b257cfcc9.patch";
-    sha256 = "1frygr6sc1vakdfx1hf6jj0dbwibiqz8hw9maf1b605cbslc9nay";
-  };
-
-in
-
 buildPythonPackage rec {
   pname = "blessed";
-  version = "1.15.0";
+  version = "1.17.10";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "777b0b6b5ce51f3832e498c22bc6a093b6b5f99148c7cbf866d26e2dec51ef21";
+    sha256 = "09kcz6w87x34a3h4r142z3zgw0av19cxn9jrbz52wkpm1534dfaq";
   };
-
-  patches = [ fixTestSuiteFailure_1 fixTestSuiteFailure_2 ];
 
   checkInputs = [ pytest mock glibcLocales ];
 
+  # Default tox.ini parameters not needed
   checkPhase = ''
-    LANG=en_US.utf-8 py.test blessed/tests
+    rm tox.ini
+    pytest
   '';
 
   propagatedBuildInputs = [ wcwidth six ];


### PR DESCRIPTION
###### Motivation for this change

Looking into fixing the `inquirer` Python package for ZHF and it depends on a new version of `blessed`. Also just to upgrade the package in general.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).