### PR TITLE
rofimoji: init at 4.3.0, wtype: init at 2020-09-14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4262,6 +4262,12 @@
     githubId = 39434424;
     name = "Felix Springer";
   };
+  justinlovinger = {
+    email = "git@justinlovinger.com";
+    github = "JustinLovinger";
+    githubID = 7183441;
+    name = "Justin Lovinger";
+  };
   justinwoo = {
     email = "moomoowoo@gmail.com";
     github = "justinwoo";

--- a/pkgs/applications/misc/rofimoji/default.nix
+++ b/pkgs/applications/misc/rofimoji/default.nix
@@ -1,0 +1,45 @@
+{ buildPythonApplication
+, fetchFromGitHub
+, lib
+
+, waylandSupport ? true
+, x11Support ? true
+
+, ConfigArgParse
+, pyxdg
+, rofi
+, wl-clipboard
+, wtype
+, xdotool
+, xsel
+}:
+
+buildPythonApplication rec {
+  pname = "rofimoji";
+  version = "4.3.0";
+
+  src = fetchFromGitHub {
+    owner = "fdw";
+    repo = "rofimoji";
+    rev = version;
+    sha256 = "08ayndpifr04njpijc5n5ii5nvibfpab39p6ngyyj0pb43792a8j";
+  };
+
+  # `rofi` and the `waylandSupport` and `x11Support` dependencies
+  # contain binaries needed at runtime.
+  propagatedBuildInputs = with lib; [ ConfigArgParse pyxdg rofi ]
+    ++ optionals waylandSupport [ wl-clipboard wtype ]
+    ++ optionals x11Support [ xdotool xsel ];
+
+  # The 'extractors' sub-module is used for development
+  # and has additional dependencies.
+  postPatch = "rm -rf extractors";
+
+  meta = with lib; {
+    description = "A simple emoji and character picker for rofi";
+    homepage = "https://github.com/fdw/rofimoji";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ justinlovinger ];
+  };
+}

--- a/pkgs/tools/wayland/wtype/default.nix
+++ b/pkgs/tools/wayland/wtype/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+
+, meson
+, ninja
+, pkg-config
+
+, libxkbcommon
+, wayland
+}:
+
+stdenv.mkDerivation {
+  pname = "wtype";
+  version = "2020-09-14";
+
+  src = fetchFromGitHub {
+    owner = "atx";
+    repo = "wtype";
+    rev = "74071228dea4047157ae82960a2541ecc431e4a1";
+    sha256 = "1ncspxpnbwv1vkfmxs58q7aykjb6skaa1pg5sw5h798pss5j80rd";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config wayland ];
+  buildInputs = [ libxkbcommon wayland ];
+
+  meta = with lib; {
+    description = "xdotool type for wayland";
+    homepage = "https://github.com/atx/wtype";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ justinlovinger ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3406,6 +3406,8 @@ in
 
   wob = callPackage ../tools/misc/wob { };
 
+  wtype = callPackage ../tools/wayland/wtype { };
+
   wrangler = callPackage ../development/tools/wrangler { };
 
   xkcdpass = with pythonPackages; toPythonApplication xkcdpass;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23077,6 +23077,10 @@ in
 
   rofi-systemd = callPackage ../tools/system/rofi-systemd { };
 
+  rofimoji = callPackage ../applications/misc/rofimoji {
+    inherit (python3Packages) buildPythonApplication ConfigArgParse pyxdg;
+  };
+
   rootlesskit = callPackage ../tools/virtualization/rootlesskit {};
 
   rpcs3 = libsForQt514.callPackage ../misc/emulators/rpcs3 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`rofimoji` is a unicode selector using Rofi. Now with Wayland support. Wayland support depends on `wtype`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
