### PR TITLE
octant: init at 0.16.0

### DIFF
--- a/pkgs/applications/networking/cluster/octant/default.nix
+++ b/pkgs/applications/networking/cluster/octant/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl }:
+let
+  version = "0.16.0";
+
+  system = stdenv.hostPlatform.system;
+  suffix = {
+    x86_64-linux = "Linux-64bit";
+    aarch64-linux = "Linux-arm64";
+    x86_64-darwin = "macOS-64bit";
+  }."${system}" or (throw "Unsupported system: ${system}");
+
+  baseurl = "https://github.com/vmware-tanzu/octant/releases/download";
+  fetchsrc = sha256: fetchurl {
+    url = "${baseurl}/v${version}/octant_${version}_${suffix}.tar.gz";
+    sha256 = sha256."${system}";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "octant";
+  inherit version;
+
+  src = fetchsrc {
+    x86_64-linux = "1i6i42hwxaczkfv8ldxn3wp6bslgwfkycvh88khfmapw2f5f9mhr";
+    aarch64-linux = "1ka5vscyqxckxnhnymp06yi0r2ljw42q0g62yq7qv4safljd452p";
+    x86_64-darwin = "1c50c2r2hq2fi8jcijq6vn336w96ar7b6qccv5w2240i0szsxxql";
+  };
+
+  doBuild = false;
+  doCheck = false;
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mv octant $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Highly extensible platform for developers to better understand the complexity of Kubernetes clusters.";
+    longDescription = ''
+      Octant is a tool for developers to understand how applications run on a Kubernetes cluster.
+      It aims to be part of the developer's toolkit for gaining insight and approaching complexity found in Kubernetes.
+      Octant offers a combination of introspective tooling, cluster navigation, and object management along with a
+      plugin system to further extend its capabilities.
+    '';
+    homepage = "https://octant.dev/";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -471,6 +471,8 @@ in
 
   ociTools = callPackage ../build-support/oci-tools { };
 
+  octant = callPackage ../applications/networking/cluster/octant { };
+
   pathsFromGraph = ../build-support/kernel/paths-from-graph.pl;
 
   pruneLibtoolFiles = makeSetupHook { name = "prune-libtool-files"; }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add `octant` k8s observability dashboard tool to nixpkgs.

I've categorized it in `applications/networking/cluster` as most k8s tools go there.

This style of grabbing sources is adapted from `firecracker`.
I've tried building from source but I haven't quite got my head around node2nix yet. I see lots of examples where it's used just to package node but I can't find many examples where it's just used to build a private frontend module to be used by something else. I think I've seen a couple that use `mkYarnPackage`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [X] other Linux distributions (aarch64 archlinux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
