### PR TITLE
sqlitecpp: init 3.1.1

### DIFF
--- a/pkgs/development/libraries/sqlitecpp/default.nix
+++ b/pkgs/development/libraries/sqlitecpp/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, cmake, sqlite, cppcheck, gtest }:
+
+stdenv.mkDerivation rec {
+  pname = "SQLiteCpp";
+  version = "3.1.1";
+
+  src = fetchFromGitHub {
+    owner = "SRombauts";
+    repo = pname;
+    rev = version;
+    sha256 = "1c2yyipiqswi5sf9xmpsgw6l1illzmcpkjm56agk6kl2hay23lgr";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  checkInputs = [ cppcheck gtest ];
+  buildInputs = [ sqlite ];
+  doCheck = true;
+
+  cmakeFlags = [
+    "-DSQLITECPP_INTERNAL_SQLITE=OFF"
+    "-DSQLITECPP_BUILD_TESTS=ON"
+  ];
+
+  meta = with lib; {
+    homepage = "http://srombauts.github.com/SQLiteCpp";
+    description = "C++ SQLite3 wrapper";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.jbedo maintainers.doronbehar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17249,6 +17249,8 @@ in
 
   sqlar = callPackage ../development/libraries/sqlite/sqlar.nix { };
 
+  sqlitecpp = callPackage ../development/libraries/sqlitecpp { };
+
   sqlite-interactive = appendToName "interactive" (sqlite.override { interactive = true; }).bin;
 
   sqlite-jdbc = callPackage ../servers/sql/sqlite/jdbc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Init GenomicSQLite and required SQLiteC++ dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
