### PR TITLE
kube-capacity: init at 0.5.1

### DIFF
--- a/pkgs/applications/networking/cluster/kube-capacity/default.nix
+++ b/pkgs/applications/networking/cluster/kube-capacity/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kube-capacity";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "robscott";
+    repo = pname;
+    sha256 = "127583hmpj04y522wir76a39frm6zg9z7mb4ny5lxxjqhn0q0cd5";
+  };
+
+  vendorSha256 = "sha256-EgLWZs282IV1euCUCc5ucf267E2Z7GF9SgoImiGvuVM=";
+
+  meta = with lib; {
+    description =
+      "A simple CLI that provides an overview of the resource requests, limits, and utilization in a Kubernetes cluster";
+    homepage = "https://github.com/robscott/kube-capacity";
+    changelog = "https://github.com/robscott/kube-capacity/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = [ maintainers.bryanasdev000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21638,6 +21638,8 @@ in
 
   popeye = callPackage ../applications/networking/cluster/popeye { };
 
+  kube-capacity = callPackage ../applications/networking/cluster/kube-capacity { };
+
   fluxctl = callPackage ../applications/networking/cluster/fluxctl { };
 
   linkerd = callPackage ../applications/networking/cluster/linkerd { };


### PR DESCRIPTION
###### Motivation for this change

Add kube-capacity, a simple CLI tool that provides an overview of the resource requests, limits, and utilization in a Kubernetes cluster, in standalone mode (without krew, kubectl plugin manager).

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
