### PR TITLE
physlock: expose option to mute kernel messages when locked

### DIFF
--- a/nixos/modules/services/security/physlock.nix
+++ b/nixos/modules/services/security/physlock.nix
@@ -10,6 +10,8 @@ in
 
   ###### interface
 
+  meta.maintainers = with lib.maintainers; [ ghuntley ];
+
   options = {
 
     services.physlock = {
@@ -94,6 +96,14 @@ in
 
       };
 
+      muteKernelMessages = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to mute kernel messages on console while physlock is running.
+        '';
+      };
+
     };
 
   };
@@ -119,7 +129,7 @@ in
                 ++ cfg.lockOn.extraTargets;
         serviceConfig = {
           Type = "forking";
-          ExecStart = "${pkgs.physlock}/bin/physlock -d${optionalString cfg.disableSysRq "s"}${optionalString (cfg.lockMessage != "") " -p \"${cfg.lockMessage}\""}";
+          ExecStart = "${pkgs.physlock}/bin/physlock -d${optionalString cfg.disableSysRq "s"}${optionalString cfg.muteKernelMessages "m"}${optionalString (cfg.lockMessage != "") " -p \"${cfg.lockMessage}\""}";
         };
       };
 


### PR DESCRIPTION

###### Motivation for this change

https://jlk.fjfi.cvut.cz/arch/manpages/man/physlock.1.en

Enable `-m Mute kernel messages on console while physlock is running.` in

```
OPTIONS
-d Fork and detach physlock before prompting for authentication. The parent process returns right after everything is set up, so this option is useful for use in suspend/hibernate scripts.
-h Print brief usage information to standard output and exit.
-l Only lock console switching and exit.
-L Only enable (unlock) console switching and exit. This is useful when a prior instance of physlock has crashed and leaved the console switching mechanism locked.
-m Mute kernel messages on console while physlock is running.
-p MSG
Display MSG before the password prompt.
-s Disable SysRq mechanism while physlock is running.
-v Print version information to standard output and exit.
```

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
