### PR TITLE
avro-python3: Add missing dependencies

### DIFF
--- a/pkgs/development/python-modules/avro-python3/default.nix
+++ b/pkgs/development/python-modules/avro-python3/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, isPy3k }:
+{ lib, stdenv, buildPythonPackage, fetchPypi, isPy3k, pycodestyle, isort }:
 
 buildPythonPackage rec {
   pname = "avro-python3";
@@ -10,6 +10,7 @@ buildPythonPackage rec {
     sha256 = "a455c215540b1fceb1823e2a918e94959b54cb363307c97869aa46b5b55bde05";
   };
 
+  buildInputs = [ pycodestyle isort ];
   doCheck = false;        # No such file or directory: './run_tests.py
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Without these dependencies:
```
nix-build -A python3Packages.avro-python3
```
fails with
```
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7ffff5da2430>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/pycodestyle/
```
and the same for isort.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
