### PR TITLE
aldo: 0.7.7 -> 0.7.8

### DIFF
--- a/pkgs/applications/radio/aldo/default.nix
+++ b/pkgs/applications/radio/aldo/default.nix
@@ -1,13 +1,18 @@
-{ stdenv, fetchurl, libao }:
+{ stdenv, fetchgit, libao, autoreconfHook }:
 
-stdenv.mkDerivation rec {
+let
   pname = "aldo";
-  version = "0.7.7";
+  version = "0.7.8";
+in stdenv.mkDerivation {
+  inherit pname version;
 
-  src = fetchurl {
-    url = "mirror://savannah/${pname}/${pname}-${version}.tar.bz2";
-    sha256 = "14lzgldqzbbzydsy1cai3wln3hpyj1yhj8ji3wygyzr616fq9f7i";
+  src = fetchgit {
+    url = "git://git.savannah.gnu.org/${pname}.git";
+    rev = "v${version}";
+    sha256 = "0swvdq0pw1msy40qkpn1ar9kacqjyrw2azvf2fy38y0svyac8z2i";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [ libao ];
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
