### PR TITLE
OpenAFS 1.8 fixups

### DIFF
--- a/pkgs/servers/openafs/1.8/default.nix
+++ b/pkgs/servers/openafs/1.8/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPackages, fetchurl, which, autoconf, automake, flex
-, docbook_xml_dtd_43 , libtool_2, removeReferencesTo
 , yacc , glibc, perl, kerberos, libxslt, docbook_xsl, file
+, docbook_xml_dtd_43, libtool_2
 , ncurses # Extra ncurses utilities. Needed for debugging and monitoring.
 , tsmbac ? null # Tivoli Storage Manager Backup Client from IBM
 }:
@@ -15,13 +15,13 @@ in stdenv.mkDerivation {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ autoconf automake flex libxslt libtool_2 perl
-    removeReferencesTo which yacc ];
+    which yacc ];
 
   buildInputs = [ kerberos ncurses ];
 
   patches = [ ./bosserver.patch ./cross-build.patch ] ++ optional (tsmbac != null) ./tsmbac.patch;
 
-  outputs = [ "out" "dev" "man" "doc" "server" ];
+  outputs = [ "out" "dev" "man" "doc" ];
 
   enableParallelBuilding = false;
 
@@ -57,7 +57,6 @@ in stdenv.mkDerivation {
       ${optionalString (tsmbac != null) "--enable-tivoli-tsm"}
       ${optionalString (ncurses == null) "--disable-gtx"}
       "--disable-linux-d_splice-alias-extra-iput"
-      "--libexecdir=$server/libexec"
     )
   '' + optionalString (tsmbac != null) ''
     export XBSA_CFLAGS="-Dxbsa -DNEW_XBSA -I${tsmbac}/lib64/sample -DXBSA_TSMLIB=\\\"${tsmbac}/lib64/libApiTSM64.so\\\""
@@ -86,8 +85,6 @@ in stdenv.mkDerivation {
   # binaries.
   preFixup = ''
     rm -rf "$(pwd)" && mkdir "$(pwd)"
-
-    find $out -type f -exec remove-references-to -t $server '{}' '+'
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Volume salvaging was partly broken. Parallel building is also broken.

###### Things done
Some fixes and improvements:
- FIX :: disable parallel building, as it is broken (in rare cases)
- FIX :: merge the `server` output with `out`, as it was breaking volume salvaging, due to hard-coded cross dependencies that got broken during fixup phase
- IMPROVEMENT :: add option to produce developer documentation
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
