### PR TITLE
systemd: create options for smaller derivation

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1,27 +1,61 @@
-{ stdenv, lib, fetchFromGitHub, pkgconfig, intltool, gperf, libcap
-, curl, kmod, gnupg, gnutar, xz, pam, acl, libuuid, m4, e2fsprogs, utillinux, libffi
-, glib, kbd, libxslt, coreutils, libgcrypt, libgpgerror, libidn2, libapparmor
-, audit, lz4, bzip2, pcre2
-, linuxHeaders ? stdenv.cc.libc.linuxHeaders
-, iptables, gnu-efi, bashInteractive
-, gettext, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_45
-, ninja, meson, python3Packages, glibcLocales
-, patchelf
-, substituteAll
-, getent
-, cryptsetup, lvm2
+{ stdenv, lib, fetchFromGitHub
 , buildPackages
-, perl
+, ninja, meson, m4, pkgconfig, coreutils, gperf, getent
+, patchelf, perl, glibcLocales, glib, substituteAll
+, gettext, python3Packages
+
+# Mandatory dependencies
+, libcap
+, utillinux
+, kbd
+, kmod
+
+# Optional dependencies
+, pam, cryptsetup, lvm2, audit, acl
+, lz4, libgcrypt, libgpgerror, libidn2
+, curl, gnutar, gnupg, zlib
+, xz, libuuid, libffi
+, libapparmor, intltool
+, bzip2, pcre2, e2fsprogs
+, linuxHeaders ? stdenv.cc.libc.linuxHeaders
+, gnu-efi
+, iptables
 , withSelinux ? false, libselinux
 , withLibseccomp ? lib.any (lib.meta.platformMatch stdenv.hostPlatform) libseccomp.meta.platforms, libseccomp
 , withKexectools ? lib.any (lib.meta.platformMatch stdenv.hostPlatform) kexectools.meta.platforms, kexectools
+, bashInteractive
+
+, withResolved ? true
+, withLogind ? true
+, withHostnamed ? true
+, withLocaled ? true
+, withNetworkd ? true
+, withTimedated ? true
+, withTimesyncd ? true
+, withHwdb ? true
+, withEfi ? stdenv.hostPlatform.isEfi
+, withImportd ? true
+, withCryptsetup ? true
+
+# name argument
+, pname ? "systemd"
+
+
+, libxslt, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_45
 }:
+
+assert withResolved -> (libgcrypt != null && libgpgerror != null);
+assert withImportd ->
+  ( curl.dev != null && zlib != null && xz != null && libgcrypt != null
+  && gnutar != null && gnupg != null);
+
+assert withCryptsetup ->
+  ( cryptsetup != null );
 
 let
   version = "246.6";
 in stdenv.mkDerivation {
-  inherit version;
-  pname = "systemd";
+  inherit version pname;
 
   # We use systemd/systemd-stable for src, and ship NixOS-specific patches inside nixpkgs directly
   # This has proven to be less error-prone than the previous systemd fork.
@@ -71,13 +105,17 @@ in stdenv.mkDerivation {
   outputs = [ "out" "man" "dev" ];
 
   nativeBuildInputs =
-    [ pkgconfig intltool gperf libxslt gettext docbook_xsl docbook_xml_dtd_42 docbook_xml_dtd_45
+    [ pkgconfig gperf
       ninja meson
       coreutils # meson calls date, stat etc.
       glibcLocales
       patchelf getent m4
       perl # to patch the libsystemd.so and remove dependencies on aarch64
 
+      intltool
+      gettext
+
+      libxslt docbook_xsl docbook_xml_dtd_42 docbook_xml_dtd_45
       (buildPackages.python3Packages.python.withPackages ( ps: with ps; [ python3Packages.lxml ]))
     ];
   buildInputs =
@@ -86,9 +124,10 @@ in stdenv.mkDerivation {
       pcre2 ] ++
       stdenv.lib.optional withKexectools kexectools ++
       stdenv.lib.optional withLibseccomp libseccomp ++
-    [ libffi audit lz4 bzip2 libapparmor
-      iptables gnu-efi
-    ] ++ stdenv.lib.optional withSelinux libselinux;
+      [ libffi audit lz4 bzip2 libapparmor iptables ] ++
+      stdenv.lib.optional withEfi gnu-efi ++
+      stdenv.lib.optional withSelinux libselinux ++
+      stdenv.lib.optional withCryptsetup cryptsetup.dev;
 
   #dontAddPrefix = true;
 
@@ -106,19 +145,23 @@ in stdenv.mkDerivation {
     "-Ddebug-shell=${bashInteractive}/bin/bash"
     # while we do not run tests we should also not build them. Removes about 600 targets
     "-Dtests=false"
-    "-Dimportd=true"
+    "-Dimportd=${stdenv.lib.boolToString withImportd}"
     "-Dlz4=true"
     "-Dhomed=false"
-    "-Dhostnamed=true"
-    "-Dnetworkd=true"
+    "-Dlogind=${stdenv.lib.boolToString withLogind}"
+    "-Dlocaled=${stdenv.lib.boolToString withLocaled}"
+    "-Dhostnamed=${stdenv.lib.boolToString withHostnamed}"
+    "-Dnetworkd=${stdenv.lib.boolToString withNetworkd}"
+    "-Dcryptsetup=${stdenv.lib.boolToString withCryptsetup}"
     "-Dportabled=false"
+    "-Dhwdb=${stdenv.lib.boolToString withHwdb}"
     "-Dremote=false"
     "-Dsysusers=false"
-    "-Dtimedated=true"
-    "-Dtimesyncd=true"
+    "-Dtimedated=${stdenv.lib.boolToString withTimedated}"
+    "-Dtimesyncd=${stdenv.lib.boolToString withTimesyncd}"
     "-Dfirstboot=false"
     "-Dlocaled=true"
-    "-Dresolve=true"
+    "-Dresolve=${stdenv.lib.boolToString withResolved}"
     "-Dsplit-usr=false"
     "-Dlibcurl=true"
     "-Dlibidn=false"
@@ -141,11 +184,6 @@ in stdenv.mkDerivation {
     "-Dsystem-gid-max=999"
     # "-Dtime-epoch=1"
 
-    (if !stdenv.hostPlatform.isEfi then "-Dgnu-efi=false" else "-Dgnu-efi=true")
-    "-Defi-libdir=${toString gnu-efi}/lib"
-    "-Defi-includedir=${toString gnu-efi}/include/efi"
-    "-Defi-ldsdir=${toString gnu-efi}/lib"
-
     "-Dsysvinit-path="
     "-Dsysvrcnd-path="
 
@@ -161,6 +199,12 @@ in stdenv.mkDerivation {
     # Upstream defaulted to disable manpages since they optimize for the much
     # more frequent development builds
     "-Dman=true"
+
+    "-Dgnu-efi=${stdenv.lib.boolToString (withEfi && gnu-efi != null)}"
+  ] ++ stdenv.lib.optionals (withEfi && gnu-efi != null) [
+    "-Defi-libdir=${toString gnu-efi}/lib"
+    "-Defi-includedir=${toString gnu-efi}/include/efi"
+    "-Defi-ldsdir=${toString gnu-efi}/lib"
   ];
 
   preConfigure = ''
@@ -284,6 +328,6 @@ in stdenv.mkDerivation {
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     priority = 10;
-    maintainers = with maintainers; [ andir eelco flokli ];
+    maintainers = with maintainers; [ andir eelco flokli kloenk ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18241,7 +18241,7 @@ in
     # udev is the same package as systemd which depends on cryptsetup
     # which depends on lvm2 again.  But we only need the libudev part
     # which does not depend on cryptsetup.
-    udev = udev.override { cryptsetup = null; };
+    udev = systemdMinimal;
   };
   lvm2_dmeventd = callPackage ../os-specific/linux/lvm2 {
     enableDmeventd = true;
@@ -18588,8 +18588,23 @@ in
       bzip2 = null;
     };
   };
+  systemdMinimal = systemd.override {
+    pname = "systemd-minimal";
+    withResolved = false;
+    withLogind = false;
+    withHostnamed = false;
+    withLocaled = false;
+    withTimedated = false;
+    withHwdb = false;
+    withEfi = false;
+    withImportd = false;
+    withCryptsetup = false;
+    cryptsetup = null;
+    lvm2 = null;
+  };
 
-  udev = systemd; # TODO: move to aliases.nix
+
+  udev = systemd; # TODO: change to systemdMinimal
 
   systemd-wait = callPackage ../os-specific/linux/systemd-wait { };
 


### PR DESCRIPTION
###### Motivation for this change
Base work for #98299 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
