### PR TITLE
vsh: init at 0.7.2

### DIFF
--- a/pkgs/tools/misc/vsh/default.nix
+++ b/pkgs/tools/misc/vsh/default.nix
@@ -1,0 +1,26 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "vsh";
+  version = "0.7.2";
+
+  src = fetchFromGitHub {
+    owner = "fishi0x01";
+    repo = "vsh";
+    rev = "v${version}";
+    sha256 = "0k9bbfzqhijzimng8plk2xx9h37h7d2wj8g3plvvs3wrf7pmwxs7";
+  };
+
+  # vendor dir is already part of repository
+  vendorSha256 = null;
+
+  # make sure version gets set at compile time
+  buildFlagsArray = [ "-ldflags=-s -w -X main.vshVersion=v${version}" ];
+
+  meta = with lib; {
+    description = "HashiCorp Vault interactive shell";
+    homepage = "https://github.com/fishi0x01/vsh";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fishi0x01 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27724,6 +27724,8 @@ in
     inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly;
   };
 
+  vsh = callPackage ../tools/misc/vsh { };
+
   vttest = callPackage ../tools/misc/vttest { };
 
   wacomtablet = libsForQt514.callPackage ../tools/misc/wacomtablet { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [vsh](https://github.com/fishi0x01/vsh) tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
