### PR TITLE
kubectl-example: init at 1.0.1

### DIFF
--- a/pkgs/applications/networking/cluster/kubectl-example/default.nix
+++ b/pkgs/applications/networking/cluster/kubectl-example/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kubectl-example";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "seredot";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "18vp53cda93qjssxygwqp55yc80a93781839gf3138awngf731yq";
+  };
+
+  vendorSha256 = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
+
+  meta = with lib; {
+    description = "kubectl plugin for retrieving resource example YAMLs";
+    homepage = "https://github.com/seredot/kubectl-example";
+    changelog = "https://github.com/seredot/kubectl-example/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = [ maintainers.bryanasdev000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21630,6 +21630,8 @@ in
 
   kubectl = callPackage ../applications/networking/cluster/kubectl { };
 
+  kubectl-example = callPackage ../applications/networking/cluster/kubectl-example { };
+
   kubeless = callPackage ../applications/networking/cluster/kubeless { };
 
   kubelogin = callPackage ../applications/networking/cluster/kubelogin { };


### PR DESCRIPTION
###### Motivation for this change

Add kubectl-example, a simple CLI for retrieving resource example YAMLs of Kubernetes, in standalone mode (without krew, kubectl plugin manager).

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
