### PR TITLE
haskell-language-server: Init wrapper for multiple ghc versions at 0.5.0

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -359,6 +359,38 @@ services.hoogle = {
 };
 ```
 
+### How to install haskell-language-server
+
+In short: Install `pkgs.haskell-language-server` and use the
+`haskell-language-server-wrapper` command to run it. See the [hls
+README](https://github.com/haskell/haskell-language-server) on how to configure
+your text editor to use hls and how to test your setup.
+
+Hls needs to be compiled with the ghc version of the project you use it on.
+
+`pkgs.haskell-language-server` provides `haskell-language-server-wrapper`,
+`haskell-language-server`, `haskell-language-server-x.x` and
+`haskell-language-server-x.x.x` binaries, where x.x.x is the ghc version for
+which it is compiled.  By default it includes binaries for all ghc versions
+that are provided in the binary caches. You can override that list with e.g.
+
+```nix
+pkgs.haskell-language-server.override { supportedGhcVersions = [ "884" "901" ]; }
+```
+When you run `haskell-language-server-wrapper` it will detect the ghc version
+used by the project you are working on (by asking e.g. cabal or stack) and pick
+the appropriate above mentioned binary from your path.
+
+Be careful when installing hls globally and using pinned nixpkgs for a Haskell
+project in a nix-shell. If the nixpkgs versions deviate to much (e.g. use
+different `glibc` versions) hls might fail. It is recommend to then install hls
+in the nix-shell from the nixpkgs version pinned in there.
+
+If you know, that you only use one ghc version, e.g. in a project specific
+nix-shell You can either use an override as given above or simply install
+`pkgs.haskellPackages.haskell-language-server` instead of the top-level
+attribute `pkgs.haskell-language-server`.
+
 ### How to build a Haskell project using Stack
 
 [Stack](http://haskellstack.org) is a popular build tool for Haskell projects.

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -370,20 +370,21 @@ Hls needs to be compiled with the ghc version of the project you use it on.
 
 `pkgs.haskell-language-server` provides `haskell-language-server-wrapper`,
 `haskell-language-server`, `haskell-language-server-x.x` and
-`haskell-language-server-x.x.x` binaries, where x.x.x is the ghc version for
+`haskell-language-server-x.x.x` binaries, where `x.x.x` is the ghc version for
 which it is compiled.  By default it includes binaries for all ghc versions
 that are provided in the binary caches. You can override that list with e.g.
 
 ```nix
 pkgs.haskell-language-server.override { supportedGhcVersions = [ "884" "901" ]; }
 ```
+
 When you run `haskell-language-server-wrapper` it will detect the ghc version
 used by the project you are working on (by asking e.g. cabal or stack) and pick
 the appropriate above mentioned binary from your path.
 
-Be careful when installing hls globally and using pinned nixpkgs for a Haskell
+Be careful when installing hls globally and using a pinned nixpkgs for a Haskell
 project in a nix-shell. If the nixpkgs versions deviate to much (e.g. use
-different `glibc` versions) hls might fail. It is recommend to then install hls
+different `glibc` versions) hls might fail. It is recommended to then install hls
 in the nix-shell from the nixpkgs version pinned in there.
 
 If you know, that you only use one ghc version, e.g. in a project specific

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -782,4 +782,14 @@ self: super: builtins.intersectAttrs super {
     testToolDepends = [ pkgs.git pkgs.mercurial ];
   });
 
+  haskell-language-server = overrideCabal super.haskell-language-server (drv: {
+    postInstall = let
+      inherit (pkgs.lib) concatStringsSep take splitString;
+      ghc_version = self.ghc.version;
+      ghc_major_version = concatStringsSep "." (take 2 (splitString "." ghc_version));
+    in ''
+        ln -s $out/bin/haskell-language-server $out/bin/haskell-language-server-${ghc_version}
+        ln -s $out/bin/haskell-language-server $out/bin/haskell-language-server-${ghc_major_version}
+       '';
+  });
 }

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -782,14 +782,4 @@ self: super: builtins.intersectAttrs super {
     testToolDepends = [ pkgs.git pkgs.mercurial ];
   });
 
-  haskell-language-server = overrideCabal super.haskell-language-server (drv: {
-    postInstall = let
-      inherit (pkgs.lib) concatStringsSep take splitString;
-      ghc_version = self.ghc.version;
-      ghc_major_version = concatStringsSep "." (take 2 (splitString "." ghc_version));
-    in ''
-        ln -s $out/bin/haskell-language-server $out/bin/haskell-language-server-${ghc_version}
-        ln -s $out/bin/haskell-language-server $out/bin/haskell-language-server-${ghc_major_version}
-       '';
-  });
 }

--- a/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
@@ -1,0 +1,42 @@
+{ lib, supportedGhcVersions ? [ "865" "884" "8102" ], stdenv, haskellPackages
+, haskell }:
+let
+  inherit (lib) concatStringsSep concatMapStringsSep take splitString;
+  getPackages = version: haskell.packages."ghc${version}";
+  getMajorVersion = packages:
+    concatStringsSep "." (take 2 (splitString "." packages.ghc.version));
+  targets = version:
+    let packages = getPackages version;
+    in [
+      "haskell-language-server-${packages.ghc.version}"
+      "haskell-language-server-${getMajorVersion packages}"
+    ];
+  makeSymlinks = version:
+    concatMapStringsSep "\n" (x:
+      "ln -s ${
+        haskell.lib.justStaticExecutables
+        (getPackages version).haskell-language-server
+      }/bin/haskell-language-server $out/bin/${x}") (targets version);
+  pkg =
+    haskell.lib.justStaticExecutables haskellPackages.haskell-language-server;
+in stdenv.mkDerivation {
+  pname = "haskell-language-server";
+  version = haskellPackages.haskell-language-server.version;
+  buildCommand = ''
+    mkdir -p $out/bin
+    ln -s ${pkg}/bin/haskell-language-server $out/bin/haskell-language-server
+    ln -s ${pkg}/bin/haskell-language-server-wrapper $out/bin/haskell-language-server-wrapper
+    ${concatMapStringsSep "\n" makeSymlinks supportedGhcVersions}
+  '';
+  meta = haskellPackages.haskell-language-server.meta // {
+    maintainers = [ lib.maintainers.maralorn ];
+    longDescription = ''
+      This package provides haskell-language-server, haskell-language-server-wrapper, ${
+        concatMapStringsSep ", " (x: concatStringsSep ", " (targets x))
+        supportedGhcVersions
+      }.
+
+      You can override the list supportedGhcVersions.
+    '';
+  };
+}

--- a/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
@@ -1,5 +1,12 @@
 { lib, supportedGhcVersions ? [ "865" "884" "8102" ], stdenv, haskellPackages
 , haskell }:
+#
+# The recommended way to override this package is
+#
+# pkgs.haskell-language-server.override { supportedGhcVersions = [ "901" ]; }
+#
+# for example. Read more about this in the haskell-language-server section of the nixpkgs manual.
+#
 let
   inherit (lib) concatStringsSep concatMapStringsSep take splitString;
   getPackages = version: haskell.packages."ghc${version}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4340,6 +4340,8 @@ in
 
   hash-slinger = callPackage ../tools/security/hash-slinger { };
 
+  haskell-language-server = callPackage ../development/tools/haskell/haskell-language-server/withWrapper.nix { };
+
   hasmail = callPackage ../applications/networking/mailreaders/hasmail { };
 
   hal-flash = callPackage ../os-specific/linux/hal-flash { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

haskell-language-server needs a binary which is compiled with the ghc the user uses for their project. That's why hls normally get's distributed (e.g. via ghcup) with the haskell-language-server-wrapper that picks the right binary based on the current project and a binary for every supported ghc version.
I want hls support in nixpkgs to be as good as that, so we also need to provide all those binaries.

I am introducing `pkgs.haskell-language-server` here which has a overridable `supportedGhcVersions` list.

I have fixed the closure size with reference-to. A glance at the binary made a reasonable impression that those references aren‘t needed. A quick test of the binary seems to do just fine.

\cc @peti @GuillaumeDesforges @cdepillabout 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
