### PR TITLE
freetype: init demos output

### DIFF
--- a/pkgs/development/libraries/freetype/fix-find-libX11.patch
+++ b/pkgs/development/libraries/freetype/fix-find-libX11.patch
@@ -1,0 +1,73 @@
+diff --git a/graph/x11/rules.mk b/graph/x11/rules.mk
+index 9aa219a..319d9e7 100644
+--- a/graph/x11/rules.mk
++++ b/graph/x11/rules.mk
+@@ -48,30 +48,8 @@
+ #
+ FT_PATH := $(subst ;, ,$(subst :, ,$(subst $(SEP),/,$(PATH))))
+ 
+-ifndef X11_PATH
+-  ifneq ($(findstring X11/bin,$(FT_PATH)),)
+-    xversion := X11
+-  else
+-    ifneq ($(findstring X11R6/bin,$(FT_PATH)),)
+-      xversion := X11R6
+-    else
+-      ifneq ($(findstring X11R5/bin,$(FT_PATH)),)
+-        xversion := X11R5
+-      endif
+-    endif
+-  endif
+-
+-  ifdef xversion
+-    X11_PATH := $(filter %$(xversion)/bin,$(FT_PATH))
+-    X11_PATH := $(X11_PATH:%/bin=%)
+-  else
+-    X11_DIRS := /usr /usr/X11R6 /usr/local/X11R6
+-    X11_XLIB := include/X11/Xlib.h
+-    X11_PATH := $(foreach dir,$(X11_DIRS),$(wildcard $(dir)/$(X11_XLIB)))
+-    X11_PATH := $(X11_PATH:%/$(X11_XLIB)=%)
+-  endif
+-endif
+-
++X11_INCLUDE := $(shell pkg-config --cflags x11)
++GRAPH_LINK  += $(shell pkg-config --libs x11)
+ 
+ ##########################################################################
+ #
+@@ -80,19 +58,7 @@ endif
+ # gcc on the latter platform, which is why it is safe to use the flags
+ # `-L' and `-l' in GRAPH_LINK.
+ #
+-ifneq ($(X11_PATH),)
+-
+-  X11_INCLUDE := $(subst /,$(COMPILER_SEP),$(X11_PATH:%=%/include))
+-  X11_LIB     := $(subst /,$(COMPILER_SEP),$(X11_PATH:%=%/lib64) \
+-                                           $(X11_PATH:%=%/lib))
+-
+-  # The GRAPH_LINK variable is expanded each time an executable is linked
+-  # against the graphics library.
+-  #
+-  ifeq ($(PLATFORM),unix)
+-    GRAPH_LINK += $(X11_LIB:%=-R%)
+-  endif
+-  GRAPH_LINK += $(X11_LIB:%=-L%) -lX11
++ifneq ($(X11_INCLUDE),)
+ 
+   # Solaris needs a -lsocket in GRAPH_LINK.
+   #
+@@ -117,12 +83,12 @@ ifneq ($(X11_PATH),)
+ 	  $(LIBTOOL) --mode=compile $(CC) -static $(CFLAGS) \
+                      $(GRAPH_INCLUDES:%=$I%) \
+                      $I$(subst /,$(COMPILER_SEP),$(GR_X11)) \
+-                     $(X11_INCLUDE:%=$I%) \
++                     $(X11_INCLUDE) \
+                      $T$(subst /,$(COMPILER_SEP),$@ $<)
+   else
+ 	  $(CC) $(CFLAGS) $(GRAPH_INCLUDES:%=$I%) \
+                 $I$(subst /,$(COMPILER_SEP),$(GR_X11)) \
+-                $(X11_INCLUDE:%=$I%) \
++                $(X11_INCLUDE) \
+                 $T$(subst /,$(COMPILER_SEP),$@ $<)
+   endif
+ endif

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12453,6 +12453,7 @@ in
   };
 
   freetype = callPackage ../development/libraries/freetype { };
