### PR TITLE
libetpan: 1.9.3 -> 1.9.4

### DIFF
--- a/pkgs/development/libraries/libetpan/default.nix
+++ b/pkgs/development/libraries/libetpan/default.nix
@@ -1,31 +1,29 @@
-{ stdenv, fetchFromGitHub
-, autoconf
-, automake
-, libtool
-, openssl
+{ stdenv, lib, fetchFromGitHub
+, autoconf, automake, libtool, openssl, pkg-config
 }:
 
 stdenv.mkDerivation rec {
   pname = "libetpan";
-  version = "1.9.3";
+  version = "1.9.4";
 
   src = fetchFromGitHub {
     owner = "dinhviethoa";
     repo = "libetpan";
     rev = version;
-    sha256 = "19g4qskg71jv7sxfxsdkjmrxk9mk5kf9b6fhw06g6wvm3205n95f";
+    sha256 = "0g7an003simfdn7ihg9yjv7hl2czsmjsndjrp39i7cad8icixscn";
   };
 
-  nativeBuildInputs = [ libtool autoconf automake ];
+  nativeBuildInputs = [ autoconf automake libtool pkg-config ];
 
   buildInputs = [ openssl ];
 
   configureScript = "./autogen.sh";
 
-  meta = with stdenv.lib; {
-    description = "An efficient, portable library for different kinds of mail access: IMAP, SMTP, POP, and NNTP";
+  meta = with lib; {
+    description = "Mail Framework for the C Language";
     homepage = "http://www.etpan.org/libetpan.html";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ oxzi ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Also added myself as a maintainer because there are none.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update libetpan to its latest release. Also added myself as a maintainer because there are none.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
