### PR TITLE
fbpanel: fix build by adding gdk-pixbuf-xlib

### DIFF
--- a/pkgs/applications/window-managers/fbpanel/default.nix
+++ b/pkgs/applications/window-managers/fbpanel/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig
-, libX11, libXmu, libXpm, gtk2, libpng, libjpeg, libtiff, librsvg
+, libX11, libXmu, libXpm, gtk2, libpng, libjpeg, libtiff, librsvg, gdk-pixbuf, gdk-pixbuf-xlib
 }:
 
 stdenv.mkDerivation rec {
@@ -10,9 +10,14 @@ stdenv.mkDerivation rec {
     sha256 = "e14542cc81ea06e64dd4708546f5fd3f5e01884c3e4617885c7ef22af8cf3965";
   };
   buildInputs =
-    [ pkgconfig libX11 libXmu libXpm gtk2 libpng libjpeg libtiff librsvg ];
+    [ pkgconfig libX11 libXmu libXpm gtk2 libpng libjpeg libtiff librsvg gdk-pixbuf gdk-pixbuf-xlib.dev ];
 
   preConfigure = "patchShebangs .";
+
+  postConfigure = ''
+    substituteInPlace config.mk \
+      --replace "CFLAGSX =" "CFLAGSX = -I${gdk-pixbuf-xlib.dev}/include/gdk-pixbuf-2.0"
+  '';
 
   NIX_LDFLAGS="-lX11";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes fbpanel which was broken since #88086 I think.
ZHF: #97479
cc @jonringer @worldofpeace

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
