### PR TITLE
ocamlPackages.earley: 2.0.0 → 3.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/earley/default.nix
+++ b/pkgs/development/ocaml-modules/earley/default.nix
@@ -1,18 +1,23 @@
-{ lib, fetchurl, ocaml, buildDunePackage }:
-
-if lib.versionAtLeast ocaml.version "4.08"
-then throw "earley is not available for OCaml ${ocaml.version}"
-else
+{ lib, fetchFromGitHub, ocaml, buildDunePackage
+, stdlib-shims
+}:
 
 buildDunePackage rec {
-  version = "2.0.0";
+  version = "3.0.0";
   pname = "earley";
-  src = fetchurl {
-    url = "https://github.com/rlepigre/ocaml-earley/releases/download/${version}/earley-${version}.tbz";
-    sha256 = "1kjr0wh3lji7f493kf48rphxnlv3sygj5a8rmx9z3xkpbd7aqyyw";
+  src = fetchFromGitHub {
+    owner = "rlepigre";
+    repo = "ocaml-earley";
+    rev = version;
+    sha256 = "1vi58zdxchpw6ai0bz9h2ggcmg8kv57yk6qbx82lh47s5wb3mz5y";
   };
 
-  minimumOCamlVersion = "4.03";
+  minimumOCamlVersion = "4.07";
+  useDune2 = true;
+
+  buildInputs = [ stdlib-shims ];
+
+  doCheck = true;
 
   meta = {
     description = "Parser combinators based on Earley Algorithm";


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml ≥ 4.08

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
