### PR TITLE
[20.09] freecad: 0.18.4 -> unstable-2020-09-25

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -1,5 +1,5 @@
 { stdenv, mkDerivation, fetchFromGitHub, fetchpatch, cmake, ninja, coin3d,
-xercesc, ode, eigen, qtbase, qttools, qtwebkit, wrapQtAppsHook,
+xercesc, ode, eigen, qtbase, qttools, qtwebengine, qtxmlpatterns, wrapQtAppsHook,
 opencascade-occt, gts, hdf5, vtk, medfile, zlib, python3Packages, swig,
 gfortran, libXmu, soqt, libf2c, libGLU, makeWrapper, pkgconfig, mpi ? null }:
 
@@ -8,14 +8,14 @@ assert mpi != null;
 let
   pythonPackages = python3Packages;
 in mkDerivation rec {
-  pname = "freecad";
-  version = "0.18.4";
+  pname = "freecad-unstable";
+  version = "2020-09-25";
 
   src = fetchFromGitHub {
     owner = "FreeCAD";
     repo = "FreeCAD";
-    rev = version;
-    sha256 = "1phs9a0px5fnzpyx930cz39p5dis0f0yajxzii3c3sazgkzrd55s";
+    rev = "7616153b3c31ace006169cdc2fdafab484498858";
+    sha256 = "1vffvzv3gkndfj2k8ik0afyk9rgngnr4aai5py66qd63qd7kmxch";
   };
 
   nativeBuildInputs = [
@@ -29,19 +29,10 @@ in mkDerivation rec {
   buildInputs = [
     cmake coin3d xercesc ode eigen opencascade-occt gts
     zlib swig gfortran soqt libf2c makeWrapper mpi vtk hdf5 medfile
-    libGLU libXmu qtbase qttools qtwebkit
+    libGLU libXmu qtbase qttools qtwebengine qtxmlpatterns
   ] ++ (with pythonPackages; [
     matplotlib pycollada shiboken2 pyside2 pyside2-tools pivy python boost
   ]);
-
-  # Fix missing app icon on Wayland. Has been upstreamed and should be safe to
-  # remove in versions >= 0.19
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/FreeCAD/FreeCAD/commit/c4d2a358ca125d51d059dfd72dcbfba326196dfc.patch";
-      sha256 = "0yqc9zrxgi2c2xcidm8wh7a9yznkphqvjqm9742qm5fl20p8gl4h";
-    })
-  ];
 
   cmakeFlags = [
     "-DBUILD_QT5=ON"

--- a/pkgs/applications/graphics/freecad/stable.nix
+++ b/pkgs/applications/graphics/freecad/stable.nix
@@ -1,0 +1,85 @@
+{ stdenv, mkDerivation, fetchFromGitHub, fetchpatch, cmake, ninja, coin3d,
+xercesc, ode, eigen, qtbase, qttools, qtwebkit, wrapQtAppsHook,
+opencascade-occt, gts, hdf5, vtk, medfile, zlib, python3Packages, swig,
+gfortran, libXmu, soqt, libf2c, libGLU, makeWrapper, pkgconfig, mpi ? null }:
+
+assert mpi != null;
+
+let
+  pythonPackages = python3Packages;
+in mkDerivation rec {
+  pname = "freecad";
+  version = "0.18.4";
+
+  src = fetchFromGitHub {
+    owner = "FreeCAD";
+    repo = "FreeCAD";
+    rev = version;
+    sha256 = "1phs9a0px5fnzpyx930cz39p5dis0f0yajxzii3c3sazgkzrd55s";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkgconfig
+    pythonPackages.pyside2-tools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    cmake coin3d xercesc ode eigen opencascade-occt gts
+    zlib swig gfortran soqt libf2c makeWrapper mpi vtk hdf5 medfile
+    libGLU libXmu qtbase qttools qtwebkit
+  ] ++ (with pythonPackages; [
+    matplotlib pycollada shiboken2 pyside2 pyside2-tools pivy python boost
+  ]);
+
+  # Fix missing app icon on Wayland. Has been upstreamed and should be safe to
+  # remove in versions >= 0.19
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/FreeCAD/FreeCAD/commit/c4d2a358ca125d51d059dfd72dcbfba326196dfc.patch";
+      sha256 = "0yqc9zrxgi2c2xcidm8wh7a9yznkphqvjqm9742qm5fl20p8gl4h";
+    })
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_QT5=ON"
+    "-DSHIBOKEN_INCLUDE_DIR=${pythonPackages.shiboken2}/include"
+    "-DSHIBOKEN_LIBRARY=Shiboken2::libshiboken"
+    ("-DPYSIDE_INCLUDE_DIR=${pythonPackages.pyside2}/include"
+      + ";${pythonPackages.pyside2}/include/PySide2/QtCore"
+      + ";${pythonPackages.pyside2}/include/PySide2/QtWidgets"
+      + ";${pythonPackages.pyside2}/include/PySide2/QtGui"
+      )
+    "-DPYSIDE_LIBRARY=PySide2::pyside2"
+  ];
+
+  # This should work on both x86_64, and i686 linux
+  preBuild = ''
+    export NIX_LDFLAGS="-L${gfortran.cc}/lib64 -L${gfortran.cc}/lib $NIX_LDFLAGS";
+  '';
+
+  # Their main() removes PYTHONPATH=, and we rely on it.
+  preConfigure = ''
+    sed '/putenv("PYTHONPATH/d' -i src/Main/MainGui.cpp
+
+    qtWrapperArgs+=(--prefix PYTHONPATH : "$PYTHONPATH")
+  '';
+
+  qtWrapperArgs = [
+    "--set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1"
+  ];
+
+  postFixup = ''
+    mv $out/share/doc $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "General purpose Open Source 3D CAD/MCAD/CAx/CAE/PLM modeler";
+    homepage = "https://www.freecadweb.org/";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ viric gebner ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/coin3d/default.nix
+++ b/pkgs/development/libraries/coin3d/default.nix
@@ -1,14 +1,14 @@
-{ fetchFromBitbucket, stdenv, boost, cmake, libGL, libGLU }:
+{ fetchFromGitHub, stdenv, boost, cmake, libGL, libGLU }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "coin";
-  version = "unstable-2019-06-12";
+  version = "4.0.0";
 
