### PR TITLE
[20.09]  pythonPackages.pyscreenshot: add missing dependencies 

### DIFF
--- a/pkgs/development/python-modules/entrypoint2/default.nix
+++ b/pkgs/development/python-modules/entrypoint2/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchPypi, EasyProcess, pathpy, pytest }:
+
+buildPythonPackage rec {
+  pname = "entrypoint2";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15dya04884armqjdyqz1jgachkqgh9dc3p25lvyz9afvg73k2qav";
+  };
+
+  propagatedBuildInputs = [ ];
+
+  pythonImportsCheck = [ "entrypoint2" ];
+
+  # argparse is part of the standardlib
+  prePatch = ''
+    substituteInPlace setup.py --replace "argparse" ""
+  '';
+
+  checkInputs = [ EasyProcess pathpy pytest ];
+
+  # 0.2.1 has incompatible pycache files included
+  # https://github.com/ponty/entrypoint2/issues/8
+  checkPhase = ''
+    rm -rf tests/__pycache__
+    pytest tests
+  '';
+
+  meta = with lib; {
+    description = "Easy to use command-line interface for python modules";
+    homepage = "https://github.com/ponty/entrypoint2/";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/development/python-modules/mss/default.nix
+++ b/pkgs/development/python-modules/mss/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "mss";
+  version = "6.0.0";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0dicp55adbqxb7hqlck95hngb1klv5s26lszw3xim30k18bwqaxl";
+  };
+
+  propagatedBuildInputs = [ ];
+
+  # By default it attempts to build Windows-only functionality
+  prePatch = ''
+    rm mss/windows.py
+  '';
+
+  # Skipping tests due to most relying on DISPLAY being set
+  pythonImportsCheck = [ "mss" ];
+
+  meta = with lib; {
+    description = "Cross-platform multiple screenshots module in pure Python";
+    homepage = "https://github.com/BoboTiG/mss/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/development/python-modules/pyscreenshot/default.nix
+++ b/pkgs/development/python-modules/pyscreenshot/default.nix
@@ -6,6 +6,7 @@
 , entrypoint2
 , jeepney
 , mss
+, pillow
 }:
 
 buildPythonPackage rec {
@@ -20,6 +21,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     EasyProcess
     entrypoint2
+    pillow
   ] ++ lib.optionals (isPy3k) [
     jeepney
     mss
@@ -27,6 +29,8 @@ buildPythonPackage rec {
 
   # recursive dependency on pyvirtualdisplay
   doCheck = false;
+
+  pythonImportsCheck = [ "pyscreenshot" ];
 
   meta = with lib; {
     description = "python screenshot";

--- a/pkgs/development/python-modules/pyscreenshot/default.nix
+++ b/pkgs/development/python-modules/pyscreenshot/default.nix
@@ -1,7 +1,11 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy3k
 , EasyProcess
+, entrypoint2
+, jeepney
+, mss
 }:
 
 buildPythonPackage rec {
@@ -15,6 +19,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     EasyProcess
+    entrypoint2
+  ] ++ lib.optionals (isPy3k) [
+    jeepney
+    mss
   ];
 
   # recursive dependency on pyvirtualdisplay

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1858,6 +1858,8 @@ in {
 
   entrance-with-router-features = callPackage ../development/python-modules/entrance { routerFeatures = true; };
 
+  entrypoint2 = callPackage ../development/python-modules/entrypoint2 { };
+
   entrypoints = callPackage ../development/python-modules/entrypoints { };
 
   enum34 = callPackage ../development/python-modules/enum34 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3798,6 +3798,8 @@ in {
 
   msgpack-numpy = callPackage ../development/python-modules/msgpack-numpy { };
 
+  mss = callPackage ../development/python-modules/mss { };
+
   msrestazure = callPackage ../development/python-modules/msrestazure { };
 
   msrest = callPackage ../development/python-modules/msrest { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backport to release-20.09 the following PRs (apparently, this has not been done):

-  #98895
-  #98898
-  #98922

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
