### PR TITLE
noto-fonts-emoji: Work around Hydra silence timeouts on AArch64 by being noisy

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -141,6 +141,10 @@ in
       # remove check for virtualenv, since we handle
       # python requirements using python.withPackages
       sed -i '/ifndef VIRTUAL_ENV/,+2d' Makefile
+
+      # Make the build verbose so it won't get culled by Hydra thinking that
+      # it somehow got stuck doing nothing.
+      sed -i 's;\t@;\t;' Makefile
     '';
 
     enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

This package is timing out with the current situation of AArch64 builds on the organization's Hydra.

```
building of '/nix/store/m2ks0z3wgixmwq0xrjl9nmxinv1l15qn-noto-fonts-emoji-unstable-2020-08-20' timed out after 7200 seconds of silence
```

It seems to always be out of being silent. I have not **observed** a failure due to exhausting all its build time yet. My assumption is that file I/O is problematic on the somewhat overloaded AArch64 builders, and churning silently through thousands of files is breaking an assumption from Hydra: "silent builds are failing".

cc @worldofpeace @jonringer for a backport.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

~~(Currently building on my machine, I believe it'll end up building just fine.)~~ Took fifteen minutes to build, was noisy.