### PR TITLE
Revert "nixos/gnome3: launch gnome-shell wayland with RT scheduling"

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -289,26 +289,6 @@ in
         source-sans-pro
       ];
 
-      ## Enable soft realtime scheduling, only supported on wayland ##
-
-      security.wrappers.".gnome-shell-wrapped" = {
-        source = "${pkgs.gnome3.gnome-shell}/bin/.gnome-shell-wrapped";
-        capabilities = "cap_sys_nice=ep";
-      };
-
-      systemd.user.services.gnome-shell-wayland = let
-        gnomeShellRT = with pkgs.gnome3; pkgs.runCommand "gnome-shell-rt" {} ''
-          mkdir -p $out/bin/
-          cp ${gnome-shell}/bin/gnome-shell $out/bin
-          sed -i "s@${gnome-shell}/bin/@${config.security.wrapperDir}/@" $out/bin/gnome-shell
-        '';
-      in {
-        # Note we need to clear ExecStart before overriding it
-        serviceConfig.ExecStart = ["" "${gnomeShellRT}/bin/gnome-shell"];
-        # Do not use the default environment, it provides a broken PATH
-        environment = mkForce {};
-      };
-
       # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/blob/gnome-3-36/elements/core/meta-gnome-core-shell.bst
       environment.systemPackages = with pkgs.gnome3; [
         adwaita-icon-theme


### PR DESCRIPTION
###### Motivation for this change
This reverts commit 927a6fdaad493044f2344cba73e6310d3450ca00.

Fixes:
https://github.com/NixOS/nixpkgs/issues/90201
https://github.com/NixOS/nixpkgs/issues/90184
https://github.com/NixOS/nixpkgs/issues/86730

That commit adds support for an experimental feature that is disabled by default and has caused multiple people to waste hours debugging. [To quote the author of the commit](https://github.com/NixOS/nixpkgs/issues/90201#issuecomment-683304279):

>I've kinda forgot about the issue, but we should probably disable the wrapper for now since it breaks things (would be nice to get into 20.09). Regardless of our understanding the underlying issue, it's a fairly minor feature which probably aren't used by many people (especially since it's not enabled by default).

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
