### PR TITLE
mediawiki: 1.34.2 -> 1.35.0

### DIFF
--- a/pkgs/servers/web-apps/mediawiki/default.nix
+++ b/pkgs/servers/web-apps/mediawiki/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mediawiki";
-  version = "1.34.2";
+  version = "1.35.0";
 
   src = with stdenv.lib; fetchurl {
     url = "https://releases.wikimedia.org/mediawiki/${versions.majorMinor version}/${pname}-${version}.tar.gz";
-    sha256 = "1mi46a14b2080x6mh61mb49xq0ky27g0lbm3gqgvkgckc1zmbp0f";
+    sha256 = "1m1f7yaabmfpp3ma394j9nqhx9xv47vpbc48qrbknlq3xhfvqzrs";
   };
 
   prePatch = ''


### PR DESCRIPTION
###### Motivation for this change

This is the new LTS version of mediawiki, it also fixes a few CVE
https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/core/+/1.35.0/RELEASE-NOTES-1.35

Note that from this version, you need at least php 7.3

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
