### PR TITLE
klipper: init at 0.8.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -466,6 +466,7 @@
   ./services/misc/irkerd.nix
   ./services/misc/jackett.nix
   ./services/misc/jellyfin.nix
+  ./services/misc/klipper.nix
   ./services/misc/logkeys.nix
   ./services/misc/leaps.nix
   ./services/misc/lidarr.nix

--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.klipper;
+  package = pkgs.klipper;
+  format = pkgs.formats.ini { mkKeyValue = generators.mkKeyValueDefault {} ":"; };
+in
+{
+  ##### interface
+  options = {
+    services.klipper = {
+      enable = mkEnableOption "Klipper, the 3D printer firmware";
+
+      octoprintIntegration = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Allows Octoprint to control Klipper.";
+      };
+
+      settings = mkOption {
+        type = format.type;
+        default = { };
+        description = ''
+          Configuration for Klipper. See the <link xlink:href="https://www.klipper3d.org/Overview.html#configuration-and-tuning-guides">documentation</link>
+          for supported values.
+        '';
+      };
+    };
+  };
+
+  ##### implementation
+  config = mkIf cfg.enable {
+    assertions = [{
+      assertion = cfg.octoprintIntegration -> config.services.octoprint.enable;
+      message = "Option klipper.octoprintIntegration requires Octoprint to be enabled on this system. Please enable services.octoprint to use it.";
+    }];
+
+    environment.etc."klipper.cfg".source = format.generate "klipper.cfg" cfg.settings;
+
+    systemd.services.klipper = {
+      description = "Klipper 3D Printer Firmware";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        ExecStart = "${package}/lib/klipper/klippy.py --input-tty=/run/klipper/tty /etc/klipper.cfg";
+        RuntimeDirectory = "klipper";
+        SupplementaryGroups = [ "dialout" ];
+        WorkingDirectory = "${package}/lib";
+      } // (if cfg.octoprintIntegration then {
+        Group = config.services.octoprint.group;
+        User = config.services.octoprint.user;
+      } else {
+        DynamicUser = true;
+        User = "klipper";
+      });
+    };
+  };
+}

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, python2
+}:
+stdenv.mkDerivation rec {
+  name = "klipper";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "KevinOConnor";
+    repo = "klipper";
+    rev = "v${version}";
+    sha256 = "1ijy2ij9yii5hms10914i614wkjpsy0k4rbgnm6l594gphivdfm7";
+  };
+
+  sourceRoot = "source/klippy";
+
+  # there is currently an attempt at moving it to Python 3, but it will remain
+  # Python 2 for the foreseeable future.
+  # c.f. https://github.com/KevinOConnor/klipper/pull/3278
+  # NB: This is needed for the postBuild step
+  nativeBuildInputs = [ (python2.withPackages ( p: with p; [ cffi ] )) ];
+
+  buildInputs = [ (python2.withPackages (p: with p; [ cffi pyserial greenlet jinja2 ])) ];
+
+  # we need to run this to prebuild the chelper.
+  postBuild = "python2 ./chelper/__init__.py";
+
+  # NB: We don't move the main entry point into `/bin`, or even symlink it,
+  # because it uses relative paths to find necessary modules. We could wrap but
+  # this is used 99% of the time as a service, so it's not worth the effort.
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/klipper
+    cp -r ./* $out/lib/klipper
+
+    chmod 755 $out/lib/klipper/klippy.py
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The Klipper 3D printer firmware";
+    homepage = "https://github.com/KevinOConnor/klipper";
+    maintainers = with maintainers; [ lovesegfault ];
+    platforms = platforms.linux;
+    license = licenses.gpl3Only;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2164,6 +2164,8 @@ in
 
   kramdown-rfc2629 = callPackage ../tools/text/kramdown-rfc2629 { };
 
+  klipper = callPackage ../servers/klipper { };
+
   lcdproc = callPackage ../servers/monitoring/lcdproc { };
 
   languagetool = callPackage ../tools/text/languagetool {  };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I need this to run the 3D printer I'm building. The firmware runs a daemon on a RPi that talks/commands it, which is what is being packaged here.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
