### PR TITLE
volctl: 0.6.3 -> 0.8.0

### DIFF
--- a/pkgs/tools/audio/volctl/default.nix
+++ b/pkgs/tools/audio/volctl/default.nix
@@ -7,7 +7,7 @@ pythonPackages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "buzz";
     repo = pname;
-    rev = version;
+    rev = "v${version}";
     sha256 = "02scfscf4mdrphzrd7cbwbhpig9bhvaws8qk4zc81z8vvf3mcfv2";
   };
 

--- a/pkgs/tools/audio/volctl/default.nix
+++ b/pkgs/tools/audio/volctl/default.nix
@@ -2,13 +2,13 @@
 
 pythonPackages.buildPythonApplication rec {
   pname = "volctl";
-  version = "0.6.3";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "buzz";
     repo = pname;
     rev = version;
-    sha256 = "0rppqc5wiqxd83z2mgvhi6gdx7yhy9wnav1dbbi1wvm7lzw6fnil";
+    sha256 = "02scfscf4mdrphzrd7cbwbhpig9bhvaws8qk4zc81z8vvf3mcfv2";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Update to version [0.8.0](https://github.com/buzz/volctl/releases/tag/v0.8.0)


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
