### PR TITLE
man-pages: Make it findable by manpages

### DIFF
--- a/pkgs/data/documentation/man-pages/default.nix
+++ b/pkgs/data/documentation/man-pages/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
     # conflict with shadow-utils
     rm $out/share/man/man5/passwd.5 \
        $out/share/man/man3/getspnam.3
+
+    # The manpath executable looks up manpages from PATH. And this package won't
+    # appear in PATH unless it has a /bin folder
+    mkdir -p $out/bin
   '';
   outputDocdev = "out";
 


### PR DESCRIPTION
###### Motivation for this change
Previously `nix-shell -p man-pages` wouldn't work, because `man` by
default looks up man pages only for the packages that appear in PATH.
Since man-pages didn't have anything in $out/bin though, it wouldn't be
put on PATH.

This fixes that by just creating an empty $out/bin


###### Things done

- [x] Tested with `nix-shell -p manpages -I nixpkgs=$PWD --run 'man getchar'`