### PR TITLE
bmon: fix cross-compilation

### DIFF
--- a/pkgs/tools/misc/bmon/default.nix
+++ b/pkgs/tools/misc/bmon/default.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses libconfuse libnl ];
 
+  preConfigure = ''
+    # Must be an absolute path
+    export PKG_CONFIG="$(command -v "$PKG_CONFIG")"
+  '';
+
   meta = with stdenv.lib; {
     description = "Network bandwidth monitor";
     homepage = "https://github.com/tgraf/bmon";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`PKG_CONFIG` must be an absolute path, otherwise the build fails with the following error:
```
configure: error: 
      *** The pkg-config script could not be found. Make sure it is
      *** in your path, or set the PKG_CONFIG environment variable
      *** to the full path to pkg-config.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @bjornfor @pSub 