### PR TITLE
coqPackages.VST: init at 2.6

### DIFF
--- a/pkgs/development/compilers/compcert/default.nix
+++ b/pkgs/development/compilers/compcert/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper
+{ stdenv, lib, fetchFromGitHub, fetchpatch, makeWrapper
 , coq, ocamlPackages, coq2html
 , tools ? stdenv.cc
 }:
@@ -21,11 +21,22 @@ stdenv.mkDerivation rec {
     sha256 = "1h4zhk9rrqki193nxs9vjvya7nl9yxjcf07hfqb6g77riy1vd2jr";
   };
 
+  patches = [
+   (fetchpatch {
+      url = "https://github.com/AbsInt/CompCert/commit/0a2db0269809539ccc66f8ec73637c37fbd23580.patch";
+      sha256 = "0n8qrba70x8f422jdvq9ddgsx6avf2dkg892g4ldh3jiiidyhspy";
+    })
+   (fetchpatch {
+      url = "https://github.com/AbsInt/CompCert/commit/5e29f8b5ba9582ecf2a1d0baeaef195873640607.patch";
+      sha256 = "184nfdgxrkci880lkaj5pgnify3plka7xfgqrgv16275sqppc5hc";
+    })
+  ];
+
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = ocaml-pkgs ++ [ coq coq2html ];
   enableParallelBuilding = true;
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace ./configure \
       --replace '{toolprefix}gcc' '{toolprefix}cc'
   '';
@@ -33,6 +44,7 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     ./configure -clightgen \
       -prefix $out \
+      -coqdevdir $lib/lib/coq/${coq.coq-version}/user-contrib/compcert/ \
       -toolprefix ${tools}/bin/ \
       ${ccomp-platform}
   '';
@@ -46,12 +58,6 @@ stdenv.mkDerivation rec {
     # move docs into place
     mkdir -p $doc/share/doc/compcert
     mv doc/html $doc/share/doc/compcert/
-
-    # install compcert lib files; remove copy from $out, too
-    mkdir -p $lib/lib/coq/${coq.coq-version}/user-contrib/compcert/
-    mv backend cfrontend common cparser driver flocq x86 x86_64 lib \
-      $lib/lib/coq/${coq.coq-version}/user-contrib/compcert/
-    rm -rf $out/lib/compcert/coq
 
     # wrap ccomp to undefine _FORTIFY_SOURCE; ccomp invokes cc1 which sets
     # _FORTIFY_SOURCE=2 by default, but undefines __GNUC__ (as it should),

--- a/pkgs/development/coq-modules/VST/default.nix
+++ b/pkgs/development/coq-modules/VST/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, coq, compcert }:
+
+stdenv.mkDerivation rec {
+  pname = "coq${coq.coq-version}-VST";
+  version = "2.6";
+
+  src = fetchFromGitHub {
+    owner = "PrincetonUniversity";
+    repo = "VST";
+    rev = "v${version}";
+    sha256 = "00bf9hl4pvmsqa08lzjs1mrxyfgfxq4k6778pnldmc8ichm90jgk";
+  };
+
+  buildInputs = [ coq ];
+  propagatedBuildInputs = [ compcert ];
+
+  preConfigure = "patchShebangs util";
+
+  makeFlags = [
+    "BITSIZE=64"
+    "COMPCERT=inst_dir"
+    "COMPCERT_INST_DIR=${compcert.lib}/lib/coq/${coq.coq-version}/user-contrib/compcert"
+    "INSTALLDIR=$(out)/lib/coq/${coq.coq-version}/user-contrib/VST"
+  ];
+
+  postInstall = ''
+    for d in msl veric floyd sepcomp progs64
+    do
+      cp -r $d $out/lib/coq/${coq.coq-version}/user-contrib/VST/
+    done
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru.compatibleCoqVersions = stdenv.lib.flip builtins.elem [ "8.11" ];
+
+  meta = {
+    description = "Verified Software Toolchain";
+    homepage = "https://vst.cs.princeton.edu/";
+    inherit (compcert.meta) platforms;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8588,9 +8588,7 @@ in
 
   cmucl_binary = pkgsi686Linux.callPackage ../development/compilers/cmucl/binary.nix { };
 
-  compcert = callPackage ../development/compilers/compcert {
-    inherit (coqPackages_8_10) coq;
-  };
+  compcert = callPackage ../development/compilers/compcert {};
 
   computecpp-unwrapped = callPackage ../development/compilers/computecpp {};
   computecpp = wrapCCWith rec {

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -59,6 +59,7 @@ let
       tlc = callPackage ../development/coq-modules/tlc {};
       Velisarios = callPackage ../development/coq-modules/Velisarios {};
       Verdi = callPackage ../development/coq-modules/Verdi {};
+      VST = callPackage ../development/coq-modules/VST {};
 
       filterPackages = filterCoqPackages;
     };


### PR DESCRIPTION
###### Motivation for this change

Yet another cool Coq package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
