### PR TITLE
msglint: init at 1.04

### DIFF
--- a/pkgs/applications/misc/msglint/default.nix
+++ b/pkgs/applications/misc/msglint/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "msglint";
+  version = "1.04";
+
+  sourceRoot = ".";
+
+  src = fetchurl {
+    url = "https://tools.ietf.org/tools/msglint/msglint-${version}.tar.gz";
+    sha256 = "1yasj6nijip3z86m526bsssd5vgqrx233azvpz1c0z564wngvzbm";
+  };
+
+  patches = [ ./fixfree.patch ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp msglint $out/bin/msglint
+  '';
+
+  meta = with stdenv.lib; {
+    description  = "RFC 822/MIME/DSN/MDN/Tracking-Status message validator.";
+    homepage     = "https://tools.ietf.org/tools/msglint/";
+    maintainers  = with maintainers; [ apeyroux ];
+    license      = licenses.mit;
+  };
+}

--- a/pkgs/applications/misc/msglint/fixfree.patch
+++ b/pkgs/applications/misc/msglint/fixfree.patch
@@ -1,0 +1,14 @@
+diff --git a/msglint.c b/msglint.c
+index cf48b4b..de2ce4e 100644
+--- a/msglint.c
++++ b/msglint.c
+@@ -3980,9 +3980,6 @@ int main(int argc, char **argv)
+ 
+ 	r = parsemessage(buf, used);
+ 
+-	/* close file */
+-	if (infile != stdin) fclose(infile);
+-
+ 	/* release buffer */
+ 	free(basebuf);
+     } while (r == 0 && *argv != NULL);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22359,6 +22359,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  msglint = callPackage ../applications/misc/msglint { };
+
   msmtp = callPackage ../applications/networking/msmtp {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change

init msglint 

**! I don't understand the license the developer wanted to use !**

```
(C) Copyright 1991-1997,2002 by Chris Newman
All Rights Reserved.

Permission to use, copy, modify, distribute, and sell this software
and its documentation for any purpose is hereby granted without fee,
provided that the above copyright notice appear in all copies, and
that the name of Chris Newman not be used in advertising or publicity
pertaining to distribution of the software without specific, written
prior permission.  Chris Newman makes no representations about the
suitability of this software for any purpose.  It is provided "as is"
without express or implied warranty.

CHRIS NEWMAN DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
EVENT SHALL CHRIS NEWMAN BE LIABLE FOR ANY SPECIAL, INDIRECT OR
CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
PERFORMANCE OF THIS SOFTWARE.
```


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
