### PR TITLE
nixadd: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4035,6 +4035,12 @@
     githubId = 60272884;
     name = "Jonathan Jeppener-Haltenhoff";
   };
+  joelancaster = {
+    email = "joe.a.lancas@gmail.com";
+    github = "joelancaster";
+    githubId = 16760945;
+    name = "Joe Lancaster";
+  };
   joelburget = {
     email = "joelburget@gmail.com";
     github = "joelburget";

--- a/pkgs/tools/nix/nixadd/default.nix
+++ b/pkgs/tools/nix/nixadd/default.nix
@@ -1,0 +1,24 @@
+{stdenv, fetchFromGitHub, gcc}:
+
+stdenv.mkDerivation rec {
+  pname = "nixadd";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "JoeLancaster";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "120jxmvalcb68qhywa1izlimchgvzgjpbdsv907iyd9fpmwli7kf";
+  };
+  installPhase = ''
+                 mkdir -p $out
+                 make DESTDIR=$out install
+                 '';
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/${owner}/${pname}";
+    description = "Adds packages declaratively on the command line";
+    licence = licence.gpl3;
+    maintainers = with maintainers; [ joelancaster ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27300,6 +27300,8 @@ in
 
   nix-simple-deploy = callPackage ../tools/package-management/nix-simple-deploy { };
 
+  nixadd = callPackage ../tools/nix/nixadd { };
+
   nixfmt = haskell.lib.justStaticExecutables haskellPackages.nixfmt;
 
   nixpkgs-fmt = callPackage ../tools/nix/nixpkgs-fmt { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I wanted a tool to add NixOS packages with a single command (nix-env -i style) that still works declaratively and leaves my system congruent to my configuration.nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
