### PR TITLE
[20.09] minizinc: fix build against bison 3.7

### DIFF
--- a/pkgs/development/tools/minizinc/default.nix
+++ b/pkgs/development/tools/minizinc/default.nix
@@ -22,6 +22,16 @@ stdenv.mkDerivation {
       url = "https://github.com/MiniZinc/libminizinc/commit/d3136f6f198d3081943c17ac6890dbe14a81d112.diff";
       sha256 = "1f4wxn9422ndgq6dd0vqdxm2313srm7gn9nh82aas2xijdxlmz2c";
     })
+    (fetchpatch {
+      name = "bison-3.7-compat-1.patch";
+      url = "https://github.com/MiniZinc/libminizinc/commit/8d4dcf302e78231f7c2665150e8178cacd06f91c.patch";
+      sha256 = "1wgciyrqijv7b4wqha94is5skji8j7b9wq6fkdsnsimfd3xpxhqw";
+    })
+    (fetchpatch {
+      name = "bison-3.7-compat-2.patch";
+      url = "https://github.com/MiniZinc/libminizinc/commit/952ffda0bd23dc21f83d3e3f080ea5b3a414e8e0.patch";
+      sha256 = "0cnsfqw0hwm7rmazqnb99725rm2vdwab75vdpr5x5l3kjwsn76rj";
+    })
   ];
 
   meta = with stdenv.lib; {
@@ -37,7 +47,7 @@ stdenv.mkDerivation {
     '';
 
     license = licenses.mpl20;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.sheenobu ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of  #99034

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
