### PR TITLE
[20.09] digikam: 6.4.0 -> 7.1.0

### DIFF
--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -27,6 +27,8 @@
 , ffmpeg
 , flex
 , jasper ? null, withJpeg2k ? false  # disable JPEG2000 support, jasper has unfixed CVE
+, graphviz
+, imagemagick
 , lcms2
 , lensfun
 , libgphoto2
@@ -40,6 +42,7 @@
 , opencv3
 , pcre
 , threadweaver
+, x265
 
 # For panorama and focus stacking
 , enblend-enfuse
@@ -51,11 +54,11 @@
 
 mkDerivation rec {
   pname   = "digikam";
-  version = "6.4.0";
+  version = "7.1.0";
 
   src = fetchurl {
-    url = "https://download.kde.org/stable/${pname}/${version}/${pname}-${version}.tar.xz";
-    sha256 = "0vwd97zkxv30y8x0z76s4fsj4w9ysgsmpjclp2h2bpava7zi4l3p";
+    url = "mirror://kde/stable/${pname}/${version}/${pname}-${version}.tar.xz";
+    sha256 = "1gmblnsm0aida3yynyddm6jdh59hx3w177hrhfar616z793ch0xi";
   };
 
   nativeBuildInputs = [ cmake doxygen extra-cmake-modules kdoctools wrapGAppsHook ];
@@ -67,6 +70,8 @@ mkDerivation rec {
     exiv2
     ffmpeg
     flex
+    graphviz
+    imagemagick
     lcms2
     lensfun
     libgphoto2
@@ -78,6 +83,7 @@ mkDerivation rec {
     libGLU
     opencv3
     pcre
+    x265
 
     qtbase
     qtxmlpatterns

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14900,8 +14900,8 @@ in
       kmime kontactinterface kpimtextedit kpkpass kqtquickcharts ksmtp ktnef
       libgravatar libkcddb libkdcraw libkdegames libkdepim libkexiv2 libkgapi
       libkipi libkleo libkmahjongg libkomparediff2 libksane libksieve mailcommon
-      mailimporter messagelib pim-sieve-editor pimcommon kdegraphics-thumbnailers
-      kio-extras print-manager;
+      mailimporter marble messagelib pim-sieve-editor pimcommon
+      kdegraphics-thumbnailers kio-extras print-manager;
 
     ### LIBRARIES
 
@@ -24688,7 +24688,6 @@ in
   dhewm3 = callPackage ../games/dhewm3 {};
 
   digikam = libsForQt514.callPackage ../applications/graphics/digikam {
-    inherit (plasma5) oxygen;
     opencv3 = opencv3WithoutCuda;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to digikam 7.1.0 and fix dependencies.

Fixes: #98879 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
