### PR TITLE
pony-corral: init 0.4.0

### DIFF
--- a/pkgs/development/compilers/ponyc/pony-corral.nix
+++ b/pkgs/development/compilers/ponyc/pony-corral.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, ponyc }:
+
+stdenv.mkDerivation ( rec {
+  pname = "corral";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "ponylang";
+    repo = pname;
+    rev = version;
+    sha256 = "0kydx4psl6k4n46as9xc5xwbwapibm6g7haxds7y9d392807qfqk";
+  };
+
+  buildInputs = [ ponyc ];
+
+  installFlags = [ "prefix=${placeholder "out"}" "install" ];
+
+  meta = with stdenv.lib; {
+    description = "Corral is a dependency management tool for ponylang (ponyc)";
+    homepage = "https://www.ponylang.io";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ redvers ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9609,6 +9609,7 @@ in
     stdenv = clangStdenv;
   };
 
+  pony-corral = callPackage ../development/compilers/ponyc/pony-corral.nix { };
   pony-stable = callPackage ../development/compilers/ponyc/pony-stable.nix { };
 
   qbe = callPackage ../development/compilers/qbe { };


### PR DESCRIPTION
###### Motivation for this change

Corral is the new package manager for ponylang (ponyc).  It is designed to replace pony-stable (which was like a pony stable, not a stable pony - which caused confusion) ;-)

pony-stable is officially deprecated upstream.  I've not removed it as I want to provide a window of opportunity for developers to switch their configurations from one to the other.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Thank you in advance for your kind considerations...
