### PR TITLE
ocamlPackages.z3: init at 4.8.9

### DIFF
--- a/pkgs/development/ocaml-modules/z3/default.nix
+++ b/pkgs/development/ocaml-modules/z3/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, ocaml, findlib, zarith, z3 }:
+
+let z3-with-ocaml = z3.override {
+  ocamlBindings = true;
+  inherit ocaml findlib zarith;
+}; in
+
+stdenv.mkDerivation {
+
+  pname = "ocaml${ocaml.version}-z3";
+  inherit (z3-with-ocaml) version;
+
+  phases = [ "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $OCAMLFIND_DESTDIR
+    cp -r ${z3-with-ocaml.ocaml}/lib/ocaml/${ocaml.version}/site-lib/stublibs $OCAMLFIND_DESTDIR
+    cp -r ${z3-with-ocaml.ocaml}/lib/ocaml/${ocaml.version}/site-lib/Z3 $OCAMLFIND_DESTDIR/z3
+    runHook postInstall
+  '';
+
+  buildInputs = [ findlib ];
+  propagatedBuildInputs = [ zarith ];
+
+  meta = z3.meta // {
+    description = "Z3 Theorem Prover (OCaml API)";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -993,6 +993,10 @@ let
 
     yojson = callPackage ../development/ocaml-modules/yojson { };
 
+    z3 = callPackage ../development/ocaml-modules/z3 {
+      inherit (pkgs) z3;
+    };
+
     zarith = callPackage ../development/ocaml-modules/zarith { };
 
     zed = callPackage ../development/ocaml-modules/zed { };


### PR DESCRIPTION
###### Motivation for this change

OCaml bindings to the Z3 theorem prover. This is a dependency of BAP.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`: `petrinizer` and `solc` fail to build, but that is already the case without this change.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
