### PR TITLE
cpython: fix cross-compiling extension modules

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.6/fix-finding-headers-when-cross-compiling.patch
+++ b/pkgs/development/interpreters/python/cpython/3.6/fix-finding-headers-when-cross-compiling.patch
@@ -1,0 +1,54 @@
+From 45dfbbb4f5b67ab83e4365564ea569334e979f8e Mon Sep 17 00:00:00 2001
+From: Ben Wolsieffer <benwolsieffer@gmail.com>
+Date: Fri, 25 Sep 2020 16:49:16 -0400
+Subject: [PATCH] Fix finding headers when cross compiling
+
+When cross-compiling third-party extensions, get_python_inc() may be called to
+return the path to Python's headers. However, it uses the sys.prefix or
+sys.exec_prefix of the build Python, which returns incorrect paths when
+cross-compiling (paths pointing to build system headers).
+
+To fix this, we use the INCLUDEPY and CONFINCLUDEPY conf variables, which can
+be configured to point at host Python by setting _PYTHON_SYSCONFIGDATA_NAME.
+The existing behavior is maintained on non-POSIX platforms or if a prefix is
+manually specified.
+---
+ Lib/distutils/sysconfig.py | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/Lib/distutils/sysconfig.py b/Lib/distutils/sysconfig.py
+index 2bcd1dd288..567375e488 100644
+--- a/Lib/distutils/sysconfig.py
++++ b/Lib/distutils/sysconfig.py
+@@ -84,8 +84,6 @@ def get_python_inc(plat_specific=0, prefix=None):
+     If 'prefix' is supplied, use it instead of sys.base_prefix or
+     sys.base_exec_prefix -- i.e., ignore 'plat_specific'.
+     """
+-    if prefix is None:
+-        prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
+     if os.name == "posix":
+         if python_build:
+             # Assume the executable is in the build directory.  The
+@@ -98,9 +96,17 @@ def get_python_inc(plat_specific=0, prefix=None):
+             else:
+                 incdir = os.path.join(get_config_var('srcdir'), 'Include')
+                 return os.path.normpath(incdir)
+-        python_dir = 'python' + get_python_version() + build_flags
+-        return os.path.join(prefix, "include", python_dir)
++        if prefix is None:
++          if plat_specific:
++            return get_config_var('CONFINCLUDEPY')
++          else:
++            return get_config_var('INCLUDEPY')
++        else:
++          python_dir = 'python' + get_python_version() + build_flags
++          return os.path.join(prefix, "include", python_dir)
+     elif os.name == "nt":
++        if prefix is None:
++          prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
+         return os.path.join(prefix, "include")
+     else:
+         raise DistutilsPlatformError(
+-- 
+2.28.0
+

--- a/pkgs/development/interpreters/python/cpython/3.7/fix-finding-headers-when-cross-compiling.patch
+++ b/pkgs/development/interpreters/python/cpython/3.7/fix-finding-headers-when-cross-compiling.patch
@@ -1,0 +1,54 @@
+From debccd4be0a8d619770f63622d9de1b451dd02ac Mon Sep 17 00:00:00 2001
+From: Ben Wolsieffer <benwolsieffer@gmail.com>
+Date: Fri, 25 Sep 2020 16:49:16 -0400
+Subject: [PATCH] Fix finding headers when cross compiling
+
+When cross-compiling third-party extensions, get_python_inc() may be called to
+return the path to Python's headers. However, it uses the sys.prefix or
+sys.exec_prefix of the build Python, which returns incorrect paths when
+cross-compiling (paths pointing to build system headers).
+
+To fix this, we use the INCLUDEPY and CONFINCLUDEPY conf variables, which can
+be configured to point at host Python by setting _PYTHON_SYSCONFIGDATA_NAME.
+The existing behavior is maintained on non-POSIX platforms or if a prefix is
+manually specified.
+---
+ Lib/distutils/sysconfig.py | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/Lib/distutils/sysconfig.py b/Lib/distutils/sysconfig.py
+index 37feae5df7..6d4ad06696 100644
+--- a/Lib/distutils/sysconfig.py
++++ b/Lib/distutils/sysconfig.py
+@@ -95,8 +95,6 @@ def get_python_inc(plat_specific=0, prefix=None):
+     If 'prefix' is supplied, use it instead of sys.base_prefix or
+     sys.base_exec_prefix -- i.e., ignore 'plat_specific'.
+     """
+-    if prefix is None:
+-        prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
+     if os.name == "posix":
+         if python_build:
+             # Assume the executable is in the build directory.  The
+@@ -109,9 +107,17 @@ def get_python_inc(plat_specific=0, prefix=None):
+             else:
+                 incdir = os.path.join(get_config_var('srcdir'), 'Include')
+                 return os.path.normpath(incdir)
+-        python_dir = 'python' + get_python_version() + build_flags
+-        return os.path.join(prefix, "include", python_dir)
++        if prefix is None:
++          if plat_specific:
++            return get_config_var('CONFINCLUDEPY')
++          else:
++            return get_config_var('INCLUDEPY')
++        else:
++          python_dir = 'python' + get_python_version() + build_flags
++          return os.path.join(prefix, "include", python_dir)
+     elif os.name == "nt":
++        if prefix is None:
++          prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
+         if python_build:
+             # Include both the include and PC dir to ensure we can find
+             # pyconfig.h
+-- 
+2.28.0
+

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -100,6 +100,50 @@ let
     "$out/bin/python"
   else pythonForBuild.interpreter;
 
