### PR TITLE
ocamlPackages.ocaml-version: 2.3.0 → 3.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/containers/data.nix
+++ b/pkgs/development/ocaml-modules/containers/data.nix
@@ -1,5 +1,5 @@
 { buildDunePackage, containers
-, gen, iter, mdx, ounit, qcheck
+, gen, iter, qcheck
 }:
 
 buildDunePackage {
@@ -8,7 +8,7 @@ buildDunePackage {
   inherit (containers) src version;
 
   doCheck = true;
-  checkInputs = [ gen iter mdx.bin ounit qcheck ];
+  checkInputs = [ gen iter qcheck ];
 
   propagatedBuildInputs = [ containers ];
 

--- a/pkgs/development/ocaml-modules/iter/default.nix
+++ b/pkgs/development/ocaml-modules/iter/default.nix
@@ -14,7 +14,7 @@ buildDunePackage rec {
   buildInputs = lib.optionals doCheck [ mdx.bin qtest ];
   propagatedBuildInputs = [ result ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.04";
+  doCheck = lib.versionAtLeast ocaml.version "4.07";
 
   meta = {
     homepage = "https://github.com/c-cube/sequence";

--- a/pkgs/development/ocaml-modules/ocaml-version/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-version/default.nix
@@ -1,16 +1,16 @@
-{ lib, fetchurl, buildDunePackage, result }:
+{ lib, fetchurl, buildDunePackage }:
 
 buildDunePackage rec {
 
   pname = "ocaml-version";
-  version = "2.3.0";
+  version = "3.0.0";
+
+  minimumOCamlVersion = "4.07";
 
   src = fetchurl {
     url = "https://github.com/ocurrent/ocaml-version/releases/download/v${version}/ocaml-version-v${version}.tbz";
-    sha256 = "0c711lifl35xila9k0rvhijy9zm3shd37q3jgw7xf01hn1swg0hn";
+    sha256 = "15vk8sh50p3f2mbv8z7mqnx76cffri36f2krp25zkkwix8jg7ci4";
   };
-
-  propagatedBuildInputs = [ result ];
 
   meta = {
     description = "Manipulate, parse and generate OCaml compiler version strings";


### PR DESCRIPTION
###### Motivation for this change

Drop dependency on `result` (more changes: https://github.com/ocurrent/ocaml-version/releases/tag/v3.0.0).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
