### PR TITLE
pythonPackages.protobuf: fix cross-compilation

### DIFF
--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchpatch, python, buildPythonPackage, isPy37
+{ buildPackages, stdenv, fetchpatch, python, buildPythonPackage, isPy37
 , protobuf, google_apputils, pyext, libcxx, isPy27
 , disabled, doCheck ? true }:
 
 with stdenv.lib;
 
 buildPythonPackage {
-  inherit (protobuf) name src version;
+  inherit (protobuf) pname src version;
   inherit disabled;
   doCheck = doCheck && !isPy27; # setuptools>=41.4 no longer collects correctly on python2
 
@@ -15,8 +15,10 @@ buildPythonPackage {
     ++ optional (versionOlder protobuf.version "2.7.0") "-std=c++98"
   );
 
+  outputs = [ "out" "dev" ];
+
   propagatedBuildInputs = [ google_apputils ];
-  propagatedNativeBuildInputs = [ protobuf ];  # For protoc.
+  propagatedNativeBuildInputs = [ buildPackages.protobuf ];  # For protoc.
   nativeBuildInputs = [ google_apputils pyext ];
   buildInputs = [ protobuf ];
 
@@ -43,9 +45,9 @@ buildPythonPackage {
 
   preBuild = ''
     # Workaround for https://github.com/google/protobuf/issues/2895
-    ${python.interpreter} setup.py build
+    ${python.pythonForBuild.interpreter} setup.py build
   '' + optionalString (versionAtLeast protobuf.version "2.6.0") ''
-    ${python.interpreter} setup.py build_ext --cpp_implementation
+    ${python.pythonForBuild.interpreter} setup.py build_ext --cpp_implementation
   '';
 
   installFlags = optional (versionAtLeast protobuf.version "2.6.0")


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes cross-compilation of the protobuf Python library. This may need #98915 to actually successfully cross-compile (I haven't tested it without it), but I don't think that needs to block merging this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Ericson2314 @jonringer @dotlambda @delroth 