### PR TITLE
knightos-z80e: init at 0.5.0

### DIFF
--- a/pkgs/development/tools/knightos/z80e/default.nix
+++ b/pkgs/development/tools/knightos/z80e/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, cmake, knightos-scas, readline, SDL2 }:
+
+stdenv.mkDerivation rec {
+  pname = "z80e";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "KnightOS";
+    repo = "z80e";
+    rev = version;
+    sha256 = "18nnip6nv1pq19bxgd07fv7ci3c5yj8d9cip97a4zsfab7bmbq6k";
+  };
+
+  nativeBuildInputs = [ cmake knightos-scas ];
+
+  buildInputs = [ readline SDL2 ];
+
+  cmakeFlags = [ "-Denable-sdl=YES" ];
+
+  meta = with stdenv.lib; {
+    homepage    = "https://knightos.org/";
+    description = "A Z80 calculator emulator and debugger";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9338,6 +9338,8 @@ in
 
   knightos-scas = callPackage ../development/tools/knightos/scas { };
 
+  knightos-z80e = callPackage ../development/tools/knightos/z80e { };
+
   kotlin = callPackage ../development/compilers/kotlin { };
 
   lazarus = callPackage ../development/compilers/fpc/lazarus.nix {


### PR DESCRIPTION
###### Motivation for this change
knightos-z80e: init at 0.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
