### PR TITLE
pythonPackages.debugpy: 1.0.0b12 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -1,19 +1,30 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub
-, substituteAll, gdb
-, colorama, django, flask, gevent, psutil, pytest
-, pytest-timeout, pytest_xdist, requests
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, substituteAll
+, gdb
+, colorama
+, flask
+, psutil
+, pytest-timeout
+, pytest_xdist
+, pytestCheckHook
+, requests
 , isPy27
+, django
+, gevent
 }:
 
 buildPythonPackage rec {
   pname = "debugpy";
-  version = "1.0.0b12";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0sz33aq5qldl7kh4qjf5w3d08l9s77ipcj4i9wfklj8f6vf9w1wh";
+    sha256 = "1cxwbq97n5pfmq0hji1ybbc6i1jg5bjy830dq23zqxbwxxwjx98m";
   };
 
   patches = [
@@ -49,16 +60,31 @@ buildPythonPackage rec {
   )'';
 
   checkInputs = [
-    colorama django flask gevent psutil pytest
-    pytest-timeout pytest_xdist requests
+    colorama
+    flask
+    psutil
+    pytest-timeout
+    pytest_xdist
+    pytestCheckHook
+    requests
+  ] ++ lib.optionals (!isPy27) [
+    django
+    gevent
   ];
 
   # Override default arguments in pytest.ini
-  checkPhase = "pytest --timeout 0 -n $NIX_BUILD_CORES"
-               # gevent fails to import zope.interface with Python 2.7
-               + stdenv.lib.optionalString isPy27 " -k 'not test_gevent'";
+  pytestFlagsArray = [ "--timeout=0" "-n=$NIX_BUILD_CORES" ];
 
-  meta = with stdenv.lib; {
+  disabledTests = lib.optionals isPy27 [
+    # django 1.11 is the last version to support Python 2.7
+    # and is no longer built in nixpkgs
+    "django"
+
+    # gevent fails to import zope.interface with Python 2.7
+    "gevent"
+  ];
+
+  meta = with lib; {
     description = "An implementation of the Debug Adapter Protocol for Python";
     homepage = "https://github.com/microsoft/debugpy";
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the first official release: https://github.com/microsoft/debugpy/releases/tag/v1.0.0

Also fixes the Python 2.7 build

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  ```
  $ nix-env -f /home/kira/.cache/nixpkgs-review/rev-7539c63103c14fe3ed5da473fa26988d71b51450/nixpkgs -qaP --xml --out-path --show-trace --meta
  1 package added:
  python27Packages.debugpy (init at 1.0.0)
  
  2 packages updated:
  python37Packages.debugpy (1.0.0b12 → 1.0.0) python38Packages.debugpy (1.0.0b12 → 1.0.0)
  
  $ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/kira/.cache/nixpkgs-review/rev-7539c63103c14fe3ed5da473fa26988d71b51450/build.nix
  3 packages built:
  python27Packages.debugpy python37Packages.debugpy python38Packages.debugpy
  ```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No bin files, only a python library. Tested through dap-mode in Emacs.

- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).