### PR TITLE
pythonPackages.pygls: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/development/python-modules/pygls/default.nix
+++ b/pkgs/development/python-modules/pygls/default.nix
@@ -1,30 +1,29 @@
-{ stdenv, buildPythonPackage, isPy3k, fetchFromGitHub
-, mock, pytest, pytest-asyncio
+{ lib
+, buildPythonPackage
+, isPy3k
+, fetchFromGitHub
+, mock
+, pytest-asyncio
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pygls";
-  version = "0.9.0";
+  version = "0.9.1";
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner = "openlawlibrary";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1wfp4hjin1mb6nkzhpfh5v8q8rwvn9zh0mwwj4dlxkqx5lp272hl";
+    sha256 = "1v7x5598d6jg8ya0spqjma56y062rznwimsrp8nq6fkskqgfm0ds";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "pytest==4.5.0" "pytest"
-  '';
+  checkInputs = [ mock pytest-asyncio pytestCheckHook ];
 
-  checkInputs = [ mock pytest pytest-asyncio ];
-  checkPhase = "pytest";
-
-  meta = with stdenv.lib; {
-    homepage = "https://github.com/openlawlibrary/pygls";
+  meta = with lib; {
     description = "Pythonic generic implementation of the Language Server Protocol";
+    homepage = "https://github.com/openlawlibrary/pygls";
     license = licenses.asl20;
     maintainers = with maintainers; [ metadark ];
   };


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest version: https://github.com/openlawlibrary/pygls/releases/tag/v0.9.1

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  ```shell
  $ nix-env -f /home/kira/.cache/nixpkgs-review/rev-e4a70831a72f434b9d7bedf2bfbd21f5ed0f69c9/nixpkgs -qaP --xml --out-path --show-trace --meta
  3 packages updated:
  cmake-language-server python37Packages.pygls (0.9.0 → 0.9.1) python38Packages.pygls (0.9.0 → 0.9.1)
  
  $ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/kira/.cache/nixpkgs-review/rev-e4a70831a72f434b9d7bedf2bfbd21f5ed0f69c9/build.nix
  3 packages built:
  cmake-language-server python37Packages.pygls python38Packages.pygls
  ```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  No binary files

- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).