### PR TITLE
r128gain: 1.0.1 -> 1.0.3

### DIFF
--- a/pkgs/applications/audio/r128gain/default.nix
+++ b/pkgs/applications/audio/r128gain/default.nix
@@ -1,6 +1,8 @@
 { lib
 , fetchFromGitHub
+, genericUpdater
 , substituteAll
+, common-updater-scripts
 , ffmpeg_3
 , python3Packages
 , sox
@@ -32,6 +34,13 @@ python3Packages.buildPythonApplication rec {
   # Testing downloads media files for testing, which requires the
   # sandbox to be disabled.
   doCheck = false;
+
+  passthru = {
+    updateScript = genericUpdater {
+      inherit pname version;
+      versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
+    };
+  };
 
   meta = with lib; {
     description = "Fast audio loudness scanner & tagger (ReplayGain v2 / R128)";

--- a/pkgs/applications/audio/r128gain/default.nix
+++ b/pkgs/applications/audio/r128gain/default.nix
@@ -10,13 +10,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "r128gain";
-  version = "1.0.1";
+  version = "1.0.3";
 
   src = fetchFromGitHub {
     owner = "desbma";
     repo = "r128gain";
     rev = version;
-    sha256 = "0fnxis2g7mw8mb0cz9bws909lrndli7ml54nnzda49vc2fhbjwxr";
+    sha256 = "0w2i2szajv1vcmc96w0fczdr8xc28ijcf1gdg180f21gi6yh96sc";
   };
 
   patches = [

--- a/pkgs/applications/audio/r128gain/ffmpeg-location.patch
+++ b/pkgs/applications/audio/r128gain/ffmpeg-location.patch
@@ -1,5 +1,3 @@
-diff --git i/r128gain/__init__.py w/r128gain/__init__.py
-index 53fc3ef..f144e15 100755
 --- i/r128gain/__init__.py
 +++ w/r128gain/__init__.py
 @@ -78,7 +78,7 @@ def get_ffmpeg_lib_versions(ffmpeg_path=None):
@@ -14,7 +12,7 @@ index 53fc3ef..f144e15 100755
 @@ -156,7 +156,7 @@ def get_r128_loudness(audio_filepaths, *, calc_peak=True, enable_ffmpeg_threadin
                                       os.devnull,
                                       **additional_ffmpeg_args,
-                                      f="null"),
+                                      f="null").global_args("-hide_banner", "-nostats"),
 -                       cmd=ffmpeg_path or "ffmpeg")
 +                       cmd=ffmpeg_path or "@ffmpeg@/bin/ffmpeg")
  


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Aside from the update, override the updateScript set by buildPythonApplication as it doesn't support GitHub sources. Manual intervention might still be needed for the patch file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
