### PR TITLE
python3Packages.pyelftools: 0.26 -> unstable-09-23

### DIFF
--- a/pkgs/development/python-modules/pyelftools/default.nix
+++ b/pkgs/development/python-modules/pyelftools/default.nix
@@ -1,31 +1,34 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , python
 }:
 
 buildPythonPackage rec {
   pname = "pyelftools";
-  version = "0.26";
+  version = "unstable-2020-09-23";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "86ac6cee19f6c945e8dedf78c6ee74f1112bd14da5a658d8c9d4103aed5756a2";
+  src = fetchFromGitHub {
+    owner = "eliben";
+    repo = pname;
+    rev = "ab84e68837113b2d700ad379d94c1dd4a73125ea";
+    sha256 = "sha256-O7l1kj0k8bOSOtZJVzS674oVnM+X3oP00Ybs0qjb64Q=";
   };
 
+  doCheck = stdenv.is64bit;
+
   checkPhase = ''
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" test/external_tools/readelf
     ${python.interpreter} test/all_tests.py
   '';
 
-  # Tests cannot pass against system-wide readelf
-  # https://github.com/eliben/pyelftools/issues/65
-  doCheck = false;
+  pythonImportsCheck = [ "elftools" ];
 
   meta = with stdenv.lib; {
     description = "A library for analyzing ELF files and DWARF debugging information";
     homepage = "https://github.com/eliben/pyelftools";
     license = licenses.publicDomain;
-    maintainers = [ maintainers.igsha ];
+    maintainers = with maintainers; [ igsha pamplemousse ];
   };
 
 }


### PR DESCRIPTION
##### Motivation for this change

Last tagged version (dating from 12/2019) lack of several patches produced recently.
And run the tests!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] ~Ensured that relevant documentation is up to date~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
