### PR TITLE
matrix-synapse module: fix documentation and add release notes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -258,6 +258,11 @@ GRANT ALL PRIVILEGES ON *.* TO 'mysql'@'localhost' WITH GRANT OPTION;
   <itemizedlist>
    <listitem>
     <para>
+     The <link linkend="opt-services.matrix-synapse.enable">matrix-synapse</link> module no longer includes optional dependencies by default, they have to be added through the <link linkend="opt-services.matrix-synapse.plugins">plugins</link> option.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      <literal>buildGoModule</literal> now internally creates a vendor directory
      in the source tree for downloaded modules instead of using go's <link
      xlink:href="https://golang.org/cmd/go/#hdr-Module_proxy_protocol">module

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -131,7 +131,12 @@ in {
       plugins = mkOption {
         type = types.listOf types.package;
         default = [ ];
-        defaultText = "with config.services.matrix-synapse.package.plugins [ matrix-synapse-ldap3 matrix-synapse-pam ]";
+        example = literalExample ''
+          with config.services.matrix-synapse.package.plugins; [
+            matrix-synapse-ldap3
+            matrix-synapse-pam
+          ];
+        '';
         description = ''
           List of additional Matrix plugins to make available.
         '';


### PR DESCRIPTION
Just tried updating my production server to 20.09, and hit this roadblock with the LDAP module.

Switching to defaulting to no-plugins sounds good to me, so I've just updated the documentation and release notes to make things explicit.

cc @fmap who introduced the plugins option