### PR TITLE
pythonPackages.pyscreenshot: add missing dependencies

### DIFF
--- a/pkgs/development/python-modules/pyscreenshot/default.nix
+++ b/pkgs/development/python-modules/pyscreenshot/default.nix
@@ -1,7 +1,11 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy3k
 , EasyProcess
+, entrypoint2
+, jeepney
+, mss
 }:
 
 buildPythonPackage rec {
@@ -15,6 +19,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     EasyProcess
+    entrypoint2
+  ] ++ lib.optionals (isPy3k) [
+    jeepney
+    mss
   ];
 
   # recursive dependency on pyvirtualdisplay


### PR DESCRIPTION
###### Motivation for this change

Fixes broken build due to missing dependencies, which were just added in https://github.com/NixOS/nixpkgs/pull/98895 and https://github.com/NixOS/nixpkgs/pull/98898. Will backport for 20.09 as well.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).