### PR TITLE
ocamlPackages.patdiff: init at 0.13

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.13.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.13.nix
@@ -3,6 +3,7 @@
 , dune-configurator
 , num
 , octavius
+, ocaml_pcre
 , ppxlib
 , re
 , openssl
@@ -468,6 +469,13 @@ rec {
     hash = "012rlbnw21yq2lsbfk3f7l4m4qq3jdx238146z36v54vnhhs6r2r";
     meta.description = "Diff library using Bram Cohen's patience diff algorithm";
     propagatedBuildInputs = [ core_kernel ];
+  };
+
+  patdiff = janePackage {
+    pname = "patdiff";
+    hash = "1yqvxdmkgcwgx3npgncpdqwkpdxiqr1q41wci7589s8z7xi5nwyz";
+    propagatedBuildInputs = [ core ocaml_pcre patience_diff ];
+    meta.description = "File Diff using the Patience Diff algorithm";
   };
 
   ecaml = janePackage {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1021,7 +1021,7 @@ let
     janeStreet =
     if lib.versionOlder "4.08" ocaml.version
     then import ../development/ocaml-modules/janestreet/0.13.nix {
-      inherit ctypes dune-configurator janePackage num octavius ppxlib re;
+      inherit ctypes dune-configurator janePackage num octavius ocaml_pcre ppxlib re;
       inherit (pkgs) openssl;
     }
     else if lib.versionOlder "4.07" ocaml.version


### PR DESCRIPTION
###### Motivation for this change

Patdiff is a diff tool and OCaml library optimized for code and config files, based on the Patience diff algorithm.

See also https://opensource.janestreet.com/patdiff/.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
