### PR TITLE
pythonPackages.hidapi: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/hidapi/default.nix
+++ b/pkgs/development/python-modules/hidapi/default.nix
@@ -19,7 +19,11 @@ buildPythonPackage rec {
     libusb=${libusb1.dev}/include/libusb-1.0
     test -d $libusb || { echo "ERROR: $libusb doesn't exist, please update/fix this build expression."; exit 1; }
     sed -i -e "s|/usr/include/libusb-1.0|$libusb|" setup.py
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace setup.py --replace 'macos_sdk_path =' 'macos_sdk_path = "" #'
   '';
+
+  pythonImportsCheck = [ "hid" ];
 
   meta = with stdenv.lib; {
     description = "A Cython interface to the hidapi from https://github.com/signal11/hidapi";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

We have no need of this "`xcrun`" you speak of.

There are still some reverse-dependencies broken on macos that are opened up by the fixing of this. May address separately.

Also add `pythonImportsCheck`.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
