### PR TITLE
tarssh: init at 0.4.0

### DIFF
--- a/pkgs/servers/tarssh/default.nix
+++ b/pkgs/servers/tarssh/default.nix
@@ -1,0 +1,25 @@
+{ fetchFromGitHub, rustPlatform, stdenv }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  pname = "tarssh";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "Freaky";
+    repo = pname;
+    sha256 = "0fm0rwknhm39nhd6g0pnxby34i5gpmi5ri795d9ylsw0pqwz6kd0";
+  };
+
+  cargoSha256 = "108xdpgfgfd4z455snif0mzbla0rv8gjqxci5qgwjzfyshwkprgv";
+
+  meta = with stdenv.lib; {
+    description = "A simple SSH tarpit inspired by endlessh";
+    homepage = "https://github.com/Freaky/tarssh";
+    license = [ licenses.mit ];
+    maintainers = with maintainers; [ sohalt ];
+    platforms = platforms.unix ;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7323,6 +7323,8 @@ in
 
   tarsnapper = callPackage ../tools/backup/tarsnapper { };
 
+  tarssh = callPackage ../servers/tarssh { };
+
   tartube = callPackage ../applications/video/tartube { };
 
   tayga = callPackage ../tools/networking/tayga { };


### PR DESCRIPTION
###### Motivation for this change

I want to use this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
