### PR TITLE
generate-expr-from-tarballs.pl: fix insecure temporary file

### DIFF
--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -11,8 +11,7 @@ use warnings;
 
 use File::Basename;
 use File::Spec::Functions;
-
-my $tmpDir = "/tmp/xorg-unpack";
+use File::Temp;
 
 
 my %pkgURLs;
@@ -93,8 +92,7 @@ while (<>) {
     $pkgHashes{$pkg} = $hash;
 
     print "\nunpacking $path\n";
-    system "rm -rf '$tmpDir'";
-    mkdir $tmpDir, 0700;
+    my $tmpDir = File::Temp->newdir();
     system "cd '$tmpDir' && tar xf '$path'";
     die "cannot unpack `$path'" if $? != 0;
     print "\n";


### PR DESCRIPTION
##### Motivation for this change
https://cwe.mitre.org/data/definitions/377.html

###### Things done
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
