### PR TITLE
oq: fix build

### DIFF
--- a/pkgs/development/tools/oq/default.nix
+++ b/pkgs/development/tools/oq/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, crystal, jq, libxml2, makeWrapper }:
+{ lib, fetchFromGitHub, crystal, jq, libxml2, makeWrapper, fetchpatch }:
 
 crystal.buildCrystalPackage rec {
   pname = "oq";
@@ -10,6 +10,15 @@ crystal.buildCrystalPackage rec {
     rev = "v${version}";
     sha256 = "1zg4kxpfi3sap4cwp42zg46j5dv0nf926qdqm7k22ncm6jdrgpgw";
   };
+
+  patches = [
+    (fetchpatch {
+        # remove once we have upgraded to oq 1.1.2+
+        name = "yaml-test-leniency.patch";
+        url = "https://github.com/Blacksmoke16/oq/commit/93ed2fe50c9ce3fd8d35427e007790ddaaafce60.patch";
+        sha256 = "1iyz0c0w0ykz268bkrlqwvh1jnnrja0mqip6y89sbpa14lp0l37n";
+    })
+  ];
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ jq libxml2 ];
@@ -32,6 +41,6 @@ crystal.buildCrystalPackage rec {
     homepage = "https://blacksmoke16.github.io/oq/";
     license = licenses.mit;
     maintainers = with maintainers; [ filalex77 ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

A `libyaml` upgrade broke some overly strict tests in `oq`. Add a patch from upstream to make these more lenient.

This patch is actually included in the already-released oq 1.1.2, but we can't upgrade to that because it requires crystal 0.35, which we don't seem to have yet.

Also enable for darwin because it WFM macos 10.14.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
