### PR TITLE
emacsPackages.magit-delta: add git as a build-time dependency

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -125,15 +125,9 @@ let
           packageRequires = with self; [ evil ];
         });
 
-        evil-magit = buildWithGit super.evil-magit;
-
-        eopengrok = buildWithGit super.eopengrok;
-
         ess-R-data-view = super.ess-R-data-view.override {
           inherit (self.melpaPackages) ess ctable popup;
         };
-
-        forge = buildWithGit super.forge;
 
         flycheck-rtags = fix-rtags super.flycheck-rtags;
 
@@ -205,6 +199,12 @@ let
           '';
         });
 
+        evil-magit = buildWithGit super.evil-magit;
+
+        eopengrok = buildWithGit super.eopengrok;
+
+        forge = buildWithGit super.forge;
+
         magit = buildWithGit super.magit;
 
         magit-find-file = buildWithGit super.magit-find-file;
@@ -240,6 +240,38 @@ let
         kubernetes = buildWithGit super.kubernetes;
 
         kubernetes-evil = buildWithGit super.kubernetes-evil;
+
+        egg = buildWithGit super.egg;
+
+        kapacitor = buildWithGit super.kapacitor;
+
+        gerrit = buildWithGit super.gerrit;
+
+        gerrit-download = buildWithGit super.gerrit-download;
+
+        github-pullrequest = buildWithGit super.github-pullrequest;
+
+        jist = buildWithGit super.jist;
+
+        mandoku = buildWithGit super.mandoku;
+
+        mandoku-tls = buildWithGit super.mandoku-tls;
+
+        magit-p4 = buildWithGit super.magit-p4;
+
+        magit-rbr = buildWithGit super.magit-rbr;
+
+        magit-diff-flycheck = buildWithGit super.magit-diff-flycheck;
+
+        magit-reviewboard = buildWithGit super.magit-reviewboard;
+
+        magit-patch-changelog = buildWithGit super.magit-patch-changelog;
+
+        magit-circleci = buildWithGit super.magit-circleci;
+
+        orgit = buildWithGit super.orgit;
+
+        orgit-forge = buildWithGit super.orgit-forge;
 
         # upstream issue: missing file header
         mhc = super.mhc.override {
@@ -384,44 +416,12 @@ let
           propagatedUserEnvPkgs = [ external.editorconfig-core-c ];
         });
 
-        egg = buildWithGit super.egg;
-
         # missing dependencies
         evil-search-highlight-persist = super.evil-search-highlight-persist.overrideAttrs (attrs: {
           packageRequires = with self; [ evil highlight ];
         });
 
-        kapacitor = buildWithGit super.kapacitor;
-
-        gerrit = buildWithGit super.gerrit;
-
-        gerrit-download = buildWithGit super.gerrit-download;
-
-        github-pullrequest = buildWithGit super.github-pullrequest;
-
         helm-rtags = fix-rtags super.helm-rtags;
-
-        jist = buildWithGit super.jist;
-
-        mandoku = buildWithGit super.mandoku;
-
-        mandoku-tls = buildWithGit super.mandoku-tls;
-
-        magit-p4 = buildWithGit super.magit-p4;
-
-        magit-rbr = buildWithGit super.magit-rbr;
-
-        magit-diff-flycheck = buildWithGit super.magit-diff-flycheck;
-
-        magit-reviewboard = buildWithGit super.magit-reviewboard;
-
-        magit-patch-changelog = buildWithGit super.magit-patch-changelog;
-
-        magit-circleci = buildWithGit super.magit-circleci;
-
-        orgit = buildWithGit super.orgit;
-
-        orgit-forge = buildWithGit super.orgit-forge;
 
         # tries to write to $HOME
         php-auto-yasnippets = super.php-auto-yasnippets.overrideAttrs (attrs: {

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -47,6 +47,11 @@ let
       });
     }) else null;
 
+  buildWithGit = pkg: pkg.overrideAttrs (attrs: {
+    nativeBuildInputs =
+      (attrs.nativeBuildInputs or [ ]) ++ [ pkgs.git ];
+  });
+
   fix-rtags = pkg:
     if pkg != null then dontConfigure (externalSrc pkg external.rtags)
     else null;
@@ -120,26 +125,15 @@ let
           packageRequires = with self; [ evil ];
         });
 
-        evil-magit = super.evil-magit.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        evil-magit = buildWithGit super.evil-magit;
 
-        eopengrok = super.eopengrok.overrideAttrs (attrs: {
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        eopengrok = buildWithGit super.eopengrok;
 
         ess-R-data-view = super.ess-R-data-view.override {
           inherit (self.melpaPackages) ess ctable popup;
         };
 
-        forge = super.forge.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        forge = buildWithGit super.forge;
 
         flycheck-rtags = fix-rtags super.flycheck-rtags;
 
@@ -211,113 +205,41 @@ let
           '';
         });
 
-        magit = super.magit.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit = buildWithGit super.magit;
 
-        magit-find-file = super.magit-find-file.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-find-file = buildWithGit super.magit-find-file;
 
-        magit-gh-pulls = super.magit-gh-pulls.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-gh-pulls = buildWithGit super.magit-gh-pulls;
 
