### PR TITLE
qtile: add missing python package dependencies

### DIFF
--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -45,7 +45,7 @@ python37Packages.buildPythonApplication rec {
     psutil
     pyxdg
     pygobject3
-  ]; 
+  ];
 
   postInstall = ''
     wrapProgram $out/bin/qtile \

--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -34,7 +34,18 @@ python37Packages.buildPythonApplication rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib libxcb cairo pango python37Packages.xcffib ];
 
-  pythonPath = with python37Packages; [ xcffib cairocffi-xcffib setuptools setuptools_scm ]; 
+  pythonPath = with python37Packages; [
+    xcffib
+    cairocffi-xcffib
+    setuptools
+    setuptools_scm
+    dateutil
+    dbus-python
+    mpd2
+    psutil
+    pyxdg
+    pygobject3
+  ]; 
 
   postInstall = ''
     wrapProgram $out/bin/qtile \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Qtile cannot connect to dbus and cause applications to freeze when they attempt to send notifications.
For example, slack will completely freeze when a new message comes in after it attempts to send a notification.

This is caused by an inability to import dbus and pygobject3 as evidenced by this error in the logs
`WARNING libqtile manager.py:setup_eventloop():L240 importing dbus/gobject failed, dbus will not work.`

Also added the python packages dependencies mentioned here:
#45039
DavHau/mach-nix#125

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
