### PR TITLE
[20.09] pythonPackages.chameleon: fix tests by switching to github source

### DIFF
--- a/pkgs/development/python-modules/chameleon/default.nix
+++ b/pkgs/development/python-modules/chameleon/default.nix
@@ -1,16 +1,21 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 }:
 
 buildPythonPackage rec {
   pname = "Chameleon";
   version = "3.8.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "adf9609a2fa4ad20deb390605495f9a5d617b737bfbd86e51a49bbac2acaf316";
+  # tests not included in pypi tarball
+  src = fetchFromGitHub {
+    owner = "malthe";
+    repo = "chameleon";
+    rev = version;
+    sha256 = "0nf8x4w2vh1a31wdb86nnvlic9xmr23j3in1f6fq4z6mv2jkwa87";
   };
+
+  pythonImportsCheck = [ "chameleon" ];
 
   meta = with stdenv.lib; {
     homepage = "https://chameleon.readthedocs.io/";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of #98947

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
