### PR TITLE
python3Packages.localzone: Downgrade dnspython dependency

### DIFF
--- a/pkgs/development/python-modules/localzone/default.nix
+++ b/pkgs/development/python-modules/localzone/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchFromGitHub
-, dnspython
+, dnspython_1
 , sphinx
 , pytest
 }:
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "154l7qglsm4jrhqddvlas8cgl9qm2z4dzihv05jmsyqjikcmfwk8";
   };
 
-  propagatedBuildInputs = [ dnspython sphinx ];
+  propagatedBuildInputs = [ dnspython_1 sphinx ];
 
   checkInputs = [ pytest ];
 


### PR DESCRIPTION
The current localezone release is not compatible with dnspython 2.x that
was introduced in nixpkgs with commit a7b5b18ab92f4f4b303d3d3526b91a28f627c68c

###### Motivation for this change
Fix broken build
ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
