### PR TITLE
trivy: init at 0.11.0

### DIFF
--- a/pkgs/tools/admin/trivy/default.nix
+++ b/pkgs/tools/admin/trivy/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "trivy";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "aquasecurity";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0mqzs0yjlqpsn2540kgl4gn77qjg3kfls1zwgjfxy66lazic3f1h";
+  };
+
+  vendorSha256 = "1jmmx83c0qbqyppx0w8d9djz2j2i7dgibq9lb3vhdz78wc40zywy";
+
+  buildFlagsArray = [
+    "-ldflags="
+    "-s"
+    "-w"
+    "-X main.version=v${version}"
+  ];
+
+  meta = with lib; {
+    description = "A simple and comprehensive vulnerability scanner for containers, suitable for CI";
+    longDescription = ''
+      Trivy is a simple and comprehensive vulnerability scanner for containers
+      and other artifacts. A software vulnerability is a glitch, flaw, or
+      weakness present in the software or in an Operating System. Trivy detects
+      vulnerabilities of OS packages (Alpine, RHEL, CentOS, etc.) and
+      application dependencies (Bundler, Composer, npm, yarn, etc.).
+    '';
+    homepage = src.meta.homepage;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3392,6 +3392,8 @@ in
 
   tridactyl-native = callPackage ../tools/networking/tridactyl-native { };
 
+  trivy = callPackage ../tools/admin/trivy { };
+
   trompeloeil = callPackage ../development/libraries/trompeloeil { };
 
   uudeview = callPackage ../tools/misc/uudeview { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add the `trivy` vulnerability scanner to nixpkgs

I categorized it in `tools/admin` because that's where the `clair` vulnerability scanner is already.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [X] other Linux distributions (aarch64 archlinux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
