### PR TITLE
ocamlPackages.jingoo: 1.3.4 → 1.4.1

### DIFF
--- a/pkgs/development/ocaml-modules/jingoo/default.nix
+++ b/pkgs/development/ocaml-modules/jingoo/default.nix
@@ -3,7 +3,7 @@
 
 buildDunePackage rec {
   pname = "jingoo";
-  version = "1.3.4";
+  version = "1.4.1";
 
   minimumOCamlVersion = "4.04";
 
@@ -11,7 +11,7 @@ buildDunePackage rec {
     owner = "tategakibunko";
     repo = "jingoo";
     rev = "v${version}";
-    sha256 = "0fsmm6wxa3axwbcgwdidik3drg754wyh2vxri2w12d662221m98s";
+    sha256 = "16wzggwi3ri13v93mjk8w7zxwp65qmi1rnng2kpk9vffx5g1kv6f";
   };
 
   buildInputs = [ menhir ];


### PR DESCRIPTION
###### Motivation for this change

New features: https://github.com/tategakibunko/jingoo/blob/v1.4.1/CHANGES

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
