### PR TITLE
bottom: init at 0.4.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9706,4 +9706,14 @@
       fingerprint = "F1C5 760E 45B9 9A44 72E9  6BFB D65C 9AFB 4C22 4DA3";
     }];
   };
+  berbiche = {
+    name = "Nicolas Berbiche";
+    email = "nicolas@normie.dev";
+    github = "berbiche";
+    githubId = 20448408;
+    keys = [{
+      longkeyid = "rsa4096/0xB461292445C6E696";
+      fingerprint = "D446 E58D 87A0 31C7 EC15  88D7 B461 2924 45C6 E696";
+    }];
+  };
 }

--- a/pkgs/tools/system/bottom/default.nix
+++ b/pkgs/tools/system/bottom/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, rustPlatform, darwin }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "bottom";
+  version = "0.4.7";
+
+  src = fetchFromGitHub {
+    owner = "ClementTsang";
+    repo = pname;
+    rev = version;
+    sha256 = "rDcJ5XF7L13MKZ8/J4sYD+UqC+HkZvxRtDkY9IVLH50=";
+  };
+
+  buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.IOKit;
+
+  cargoSha256 = "XeX6QM0a628mcaptNZkKAvDnGfW5tx+aWNBpMyjz44M=";
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A cross-platform graphical process/system monitor with a customizable interface";
+    homepage = "https://github.com/ClementTsang/bottom";
+    license = licenses.mit;
+    maintainers = with maintainers; [ berbiche ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28175,4 +28175,6 @@ in
 
   fac-build = callPackage ../development/tools/build-managers/fac {};
 
+  bottom = callPackage ../tools/system/bottom {};
+
 }


### PR DESCRIPTION
##### Motivation for this change

bottom is "a cross-platform graphical process/system monitor with a customizable interface and a multitude of features".
[ytop](https://github.com/cjbassi/ytop) has been archived by its owner.
`bottom` has been recommended by `ytop`'s creator.

Some tests are failing because they call the binary and it tries to create its default file in `$XDG_CONFIG_HOME/bottom/bottom.toml`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
