### PR TITLE
knightos-patchrom: init at 1.1.3

### DIFF
--- a/pkgs/development/tools/knightos/patchrom/default.nix
+++ b/pkgs/development/tools/knightos/patchrom/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, asciidoc, libxslt, docbook_xsl }:
+
+
+stdenv.mkDerivation rec {
+  pname = "patchrom";
+
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "KnightOS";
+    repo = "patchrom";
+    rev = version;
+    sha256 = "0yc4q7n3k7k6rx3cxq5ddd5r0la8gw1287a74kql6gwkxjq0jmcv";
+  };
+
+  nativeBuildInputs = [ cmake asciidoc docbook_xsl ];
+
+  buildInputs = [ libxslt ];
+
+  hardeningDisable = [ "format" ];
+
+  meta = with stdenv.lib; {
+    homepage    = "https://knightos.org/";
+    description = "Patches jumptables into TI calculator ROM files and generates an include file";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9336,6 +9336,8 @@ in
     asciidoc = asciidoc-full;
   };
 
+  knightos-patchrom = callPackage ../development/tools/knightos/patchrom { };
+
   knightos-scas = callPackage ../development/tools/knightos/scas { };
 
   kotlin = callPackage ../development/compilers/kotlin { };


### PR DESCRIPTION
###### Motivation for this change
knightos-patchrom: init at 1.1.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
