### PR TITLE
matrix-appservice-discord: patch to use new API endpoint

### DIFF
--- a/pkgs/servers/matrix-appservice-discord/default.nix
+++ b/pkgs/servers/matrix-appservice-discord/default.nix
@@ -9,6 +9,17 @@ let
 in nodePackages."matrix-appservice-discord-git+https://github.com/Half-Shot/matrix-appservice-discord.git#v0.5.2".override {
   nativeBuildInputs = [ pkgs.makeWrapper ];
 
+  # Discord's API is migrating from discordapp.com to discord.com
+  # and will only be accessible through the latter domain after 2020-11-07.
+  # The CDN domain (cdn.discordapp.com) remains unchanged.
+  # https://github.com/Half-Shot/matrix-appservice-discord/issues/611
+  preRebuild = ''
+    shopt -s globstar
+    sed -i 's|https://discordapp.com|https://discord.com|g' \
+      ./node_modules/discord.js/src/**/*.js \
+      ./src/**/*.ts
+  '';
+
   postInstall = ''
     # compile Typescript sources
     npm run build


### PR DESCRIPTION
###### Motivation for this change

Discord's API is migrating from discordapp.com to discord.com
and will only be accessible through the latter domain after 2020-11-07.

This patch allows the current stable release of the bridge program to
continue working beyond that date.

See https://github.com/Half-Shot/matrix-appservice-discord/issues/611


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
