### PR TITLE
lib/modules: Make sure to not import module _file's into the store

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -224,7 +224,7 @@ rec {
       if badAttrs != {} then
         throw "Module `${key}' has an unsupported attribute `${head (attrNames badAttrs)}'. This is caused by introducing a top-level `config' or `options' attribute. Add configuration attributes immediately on the top level instead, or move all of them (namely: ${toString (attrNames badAttrs)}) into the explicit `config' attribute."
       else
-        { _file = m._file or file;
+        { _file = toString m._file or file;
           key = toString m.key or key;
           disabledModules = m.disabledModules or [];
           imports = m.imports or [];
@@ -232,7 +232,7 @@ rec {
           config = addFreeformType (addMeta (m.config or {}));
         }
     else
-      { _file = m._file or file;
+      { _file = toString m._file or file;
         key = toString m.key or key;
         disabledModules = m.disabledModules or [];
         imports = m.require or [] ++ m.imports or [];


### PR DESCRIPTION
###### Motivation for this change

Previously if `_file` was specified by a module:

    trace: warning: The type `types.string' of option `foo' defined in `/nix/store/yxhm2il5yrb92fldgriw0wyqh2kk9qyc-bug.nix' is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.

With this change:

    trace: warning: The type `types.string' of option `foo' defined in `/home/infinisil/src/nixpkgs/bug.nix' is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.

###### Things done

- [x] Tested this with
    ```nix
    with import ./lib;
    evalModules {
      modules = [({ lib, ... }: {
        _file = ./bug.nix;
        options.foo = lib.mkOption {
          type = lib.types.string;
        };
      })];
    }
    ```
