### PR TITLE
dbus: build manpages from xml

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -10,6 +10,9 @@
 , libSM ? null
 , x11Support ? (stdenv.isLinux || stdenv.isDarwin)
 , dbus
+, docbook_xml_dtd_44
+, docbook-xsl-nons
+, xmlto
 }:
 
 assert
@@ -43,10 +46,13 @@ stdenv.mkDerivation rec {
       --replace 'DBUS_DAEMONDIR"/dbus-daemon"' '"/run/current-system/sw/bin/dbus-daemon"'
   '';
 
-  outputs = [ "out" "dev" "lib" "doc" ];
+  outputs = [ "out" "dev" "lib" "doc" "man" ];
 
   nativeBuildInputs = [
     pkgconfig
+    docbook_xml_dtd_44
+    docbook-xsl-nons
+    xmlto
   ];
 
   propagatedBuildInputs = [
@@ -63,6 +69,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--enable-user-session"
+    "--enable-xml-docs"
     "--libexecdir=${placeholder ''out''}/libexec"
     "--datadir=/etc"
     "--localstatedir=/var"


### PR DESCRIPTION
###### Motivation for this change

I noticed that manual pages like [`dbus-send(1)`](https://dbus.freedesktop.org/doc/dbus-send.1.html) and [`dbus-monitor(1)`](https://dbus.freedesktop.org/doc/dbus-monitor.1.html) were missing from my system.

The `docbook_xml_dtd_44` and `docbook_xsl` bits are necessary to prevent `xmlto` from trying to use the network during build. ~~I copied from other nix packages that have the same issue.~~ (Edit: Did it a cleaner way.)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I don't think my machine is powerful enough to run the `nixpkgs-review` for this change, given the sheer number of packages that depend on `dbus`. I confirmed the manpages were generated correctly and that simple binaries like `dbus-send`, `dbus-monitor`, and `dbus-uuidgen` work (I'm not sure how to use or test the others).