### PR TITLE
terraform-provider-libvirt: base volume snapshot or copy

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildGoPackage, fetchFromGitHub, libvirt, pkg-config, makeWrapper, cdrtools }:
+{ lib, stdenv, buildGoPackage, fetchFromGitHub, fetchpatch, libvirt, pkg-config, makeWrapper, cdrtools }:
 
 # USAGE:
 # install the following package globally or in nix-shell:
@@ -22,6 +22,14 @@ buildGoPackage rec {
   version = "0.6.3";
 
   goPackagePath = "github.com/dmacvicar/terraform-provider-libvirt";
+
+  patches = [
+    (fetchpatch {
+      name = "base_volume_copy.patch";
+      url = "https://github.com/cyril-s/terraform-provider-libvirt/commit/52df264e8a28c40ce26e2b614ee3daea882931c3.patch";
+      sha256 = "1fg7ii2fi4c93hl41nhcncy9bpw3avbh6yiq99p1vkf87hhrw72n";
+    })
+  ];
 
   src = fetchFromGitHub {
     owner = "dmacvicar";


### PR DESCRIPTION
#### Motivation for this change

When using LVM pool `size` field in `libvirt_volume` resource will be ignored because snapshot of base image is COW and cannot be resized. This patch solves this by adding extra parameter `base_volume_copy`, for more information see: https://github.com/dmacvicar/terraform-provider-libvirt/pull/675

Part of working example (ubuntu container on nixos with libvirt):
```
 resource "libvirt_volume" "ubuntu_focal_image" {
  name = "ubuntu_focal_image"
  pool = "default"
  source = "/var/lib/libvirt/focal-server-cloudimg-amd64-disk-kvm.raw"
}

resource "libvirt_volume" "disk" {
  name = "u1-root"
  base_volume_id = libvirt_volume.ubuntu_focal_image.id
  base_volume_copy = true
  size = 100 * 1024 * 1024 * 1024
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
