### PR TITLE
uudeview: don't hardeningDisable format

### DIFF
--- a/pkgs/tools/misc/uudeview/default.nix
+++ b/pkgs/tools/misc/uudeview/default.nix
@@ -1,19 +1,35 @@
-{ lib, stdenv, fetchurl, tcl, tk }:
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, tcl
+, tk
+}:
 
 stdenv.mkDerivation rec {
   pname = "uudeview";
   version = "0.5.20";
+
   src = fetchurl {
-    url = "http://www.fpx.de/fp/Software/UUDeview/download/uudeview-${version}.tar.gz";
+    url = "http://www.fpx.de/fp/Software/UUDeview/download/${pname}-${version}.tar.gz";
     sha256 = "0dg4v888fxhmf51vxq1z1gd57fslsidn15jf42pj4817vw6m36p4";
   };
 
   buildInputs = [ tcl tk ];
-  hardeningDisable = [ "format" ];
+
   configureFlags = [ "--enable-tk=${tk.dev}" "--enable-tcl=${tcl}" ];
 
-  # https://wiki.tcl.tk/3577
-  patches = [ ./matherr.patch ];
+  patches = [
+    # https://wiki.tcl.tk/3577
+    ./matherr.patch
+    # format hardening
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/OpenMandrivaAssociation/uudeview/master/uudeview-0.5.20-fix-str-fmt.patch";
+      sha256 = "1biipck60mhpd0j6jwizaisvqa8alisw1dpfqm6zf7ic5b93hmfw";
+      extraPrefix = "";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace tcl/xdeview --replace "exec uuwish" "exec $out/bin/uuwish"
   '';
@@ -21,7 +37,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "The Nice and Friendly Decoder";
     homepage = "http://www.fpx.de/fp/Software/UUDeview/";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ woffs ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
- adopt a patch which several other distributions use
- name -> pname + version

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
