### PR TITLE
nixos/tests: fix x11 tests

### DIFF
--- a/nixos/modules/config/fonts/fonts.nix
+++ b/nixos/modules/config/fonts/fonts.nix
@@ -35,19 +35,21 @@ with lib;
   config = {
 
     fonts.fonts = mkIf config.fonts.enableDefaultFonts
-      [
-        pkgs.xorg.fontbhlucidatypewriter100dpi
-        pkgs.xorg.fontbhlucidatypewriter75dpi
+      ([
         pkgs.dejavu_fonts
         pkgs.freefont_ttf
         pkgs.gyre-fonts # TrueType substitutes for standard PostScript fonts
         pkgs.liberation_ttf
-        pkgs.xorg.fontbh100dpi
         pkgs.xorg.fontmiscmisc
         pkgs.xorg.fontcursormisc
         pkgs.unifont
         pkgs.noto-fonts-emoji
-      ];
+      ] ++ lib.optionals (config.nixpkgs.config.allowUnfree or false) [
+        # these are unfree, and will make usage with xserver fail
+        pkgs.xorg.fontbhlucidatypewriter100dpi
+        pkgs.xorg.fontbhlucidatypewriter75dpi
+        pkgs.xorg.fontbh100dpi
+      ]);
 
   };
 


### PR DESCRIPTION

###### Motivation for this change
when trying to fix the plasma tests to fix https://github.com/NixOS/nixpkgs/pull/98657#issuecomment-701060595 I stumbled onto the fact that all plasma tests are broken in master right now

git bisect'd it to https://github.com/NixOS/nixpkgs/commit/c45160366b824a2d7a70c14b9ef1f797718fdd45

this is because the nixos tests don't allow for unfree fonts.
example error:
```
$ nix-build -A nixosTests.plasma5
error: Package ‘font-bh-lucidatypewriter-100dpi-1.0.3’ in /home/jon/projects/nixpkgs/pkgs/servers/x11/xorg/default.nix:199 has an unfree license (‘unfree’), refusing to evaluate.

a) For `nixos-rebuild` you can set
  { nixpkgs.config.allowUnfree = true; }
in configuration.nix to override this.

b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
  { allowUnfree = true; }
to ~/.config/nixpkgs/config.nix.

(use '--show-trace' to show detailed location information)
```

This PR is just a "quick fix". not sure what ramification this will have normal users

broken tests:
```
[19:42:41] jon@nixos ~/projects/nixpkgs/nixos/tests (fix-nixos-tests)
$ rg xserver -l
lightdm.nix
xfce.nix
xautolock.nix
xmonad.nix
pt2-clone.nix
signal-desktop.nix
networking-proxy.nix
gnome3.nix
gnome3-xorg.nix
i3wm.nix
common/auto.nix
common/x11.nix
plasma5.nix
enlightenment.nix
pantheon.nix
keymap.nix
shattered-pixel-dungeon.nix
sddm.nix
virtualbox.nix
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
