### PR TITLE
ssm-agent: remove bad user declaration

### DIFF
--- a/nixos/modules/services/misc/ssm-agent.nix
+++ b/nixos/modules/services/misc/ssm-agent.nix
@@ -29,8 +29,6 @@ in {
 
   config = mkIf cfg.enable {
     systemd.services.ssm-agent = {
-      users.extraUsers.ssm-user = {};
-
       inherit (cfg.package.meta) description;
       after    = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
###### Motivation for this change

The user declaration is wrong, so the module won't build.
The SSM agent was running as root, anyway. Current Amazon Linux 2
images run the ssm-agent process as root, so there's little point
creating an ssm-user and giving it NOPASSWD: sudo access.

Reopening of: #99053 
Supersedes: #99404

###### Things done


