### PR TITLE
python3Packages.alerta: add missing dependency

### DIFF
--- a/pkgs/development/python-modules/alerta/default.nix
+++ b/pkgs/development/python-modules/alerta/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, six, click, requests, pytz, tabulate, pythonOlder
+, six, click, requests, requests-hawk, pytz, tabulate, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "49e0862c756d644e9349f5040dd59d135cd871ffeaea5fc288eb3a2e818cf61a";
   };
 
-  propagatedBuildInputs = [ six click requests pytz tabulate ];
+  propagatedBuildInputs = [ six click requests requests-hawk pytz tabulate ];
 
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change

Following from https://github.com/NixOS/nixpkgs/pull/98881, this finally fixes the Alerta Hydra failure.

ZHF: #97479
https://hydra.nixos.org/build/127654289

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).