### PR TITLE
Reintroduce lib output for systemd

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -96,7 +96,7 @@ in stdenv.mkDerivation {
     "-Ddbussessionservicedir=${placeholder "out"}/share/dbus-1/services"
     "-Ddbussystemservicedir=${placeholder "out"}/share/dbus-1/system-services"
     "-Dpamconfdir=${placeholder "out"}/etc/pam.d"
-    "-Drootprefix=${placeholder "out"}"
+    "-Drootprefix=/run/current-system/systemd"
     "-Dpkgconfiglibdir=${placeholder "dev"}/lib/pkgconfig"
     "-Dpkgconfigdatadir=${placeholder "dev"}/share/pkgconfig"
     "-Dloadkeys-path=${kbd}/bin/loadkeys"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -67,7 +67,7 @@ in stdenv.mkDerivation {
       "find_program('${stdenv.cc.bintools.targetPrefix}objcopy'"
   '';
 
-  outputs = [ "out" "man" "dev" ];
+  outputs = [ "out" "lib" "man" "dev" ];
 
   nativeBuildInputs =
     [ pkgconfig intltool gperf libxslt gettext docbook_xsl docbook_xml_dtd_42 docbook_xml_dtd_45
@@ -97,6 +97,7 @@ in stdenv.mkDerivation {
     "-Ddbussystemservicedir=${placeholder "out"}/share/dbus-1/system-services"
     "-Dpamconfdir=${placeholder "out"}/etc/pam.d"
     "-Drootprefix=/run/current-system/systemd"
+    "-Drootlibdir=${placeholder "lib"}/lib"
     "-Dpkgconfiglibdir=${placeholder "dev"}/lib/pkgconfig"
     "-Dpkgconfigdatadir=${placeholder "dev"}/share/pkgconfig"
     "-Dloadkeys-path=${kbd}/bin/loadkeys"
@@ -265,9 +266,38 @@ in stdenv.mkDerivation {
 
     # "kernel-install" shouldn't be used on NixOS.
     find $out -name "*kernel-install*" -exec rm {} \;
+
+    # Keep only libudev and libsystemd in the lib output.
+    mkdir -p $out/lib
+    mv $lib/lib/security $lib/lib/libnss* $out/lib/
   ''; # */
 
   enableParallelBuilding = true;
+
+  # On aarch64 we "leak" a reference to $out/lib/systemd/catalog in the lib
+  # output. The result of that is a dependency cycle between $out and $lib.
+  # Thus nix (rightfully) marks the build as failed. That reference originates
+  # from an array of strings (catalog_file_dirs) in systemd
+  # (src/src/journal/catalog.{c,h}).  The only consumer (as of v242) of the
+  # symbol is the main function of journalctl.  Still libsystemd.so contains
+  # the VALUE but not the symbol.  Systemd seems to be properly using function
+  # & data sections together with the linker flags to garbage collect unused
+  # sections (-Wl,--gc-sections).  For unknown reasons those flags do not
+  # eliminate the unused string constants, in this case on aarch64-linux. The
+  # hacky way is to just remove the reference after we finished compiling.
+  # Since it can not be used (there is no symbol to actually refer to it) there
+  # should not be any harm.  It is a bit odd and I really do not like starting
+  # these kind of hacks but there doesn't seem to be a straight forward way at
+  # this point in time.
+  # The reference will be replaced by the same reference the usual nukeRefs
+  # tooling uses.  The standard tooling can not / should not be uesd since it
+  # is a bit too excessive and could potentially do us some (more) harm.
+  postFixup = ''
+    nukedRef=$(echo $out | sed -e "s,$NIX_STORE/[^-]*-\(.*\),$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-\1,")
+    cat $lib/lib/libsystemd.so | perl -pe "s|$out/lib/systemd/catalog|$nukedRef/lib/systemd/catalog|" > $lib/lib/libsystemd.so.tmp
+    mv $lib/lib/libsystemd.so.tmp $(readlink -f $lib/lib/libsystemd.so)
+  '';
+
 
   # The interface version prevents NixOS from switching to an
   # incompatible systemd at runtime.  (Switching across reboots is


### PR DESCRIPTION

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/94354 removed $lib output but this causes significant closure bloat
See https://github.com/NixOS/nixpkgs/issues/98094

This reintroduces $lib, by getting rid of the problematic cyclic dependency

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
