### PR TITLE
termbox: 1.1.2 -> 1.1.3

### DIFF
--- a/pkgs/development/libraries/termbox/default.nix
+++ b/pkgs/development/libraries/termbox/default.nix
@@ -1,31 +1,22 @@
-{ stdenv, fetchFromGitHub, python3, wafHook, fetchpatch }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "termbox";
-  version = "1.1.2";
+  version = "1.1.3";
   src = fetchFromGitHub {
-    owner = "nsf";
+    owner = "termbox";
     repo = "termbox";
     rev = "v${version}";
-    sha256 = "08yqxzb8fny8806p7x8a6f3phhlbfqdd7dhkv25calswj7w1ssvs";
+    sha256 = "08sq5n9l9zcrbkjvqyl1gqd57yaz9jh291fwfcwdfdjb4a8zhd17";
   };
 
-  # patch which updates the `waf` version used to build
-  # to make the package buildable on Python 3.7
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/nsf/termbox/commit/6fe63ac3ad63dc2c3ac45b770541cc8b7a1d2db7.patch";
-      sha256 = "1s5747v51sdwvpsg6k9y1j60yn9f63qnylkgy8zrsifjzzd5fzl6";
-    })
-  ];
-
-  nativeBuildInputs = [ python3 wafHook ];
+  makeFlags = [ "prefix=${placeholder "out"}" ];
 
   meta = with stdenv.lib; {
     description = "Library for writing text-based user interfaces";
     license = licenses.mit;
-    homepage = "https://github.com/nsf/termbox#readme";
-    downloadPage = "https://github.com/nsf/termbox/releases";
+    homepage = "https://github.com/termbox/termbox#readme";
+    downloadPage = "https://github.com/termbox/termbox/releases";
     maintainers = with maintainers; [ fgaz ];
   };
 }


### PR DESCRIPTION
Repointing repo to termbox/termbox as nsf/termbox is no longer maintained.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update version and repo location

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
