### PR TITLE
Skipper: init at 3.2.25.1701

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6237,6 +6237,12 @@
     githubId = 2946283;
     name = "Brian Cohen";
   };
+  nover = {
+    email = "nicolas.guilloux@protonmail.com";
+    github = "NicolasGuilloux";
+    githubId = 4090627;
+    name = "Nicolas Guilloux";
+  };
   novoxudonoser = {
     email = "radnovox@gmail.com";
     github = "novoxudonoser";

--- a/pkgs/applications/editors/inventic/skipper.desktop
+++ b/pkgs/applications/editors/inventic/skipper.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Skipper
+Exec=
+Icon=
+Type=Application
+Categories=Development;Utility;

--- a/pkgs/applications/editors/inventic/skipper.nix
+++ b/pkgs/applications/editors/inventic/skipper.nix
@@ -1,0 +1,60 @@
+{ stdenv, lib, fetchzip, autoPatchelfHook, makeWrapper, unzip,
+boost172, curl, libX11, libpng12, libxml2, libxslt, openssl, postgresql, qt5
+, zlib }:
+
+let
+  desktopFileTemplate = ./skipper.desktop;
+in
+stdenv.mkDerivation rec {
+  pname = "skipper";
+  version = "3.2.31.1730";
+  src = fetchzip {
+    url = "https://downloads.skipper18.com/${version}/Skipper-${version}-Linux-all-64bit.zip";
+    sha256 = "1cddxxsqdsbhrxxz411565bbbn3gddxwk6kc6nq8bdbrcdza51rl";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ unzip autoPatchelfHook qt5.wrapQtAppsHook makeWrapper ];
+
+  buildInputs = [
+    boost172
+    curl
+    libX11
+    libxml2
+    libxslt
+    openssl
+    postgresql
+    qt5.qtbase
+    qt5.qtscript
+  ];
+
+  runtimeDependencies = [ libpng12 ];
+
+  installPhase = ''
+    mkdir -p $out/lib
+    mv ./libs/libQtitan*.so* $out/lib
+    rm -r ./libs ./bearer ./platforms
+
+    mkdir -p $out/opt
+    chmod +x ./Skipper
+    mv ./* $out/opt
+
+    makeWrapper $out/opt/Skipper $out/bin/skipper \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runtimeDependencies} \
+      ''${qtWrapperArgs[@]}
+
+    mkdir -p $out/share/applications
+    substitute ${desktopFileTemplate} \
+      $out/share/applications/skipper.desktop \
+      --replace "Exec=" "Exec=$out/bin/skipper" \
+      --replace "Icon=" "Icon=$out/opt/Skipper.ico"
+  '';
+
+  meta = with lib; {
+    description = "An ORM framework editor for Doctrine, Symfony, Laravel, etc.";
+    homepage = "https://www.skipper18.com/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ nover ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20944,6 +20944,8 @@ in
 
   rhvoice = callPackage ../applications/audio/rhvoice { };
 
+  skipper = callPackage ../applications/editors/inventic/skipper.nix { };
+
   svox = callPackage ../applications/audio/svox { };
 
   giada = callPackage ../applications/audio/giada {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Skipper: init at 3.2.25.1701 (fixes partially #99232).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
