### PR TITLE
gscan2pdf: 2.8.1 -> 2.9.1

### DIFF
--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -10,11 +10,11 @@ with stdenv.lib;
 
 perlPackages.buildPerlPackage rec {
   pname = "gscan2pdf";
-  version = "2.8.1";
+  version = "2.9.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/gscan2pdf/${version}/${pname}-${version}.tar.xz";
-    sha256 = "00g2vw7lz3yb4nq358x8d3r4mf3hkrq2vw1g9lli27zdp5p6jja1";
+    sha256 = "1ls6n1a8vjgwkb40drpc3rapjligaf9fp218539fnwvhv26div69";
   };
 
   nativeBuildInputs = [ wrapGAppsHook ];
@@ -29,6 +29,7 @@ perlPackages.buildPerlPackage rec {
       Glib
       GlibObjectIntrospection
       GooCanvas2
+      LocaleCodes
       LocaleGettext
       PDFAPI2
       ImageSane


### PR DESCRIPTION
###### Motivation for this change

This updates gscan2pdf to the latest available version.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] Scanned a document
  - [x] Saved to PDF
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
