### PR TITLE
qubes-core-vchan-xen: 4.1.2 -> 4.1.4

### DIFF
--- a/pkgs/applications/qubes/qubes-core-vchan-xen/default.nix
+++ b/pkgs/applications/qubes/qubes-core-vchan-xen/default.nix
@@ -1,20 +1,25 @@
-{ stdenv, fetchFromGitHub, xen_4_10 }:
+{ stdenv
+, fetchFromGitHub
+, xen_4_10
+}:
 
 stdenv.mkDerivation rec {
   pname = "qubes-core-vchan-xen";
-  version = "4.1.2";
+  version = "4.1.4";
 
   src = fetchFromGitHub {
     owner = "QubesOS";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1wj4vv8nkzzig52r2nzkd4jy0cwznfkyddx379hfsdl4pzsp55mj";
+    sha256 = "sha256:02l1vs5c2jfw22gxvl2fb66m0d99n8ya1i7rphsb5cxsljvxary0";
   };
 
   buildInputs = [ xen_4_10 ];
+
   buildPhase = ''
-    make all PREFIX=/
+    make all PREFIX=/ LIBDIR="$out/lib" INCLUDEDIR="$out/include"
   '';
+
   installPhase = ''
     make install DESTDIR=$out PREFIX=/
   '';
@@ -26,4 +31,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ _0x4A6F ];
     platforms = platforms.linux;
   };
+
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade to [4.1.4](https://github.com/QubesOS/qubes-core-vchan-xen/releases/tag/v4.1.4).
Fix generation of `pkgconfig/vchan-xen.pc`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
