### PR TITLE
timescale-prometheus -> promscale: 0.1.0-beta.4 -> 0.1.0-beta.5

### DIFF
--- a/pkgs/servers/monitoring/prometheus/promscale.nix
+++ b/pkgs/servers/monitoring/prometheus/promscale.nix
@@ -4,8 +4,8 @@
 }:
 
 buildGoModule rec {
-  pname = "timescale-prometheus";
-  version = "0.1.0-beta.4";
+  pname = "promscale";
+  version = "0.1.0-beta.5";
 
   src = fetchFromGitHub {
     owner = "timescale";
@@ -16,13 +16,13 @@ buildGoModule rec {
 
   vendorSha256 = "sha256:0y5rq2y48kf2z1z3a8ags6rqzfvjs54klk2679fk8x0yjamj5x04";
 
-  buildFlagsArray = [ "-ldflags=-s -w -X github.com/timescale/timescale-prometheus/pkg/version.Version=${version} -X github.com/timescale/timescale-prometheus/pkg/version.CommitHash=${src.rev}" ];
+  buildFlagsArray = [ "-ldflags=-s -w -X github.com/timescale/promscale/pkg/version.Version=${version} -X github.com/timescale/promscale/pkg/version.CommitHash=${src.rev}" ];
 
   doCheck = false;
 
   meta = with stdenv.lib; {
     description = "An open-source analytical platform for Prometheus metrics";
-    homepage = "https://github.com/timescale/timescale-prometheus";
+    homepage = "https://github.com/timescale/promscale";
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [ _0x4A6F ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -597,6 +597,7 @@ mapAliases ({
   tex-gyre-schola-math = tex-gyre-math.schola; # added 2018-04-03
   tex-gyre-termes-math = tex-gyre-math.termes; # added 2018-04-03
   tftp_hpa = tftp-hpa; # added 2015-04-03
+  timescale-prometheus = promscale; # added 2020-09-29
   tomcat85 = tomcat8; # added 2020-03-11
   torbrowser = tor-browser-bundle-bin; # added 2017-04-05
   torch = throw "torch has been removed, as the upstream project has been abandoned"; # added 2020-03-28

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16962,7 +16962,7 @@ in
     asciidoc = asciidoc-full;
   };
 
-  timescale-prometheus = callPackage ../servers/monitoring/timescale-prometheus { };
+  promscale = callPackage ../servers/monitoring/prometheus/promscale.nix { };
 
   timescaledb-parallel-copy = callPackage ../development/tools/database/timescaledb-parallel-copy { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Rename to upgraded [promscale 0.1.0-beta.5](https://github.com/timescale/promscale/releases/tag/0.1.0-beta.5).

Move into `prometheus` directory, as this is a [remote_read](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_read) and [remote_write](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) provider.

Tested with #97372.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
