### PR TITLE
skeu: init at 0.5.1

### DIFF
--- a/pkgs/data/themes/skeu/default.nix
+++ b/pkgs/data/themes/skeu/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, fetchFromGitHub
+, gdk-pixbuf
+, gtk-engine-murrine
+, gtk_engines
+, librsvg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "skeu";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "darkomarko42";
+    repo = pname;
+    rev = version;
+    sha256 = "0lbl09p0h493ya978fh7cib68qlmxfxahmbj0mpa3b65ynxda645";
+  };
+
+  buildInputs = [
+    gdk-pixbuf
+    gtk_engines
+    librsvg
+  ];
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/themes
+    cp -a Skeu* $out/share/themes
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GTK theme with skeuomorphism design";
+    homepage = "https://www.pling.com/p/1363834/";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19303,6 +19303,8 @@ in
 
   shades-of-gray-theme = callPackage ../data/themes/shades-of-gray { };
 
+  skeu = callPackage ../data/themes/skeu { };
+
   sweet = callPackage ../data/themes/sweet { };
 
   mime-types = callPackage ../data/misc/mime-types { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [Skeu](https://www.pling.com/p/1363834/), a GTK theme with skeuomorphism design.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
