### PR TITLE
pythonPackages.pyscreenshot: add missing pillow dependency

### DIFF
--- a/pkgs/development/python-modules/pyscreenshot/default.nix
+++ b/pkgs/development/python-modules/pyscreenshot/default.nix
@@ -6,6 +6,7 @@
 , entrypoint2
 , jeepney
 , mss
+, pillow
 }:
 
 buildPythonPackage rec {
@@ -20,6 +21,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     EasyProcess
     entrypoint2
+    pillow
   ] ++ lib.optionals (isPy3k) [
     jeepney
     mss
@@ -27,6 +29,8 @@ buildPythonPackage rec {
 
   # recursive dependency on pyvirtualdisplay
   doCheck = false;
+
+  pythonImportsCheck = [ "pyscreenshot" ];
 
   meta = with lib; {
     description = "python screenshot";


### PR DESCRIPTION
###### Motivation for this change

Issue spotted by @mweinelt in https://github.com/NixOS/nixpkgs/pull/99244#issuecomment-702145005

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
