### PR TITLE
[20.09] pythonPackages.git-annex-adapter: 0.2.1 -> 0.2.2, fix build

### DIFF
--- a/pkgs/development/python-modules/git-annex-adapter/default.nix
+++ b/pkgs/development/python-modules/git-annex-adapter/default.nix
@@ -1,10 +1,10 @@
 { stdenv, buildPythonPackage, isPy3k, fetchFromGitHub, substituteAll
-, python, utillinux, pygit2, gitMinimal, git-annex
+, python, utillinux, pygit2, gitMinimal, git-annex, cacert
 }:
 
 buildPythonPackage rec {
   pname = "git-annex-adapter";
-  version = "0.2.1";
+  version = "0.2.2";
 
   disabled = !isPy3k;
 
@@ -13,7 +13,7 @@ buildPythonPackage rec {
     owner = "alpernebbi";
     repo = pname;
     rev = "v${version}";
-    sha256 = "146q1jhcfc7f96ajkhjffskkljk2xzivs5ih5clb8qx0sh7mj097";
+    sha256 = "0666vqspgnvmfs6j3kifwyxr6zmxjs0wlwis7br4zcq0gk32zgdx";
   };
 
   patches = [
@@ -28,11 +28,12 @@ buildPythonPackage rec {
     utillinux # `rev` is needed in tests/test_process.py
   ];
 
-  propagatedBuildInputs = [ pygit2 ];
+  propagatedBuildInputs = [ pygit2 cacert ];
 
   checkPhase = ''
     ${python.interpreter} -m unittest
   '';
+  pythonImportsCheck = [ "git_annex_adapter" ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/alpernebbi/git-annex-adapter";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of  #98889

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
