### PR TITLE
teams: remove rect-overlay -- causes desktop sharing to break without a composer

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -40,9 +40,14 @@ stdenv.mkDerivation rec {
     gappsWrapperArgs+=(--prefix PATH : "${coreutils}/bin:${gawk}/bin:${xdg_utils}/bin")
   '';
 
+  # As of Teams 1.3 screen sharing does not work unless a window composer is
+  # used. The user will see a black screen with a red border, drawn by the
+  # program `rect-overlay`. Getting rid of `rect-overlay` makes screen sharing
+  # work.
   installPhase = ''
     mkdir -p $out/{opt,bin}
 
+    rm share/teams/resources/app.asar.unpacked/node_modules/slimcore/bin/rect-overlay
     mv share/teams $out/opt/
     mv share $out/share
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Screen sharing on Teams is currently broken unless the user is using a composer (not that common across NixOS users).
This `rect-overlay` draws a rectangular red border around the screen, indicating that a recording is in process.
Removing the file makes screen sharing work.

I am not sure if we want to include this small hack in nixpkgs, but even if this PR is closed it might still be useful as a reference for Teams users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
