### PR TITLE
knightos-mktiupgrade: init at 1.1.6

### DIFF
--- a/pkgs/development/tools/knightos/mktiupgrade/default.nix
+++ b/pkgs/development/tools/knightos/mktiupgrade/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, cmake, asciidoc }:
+
+stdenv.mkDerivation rec {
+  pname = "mktiupgrade";
+  version = "1.1.6";
+
+  src = fetchFromGitHub {
+    owner = "KnightOS";
+    repo = "mktiupgrade";
+    rev = version;
+    sha256 = "15y3rxvv7ipgc80wrvrpksxzdyqr21ywysc9hg6s7d3w8lqdq8dm";
+  };
+
+  nativeBuildInputs = [ asciidoc cmake ];
+
+  hardeningDisable = [ "format" ];
+
+  meta = with stdenv.lib; {
+    homepage    = "https://knightos.org/";
+    description = "Makes TI calculator upgrade files from ROM dumps";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9357,6 +9357,10 @@ in
 
   knightos-patchrom = callPackage ../development/tools/knightos/patchrom { };
 
+  knightos-mktiupgrade = callPackage ../development/tools/knightos/mktiupgrade {
+    asciidoc = asciidoc-full;
+  };
+
   knightos-scas = callPackage ../development/tools/knightos/scas { };
 
   kotlin = callPackage ../development/compilers/kotlin { };


### PR DESCRIPTION
###### Motivation for this change
Add knightos-mktiupgrade

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
