### PR TITLE
top-level: ignore unexpected args

### DIFF
--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -38,6 +38,9 @@
   # environment. See below for the arguments given to that function, the type of
   # list it returns.
   stdenvStages ? import ../stdenv
+
+, # Ignore unexpected args.
+  ...
 } @ args:
 
 let # Rename the function arguments

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -81,7 +81,7 @@ in
 # not be passed.
 assert args ? localSystem -> !(args ? system || args ? platform);
 
-import ./. (builtins.removeAttrs args [ "system" "platform" "inNixShell" ] // {
+import ./. (builtins.removeAttrs args [ "system" "platform" ] // {
   inherit config overlays crossSystem crossOverlays;
   # Fallback: Assume we are building packages on the current (build, in GNU
   # Autotools parlance) system.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This reverts https://github.com/NixOS/nixpkgs/pull/97807 and instead implements @glittershark's suggestion (https://github.com/NixOS/nix/issues/4003#issuecomment-690506724) to use an ellipsis in `pkgs/top-level/default.nix` so that we don't error on unexpected arguments. This allows `nix-shell -A hello` to work properly, as well as (hopefully -- we won't know for sure until the community box gets redeployed next) allows ofborg's aarch64 builds + evals to succeed again (for an example of the brokenness, see: https://logs.nix.ci/?key=nixos/nixpkgs.99076&attempt_id=d128c36f-72ef-49ab-8e8e-ab40f34347ef).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Ma27 @worldofpeace 