### PR TITLE
nixos/initrd-ssh: set more defensive pemissions on sshd test key

### DIFF
--- a/nixos/modules/system/boot/initrd-ssh.nix
+++ b/nixos/modules/system/boot/initrd-ssh.nix
@@ -159,9 +159,14 @@ in
 
     boot.initrd.extraUtilsCommandsTest = ''
       # sshd requires a host key to check config, so we pass in the test's
+      tmpkey="$(mktemp initrd-ssh-testkey.XXXXXXXXXX)"
+      cp "${../../../tests/initrd-network-ssh/ssh_host_ed25519_key}" "$tmpkey"
+      # keys from Nix store are world-readable, which sshd doesn't like
+      chmod 600 "$tmpkey"
       echo -n ${escapeShellArg sshdConfig} |
         $out/bin/sshd -t -f /dev/stdin \
-        -h ${../../../tests/initrd-network-ssh/ssh_host_ed25519_key}
+        -h "$tmpkey"
+      rm "$tmpkey"
     '';
 
     boot.initrd.network.postCommands = ''


### PR DESCRIPTION
###### Motivation for this change

Make `nixos-install` not fail on `extraUtilsCommandsTest` for initrd-ssh.

It looks like the test sshd key can never be used, because of too open permissions in the store. But since sshd tries all available keys one by one, my guess is that the test script starts working fine once the user defined ssh-hostkey has been copied into initrd.

At "nixos-install" however, the user specified host key is not present in initrd fs yet and validation fails.

fixes #91486

cc @sorpaas @reyman @emilazy

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