+  # The CPython interpreter contains a _sysconfigdata_<platform specific suffix>
+  # module that is imported by the sysconfig and distutils.sysconfig modules.
+  # The sysconfigdata module is generated at build time and contains settings
+  # required for building Python extension modules, such as include paths and
+  # other compiler flags. By default, the sysconfigdata module is loaded from
+  # the currently running interpreter (ie. the build platform interpreter), but
+  # when cross-compiling we want to load it from the host platform interpreter.
+  # This can be done using the _PYTHON_SYSCONFIGDATA_NAME environment variable.
+  # The _PYTHON_HOST_PLATFORM variable also needs to be set to get the correct
+  # platform suffix on extension modules. The correct values for these variables
+  # are not documented, and must be derived from the configure script (see links
+  # below).
+  sysconfigdataHook = with stdenv.hostPlatform; with passthru; let
+    # https://github.com/python/cpython/blob/e488e300f5c01289c10906c2e53a8e43d6de32d8/configure.ac#L428
+    # The configure script uses "arm" as the CPU name for all 32-bit ARM
+    # variants when cross-compiling, but native builds include the version
+    # suffix, so we do the same.
+    pythonHostPlatform = "${parsed.kernel.name}-${parsed.cpu.name}";
+
+    # https://github.com/python/cpython/blob/e488e300f5c01289c10906c2e53a8e43d6de32d8/configure.ac#L724
+    multiarchCpu =
+      if isAarch32 then
+        if parsed.cpu.significantByte.name == "littleEndian" then "arm" else "armeb"
+      else if isx86_32 then "i386"
+      else parsed.cpu.name;
+    multiarch =
+      if isDarwin then "darwin"
+      else "${multiarchCpu}-${parsed.kernel.name}-${parsed.abi.name}";
+
+    abiFlags = optionalString (isPy36 || isPy37) "m";
+
+    # https://github.com/python/cpython/blob/e488e300f5c01289c10906c2e53a8e43d6de32d8/configure.ac#L78
+    pythonSysconfigdataName = "_sysconfigdata_${abiFlags}_${parsed.kernel.name}_${multiarch}";
+  in ''
+    sysconfigdataHook() {
+      if [ "$1" = '${placeholder "out"}' ]; then
+        export _PYTHON_HOST_PLATFORM='${pythonHostPlatform}'
+        export _PYTHON_SYSCONFIGDATA_NAME='${pythonSysconfigdataName}'
+      fi
+    }
+
+    addEnvHooks "$hostOffset" sysconfigdataHook
+  '';
+
 in with passthru; stdenv.mkDerivation {
   pname = "python3";
   inherit version;
@@ -165,6 +209,13 @@ in with passthru; stdenv.mkDerivation {
   ] ++ [
     # LDSHARED now uses $CC instead of gcc. Fixes cross-compilation of extension modules.
     ./3.8/0001-On-all-posix-systems-not-just-Darwin-set-LDSHARED-if.patch
+    # Use sysconfigdata to find headers. Fixes cross-compilation of extension modules.
+    (
+      if isPy36 then
+        ./3.6/fix-finding-headers-when-cross-compiling.patch
+      else
+        ./3.7/fix-finding-headers-when-cross-compiling.patch
+    )
   ] ++ optionals (isPy37 || isPy38) [
     # Backport a fix for ctypes.util.find_library.
     ./3.7/find_library.patch
@@ -281,6 +332,10 @@ in with passthru; stdenv.mkDerivation {
     find $out/lib/python*/config-* -type f -print -exec nuke-refs -e $out '{}' +
     find $out/lib -name '_sysconfigdata*.py*' -print -exec nuke-refs -e $out '{}' +
 
+    # Make the sysconfigdata module accessible on PYTHONPATH
+    # This allows build Python to import host Python's sysconfigdata
+    mkdir -p "$out/${sitePackages}"
+    ln -s "$out/lib/${libPrefix}/"_sysconfigdata*.py "$out/${sitePackages}/"
     '' + optionalString stripConfig ''
     rm -R $out/bin/python*-config $out/lib/python*/config-*
     '' + optionalString stripIdlelib ''
@@ -311,6 +366,14 @@ in with passthru; stdenv.mkDerivation {
   preFixup = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     # Ensure patch-shebangs uses shebangs of host interpreter.
     export PATH=${stdenv.lib.makeBinPath [ "$out" bash ]}:$PATH
+  '';
+
+  # Add CPython specific setup-hook that configures distutils.sysconfig to
+  # always load sysconfigdata from host Python.
+  postFixup = ''
+    cat << "EOF" >> "$out/nix-support/setup-hook"
+    ${sysconfigdataHook}
+    EOF
   '';
 
   # Enforce that we don't have references to the OpenSSL -dev package, which we

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     mv wheel* wheel
     # Set up PYTHONPATH. The above folders need to be on PYTHONPATH
     # $out is where we are installing to and takes precedence
-    export PYTHONPATH="$out/${python.sitePackages}:$(pwd)/pip/src:$(pwd)/setuptools:$(pwd)/setuptools/pkg_resources:$(pwd)/wheel"
+    export PYTHONPATH="$out/${python.sitePackages}:$(pwd)/pip/src:$(pwd)/setuptools:$(pwd)/setuptools/pkg_resources:$(pwd)/wheel:$PYTHONPATH"
 
     echo "Building setuptools wheel..."
     pushd setuptools


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes cross-compiling Python native extension modules to host platforms with a different word length than the build platform as well as in a few other cases.

Currently, cross-compiling Python extension modules generally works assuming the build and host platforms have the same word size. This leads to problems like those seen here: https://github.com/NixOS/nixpkgs/issues/50925#issuecomment-648771961, where x86_64 -> aarch64 works, but x86_64 -> armv7l doesn't. Unfortunately, this PR doesn't fix `btrfs-progs` (https://github.com/NixOS/nixpkgs/issues/50925) and `talloc` (https://github.com/NixOS/nixpkgs/issues/63043), because they do not use setuptools/distutils.

This happens because the build Python's headers are used, rather than host Python's headers. The header location and other data used for compiling extension modules are available in the `_sysconfigdata__<kernel>_<platform>` module. `distutils.sysconfig` can be patched to use this data and then Python needs to be told to use `sysconfigdata` from host Python using the `_PYTHON_SYSCONFIGDATA_NAME` environment variable. I believe the patch should be upstreamable.

There was an ill-fated upstream PR to improve and document Python cross-compilation, avoiding the need to manually construct `_PYTHON_SYSCONFIGDATA_NAME`, but based on my quick review I don't think it would have worked for us as is: https://github.com/python/cpython/pull/17420

Setting `_PYTHON_HOST_PLATFORM` and `_PYTHON_SYSCONFIGDATA_NAME` appropriately also fixes some other issues, such as adding the correct platform suffix to extension module file names. This allows `cryptography` to build after a few minor fixes.

I have tested this PR by cross-compiling a number of Python packages for armv6l, including `requests` and `netifaces`, both of which failed before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
