### PR TITLE
lexicon: fix build, ape: fix inheritance

### DIFF
--- a/pkgs/applications/misc/ape/apeclex.nix
+++ b/pkgs/applications/misc/ape/apeclex.nix
@@ -2,7 +2,7 @@
 
 callPackage ./. {
   pname = "ape-clex";
-  lexicon = "${attemptoClex}/clex_lexicon.pl";
+  lexiconPath = "${attemptoClex}/clex_lexicon.pl";
   description = "Parser for Attempto Controlled English (ACE) with a large lexicon (~100,000 entries)";
   license = with stdenv.lib; [ licenses.lgpl3 licenses.gpl3 ];
 }

--- a/pkgs/applications/misc/ape/default.nix
+++ b/pkgs/applications/misc/ape/default.nix
@@ -1,10 +1,10 @@
 { stdenv, swiProlog, makeWrapper,
   fetchFromGitHub,
-  lexicon ? "prolog/lexicon/clex_lexicon.pl",
+  lexiconPath ? "prolog/lexicon/clex_lexicon.pl",
   pname ? "ape",
   description ? "Parser for Attempto Controlled English (ACE)",
   license ? with stdenv.lib; licenses.lgpl3
-  }:
+}:
 
 stdenv.mkDerivation rec {
   inherit pname;
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     # We move the file first to avoid "same file" error in the default case
-    cp ${lexicon} new_lexicon.pl
+    cp ${lexiconPath} new_lexicon.pl
     rm prolog/lexicon/clex_lexicon.pl
     cp new_lexicon.pl prolog/lexicon/clex_lexicon.pl
   '';

--- a/pkgs/tools/admin/lexicon/default.nix
+++ b/pkgs/tools/admin/lexicon/default.nix
@@ -31,14 +31,19 @@ in
 
 buildPythonApplication rec {
   pname = "lexicon";
-  version = "3.3.27";
+  version = "3.4.3";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "AnalogJ";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0i6grrpdwh7axhnsabb0pfjhpd3prc9ji1afivi7q3c0krgvncmc";
+    sha256 = "1ym4gj4xyd69rsc5niilvcb72gys22rjxhj4qd574vyx3ryl34za";
   };
+
+  nativeBuildInputs = [
+    poetry
+  ];
 
   propagatedBuildInputs = [
     beautifulsoup4

--- a/pkgs/tools/admin/lexicon/default.nix
+++ b/pkgs/tools/admin/lexicon/default.nix
@@ -1,19 +1,37 @@
 { lib
-, python3Packages
+, python3
 , fetchFromGitHub
 }:
 
-python3Packages.buildPythonApplication rec {
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+      # until https://github.com/ags-slc/localzone/issues/1 gets resolved
+      dnspython = super.dnspython.overridePythonAttrs(oldAttrs: rec {
+        pname = "dnspython";
+        version = "1.16.0";
+        # since name is defined from the previous derivation, need to override
+        # name explicity for correct version to show in drvName
+        name = "${pname}-${version}";
+
+        src = super.fetchPypi {
+          inherit pname version;
+          extension = "zip";
+          sha256 = "00cfamn97w2vhq3id87f10mjna8ag5yz5dw0cy5s0sa3ipiyii9n";
+        };
+      });
+
+      localzone = super.localzone.overridePythonAttrs(oldAttrs: rec {
+        meta = oldAttrs.meta // { broken = false; };
+      });
+    };
+  };
+in
+  with py.pkgs;
+
+buildPythonApplication rec {
   pname = "lexicon";
   version = "3.3.27";
-
-  propagatedBuildInputs = with python3Packages; [ requests tldextract future cryptography pyyaml boto3 zeep xmltodict beautifulsoup4 dnspython pynamecheap softlayer transip localzone ];
-
-  checkInputs = with python3Packages; [ pytest pytestcov pytest_xdist vcrpy mock ];
-
-  checkPhase = ''
-    pytest --ignore=lexicon/tests/providers/test_auto.py
-  '';
 
   src = fetchFromGitHub {
     owner = "AnalogJ";
@@ -21,6 +39,35 @@ python3Packages.buildPythonApplication rec {
     rev = "v${version}";
     sha256 = "0i6grrpdwh7axhnsabb0pfjhpd3prc9ji1afivi7q3c0krgvncmc";
   };
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    boto3
+    cryptography
+    dnspython
+    future
+    localzone
+    pynamecheap
+    pyyaml
+    requests
+    softlayer
+    tldextract
+    transip
+    xmltodict
+    zeep
+  ];
+
+  checkInputs = [
+    mock
+    pytest
+    pytestcov
+    pytest_xdist
+    vcrpy
+  ];
+
+  checkPhase = ''
+    pytest --ignore=lexicon/tests/providers/test_auto.py
+  '';
 
   meta = with lib; {
     description = "Manipulate DNS records on various DNS providers in a standardized way.";


### PR DESCRIPTION
###### Motivation for this change
follow up to: https://github.com/NixOS/nixpkgs/pull/99568

created a python packages overlay for lexicon.
bumped lexicon

fixed ape from inheriting the `lexicon` attr from pkgs scope.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/99571
2 packages built:
ape lexicon
```