### PR TITLE
pythonPackages.arviz: 0.7.0 -> 0.10.0, fixing tests

### DIFF
--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -22,13 +22,13 @@
 
 buildPythonPackage rec {
   pname = "arviz";
-  version = "0.7.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "arviz-devs";
     repo = "arviz";
-    rev = version;
-    sha256 = "03hj7bkkj6kfqdk6ri2mp53wk4k7xpafxk01vgs6k9zg3rlnq7ny";
+    rev = "v${version}";
+    sha256 = "1cnj972knkvi084cfcpc12lv0wxm8xm9clfd55r3hvv42g1ms5d9";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

This _doesn't_ fix:
  - reverse dependency `pymc3`, which now shows its own build failure. Perhaps I will get onto that next.
  - building on darwin, which is blocked by broken dependency `tensorflow` there. I'm not touching that one with a bargepole.

There are also some existing suggestions in comments in this package of how more of the tests could be enabled, but I haven't done anything about that. Some tests it seems require `pymc3`, which, now, itself depends on `arviz`, so that's unlikely to happen unless we move some of the tests to a `passthru.tests`, which could depend on both by being outside the dependency cycle (?)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
