### PR TITLE
crudini: py2 -> py3

### DIFF
--- a/pkgs/tools/misc/crudini/default.nix
+++ b/pkgs/tools/misc/crudini/default.nix
@@ -1,24 +1,19 @@
-{ stdenv, fetchFromGitHub, python2Packages, help2man, installShellFiles }:
+{ stdenv, fetchFromGitHub, python3Packages, help2man, installShellFiles }:
 
-let
-  # py3 is supposedly working in version 0.9.3 but the tests fail so stick to py2
-  pypkgs = python2Packages;
-
-in
-pypkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "crudini";
   version = "0.9.3";
 
   src = fetchFromGitHub {
-    owner  = "pixelb";
-    repo   = "crudini";
-    rev    = version;
+    owner = "pixelb";
+    repo = "crudini";
+    rev = version;
     sha256 = "0298hvg0fpk0m0bjpwryj3icksbckwqqsr9w1ain55wf5s0v24k3";
   };
 
   nativeBuildInputs = [ help2man installShellFiles ];
 
-  propagatedBuildInputs = with pypkgs; [ iniparse ];
+  propagatedBuildInputs = with python3Packages; [ iniparse ];
 
   postPatch = ''
     substituteInPlace crudini-help \
@@ -48,7 +43,7 @@ pypkgs.buildPythonApplication rec {
   meta = with stdenv.lib; {
     description = "A utility for manipulating ini files ";
     homepage = "https://www.pixelbeat.org/programs/crudini/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ peterhoeg ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

With a recent-ish python-iniparse update, crudini now supports py3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).