### PR TITLE
.github/workflows: add auto label merge conflicts

### DIFF
--- a/.github/workflows/auto-label-merge-conflicts.yml
+++ b/.github/workflows/auto-label-merge-conflicts.yml
@@ -1,0 +1,20 @@
+# To run it manually:
+# 1. Acquire a GITHUB OAUTH token with permission edit nixos/nixpkgs labels
+# 2. Make sure the git remote origin exists and points to
+#    https://github.com/NixOS/nixpkgs.git (it doesn't work with SSH).
+# 3. Run nix-shell -p act --run "act -s GITHUB_TOKEN=xxx -j label-merge-conflict > label-merge-conflict.log"
+
+on:
+  schedule:
+    #daily
+    - cron: '0 0 * * *'
+
+jobs:
+  label-merge-conflict:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-label merge conflicts
+        uses: ryantm/auto-label-merge-conflicts@720e6dddd1a208158b2b880393ff54c9e905e99f
+        with:
+          CONFLICT_LABEL_NAME: "2.status: merge conflict"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
OfBorg labels merge conflicts when people push to their branch, but it
doesn't relabel PRs when there are updates to master. This would do
that.

The reason to have good merge conflict labeling is then you can search
and filter PRs. GitHub does not provide this feature itself,
unfortunately.

I do not know how technically and/or economically efficient this
action is.

I looked over the code for the action, it seems legit.