### PR TITLE
nixpkgs-review: 2.4.0 -> 2.4.1

### DIFF
--- a/pkgs/tools/package-management/nixpkgs-review/default.nix
+++ b/pkgs/tools/package-management/nixpkgs-review/default.nix
@@ -8,13 +8,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "nixpkgs-review";
-  version = "2.4.0";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "Mic92";
     repo = "nixpkgs-review";
     rev = version;
-    sha256 = "0kca4442mla8j9980gi8kgp0vgm0f15hcjd0w0wdj8rlmkx9yf2l";
+    sha256 = "04g2b3nj1ayn4vrqhgslpmmij4sd1c0d4m3acg9a9r3w5hnsjxvv";
   };
 
   makeWrapperArgs = [


### PR DESCRIPTION
###### Motivation for this change
Fixes categorization of broken packages by using 'checkMeta' https://github.com/Mic92/nixpkgs-review/pull/131

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/99024
1 package built:
nix-review
```