### PR TITLE
smartdns: 30 -> 33

### DIFF
--- a/pkgs/tools/networking/smartdns/default.nix
+++ b/pkgs/tools/networking/smartdns/default.nix
@@ -2,14 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "smartdns";
-  version =
-    "30"; # This would be used later in the next release as the FHS commit integrated into realse 31.
+  version = "33";
 
   src = fetchFromGitHub {
     owner = "pymumu";
     repo = pname;
-    rev = "3ad7cd7f454eec2fbdf338c0eb0541da301f1e73";
-    sha256 = "1y9p8gxpj2k4a10maggkxg8l55jvr7x1wyxi69waxf56ggh2dvv0";
+    rev = "Release${version}";
+    sha256 = "0cmzpm4y1yi96mg2cz2byqw6vl62dgnikldy08q43vi7jl3y0749";
   };
 
   buildInputs = [ openssl ];


### PR DESCRIPTION
Bump release from 30 to 33 for smartdns.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done
Simply bump the version number

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
