### PR TITLE
precice: fix build, 2.0.2 -> 2.1.0, enable for darwin

### DIFF
--- a/pkgs/development/libraries/precice/default.nix
+++ b/pkgs/development/libraries/precice/default.nix
@@ -2,14 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "precice";
-  version = "2.0.2";
-  # Todo next release switch back to versioning but for python3 support master is needed
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "precice";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1s41wv2077d2gqj0wsxls6wkgdk9cgzcbmk2q43ha08ccq5i3dav";
+    sha256 = "1268dz39sx3gygnm7vpg59k1wdhy6rhf72i8i0kz4jckll0s9102";
   };
 
   cmakeFlags = [

--- a/pkgs/development/libraries/precice/default.nix
+++ b/pkgs/development/libraries/precice/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
     "-DPYTHON_INCLUDE_DIR=${python3}/include/${python3.libPrefix}m"
   ];
 
+  NIX_CFLAGS_COMPILE = lib.optional stdenv.isDarwin [ "-D_GNU_SOURCE" ];
+
   nativeBuildInputs = [ cmake gcc ];
   buildInputs = [ boost eigen libxml2 openmpi python3 python3.pkgs.numpy ];
   enableParallelBuilding = true;
@@ -26,7 +28,7 @@ stdenv.mkDerivation rec {
     description = "preCICE stands for Precise Code Interaction Coupling Environment";
     license = with lib.licenses; [ gpl3 ];
     homepage = "https://www.precice.org/";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ Scriptkiddi ];
   };
 }

--- a/pkgs/development/libraries/precice/default.nix
+++ b/pkgs/development/libraries/precice/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, gcc, boost, eigen, libxml2, openmpi, python3, python3Packages, petsc }:
+{ lib, stdenv, fetchFromGitHub, cmake, gcc, boost, eigen, libxml2, openmpi, python3, petsc }:
 
 stdenv.mkDerivation rec {
   pname = "precice";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake gcc ];
-  buildInputs = [ boost eigen libxml2 openmpi python3 python3Packages.numpy ];
+  buildInputs = [ boost eigen libxml2 openmpi python3 python3.pkgs.numpy ];
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2351,7 +2351,7 @@ in
 
   psstop = callPackage ../tools/system/psstop { };
 
-  precice = callPackage ../development/libraries/precice { };
+  precice = callPackage ../development/libraries/precice { python3 = python37; };
 
   pueue = callPackage ../applications/misc/pueue { };
 


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

This broke when `python3` was switched to 3.8: cmake gets confused with python 3.8's version number. Switch back to 3.7 for now until upstream's resolved that.

Bump to 2.1.0 while we're at it and enable for darwin because it builds for me macos 10.14

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
