### PR TITLE
kube3d: increase discoverability

### DIFF
--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -36,6 +36,7 @@ buildGoModule rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/rancher/k3d";
+    description = "A helper to run k3s (Lightweight Kubernetes. 5 less than k8s) in a docker container - k3d";
     longDescription = ''
       k3s is the lightweight Kubernetes distribution by Rancher: rancher/k3s
 

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -1,11 +1,13 @@
-{ stdenv, buildGoModule, fetchFromGitHub, installShellFiles }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
+let
+  k3sVersion = "1.19.3-k3s3";
+in
 buildGoModule rec {
   pname = "kube3d";
   version = "3.3.0";
-  k3sVersion = "1.19.3-k3s3";
 
-  excludedPackages = ''tools'';
+  excludedPackages = "tools";
 
   src = fetchFromGitHub {
     owner = "rancher";
@@ -14,14 +16,19 @@ buildGoModule rec {
     sha256 = "1pq5x4fyn98f01mzfjv335gx29c61zd85qc5vhx9rk27hi825ima";
   };
 
-  buildFlagsArray = ''
-    -ldflags=
-      -w -s
-      -X github.com/rancher/k3d/v3/version.Version=v${version}
-      -X github.com/rancher/k3d/v3/version.K3sVersion=v${k3sVersion}
-  '';
+  vendorSha256 = null;
 
   nativeBuildInputs = [ installShellFiles ];
+
+  buildFlagsArray = [
+    "-ldflags="
+    "-w"
+    "-s"
+    "-X github.com/rancher/k3d/v3/version.Version=v${version}"
+    "-X github.com/rancher/k3d/v3/version.K3sVersion=v${k3sVersion}"
+  ];
+
+  doCheck = false;
 
   postInstall = ''
     installShellCompletion --cmd k3d \
@@ -30,11 +37,7 @@ buildGoModule rec {
       --zsh <($out/bin/k3d completion zsh)
   '';
 
-  vendorSha256 = null;
-
-  doCheck = false;
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/rancher/k3d";
     description = "A helper to run k3s (Lightweight Kubernetes. 5 less than k8s) in a docker container - k3d";
     longDescription = ''

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -8,9 +8,9 @@ buildGoModule rec {
   excludedPackages = ''tools'';
 
   src = fetchFromGitHub {
-    owner  = "rancher";
-    repo   = "k3d";
-    rev    = "v${version}";
+    owner = "rancher";
+    repo = "k3d";
+    rev = "v${version}";
     sha256 = "1pq5x4fyn98f01mzfjv335gx29c61zd85qc5vhx9rk27hi825ima";
   };
 

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -36,7 +36,12 @@ buildGoModule rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/rancher/k3d";
-    description = "A helper to run k3s (Lightweight Kubernetes. 5 less than k8s) in a docker container";
+    longDescription = ''
+      k3s is the lightweight Kubernetes distribution by Rancher: rancher/k3s
+
+      k3d creates containerized k3s clusters. This means, that you can spin up a
+      multi-node k3s cluster on a single machine using docker.
+    '';
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ kuznero jlesquembre ngerstle jk ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I've searched for "k3d" previously using https://search.nixos.org but `kube3d` didn't show up so I've been maitaining my own copy of it for months :sweat_smile: 
Mentioning "k3d" in the `description` and `longDescription` should make it easier to find.

###### Things done

`nixpkgs-fmt`ed the file to fit with contributing guidelines.

Mentioned `k3d` in the `description` and `longDescription`

https://search.nixos.org can find things from either description but `nix search` just looks at the short description.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - ~[ ] macOS~ Not on the platforms list
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
