### PR TITLE
nixos/avahi: fix nss module

### DIFF
--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -239,7 +239,7 @@ in
 
     system.nssModules = optional cfg.nssmdns pkgs.nssmdns;
     system.nssDatabases.hosts = optionals cfg.nssmdns (mkMerge [
-      [ "mdns_minimal [NOTFOUND=return]" ]
+      (mkOrder 900 [ "mdns_minimal [NOTFOUND=return]" ]) # must be before resolve
       (mkOrder 1501 [ "mdns" ]) # 1501 to ensure it's after dns
     ]);
 


### PR DESCRIPTION
`mdns_minimal` must be placed before `resolve` in nsswitch.conf. This was broken by #86940 or #87016, when the config was split up into multiple modules and the ordering was lost. This PR uses `mkOrder` to restore the correct ordering.

This PR ends up placing `mymachines` between `mdns_minimal` and `resolve`, but I believe this is fine. My understanding of the problem is that `resolve` responds to all hostnames, so `.local` domains currently never make it to `mdns_minimal`. On the other hand, `mdns_minimal` only responds to `.local` domains and all other are passed on to the next module. So as long as a systemd container doesn't have a `.local` domain there shouldn't be a problem.

Fixes #98050.

cc @flokli 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
