### PR TITLE
grb: init at unstable-2020-02-15

### DIFF
--- a/pkgs/applications/misc/grb/default.nix
+++ b/pkgs/applications/misc/grb/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  pname = "grb";
+  version = "unstable-2020-02-15";
+
+  src = fetchFromGitHub {
+    owner = "LukeSmithxyz";
+    repo = pname;
+    rev = "e27769a14401b385553b1df7b4cf027bbed0144b";
+    sha256 = "1gxg1aj83c7nc272rnxvhadbjadf0fpd4pd4xd2rbwbg80aihh1j";
+  };
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Greek Bible on the Command Line";
+    homepage = "https://github.com/LukeSmithxyz/grb";
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.jtobin ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -230,6 +230,8 @@ in
 
   digitalbitbox = libsForQt514.callPackage ../applications/misc/digitalbitbox { };
 
+  grb = callPackage ../applications/misc/grb { };
+
   grsync = callPackage ../applications/misc/grsync { };
 
   dockerTools = callPackage ../build-support/docker {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Simply adds @LukeSmithxyz's `grb` to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
