### PR TITLE
pythonPackages.pymc3: fix build, init  pythonPackages.fastprogress at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/fastprogress/default.nix
+++ b/pkgs/development/python-modules/fastprogress/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, numpy
+, pytest
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "fastprogress";
+  version = "1.0.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1zhv37q6jkqd1pfhlkd4yzrc3dg83vyksgzf32mjlhd5sb0qmql9";
+  };
+
+  propagatedBuildInputs = [ numpy ];
+
+  # no real tests
+  doCheck = false;
+  pythonImportsCheck = [ "fastprogress" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/fastai/fastprogress";
+    description = "Simple and flexible progress bar for Jupyter Notebook and console";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ris ];
+  };
+
+}

--- a/pkgs/development/python-modules/pymc3/default.nix
+++ b/pkgs/development/python-modules/pymc3/default.nix
@@ -14,6 +14,8 @@
 , pytest
 , nose
 , parameterized
+, fastprogress
+, typing-extensions
 }:
 
 buildPythonPackage rec {
@@ -41,6 +43,8 @@ buildPythonPackage rec {
     h5py
     arviz
     packaging
+    fastprogress
+    typing-extensions
   ];
 
   checkInputs = [
@@ -52,6 +56,7 @@ buildPythonPackage rec {
   # The test suite is computationally intensive and test failures are not
   # indicative for package usability hence tests are disabled by default.
   doCheck = false;
+  pythonImportsCheck = [ "pymc3" ];
 
   # For some reason tests are run as a part of the *install* phase if enabled.
   # Theano writes compiled code to ~/.theano hence we set $HOME.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2002,6 +2002,8 @@ in {
 
   fastpbkdf2 = callPackage ../development/python-modules/fastpbkdf2 { };
 
+  fastprogress = callPackage ../development/python-modules/fastprogress { };
+
   fastrlock = callPackage ../development/python-modules/fastrlock { };
 
   fasttext = callPackage ../development/python-modules/fasttext { };


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

This has to wait on both:
 - ~getting `Theano` fixed and working again, either by #99516 or other means~
 - ~getting `arviz` building again: #99500~

Includes new dependency `fastprogress`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
