### PR TITLE
python3Packages.fastecdsa: init at 2.1.5

### DIFF
--- a/pkgs/development/python-modules/fastecdsa/default.nix
+++ b/pkgs/development/python-modules/fastecdsa/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, gmp
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "fastecdsa";
+  version = "2.1.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d0772f7fe243e8a82d33e95c542ea6cc0ef7f3cfcced7440d6defa71a35addfa";
+  };
+
+  buildInputs = [ gmp ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  # skip tests which require being online to download test vectors
+  pytestFlags = [
+     "--ignore=fastecdsa/tests/test_wycheproof_vectors.py"
+     "--ignore=fastecdsa/tests/test_rfc6979_ecdsa.py"
+  ];
+
+  # skip tests for now, they fail with
+  # ImportError: cannot import name '_ecdsa' from 'fastecdsa'
+  # but the installed package works just fine
+  doCheck = false;
+
+  pythonImportsCheck = [ "fastecdsa" ];
+
+  meta = with lib; {
+    description = "Fast elliptic curve digital signatures";
+    homepage = "https://github.com/AntonKueltz/fastecdsa";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2012,6 +2012,8 @@ in {
 
   fastdtw = callPackage ../development/python-modules/fastdtw { };
 
+  fastecdsa = callPackage ../development/python-modules/fastecdsa { };
+
   fasteners = callPackage ../development/python-modules/fasteners { };
 
   fastentrypoints = callPackage ../development/python-modules/fastentrypoints { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

new python module for fast ecdsa operations

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
