### PR TITLE
ezquake: 3.2 -> 3.2.2

### DIFF
--- a/pkgs/games/ezquake/default.nix
+++ b/pkgs/games/ezquake/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ezquake";
-  version = "3.2";
+  version = "3.2.2";
 
   src = fetchFromGitHub {
     owner = "ezQuake";
     repo = pname + "-source";
     rev = version;
-    sha256 = "11kyrqpc8w393kvfz2p2h2m7k8rm4w644m86w733b8w157f2fsk0";
+    sha256 = "1rfp816gnp7jfd27cg1la5n1q6z2wgd9qljnlmnx7v2jixql8brf";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Update to 3.2.2

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
