### PR TITLE
xdummy: make unfree fonts optional; see also #99136

### DIFF
--- a/pkgs/tools/misc/xdummy/default.nix
+++ b/pkgs/tools/misc/xdummy/default.nix
@@ -1,4 +1,5 @@
-{ writeText, writeScriptBin, xorg, xkeyboard_config, runtimeShell }:
+{ writeText, writeScriptBin, xorg, xkeyboard_config, runtimeShell
+, unfreeFonts ? false, lib}:
 
 let
   xorgConfig = writeText "dummy-xorg.conf" ''
@@ -23,11 +24,13 @@ let
       XkbDir "${xkeyboard_config}/share/X11/xkb"
       FontPath "${xorg.fontadobe75dpi}/lib/X11/fonts/75dpi"
       FontPath "${xorg.fontadobe100dpi}/lib/X11/fonts/100dpi"
+      FontPath "${xorg.fontmiscmisc}/lib/X11/fonts/misc"
+      FontPath "${xorg.fontcursormisc}/lib/X11/fonts/misc"
+    ${lib.optionalString unfreeFonts ''
       FontPath "${xorg.fontbhlucidatypewriter75dpi}/lib/X11/fonts/75dpi"
       FontPath "${xorg.fontbhlucidatypewriter100dpi}/lib/X11/fonts/100dpi"
       FontPath "${xorg.fontbh100dpi}/lib/X11/fonts/100dpi"
-      FontPath "${xorg.fontmiscmisc}/lib/X11/fonts/misc"
-      FontPath "${xorg.fontcursormisc}/lib/X11/fonts/misc"
+    ''}
     EndSection
 
     Section "Module"


### PR DESCRIPTION
Tested by starting Firefox in xdummy in a Nix-build.

Will self-merge

###### Motivation for this change

`xdummy` cannot be built without `allowUnfree`

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
