### PR TITLE
nvidiabl: 2017-09-26 -> 2020-10-01 (fix build)

### DIFF
--- a/pkgs/os-specific/linux/nvidiabl/default.nix
+++ b/pkgs/os-specific/linux/nvidiabl/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "nvidiabl-${version}-${kernel.version}";
-  version = "2017-09-26";
+  version = "2020-10-01";
 
   # We use a fork which adds support for newer kernels -- upstream has been abandoned.
   src = fetchFromGitHub {
     owner = "yorickvP";
     repo = "nvidiabl";
-    rev = "2d909f4dfceb24ce98479fd571411c6ec3b71bea";
-    sha256 = "0dsar8fsaxwywjh6rbrxkhdp142vqjnsyxfz6bgpbqml6slpiqs1";
+    rev = "9e21bdcb7efedf29450373a2e9ff2913d1b5e3ab";
+    sha256 = "1z57gbnayjid2jv782rpfpp13qdchmbr1vr35g995jfnj624nlgy";
   };
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The Linux API changed slightly, removing ioremap_nocache from Linux >= 5.7. It may be time to deprecate this module soon, but this fix is easy enough. This fixes 8 hydra failures.

ZHF: #97479
@NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
