### PR TITLE
systemd-journal2gelf: 20190702 -> 20200813

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -58,8 +58,10 @@
   </para>
 
   <itemizedlist>
-   <listitem>
-    <para />
+    <listitem>
+      <para>
+        <literal>systemd-journal2gelf</literal> no longer parses json and expects the receiving system to handle it. How to achieve this with Graylog is described in this <link xlink:href="https://github.com/parse-nl/SystemdJournal2Gelf/issues/10">GitHub issue</link>.
+      </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/pkgs/tools/system/systemd-journal2gelf/default.nix
+++ b/pkgs/tools/system/systemd-journal2gelf/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   pname = "SystemdJournal2Gelf-unstable";
-  version = "20190702";
+  version = "20200813";
 
   src = fetchFromGitHub {
-    rev = "b1aa5ff31307d11a3c9b4dd08c3cd6230d935ec5";
+    rev = "d389dc8583b752cbd37c389a55a6c82200e47394";
     owner = "parse-nl";
     repo = "SystemdJournal2Gelf";
-    sha256 = "13jyh34wprjixinmh6l7wj7lr1f6qy6nrjcf8l29a74mczbphnvv";
+    sha256 = "0p38r5kdfcn6n2d44dygrs5xgv51s5qlsfhzzwn16r3n6x91s62b";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Tracking upstream changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
