### PR TITLE
krusader: use specific license

### DIFF
--- a/pkgs/applications/misc/krusader/default.nix
+++ b/pkgs/applications/misc/krusader/default.nix
@@ -4,25 +4,23 @@
   karchive, kconfig, kcrash, kguiaddons, kinit, kparts, kwindowsystem
 }:
 
-let
+mkDerivation rec {
   pname = "krusader";
   version = "2.7.2";
-in mkDerivation rec {
-  pname = "krusader";
-  inherit version;
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/${pname}-${version}.tar.xz";
     sha256 = "02b1jz5a7cjr13v6c7fczrhs1xmg1krnva5fxk8x2bf4nd1rm8s1";
   };
 
+  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
+
+  propagatedBuildInputs = [ karchive kconfig kcrash kguiaddons kinit kparts kwindowsystem ];
+
   meta = with lib; {
     description = "Norton/Total Commander clone for KDE";
-    license = licenses.gpl2;
     homepage = "http://www.krusader.org";
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ sander turion ];
   };
-
-  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
-  propagatedBuildInputs = [ karchive kconfig kcrash kguiaddons kinit kparts kwindowsystem ];
 }


### PR DESCRIPTION
###### Motivation for this change

Judging by the license distributed with the source, it's GPLv2 only but
I have opened a ticket with upstream requesting clarification.

https://bugs.kde.org/show_bug.cgi?id=427110


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).