### PR TITLE
monoid: 2016-07-21 -> 2018-06-03, use python3

### DIFF
--- a/pkgs/data/fonts/monoid/default.nix
+++ b/pkgs/data/fonts/monoid/default.nix
@@ -1,19 +1,25 @@
-{ stdenv, fetchFromGitHub, python2 }:
-# Python 3 support requires https://github.com/larsenwork/monoid/pull/233 to be merged
+{ stdenv, fetchFromGitHub, fetchpatch, python3 }:
 
 stdenv.mkDerivation {
   pname = "monoid";
-  version = "2016-07-21";
+  version = "2018-06-03";
 
   src = fetchFromGitHub {
     owner = "larsenwork";
     repo = "monoid";
-    rev = "e9d77ec18c337dc78ceae787a673328615f0b120";
-    sha256 = "07h5q6cn6jjpmxp9vyag1bxx481waz344sr2kfs7d37bba8yjydj";
+    rev = "a331c7c5f402c449f623e0d0895bd2fd8dc30ccf";
+    sha256 = "sha256-RV6lxv5CjywTMcuPMj6rdjLKrap7zLJ7niaNeF//U1Y=";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/larsenwork/monoid/pull/233/commits/f84f2ed61301ee84dadd16351314394f22ebed2f.patch";
+      sha256 = "sha256-CxfFHlR7TB64pvrfzVfUDkPwuRO2UdGOhXwW98c+oQU=";
+    })
+  ];
+
   nativeBuildInputs = [
-    (python2.withPackages (pp: with pp; [
+    (python3.withPackages (pp: with pp; [
       fontforge
     ]))
   ];


### PR DESCRIPTION

###### Motivation for this change

`monoid` is broken, as fontforge doesn't supply python2 bindings anymore.

Also address https://github.com/NixOS/nixpkgs/issues/98475.

###### Things done

Bumped version, applied https://github.com/larsenwork/monoid/pull/233, use `python3Packages.fontforge`.

This needs to be backported to `nixos-20.09`. For `nixos-20.03` see https://github.com/NixOS/nixpkgs/pull/99558.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Also pinging @romildo as the maintainer of the package.