### PR TITLE
nixos/borgbackup: Borgbackup retry

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -93,6 +93,8 @@ let
           ++ cfg.readWritePaths
           # Borg needs write access to repo if it is not remote
           ++ optional (isLocalPath cfg.repo) cfg.repo;
+        Restart = if cfg.restartSec == null then "no" else "on-failure";
+        RestartSec = cfg.restartSec;
         PrivateTmp = cfg.privateTmp;
       };
       environment = {
@@ -315,6 +317,19 @@ in {
             '';
             default = "+%Y-%m-%dT%H:%M:%S";
             example = "-u +%s";
+          };
+
+          restartSec = mkOption {
+            type = with types; nullOr (either str (listOf str));
+            default = null;
+            description = ''
+              Whether and how soon a failed backup should be restarted.
+              Must be in the format described in
+              <citerefentry><refentrytitle>systemd.service</refentrytitle>
+              <manvolnum>7</manvolnum></citerefentry>.
+              If you do not want a failed backup to restart
+              automatically, use <literal>null</literal>.
+            '';
           };
 
           startAt = mkOption {

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -359,7 +359,8 @@ in {
               (in seconds) or a time span value, e.g.,
               <literal>"5min 20s"</literal>.
               If you do not want a failed backup to restart automatically, use
-              <literal>null</literal>.  '';
+              <literal>null</literal>.
+            '';
             example = "10 min";
           };
 

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -339,7 +339,11 @@ in {
             description = ''
               Backups are delayed by a uniformly random amount of time up to
               the value. Useful to stagger remote backups on a weak network
-              connection.
+              connection. Must be in the format described in
+              <citerefentry><refentrytitle>systemd.time</refentrytitle>
+              <manvolnum>7</manvolnum></citerefentry>. Either a unit-less value
+              (in seconds) or a time span value, e.g.,
+              <literal>"5min 20s"</literal>.
             '';
             example = "5 min";
           };
@@ -350,11 +354,12 @@ in {
             description = ''
               Whether and how soon a failed backup should be restarted.
               Must be in the format described in
-              <citerefentry><refentrytitle>systemd.service</refentrytitle>
-              <manvolnum>7</manvolnum></citerefentry>.
-              If you do not want a failed backup to restart
-              automatically, use <literal>null</literal>.
-            '';
+              <citerefentry><refentrytitle>systemd.time</refentrytitle>
+              <manvolnum>7</manvolnum></citerefentry>. Either a unit-less value
+              (in seconds) or a time span value, e.g.,
+              <literal>"5min 20s"</literal>.
+              If you do not want a failed backup to restart automatically, use
+              <literal>null</literal>.  '';
             example = "10 min";
           };
 

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -349,7 +349,7 @@ in {
           };
 
           restartSec = mkOption {
-            type = with types; nullOr (either str (listOf str));
+            type = with types; nullOr str;
             default = null;
             description = ''
               Whether and how soon a failed backup should be restarted.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I was lacking an option to specify borgbackup jobs should restart if
they failed. My remote borg repo isn't always available so setting up
weekly backups wasn't very useful. The backups failed every time so my
files were never backed up. Specifying `Restart=on-failure` and
`RestartSec=X min` should prevent spurious failures from ruining your
day when it comes time to restore your non-existent backups : )

###### Things done

I've run this patch (applied at nixos-19.09) for quite a while now and it's worked like a charm.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
