### PR TITLE
gnat-wrapper/cc-wrapper cleanup and fixes

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -137,14 +137,18 @@ fi
 
 source @out@/nix-support/add-hardening.sh
 
-# Add the flags for the C compiler proper.
+# Add the flags for the C compiler proper.  Explicitly converting
+# space-separated words into array elements.
+# shellcheck disable=SC2206
 extraAfter=($NIX_CFLAGS_COMPILE_@suffixSalt@)
+# shellcheck disable=SC2206
 extraBefore=(${hardeningCFlags[@]+"${hardeningCFlags[@]}"} $NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@)
 
 if [ "$dontLink" != 1 ]; then
 
     # Add the flags that should only be passed to the compiler when
     # linking.
+    # shellcheck disable=SC2206
     extraAfter+=($NIX_CFLAGS_LINK_@suffixSalt@)
 
     # Add the flags that should be passed to the linker (and prevent

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -114,7 +114,7 @@ if [ -z "${NIX_CC_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
 fi
 
 # Clear march/mtune=native -- they bring impurity.
-if [ "$NIX_ENFORCE_NO_NATIVE_@suffixSalt@" = 1 ]; then
+if [ "${NIX_ENFORCE_NO_NATIVE_@suffixSalt@:-0}" = 1 ]; then
     rest=()
     # Old bash empty array hack
     for p in ${params+"${params[@]}"}; do

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -9,7 +9,7 @@ fi
 path_backup="$PATH"
 
 # That @-vars are substituted separately from bash evaluation makes
-# shellcheck think this, and others like it, are useless conditionals.
+# "shellcheck" think this, and others like it, are useless conditionals.
 # shellcheck disable=SC2157
 if [[ -n "@coreutils_bin@" && -n "@gnugrep_bin@" ]]; then
     PATH="@coreutils_bin@/bin:@gnugrep_bin@/bin"

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -437,7 +437,7 @@ stdenv.mkDerivation {
     '' + optionalString targetPlatform.isNetBSD ''
       hardening_unsupported_flags+=" stackprotector fortify"
     '' + optionalString cc.langAda or false ''
-      hardening_unsupported_flags+=" stackprotector strictoverflow"
+      hardening_unsupported_flags+=" stackprotector strictoverflow format"
     '' + optionalString cc.langD or false ''
       hardening_unsupported_flags+=" format"
     '' + optionalString targetPlatform.isWasm ''

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -110,7 +110,7 @@ fi
 
 
 # Clear march/mtune=native -- they bring impurity.
-if [ "$NIX_ENFORCE_NO_NATIVE_@suffixSalt@" = 1 ]; then
+if [ "${NIX_ENFORCE_NO_NATIVE_@suffixSalt@:-0}" = 1 ]; then
     rest=()
     # Old bash empty array hack
     for p in ${params+"${params[@]}"}; do

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -9,7 +9,7 @@ fi
 path_backup="$PATH"
 
 # That @-vars are substituted separately from bash evaluation makes
-# shellcheck think this, and others like it, are useless conditionals.
+# "shellcheck" think this, and others like it, are useless conditionals.
 # shellcheck disable=SC2157
 if [[ -n "@coreutils_bin@" && -n "@gnugrep_bin@" ]]; then
     PATH="@coreutils_bin@/bin:@gnugrep_bin@/bin"

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -91,20 +91,30 @@ if [ "${NIX_ENFORCE_NO_NATIVE_@suffixSalt@:-0}" = 1 ]; then
     params=(${rest+"${rest[@]}"})
 fi
 
-if [ "$(basename $0)x" = "gnatmakex" ]; then
-    extraBefore=("--GNATBIND=@out@/bin/gnatbind" "--GNATLINK=@out@/bin/gnatlink")
-    extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@)
-fi
-
-if [ "$(basename $0)x" = "gnatbindx" ]; then
-    extraBefore=()
-    extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@)
-fi
-
-if [ "$(basename $0)x" = "gnatlinkx" ]; then
-    extraBefore=()
-    extraAfter=("--GCC=@out@/bin/gcc")
-fi
+toolname=$(basename "$0")
+case $toolname in
+    gnatmake)
+        extraBefore=("--GNATBIND=@out@/bin/gnatbind"
+                     "--GNATLINK=@out@/bin/gnatlink")
+        # Explicit multi-word to array conversion
+        # shellcheck disable=SC2206
+        extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@)
+        ;;
+    gnatbind)
+        extraBefore=()
+        # Explicit multi-word to array conversion
+        # shellcheck disable=SC2206
+        extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@)
+        ;;
+    gnatlink)
+        extraBefore=()
+        extraAfter=("--GCC=@out@/bin/gcc")
+        ;;
+    *)
+        extraBefore=()
+        extraAfter=()
+        ;;
+esac
 
 # As a very special hack, if the arguments are just `-v', then don't
 # add anything.  This is to prevent `gcc -v' (which normally prints

--- a/pkgs/build-support/setup-hooks/role.bash
+++ b/pkgs/build-support/setup-hooks/role.bash
@@ -17,7 +17,7 @@ function getRole() {
             role_post='_FOR_TARGET'
             ;;
         *)
-            echo "@name@: used as improper sort of dependency" >2
+            echo "@name@: used as improper sort of dependency" >&2
             return 1
             ;;
     esac
@@ -64,7 +64,7 @@ function getTargetRoleWrapper() {
             export NIX_@wrapperName@_TARGET_TARGET_@suffixSalt@=1
             ;;
         *)
-            echo "@name@: used as improper sort of dependency" >2
+            echo "@name@: used as improper sort of dependency" >&2
             return 1
             ;;
     esac


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Observation of #98274 which fixed the gnat issue I also encountered led to some additional cleanup and corner-case fixes in both the gnat-wrapper, the cc-wrapper, and the role.bash setup hook.

Re-submitted version of https://github.com/NixOS/nixpkgs/pull/98369 to build against staging instead of master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
     - Since this changes the core stdenv wrappers, everything rebuilds. I've run several hundred package rebuilds, along with gcc/gnat builds, but don't have the machine power or time to wait for every package to rebuild. :-)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
