### PR TITLE
jpexs: init at 11.3.0

### DIFF
--- a/pkgs/development/tools/jpexs/default.nix
+++ b/pkgs/development/tools/jpexs/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchzip, makeWrapper, makeDesktopItem, jdk8 }:
+
+stdenv.mkDerivation rec {
+  pname = "jpexs";
+  version = "11.3.0";
+
+  src = fetchzip {
+    url = "${meta.homepage}/releases/download/version${version}/ffdec_${version}.zip";
+    sha256 = "0d1xmq21vdpn0glwfzr00s62ic8jynmgmgxl0m1834xqf3ma0ihv";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/{ffdec,icons/hicolor/512x512/apps}
+
+    cp ffdec.jar $out/share/ffdec
+    cp -r lib $out/share/ffdec
+    cp icon.png $out/share/icons/hicolor/512x512/apps/ffdec.png
+    cp -r ${desktopItem}/share/applications $out/share
+
+    makeWrapper ${jdk8}/bin/java $out/bin/ffdec \
+      --add-flags "-jar $out/share/ffdec/ffdec.jar"
+  '';
+
+  desktopItem = makeDesktopItem rec {
+    name = "ffdec";
+    exec = name;
+    icon = name;
+    desktopName = "JPEXS Free Flash Decompiler";
+    genericName = "Flash Decompiler";
+    comment = meta.description;
+    categories = "Development;Java;";
+    extraEntries = ''
+      StartupWMClass=com-jpexs-decompiler-flash-gui-Main
+    '';
+  };
+
+  meta = with stdenv.lib; {
+    description = "Flash SWF decompiler and editor";
+    longDescription = ''
+      Open-source Flash SWF decompiler and editor. Extract resources,
+      convert SWF to FLA, edit ActionScript, replace images, sounds,
+      texts or fonts.
+    '';
+    homepage = "https://github.com/jindrapetrik/jpexs-decompiler";
+    license = licenses.gpl3;
+    platforms = jdk8.meta.platforms;
+    maintainers = with maintainers; [ samuelgrf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11189,6 +11189,8 @@ in
 
   jenkins-job-builder = with python3Packages; toPythonApplication jenkins-job-builder;
 
+  jpexs = callPackage ../development/tools/jpexs { };
+
   julius = callPackage ../games/julius { };
 
   augustus = callPackage ../games/augustus { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I use this for removing copy protection from Flash games/animations, so they can be archived and played offline.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
