### PR TITLE
greenfoot: init at 3.6.1

### DIFF
--- a/pkgs/applications/editors/greenfoot/default.nix
+++ b/pkgs/applications/editors/greenfoot/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, makeWrapper, jdk }:
+
+stdenv.mkDerivation rec {
+  pname = "greenfoot";
+  version = "3.6.1";
+  src = fetchurl {
+    # We use the deb here. First instinct might be to go for the "generic" JAR
+    # download, but that is actually a graphical installer that is much harder
+    # to unpack than the deb.
+    url = "https://www.greenfoot.org/download/files/Greenfoot-linux-${builtins.replaceStrings ["."] [""] version}.deb";
+    sha256 = "112h6plpclj8kbv093m4pcczljhpd8d47d7a2am1yfgbyckx6hf0";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  unpackPhase = ''
+    ar xf $src
+    tar xf data.tar.xz
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r usr/* $out
+    rm -r $out/share/greenfoot/jdk
+    rm -r $out/share/greenfoot/javafx
+
+    makeWrapper ${jdk}/bin/java $out/bin/greenfoot \
+      --add-flags "-Djavafx.embed.singleThread=true -Dawt.useSystemAAFontSettings=on -Xmx512M -cp \"$out/share/greenfoot/bluej.jar\" bluej.Boot -greenfoot=true -bluej.compiler.showunchecked=false -greenfoot.scenarios=$out/share/doc/Greenfoot/scenarios -greenfoot.url.javadoc=file://$out/share/doc/Greenfoot/API"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple integrated development environment for Java";
+    homepage = "https://www.greenfoot.org/";
+    license = licenses.gpl2ClasspathPlus;
+    maintainers = [ maintainers.charvp ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21023,6 +21023,10 @@ in
 
   gpg-mdp = callPackage ../applications/misc/gpg-mdp { };
 
+  greenfoot = callPackage ../applications/editors/greenfoot/default.nix {
+    jdk = jetbrains.jdk;
+  };
+
   gspeech = callPackage ../applications/audio/gspeech { };
 
   icesl = callPackage ../applications/misc/icesl { };


### PR DESCRIPTION
###### Motivation for this change

I need it for a university course I'm a teaching assistent for. Heavily based on #98204, since the programs are very similar.

###### Things done

Running the program works. In the program, creating a new project, compiling a class and running a simulation works.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