+  freetype-demos = pkgs.freetype.demos;
 
   frei0r = callPackage ../development/libraries/frei0r { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add the official freetype2-demos executables that are already packaged in for example Debian and Arch. Discovered them through this [very nice article](https://venam.nixers.net/blog/unix/2020/09/14/playing_with_fonts.html) which may be useful if you want to tests those tools.

I haven't tried rebuilding every reverse-dependency of freetype, but poppler builds fine with this patch.

<details>
<summary> Here is the diffoscope between the "out" output before/after this patch:</summary>

```
--- result-before
+++ result
├── stat {}
│ @@ -1,7 +1,7 @@
│  
│    Size: 59        	Blocks: 0          IO Block: 4096   symbolic link
│  Access: (0777/lrwxrwxrwx)  Uid: ( 1000/minijackson)   Gid: (  100/   users)
│  
│ -Modify: 2020-10-04 20:59:14.711111931 +0000
│ +Modify: 2020-10-04 21:03:19.073979372 +0000
│   --- result-before/lib
├── +++ result/lib
│ │   --- result-before/lib/libfreetype.la
│ ├── +++ result/lib/libfreetype.la
│ │ @@ -34,8 +34,8 @@
│ │  shouldnotlink=no
│ │  
│ │  # Files to dlopen/dlpreopen
│ │  dlopen=''
│ │  dlpreopen=''
│ │  
│ │  # Directory that this library needs to be installed in:
│ │ -libdir='/nix/store/fkhsnzjz23rvw5gpgagy9w53cwd8156s-freetype-2.10.2/lib'
│ │ +libdir='/nix/store/cwkk58291a11nanzmh56mjjswgyazmjb-freetype-2.10.2/lib'

```

</details>

<details>
<summary> Here is the diffoscope between the "dev" output before/after this patch:</summary>

```
--- result-dev-before
+++ result-dev
├── stat {}
│ @@ -1,7 +1,7 @@
│  
│    Size: 63        	Blocks: 8          IO Block: 4096   symbolic link
│  Access: (0777/lrwxrwxrwx)  Uid: ( 1000/minijackson)   Gid: (  100/   users)
│  
│ -Modify: 2020-10-04 20:59:17.382110340 +0000
│ +Modify: 2020-10-04 21:03:16.711980546 +0000
│   --- result-dev-before/bin
├── +++ result-dev/bin
│ │   --- result-dev-before/bin/.freetype-config-wrapped
│ ├── +++ result-dev/bin/.freetype-config-wrapped
│ │ @@ -31,19 +31,19 @@
│ │  
│ │    version=`pkg-config --modversion freetype2`
│ │  
│ │    cflags=`pkg-config --cflags freetype2`
│ │    dynamic_libs=`pkg-config --libs freetype2`
│ │    static_libs=`pkg-config --static --libs freetype2`
│ │  else
│ │ -  prefix="/nix/store/fkhsnzjz23rvw5gpgagy9w53cwd8156s-freetype-2.10.2"
│ │ -  exec_prefix="/nix/store/fkhsnzjz23rvw5gpgagy9w53cwd8156s-freetype-2.10.2"
│ │ +  prefix="/nix/store/cwkk58291a11nanzmh56mjjswgyazmjb-freetype-2.10.2"
│ │ +  exec_prefix="/nix/store/cwkk58291a11nanzmh56mjjswgyazmjb-freetype-2.10.2"
│ │  
│ │ -  includedir="/nix/store/a33makx5vm3dgcpc98qi3rd6blikla7p-freetype-2.10.2-dev/include"
│ │ -  libdir="/nix/store/fkhsnzjz23rvw5gpgagy9w53cwd8156s-freetype-2.10.2/lib"
│ │ +  includedir="/nix/store/vjja46iqckd2hqkqid2bid4vl8g6yl61-freetype-2.10.2-dev/include"
│ │ +  libdir="/nix/store/cwkk58291a11nanzmh56mjjswgyazmjb-freetype-2.10.2/lib"
│ │  
│ │    version=23.2.17
│ │  
│ │    cflags="-I${SYSROOT}$includedir/freetype2"
│ │    dynamic_libs="-lfreetype"
│ │    static_libs="-lfreetype -L/nix/store/9sfmwj09ij65qnc8dgv8h56gf12b60nn-zlib-1.2.11/lib -lz -L/nix/store/z0sf96nxxw6qdl5yf1vl0sn07cnh1fqd-bzip2-1.0.6.0.1/lib -lbz2 -L/nix/store/9sfmwj09ij65qnc8dgv8h56gf12b60nn-zlib-1.2.11/lib -L/nix/store/4wxw447p6ydk30gwrggz9kyh5xfgaxl9-libpng-apng-1.6.37/lib -lpng16 -lm -lz -lm -lz"
│ │    if test "${SYSROOT}$libdir" != "/usr/lib"   &&
│ │   --- result-dev-before/bin/freetype-config
│ ├── +++ result-dev/bin/freetype-config
│ │ @@ -1,3 +1,3 @@
│ │  #! /nix/store/2jysm3dfsgby5sw5jgj43qjrb5v79ms9-bash-4.4-p23/bin/bash -e
│ │ -export PKG_CONFIG_PATH='/nix/store/yc2npbij60jxn3fvdys5pyvnjb1wasa6-zlib-1.2.11-dev/lib/pkgconfig:/nix/store/iyy0j8c1njdb0aic3dqcbbhkqv4gwpxa-bzip2-1.0.6.0.1-dev/lib/pkgconfig:/nix/store/jsn2hx31hzq5d625m6479xvsl8f9jggv-libpng-apng-1.6.37-dev/lib/pkgconfig:/nix/store/yc2npbij60jxn3fvdys5pyvnjb1wasa6-zlib-1.2.11-dev/lib/pkgconfig:/nix/store/iyy0j8c1njdb0aic3dqcbbhkqv4gwpxa-bzip2-1.0.6.0.1-dev/lib/pkgconfig:/nix/store/jsn2hx31hzq5d625m6479xvsl8f9jggv-libpng-apng-1.6.37-dev/lib/pkgconfig:/nix/store/a33makx5vm3dgcpc98qi3rd6blikla7p-freetype-2.10.2-dev/lib/pkgconfig'
│ │ -exec -a "$0" "/nix/store/a33makx5vm3dgcpc98qi3rd6blikla7p-freetype-2.10.2-dev/bin/.freetype-config-wrapped"  "$@"
│ │ +export PKG_CONFIG_PATH='/nix/store/yc2npbij60jxn3fvdys5pyvnjb1wasa6-zlib-1.2.11-dev/lib/pkgconfig:/nix/store/iyy0j8c1njdb0aic3dqcbbhkqv4gwpxa-bzip2-1.0.6.0.1-dev/lib/pkgconfig:/nix/store/jsn2hx31hzq5d625m6479xvsl8f9jggv-libpng-apng-1.6.37-dev/lib/pkgconfig:/nix/store/ciazf7whrg6pxly22kx0izy755pjll83-libX11-1.6.8-dev/lib/pkgconfig:/nix/store/mxvpxymvhxizkpzxmr6qfvikhmy7wv3n-xorgproto-2019.1/share/pkgconfig:/nix/store/v1v5ch5zf9r9x3hgw0s6ad7i7iiwm8g2-libxcb-1.13.1-dev/lib/pkgconfig:/nix/store/yc2npbij60jxn3fvdys5pyvnjb1wasa6-zlib-1.2.11-dev/lib/pkgconfig:/nix/store/iyy0j8c1njdb0aic3dqcbbhkqv4gwpxa-bzip2-1.0.6.0.1-dev/lib/pkgconfig:/nix/store/jsn2hx31hzq5d625m6479xvsl8f9jggv-libpng-apng-1.6.37-dev/lib/pkgconfig:/nix/store/ciazf7whrg6pxly22kx0izy755pjll83-libX11-1.6.8-dev/lib/pkgconfig:/nix/store/mxvpxymvhxizkpzxmr6qfvikhmy7wv3n-xorgproto-2019.1/share/pkgconfig:/nix/store/v1v5ch5zf9r9x3hgw0s6ad7i7iiwm8g2-libxcb-1.13.1-dev/lib/pkgconfig:/nix/store/vjja46iqckd2hqkqid2bid4vl8g6yl61-freetype-2.10.2-dev/lib/pkgconfig'
│ │ +exec -a "$0" "/nix/store/vjja46iqckd2hqkqid2bid4vl8g6yl61-freetype-2.10.2-dev/bin/.freetype-config-wrapped"  "$@"
│ │ ├── stat {}
│ │ │ @@ -1,7 +1,7 @@
│ │ │  
│ │ │ -  Size: 755       	Blocks: 8          IO Block: 4096   regular file
│ │ │ +  Size: 1211      	Blocks: 8          IO Block: 4096   regular file
│ │ │  Access: (0555/-r-xr-xr-x)  Uid: (    0/    root)   Gid: (    0/    root)
│ │ │  
│ │ │  Modify: 1970-01-01 00:00:01.000000000 +0000
│   --- result-dev-before/lib
├── +++ result-dev/lib
│ │   --- result-dev-before/lib/pkgconfig
│ ├── +++ result-dev/lib/pkgconfig
│ │ │   --- result-dev-before/lib/pkgconfig/freetype2.pc
│ │ ├── +++ result-dev/lib/pkgconfig/freetype2.pc
│ │ │ @@ -1,11 +1,11 @@
│ │ │ -prefix=/nix/store/fkhsnzjz23rvw5gpgagy9w53cwd8156s-freetype-2.10.2
│ │ │ -exec_prefix=/nix/store/fkhsnzjz23rvw5gpgagy9w53cwd8156s-freetype-2.10.2
│ │ │ -libdir=/nix/store/fkhsnzjz23rvw5gpgagy9w53cwd8156s-freetype-2.10.2/lib
│ │ │ -includedir=/nix/store/a33makx5vm3dgcpc98qi3rd6blikla7p-freetype-2.10.2-dev/include
│ │ │ +prefix=/nix/store/cwkk58291a11nanzmh56mjjswgyazmjb-freetype-2.10.2
│ │ │ +exec_prefix=/nix/store/cwkk58291a11nanzmh56mjjswgyazmjb-freetype-2.10.2
│ │ │ +libdir=/nix/store/cwkk58291a11nanzmh56mjjswgyazmjb-freetype-2.10.2/lib
│ │ │ +includedir=/nix/store/vjja46iqckd2hqkqid2bid4vl8g6yl61-freetype-2.10.2-dev/include
│ │ │  
│ │ │  Name: FreeType 2
│ │ │  URL: https://freetype.org
│ │ │  Description: A free, high-quality, and portable font engine.
│ │ │  Version: 23.2.17
│ │ │  Requires:
│ │ │  Requires.private: zlib, bzip2, libpng
│   --- result-dev-before/nix-support
├── +++ result-dev/nix-support
│ │   --- result-dev-before/nix-support/propagated-build-inputs
│ ├── +++ result-dev/nix-support/propagated-build-inputs
│ │ @@ -1 +1 @@
│ │ -/nix/store/yc2npbij60jxn3fvdys5pyvnjb1wasa6-zlib-1.2.11-dev /nix/store/iyy0j8c1njdb0aic3dqcbbhkqv4gwpxa-bzip2-1.0.6.0.1-dev /nix/store/jsn2hx31hzq5d625m6479xvsl8f9jggv-libpng-apng-1.6.37-dev  /nix/store/fkhsnzjz23rvw5gpgagy9w53cwd8156s-freetype-2.10.2
│ │ +/nix/store/yc2npbij60jxn3fvdys5pyvnjb1wasa6-zlib-1.2.11-dev /nix/store/iyy0j8c1njdb0aic3dqcbbhkqv4gwpxa-bzip2-1.0.6.0.1-dev /nix/store/jsn2hx31hzq5d625m6479xvsl8f9jggv-libpng-apng-1.6.37-dev /nix/store/ciazf7whrg6pxly22kx0izy755pjll83-libX11-1.6.8-dev  /nix/store/cwkk58291a11nanzmh56mjjswgyazmjb-freetype-2.10.2
│ │ ├── stat {}
│ │ │ @@ -1,7 +1,7 @@
│ │ │  
│ │ │ -  Size: 251       	Blocks: 8          IO Block: 4096   regular file
│ │ │ +  Size: 312       	Blocks: 8          IO Block: 4096   regular file
│ │ │  Access: (0444/-r--r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
│ │ │  
│ │ │  Modify: 1970-01-01 00:00:01.000000000 +0000
```

</details>

As shown by the second diffoscope output, this adds a dependency on libX11 for the "dev" package, which I would like to avoid but I'm not sure how to go about that. Any ideas?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
