### PR TITLE
libjpeg: 2.0.4 -> 2.0.5

### DIFF
--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -1,30 +1,18 @@
-{ stdenv, fetchurl, fetchpatch, cmake, nasm, enableStatic ? false, enableShared ? true }:
+{ stdenv, fetchFromGitHub, cmake, nasm, enableStatic ? false, enableShared ? true }:
 
 stdenv.mkDerivation rec {
 
   pname = "libjpeg-turbo";
-  version = "2.0.4";
+  version = "2.0.5";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "01ill8bgjyk582wipx7sh7gj2nidylpbzvwhx0wkcm6mxx3qbp9k";
+  src = fetchFromGitHub {
+    owner = "libjpeg-turbo";
+    repo = "libjpeg-turbo";
+    rev = version;
+    sha256 = "0p32yivybxdicm01qa9h1vj91apygzxpvnklrjmbx8z9z2l3qxc9";
   };
 
   patches =
-    [
-      # Fixes race in tests that causes "jpegtran-shared-icc" to fail
-      # https://github.com/libjpeg-turbo/libjpeg-turbo/pull/425
-      (fetchpatch {
-        url = "https://github.com/libjpeg-turbo/libjpeg-turbo/commit/a2291b252de1413a13db61b21863ae7aea0946f3.patch";
-        sha256 = "0nc5vcch5h52gpi07h08zf8br58q8x81q2hv871hrn0dinb53vym";
-      })
-
-      (fetchpatch {
-        name = "cve-2020-13790.patch";
-        url = "https://github.com/libjpeg-turbo/libjpeg-turbo/commit/3de15e0c344d.diff";
-        sha256 = "0hm5i6qir5w3zxb0xvqdh4jyvbfg7xnd28arhyfsaclfz9wdb0pb";
-      })
-    ] ++
     stdenv.lib.optional (stdenv.hostPlatform.libc or null == "msvcrt")
       ./mingw-boolean.patch;
 
@@ -41,7 +29,7 @@ stdenv.mkDerivation rec {
   installCheckTarget = "test";
 
   meta = with stdenv.lib; {
-    homepage = "http://libjpeg-turbo.virtualgl.org/";
+    homepage = "https://libjpeg-turbo.org/";
     description = "A faster (using SIMD) libjpeg implementation";
     license = licenses.ijg; # and some parts under other BSD-style licenses
     maintainers = with maintainers; [ vcunat colemickens ];


### PR DESCRIPTION
###### Motivation for this change
https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/2.0.5

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
