### PR TITLE
python3Packages.skein: mark broken, maven repo unstable

### DIFF
--- a/pkgs/development/python-modules/skein/default.nix
+++ b/pkgs/development/python-modules/skein/default.nix
@@ -34,6 +34,7 @@ buildPythonPackage rec {
     description = "A tool and library for easily deploying applications on Apache YARN";
     license = licenses.bsd3;
     maintainers = with maintainers; [ alexbiehl ];
+    broken = true; # maven repo src isn't stable
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
seen it fail many times in the past few weeks when reviewing other packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
$ nix-env -f /home/jon/.cache/nixpkgs-review/pr-99030/nixpkgs -qaP --xml --out-path --show-trace --meta
Nothing to be built.
https://github.com/NixOS/nixpkgs/pull/99030
$ nix-shell /home/jon/.cache/nixpkgs-review/pr-99030/shell.nix
```