### PR TITLE
sphinx-intl: init at 2.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2765,6 +2765,10 @@
       fingerprint = "67FE 98F2 8C44 CF22 1828  E12F D57E FA62 5C9A 925F";
     }];
   };
+  euandreh = {
+    name = "EuAndreh";
+    email = "eu@euandre.org";
+  };
   euank = {
     email = "euank-nixpkg@euank.com";
     github = "euank";

--- a/pkgs/development/python-modules/sphinx-intl/default.nix
+++ b/pkgs/development/python-modules/sphinx-intl/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, Babel
+, click
+, sphinx
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-intl";
+  version = "2.0.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1d1q0sanjp4nkfvhsxi75zf3xjyyi8nzxvl3v7l0jy9ld70nwnmj";
+  };
+
+  propagatedBuildInputs = [ Babel click sphinx ];
+
+  # package does not contain any tests
+  doChecks = false;
+
+  meta = with stdenv.lib; {
+    description = "Translation support for Sphinx";
+    homepage = "https://github.com/sphinx-doc/sphinx-intl";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ euandreh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6885,6 +6885,8 @@ in {
 
   sphinx-argparse = callPackage ../development/python-modules/sphinx-argparse { };
 
+  sphinx-intl = callPackage ../development/python-modules/sphinx-intl { };
+
   sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
 
   sphinx-navtree = callPackage ../development/python-modules/sphinx-navtree { };


### PR DESCRIPTION
###### Motivation for this change

Add `sphinx-intl` package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Execution of binary tested with:
```shell
nix-shell -I nixpkgs=. -p 'python3.withPackages (p: [ p.sphinx-intl ])' --run sphinx-intl
```