### PR TITLE
gomplate: init at 3.8.0

### DIFF
--- a/pkgs/development/tools/gomplate/default.nix
+++ b/pkgs/development/tools/gomplate/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "gomplate";
+  version = "3.8.0";
+  owner = "hairyhenderson";
+  rev = "v${version}";
+
+  src = fetchFromGitHub {
+    inherit owner rev;
+    repo = pname;
+    sha256 = "058shbrhpd8ghdj5qa6n7mf1bh8qvpmiv3yjj39jys359zhin06n";
+  };
+
+  vendorSha256 = "0wqz3anxlzb0ds6xmpnaxq5rjgcmzkzrdqhnkfkjq32b7mj9mks3";
+
+  # some tests require network access
+  postPatch = ''
+    rm net/net_test.go
+  '';
+
+  buildFlagsArray = [
+    "-ldflags="
+    "-s"
+    "-w"
+    "-X github.com/${owner}/${pname}/v3/version.Version=${rev}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A flexible commandline tool for template rendering";
+    homepage = "https://gomplate.ca/";
+    maintainers = with maintainers; [ ris jlesquembre ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17516,6 +17516,8 @@ in
 
   gomp = callPackage ../applications/version-management/gomp { };
 
+  gomplate = callPackage ../development/tools/gomplate {};
+
   gpm = callPackage ../servers/gpm {
     ncurses = null;  # Keep curses disabled for lack of value
   };


### PR DESCRIPTION

###### Motivation for this change
> gomplate is a template renderer which supports a growing list of datasources

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
