### PR TITLE
mumble-overlay: fix outdated install phase

### DIFF
--- a/pkgs/applications/networking/mumble/overlay.nix
+++ b/pkgs/applications/networking/mumble/overlay.nix
@@ -12,11 +12,13 @@ in stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/lib
-    ln -s ${mumble}/lib/libmumble.so.1.2.* $out/lib/libmumble.so.1
+    ln -s ${mumble}/lib/libmumble.so.1 $out/lib/
+
     ${lib.optionalString (mumble_i686 != null) ''
       mkdir -p $out/lib32
-      ln -s ${mumble_i686}/lib/libmumble.so.1.2.* $out/lib32/libmumble.so.1
+      ln -s ${mumble_i686}/lib/libmumble.so.1 $out/lib32/
     ''}
+
     install -Dm755 scripts/mumble-overlay $out/bin/mumble-overlay
     sed -i "s,/usr/lib,$out/lib,g" $out/bin/mumble-overlay
     sed -i '2iPATH="${binPath}:$PATH"' $out/bin/mumble-overlay


### PR DESCRIPTION
As it stands, the mumble-overlay install phase attemps to link
`{mumble}/lib/libmumble.so.1.2.*` to its output's `lib/libmumble.so.1`,
this has stopped matching any file ever since mumble has passed
version 1.3.
Instead, we simply link from `{mumble}/lib/libmumble.so.1`

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://hydra.nixos.org/build/128015584
ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
