### PR TITLE
kapowbang: rename from kapow

### DIFF
--- a/pkgs/servers/kapowbang/default.nix
+++ b/pkgs/servers/kapowbang/default.nix
@@ -1,14 +1,14 @@
 { stdenv, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
-  pname = "kapow";
+  pname = "kapowbang";
   version = "0.5.4";
 
   subPackages = [ "." ];
 
   src = fetchFromGitHub {
     owner = "BBVA";
-    repo = pname;
+    repo = "kapow";
     rev = "v${version}";
     sha256 = "09qr631vzlgibz6q64f35lqzz9h1g3gxqfbapkrci5i0n3h04yr4";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16550,7 +16550,7 @@ in
 
   jitsi-videobridge = callPackage ../servers/jitsi-videobridge { };
 
-  kapow = callPackage ../servers/kapow { };
+  kapowbang = callPackage ../servers/kapowbang { };
 
   keycloak = callPackage ../servers/keycloak { };
 


### PR DESCRIPTION
###### Motivation for this change

kapow is an established name of an older project, being packaged in #78407.
Repology and ArchLinux call the Go project kapowbang because its name is "Kapow!":
https://github.com/BBVA/kapow
https://repology.org/projects/?search=kapow
https://aur.archlinux.org/packages/?K=kapow
Kapow! was packaged as kapow in #88458.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc maintainer @nilp0inter