### PR TITLE
ocamlPackages.result: 1.2 -> 1.5

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-result/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-result/default.nix
@@ -1,20 +1,13 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib }:
+{ lib, buildDunePackage, fetchurl }:
 
-let version = "1.2"; in
+buildDunePackage rec {
+  pname = "result";
+  version = "1.5";
 
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-result-${version}";
-
-  src = fetchFromGitHub {
-    owner = "janestreet";
-    repo = "result";
-    rev = version;
-    sha256 = "1jwzpcmxwgkfsbjz9zl59v12hf1vv4r9kiifancn9p8gm206g3g0";
+  src = fetchurl {
+    url = "https://github.com/janestreet/result/releases/download/${version}/result-${version}.tbz";
+    sha256 = "0cpfp35fdwnv3p30a06wd0py3805qxmq3jmcynjc3x2qhlimwfkw";
   };
-
-  buildInputs = [ ocaml findlib ];
-
-  createFindlibDestdir = true;
 
   meta = {
     homepage = "https://github.com/janestreet/result";
@@ -24,7 +17,6 @@ stdenv.mkDerivation {
       while staying compatible with older version of OCaml should use the
       Result module defined in this library.
     '';
-    license = stdenv.lib.licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    license = lib.licenses.bsd3;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`result` 1.5 improves compatibility for OCaml >= 4.08. 


References: 
- https://github.com/janestreet/result/pull/9
- https://github.com/ocaml/opam-repository/pull/15853

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions: Ubuntu
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
