### PR TITLE
zeroc-mcpp: decouple from original mcpp

### DIFF
--- a/pkgs/development/libraries/zeroc-ice/default.nix
+++ b/pkgs/development/libraries/zeroc-ice/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, lib, fetchFromGitHub, mcpp, bzip2, expat, openssl, lmdb
+{ stdenv, lib, fetchFromGitHub, bzip2, expat, openssl, lmdb
 , darwin, libiconv, Security
 , cpp11 ? false
 }:
 
 let
-  zeroc_mcpp = mcpp.overrideAttrs (self: rec {
+  zeroc_mcpp = stdenv.mkDerivation rec {
     pname = "zeroc-mcpp";
     version = "2.7.2.14";
 
@@ -15,8 +15,9 @@ let
       sha256 = "1psryc2ql1cp91xd3f8jz84mdaqvwzkdq2pr96nwn03ds4cd88wh";
     };
 
+    configureFlags = [ "--enable-mcpplib" ];
     installFlags = [ "PREFIX=$(out)" ];
-  });
+  };
 
 in stdenv.mkDerivation rec {
   pname = "zeroc-ice";
@@ -63,7 +64,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = "http://www.zeroc.com/ice.html";
+    homepage = "https://www.zeroc.com/ice.html";
     description = "The internet communications engine";
     license = licenses.gpl2;
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

zeroc-ice used to smuggle a forked mcpp version in with an override,
which broke after applying a security patch against mcpp in
c60cafa719ba22772114f4c35df14fb18f66a66f. Overriding instead of defining
a new derivation is a questionable optimization since in fact, only the
'configureFlags' line is shared.

Remove the override and give the forked mcpp a live on its own.

The security patch for mcpp is not relevant for this fork.

Fix #98581

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions *Ubuntu*
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of *some& pkgs that depend on this change: *murmur*
- [ ] Tested execution of all binary files (usually in `./result/bin/`) *N/A*
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Cc @abbradar @K900 @sumnerevans