### PR TITLE
material-shell: init at v6

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/material-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/material-shell/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub, gnome3 }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-material-shell";
+  version = "6";
+
+  src = fetchFromGitHub {
+    owner = "material-shell";
+    repo = "material-shell";
+    rev = version;
+    sha256 = "1mvaiaszlwydwjfsbam4s60idww5g5fi63xazwjcakdid3gbq6cl";
+  };
+
+  # This package has a Makefile, but it's used for building a zip for
+  # publication to extensions.gnome.org. Disable the build phase so
+  # installing doesn't build an unnecessary release.
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp -r * $out/share/gnome-shell/extensions/${uuid}/
+    runHook postInstall
+  '';
+
+  uuid = "material-shell@papyelgringo";
+
+  meta = with stdenv.lib; {
+    description = "A modern desktop interface for Linux";
+    license = licenses.mit;
+    maintainers = with maintainers; [ benley ];
+    homepage = "https://github.com/material-shell/material-shell";
+    platforms = gnome3.gnome-shell.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25547,6 +25547,7 @@ in
     gsconnect = callPackage ../desktops/gnome-3/extensions/gsconnect { };
     icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };
     impatience = callPackage ../desktops/gnome-3/extensions/impatience { };
+    material-shell = callPackage ../desktops/gnome-3/extensions/material-shell { };
     mpris-indicator-button = callPackage ../desktops/gnome-3/extensions/mpris-indicator-button { };
     night-theme-switcher = callPackage ../desktops/gnome-3/extensions/night-theme-switcher { };
     no-title-bar = callPackage ../desktops/gnome-3/extensions/no-title-bar { };


### PR DESCRIPTION
New gnome-shell extension: https://material-shell.com/

#### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).