### PR TITLE
poetry2nix: fix "invalid Git revision 'master'"

### DIFF
--- a/pkgs/development/tools/poetry2nix/poetry2nix/bin/poetry2nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/bin/poetry2nix
@@ -32,7 +32,7 @@ def fetch_git(pkg):
                 "--url",
                 pkg["source"]["url"],
                 "--rev",
-                pkg["source"]["reference"],
+                pkg["source"]["resolved_reference"],
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/pkgs/development/tools/poetry2nix/poetry2nix/mk-poetry-dep.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/mk-poetry-dep.nix
@@ -157,7 +157,7 @@ pythonPackages.callPackage
           (
             builtins.fetchGit {
               inherit (source) url;
-              rev = source.reference;
+              rev = source.resolved_reference;
               ref = sourceSpec.branch or sourceSpec.rev or sourceSpec.tag or "HEAD";
             }
           ) else if isLocal then (poetryLib.cleanPythonSources { src = localDepPath; }) else


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

When running `nix-shell` after added a git dependency, it complains `invalid Git revision 'master'`.
I think it should always prefer `resolved_reference` to `reference`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
