### PR TITLE
mozwire: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/tools/networking/mozwire/default.nix
+++ b/pkgs/tools/networking/mozwire/default.nix
@@ -2,18 +2,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "MozWire";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "NilsIrl";
     repo = pname;
     rev = "v${version}";
-    sha256 = "07icgswmfvrvlm3mkm78pbbk6m2hb73j7ffj7r77whzb11v027v1";
+    sha256 = "0r3x8y1qxxkkac9lqgd0s339zbrm9zmir1f6qs0r5f0bw3ngzqc4";
   };
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
-  
-  cargoSha256 = "10lhz7bdlfqj7wgsqnsxdfskms33pvj176fhf4kwci7nb8vgai4b";
+
+  cargoSha256 = "0hyps2wi4wmpllfams3p59jpccwa0ylgzxq7qdn6g6zvf0cajpc0";
 
   meta = with stdenv.lib; {
     description = "MozillaVPN configuration manager giving Linux, macOS users (among others), access to MozillaVPN";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
