### PR TITLE
eweb: "pname-version" rewriting

### DIFF
--- a/pkgs/development/tools/literate-programming/eweb/default.nix
+++ b/pkgs/development/tools/literate-programming/eweb/default.nix
@@ -1,25 +1,24 @@
 { stdenv, fetchurl, python3, asciidoc }:
 
 stdenv.mkDerivation rec {
-
-  name = "eweb-${meta.version}";
+  pname = "eweb";
+  version = "9.10";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/eweb/${name}.tar.bz2";
+    url = "mirror://sourceforge/project/eweb/${pname}-${version}.tar.bz2";
     sha256 = "1xy7vm2sj5q6s620fm25klmnwnz9xkrxmx4q2f8h6c85ydisayd5";
   };
 
   buildInputs = [ python3 asciidoc ];
 
   installPhase = ''
-    install -d $out/bin $out/share/doc/${name}
+    install -d $out/bin $out/share/doc/${pname}-${version}
     cp etangle.py $out/bin
-    cp etangle.w etangle.html $out/share/doc/${name}
+    cp etangle.w etangle.html $out/share/doc/${pname}-${version}
   '';
 
   meta = with stdenv.lib; {
-    version = "9.10" ;
-    homepage = "http://eweb.sf.net";
+    homepage = "http://eweb.sourceforge.net/";
     description = "An Asciidoc-based literate programming tool, written in Python";
     platforms = platforms.linux;
     license = licenses.gpl3Plus;


### PR DESCRIPTION
A cosmetic modification.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
