### PR TITLE
python3Packages.dash*: bump

### DIFF
--- a/pkgs/development/python-modules/dash-core-components/default.nix
+++ b/pkgs/development/python-modules/dash-core-components/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "dash_core_components";
-  version = "1.10.2";
+  version = "1.12.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6152346ff2ac8a7fcdb76c8b8acbf3ee4e72f3822cd2a02a9f3a963db66f94a3";
+    sha256 = "27f2ac612f5574dcd0d645f9302ceca5975bbdac6791865692e3ac51d0aec7f4";
   };
 
   # No tests in archive

--- a/pkgs/development/python-modules/dash-html-components/default.nix
+++ b/pkgs/development/python-modules/dash-html-components/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "dash_html_components";
-  version = "1.0.3";
+  version = "1.1.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1fj5wlh6x9nngmz1rzb5xazc5pl34yrp4kf7a3zgy0dniap59yys";
+    sha256 = "2c662e640528c890aaa0fa23d48e51c4d13ce69a97841d856ddcaaf2c6a47be3";
   };
 
   # No tests in archive

--- a/pkgs/development/python-modules/dash-renderer/default.nix
+++ b/pkgs/development/python-modules/dash-renderer/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "dash_renderer";
-  version = "1.6.0";
+  version = "1.8.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8e9c0c0c2efb8ea562489c37665417cd608c30bca20425ac4d847420b5bbc128";
+    sha256 = "84cbb22019299a5a3c268ec1143c6f241c3f136e95753edac83a81673b7fa04e";
   };
 
   # No tests in archive

--- a/pkgs/development/python-modules/dash-table/default.nix
+++ b/pkgs/development/python-modules/dash-table/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "dash_table";
-  version = "4.9.0";
+  version = "4.10.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2f19000051730291100cd3a79b13fa62c478aea7908f2e4323c13b90f09e3320";
+    sha256 = "1aa02180faef13434364286b60404d26164d1ce2779c765c9c52e6935991a4e9";
   };
 
   # No tests in archive

--- a/pkgs/development/python-modules/dash/default.nix
+++ b/pkgs/development/python-modules/dash/default.nix
@@ -16,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "dash";
-  version = "1.14.0";
+  version = "1.16.2";
 
   src = fetchFromGitHub {
     owner = "plotly";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1f7gal9x0bjsmwxlbvlkwfwz1cyyg5d0n6jh4399wkjilpd966d5";
+    sha256 = "1krhwxlz8kpaklf5ii3h339id6c3139xzxxkq7mvvag330j6nbgg";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
closes #99025
closes #99072
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/99031
15 packages built:
python27Packages.dash python27Packages.dash-core-components python27Packages.dash-html-components python27Packages.dash-renderer python27Packages.dash-table python37Packages.dash python37Packages.dash-core-components python37Packages.dash-html-components python37Packages.dash-renderer python37Packages.dash-table python38Packages.dash python38Packages.dash-core-components python38Packages.dash-html-components python38Packages.dash-renderer python38Packages.dash-table
```