### PR TITLE
pythonPackages.namedlist: 1.7 -> 1.8

### DIFF
--- a/pkgs/development/python-modules/namedlist/default.nix
+++ b/pkgs/development/python-modules/namedlist/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Similar to namedtuple, but instances are mutable";
-    homepage = "https://bitbucket.org/ericvsmith/namedlist";
+    homepage = "https://gitlab.com/ericvsmith/namedlist";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ivan ];
   };

--- a/pkgs/development/python-modules/namedlist/default.nix
+++ b/pkgs/development/python-modules/namedlist/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "namedlist";
-  version = "1.7";
+  version = "1.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "11n9c4a5ak9971awkf1g92m6mcmiprhrw98ik2cmjsqxmz73j2qr";
+    sha256 = "34f89fc992592c80b39a709e136edcf41ea17f24ba31eaf84a314a02c8b9bcef";
   };
 
   # Test file has a `unittest.main()` at the bottom that fails the tests;


### PR DESCRIPTION
###### Motivation for this change

- ZHF: #97479
  - bump to latest upstream version ([1.8](https://pypi.org/project/namedlist/1.8/), [change log](https://gitlab.com/ericvsmith/namedlist/-/blob/1.8/CHANGES.txt#L4)), thereby gaining support for Python 3.8
- adapt homepage, as upstream [has moved to gitlab.com](https://gitlab.com/ericvsmith/namedlist/-/commit/015f7f523dd3b8af8c7866b8ebf26835b6eccbb8#fda3484edf8db0684440157ce0b110d784d42704_335_341)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - (there are none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
