### PR TITLE
[20.09] kdeApplications: expose missing packages, fix hydra

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14899,7 +14899,8 @@ in
       kmime kontactinterface kpimtextedit kpkpass kqtquickcharts ksmtp ktnef
       libgravatar libkcddb libkdcraw libkdegames libkdepim libkexiv2 libkgapi
       libkipi libkleo libkmahjongg libkomparediff2 libksane libksieve mailcommon
-      mailimporter messagelib pim-sieve-editor pimcommon;
+      mailimporter messagelib pim-sieve-editor pimcommon kdegraphics-thumbnailers
+      kio-extras print-manager;
 
     ### LIBRARIES
 
@@ -21324,7 +21325,7 @@ in
         inherit (forQt512)
           ark
           bomber bovo
-          dolphin dragon
+          dolphin dolphin-plugins dragon
           ffmpegthumbs filelight
           granatier gwenview
           k3b


### PR DESCRIPTION
###### Motivation for this change
fixes `nixosTests.plasma5`
fixes https://github.com/NixOS/nixpkgs/pull/98657#issuecomment-701060595

fixes broken hydra eval  https://hydra.nixos.org/jobset/nixos/release-20.09#tabs-errors

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
