### PR TITLE
virt-manager-qt: Add patch to rename variables

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/qt.nix
+++ b/pkgs/applications/virtualization/virt-manager/qt.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake, pkgconfig
+{ mkDerivation, lib, fetchFromGitHub, fetchpatch, cmake, pkgconfig
 , qtbase, qtmultimedia, qtsvg, qttools, krdc
 , libvncserver, libvirt, pcre, pixman, qtermwidget, spice-gtk, spice-protocol
 , libselinux, libsepol, utillinux
@@ -18,6 +18,15 @@ mkDerivation rec {
   cmakeFlags = [
     "-DBUILD_QT_VERSION=5"
     "-DQTERMWIDGET_INCLUDE_DIRS=${qtermwidget}/include/qtermwidget5"
+  ];
+
+  patches = [
+    (fetchpatch {
+      # Maintainer note: Check whether this patch is still needed when a new version is released
+      name = "krdc-variable-name-changes.patch";
+      url = "https://github.com/fadenb/qt-virt-manager/commit/4640f5f64534ed7c8a1ecc6851f1c7503988de6d.patch";
+      sha256 = "1chl58nra1mj96n8jmnjbsyr6vlwkhn38afhwqsbr0bgyg23781v";
+    })
   ];
 
   buildInputs = [


### PR DESCRIPTION
KDE/krdc@56a0222b518d05c1816aba5a142ea616983ee9ef renamed some
variables resulting in a build failure. The added patch renames the
variables in virt-manager-qt accordingly.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix broken build
ZHF: #97479

###### Things done
* Manually tested by accessing a VM  using VNC instead of spice

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
