### PR TITLE
spidermonkey: remove spidermonkey_38 -> spidermonkey alias

### DIFF
--- a/pkgs/applications/networking/browsers/elinks/default.nix
+++ b/pkgs/applications/networking/browsers/elinks/default.nix
@@ -4,7 +4,7 @@
   enableGuile        ? false,                                         guile ? null
 , enablePython       ? false,                                         python ? null
 , enablePerl         ? (stdenv.hostPlatform == stdenv.buildPlatform), perl ? null
-, enableSpidermonkey ? (stdenv.hostPlatform == stdenv.buildPlatform), spidermonkey ? null
+, enableSpidermonkey ? (stdenv.hostPlatform == stdenv.buildPlatform), spidermonkey_38 ? null
 }:
 
 assert enableGuile -> guile != null;
@@ -33,9 +33,9 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional enableGuile guile
     ++ stdenv.lib.optional enablePython python
     ++ stdenv.lib.optional enablePerl perl
-    ++ stdenv.lib.optional enableSpidermonkey spidermonkey
+    ++ stdenv.lib.optional enableSpidermonkey spidermonkey_38
     ;
-  
+
   nativeBuildInputs = [ autoconf automake gettext pkgconfig ];
 
   configureFlags = [
@@ -50,9 +50,9 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional enableGuile        "--with-guile"
     ++ stdenv.lib.optional enablePython       "--with-python"
     ++ stdenv.lib.optional enablePerl         "--with-perl"
-    ++ stdenv.lib.optional enableSpidermonkey "--with-spidermonkey=${spidermonkey}"
+    ++ stdenv.lib.optional enableSpidermonkey "--with-spidermonkey=${spidermonkey_38}"
     ;
-  
+
   preConfigure = ''
     patchShebangs ./autogen.sh
     ./autogen.sh

--- a/pkgs/applications/networking/pyload/default.nix
+++ b/pkgs/applications/networking/pyload/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, pythonPackages, gocr, unrar, rhino, spidermonkey }:
+{ stdenv, fetchFromGitHub, fetchpatch, pythonPackages, gocr, unrar, rhino, spidermonkey_38 }:
 
 let
   beautifulsoup = pythonPackages.callPackage ./beautifulsoup.nix {
@@ -30,7 +30,7 @@ in pythonPackages.buildPythonApplication rec {
     in [ configParserPatch setupPyPatch ];
 
   buildInputs = [
-    unrar rhino spidermonkey gocr pythonPackages.paver
+    unrar rhino spidermonkey_38 gocr pythonPackages.paver
   ];
 
   propagatedBuildInputs = with pythonPackages; [

--- a/pkgs/development/interpreters/spidermonkey/38.nix
+++ b/pkgs/development/interpreters/spidermonkey/38.nix
@@ -67,5 +67,6 @@ stdenv.mkDerivation rec {
 
     maintainers = [ maintainers.abbradar ];
     platforms = platforms.unix;
+    knownVulnerabilities = [ "SpiderMonkey 38 is outdated and contains known security vulnerabilities." ]; # as per https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Releases/38
   };
 }

--- a/pkgs/tools/misc/plowshare/default.nix
+++ b/pkgs/tools/misc/plowshare/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, curl, recode, spidermonkey }:
+{ stdenv, fetchFromGitHub, makeWrapper, curl, recode, spidermonkey_38 }:
 
 stdenv.mkDerivation rec {
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     make PREFIX="$out" install
 
     for fn in plow{del,down,list,mod,probe,up}; do
-      wrapProgram "$out/bin/$fn" --prefix PATH : "${stdenv.lib.makeBinPath [ curl recode spidermonkey ]}"
+      wrapProgram "$out/bin/$fn" --prefix PATH : "${stdenv.lib.makeBinPath [ curl recode spidermonkey_38 ]}"
     done
   '';
 

--- a/pkgs/tools/text/jsawk/default.nix
+++ b/pkgs/tools/text/jsawk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, spidermonkey }:
+{ stdenv, fetchFromGitHub, makeWrapper, spidermonkey_38 }:
 
 stdenv.mkDerivation {
   pname = "jsawk";
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     cp $src/jsawk $out/bin/
     wrapProgram $out/bin/jsawk \
-      --prefix PATH : "${spidermonkey}/bin"
+      --prefix PATH : "${spidermonkey_38}/bin"
   '';
 
   meta = {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -658,6 +658,7 @@ mapAliases ({
   youtubeDL = youtube-dl;  # added 2014-10-26
   zdfmediathk = mediathekview; # added 2019-01-19
   gnome_user_docs = gnome-user-docs; # added 2019-11-20
+  spidermonkey = spidermonkey_68; # added 2020-09-30
 
   # TODO(ekleog): add ‘wasm’ alias to ‘ocamlPackages.wasm’ after 19.03
   # branch-off


### PR DESCRIPTION
This removes the spidermonkey alias and renames it in the packages still 
using it

Not sure if we need it in aliases.nix since just about nothing depends 
on it anymore

Additionally considering removal should be a good choice, it's at least 
insecure so it should get tagged as such

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
