### PR TITLE
kmon: fix checkPhase

### DIFF
--- a/pkgs/tools/system/kmon/default.nix
+++ b/pkgs/tools/system/kmon/default.nix
@@ -21,6 +21,10 @@ rustPlatform.buildRustPackage rec {
     install -D man/kmon.8 -t $out/share/man/man8/
   '';
 
+  # NOTICE: tests will parse provided arguments, thus do not provide
+  # any arguments
+  checkPhase = "cargo test";
+
   meta = with stdenv.lib; {
     description = "Linux Kernel Manager and Activity Monitor";
     homepage = "https://github.com/orhun/kmon";


### PR DESCRIPTION
Kmon contains tests which parse the given arguments. The argument
parser used in the test is the actual argument parser used by the Kmon
binary. By default Nix provides the `--test-threads` argument. This
argument can not be parsed by the Kmon parser, thus the test fails.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
 
Building the package fails due to the `checkPhase`. By overwriting the `checkPhase` the problem is solved and the package builds properly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
