### PR TITLE
 bento4: 1.5.1-629 -> 1.6.0-637 

### DIFF
--- a/pkgs/tools/video/bento4/default.nix
+++ b/pkgs/tools/video/bento4/default.nix
@@ -3,13 +3,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "bento4";
-  version = "1.5.1-629";
+  version = "1.6.0-637";
 
   src = fetchFromGitHub {
     owner = "axiomatic-systems";
     repo = "Bento4";
     rev = "v${version}";
-    sha256 = "1614idy0r7qrkiaq4kz3gh1b1bpx592aqvi574kxnjrxc34kpmb3";
+    sha256 = "0iwqi71nj0iczffvpxmz0prvmmnyiqypfwvzivkh38wl0br82bkp";
   };
 
   patches = [ ./libap4.patch ];


### PR DESCRIPTION
###### Motivation for this change

Update bento4 to latest version

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
