### PR TITLE
smtp-to-telegram: init at 2f1167e

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -546,6 +546,8 @@
   ./services/mail/rss2email.nix
   ./services/mail/schleuder.nix
   ./services/mail/spamassassin.nix
+  ./services/mail/smtp-to-telegram.nix
+  ./services/mail/roundcube.nix
   ./services/mail/sympa.nix
   ./services/matrix/appservice-discord.nix
   ./services/matrix/appservice-irc.nix

--- a/nixos/modules/services/mail/smtp-to-telegram.nix
+++ b/nixos/modules/services/mail/smtp-to-telegram.nix
@@ -1,0 +1,110 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.smtp-to-telegram;
+
+in
+
+{
+  meta = {
+    maintainers = with maintainers; [ patryk27 ];
+  };
+
+  ###### interface
+
+  options = {
+    services.smtp-to-telegram = {
+      enable = mkEnableOption (lib.mdDoc "SMTP server that forwards messages to Telegram");
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.smtp-to-telegram;
+        defaultText = lib.literalMD "pkgs.smtp-to-telegram";
+        description = lib.mdDoc "Which smtp-to-telegram derivation to use.";
+      };
+
+      messageTemplate = mkOption {
+        type = types.str;
+        default = "From: {from}\\nTo: {to}\\nSubject: {subject}\\n\\n{body}\\n\\n{attachments_details}";
+        description = lib.mdDoc ''
+          Template used to convert e-mails into Telegram messages.
+
+          Available variables: `from`, `to`, `subject`, `body`, `attachments_details`.
+        '';
+      };
+
+      smtpListen = mkOption {
+        type = types.str;
+        default = "127.0.0.1:2525";
+        description = lib.mdDoc "Address at which the SMTP server will be listening.";
+      };
+
+      smtpPrimaryHost = mkOption {
+        type = types.str;
+        default = config.networking.hostName;
+        defaultText = literalExpression "config.networking.hostName";
+        description = lib.mdDoc "Hostname at which the SMTP server will be listening.";
+      };
+
+      telegramApiPrefix = mkOption {
+        type = types.str;
+        default = "https://api.telegram.org/";
+        description = lib.mdDoc "Telegram API's URL; must end with a slash.";
+      };
+
+      telegramBotTokenFile = mkOption {
+        type = types.str;
+        default = "";
+        description = lib.mdDoc ''
+          An absolute file path (outside of Nix-store) to a secret file containing your bot's token; required.
+
+          Please see <https://core.telegram.org> for more details.
+        '';
+      };
+
+      telegramChatIds = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = lib.mdDoc ''
+          Your chat's id; required.
+
+          Please see <https://core.telegram.org> for more details.
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf config.services.smtp-to-telegram.enable {
+    assertions = [
+      {
+        assertion = cfg.telegramBotTokenFile != "";
+        message = "`config.services.smtp-to-telegram.telegramBotTokenFile` cannot be empty";
+      }
+      {
+        assertion = cfg.telegramChatIds != [ ];
+        message = "`config.services.smtp-to-telegram.telegramChatIds` cannot be empty";
+      }
+    ];
+
+    systemd.services.smtp-to-telegram = {
+      description = "smtp-to-telegram server";
+
+      script = ''
+        ${cfg.package}/bin/smtp_to_telegram \
+          --message-template "${cfg.messageTemplate}" \
+          --smtp-listen "${cfg.smtpListen}" \
+          --smtp-primary-host "${cfg.smtpPrimaryHost}" \
+          --telegram-api-prefix "${cfg.telegramApiPrefix}" \
+          --telegram-bot-token "$(${pkgs.coreutils}/bin/cat ${cfg.telegramBotTokenFile})" \
+          --telegram-chat-ids "${concatStringsSep "," cfg.telegramChatIds}"
+      '';
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -584,6 +584,7 @@ in {
   simple = handleTest ./simple.nix {};
   slurm = handleTest ./slurm.nix {};
   smokeping = handleTest ./smokeping.nix {};
+  smtp-to-telegram = handleTest ./smtp-to-telegram.nix {};
   snapcast = handleTest ./snapcast.nix {};
   snapper = handleTest ./snapper.nix {};
   soapui = handleTest ./soapui.nix {};

--- a/nixos/tests/smtp-to-telegram.nix
+++ b/nixos/tests/smtp-to-telegram.nix
@@ -1,0 +1,63 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "smtp-to-telegram";
+
+  meta = with lib.maintainers; {
+    maintainers = [ patryk27 ];
+  };
+
+  nodes = {
+    machine = { pkgs, ... }: {
+      environment.systemPackages =
+        let
+          sendTestMail = pkgs.writeScriptBin "send-test-mail" ''
+            #!${pkgs.python3.interpreter}
+            import smtplib, sys
+
+            with smtplib.SMTP('127.0.0.1:2525') as smtp:
+              smtp.sendmail('root@localhost', 'root@localhost', """
+                From: root@localhost
+                To: root@localhost
+                Subject: Test
+
+                Hello, World!
+              """)
+          '';
+
+        in
+        [ sendTestMail ];
+
+      services.nginx = {
+        enable = true;
+
+        virtualHosts.localhost = {
+          listen = [{
+            addr = "127.0.0.1";
+            port = 8080;
+          }];
+
+          locations."/bot123:cafebabe/sendMessage" = {
+            return = "200 '{ \"ok\": true }'";
+          };
+        };
+      };
+
+      services.smtp-to-telegram = {
+        enable = true;
+        telegramApiPrefix = "http://127.0.0.1:8080/";
+        telegramChatIds = [ "1234" ];
+
+        telegramBotTokenFile = toString (pkgs.writeText "secret-token.txt" ''
+          123:cafebabe
+        '');
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("nginx")
+    machine.wait_for_unit("smtp-to-telegram")
+    machine.succeed("send-test-mail")
+    machine.succeed("grep sendMessage /var/log/nginx/access.log")
+  '';
+})

--- a/pkgs/servers/mail/smtp-to-telegram/default.nix
+++ b/pkgs/servers/mail/smtp-to-telegram/default.nix
@@ -1,0 +1,23 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule {
+  pname = "smtp-to-telegram";
+  version = "unstable-2022-11-06";
+  rev = "2f1167e45450151ec09f420ae6deb4a101ed1d30";
+
+  src = fetchFromGitHub {
+    owner = "KostyaEsmukov";
+    repo = "smtp_to_telegram";
+    rev = "2f1167e45450151ec09f420ae6deb4a101ed1d30";
+    hash = "sha256-7erh+Bpl4il5auQXg+00W1rjkxbuEKlkczHVKCfdkdg=";
+  };
+
+  vendorSha256 = "sha256-o1huUGDPJMJruA11ny8aAKZHkXg1ksqhzTaBeXpOFGA=";
+
+  meta = {
+    description = "SMTP server that forwards messages to Telegram";
+    homepage = "https://github.com/KostyaEsmukov/smtp_to_telegram";
+    maintainers = with lib.maintainers; [ patryk27 ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24319,6 +24319,8 @@ with pkgs;
 
   rspamd = callPackage ../servers/mail/rspamd { };
 
+  smtp-to-telegram = callPackage ../servers/mail/smtp-to-telegram { };
+
   pfixtools = callPackage ../servers/mail/postfix/pfixtools.nix {
     gperf = gperf_3_0;
   };


### PR DESCRIPTION
###### Motivation for this change

[`smtp_to_telegram`](https://github.com/KostyaEsmukov/smtp_to_telegram) is an SMTP server that forwards messages to Telegram; I'm personally using it together with `monit` (which is kinda hard-coded to alert via mails), but sky's the limit.

This pull request provides `smtp_to_telegram` both as an application (ready to be installed via e.g. `environment.systemPackages`) _and_ as a systemd service.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
