### PR TITLE
meson: Remove propagated native C compiler

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -3,7 +3,6 @@
 , stdenv
 , writeTextDir
 , substituteAll
-, pkgsHostHost
 , fetchpatch
 }:
 
@@ -62,10 +61,6 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   setupHook = ./setup-hook.sh;
-
-  # Ensure there will always be a native C compiler when meson is used, as a
-  # workaround until https://github.com/mesonbuild/meson/pull/6512 lands.
-  depsHostHostPropagated = [ pkgsHostHost.stdenv.cc ];
 
   # 0.45 update enabled tests but they are failing
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

Now that we have a Meson release containting [1], Meson will work fine
without a native compiler, so we don't need this trick anymore.

Fixes #58831

[1]: https://github.com/mesonbuild/meson/pull/6512

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @leotaku