### PR TITLE
python3Packages.dask: limit processes on tests

### DIFF
--- a/pkgs/development/python-modules/clifford/default.nix
+++ b/pkgs/development/python-modules/clifford/default.nix
@@ -1,14 +1,15 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, numpy
-, scipy
-, sparse
-, numba
+, isPy27
 , future
 , h5py
-, nose
-, isPy27
+, ipython
+, numba
+, numpy
+, pytestCheckHook
+, scipy
+, sparse
 }:
 
 buildPythonPackage rec {
@@ -22,26 +23,34 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    future
+    h5py
+    numba
     numpy
     scipy
     sparse
-    numba
-    future
-    h5py
   ];
 
   checkInputs = [
-    nose
+    pytestCheckHook
+    ipython
   ];
 
-  preConfigure = ''
+  postPatch = ''
     substituteInPlace setup.py \
       --replace "'numba==0.43'" "'numba'"
   '';
 
-  checkPhase = ''
-    nosetests
+  # avoid collecting local files
+  preCheck = ''
+    cd clifford/test
   '';
+
+  pytestFlagsArray = [
+    "-m \"not veryslow\""
+    "--ignore=test_algebra_initialisation.py" # fails without JIT
+    "--ignore=test_cga.py"
+  ];
 
   meta = with lib; {
     description = "Numerical Geometric Algebra Module";

--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -32,8 +32,6 @@ buildPythonPackage rec {
     pytest_xdist # takes >10mins to run single-threaded
   ];
 
-  pytestFlagsArray = [ "-n $NIX_BUILD_CORES" ];
-
   dontUseSetuptoolsCheck = true;
 
   propagatedBuildInputs = [
@@ -55,6 +53,13 @@ buildPythonPackage rec {
       --replace "version=versioneer.get_version()," "version='${version}'," \
       --replace "cmdclass=versioneer.get_cmdclass()," ""
   '';
+
+  # dask test suite with consistently fail when using high core counts
+  preCheck = ''
+    NIX_BUILD_CORES=$((NIX_BUILD_CORES > 8 ? 8 : NIX_BUILD_CORES))
+  '';
+
+  pytestFlagsArray = [ "-n $NIX_BUILD_CORES" ];
 
   disabledTests = [
     "test_argwhere_str"

--- a/pkgs/development/python-modules/datashader/default.nix
+++ b/pkgs/development/python-modules/datashader/default.nix
@@ -74,8 +74,9 @@ buildPythonPackage rec {
       --replace "'numba >=0.37.0,<0.49'" "'numba'"
   '';
 
+  # dask doesn't do well with large core counts
   checkPhase = ''
-    pytest -n $NIX_BUILD_CORES datashader
+    pytest -n $NIX_BUILD_CORES datashader -k 'not dask.array'
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -6,19 +6,19 @@
 , holoviews
 , hvplot
 , jinja2
-, msgpack-numpy
 , msgpack
+, msgpack-numpy
 , numpy
 , pandas
 , panel
 , pyarrow
+, pytestCheckHook
+, pythonOlder
 , python-snappy
 , requests
 , ruamel_yaml
 , six
 , tornado
-, pytest
-, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -32,7 +32,6 @@ buildPythonPackage rec {
     sha256 = "0c284abeb74927a7366dcab6cefc010c4d050365b8af61c37326a2473a490a4e";
   };
 
-  checkInputs = [ pyarrow pytest ];
   propagatedBuildInputs = [
     appdirs
     dask
@@ -51,6 +50,8 @@ buildPythonPackage rec {
     tornado
   ];
 
+  checkInputs = [ pyarrow pytestCheckHook ];
+
   postPatch = ''
     # Is in setup_requires but not used in setup.py...
     substituteInPlace setup.py --replace "'pytest-runner'" ""
@@ -58,8 +59,18 @@ buildPythonPackage rec {
 
   # test_discover requires driver_with_entrypoints-0.1.dist-info, which is not included in tarball
   # test_filtered_compressed_cache requires calvert_uk_filter.tar.gz, which is not included in tarball
-  checkPhase = ''
-    PATH=$out/bin:$PATH HOME=$(mktemp -d) pytest -k "not test_discover and not test_filtered_compressed_cache"
+  preCheck = ''
+    HOME=$TMPDIR
+    PATH=$out/bin:$PATH
+  '';
+
+  # disable tests which touch network
+  disabledTests = ''
+    "test_discover"
+    "test_filtered_compressed_cache"
+    "test_get_dir"
+    "test_remote_cat"
+    "http"
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mask-rcnn/default.nix
+++ b/pkgs/development/python-modules/mask-rcnn/default.nix
@@ -12,7 +12,7 @@
 , pillow
 , scikitimage
 , scipy
-, tensorflow
+, tensorflow_2
 }:
 
 buildPythonPackage rec {
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pillow
     scikitimage
     scipy
-    tensorflow
+    tensorflow_2 # Keras only supports tensorflow 2 now
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/tensorly/default.nix
+++ b/pkgs/development/python-modules/tensorly/default.nix
@@ -22,7 +22,9 @@ buildPythonPackage rec {
     sha256 = "1ml91yaxwx4msisxbm92yf22qfrscvk58f3z2r1jhi96pw2k4i7x";
   };
 
-  propagatedBuildInputs = [ numpy scipy sparse ];
+  propagatedBuildInputs = [ numpy scipy sparse ]
+    ++ lib.optionals (!doCheck) [ nose ]; # upstream added nose to install_requires
+
   checkInputs = [ pytest nose pytorch ];
   # also has a cupy backend, but the tests are currently broken
   # (e.g. attempts to access cupy.qr instead of cupy.linalg.qr)
@@ -30,11 +32,15 @@ buildPythonPackage rec {
   # as well as tensorflow and mxnet backends, but the tests don't
   # seem to exercise these backend by default
 
+  # uses >= 140GB of ram to test
+  doCheck = false;
   checkPhase = ''
     runHook preCheck
     nosetests -e "test_cupy"
     runHook postCheck
   '';
+
+  pythonImportsCheck = [ "tensorly" ];
 
   meta = with lib; {
     description = "Tensor learning in Python";


### PR DESCRIPTION
###### Motivation for this change
this consistently fails on my server which is passing it 32 cores.

creates a lot of noise when reviewing python packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


```
https://github.com/NixOS/nixpkgs/pull/99575
1 package marked as broken and skipped:
python37Packages.rl-coach

60 packages built:
python37Packages.aplpy python37Packages.batchgenerators python37Packages.caffe python37Packages.clifford python37Packages.dask python37Packages.dask-gateway python37Packages.dask-glm python37Packages.dask-image python37Packages.dask-jobqueue python37Packages.dask-ml python37Packages.dask-mpi python37Packages.dask-xgboost python37Packages.datashader python37Packages.distributed python37Packages.glymur python37Packages.image-match python37Packages.imagecorruptions python37Packages.imgaug python37Packages.intake python37Packages.mask-rcnn python37Packages.pims python37Packages.pyfftw python37Packages.scikitimage python37Packages.sparse python37Packages.spectral-cube python37Packages.streamz python37Packages.stumpy python37Packages.stytra python37Packages.sunpy python37Packages.tensorly python38Packages.aplpy python38Packages.batchgenerators python38Packages.caffe python38Packages.clifford python38Packages.dask python38Packages.dask-gateway python38Packages.dask-glm python38Packages.dask-image python38Packages.dask-jobqueue python38Packages.dask-ml python38Packages.dask-mpi python38Packages.dask-xgboost python38Packages.datashader python38Packages.distributed python38Packages.glymur python38Packages.image-match python38Packages.imagecorruptions python38Packages.imgaug python38Packages.intake python38Packages.mask-rcnn python38Packages.pims python38Packages.pyfftw python38Packages.scikitimage python38Packages.sparse python38Packages.spectral-cube python38Packages.streamz python38Packages.stumpy python38Packages.stytra python38Packages.sunpy python38Packages.tensor
```