### PR TITLE
knightos-scas: 0.4.6 -> 0.5.3, knightos-z80e: 0.5.0 -> 0.5.2

### DIFF
--- a/pkgs/development/tools/knightos/scas/default.nix
+++ b/pkgs/development/tools/knightos/scas/default.nix
@@ -1,26 +1,26 @@
 { fetchFromGitHub, stdenv, cmake }:
 
-
 stdenv.mkDerivation rec {
   pname = "scas";
 
-  version = "0.4.6";
+  version = "0.5.3";
 
   src = fetchFromGitHub {
     owner = "KnightOS";
     repo = "scas";
     rev = version;
-    sha256 = "1c6s9nivbwgv0f8n7j73h54ydgqw5dcpq8l752dfrnqg3kv3nn0h";
+    sha256 = "0z6r07cl92kq860ddas5p88l990ih9cfqlzy5y4mk5hrmjzya60j";
   };
 
-  nativeBuildInputs = [ cmake ];
+  cmakeFlags = [ "-DSCAS_LIBRARY=1" ];
 
-  hardeningDisable = [ "format" ];
+  nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
     homepage    = "https://knightos.org/";
     description = "Assembler and linker for the Z80";
     license     = licenses.mit;
     maintainers = with maintainers; [ siraben ];
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/tools/knightos/z80e/default.nix
+++ b/pkgs/development/tools/knightos/z80e/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "z80e";
-  version = "0.5.0";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "KnightOS";
     repo = "z80e";
     rev = version;
-    sha256 = "18nnip6nv1pq19bxgd07fv7ci3c5yj8d9cip97a4zsfab7bmbq6k";
+    sha256 = "0gdv17ynjd6zf3i4hkimd89xkrd8kxas3bf8d5sq54fdicapvkzc";
   };
 
   nativeBuildInputs = [ cmake knightos-scas ];


### PR DESCRIPTION
###### Motivation for this change
Update scas

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
