### PR TITLE
nixos/hardened: update blacklisted filesystems

### DIFF
--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -67,6 +67,8 @@ with lib;
     "jfs"
     "minix"
     "nilfs2"
+    "ntfs"
+    "omfs"
     "qnx4"
     "qnx6"
     "sysv"


### PR DESCRIPTION
##### Motivation for this change
https://github.com/openSUSE/suse-module-tools/blob/241a1582698c6a7f96f877a5ec64f478fdf90c82/suse-module-tools.spec#L24

###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
