### PR TITLE
python3Packages.transformers: 3.2.0 -> 3.3.1

### DIFF
--- a/pkgs/development/python-modules/transformers/default.nix
+++ b/pkgs/development/python-modules/transformers/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "transformers";
-  version = "3.2.0";
+  version = "3.3.1";
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0jj94153kgdyklra30xcszxv11hwzfigzy82fgvgzvbwlxv3a1j5";
+    sha256 = "1j9nzhl0zw5z9rnvzfih7v6bax353rxp05b3f0cvkii3b5dbkc2j";
   };
 
   propagatedBuildInputs = [
@@ -52,9 +52,12 @@ buildPythonPackage rec {
   preCheck = ''
     export HOME="$TMPDIR"
 
-    # This test requires the nlp module, which we haven't
-    # packaged yet. However, nlp is optional for transformers
-    # itself
+    # This test requires the `datasets` module to download test
+    # data. However, since we cannot download in the Nix sandbox
+    # and `dataset` is an optional dependency for transformers
+    # itself, we will just remove the tests files that import
+    # `dataset`.
+    rm tests/test_retrieval_rag.py
     rm tests/test_trainer.py
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Changes:

https://github.com/huggingface/transformers/releases/tag/v3.3.0
https://github.com/huggingface/transformers/releases/tag/v3.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).