-        magit-imerge = super.magit-imerge.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-imerge = buildWithGit super.magit-imerge;
 
-        magit-lfs = super.magit-lfs.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-lfs = buildWithGit super.magit-lfs;
 
-        magit-org-todos = super.magit-org-todos.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-org-todos = buildWithGit super.magit-org-todos;
 
-        magit-tbdiff = super.magit-tbdiff.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-tbdiff = buildWithGit super.magit-tbdiff;
 
-        magit-topgit = super.magit-topgit.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-topgit = buildWithGit super.magit-topgit;
 
-        magit-vcsh = super.magit-vcsh.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-vcsh = buildWithGit super.magit-vcsh;
 
-        magit-gerrit = super.magit-gerrit.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-gerrit = buildWithGit super.magit-gerrit;
 
-        magit-annex = super.magit-annex.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-annex = buildWithGit super.magit-annex;
 
-        magit-todos = super.magit-todos.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-todos = buildWithGit super.magit-todos;
 
-        magit-filenotify = super.magit-filenotify.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-filenotify = buildWithGit super.magit-filenotify;
 
-        magit-gitflow = super.magit-gitflow.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-gitflow = buildWithGit super.magit-gitflow;
 
-        magithub = super.magithub.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magithub = buildWithGit super.magithub;
 
-        magit-svn = super.magit-svn.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-svn = buildWithGit super.magit-svn;
 
-        kubernetes = super.kubernetes.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        kubernetes = buildWithGit super.kubernetes;
 
-        kubernetes-evil = super.kubernetes-evil.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        kubernetes-evil = buildWithGit super.kubernetes-evil;
 
         # upstream issue: missing file header
         mhc = super.mhc.override {
@@ -462,105 +384,44 @@ let
           propagatedUserEnvPkgs = [ external.editorconfig-core-c ];
         });
 
-        egg = super.egg.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        egg = buildWithGit super.egg;
 
         # missing dependencies
         evil-search-highlight-persist = super.evil-search-highlight-persist.overrideAttrs (attrs: {
           packageRequires = with self; [ evil highlight ];
         });
 
-        kapacitor = super.kapacitor.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        kapacitor = buildWithGit super.kapacitor;
 
-        gerrit = super.gerrit.overrideAttrs (attrs: {
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        gerrit = buildWithGit super.gerrit;
 
-        gerrit-download = super.gerrit-download.overrideAttrs (attrs: {
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        gerrit-download = buildWithGit super.gerrit-download;
 
-        github-pullrequest = super.github-pullrequest.overrideAttrs (attrs: {
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        github-pullrequest = buildWithGit super.github-pullrequest;
 
         helm-rtags = fix-rtags super.helm-rtags;
 
-        jist = super.jist.overrideAttrs (attrs: {
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        jist = buildWithGit super.jist;
 
-        mandoku = super.mandoku.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        mandoku = buildWithGit super.mandoku;
 
-        mandoku-tls = super.mandoku-tls.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        mandoku-tls = buildWithGit super.mandoku-tls;
 
-        magit-p4 = super.magit-p4.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-p4 = buildWithGit super.magit-p4;
 
-        magit-rbr = super.magit-rbr.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-rbr = buildWithGit super.magit-rbr;
 
-        magit-diff-flycheck = super.magit-diff-flycheck.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-diff-flycheck = buildWithGit super.magit-diff-flycheck;
 
-        magit-reviewboard = super.magit-reviewboard.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-reviewboard = buildWithGit super.magit-reviewboard;
 
-        magit-patch-changelog = super.magit-patch-changelog.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-patch-changelog = buildWithGit super.magit-patch-changelog;
 
-        magit-circleci = super.magit-circleci.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        magit-circleci = buildWithGit super.magit-circleci;
 
-        orgit =
-          (super.orgit.overrideAttrs (attrs: {
-            # searches for Git at build time
-            nativeBuildInputs =
-              (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-          }));
+        orgit = buildWithGit super.orgit;
 
-        orgit-forge = super.orgit-forge.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
+        orgit-forge = buildWithGit super.orgit-forge;
 
         # tries to write to $HOME
         php-auto-yasnippets = super.php-auto-yasnippets.overrideAttrs (attrs: {

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -269,6 +269,8 @@ let
 
         magit-circleci = buildWithGit super.magit-circleci;
 
+        magit-delta = buildWithGit super.magit-delta;
+
         orgit = buildWithGit super.orgit;
 
         orgit-forge = buildWithGit super.orgit-forge;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`emacsPackages.magit-delta` fails to build:

```
Searching for program: No such file or directory, git
builder for '/nix/store/p49kg7xj0wxw2psfh1ks33qww2dzcmcs-emacs-magit-delta-20200518.2205.drv' failed with exit code 255
error: build of '/nix/store/p49kg7xj0wxw2psfh1ks33qww2dzcmcs-emacs-magit-delta-20200518.2205.drv' failed
```

Like many other magit-related packages it wants to find `git` in `PATH` at build time.

###### Things done

Added `buildWith` and `buildWithGit` functions to remove some repetitive code that adds build dependencies to Emacs packages. These are in a separate commit.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
