### PR TITLE
[20.09] update mysql release notes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -116,15 +116,24 @@ services.mysql.initialScript = pkgs.writeText "mariadb-init.sql" ''
       MySQL server is now started with additional systemd sandbox/hardening options for better security. The PrivateTmp, ProtectHome, and ProtectSystem options
       may be problematic when MySQL is attempting to read from or write to your filesystem anywhere outside of its own state directory, for example when
       calling <literal>LOAD DATA INFILE or SELECT * INTO OUTFILE</literal>. In this scenario a variant of the following may be required:
-        - allow MySQL to read from /home and /tmp directories when using <literal>LOAD DATA INFILE</literal>
+      <itemizedlist>
+       <listitem>
+        <para>allow MySQL to read from /home and /tmp directories when using <literal>LOAD DATA INFILE</literal>
 <programlisting>
 systemd.services.mysql.serviceConfig.ProtectHome = lib.mkForce "read-only";
 </programlisting>
-        - allow MySQL to write to custom folder <literal>/var/data</literal> when using <literal>SELECT * INTO OUTFILE</literal>, assuming the mysql user has write
-          access to <literal>/var/data</literal>
+        </para>
+       </listitem>
+      <listitem>
+       <para>
+        allow MySQL to write to custom folder <literal>/var/data</literal> when using <literal>SELECT * INTO OUTFILE</literal>, assuming the mysql user has write
+        access to <literal>/var/data</literal>
 <programlisting>
 systemd.services.mysql.serviceConfig.ReadWritePaths = [ "/var/data" ];
 </programlisting>
+</para>
+      </listitem>
+     </itemizedlist>
     </para>
     <para>
       The MySQL service no longer runs its <literal>systemd</literal> service startup script as <literal>root</literal> anymore. A dedicated non <literal>root</literal>

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -108,7 +108,19 @@ services.mysql.initialScript = pkgs.writeText "mariadb-init.sql" ''
   ALTER USER root@localhost IDENTIFIED VIA mysql_native_password USING PASSWORD("verysecret");
 '';
 </programlisting>
-      When MariaDB data directory is just upgraded (not initialized), the users are not created or modified.
+  When MariaDB data directory is just upgraded (not initialized), the users are not created or modified. You have to create users beforehand.
+  Continue reading the next paragraph for instructions.
+    </para>
+    <para>
+      The MySQL service no longer runs its <literal>systemd</literal> service startup script as <literal>root</literal> anymore. A dedicated non <literal>root</literal>
+      super user account is required for operation. This means users with an existing MySQL or MariaDB database server are required to run the following SQL statements
+      as a super admin user before upgrading:
+<programlisting>
+CREATE USER IF NOT EXISTS 'mysql'@'localhost' identified with unix_socket;
+GRANT ALL PRIVILEGES ON *.* TO 'mysql'@'localhost' WITH GRANT OPTION;
+</programlisting>
+      If you use MySQL instead of MariaDB please replace <literal>unix_socket</literal> with <literal>auth_socket</literal>. If you have changed the value of <xref linkend="opt-services.mysql.user"/>
+      from the default of <literal>mysql</literal> to a different user please change <literal>'mysql'@'localhost'</literal> to the corresponding user instead.
     </para>
    </listitem>
    <listitem>
@@ -134,17 +146,6 @@ systemd.services.mysql.serviceConfig.ReadWritePaths = [ "/var/data" ];
 </para>
       </listitem>
      </itemizedlist>
-    </para>
-    <para>
-      The MySQL service no longer runs its <literal>systemd</literal> service startup script as <literal>root</literal> anymore. A dedicated non <literal>root</literal>
-      super user account is required for operation. This means users with an existing MySQL or MariaDB database server are required to run the following SQL statements
-      as a super admin user before upgrading:
-<programlisting>
-CREATE USER IF NOT EXISTS 'mysql'@'localhost' identified with unix_socket;
-GRANT ALL PRIVILEGES ON *.* TO 'mysql'@'localhost' WITH GRANT OPTION;
-</programlisting>
-      If you use MySQL instead of MariaDB please replace <literal>unix_socket</literal> with <literal>auth_socket</literal>. If you have changed the value of <xref linkend="opt-services.mysql.user"/>
-      from the default of <literal>mysql</literal> to a different user please change <literal>'mysql'@'localhost'</literal> to the corresponding user instead.
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
###### Motivation for this change

I just upgraded a stateful machine to 20.09 and stumbled a bit on the release notes. The most important bit seems to be the version upgrade and the commands to run *before* the upgrade were on the other end of the changelog. I've moved them up directly after the part where the upgrade is being mentioned. I also fixed some formatting on the nested lists that did look weird in the rendered HTML.

I've a rendered version of this at https://s.rammhold.de/nixos-manual/release-notes.html#sec-release-20.09

