### PR TITLE
python3Packages.CppHeaderParser: init at 2.7.4

### DIFF
--- a/pkgs/development/python-modules/cppheaderparser/default.nix
+++ b/pkgs/development/python-modules/cppheaderparser/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage
+, fetchPypi
+, ply
+, stdenv
+}:
+
+buildPythonPackage rec {
+  pname = "CppHeaderParser";
+  version = "2.7.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-OCswQW2VsKXoUCshSBDcrCpWQykX4mUUR9Or4lPjzEI=";
+  };
+
+  propagatedBuildInputs = [ ply ];
+
+  pythonImportsCheck = [ "CppHeaderParser" ];
+
+  meta = with stdenv.lib; {
+    description = "Parse C++ header files using ply.lex to generate navigable class tree representing the class structure";
+    homepage = "https://sourceforge.net/projects/cppheaderparser/";
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ pamplemousse ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1321,6 +1321,8 @@ in {
 
   cozy = callPackage ../development/python-modules/cozy { };
 
+  cppheaderparser = callPackage ../development/python-modules/cppheaderparser { };
+
   cppy = callPackage ../development/python-modules/cppy { };
 
   cram = callPackage ../development/python-modules/cram { };


### PR DESCRIPTION
##### Motivation for this change

Needed as a dependency for a NUR package;
Figured it could be put here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] ~Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`~
- [ ] ~Tested execution of all binary files (usually in `./result/bin/`)~
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] ~Ensured that relevant documentation is up to date~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
