### PR TITLE
grub2: Properly disable zfs by default

### DIFF
--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -3,7 +3,7 @@
 , fuse # only needed for grub-mount
 , zfs ? null
 , efiSupport ? false
-, zfsSupport ? true
+, zfsSupport ? false
 , xenSupport ? false
 }:
 


### PR DESCRIPTION
###### Motivation for this change
Make the system derivation smaller.
Minimal closure size change: 773,395648 MB -> 672,400544 MB (If I measured correctly)

###### Things done
I don't know if this is the proper change or if this breaks peoples system.
https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/tasks/filesystems/zfs.nix#L450 seems to enable zfsSupport if needed. https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/system/boot/loader/grub/grub.nix#L16 overrides zfsSupport to true if needed and the default is used otherwise (https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/system/boot/loader/grub/grub.nix#L21).

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
