### PR TITLE
rsync: 3.1.3 -> 3.2.3; add additional dependencies

### DIFF
--- a/pkgs/applications/networking/sync/rsync/base.nix
+++ b/pkgs/applications/networking/sync/rsync/base.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchurl }:
 
 rec {
-  version = "3.1.3";
+  version = "3.2.3";
   src = fetchurl {
     # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
     url = "mirror://samba/rsync/src/rsync-${version}.tar.gz";
-    sha256 = "1h0011dj6jgqpgribir4anljjv7bbrdcs8g91pbsmzf5zr75bk2m";
+    sha256 = "03p5dha9g9krq61mdbcrjkpz5nglri0009ks2vs9k97f9i83rk5y";
   };
   upstreamPatchTarball = fetchurl {
     # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
     url = "mirror://samba/rsync/rsync-patches-${version}.tar.gz";
-    sha256 = "167vk463bb3xl9c4gsbxms111dk1ip7pq8y361xc0xfa427q9hhd";
+    sha256 = "1wj21v57v135n6fnmlm2dxmb9lhrrg62jgkggldp1gb7d6s4arny";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -1,9 +1,17 @@
 { stdenv, fetchurl, perl, libiconv, zlib, popt
 , enableACLs ? !(stdenv.isDarwin || stdenv.isSunOS || stdenv.isFreeBSD), acl ? null
+, enableLZ4 ? true, lz4 ? null
+, enableOpenSSL ? true, openssl ? null
+, enableXXHash ? true, xxHash ? null
+, enableZstd ? true, zstd ? null
 , enableCopyDevicesPatch ? false
 }:
 
 assert enableACLs -> acl != null;
+assert enableLZ4 -> lz4 != null;
+assert enableOpenSSL -> openssl != null;
+assert enableXXHash -> xxHash != null;
+assert enableZstd -> zstd != null;
 
 let
   base = import ./base.nix { inherit stdenv fetchurl; };
@@ -18,7 +26,12 @@ stdenv.mkDerivation rec {
   srcs = [mainSrc] ++ stdenv.lib.optional enableCopyDevicesPatch patchesSrc;
   patches = stdenv.lib.optional enableCopyDevicesPatch "./patches/copy-devices.diff";
 
-  buildInputs = [libiconv zlib popt] ++ stdenv.lib.optional enableACLs acl;
+  buildInputs = [libiconv zlib popt]
+                ++ stdenv.lib.optional enableACLs acl
+                ++ stdenv.lib.optional enableZstd zstd
+                ++ stdenv.lib.optional enableLZ4 lz4
+                ++ stdenv.lib.optional enableOpenSSL openssl
+                ++ stdenv.lib.optional enableXXHash xxHash;
   nativeBuildInputs = [perl];
 
   configureFlags = ["--with-nobody-group=nogroup"];


### PR DESCRIPTION
###### Motivation for this change
I wanted support for zstd compression in rsync; I added LZ4, OpenSSL, and xxHash support as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) (33936936 :arrow_right: 40755760)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
