### PR TITLE
opencascade-occt, opencascade-occt730: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/opencascade-occt/7.3.nix
+++ b/pkgs/development/libraries/opencascade-occt/7.3.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, cmake, ninja, tcl, tk,
-  libGL, libGLU, libXext, libXmu, libXi }:
+  libGL, libGLU, libXext, libXmu, libXi, darwin }:
 
 stdenv.mkDerivation rec {
   pname = "opencascade-occt";
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ninja ];
-  buildInputs = [ tcl tk libGL libGLU libXext libXmu libXi ];
+  buildInputs = [ tcl tk libGL libGLU libXext libXmu libXi ]
+    ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Cocoa;
 
   meta = with stdenv.lib; {
     description = "Open CASCADE Technology, libraries for 3D modeling and numerical simulation";

--- a/pkgs/development/libraries/opencascade-occt/default.nix
+++ b/pkgs/development/libraries/opencascade-occt/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, cmake, ninja, tcl, tk,
-  libGL, libGLU, libXext, libXmu, libXi }:
+  libGL, libGLU, libXext, libXmu, libXi, darwin }:
 
 stdenv.mkDerivation rec {
   pname = "opencascade-occt";
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ninja ];
-  buildInputs = [ tcl tk libGL libGLU libXext libXmu libXi ];
+  buildInputs = [ tcl tk libGL libGLU libXext libXmu libXi ]
+    ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Cocoa;
 
   meta = with stdenv.lib; {
     description = "Open CASCADE Technology, libraries for 3D modeling and numerical simulation";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Now seems to need cocoa on macos.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
