### PR TITLE
plasma-workspace: add systementry sessionmanagement patch 

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-workspace/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-workspace/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib,
+  mkDerivation, lib, fetchpatch,
 
   extra-cmake-modules, kdoctools,
 
@@ -46,6 +46,18 @@ mkDerivation {
   patches = [
     ./0001-startkde.patch
     ./0002-absolute-wallpaper-install-dir.patch
+    ( # Systemd v246 hides the interface used by KDE to fetch the
+      # user session details.
+      # We're applying this commit from 5.19.90 upgrading the
+      # systementry applet to use the new sessionmanagement API.
+      # See https://github.com/NixOS/nixpkgs/issues/98141 for more
+      # details.
+      # /!\ Remove this patch for version >= v5.19.90
+      fetchpatch {
+      name = "0003-port-systementry-to-sessionmanagement-api.patch";
+      url = "https://invent.kde.org/plasma/plasma-workspace/-/commit/05414ed58d43d87d907326636faac53ae2e7bd60.patch";
+      sha256 = "16izfcwxjkdn99j777ywjkzl01iyl542h4hpsbpkckccj7hz8sin";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Systemd v246 hides the interface used by KDE to fetch the user session
details. We're applying this commit from 5.19.90 upgrading the
systementry applet to use the new sessionmanagement API.

Because of this API breakage, the "Switch User" item was absent from
the KDE application laucher.

See the https://github.com/NixOS/nixpkgs/issues/98141 issue for the
full story.

###### Things done
Pick https://invent.kde.org/plasma/plasma-workspace/-/commit/05414ed58d43d87d907326636faac53ae2e7bd60 from upstream.

The missing items are appearing again and are fully functional.

![Screenshot showing the "switch user" item re-appearing in the launch menu](https://user-images.githubusercontent.com/1219785/95022536-3af66300-0678-11eb-8b0f-f96960c53a75.png)

###### How to Test?

I used this trick https://github.com/NixOS/nixpkgs/issues/98141#issuecomment-695153649.

Don't forget to point to your local nixpkgs checkout:

```bash
mid=$(nixops create nixops-kde-test.nix)
nixops modify -d $mid -I nixpkgs=/path/to/your/checkout nixops-kde-test.nix
nixops deploy -d $mid
```

Note for @ttuegel: I'll let you handle the backport (if you're ok with this PR ofc :)).

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
