### PR TITLE
terraform-providers.ct: 0.5.0 -> 0.6.1

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/data.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/data.nix
@@ -244,9 +244,9 @@
     {
       owner   = "poseidon";
       repo    = "terraform-provider-ct";
-      rev     = "v0.5.0";
-      version = "0.5.0";
-      sha256  = "1zqfaxlyhr9vpqj2qqpfyh1f1nfpynb7c5ris6mdmy9zin55ppni";
+      rev     = "v0.6.1";
+      version = "0.6.1";
+      sha256  = "0hh3hvi8lwb0h8x9viz5p991w94gn7354nw95b51rdmir9qi2x89";
     };
   datadog =
     {


### PR DESCRIPTION
0.6.0 added support for Fedora CoreOS Config v1.1.0.

 - Add Fedora CoreOS Config v1.1.0 support (#63)
 -  - Accept FCC v1.1.0 and output Ignition v3.1.0
 -  - Continue to support FCC v1.0.0 and output Ignition v3.0.0
 -  - Support merging FCC snippets into v1.0.0 or v1.1.0 FCC content
 -  - Note: Version skew among snippets and content is not supported
 - Change Container Linux Config to render Ignition v2.3.0 (#60)
 - Add zip archive format with signed checksum

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
