### PR TITLE
[20.09] wpsoffice: revert ffmpeg version

### DIFF
--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -12,7 +12,7 @@
 , cups
 , dbus
 , expat
-, ffmpeg
+, ffmpeg_3
 , fontconfig
 , freetype
 , gdk-pixbuf
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     cairo
     dbus.lib
     expat
-    ffmpeg
+    ffmpeg_3
     fontconfig
     freetype
     gdk-pixbuf


### PR DESCRIPTION
Partial revert of aa919664306e000db2085f80cc230f7d44214fc3

Related to #98945

###### Motivation for this change

#98945 

Clearly an improvement, although on my laptop the build hangs either way (unlike what reporter observes)

Will self-merge

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
