### PR TITLE
lib/types: Fix type description of bool enum values

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -499,6 +499,7 @@ rec {
         show = v:
                if builtins.isString v then ''"${v}"''
           else if builtins.isInt v then builtins.toString v
+          else if builtins.isBool v then if v then "true" else "false"
           else ''<${builtins.typeOf v}>'';
       in
       mkOptionType rec {


### PR DESCRIPTION
###### Motivation for this change
Previously bool values would show as `<bool>`. Discovered by @grahamc 

###### Things done
- [x] Built the manual and checked that the `security.audit.enable` option type shows `true` and `false`