### PR TITLE
makeRustPlatform: Put back in it's own file.

### DIFF
--- a/pkgs/development/compilers/rust/1_44.nix
+++ b/pkgs/development/compilers/rust/1_44.nix
@@ -13,6 +13,7 @@
 , CoreFoundation, Security
 , llvmPackages_5
 , pkgsBuildTarget, pkgsBuildBuild
+, makeRustPlatform
 } @ args:
 
 import ./default.nix {

--- a/pkgs/development/compilers/rust/1_45.nix
+++ b/pkgs/development/compilers/rust/1_45.nix
@@ -13,6 +13,7 @@
 , CoreFoundation, Security
 , llvmPackages_5
 , pkgsBuildTarget, pkgsBuildBuild
+, makeRustPlatform
 } @ args:
 
 import ./default.nix {

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -12,6 +12,7 @@
 , CoreFoundation, Security
 , llvmPackages_5
 , pkgsBuildTarget, pkgsBuildBuild
+, makeRustPlatform
 }: rec {
   toRustTarget = platform: with platform.parsed; let
     cpu_ = {
@@ -21,24 +22,6 @@
     }.${cpu.name} or platform.rustc.arch or cpu.name;
   in platform.rustc.config
     or "${cpu_}-${vendor.name}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}";
-
-  makeRustPlatform = { rustc, cargo, ... }: rec {
-    rust = {
-      inherit rustc cargo;
-    };
-
-    fetchCargoTarball = buildPackages.callPackage ../../../build-support/rust/fetchCargoTarball.nix {
-      inherit cargo;
-    };
-
-    buildRustPackage = callPackage ../../../build-support/rust {
-      inherit rustc cargo fetchCargoTarball;
-    };
-
-    rustcSrc = callPackage ./rust-src.nix {
-      inherit rustc;
-    };
-  };
 
   # This just contains tools for now. But it would conceivably contain
   # libraries too, say if we picked some default/recommended versions from

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -1,0 +1,21 @@
+{ buildPackages, callPackage }:
+
+{ rustc, cargo, ... }:
+
+rec {
+  rust = {
+    inherit rustc cargo;
+  };
+
+  fetchCargoTarball = buildPackages.callPackage ../../../build-support/rust/fetchCargoTarball.nix {
+    inherit cargo;
+  };
+
+  buildRustPackage = callPackage ../../../build-support/rust {
+    inherit rustc cargo fetchCargoTarball;
+  };
+
+  rustcSrc = callPackage ./rust-src.nix {
+    inherit rustc;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9659,7 +9659,8 @@ in
   rustPackages = rustPackages_1_45;
 
   inherit (rustPackages) cargo clippy rustc rustPlatform;
-  inherit (rust) makeRustPlatform;
+
+  makeRustPlatform = callPackage ../development/compilers/rust/make-rust-platform.nix {};
 
   buildRustCrate = callPackage ../build-support/rust/build-rust-crate { };
   buildRustCrateHelpers = callPackage ../build-support/rust/build-rust-crate/helpers.nix { };


### PR DESCRIPTION
###### Motivation for this change

We expose it on the top level, but I don't think it makes sense to pull it from a specific version of the rust tools when it is in fact version agnostic.

This reverts a tiny portion of 912dca193aee9da77a4d429285db53729d81aa3d.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
