### PR TITLE
rebar3: 3.12.0 -> 3.14.2

### DIFF
--- a/pkgs/development/tools/build-managers/rebar3/default.nix
+++ b/pkgs/development/tools/build-managers/rebar3/default.nix
@@ -3,79 +3,85 @@
   tree }:
 
 let
-  version = "3.12.0";
+  version = "3.14.2";
 
+  # Dependencies should match the ones in:
+  # https://github.com/erlang/rebar3/blob/${version}/rebar.lock
+  # `sha256` could also be taken from https://hex.pm - Checksum
+
+  bbmustache = fetchHex {
+    pkg = "bbmustache";
+    version = "1.10.0";
+    sha256 = "43effa3fd4bb9523157af5a9e2276c493495b8459fc8737144aa186cb13ce2ee";
+  };
+  certifi = fetchHex {
+    pkg = "certifi";
+    version = "2.5.2";
+    sha256 = "3b3b5f36493004ac3455966991eaf6e768ce9884693d9968055aeeeb1e575040";
+  };
+  cf = fetchHex {
+    pkg = "cf";
+    version = "0.3.1";
+    sha256 = "315e8d447d3a4b02bcdbfa397ad03bbb988a6e0aa6f44d3add0f4e3c3bf97672";
+  };
+  cth_readable = fetchHex {
+    pkg = "cth_readable";
+    version = "1.4.9";
+    sha256 = "b4c6ababdb046c5f2fbb3c22f030b4c5a679083956dcdd29c1df0cb30b18da24";
+  };
   erlware_commons = fetchHex {
     pkg = "erlware_commons";
     version = "1.3.1";
     sha256 = "7aada93f368d0a0430122e39931b7fb4ac9e94dbf043cdc980ad4330fd9cd166";
-  };
-  ssl_verify_fun = fetchHex {
-    pkg = "ssl_verify_fun";
-    version = "1.1.3";
-    sha256 = "2e120e6505d6e9ededb2836611dfe2f7028432dc280957998e154307b5ea92fe";
-  };
-  certifi = fetchHex {
-    pkg = "certifi";
-    version = "2.3.1";
-    sha256 = "e12d667d042c11d130594bae2b0097e63836fe8b1e6d6b2cc48f8bb7a2cf7d68";
-  };
-  providers = fetchHex {
-    pkg = "providers";
-    version = "1.7.0";
-    sha256 = "8be66129ca85c2fa74efd8737cdaedd31c1c1af51dd2fd601495a6def4cae4a6";
-  };
-  getopt = fetchHex {
-    pkg = "getopt";
-    version = "1.0.1";
-    sha256 = "53e1ab83b9ceb65c9672d3e7a35b8092e9bdc9b3ee80721471a161c10c59959c";
-  };
-  bbmustache = fetchHex {
-    pkg = "bbmustache";
-    version = "1.6.0";
-    sha256 = "53e02d296512a57be03a98c91541b34d2ca64930268030b2d12364a0332015df";
-  };
-  relx = fetchHex {
-    pkg = "relx";
-    version = "3.28.0";
-    sha256 = "8afb871c0a2a27f0063d973903fc64d2207bc705ecc3607462920683d24ac7b5";
-  };
-  cf = fetchHex {
-    pkg = "cf";
-    version = "0.2.2";
-    sha256 = "08cvy7skn5d2k4manlx5k3anqgjdvajjhc5jwxbaszxw34q3na28";
-  };
-  cth_readable = fetchHex {
-    pkg = "cth_readable";
-    version = "1.4.3";
-    sha256 = "0wr0hba6ka74s3628jrrd7ynjdh7syxigkh7ildg8fgi20ab88fd";
   };
   eunit_formatters = fetchHex {
     pkg = "eunit_formatters";
     version = "0.5.0";
     sha256 = "1jb3hzb216r29x2h4pcjwfmx1k81431rgh5v0mp4x5146hhvmj6n";
   };
