### PR TITLE
material-shell: 6 -> 7

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/material-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/material-shell/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-material-shell";
-  version = "6";
+  version = "7";
 
   src = fetchFromGitHub {
     owner = "material-shell";
     repo = "material-shell";
     rev = version;
-    sha256 = "1mvaiaszlwydwjfsbam4s60idww5g5fi63xazwjcakdid3gbq6cl";
+    sha256 = "076cv1l5qr5x71przjwvbzx0m91n4z0byc2gc3r48l8vsr2d0hwf";
   };
 
   # This package has a Makefile, but it's used for building a zip for


### PR DESCRIPTION
###### Motivation for this change

Version bump.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
