### PR TITLE
pipr: 0.0.12 -> 0.0.15

### DIFF
--- a/pkgs/applications/misc/pipr/default.nix
+++ b/pkgs/applications/misc/pipr/default.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "pipr";
-  version = "0.0.12";
+  version = "0.0.15";
 
   src = fetchFromGitHub {
     owner = "ElKowar";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0l7yvpc59mbzh87lngj6pj8w586fwa07829l5x9mmxnkf6srapmc";
+    sha256 = "1pbj198nqi27kavz9bm31a3h7h70by6l00046x09yf9n8qjpp01w";
   };
 
-  cargoSha256 = "1xzc1x5mjvj2jgdhwmjbdbqi8d7ln1ss7akn72d96kmy1wsj1qsa";
+  cargoSha256 = "1dcrafpf252dpjvimaibb93082nymb26wwbvr34zd6j7z285vach";
 
   nativeBuildInputs = [ makeWrapper ];
   postFixup = ''


### PR DESCRIPTION
###### Motivation for this change
Simple version bump.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
