### PR TITLE
libvirt: 6.3.0 -> 6.6.0

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -2,9 +2,9 @@
 , pkgconfig, makeWrapper, autoreconfHook, fetchpatch
 , coreutils, libxml2, gnutls, perl, python2, attr, glib, docutils
 , iproute, iptables, readline, lvm2, utillinux, systemd, libpciaccess, gettext
-, libtasn1, ebtables, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
+, libtasn1, ebtables, libgcrypt, yajl, pmutils, libcap_ng, libapparmor, libtirpc
 , dnsmasq, libnl, libpcap, libxslt, xhtml1, numad, numactl, perlPackages
-, curl, libiconv, gmp, zfs, parted, bridge-utils, dmidecode, dbus
+, curl, libiconv, gmp, zfs, parted, bridge-utils, dmidecode, dbus, darwin
 , enableXen ? false, xen ? null
 , enableIscsi ? false, openiscsi
 , enableCeph ? false, ceph
@@ -17,29 +17,35 @@ let
   buildFromTarball = stdenv.isDarwin;
 in stdenv.mkDerivation rec {
   pname = "libvirt";
-  version = "6.3.0";
+  version = "6.6.0";
 
   src =
     if buildFromTarball then
       fetchurl {
         url = "http://libvirt.org/sources/${pname}-${version}.tar.xz";
-        sha256 = "1xcng497hs1gary3pz3fp590a4r1kqs4d0d8k5p370j0scw981kl";
+        sha256 = "1y8y13zvh820f4b15287wb77wq7ra7kbfnpblzhm1dki5pfjvrcl";
       }
     else
       fetchgit {
         url = "git://libvirt.org/libvirt.git";
         rev = "v${version}";
-        sha256 = "129b3p72jlb40dsidak3nvpssv75xx2v99y63gzp5k074fp8y8x4";
+        sha256 = "09hsbm2qmx0jfmm418rf5lx374g85bwgg0kzlga62x5180jhsssn";
         fetchSubmodules = true;
       };
 
-  nativeBuildInputs = [ makeWrapper pkgconfig docutils ] ++ optionals (!buildFromTarball) [ autoreconfHook ];
+  nativeBuildInputs = [
+    makeWrapper pkgconfig docutils
+  ] ++ optionals (!buildFromTarball) [
+    autoreconfHook
+  ] ++ optionals stdenv.isDarwin [
+    darwin.developer_cmds # needed for rpcgen
+  ];
   buildInputs = [
     libxml2 gnutls perl python2 readline gettext libtasn1 libgcrypt yajl
     libxslt xhtml1 perlPackages.XMLXPath curl libpcap glib dbus
   ] ++ optionals stdenv.isLinux [
     libpciaccess lvm2 utillinux systemd libnl numad zfs
-    libapparmor libcap_ng numactl attr parted
+    libapparmor libcap_ng numactl attr parted libtirpc
   ] ++ optionals (enableXen && stdenv.isLinux && stdenv.isx86_64) [
     xen
   ] ++ optionals enableIscsi [

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "libvirt";
-  version = "6.3.0";
+  version = "6.6.0";
 
   src = assert version == libvirt.version; fetchgit {
     url = "git://libvirt.org/libvirt-python.git";
     rev = "v${version}";
-    sha256 = "088cksq59jxkkzbvmwl8jw9v2k3zibwksl7j57yb51bxaa2sa1cx";
+    sha256 = "0jj6b2nlx7qldwbvixz74abn3p0sq4lkf6ak74vynrv5xvlycb9v";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/os-specific/darwin/apple-source-releases/developer_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/developer_cmds/default.nix
@@ -1,11 +1,18 @@
-{ stdenv, appleDerivation, xcbuildHook }:
+{ stdenv, appleDerivation, xcbuildHook, llvmPackages }:
 
 appleDerivation {
   nativeBuildInputs = [ xcbuildHook ];
 
-  patchPhase = ''
+  patches = [
+    # The following copied from
+    # https://github.com/Homebrew/homebrew-core/commit/712ed3e948868e17f96b7e59972b5f45d4faf688
+    # is needed to build libvirt.
+    ./rpcgen-support-hyper-and-quad-types.patch
+  ];
+
+  postPatch = ''
     substituteInPlace rpcgen/rpc_main.c \
-      --replace "/usr/bin/cpp" "${stdenv.cc}/bin/cpp"
+      --replace "/usr/bin/cpp" "${llvmPackages.clang-unwrapped}/bin/clang-cpp"
   '';
 
   # temporary install phase until xcodebuild has "install" support

--- a/pkgs/os-specific/darwin/apple-source-releases/developer_cmds/rpcgen-support-hyper-and-quad-types.patch
+++ b/pkgs/os-specific/darwin/apple-source-releases/developer_cmds/rpcgen-support-hyper-and-quad-types.patch
@@ -1,0 +1,66 @@
+diff --git a/rpcgen/rpc_parse.c b/rpcgen/rpc_parse.c
+index 52edc9f..db0c1f1 100644
+--- a/rpcgen/rpc_parse.c
++++ b/rpcgen/rpc_parse.c
+@@ -580,6 +580,10 @@ get_type(prefixp, typep, dkind)
+		*typep = "long";
+		(void) peekscan(TOK_INT, &tok);
+		break;
++	case TOK_HYPER:
++		*typep = "int64_t";
++		(void) peekscan(TOK_INT, &tok);
++		break;
+	case TOK_VOID:
+		if (dkind != DEF_UNION && dkind != DEF_PROGRAM) {
+			error("voids allowed only inside union and program definitions with one argument");
+@@ -592,6 +596,7 @@ get_type(prefixp, typep, dkind)
+	case TOK_INT:
+	case TOK_FLOAT:
+	case TOK_DOUBLE:
++	case TOK_QUAD:
+	case TOK_BOOL:
+		*typep = tok.str;
+		break;
+@@ -622,6 +627,11 @@ unsigned_dec(typep)
+		*typep = "u_long";
+		(void) peekscan(TOK_INT, &tok);
+		break;
++	case TOK_HYPER:
++		get_token(&tok);
++		*typep = "u_int64_t";
++		(void) peekscan(TOK_INT, &tok);
++		break;
+	case TOK_INT:
+		get_token(&tok);
+		*typep = "u_int";
+diff --git a/rpcgen/rpc_scan.c b/rpcgen/rpc_scan.c
+index a8df441..4130107 100644
+--- a/rpcgen/rpc_scan.c
++++ b/rpcgen/rpc_scan.c
+@@ -419,8 +419,10 @@ static token symbols[] = {
+	{TOK_UNSIGNED, "unsigned"},
+	{TOK_SHORT, "short"},
+	{TOK_LONG, "long"},
++	{TOK_HYPER, "hyper"},
+	{TOK_FLOAT, "float"},
+	{TOK_DOUBLE, "double"},
++	{TOK_QUAD, "quadruple"},
+	{TOK_STRING, "string"},
+	{TOK_PROGRAM, "program"},
+	{TOK_VERSION, "version"},
+diff --git a/rpcgen/rpc_scan.h b/rpcgen/rpc_scan.h
+index bac2be4..e4c57c8 100644
+--- a/rpcgen/rpc_scan.h
++++ b/rpcgen/rpc_scan.h
+@@ -66,9 +66,11 @@ enum tok_kind {
+	TOK_INT,
+	TOK_SHORT,
+	TOK_LONG,
++	TOK_HYPER,
+	TOK_UNSIGNED,
+	TOK_FLOAT,
+	TOK_DOUBLE,
++	TOK_QUAD,
+	TOK_OPAQUE,
+	TOK_CHAR,
+	TOK_STRING,


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/libvirt/libvirt/blob/master/NEWS.rst#v660-2020-08-02

###### Things done

Also upgrades `python3Packages.libvirt`
and patches the `rpcgen` tool from Apple's `developer_cmds` package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
