### PR TITLE
Add 'environment.opt' (similar to 'environment.etc')

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -977,6 +977,7 @@
   ./system/boot/timesyncd.nix
   ./system/boot/tmp.nix
   ./system/etc/etc.nix
+  ./system/opt/opt.nix
   ./tasks/auto-upgrade.nix
   ./tasks/bcache.nix
   ./tasks/cpu-freq.nix

--- a/nixos/modules/system/opt/make-opt.sh
+++ b/nixos/modules/system/opt/make-opt.sh
@@ -1,0 +1,45 @@
+source $stdenv/setup
+
+mkdir -p $out/opt
+
+set -f
+sources_=($sources)
+targets_=($targets)
+modes_=($modes)
+users_=($users)
+groups_=($groups)
+set +f
+
+for ((i = 0; i < ${#targets_[@]}; i++)); do
+    source="${sources_[$i]}"
+    target="${targets_[$i]}"
+
+    if [[ "$source" =~ '*' ]]; then
+
+        # If the source name contains '*', perform globbing.
+        mkdir -p $out/opt/$target
+        for fn in $source; do
+            ln -s "$fn" $out/opt/$target/
+        done
+
+    else
+
+        mkdir -p $out/opt/$(dirname $target)
+        if ! [ -e $out/opt/$target ]; then
+            ln -s $source $out/opt/$target
+        else
+            echo "duplicate entry $target -> $source"
+            if test "$(readlink $out/opt/$target)" != "$source"; then
+                echo "mismatched duplicate entry $(readlink $out/opt/$target) <-> $source"
+                exit 1
+            fi
+        fi
+
+        if test "${modes_[$i]}" != symlink; then
+            echo "${modes_[$i]}"  > $out/opt/$target.mode
+            echo "${users_[$i]}"  > $out/opt/$target.uid
+            echo "${groups_[$i]}" > $out/opt/$target.gid
+        fi
+
+    fi
+done

--- a/nixos/modules/system/opt/opt.nix
+++ b/nixos/modules/system/opt/opt.nix
@@ -1,0 +1,161 @@
+
+# Management of static files in /opt.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  opt' = filter (f: f.enable) (attrValues config.environment.opt);
+
+  opt = pkgs.stdenvNoCC.mkDerivation {
+    name = "opt";
+
+    builder = ./make-opt.sh;
+
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+
+    /* !!! Use toXML. */
+    sources = map (x: x.source) opt';
+    targets = map (x: x.target) opt';
+    modes = map (x: x.mode) opt';
+    users  = map (x: x.user) opt';
+    groups  = map (x: x.group) opt';
+  };
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    environment.opt = mkOption {
+      default = {};
+      example = literalExample ''
+        { example-configuration-file =
+            { source = "/nix/store/.../opt/dir/file.conf.example";
+              mode = "0440";
+            };
+          "default/useradd".text = "GROUP=100 ...";
+        }
+      '';
+      description = ''
+        Set of files that have to be linked in <filename>/opt</filename>.
+      '';
+
+      type = with types; attrsOf (submodule (
+        { name, config, ... }:
+        { options = {
+
+            enable = mkOption {
+              type = types.bool;
+              default = true;
+              description = ''
+                Whether this /opt file should be generated.  This
+                option allows specific /opt files to be disabled.
+              '';
+            };
+
+            target = mkOption {
+              type = types.str;
+              description = ''
+                Name of symlink (relative to
+                <filename>/opt</filename>).  Defaults to the attribute
+                name.
+              '';
+            };
+
+            text = mkOption {
+              default = null;
+              type = types.nullOr types.lines;
+              description = "Text of the file.";
+            };
+
+            source = mkOption {
+              type = types.path;
+              description = "Path of the source file.";
+            };
+
+            mode = mkOption {
+              type = types.str;
+              default = "symlink";
+              example = "0600";
+              description = ''
+                If set to something else than <literal>symlink</literal>,
+                the file is copied instead of symlinked, with the given
+                file mode.
+              '';
+            };
+
+            uid = mkOption {
+              default = 0;
+              type = types.int;
+              description = ''
+                UID of created file. Only takes effect when the file is
+                copied (that is, the mode is not 'symlink').
+                '';
+            };
+
+            gid = mkOption {
+              default = 0;
+              type = types.int;
+              description = ''
+                GID of created file. Only takes effect when the file is
+                copied (that is, the mode is not 'symlink').
+              '';
+            };
+
+            user = mkOption {
+              default = "+${toString config.uid}";
+              type = types.str;
+              description = ''
+                User name of created file.
+                Only takes effect when the file is copied (that is, the mode is not 'symlink').
+                Changing this option takes precedence over <literal>uid</literal>.
+              '';
+            };
+
+            group = mkOption {
+              default = "+${toString config.gid}";
+              type = types.str;
+              description = ''
+                Group name of created file.
+                Only takes effect when the file is copied (that is, the mode is not 'symlink').
+                Changing this option takes precedence over <literal>gid</literal>.
+              '';
+            };
+
+          };
+
+          config = {
+            target = mkDefault name;
+            source = mkIf (config.text != null) (
+              let name' = "opt" + baseNameOf name;
+              in mkDefault (pkgs.writeText name' config.text));
+          };
+
+        }));
+
+    };
+  };
+
+
+  ###### implementation
+
+  config = {
+
+    system.activationScripts.opt = stringAfter [ "users" "groups" ]
+      ''
+        # Set up the statically computed bits of /opt.
+        echo "setting up /opt..."
+        mkdir -p /opt
+        chmod 755 /opt
+        ${pkgs.perl}/bin/perl -I${pkgs.perlPackages.FileSlurp}/${pkgs.perl.libPrefix} ${./setup-opt.pl} ${opt}/opt
+      '';
+
+  };
+
+}

--- a/nixos/modules/system/opt/setup-opt.pl
+++ b/nixos/modules/system/opt/setup-opt.pl
@@ -1,0 +1,143 @@
+use strict;
+use File::Find;
+use File::Copy;
+use File::Path;
+use File::Basename;
+use File::Slurp;
+
+my $opt = $ARGV[0] or die;
+my $static = "/opt/static";
+
+sub atomicSymlink {
+    my ($source, $target) = @_;
+    my $tmp = "$target.tmp";
+    unlink $tmp;
+    symlink $source, $tmp or return 0;
+    rename $tmp, $target or return 0;
+    return 1;
+}
+
+
+# Atomically update /opt/static to point at the opt files of the
+# current configuration.
+atomicSymlink $opt, $static or die;
+
+# Returns 1 if the argument points to the files in /opt/static.  That
+# means either argument is a symlink to a file in /opt/static or a
+# directory with all children being static.
+sub isStatic {
+    my $path = shift;
+
+    if (-l $path) {
+        my $target = readlink $path;
+        return substr($target, 0, length "/opt/static/") eq "/opt/static/";
+    }
+
+    if (-d $path) {
+        opendir DIR, "$path" or return 0;
+        my @names = readdir DIR or die;
+        closedir DIR;
+
+        foreach my $name (@names) {
+            next if $name eq "." || $name eq "..";
+            unless (isStatic("$path/$name")) {
+                return 0;
+            }
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
+# Remove dangling symlinks that point to /opt/static.  These are
+# configuration files that existed in a previous configuration but not
+# in the current one.
+sub cleanup {
+    if (-l $_) {
+        my $target = readlink $_;
+        if (substr($target, 0, length $static) eq $static) {
+            my $x = "/opt/static/" . substr($File::Find::name, length "/opt/");
+            unless (-l $x) {
+                print STDERR "removing obsolete symlink ‘$File::Find::name’...\n";
+                unlink "$_";
+            }
+        }
+    }
+}
+
+find(\&cleanup, "/opt");
+
+
+# Use /opt/.clean to keep track of copied files.
+my @oldCopied = read_file("/opt/.clean", chomp => 1, err_mode => 'quiet');
+open CLEAN, ">>/opt/.clean";
+
+
+# For every file in the opt tree, create a corresponding symlink in
+# /opt to /opt/static.  The indirection through /opt/static is to make
+# switching to a new configuration somewhat more atomic.
+my %created;
+my @copied;
+
+sub link {
+    my $fn = substr $File::Find::name, length($opt) + 1 or next;
+    my $target = "/opt/$fn";
+    File::Path::make_path(dirname $target);
+    $created{$fn} = 1;
+
+    # Rename doesn't work if target is directory.
+    if (-l $_ && -d $target) {
+        if (isStatic $target) {
+            rmtree $target or warn;
+        } else {
+            warn "$target directory contains user files. Symlinking may fail.";
+        }
+    }
+
+    if (-e "$_.mode") {
+        my $mode = read_file("$_.mode"); chomp $mode;
+
+
+
+        warn "Mode: $mode, target: $target, static: $static, fn: $fn";
+
+
+
+        if ($mode eq "direct-symlink") {
+            atomicSymlink readlink("$static/$fn"), $target or warn;
+        } else {
+            my $uid = read_file("$_.uid"); chomp $uid;
+            my $gid = read_file("$_.gid"); chomp $gid;
+            copy "$static/$fn", "$target.tmp" or warn;
+            $uid = getpwnam $uid unless $uid =~ /^\+/;
+            $gid = getgrnam $gid unless $gid =~ /^\+/;
+            chown int($uid), int($gid), "$target.tmp" or warn;
+            chmod oct($mode), "$target.tmp" or warn;
+            rename "$target.tmp", $target or warn;
+        }
+        push @copied, $fn;
+        print CLEAN "$fn\n";
+    } elsif (-l "$_") {
+        warn "ATOMIC SYMLINK: target: $target, static: $static, fn: $fn";
+        atomicSymlink "$static/$fn", $target or warn;
+    }
+}
+
+find(\&link, $opt);
+
+
+# Delete files that were copied in a previous version but not in the
+# current.
+foreach my $fn (@oldCopied) {
+    if (!defined $created{$fn}) {
+        $fn = "/opt/$fn";
+        print STDERR "removing obsolete file ‘$fn’...\n";
+        unlink "$fn";
+    }
+}
+
+
+# Rewrite /opt/.clean.
+close CLEAN;
+write_file("/opt/.clean", map { "$_\n" } @copied);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I'd like to have an `environment.etc` alternative for `/opt` folder. Use case: a way to pin some specific folders that are generated by Nix (in my particular use case this is used to integrate with Intellij Idea and multiple JDK's):
```
  environment.opt = {
    # Main use case would be pinning stuff like NodeJS or Java home folders to make users life easier 
    "jdk8".source = pkgs.jdk8.home;
    "jdk11".source = pkgs.jdk11.home;
  };
```
The configuration is mostly copy-pasted from etc.nix.
One issue is that /opt folder is created without read permissions (why!?!??!), as a workaround I added `chmod` within the script. This should probably be handled as whenever /opt folder is generated (but then we run into other issues like migrating from older generations. TL;DR: I don't know what is an appropriate way to handle it)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
