### PR TITLE
coqPackages.{bignums,coq-ext-lib,dpdgraph}: clean dependencies

### DIFF
--- a/pkgs/development/coq-modules/bignums/default.nix
+++ b/pkgs/development/coq-modules/bignums/default.nix
@@ -43,7 +43,9 @@ stdenv.mkDerivation {
     inherit (param) rev sha256;
   };
 
-  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 findlib coq ];
+  buildInputs = with coq.ocamlPackages; [ ocaml findlib coq ]
+  ++ stdenv.lib.optional (!stdenv.lib.versionAtLeast coq.coq-version "8.10") camlp5
+  ;
 
   installFlags = [ "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];
 

--- a/pkgs/development/coq-modules/coq-ext-lib/default.nix
+++ b/pkgs/development/coq-modules/coq-ext-lib/default.nix
@@ -26,8 +26,7 @@ stdenv.mkDerivation rec {
     inherit (param) sha256;
   };
 
-  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 ];
-  propagatedBuildInputs = [ coq ];
+  buildInputs = [ coq ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/coq-modules/dpdgraph/default.nix
+++ b/pkgs/development/coq-modules/dpdgraph/default.nix
@@ -53,7 +53,8 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ coq ]
-  ++ (with coq.ocamlPackages; [ ocaml camlp5 findlib ocamlgraph ]);
+  ++ (with coq.ocamlPackages; [ ocaml findlib ocamlgraph ]
+    ++ stdenv.lib.optional (!stdenv.lib.versionAtLeast coq.coq-version "8.10") camlp5);
 
   # dpd_compute.ml uses deprecated Pervasives.compare
   # Versions prior to 0.6.5 do not have the WARN_ERR build flag


### PR DESCRIPTION
###### Motivation for this change

A few Coq libraries no longer depend on camlp5.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
