### PR TITLE
pythonPackages.entrypoint2: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/entrypoint2/default.nix
+++ b/pkgs/development/python-modules/entrypoint2/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchPypi, EasyProcess, pathpy, pytest }:
+
+buildPythonPackage rec {
+  pname = "entrypoint2";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15dya04884armqjdyqz1jgachkqgh9dc3p25lvyz9afvg73k2qav";
+  };
+
+  propagatedBuildInputs = [ ];
+
+  pythonImportsCheck = [ "entrypoint2" ];
+
+  # argparse is part of the standardlib
+  prePatch = ''
+    substituteInPlace setup.py --replace "argparse" ""
+  '';
+
+  checkInputs = [ EasyProcess pathpy pytest ];
+
+  # 0.2.1 has incompatible pycache files included
+  # https://github.com/ponty/entrypoint2/issues/8
+  checkPhase = ''
+    rm -rf tests/__pycache__
+    pytest tests
+  '';
+
+  meta = with lib; {
+    description = "Easy to use command-line interface for python modules";
+    homepage = "https://github.com/ponty/entrypoint2/";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1869,6 +1869,8 @@ in {
 
   entrance-with-router-features = callPackage ../development/python-modules/entrance { routerFeatures = true; };
 
+  entrypoint2 = callPackage ../development/python-modules/entrypoint2 { };
+
   entrypoints = callPackage ../development/python-modules/entrypoints { };
 
   enum34 = callPackage ../development/python-modules/enum34 { };


### PR DESCRIPTION
###### Motivation for this change

ZHF: `pyscreenshot` failing due to missing this dependency.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).