### PR TITLE
starboard: init at 0.4.0

### DIFF
--- a/pkgs/applications/networking/cluster/starboard/default.nix
+++ b/pkgs/applications/networking/cluster/starboard/default.nix
@@ -1,0 +1,40 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "starboard";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "aquasecurity";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0jvr8lf3wdg6svsfi3fdknqw543495gysznbqhl42w7d3r5krcyw";
+  };
+
+  vendorSha256 = "0p5svprhbnb7mfln1mhaq55w8xnj8v3sinwkysxjzh1g8p36mglp";
+
+  doCheck = false;
+
+  buildFlagsArray = [
+    "-ldflags="
+    "-s"
+    "-w"
+    "-X main.version=v${version}"
+  ];
+
+  meta = with lib; {
+    description = "Kubernetes-native security tool kit";
+    longDescription = ''
+      Starboard integrates security tools into the Kubernetes environment, so
+      that users can find and view the risks that relate to different resources
+      in a Kubernetes-native way. Starboard provides custom security resources
+      definitions and a Go module to work with a range of existing security
+      tools, as well as a kubectl-compatible command-line tool and an Octant
+      plug-in that make security reports available through familiar Kubernetes
+      tools.
+    '';
+    homepage = src.meta.homepage;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2393,6 +2393,8 @@ in
 
   stagit = callPackage ../development/tools/stagit { };
 
+  starboard = callPackage ../applications/networking/cluster/starboard { };
+
   statserial = callPackage ../tools/misc/statserial { };
 
   step-ca = callPackage ../tools/security/step-ca { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add the `starboard` k8s security toolkit to nixpkgs

I've categorized it in `applications/networking/cluster` as most k8s tools go there but I'm open to moving it if there are better suggestions.

Version is set but might check what the official release looks like. Might set the date to Unix epoch or N/A :shrug: 
`Starboard Version: {Version:v0.4.0 Commit:none Date:unknown}`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [X] other Linux distributions (aarch64 archlinux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
