### PR TITLE
onefetch: 2.2.0 -> 2.4.0

### DIFF
--- a/pkgs/tools/misc/onefetch/default.nix
+++ b/pkgs/tools/misc/onefetch/default.nix
@@ -3,27 +3,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "onefetch";
-  version = "2.2.0";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "o2sh";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1sgpai3gx3w7w3ilmbnmzgdxdim6klkfiqaqxmffpyap6qgksfqs";
+    sha256 = "sha256-3bERQ480SuvrjyqlBd9wnE4iIJAbN8HODUj0X+Uxrvs=";
   };
 
-  cargoSha256 = "18z887mklynxpjci6va4i5zhg90j824avykym24vbz9w97nqpdd5";
+  cargoSha256 = "sha256-Bq2ytwbdhYeXIUM4tYSfUamhckraH5w34sAQ96ayJxI=";
 
   buildInputs = with stdenv;
     lib.optionals isDarwin [ CoreFoundation libiconv libresolv Security ];
-
-  cargoPatches = [
-    # fix wrong version in Cargo.lock
-    (fetchpatch {
-      url = "https://github.com/o2sh/onefetch/commit/b69fe660d72b65d7efac99ac5db3b03a82d8667f.patch";
-      sha256 = "14przkdyd4yd11xpdgyscs70w9gpnh02j3xdzxf6h895w3mn84lx";
-    })
-  ];
 
   meta = with stdenv.lib; {
     description = "Git repository summary on your terminal";


### PR DESCRIPTION
###### Motivation for this change
Update onefetch to 2.4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC: @filalex77(@Br1ght0ne)
