### PR TITLE
pythonPackages.lmtpd: upgrade to Python 3

### DIFF
--- a/pkgs/development/python-modules/lmtpd/default.nix
+++ b/pkgs/development/python-modules/lmtpd/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, buildPythonPackage, fetchPypi }:
+{ buildPythonPackage, fetchPypi, isPy3k, stdenv }:
 
 buildPythonPackage rec {
   pname = "lmtpd";
   version = "6.2.0";
+
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Python 2 support was dropped on
https://github.com/moggers87/lmtpd/commit/3546d4660f8229b3d6375aebf9e56ea88a93cbb0

ZHF: #97479
https://hydra.nixos.org/build/127641301

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
