### PR TITLE
blogc: init at 0.20.0

### DIFF
--- a/pkgs/applications/misc/blogc/default.nix
+++ b/pkgs/applications/misc/blogc/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, ronn, git, cmocka }:
+
+stdenv.mkDerivation rec {
+  pname = "blogc";
+  version = "0.20.0";
+
+  src = fetchFromGitHub {
+    owner = "blogc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0hx0gpvmv7rd910czafvmcpxabbvfmvdyxk4d1mckmblx8prb807";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ ronn git cmocka ];
+
+  configureFlags = [
+    "--enable-git-receiver"
+    "--enable-make"
+    "--enable-runserver"
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "A blog compiler";
+    license = licenses.bsd3;
+    homepage = "https://blogc.rgm.io";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19834,6 +19834,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics ForceFeedback OpenAL OpenGL;
   };
 
+  blogc = callPackage ../applications/misc/blogc { };
+
   bluefish = callPackage ../applications/editors/bluefish {
     gtk = gtk3;
   };


### PR DESCRIPTION
###### Motivation for this change
**[blogc](https://blogc.rgm.io/)** is a blog compiler. It compiles source files and templates into blog/website resources.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
