### PR TITLE
[20.09] pythonPackages.snowflake-connector-python: 2.2.10 -> 2.3.2, fix build 

### DIFF
--- a/pkgs/development/python-modules/snowflake-connector-python/default.nix
+++ b/pkgs/development/python-modules/snowflake-connector-python/default.nix
@@ -25,12 +25,12 @@
 
 buildPythonPackage rec {
   pname = "snowflake-connector-python";
-  version = "2.2.10";
+  version = "2.3.2";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0beba8eb9c1dec2782d52491d058256e1f5d9e010114a80ff3b8e3905be655fd";
+    sha256 = "0as7m736wgx684wssnvhvixjkqidnhxn9i98rcdgagr67s3akfdy";
   };
 
   propagatedBuildInputs = [
@@ -57,12 +57,15 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'cffi>=1.9,<1.14'," "'cffi~=1.9',"
+      --replace "'cryptography>=2.5.0,<3.0.0'," "'cryptography'," \
+      --replace "'idna<2.10'," "'idna'," \
+      --replace "'requests<2.24.0'," "'requests',"
   '';
 
   # tests are not working
   # XXX: fix the tests
   doCheck = false;
+  pythonImportsCheck = [ "snowflake" "snowflake.connector" ];
 
   meta = with lib; {
     description = "Snowflake Connector for Python";

--- a/pkgs/development/python-modules/snowflake-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/snowflake-sqlalchemy/default.nix
@@ -19,6 +19,8 @@ buildPythonPackage rec {
     snowflake-connector-python
   ];
 
+  pythonImportsCheck = [ "snowflake.sqlalchemy" ];
+
   meta = with lib; {
     description = "Snowflake SQLAlchemy Dialect";
     homepage = "https://www.snowflake.net/";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of #98868

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
