### PR TITLE
nixos/sudo: add `package` option

### DIFF
--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -42,6 +42,15 @@ in
         '';
     };
 
+    security.sudo.package = mkOption {
+      type = types.package;
+      default = pkgs.sudo;
+      defaultText = "pkgs.sudo";
+      description = ''
+        Which package to use for `sudo`.
+      '';
+    };
+
     security.sudo.wheelNeedsPassword = mkOption {
       type = types.bool;
       default = true;
@@ -208,8 +217,8 @@ in
       '';
 
     security.wrappers = {
-      sudo.source = "${pkgs.sudo.out}/bin/sudo";
-      sudoedit.source = "${pkgs.sudo.out}/bin/sudoedit";
+      sudo.source = "${cfg.package.out}/bin/sudo";
+      sudoedit.source = "${cfg.package.out}/bin/sudoedit";
     };
 
     environment.systemPackages = [ sudo ];


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The `package`-option is always useful if modifying a package in an
overlay would mean that a lot of other packages need to be rebuilt as
well.

In case of `sudo` this is actually the case: when having an override for
it (e.g. for `withInsults = true;`), you'd have to rebuild e.g. `zfs`
and `grub` although that's not strictly needed.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
