### PR TITLE
pythonPackages.{abodepy,lomond}: init

### DIFF
--- a/pkgs/development/python-modules/abodepy/default.nix
+++ b/pkgs/development/python-modules/abodepy/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pytestCheckHook, colorlog, lomond
+, requests, isPy3k, requests-mock }:
+
+buildPythonPackage rec {
+  pname = "abodepy";
+  version = "1.2.0";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "MisterWil";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0m2cm90yy7fq7yrjyd999m48gqri65ifi7f6hc0s3pv2hfj89yj0";
+  };
+
+  propagatedBuildInputs = [ colorlog lomond requests ];
+  checkInputs = [ pytestCheckHook requests-mock ];
+
+  meta = with lib; {
+    homepage = "https://github.com/MisterWil/abodepy";
+    description = "An Abode alarm Python library running on Python 3";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/development/python-modules/lomond/default.nix
+++ b/pkgs/development/python-modules/lomond/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage, freezegun, fetchFromGitHub, lib, pytestCheckHook
+, pytest-mock, pytestrunner, six, tornado_4 }:
+
+buildPythonPackage rec {
+  pname = "lomond";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "wildfoundry";
+    repo = "dataplicity-${pname}";
+    rev = "b30dad3cc38d5ff210c5dd01f8c3c76aa6c616d1";
+    sha256 = "0lydq0imala08wxdyg2iwhqa6gcdrn24ah14h91h2zcxjhjk4gv8";
+  };
+
+  nativeBuildInputs = [ pytestrunner ];
+  propagatedBuildInputs = [ six ];
+  checkInputs = [ pytestCheckHook freezegun pytest-mock tornado_4 ];
+  # Makes HTTP requests
+  disabledTests = [ "test_proxy" "test_live" ];
+
+  meta = with lib; {
+    description = "Websocket Client Library";
+    homepage = "https://github.com/wildfoundry/dataplicity-lomond";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -4,7 +4,7 @@
 {
   version = "0.115.6";
   components = {
-    "abode" = ps: with ps; [ ]; # missing inputs: abodepy
+    "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ ]; # missing inputs: accuweather
     "acer_projector" = ps: with ps; [ pyserial ];
     "acmeda" = ps: with ps; [ ]; # missing inputs: aiopulse

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3498,6 +3498,8 @@ in {
 
   logzero = callPackage ../development/python-modules/logzero { };
 
+  lomond = callPackage ../development/python-modules/lomond { };
+
   loo-py = callPackage ../development/python-modules/loo-py { };
 
   lpod = callPackage ../development/python-modules/lpod { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -146,6 +146,8 @@ in {
 
   aafigure = callPackage ../development/python-modules/aafigure { };
 
+  abodepy = callPackage ../development/python-modules/abodepy { };
+
   absl-py = callPackage ../development/python-modules/absl-py { };
 
   accupy = callPackage ../development/python-modules/accupy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Support `abode` in home assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
