### PR TITLE
ircdog: init at 0.2.1

### DIFF
--- a/pkgs/applications/networking/irc/ircdog/default.nix
+++ b/pkgs/applications/networking/irc/ircdog/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildGoPackage
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  pname = "ircdog";
+  version = "0.2.1";
+
+  goPackagePath = "github.com/goshuirc/ircdog";
+
+  src = fetchFromGitHub {
+    owner = "goshuirc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1ppbznlkv7vajfbimxbyiq5y6pkfhm6ylhl408rwq1bawl28hpkl";
+    fetchSubmodules = true;
+  };
+
+  meta = with lib; {
+    description = "ircdog is a simple wrapper over the raw IRC protocol that can respond to pings, and interprets formatting codes";
+    homepage = "https://github.com/goshuirc/ircdog";
+    license = licenses.isc;
+    maintainers = with maintainers; [ hexa ];
+  };
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16536,6 +16536,8 @@ in
 
   imgproxy = callPackage ../servers/imgproxy { };
 
+  ircdog = callPackage ../applications/networking/irc/ircdog { };
+
   ircdHybrid = callPackage ../servers/irc/ircd-hybrid { };
 
   jboss = callPackage ../servers/http/jboss { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Tooling for assisted debugging/testing/playing with raw IRC connections.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
