### PR TITLE
python3Packages.pytest-xprocess: 0.13.1 -> 0.14.0

### DIFF
--- a/pkgs/development/python-modules/pytest-xprocess/default.nix
+++ b/pkgs/development/python-modules/pytest-xprocess/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "pytest-xprocess";
-  version = "0.13.1";
+  version = "0.14.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "779aeca517cd9c996d1544bdc510cb3cff40c48136d94bbce6148e27f30a93ff";
+    sha256 = "06g1j5079ddl2sd3pxh2jg6g83b2z3l5hzbadiry2xg673dcncmb";
   };
 
   nativeBuildInputs = [ setuptools_scm ];


### PR DESCRIPTION
###### Motivation for this change
bump package I maintain

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

failures broken on master:
```
https://github.com/NixOS/nixpkgs/pull/99103
2 packages marked as broken and skipped:
python37Packages.qasm2image python38Packages.qasm2image

2 packages failed to build:
ape lexicon

37 packages built:
apache-airflow azure-cli buku http-prompt httpie isso nvchecker papis python27Packages.pytest-xprocess python37Packages.duecredit python37Packages.flask-caching python37Packages.flask-common python37Packages.graphite_api python37Packages.habanero python37Packages.httpbin python37Packages.influxgraph python37Packages.knack python37Packages.nvchecker python37Packages.papis python37Packages.pytest-httpbin python37Packages.pytest-xprocess python37Packages.qiskit python37Packages.qiskit-ibmq-provider python37Packages.vcrpy python38Packages.duecredit python38Packages.flask-caching python38Packages.flask-common python38Packages.graphite_api python38Packages.habanero python38Packages.httpbin python38Packages.influxgraph python38Packages.knack python38Packages.pytest-httpbin python38Packages.pytest-xprocess python38Packages.qiskit python38Packages.qiskit-ibmq-provider python38Packages.vcrpy
```