### PR TITLE
rustc: enable ppc64le bootstrap

### DIFF
--- a/pkgs/development/compilers/rust/1_45.nix
+++ b/pkgs/development/compilers/rust/1_45.nix
@@ -32,6 +32,7 @@ import ./default.nix {
     armv7-unknown-linux-gnueabihf = "d44294732cf268ea84908f1135f574ab9489132a332eaa9d5bda547374b15d54";
     aarch64-unknown-linux-gnu = "a2d74ebeec0b6778026b6c37814cdc91d14db3b0d8b6d69d036216f4d9cf7e49";
     x86_64-apple-darwin = "a5464e7bcbce9647607904a4afa8362382f1fc55d39e7bbaf4483ac00eb5d56a";
+    powerpc64le-unknown-linux-gnu = "22deeca259459db31065af7c862fcab7fbfb623200520c65002ed2ba93d87ad2";
   };
 
   selectRustPackage = pkgs: pkgs.rust_1_45;

--- a/pkgs/development/compilers/rust/1_47.nix
+++ b/pkgs/development/compilers/rust/1_47.nix
@@ -34,6 +34,7 @@ import ./default.nix {
     armv7-unknown-linux-gnueabihf = "7c0640879d7f2c38db60352e3c0f09e3fc6fa3bac6ca8f22cbccb1eb5e950121";
     aarch64-unknown-linux-gnu = "f0c6d630f3dedb3db69d69ed9f833aa6b472363096f5164f1068c7001ca42aeb";
     x86_64-apple-darwin = "82d61582a3772932432a99789c3b3bd4abe6baca339e355048ca9efb9ea5b4db";
+    powerpc64le-unknown-linux-gnu = "89e2f4761d257f017a4b6aa427f36ac0603195546fa2cfded8c899789832941c";
   };
 
   selectRustPackage = pkgs: pkgs.rust_1_47;

--- a/pkgs/development/compilers/rust/print-hashes.sh
+++ b/pkgs/development/compilers/rust/print-hashes.sh
@@ -14,6 +14,7 @@ PLATFORMS=(
   armv7-unknown-linux-gnueabihf
   aarch64-unknown-linux-gnu
   x86_64-apple-darwin
+  powerpc64le-unknown-linux-gnu
 )
 BASEURL=https://static.rust-lang.org/dist
 VERSION=${1:-}


### PR DESCRIPTION
Allows native bootstrapping from upstream binaries on ppc64le
Have been using ripgrep + bat compiled via the resulting bootstrapped rustc 1.45.

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
