### PR TITLE
nixos/doc/manual: add link to nixos-generators

### DIFF
--- a/nixos/doc/manual/development/building-nixos.xml
+++ b/nixos/doc/manual/development/building-nixos.xml
@@ -24,4 +24,10 @@
 <screen>
 <prompt># </prompt>mount -o loop -t iso9660 ./result/iso/cd.iso /mnt/iso</screen>
  </para>
+ <para>
+ If you want to customize your NixOS CD in more detail, or generate other kinds
+ of images, you might want to check out <link
+ xlink:href="https://github.com/nix-community/nixos-generators">nixos-generators</link>. This can also be a good starting point when you want to use Nix to build a
+ 'minimal' image that doesn't include a NixOS installation.
+ </para>
 </chapter>


### PR DESCRIPTION
From the 'Building your Own NixOS CD' section

###### Motivation for this change

This is likely to be relevant to people reading this section of the documentation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).