### PR TITLE
python3Packages.graspy: rename to python3Packages.graspologic

### DIFF
--- a/pkgs/development/python-modules/graspologic/default.nix
+++ b/pkgs/development/python-modules/graspologic/default.nix
@@ -14,14 +14,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "graspy";
+  pname = "graspologic";
   version = "0.3";
 
   disabled = isPy27;
 
   src = fetchFromGitHub {
-    owner = "neurodata";
-    repo = pname;
+    owner = "microsoft";
+    repo = "graspologic";
     rev = "v${version}";
     sha256 = "0lab76qiryxvwl6zrcikhnxil1xywl0wkkm2vzi4v9mdzpa7w29r";
   };
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://graspy.neurodata.io";
     description = "A package for graph statistical algorithms";
-    license = licenses.asl20;
+    license = licenses.asl20;  # changing to `licenses.mit` in next release
     maintainers = with maintainers; [ bcdarwin ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2544,7 +2544,7 @@ in {
 
   grappelli_safe = callPackage ../development/python-modules/grappelli_safe { };
 
-  graspy = callPackage ../development/python-modules/graspy { };
+  graspologic = callPackage ../development/python-modules/graspologic { };
 
   greatfet = callPackage ../development/python-modules/greatfet { };
 


### PR DESCRIPTION
neurodata/graspy has merged with microsoft/topologic and now redirects to microsoft/graspologic.

There hasn't been a new release since the merger, so this is only a metadata change (note the source hash is the same).

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
