### PR TITLE
nimlsp: init at 0.2.4

### DIFF
--- a/pkgs/development/tools/misc/nimlsp/default.nix
+++ b/pkgs/development/tools/misc/nimlsp/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchFromGitHub, nim, termbox, pcre }:
+
+let
+  astpatternmatching = fetchFromGitHub {
+    owner = "krux02";
+    repo = "ast-pattern-matching";
+    rev = "87f7d163421af5a4f5e5cb6da7b93278e6897e96";
+    sha256 = "19mb5bb6riia8380p5dpc3q0vwgrj958dd6p7vw8vkvwiqrzg6zq";
+  };
+
+  jsonschema = fetchFromGitHub {
+    owner = "PMunch";
+    repo = "jsonschema";
+    rev = "7b41c03e3e1a487d5a8f6b940ca8e764dc2cbabf";
+    sha256 = "1js64jqd854yjladxvnylij4rsz7212k31ks541pqrdzm6hpblbz";
+  };
+
+  nim-src = fetchFromGitHub {
+    owner = "nim-lang";
+    repo = "Nim";
+    rev = "v1.2.6";
+    sha256 = "1rybp345szlw0b6rk88f6knlshy3ykrlhbvhgav7516zbs6xfgay";
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "nimlsp";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "PMunch";
+    repo = "nimlsp";
+    rev = "v${version}";
+    sha256 = "16j7avw2ki7bxc5nki4nazp737k2bd0ajpc5wrhn102c7rygmdrm";
+  };
+
+  nativeBuildInputs = [ nim ];
+  buildInputs = [ termbox pcre ];
+
+  buildPhase = ''
+    export HOME=$TMPDIR;
+    nim -p:${astpatternmatching}/src -p:${jsonschema}/src\
+      c --threads:on -d:nimcore -d:nimsuggest -d:debugCommunication\
+      -d:debugLogging -d:explicitSourcePath=${nim-src} -d:tempDir=/tmp src/nimlsp
+  '';
+
+  installPhase = ''
+    install -Dt $out/bin src/nimlsp
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Nim Language Server Protocol - nimlsp implements the Language Server Protocol";
+    homepage = "https://github.com/PMunch/nimlsp";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.pmunch ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9508,6 +9508,8 @@ in
 
   nrpl = callPackage ../development/tools/nrpl { };
 
+  nimlsp = callPackage ../development/tools/misc/nimlsp { };
+
   neko = callPackage ../development/compilers/neko { };
 
   nextpnr = libsForQt514.callPackage ../development/compilers/nextpnr {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
closes: #99472 

Nimlsp is the language server protocol implementation for Nim and was missing from nixpkgs, I think this could benefit Nim beginners to get started since it improves editor support for Nim and ultimately development experience.

This also is my first PR to nixpkgs and was a good exercise, feel free to give me feedback on this. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
