### PR TITLE
pythonPackages.adguardhome: init at 0.4.2

### DIFF
--- a/pkgs/development/python-modules/adguardhome/default.nix
+++ b/pkgs/development/python-modules/adguardhome/default.nix
@@ -1,0 +1,26 @@
+{ aiohttp, aresponses, buildPythonPackage, fetchFromGitHub, isPy3k, lib
+, pytest-asyncio, pytestCheckHook, yarl }:
+
+buildPythonPackage rec {
+  pname = "adguardhome";
+  version = "0.4.2";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "frenck";
+    repo = "python-${pname}";
+    rev = "v${version}";
+    sha256 = "0lcf3yg27amrnqvgn5nw4jn2j0vj4yfmyl5p5yncmn7dh6bdbsp8";
+  };
+
+  propagatedBuildInputs = [ aiohttp yarl ];
+  checkInputs = [ aresponses pytest-asyncio pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Asynchronous Python client for the AdGuard Home API.";
+    homepage = "https://github.com/frenck/python-adguardhome";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -166,6 +166,8 @@ in {
 
   addic7ed-cli = callPackage ../development/python-modules/addic7ed-cli { };
 
+  adguardhome= callPackage ../development/python-modules/adguardhome { };
+
   aenum = callPackage ../development/python-modules/aenum { };
 
   afdko = callPackage ../development/python-modules/afdko { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Support `adguard` in home assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
