### PR TITLE
matrix-corporal: init at 2.0.1

### DIFF
--- a/pkgs/servers/matrix-corporal/default.nix
+++ b/pkgs/servers/matrix-corporal/default.nix
@@ -1,4 +1,4 @@
-{lib, fetchFromGitHub, buildGoModule }:
+{ lib, fetchFromGitHub, buildGoModule }:
 
 buildGoModule rec {
   pname = "matrix-corporal";

--- a/pkgs/servers/matrix-corporal/default.nix
+++ b/pkgs/servers/matrix-corporal/default.nix
@@ -1,0 +1,26 @@
+{lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "matrix-corporal";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "devture";
+    repo = pname;
+    rev = version;
+    sha256 = "1n8yjmy3j0spgwpxgc26adhpl52fm3d2xbmkf5n9dwzw29grv68r";
+  };
+
+  buildFlagsArray = [
+    "-ldflags=-s -w -X main.GitCommit=${version} -X main.GitBranch=${version} -X main.GitState=nixpkgs -X main.GitSummary=${version} -X main.Version=${version}"
+  ];
+
+  vendorSha256 = "1gi6mff6h0fkgfq5yybd1qcy2qwrvc4kzi11x7arfl9nr0d24rb2";
+
+  meta = with lib; {
+    homepage = "https://github.com/devture/matrix-corporal";
+    description = "Reconciliator and gateway for a managed Matrix server";
+    maintainers = with maintainers; [ dandellion ];
+    license = licenses.agpl3Only;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4984,6 +4984,8 @@ in
 
   matrix-appservice-discord = callPackage ../servers/matrix-appservice-discord { };
 
+  matrix-corporal = callPackage ../servers/matrix-corporal { };
+
   mautrix-telegram = recurseIntoAttrs (callPackage ../servers/mautrix-telegram { });
 
   mautrix-whatsapp = callPackage ../servers/mautrix-whatsapp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
matrix-corporal is a proxy and reconciliator for matrix-synapse letting you allow/deny API endpoints, and automatically join users to rooms/communities according to a configuration policy

###### Things done

Only adds a package, I might make a module in the future, but settings and secrets was a little hard in #93777 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
