### PR TITLE
[20.03] graylog: 3.3.4 -> 3.3.6

### DIFF
--- a/pkgs/tools/misc/graylog/default.nix
+++ b/pkgs/tools/misc/graylog/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "graylog";
-  version = "3.3.4";
+  version = "3.3.6";
 
   src = fetchurl {
     url = "https://packages.graylog2.org/releases/graylog/graylog-${version}.tgz";
-    sha256 = "0wynnb56plch61pzjl46jx5q94c5hclzyrr8567fc1jhnqycfngs";
+    sha256 = "0yqs5zllaj7v4j9kzfkqxd4n9jdy2656pgai7v05a8wpri4b6sf5";
   };
 
   dontBuild = true;

--- a/pkgs/tools/misc/graylog/plugins.nix
+++ b/pkgs/tools/misc/graylog/plugins.nix
@@ -31,8 +31,8 @@ in {
       sha256 = "1c48almnjr0b6nvzagnb9yddqbcjs7yhrd5yc5fx9q7w3vxi50zp";
     };
     meta = {
-      homepage = https://github.com/cvtienhoven/graylog-plugin-aggregates;
-      description = "SSO support for Graylog through trusted HTTP headers set by load balancers or authentication proxies";
+      homepage = "https://github.com/cvtienhoven/graylog-plugin-aggregates";
+      description = "A plugin that enables users to execute term searches and get notified when the given criteria are met";
     };
   };
   auth_sso = glPlugin rec {
@@ -64,10 +64,10 @@ in {
   enterprise-integrations = glPlugin rec {
     name = "graylog-enterprise-integrations-${version}";
     pluginName = "graylog-plugin-enterprise-integrations";
-    version = "3.3.4";
+    version = "3.3.6";
     src = fetchurl {
       url = "https://downloads.graylog.org/releases/graylog-enterprise-integrations/graylog-enterprise-integrations-plugins-${version}.tgz";
-      sha256 = "0ln0vmnfgxg6hdq7sh58xdqn14bl86qrgy3923f3q3hx209v6vn9";
+      sha256 = "15sx53ikc49d7a7qlcac9jyx9amrcqqqpk8hwj5lc8iv7d1wnxf9";
     };
     installPhase = ''
       mkdir -p $out/bin
@@ -96,10 +96,10 @@ in {
   integrations = glPlugin rec {
     name = "graylog-integrations-${version}";
     pluginName = "graylog-plugin-integrations";
-    version = "3.3.4";
+    version = "3.3.6";
     src = fetchurl {
       url = "https://downloads.graylog.org/releases/graylog-integrations/graylog-integrations-plugins-${version}.tgz";
-      sha256 = "14g6vdyibp3rva8bwss7vjbi9fpxvgp2gbk1r8divbhhpiwsjyxc";
+      sha256 = "11cg0rn10sc1gzip88pm2yzyxighiaafw1vznr3ips307ia0c7hm";
     };
     installPhase = ''
       mkdir -p $out/bin


### PR DESCRIPTION
Backport of #99077 to 20.03 (contains security fixes)
(20.09 backport: #99080)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