-  hex_core = fetchHex {
-    pkg = "hex_core";
-    version = "0.4.0";
-    sha256 = "8ace8c6cfa10df4cb8be876f42f7446890e124203c094cc7b4e7616fb8de5d7f";
+  getopt = fetchHex {
+    pkg = "getopt";
+    version = "1.0.1";
+    sha256 = "53e1ab83b9ceb65c9672d3e7a35b8092e9bdc9b3ee80721471a161c10c59959c";
   };
   parse_trans = fetchHex {
     pkg = "parse_trans";
     version = "3.3.0";
-    sha256 = "0q5r871bzx1a8fa06yyxdi3xkkp7v5yqazzah03d6yl3vsmn7vqp";
+    sha256 = "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960";
+  };
+  providers = fetchHex {
+    pkg = "providers";
+    version = "1.8.1";
+    sha256 = "e45745ade9c476a9a469ea0840e418ab19360dc44f01a233304e118a44486ba0";
+  };
+  relx = fetchHex {
+    pkg = "relx";
+    version = "4.1.0";
+    sha256 = "b94a3f96697a479ee5217a853345e0f4977bdf40d3c040af0d3d80fadad82af4";
+  };
+  ssl_verify_fun = fetchHex {
+    pkg = "ssl_verify_fun";
+    version = "1.1.6";
+    sha256 = "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680";
   };
 
+  hex_core = fetchHex {
+    pkg = "hex_core";
+    version = "0.7.1";
+    sha256 = "05c60411511b6dc79affcd99a93e67d71e1b9d6abcb28ba75cd4ebc8585b8d02";
+  };
 in
 stdenv.mkDerivation rec {
   pname = "rebar3";
   inherit version erlang;
 
+  # How to obtain `sha256`:
+  # nix-prefetch-url --unpack https://github.com/erlang/rebar3/archive/${version}.tar.gz
   src = fetchFromGitHub {
     owner = "erlang";
     repo = pname;
     rev = version;
-    sha256 = "0936ix7lfwsamssap58b265zid7x2m97azrr2qpjcln3xysd16lg";
+    sha256 = "02gz6xs8j5rm14r6dndcpdm8q3rl4mcj363gnnx4y5xvvfnv9bfa";
   };
 
   bootstrapper = ./rebar3-nix-bootstrap;
@@ -86,18 +92,19 @@ stdenv.mkDerivation rec {
     mkdir -p _checkouts
     mkdir -p _build/default/lib/
 
-    cp --no-preserve=mode -R ${erlware_commons} _checkouts/erlware_commons
-    cp --no-preserve=mode -R ${providers} _checkouts/providers
-    cp --no-preserve=mode -R ${getopt} _checkouts/getopt
     cp --no-preserve=mode -R ${bbmustache} _checkouts/bbmustache
     cp --no-preserve=mode -R ${certifi} _checkouts/certifi
     cp --no-preserve=mode -R ${cf} _checkouts/cf
     cp --no-preserve=mode -R ${cth_readable} _checkouts/cth_readable
+    cp --no-preserve=mode -R ${erlware_commons} _checkouts/erlware_commons
     cp --no-preserve=mode -R ${eunit_formatters} _checkouts/eunit_formatters
+    cp --no-preserve=mode -R ${getopt} _checkouts/getopt
+    cp --no-preserve=mode -R ${parse_trans} _checkouts/parse_trans
+    cp --no-preserve=mode -R ${providers} _checkouts/providers
     cp --no-preserve=mode -R ${relx} _checkouts/relx
     cp --no-preserve=mode -R ${ssl_verify_fun} _checkouts/ssl_verify_fun
+
     cp --no-preserve=mode -R ${hex_core} _checkouts/hex_core
-    cp --no-preserve=mode -R ${parse_trans} _checkouts/parse_trans
 
     # Bootstrap script expects the dependencies in _build/default/lib
     # TODO: Make it accept checkouts?


### PR DESCRIPTION
### Motivation for this change

Keeping things up-to-date?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
