### PR TITLE
jdt-language-server: init at 1.8.0

### DIFF
--- a/pkgs/development/tools/jdt-language-server/default.nix
+++ b/pkgs/development/tools/jdt-language-server/default.nix
@@ -1,0 +1,103 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, jdk
+}:
+
+stdenv.mkDerivation rec {
+  pname = "jdt-language-server";
+  version = "1.8.0";
+  timestamp = "202201261434";
+
+  src = fetchurl {
+    url = "https://download.eclipse.org/jdtls/milestones/${version}/jdt-language-server-${version}-${timestamp}.tar.gz";
+    sha256 = "0wlnsr72hncdqrbpgfl9hgwqw9d9rppq4iymnjmgfn51rjcqadv8";
+  };
+
+  sourceRoot = ".";
+
+  buildInputs = [
+    jdk
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase =
+    let
+      # The application ships with config directories for linux and mac
+      configDir = if stdenv.isDarwin then "config_mac" else "config_linux";
+    in
+    ''
+      # Copy jars
+      install -D -t $out/share/java/plugins/ plugins/*.jar
+
+      # Copy config directories for linux and mac
+      install -Dm 444 -t $out/share/config ${configDir}/*
+
+      # Get latest version of launcher jar
+      # e.g. org.eclipse.equinox.launcher_1.5.800.v20200727-1323.jar
+      launcher="$(ls $out/share/java/plugins/org.eclipse.equinox.launcher_* | sort -V | tail -n1)"
+
+      # The wrapper script will create a directory in the user's cache, copy in the config
+      # files since this dir can't be read-only, and by default use this as the runtime dir.
+      #
+      # The following options are required as per the upstream documentation:
+      #
+      #   -Declipse.application=org.eclipse.jdt.ls.core.id1
+      #   -Dosgi.bundles.defaultStartLevel=4
+      #   -Declipse.product=org.eclipse.jdt.ls.core.product
+      #   -noverify
+      #   --add-modules=ALL-SYSTEM
+      #   --add-opens java.base/java.util=ALL-UNNAMED
+      #   --add-opens java.base/java.lang=ALL-UNNAMED
+      #
+      # The following options configure the server to run without writing logs to the nix store:
+      #
+      #   -Dosgi.sharedConfiguration.area.readOnly=true
+      #   -Dosgi.checkConfiguration=true
+      #   -Dosgi.configuration.cascaded=true
+      #   -Dosgi.sharedConfiguration.area=$out/share/config
+      #
+      # Other options which the caller may change:
+      #
+      #   -Dlog.level:
+      #     Log level.
+      #     This can be overidden by setting JAVA_OPTS.
+      #
+      # The caller must specify the following:
+      #
+      #   -data:
+      #     The application stores runtime data here. We set this to <cache-dir>/$PWD
+      #     so that projects don't collide with each other.
+      #     This can be overidden by specifying -configuration to the wrapper.
+      #
+      # Java options, such as -Xms and Xmx can be specified by setting JAVA_OPTS.
+      #
+      makeWrapper ${jdk}/bin/java $out/bin/jdt-language-server \
+        --add-flags "-Declipse.application=org.eclipse.jdt.ls.core.id1" \
+        --add-flags "-Dosgi.bundles.defaultStartLevel=4" \
+        --add-flags "-Declipse.product=org.eclipse.jdt.ls.core.product" \
+        --add-flags "-Dosgi.sharedConfiguration.area=$out/share/config" \
+        --add-flags "-Dosgi.sharedConfiguration.area.readOnly=true" \
+        --add-flags "-Dosgi.checkConfiguration=true" \
+        --add-flags "-Dosgi.configuration.cascaded=true" \
+        --add-flags "-Dlog.level=ALL" \
+        --add-flags "-noverify" \
+        --add-flags "\$JAVA_OPTS" \
+        --add-flags "-jar $launcher" \
+        --add-flags "--add-modules=ALL-SYSTEM" \
+        --add-flags "--add-opens java.base/java.util=ALL-UNNAMED" \
+        --add-flags "--add-opens java.base/java.lang=ALL-UNNAMED"
+    '';
+
+  meta = with lib; {
+    homepage = "https://github.com/eclipse/eclipse.jdt.ls";
+    description = "Java language server";
+    license = licenses.epl20;
+    maintainers = with maintainers; [ matt-snider ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20367,6 +20367,8 @@ in
 
   iwona = callPackage ../data/fonts/iwona { };
 
+  jdt-language-server = callPackage ../development/tools/jdt-language-server {};
+
   jetbrains-mono = callPackage ../data/fonts/jetbrains-mono { };
 
   jost = callPackage ../data/fonts/jost { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

It doesn't seem like there are any Java language servers in nixpkgs so far

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
