### PR TITLE
pythonPackages.pyads: init at 3.2.2

### DIFF
--- a/pkgs/development/libraries/adslib/default.nix
+++ b/pkgs/development/libraries/adslib/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "adslib";
+  version = "unstable-2020-08-28";
+
+  src = fetchFromGitHub {
+    owner = "stlehmann";
+    repo = "ADS";
+    rev = "c457b60d61d73325837ca50be2cc997c4792d481";
+    sha256 = "11r86xa8fr4z957hd0abn8x7182nz30a198d02y7gzpbhpi3z43k";
+  };
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp adslib.so $out/lib/adslib.so
+  '';
+
+  meta = with lib; {
+    description = "Beckhoff protocol to communicate with TwinCAT devices";
+    homepage = "https://github.com/stlehmann/ADS";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/development/python-modules/pyads/default.nix
+++ b/pkgs/development/python-modules/pyads/default.nix
@@ -1,0 +1,30 @@
+{ adslib, buildPythonPackage, fetchFromGitHub, lib, pytestCheckHook, pytest
+, pytestcov, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "pyads";
+  version = "3.2.2";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "stlehmann";
+    repo = pname;
+    rev = version;
+    sha256 = "1jd727pw0z73y4xhrykqkfcz1acrpy3rks58lr1y4yilfv11p6jb";
+  };
+
+  buildInputs = [ adslib ];
+  patchPhase = ''
+    substituteInPlace pyads/pyads_ex.py \
+      --replace "ctypes.CDLL(adslib)" "ctypes.CDLL(\"${adslib}/lib/adslib.so\")"
+  '';
+  checkInputs = [ pytestCheckHook pytest pytestcov ];
+
+  meta = with lib; {
+    description = "Python wrapper for TwinCAT ADS library";
+    homepage = "https://github.com/MrLeeh/pyads";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -10,7 +10,7 @@
     "acmeda" = ps: with ps; [ ]; # missing inputs: aiopulse
     "actiontec" = ps: with ps; [ ];
     "adguard" = ps: with ps; [ adguardhome ];
-    "ads" = ps: with ps; [ ]; # missing inputs: pyads
+    "ads" = ps: with ps; [ pyads ];
     "aftership" = ps: with ps; [ ]; # missing inputs: pyaftership
     "agent_dvr" = ps: with ps; [ ]; # missing inputs: agent-py
     "air_quality" = ps: with ps; [ ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11830,6 +11830,8 @@ in
 
   adns = callPackage ../development/libraries/adns { };
 
+  adslib = callPackage ../development/libraries/adslib { };
+
   afflib = callPackage ../development/libraries/afflib { };
 
   aften = callPackage ../development/libraries/aften { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4722,6 +4722,8 @@ in {
 
   pyacoustid = callPackage ../development/python-modules/pyacoustid { };
 
+  pyads = callPackage ../development/python-modules/pyads { };
+
   pyaes = callPackage ../development/python-modules/pyaes { };
 
   pyairvisual = callPackage ../development/python-modules/pyairvisual { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`ads` support for home assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
