### PR TITLE
[20.09] python3Packages.nbval: Fix tests

### DIFF
--- a/pkgs/development/python-modules/nbval/default.nix
+++ b/pkgs/development/python-modules/nbval/default.nix
@@ -40,8 +40,12 @@ buildPythonPackage rec {
     six
   ];
 
-  # ignore impure tests
+  # Set HOME so that matplotlib doesn't try to use
+  # /homeless-shelter/.config/matplotlib, otherwise some of the tests fail for
+  # having an unexpected warning on stderr produced by matplotlib.
+  # Ignore impure tests.
   checkPhase = ''
+    export HOME=$(mktemp -d)
     pytest tests --ignore tests/test_timeouts.py
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Backport of #99475

ZHF: #97479

cc @jonringer @worldofpeace 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
