### PR TITLE
python3Packages.mss: init at 6.0.0

### DIFF
--- a/pkgs/development/python-modules/mss/default.nix
+++ b/pkgs/development/python-modules/mss/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "mss";
+  version = "6.0.0";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0dicp55adbqxb7hqlck95hngb1klv5s26lszw3xim30k18bwqaxl";
+  };
+
+  propagatedBuildInputs = [ ];
+
+  # By default it attempts to build Windows-only functionality
+  prePatch = ''
+    rm mss/windows.py
+  '';
+
+  # Skipping tests due to most relying on DISPLAY being set
+  pythonImportsCheck = [ "mss" ];
+
+  meta = with lib; {
+    description = "Cross-platform multiple screenshots module in pure Python";
+    homepage = "https://github.com/BoboTiG/mss/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3815,6 +3815,8 @@ in {
 
   msgpack-numpy = callPackage ../development/python-modules/msgpack-numpy { };
 
+  mss = callPackage ../development/python-modules/mss { };
+
   msrestazure = callPackage ../development/python-modules/msrestazure { };
 
   msrest = callPackage ../development/python-modules/msrest { };


### PR DESCRIPTION
###### Motivation for this change

Same as https://github.com/NixOS/nixpkgs/pull/98895.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).