### PR TITLE
gitstatus: also install sh files

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
@@ -13,11 +13,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ (callPackage ./romkatv_libgit2.nix {}) ];
   patchPhase = ''
+    sed -i '1i GITSTATUS_AUTO_INSTALL=''${GITSTATUS_AUTO_INSTALL-0}' gitstatus.plugin.sh
     sed -i '1i GITSTATUS_AUTO_INSTALL=''${GITSTATUS_AUTO_INSTALL-0}' gitstatus.plugin.zsh
     sed -i "1a GITSTATUS_DAEMON=$out/bin/gitstatusd" install
   '';
   installPhase = ''
     install -Dm755 usrbin/gitstatusd $out/bin/gitstatusd
+    install -Dm444 gitstatus.plugin.sh $out
     install -Dm444 gitstatus.plugin.zsh $out
     install -Dm555 install $out
     install -Dm444 build.info $out
@@ -26,6 +28,7 @@ stdenv.mkDerivation rec {
   # should not need to worry about.
   pathsToLink = [
     "/bin/gitstatusd"
+    "/gitstatus.plugin.sh"
     "/gitstatus.plugin.zsh"
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I am developing a shell prompt segment for bash which relies on those files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
