### PR TITLE
gegl_0_4: make vapi dependencies explicit

### DIFF
--- a/pkgs/development/libraries/gegl/4.0.nix
+++ b/pkgs/development/libraries/gegl/4.0.nix
@@ -45,6 +45,15 @@ stdenv.mkDerivation rec {
     sha256 = "097427icgpgvcx40019b3dm8m84cchz79pixzpz648drs8p1wdqg";
   };
 
+  patches = [
+    # fix build with darwin: https://github.com/NixOS/nixpkgs/issues/99108
+    # https://gitlab.gnome.org/GNOME/gegl/-/merge_requests/83
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gegl/-/merge_requests/83.patch";
+      sha256 = "CSBYbJ2xnEN23xrla1qqr244jxOR5vNK8ljBSXdg4yE=";
+    })
+  ];
+
   nativeBuildInputs = [
     pkgconfig
     gettext


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Hopefully address https://github.com/NixOS/nixpkgs/issues/99108

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
