### PR TITLE
[20.09] python3Packages.alerta: add missing dependency

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -806,6 +806,12 @@
     githubId = 574938;
     name = "Jonathan Glines";
   };
+  austinbutler = {
+    email = "austinabutler@gmail.com";
+    github = "austinbutler";
+    githubId = 354741;
+    name = "Austin Butler";
+  };
   avaq = {
     email = "nixpkgs@account.avaq.it";
     github = "avaq";

--- a/pkgs/development/python-modules/alerta/default.nix
+++ b/pkgs/development/python-modules/alerta/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, six, click, requests, pytz, tabulate, pythonOlder
+, six, click, requests, requests-hawk, pytz, tabulate, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "49e0862c756d644e9349f5040dd59d135cd871ffeaea5fc288eb3a2e818cf61a";
   };
 
-  propagatedBuildInputs = [ six click requests pytz tabulate ];
+  propagatedBuildInputs = [ six click requests requests-hawk pytz tabulate ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/mohawk/default.nix
+++ b/pkgs/development/python-modules/mohawk/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, python, mock, nose, pytest, six }:
+
+with lib;
+buildPythonPackage rec {
+  pname = "mohawk";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08wppsv65yd0gdxy5zwq37yp6jmxakfz4a2yx5wwq2d222my786j";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ mock nose pytest ];
+
+  checkPhase = ''
+    pytest mohawk/tests.py
+  '';
+
+  meta = {
+    description = "Python library for Hawk HTTP authorization.";
+    homepage = "https://github.com/kumar303/mohawk";
+    license = licenses.mpl20;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/requests-hawk/default.nix
+++ b/pkgs/development/python-modules/requests-hawk/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, python, mohawk, requests }:
+
+buildPythonPackage rec {
+  pname = "requests-hawk";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qcga289yr6qlkmc6fjk0ia6l5cg0galklpdzpslf1y8ky9zb7rl";
+  };
+
+  propagatedBuildInputs = [ mohawk requests ];
+
+  meta = with lib; {
+    description = "Hawk authentication strategy for the requests python library.";
+    homepage = "https://github.com/sam-washington/requests-hawk";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6043,6 +6043,8 @@ in {
 
   requests-cache = callPackage ../development/python-modules/requests-cache { };
 
+  requests-hawk = callPackage ../development/python-modules/requests-hawk { };
+
   requests = callPackage ../development/python-modules/requests { };
 
   requests_download = callPackage ../development/python-modules/requests_download { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3705,6 +3705,8 @@ in {
 
   modestmaps = callPackage ../development/python-modules/modestmaps { };
 
+  mohawk = callPackage ../development/python-modules/mohawk { };
+
   moinmoin = callPackage ../development/python-modules/moinmoin
     { }; # Needed here because moinmoin is loaded as a Python library.
 


### PR DESCRIPTION
###### Motivation for this change

Backport of: https://github.com/NixOS/nixpkgs/pull/98894

ZHF: https://github.com/NixOS/nixpkgs/issues/97479
https://hydra.nixos.org/build/127654289

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).