### PR TITLE
lndconnect: init at 0.2.0

### DIFF
--- a/pkgs/applications/blockchains/lndconnect/default.nix
+++ b/pkgs/applications/blockchains/lndconnect/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+buildGoPackage rec {
+  pname = "lndconnect";
+  version = "0.2.0";
+
+  goPackagePath = "github.com/LN-Zap/lndconnect";
+
+  src = fetchFromGitHub {
+    owner = "LN-Zap";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0zp23vp4i4csc6x1b6z39rqcmknxd508x6clr8ckdj2fwjwkyf5a";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "Generate QRCode to connect apps to lnd Resources";
+    license = licenses.mit;
+    homepage = "https://github.com/LN-Zap/lndconnect";
+    maintainers = [ maintainers.xwvvvvwx ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/applications/blockchains/lndconnect/deps.nix
+++ b/pkgs/applications/blockchains/lndconnect/deps.nix
@@ -1,0 +1,129 @@
+[
+  {
+    goPackagePath = "github.com/Baozisoftware/qrcode-terminal-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Baozisoftware/qrcode-terminal-go";
+      rev = "c0650d8dff0f053901ff16185217b950d5e7743c";
+      sha256 = "166h9zy9y7ygayhybg7d080hpdcf1mvkf3rwnq5lqg8i3cg71s7b";
+    };
+  }
+  {
+    goPackagePath = "github.com/btcsuite/btcd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/btcsuite/btcd";
+      rev = "e9a51e8dcd673c563a549676ebd4384b0318a9b7";
+      sha256 = "053pdhhycls7cpygg4rhc0y2p937ni4cgxylgxd1zpwffqdjsxrs";
+    };
+  }
+  {
+    goPackagePath = "github.com/btcsuite/btclog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/btcsuite/btclog";
+      rev = "84c8d2346e9fc8c7b947e243b9c24e6df9fd206a";
+      sha256 = "02dl46wcnfpg9sqvg0ipipkpnd7lrf4fnvb9zy56jqa7mfcwc7wk";
+    };
+  }
+  {
+    goPackagePath = "github.com/btcsuite/btcutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/btcsuite/btcutil";
+      rev = "063c4115b3a9a7201e82447875383890698abcb6";
+      sha256 = "12dpy5ipmd751xb71hcmrl9xyl89r5rflnrvypnz1irairfqwjwm";
+    };
+  }
+  {
+    goPackagePath = "github.com/glendc/go-external-ip";
+    fetch = {
+      type = "git";
+      url = "https://github.com/glendc/go-external-ip";
+      rev = "c872357d968e33d5d9c47ea2c603f3b411150ecc";
+      sha256 = "1h9cdhab4fapa2p1r8sgl1pxv4qi1zskw8x0pj93a81y03zzr2l1";
+    };
+  }
+  {
+    goPackagePath = "github.com/jessevdk/go-flags";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jessevdk/go-flags";
+      rev = "c17162fe8fd74f119ff938c5c67af63e3bac5ded";
+      sha256 = "0byp3f79b0399n7g6nm59afb6gj9cknfqgfqadvpppv7lvnd34jf";
+    };
+  }
+  {
+    goPackagePath = "github.com/lightningnetwork/lnd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lightningnetwork/lnd";
+      rev = "fd962d322ae2a913cc357dbb63382f22a9a0a6ce";
+      sha256 = "0yj2vqb9qg5v0rbchkpwhhw51rp31z76zchhhbc837sz8l8lryra";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "f6c00982823144337e56cdb71c712eaac151d29c";
+      sha256 = "08y5c01bvyqxraj3wc0di80gbp87178rsshb74x0p3m7wwfv82l3";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "cb30d6282491c185f77d9bec5d25de1bb61a06bc";
+      sha256 = "0v59mv94acd2m72q8adhigxkx1vn38l5h0d8hp0nxga2v9f3v8kd";
+    };
+  }
+  {
+    goPackagePath = "github.com/miekg/dns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/miekg/dns";
+      rev = "7a5f1127f7f4e461b7400d6a9df1bc523e7448fd";
+      sha256 = "1xwg6zwlxwkm1x121b3idir76h7wr9wmcdmg4vgj9hma903s63md";
+    };
+  }
+  {
+    goPackagePath = "github.com/skip2/go-qrcode";
+    fetch = {
+      type = "git";
+      url = "https://github.com/skip2/go-qrcode";
+      rev = "da1b6568686e89143e94f980a98bc2dbd5537f13";
+      sha256 = "0pghd6y2x8a5fqy4rjn4d8j5jcslb236naycdza5an7vyvinsgs9";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "5c72a883971a4325f8c62bf07b6d38c20ea47a6a";
+      sha256 = "1cimmqpajys001x6yq8ycklc4w34y7iwrksv7ayv7m7fgzhcjn3d";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "05aa5d4ee32165add31ddef9d5d3946713e5dc5e";
+      sha256 = "1v532mdb32h2gan6lc9ssya2v1lk6nzyzqvxn5nkbxij9x4v1jkl";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "9d91bd62050c7b3011b7df0d2a4daa0042684420";
+      sha256 = "0d2jjd7r0zwakd1d2g2qm59w6jc6sgg0sal5gc626i8nn9adj2jg";
+    };
+  }
+]
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25680,6 +25680,8 @@ in
 
   lnd = callPackage ../applications/blockchains/lnd.nix { };
 
+  lndconnect = callPackage ../applications/blockchains/lndconnect { };
+
   monero = callPackage ../applications/blockchains/monero {
     inherit (darwin.apple_sdk.frameworks) CoreData IOKit PCSC;
     boost = boost17x;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds the [`lndconnect`](https://github.com/LN-Zap/lndconnect) utility that is useful when setting up the [`zap`](https://zaphq.io/) Bitcoin lightning wallet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
