### PR TITLE
Allow submodules to use custom `lib`/`evalModules`

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -179,6 +179,10 @@ checkConfigOutput "true" config.submodule.outer ./declare-submoduleWith-modules.
 ## Paths should be allowed as values and work as expected
 checkConfigOutput "true" config.submodule.enable ./declare-submoduleWith-path.nix
 
+# Check the file location information is propagated into submodules
+checkConfigOutput the-file.nix config.submodule.internalFiles.0 ./submoduleFiles.nix
+
+
 # Check that disabledModules works recursively and correctly
 checkConfigOutput "true" config.enable ./disable-recursive/main.nix
 checkConfigOutput "true" config.enable ./disable-recursive/{main.nix,disable-foo.nix}

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -179,6 +179,9 @@ checkConfigOutput "true" config.submodule.outer ./declare-submoduleWith-modules.
 ## Paths should be allowed as values and work as expected
 checkConfigOutput "true" config.submodule.enable ./declare-submoduleWith-path.nix
 
+## evalModules should be settable
+checkConfigOutput 10 config.submodule.value ./submoduleWithLib.nix
+
 # Check the file location information is propagated into submodules
 checkConfigOutput the-file.nix config.submodule.internalFiles.0 ./submoduleFiles.nix
 

--- a/lib/tests/modules/submoduleFiles.nix
+++ b/lib/tests/modules/submoduleFiles.nix
@@ -1,0 +1,21 @@
+{ lib, ... }: {
+  options.submodule = lib.mkOption {
+    default = {};
+    type = lib.types.submoduleWith {
+      modules = [ ({ options, ... }: {
+        options.value = lib.mkOption {};
+
+        options.internalFiles = lib.mkOption {
+          default = options.value.files;
+        };
+      })];
+    };
+  };
+
+  imports = [
+    {
+      _file = "the-file.nix";
+      submodule.value = 10;
+    }
+  ];
+}

--- a/lib/tests/modules/submoduleWithLib.nix
+++ b/lib/tests/modules/submoduleWithLib.nix
@@ -1,0 +1,13 @@
+{ lib, ... }: {
+  options.submodule = lib.mkOption {
+    default = {};
+    type = lib.types.submoduleWith {
+      evalModules = ((import ../..).extend (self: super: { value = 10; })).evalModules;
+      modules = [ ({ lib, ... }: {
+        options.value = lib.mkOption {
+          default = lib.value;
+        };
+      })];
+    };
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -414,15 +414,10 @@ rec {
       let
         inherit (lib.modules) evalModules;
 
-        coerce = unify: value: if isFunction value
-          then setFunctionArgs (args: unify (value args)) (functionArgs value)
-          else unify (if shorthandOnlyDefinesConfig then { config = value; } else value);
-
         allModules = defs: modules ++ imap1 (n: { value, file }:
-          if isAttrs value || isFunction value then
-            # Annotate the value with the location of its definition for better error messages
-            coerce (lib.modules.unifyModuleSyntax file "${toString file}-${toString n}") value
-          else value
+          if isAttrs value && shorthandOnlyDefinesConfig
+          then { _file = file; config = value; }
+          else { _file = file; imports = [ value ]; }
         ) defs;
 
         freeformType = (evalModules {

--- a/nixos/doc/manual/development/option-types.xml
+++ b/nixos/doc/manual/development/option-types.xml
@@ -319,6 +319,7 @@
      <term>
        <varname>types.submoduleWith</varname> {
         <replaceable>modules</replaceable>,
+        <replaceable>evalModules</replaceable> ? lib.evalModules,
         <replaceable>specialArgs</replaceable> ? {},
         <replaceable>shorthandOnlyDefinesConfig</replaceable> ? false }
      </term>
@@ -334,6 +335,14 @@
              <note><para>
                Only options defined with this argument are included in rendered documentation.
              </para></note>
+           </para></listitem>
+           <listitem><para>
+             <replaceable>evalModules</replaceable>
+             The function used to evaluate the given modules. This can be set to a
+             <literal>lib.evalModules</literal> from another nixpkgs version if
+             the modules require that version for evaluation. This also causes
+             the <literal>lib</literal> module argument for the submodules to
+             point to the <literal>lib</literal> from <literal>evalModules</literal>.
            </para></listitem>
            <listitem><para>
              <replaceable>specialArgs</replaceable>


### PR DESCRIPTION
###### Motivation for this change
This allows submodules to use a custom `evalModules` function, which is useful when the modules aren't compatible with the default version, especially for the `lib` module argument.

Note that previously it was possible to pass a custom `lib` argument using `specialArgs.lib`. However that still evaluated the modules using the standard `lib.evalModules`, which causes problems when e.g. `specialArgs.lib.mkOption` uses a newer nixpkgs version that adds another `mkOption` attribute (like https://github.com/NixOS/nixpkgs/pull/97114) but the standard `lib.evalModules` can't handle that attribute yet.

This allows fixing of https://github.com/Infinisil/nixus/issues/34
This is an extension of https://github.com/NixOS/nixpkgs/pull/75031

Ping @roberth @bqv

###### Things done

- [x] Added tests for all relevant features
- [x] Added docs