### PR TITLE
libcoap: 4.2.0 -> 4.2.1

### DIFF
--- a/pkgs/applications/networking/libcoap/default.nix
+++ b/pkgs/applications/networking/libcoap/default.nix
@@ -1,13 +1,13 @@
 { fetchFromGitHub, automake, autoconf, which, pkgconfig, libtool, stdenv }:
 stdenv.mkDerivation rec {
   pname = "libcoap";
-  version = "4.2.0";
+  version = "4.2.1";
   src = fetchFromGitHub {
     repo = "libcoap";
     owner = "obgm";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "0mmvkq72i4rda6b7g93qrwg2nwh2rvkq4xw70yppj51hsdrnpfl7";
+    sha256 = "1jkvha52lic13f13hnppizkl80bb2rciayb5hxici0gj6spphgha";
   };
   nativeBuildInputs = [
     automake


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Upstream release.

The [changelog](https://github.com/obgm/libcoap/blob/develop/ChangeLog) doesn't contain anything for this release, but it fixes a bug with `Uri-Query` options for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
