### PR TITLE
python3Packages.fsspec: fix tests on darwin

### DIFF
--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -5,7 +5,6 @@
 , pytestCheckHook
 , numpy
 , stdenv
-, isPy38
 }:
 
 buildPythonPackage rec {
@@ -29,8 +28,9 @@ buildPythonPackage rec {
     # Test assumes user name is part of $HOME
     # AssertionError: assert 'nixbld' in '/homeless-shelter/foo/bar'
     "test_strip_protocol_expanduser"
-  ] ++ lib.optionals (stdenv.isDarwin && isPy38) [
+  ] ++ lib.optionals (stdenv.isDarwin) [
     "test_modified" # fails on hydra, works locally
+    "test_touch" # fails on hydra, works locally
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #97479

cc: @NixOS/nixos-release-managers 

Also see: https://discourse.nixos.org/t/is-there-a-feasible-way-to-debug-test-hydra-darwin-failures-quickly/9201

Disables the `test_touch` test which fails with the following assertion error on hydra darwin only:
```
tmpdir = local('/private/tmp/nix-build-python3.8-fsspec-0.8.3.drv-0/pytest-of-nixbld3/pytest-0/test_touch0')

    def test_touch(tmpdir):
        import time

        fn = tmpdir + "/in/file"
        fs = fsspec.filesystem("file", auto_mkdir=False)
        with pytest.raises(OSError):
            fs.touch(fn)
        fs = fsspec.filesystem("file", auto_mkdir=True)
        fs.touch(fn)
        info = fs.info(fn)
        time.sleep(0.2)
        fs.touch(fn)
        info2 = fs.info(fn)
        if not WIN:
>           assert info2["mtime"] > info["mtime"]
E           assert 1601358357.0 > 1601358357.0

fsspec/implementations/tests/test_local.py:322: AssertionError
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
