### PR TITLE
rbutil: init at 1.4.1

### DIFF
--- a/pkgs/applications/misc/rbutil/default.nix
+++ b/pkgs/applications/misc/rbutil/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, fetchurl, mkDerivation
+, cryptopp
+, qmake
+, libusb
+, qttools
+, pkg-config
+, wrapQtAppsHook }:
+
+mkDerivation rec {
+  pname = "RockboxUtility";
+  version = "1.4.1";
+
+  src = fetchurl {
+    url = "http://download.rockbox.org/rbutil/source/RockboxUtility-v${version}-src.tar.bz2";
+    sha256 = "0zm9f01a810y7aq0nravbsl0vs9vargwvxnfl4iz9qsqygwlj69y";
+  };
+
+  sourceRoot = "${pname}-v${version}/rbutil/rbutilqt";
+
+  buildInputs = [ wrapQtAppsHook qmake cryptopp libusb qttools pkg-config ];
+
+  preConfigure = ''
+    lrelease rbutilqt.pro
+  '';
+
+  installPhase = ''
+    install -dm 755 "$out"/{bin,share/{applications,pixmaps}}
+    install -m 755 {,"$out"/bin/}RockboxUtility
+    install -m 644 icons/rockbox-256.png "$out"/share/pixmaps/rbutil.png
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.rockbox.org/twiki/bin/view/Main/RockboxUtility;
+    description = "QT GUI for Rockbox Utility";
+    maintainers = with maintainers; [ makefu ];
+    license = licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2417,6 +2417,8 @@ in
 
   razergenie = libsForQt5.callPackage ../applications/misc/razergenie { };
 
+  rbutil = libsForQt5.callPackage ../applications/misc/rbutil { };
+
   ring-daemon = callPackage ../applications/networking/instant-messengers/ring-daemon { };
 
   ripasso-cursive = callPackage ../tools/security/ripasso/cursive.nix {


### PR DESCRIPTION
##### Motivation for this change

Add rbutil to nixpkgs. It can be used to flash your "old" mp3 player with an alternative firmware called Rockbox

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).