### PR TITLE
[haskell-updates] haskellPackages.haskell-language-server: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1490,8 +1490,7 @@ self: super: {
     ghc-exactprint = dontCheck super.ghc-exactprint_0_6_3_2;
   };
   in {
-    # jailbreaking for hie-bios 0.7.0 (upstream PR: https://github.com/haskell/haskell-language-server/pull/357)
-    haskell-language-server = dontCheck (doJailbreak (super.haskell-language-server.overrideScope hlsScopeOverride));
+    haskell-language-server = dontCheck (super.haskell-language-server.overrideScope hlsScopeOverride);
     hls-ghcide = dontCheck (super.hls-ghcide.overrideScope hlsScopeOverride);
     hls-brittany = dontCheck (super.hls-brittany.overrideScope hlsScopeOverride);
     fourmolu = dontCheck (super.fourmolu.overrideScope hlsScopeOverride);

--- a/pkgs/development/tools/haskell/haskell-language-server/default.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/default.nix
@@ -1,45 +1,47 @@
 { mkDerivation, aeson, base, binary, blaze-markup, brittany
-, bytestring, containers, data-default, deepseq, Diff, directory
-, extra, fetchgit, filepath, floskell, fourmolu, ghc, ghc-boot-th
-, ghc-paths, ghcide, gitrev, hashable, haskell-lsp
-, haskell-lsp-types, hie-bios, hslogger, hspec, hspec-core, lens
-, lsp-test, optparse-applicative, optparse-simple, ormolu, process
-, regex-tdfa, retrie, safe-exceptions, shake, stdenv, stm
-, stylish-haskell, tasty, tasty-ant-xml, tasty-expected-failure
-, tasty-golden, tasty-hunit, tasty-rerun, temporary, text, time
-, transformers, unix, unordered-containers, yaml
+, bytestring, containers, data-default, deepseq, directory, extra
+, fetchgit, filepath, fingertree, floskell, fourmolu, ghc
+, ghc-boot-th, ghc-exactprint, ghc-paths, ghc-source-gen, ghcide
+, gitrev, hashable, haskell-lsp, hie-bios, hls-plugin-api, hslogger
+, hspec, hspec-core, lens, lsp-test, mtl, optparse-applicative
+, optparse-simple, ormolu, process, refinery, regex-tdfa, retrie
+, safe-exceptions, shake, stdenv, stm, stylish-haskell, syb, tasty
+, tasty-ant-xml, tasty-expected-failure, tasty-golden, tasty-hunit
+, tasty-rerun, temporary, text, time, transformers
+, unordered-containers, yaml
 }:
 mkDerivation {
   pname = "haskell-language-server";
-  version = "0.4.0.0";
+  version = "0.5.0.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "1fh9k9b3880m6ql4i10yn2yanskk9xhrakrrddqvainhcf2ik8hl";
-    rev = "c4576992f443a9abe48ffcfa0e2d2b9bce15d7ae";
+    sha256 = "1qi762fa72487i8fspxmr8xizm9n2s1shxsvnvsl67vj9if573r9";
+    rev = "3ca2a6cd267f373aae19f59e1cf9e04b6524eff3";
     fetchSubmodules = true;
   };
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson base binary brittany bytestring containers data-default
-    deepseq Diff directory extra filepath floskell fourmolu ghc
-    ghc-boot-th ghcide gitrev hashable haskell-lsp hie-bios hslogger
-    lens optparse-simple ormolu process regex-tdfa retrie
-    safe-exceptions shake stylish-haskell temporary text time
-    transformers unix unordered-containers
+    base containers data-default directory extra filepath ghc ghcide
+    gitrev haskell-lsp hie-bios hls-plugin-api hslogger
+    optparse-applicative optparse-simple process text
+    unordered-containers
   ];
   executableHaskellDepends = [
-    base binary containers data-default directory extra filepath ghc
-    ghc-paths ghcide gitrev hashable haskell-lsp hie-bios hslogger
-    optparse-applicative process safe-exceptions shake text time
-    unordered-containers
+    aeson base binary brittany bytestring containers deepseq directory
+    extra filepath fingertree floskell fourmolu ghc ghc-boot-th
+    ghc-exactprint ghc-paths ghc-source-gen ghcide gitrev hashable
+    haskell-lsp hie-bios hls-plugin-api hslogger lens mtl
+    optparse-applicative optparse-simple ormolu process refinery
+    regex-tdfa retrie safe-exceptions shake stylish-haskell syb
+    temporary text time transformers unordered-containers
   ];
   testHaskellDepends = [
     aeson base blaze-markup bytestring containers data-default
-    directory filepath haskell-lsp haskell-lsp-types hie-bios hslogger
-    hspec hspec-core lens lsp-test process stm tasty tasty-ant-xml
-    tasty-expected-failure tasty-golden tasty-hunit tasty-rerun
-    temporary text transformers unordered-containers yaml
+    directory extra filepath haskell-lsp hie-bios hls-plugin-api
+    hslogger hspec hspec-core lens lsp-test process stm tasty
+    tasty-ant-xml tasty-expected-failure tasty-golden tasty-hunit
+    tasty-rerun temporary text transformers unordered-containers yaml
   ];
   testToolDepends = [ ghcide ];
   homepage = "https://github.com/haskell/haskell-language-server#readme";

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-ghcide.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-ghcide.nix
@@ -1,12 +1,14 @@
 { mkDerivation, aeson, array, async, base, base16-bytestring
 , binary, bytestring, Chart, Chart-diagrams, containers
 , cryptohash-sha1, data-default, deepseq, diagrams, diagrams-svg
-, directory, extra, fetchgit, filepath, fuzzy, ghc, ghc-boot
-, ghc-boot-th, ghc-check, ghc-paths, ghc-typelits-knownnat, gitrev
-, haddock-library, hashable, haskell-lsp, haskell-lsp-types
-, hie-bios, hslogger, lens, lsp-test, mtl, network-uri
+, directory, extra, fetchgit, filepath, fingertree, fuzzy, ghc
+, ghc-boot, ghc-boot-th, ghc-check, ghc-paths
+, ghc-typelits-knownnat, gitrev, Glob, haddock-library, hashable
+, haskell-lsp, haskell-lsp-types, hie-bios, hslogger
+, implicit-hie-cradle, lens, lsp-test, mtl, network-uri
 , optparse-applicative, prettyprinter, prettyprinter-ansi-terminal
-, process, QuickCheck, quickcheck-instances, regex-tdfa
+, process, QuickCheck, quickcheck-instances
+, record-dot-preprocessor, record-hasfield, regex-tdfa
 , rope-utf16-splay, safe, safe-exceptions, shake, sorted-list
 , stdenv, stm, syb, tasty, tasty-expected-failure, tasty-hunit
 , tasty-quickcheck, tasty-rerun, text, time, transformers, unix
@@ -14,11 +16,11 @@
 }:
 mkDerivation {
   pname = "ghcide";
-  version = "0.3.0";
+  version = "0.4.0";
   src = fetchgit {
     url = "https://github.com/haskell/ghcide";
-    sha256 = "15v3g3i5v0xbq50lfvl4bv3rx01nixiqx02sddqi5lj2idgmg24g";
-    rev = "96cf8c53d0bdc16d3d2cd0559b74962593ce6dc5";
+    sha256 = "0zv14mvfhmwwkhyzkr38qpvyffa8ywzp41lr1k55pbrc5b10fjr6";
+    rev = "0bfce3114c28bd00f7bf5729c32ec0f23a8d8854";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -26,12 +28,12 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson array async base base16-bytestring binary bytestring
     containers cryptohash-sha1 data-default deepseq directory extra
-    filepath fuzzy ghc ghc-boot ghc-boot-th ghc-check ghc-paths
-    haddock-library hashable haskell-lsp haskell-lsp-types hie-bios
-    hslogger mtl network-uri prettyprinter prettyprinter-ansi-terminal
-    regex-tdfa rope-utf16-splay safe safe-exceptions shake sorted-list
-    stm syb text time transformers unix unordered-containers
-    utf8-string
+    filepath fingertree fuzzy ghc ghc-boot ghc-boot-th ghc-check
+    ghc-paths Glob haddock-library hashable haskell-lsp
+    haskell-lsp-types hie-bios hslogger implicit-hie-cradle mtl
+    network-uri prettyprinter prettyprinter-ansi-terminal regex-tdfa
+    rope-utf16-splay safe safe-exceptions shake sorted-list stm syb
+    text time transformers unix unordered-containers utf8-string
   ];
   executableHaskellDepends = [
     aeson base bytestring containers data-default directory extra
@@ -43,9 +45,10 @@ mkDerivation {
     aeson base binary bytestring containers directory extra filepath
     ghc ghc-typelits-knownnat haddock-library haskell-lsp
     haskell-lsp-types lens lsp-test network-uri optparse-applicative
-    process QuickCheck quickcheck-instances rope-utf16-splay safe
-    safe-exceptions shake tasty tasty-expected-failure tasty-hunit
-    tasty-quickcheck tasty-rerun text
+    process QuickCheck quickcheck-instances record-dot-preprocessor
+    record-hasfield rope-utf16-splay safe safe-exceptions shake tasty
+    tasty-expected-failure tasty-hunit tasty-quickcheck tasty-rerun
+    text
   ];
   benchmarkHaskellDepends = [
     aeson base Chart Chart-diagrams diagrams diagrams-svg directory


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

hls 0.5.0 has some amazing new features!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