-  src = fetchFromBitbucket {
-    owner = "Coin3D";
+  src = fetchFromGitHub {
+    owner = "coin3d";
     repo = "coin";
-    rev = "8d860d7ba112b22c4e9b289268fd8b3625ab81d3";
-    sha256 = "1cpncljqvw28k5wvpgchv593nayhby5gwpvbnyllc9hb9ms816xn";
+    rev = "Coin-${version}";
+    sha256 = "1ayg0hl8wanhadahm5xbghghxw1qjwqbrs3dl3ngnff027hsyf8p";
   };
 
   postPatch = ''
@@ -18,11 +18,11 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost libGL libGLU ];
 
-  meta = {
-    homepage = "https://bitbucket.org/Coin3D/coin/wiki/Home";
-    license = stdenv.lib.licenses.gpl2Plus;
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/coin3d/coin";
+    license = licenses.bsd3;
     description = "High-level, retained-mode toolkit for effective 3D graphics development";
-    maintainers = [ stdenv.lib.maintainers.viric ];
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = with maintainers; [ gebner viric ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/opencascade-occt/7.3.nix
+++ b/pkgs/development/libraries/opencascade-occt/7.3.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, fetchpatch, cmake, ninja, tcl, tk,
+  libGL, libGLU, libXext, libXmu, libXi }:
+
+stdenv.mkDerivation rec {
+  pname = "opencascade-occt";
+  version = "7.3.0p3";
+  commit = "V${builtins.replaceStrings ["."] ["_"] version}";
+
+  src = fetchurl {
+    name = "occt-${commit}.tar.gz";
+    url = "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=${commit};sf=tgz";
+    sha256 = "0k9c3ypcnjcilq1dhsf6xxbd52gyq4h5rchvp30k3c8ph4ris5pz";
+  };
+
+  nativeBuildInputs = [ cmake ninja ];
+  buildInputs = [ tcl tk libGL libGLU libXext libXmu libXi ];
+
+  meta = with stdenv.lib; {
+    description = "Open CASCADE Technology, libraries for 3D modeling and numerical simulation";
+    homepage = "https://www.opencascade.org/";
+    license = licenses.lgpl21;  # essentially...
+    # The special exception defined in the file OCCT_LGPL_EXCEPTION.txt
+    # are basically about making the license a little less share-alike.
+    maintainers = with maintainers; [ amiloradovsky ];
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/development/libraries/soqt/default.nix
+++ b/pkgs/development/libraries/soqt/default.nix
@@ -1,26 +1,23 @@
-{ fetchhg, stdenv, coin3d, qtbase, cmake, pkgconfig }:
+{ fetchurl, stdenv, coin3d, qtbase, cmake, pkgconfig }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "soqt";
-  version = "1.6.0a";
+  version = "1.6.0";
 
-  src = fetchhg {
-    url = "https://bitbucket.org/Coin3D/soqt";
-    rev = "5f2afb4890e0059eb27e1671f980d10ebfb9e762";
-    sha256 = "0j9lsci4cx95v16l0jaky0vzh4lbdliwz7wc17442ihjaqiqmv8m";
-    fetchSubrepos = true;
+  src = fetchurl {
+    url = "https://github.com/coin3d/soqt/releases/download/SoQt-${version}/soqt-${version}-src.tar.gz";
+    sha256 = "07qfljy286vb7y1p93205zn9sp1lpn0rcrqm5010gj87kzsmllwz";
   };
 
   buildInputs = [ coin3d qtbase ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
-  meta = {
-    homepage = "https://bitbucket.org/Coin3D/coin/wiki/Home";
-    license = stdenv.lib.licenses.gpl2Plus;
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/coin3d/soqt";
+    license = licenses.bsd3;
     description = "Glue between Coin high-level 3D visualization library and Qt";
-
-    maintainers = [ stdenv.lib.maintainers.viric ];
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = with maintainers; [ gebner viric ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/pivy/default.nix
+++ b/pkgs/development/python-modules/pivy/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "pivy";
-  version = "0.6.5a2";
+  version = "0.6.5";
 
   src = fetchFromGitHub {
-    owner = "FreeCAD";
+    owner = "coin3d";
     repo = "pivy";
     rev = version;
-    sha256 = "1w03jaha36bjyfaz8hchnv8yrkm5715w15crhd3qrlagz8fs38hm";
+    sha256 = "0vids7sxk8w5vr73xdnf8xdci71a7syl6cd35aiisppbqyyfmykx";
   };
 
   nativeBuildInputs = with pkgs; [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20609,8 +20609,6 @@ in
 
   freecad = libsForQt514.callPackage ../applications/graphics/freecad {
     mpi = openmpi;
-    # pyside2 5.12 is broken under python 3.8
-    python3Packages = python37Packages;
   };
 
   freemind = callPackage ../applications/misc/freemind { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20611,6 +20611,11 @@ in
   freecad = libsForQt514.callPackage ../applications/graphics/freecad {
     mpi = openmpi;
   };
+  freecadStable = libsForQt514.callPackage ../applications/graphics/freecad/stable.nix {
+    mpi = openmpi;
+    opencascade-occt = opencascade-occt730;
+    python3Packages = python37Packages;
+  };
 
   freemind = callPackage ../applications/misc/freemind { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14520,6 +14520,7 @@ in
 
   opencascade = callPackage ../development/libraries/opencascade { };
   opencascade-occt = callPackage ../development/libraries/opencascade-occt { };
+  opencascade-occt730 = callPackage ../development/libraries/opencascade-occt/7.3.nix { };
 
   opencl-headers = callPackage ../development/libraries/opencl-headers { };
 


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of #98845

Some failures on macos, because there are on `master` too, and if I'm going to fix them I should fix them there first and leave this as a straight backport.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
