### PR TITLE
btrbk: 0.29.1 -> 0.31.3

### DIFF
--- a/pkgs/tools/backup/btrbk/default.nix
+++ b/pkgs/tools/backup/btrbk/default.nix
@@ -1,13 +1,29 @@
-{ lib, stdenv, fetchurl, bash, btrfs-progs, openssh, perl, perlPackages
-, util-linux, asciidoc, asciidoctor, mbuffer, makeWrapper, nixosTests }:
+{ lib
+, stdenv
+, fetchurl
+, bash
+, btrfs-progs
+, openssh
+, perl
+, perlPackages
+, util-linux
+, asciidoc
+, asciidoctor
+, mbuffer
+, makeWrapper
+, genericUpdater
+, curl
+, writeShellScript
+, nixosTests
+}:
 
 stdenv.mkDerivation rec {
   pname = "btrbk";
-  version = "0.29.1";
+  version = "0.31.3";
 
   src = fetchurl {
     url = "https://digint.ch/download/btrbk/releases/${pname}-${version}.tar.xz";
-    sha256 = "153inyvvnl17hq1w3nsa783havznaykdam2yrj775bmi2wg6fvwn";
+    sha256 = "1lx7vnf386nsik8mxrrfyx1h7mkqk5zs26sy0s0lynfxcm4lkxb2";
   };
 
   nativeBuildInputs = [ asciidoc asciidoctor makeWrapper ];
@@ -22,7 +38,9 @@ stdenv.mkDerivation rec {
     done
 
     # Tainted Mode disables PERL5LIB
-    substituteInPlace btrbk --replace "perl -T" "perl"
+    substituteInPlace btrbk \
+      --replace "perl -T" "perl" \
+      --replace "\$0" "\$ENV{'program_name'}"
 
     # Fix SSH filter script
     sed -i '/^export PATH/d' ssh_filter_btrbk.sh
@@ -30,17 +48,26 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    wrapProgram $out/sbin/btrbk \
+    wrapProgram $out/bin/btrbk \
       --set PERL5LIB $PERL5LIB \
+      --run 'export program_name=$0' \
       --prefix PATH ':' "${lib.makeBinPath [ btrfs-progs bash mbuffer openssh ]}"
   '';
 
   passthru.tests.btrbk = nixosTests.btrbk;
 
+  passthru.updateScript = genericUpdater {
+    inherit pname version;
+    versionLister = writeShellScript "btrbk-versionLister" ''
+      echo "# Versions for $1:" >> "$2"
+      ${curl}/bin/curl -s https://digint.ch/download/btrbk/releases/ | ${perl}/bin/perl -lne 'print $1 if /btrbk-([0-9.]*)\.tar/'
+    '';
+  };
+
   meta = with lib; {
     description = "A backup tool for btrfs subvolumes";
     homepage = "https://digint.ch/btrbk";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     platforms = platforms.unix;
     maintainers = with maintainers; [ asymmetric ];
   };


### PR DESCRIPTION
###### Motivation for this change
- new: lsbtr
- work around non-working --argv0 when wrapping perl or shell scripts
- add updateScript

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
