### PR TITLE
xsecurelock: Add missing libraries

### DIFF
--- a/pkgs/tools/X11/xsecurelock/default.nix
+++ b/pkgs/tools/X11/xsecurelock/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
-, libX11, libXcomposite, libXft, libXmu, libXrandr, libXext, libXScrnSaver
+, libX11, libXcomposite, libXft, libXmu, libXrandr, libXext, libXScrnSaver, libXfixes, libXxf86misc
 , pam, apacheHttpd, pamtester, xscreensaver }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     autoreconfHook pkgconfig
   ];
   buildInputs = [
-    libX11 libXcomposite libXft libXmu libXrandr libXext libXScrnSaver
+    libX11 libXcomposite libXft libXmu libXrandr libXext libXScrnSaver libXfixes libXxf86misc
     pam apacheHttpd pamtester
   ];
 


### PR DESCRIPTION
According to `configure.ac` from xsecurelock:

- [The XFixes extension is used to work around possible weird leftover state from compositors.](https://github.com/google/xsecurelock/blob/master/configure.ac#L172-L176)
- [This extension (Xxf86misc) doesn't really exist anymore, but served to counteract the (also no longer existing) AllowClosedownGrabs and similar X server settings.](https://github.com/google/xsecurelock/blob/master/configure.ac#L131-L135)

I tried to add this to see if it would fix the `INCOMPATIBLE COMPOSITOR` error when using with `picom`. This didn't work, but since I already had the trouble of trying this and it does seem that this improve the program in some way, I decided to open this PR.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
