### PR TITLE
olsrd: 0.9.6.1 -> 0.9.8, fix build

### DIFF
--- a/pkgs/tools/networking/olsrd/default.nix
+++ b/pkgs/tools/networking/olsrd/default.nix
@@ -1,13 +1,24 @@
-{ stdenv, fetchurl, bison, flex }:
+{ stdenv, fetchFromGitHub, fetchpatch, bison, flex }:
 
 stdenv.mkDerivation rec {
   pname = "olsrd";
-  version = "0.9.6.1";
+  version = "0.9.8";
 
-  src = fetchurl {
-    url = "http://www.olsr.org/releases/0.9/${pname}-${version}.tar.bz2";
-    sha256 = "9cac290e9bff5fc7422110b9ccd972853f10962c962d2f31a63de9c6d1520612";
+  src = fetchFromGitHub {
+    owner = "OLSR";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1xk355dm5pfjil1j4m724vkdnc178lv6hi6s1g0xgpd59avbx90j";
   };
+
+  patches = [
+    # remove if there's ever an upstream release that incorporates
+    # https://github.com/OLSR/olsrd/pull/87
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/openwrt-routing/packages/b3897386771890ba1b15f672c2fed58630beedef/olsrd/patches/011-bison.patch";
+      sha256 = "04cl4b8dpr1yjs7wa94jcszmkdzpnrn719a5m9nhm7lvfrn1rzd0";
+    })
+  ];
 
   buildInputs = [ bison flex ];
 


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Incorporate patch fixing build against bison 3.7 pinched from openwrt (not pulling from the PR itself https://github.com/OLSR/olsrd/pull/87 as it's unmerged and therefore unstable)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
