### PR TITLE
[20.09] projectm: fix build on darwin

### DIFF
--- a/pkgs/applications/audio/projectm/default.nix
+++ b/pkgs/applications/audio/projectm/default.nix
@@ -1,4 +1,5 @@
-{ mkDerivation
+{ stdenv
+, mkDerivation
 , lib
 , fetchFromGitHub
 , autoreconfHook
@@ -39,12 +40,13 @@ mkDerivation rec {
     "--enable-sdl"
   ];
 
-  fixupPhase = ''
+  fixupPhase = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     # NOTE: 2019-10-05: Upstream inserts the src path buring build into ELF rpath, so must delete it out
     # upstream report: https://github.com/projectM-visualizer/projectm/issues/245
     for entry in $out/bin/* ; do
       patchelf --set-rpath "$(patchelf --print-rpath $entry | tr ':' '\n' | grep -v 'src/libprojectM' | tr '\n' ':')" "$entry"
     done
+  '' + ''
     wrapQtApp $out/bin/projectM-pulseaudio
     rm $out/bin/projectM-unittest
   '';


### PR DESCRIPTION
(cherry picked from commit d10d6dfa4af8c8c729595002a96d0dc9d0688f50, https://github.com/NixOS/nixpkgs/pull/98960)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF 20.09 https://github.com/NixOS/nixpkgs/issues/97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
