### PR TITLE
stenc: 1.0.7 -> 1.0.8

### DIFF
--- a/pkgs/tools/backup/stenc/default.nix
+++ b/pkgs/tools/backup/stenc/default.nix
@@ -1,14 +1,27 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, genericUpdater
+, common-updater-scripts
+, autoreconfHook
+}:
 
 stdenv.mkDerivation rec {
-  version = "1.0.7";
   pname = "stenc";
+  version = "1.0.8";
 
   src = fetchFromGitHub {
     owner = "scsitape";
     repo = "stenc";
     rev = version;
-    sha256 = "1778m1zcyzyf42k5m496yqh0gv6kqhb0sq5983dhky1fccjl905k";
+    sha256 = "0dsmvr1xpwkcd9yawv4c4vna67yag7jb8jcgn2amywz7nkpzmyxd";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  passthru.updateScript = genericUpdater {
+    inherit pname version;
+    versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
update

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
