### PR TITLE
ocamlPackages.{ipaddr,macaddr}*: 5.0.0 → 5.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/macaddr/default.nix
+++ b/pkgs/development/ocaml-modules/macaddr/default.nix
@@ -4,13 +4,13 @@
 
 buildDunePackage rec {
   pname = "macaddr";
-  version = "5.0.0";
+  version = "5.0.1";
 
   minimumOCamlVersion = "4.04";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-ipaddr/archive/v${version}.tar.gz";
-    sha256 = "1j2m2v64g3d81sixxq3g57j1iyk6042ivsszml18akrqvwfpxy66";
+    sha256 = "0ffqkhmnj8l085xgl7jxhs3ld9zsd9iavdg06nnhr1i9g1aayk1b";
   };
 
   checkInputs = [ ppx_sexp_conv ounit ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

[bug fix release](https://github.com/mirage/ocaml-ipaddr/releases/tag/v5.0.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
