### PR TITLE
Dlang toolchain update

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -4,10 +4,10 @@
 , targetPackages, fetchpatch, bash
 , dmdBootstrap ? callPackage ./bootstrap.nix { }
 , HOST_DMD ? "${dmdBootstrap}/bin/dmd"
-, version ? "2.091.1"
-, dmdSha256 ? "0brz0n84jdkhr4sq4k91w48p739psbhbb1jk2pi9q60psmx353yr"
-, druntimeSha256 ? "0smgpmfriffh110ksski1s5j921kmxbc2zjy0dyj9ksyrxbzklbl"
-, phobosSha256 ? "1n00anajgibrfs1xzvrmag28hvbvkc0w1fwlimqbznvhf28rhrxs"
+, version ? "2.094.0"
+, dmdSha256 ? "1vxbrx1m26hpvi4whjv7vrzrs9r2z8a1h2dibhcdz5sisa4gag4k"
+, druntimeSha256 ? "1syzfryg8mxicdr51bysxg9sq1cnrrdib6vkc6hh17sn5v544sk9"
+, phobosSha256 ? "0kl3r80hlliil1y051fxyhs5vzzp92i3gkcvankmrd7fw5mlyq3c"
 }:
 
 let
@@ -53,18 +53,6 @@ stdenv.mkDerivation rec {
   })
   ];
 
-  patchFlags = [ "--directory=dmd" "-p1" "-F3" ];
-  patches = [
-    (fetchpatch {
-     url = "https://github.com/dlang/dmd/commit/4157298cf04f7aae9f701432afd1de7b7e05c30f.patch";
-     sha256 = "0v4xgqmrx5r8vbx5a4v88s0xnm23mam9nm99yfga7s2sxr0hi5p2";
-    })
-    (fetchpatch {
-     url = "https://github.com/dlang/dmd/commit/1b8a4c90b040bf2f0b68a2739de4991315580b13.patch";
-     sha256 = "1iih6aalv4fsw9mbrlrybhngkkchzzrzg7q8zl047w36c0x397cs";
-    })
-  ];
-
   sourceRoot = ".";
 
   # https://issues.dlang.org/show_bug.cgi?id=19553
@@ -100,7 +88,7 @@ stdenv.mkDerivation rec {
   top = "$(echo $NIX_BUILD_TOP)";
   pathToDmd = "${top}/dmd/generated/${osname}/release/${bits}/dmd";
 
-  # Buid and install are based on http://wiki.dlang.org/Building_DMD
+  # Build and install are based on http://wiki.dlang.org/Building_DMD
   buildPhase = ''
       cd dmd
       make -j$NIX_BUILD_CORES -f posix.mak INSTALL_DIR=$out BUILD=release ENABLE_RELEASE=1 PIC=1 HOST_DMD=${HOST_DMD}

--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -1,5 +1,4 @@
 import ./generic.nix {
-  version = "1.20.1";
-  ldcSha256 = "1bqsgab22v02pc3c9gcyf15y7aimadv24d68icaw5lpgnvzxy89b";
+   version = "1.23.0";
+   ldcSha256 = "1fdgj222x29as466vdxy9c0m82zzlsb7vnvvh89n2riszcrx463d";
 }
-

--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "dub";
-  version = "1.14.0";
+  version = "1.23.0";
 
   enableParallelBuilding = true;
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "dlang";
     repo = "dub";
     rev = "v${version}";
-    sha256 = "070kfkyrkr98y1hbhcf85842c0x7l95w1ambrkdgajpb6kcmpf84";
+    sha256 = "06a4whsl1m600k096nwif83n7za3vr7pj1xwapncy5fcad1gmady";
   };
 
   postUnpack = ''
@@ -41,18 +41,25 @@ stdenv.mkDerivation rec {
     export HOME=$TMP
 
     rm -rf test/issue502-root-import
-    rm test/issue990-download-optional-selected.sh
-    rm test/timeout.sh
     rm test/issue674-concurrent-dub.sh
     rm test/issue672-upgrade-optional.sh
+    rm test/issue990-download-optional-selected.sh
+    rm test/issue877-auto-fetch-package-on-run.sh
+    rm test/issue1037-better-dependency-messages.sh
+    rm test/issue1040-run-with-ver.sh
+    rm test/issue1416-maven-repo-pkg-supplier.sh
+    rm test/issue1180-local-cache-broken.sh
     rm test/issue1574-addcommand.sh
     rm test/issue1524-maven-upgrade-dependency-tree.sh
-    rm test/issue1416-maven-repo-pkg-supplier.sh
-    rm test/issue1037-better-dependency-messages.sh
-    rm test/interactive-remove.sh
+    rm test/issue1773-lint.sh
+
+    rm test/ddox.sh
     rm test/fetchzip.sh
     rm test/feat663-search.sh
-    rm test/ddox.sh
+    rm -rf test/git-dependency
+    rm test/interactive-remove.sh
+    rm test/timeout.sh
+    rm test/version-spec.sh
     rm test/0-init-multi.sh
     rm test/0-init-multi-json.sh
 


### PR DESCRIPTION
#### Motivation for this change

Routine update of D compiler and DUB package manager versions, so the newest D code keeps compiling

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Binary `ldc-build-runtime` does not work, and neither does generating a profile for profile-guided-optimization (so I cannot test `ldc-profdata` except for it's error messages). But both of these issues exist regardless of this PR.