### PR TITLE
photoflare: init at 1.6.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6451,6 +6451,12 @@
     githubId = 167209;
     name = "Masanori Ogino";
   };
+  omgbebebe = {
+    email = "omgbebebe@gmail.com";
+    github = "omgbebebe";
+    githubId = 588167;
+    name = "Sergey Bubnov";
+  };
   omnipotententity = {
     email = "omnipotententity@gmail.com";
     github = "omnipotententity";

--- a/pkgs/applications/graphics/photoflare/default.nix
+++ b/pkgs/applications/graphics/photoflare/default.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, stdenv, graphicsmagick, fetchFromGitHub, qmake, qtbase, qttools
+}:
+
+mkDerivation rec {
+  pname = "photoflare";
+  version = "1.6.5";
+
+  src = fetchFromGitHub {
+    owner = "PhotoFlare";
+    repo = "photoflare";
+    rev = "v${version}";
+    sha256 = "0a394324h7ds567z3i3pw6kkii78n4qwdn129kgkkm996yh03q89";
+  };
+
+  nativeBuildInputs = [ qmake qttools ];
+  buildInputs = [ qtbase graphicsmagick ];
+
+  qmakeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  NIX_CFLAGS_COMPILE = "-I${graphicsmagick}/include/GraphicsMagick";
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A cross-platform image editor with a powerful features and a very friendly graphical user interface";
+    homepage = "https://photoflare.io";
+    maintainers = [ maintainers.omgbebebe ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22897,6 +22897,8 @@ in
 
   photoqt = libsForQt5.callPackage ../applications/graphics/photoqt { };
 
+  photoflare = libsForQt5.callPackage ../applications/graphics/photoflare { };
+
   photoflow = callPackage ../applications/graphics/photoflow { };
 
   phototonic = libsForQt5.callPackage ../applications/graphics/phototonic { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
initial version of nice and lightweight image editor

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
