### PR TITLE
[20.09] lilypond: add patch to restrict embedded-{ps,svg} when -dsafe is used

### DIFF
--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -16,7 +16,14 @@ stdenv.mkDerivation rec {
     sha256 = "0qd6pd4siss016ffmcyw5qc6pr2wihnvrgd4kh1x725w7wr02nar";
   };
 
-  patches = [ ./findlib.patch ];
+  patches = [
+    ./findlib.patch
+    (fetchurl {
+      name = "CVE-2020-17353.patch";
+      url = "https://git.savannah.gnu.org/gitweb/?p=lilypond.git;a=commitdiff_plain;h=b84ea4740f3279516905c5db05f4074e777c16ff;hp=b97bd35ac99efd68569327f62f3c8a19511ebe43";
+      sha256 = "1i79gy3if070rdgj7j6inw532j0f6ya5qc6kgcnlkbx02rqrhr7v";
+    })
+  ];
 
   postInstall = ''
     for f in "$out/bin/"*; do


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backport https://github.com/NixOS/nixpkgs/pull/99220
Fixes: CVE-2020-17353
(cherry picked from commit 500d7b81f92152bf54ec15113d481051f68ed6cf)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
