### PR TITLE
python3Packages.fsspec: fix tests on linux

### DIFF
--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -24,13 +24,18 @@ buildPythonPackage rec {
     numpy
   ];
 
+  pytestFlagsArray = [ "--rootdir=$(mktemp -d)" ];
+
   disabledTests = [
     # Test assumes user name is part of $HOME
     # AssertionError: assert 'nixbld' in '/homeless-shelter/foo/bar'
     "test_strip_protocol_expanduser"
   ] ++ lib.optionals (stdenv.isDarwin) [
-    "test_modified" # fails on hydra, works locally
-    "test_touch" # fails on hydra, works locally
+    # works locally on APFS, fails on hydra with AssertionError comparing timestamps
+    # darwin hydra builder uses HFS+ and has only one second timestamp resolution
+    # this two tests however, assume nanosecond resolution
+    "test_modified"
+    "test_touch"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #97479

cc: @NixOS/nixos-release-managers 

Hydra fails with a `DirectoryError: [Errno 21] Is a directory: '/build/source/fsspec/tests/__pycache__'`.
I suspect that both drvs `python37Packages.fsspec` and `python38Packages.fsspec` share the same folder/file
`'/build/source/fsspec/tests/__pycache__'` which leads to problems. To fix it I just let each drvs run in a
tmp directory using `pytestFlagsArray = [ "--rootdir=$(mktemp -d)" ];`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
