### PR TITLE
catfs: init at unstable-2020-03-21

### DIFF
--- a/pkgs/os-specific/linux/catfs/default.nix
+++ b/pkgs/os-specific/linux/catfs/default.nix
@@ -1,0 +1,47 @@
+{ lib, rustPlatform, fetchFromGitHub
+, fetchpatch
+, fuse
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "catfs";
+  version = "unstable-2020-03-21";
+
+  src = fetchFromGitHub {
+    owner = "kahing";
+    repo = pname;
+    rev = "daa2b85798fa8ca38306242d51cbc39ed122e271";
+    sha256 = "0zca0c4n2p9s5kn8c9f9lyxdf3df88a63nmhprpgflj86bh8wgf5";
+  };
+
+  cargoSha256 = "0v6lxwj4vcph32np68awpncafvf1dwcik9a2asa0lkb7kmfdjsjk";
+
+  cargoPatches = [
+    # update cargo lock
+    (fetchpatch {
+      url = "https://github.com/kahing/catfs/commit/f838c1cf862cec3f1d862492e5be82b6dbe16ac5.patch";
+      sha256 = "1r1p0vbr3j9xyj9r1ahipg4acii3m4ni4m9mp3avbi1rfgzhblhw";
+    })
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ fuse ];
+
+  # require fuse module to be active to run tests
+  # instead, run command
+  doCheck = false;
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/catfs --help > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "Caching filesystem written in Rust";
+    homepage = "https://github.com/kahing/catfs";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19924,6 +19924,8 @@ in
 
   castor = callPackage ../applications/networking/browsers/castor { };
 
+  catfs = callPackage ../os-specific/linux/catfs { };
+
   catimg = callPackage ../tools/misc/catimg { };
 
   catt = callPackage ../applications/video/catt { };


### PR DESCRIPTION
###### Motivation for this change
closes: #99315

some concerns about activity of upstream though: https://github.com/kahing/catfs/issues/47 https://github.com/kahing/catfs/pulls

anyway did this as mostly an exercise for packing rust. Don't feel strongly if this gets added

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
