### PR TITLE
fahclient: 7.6.9 -> 7.6.13

### DIFF
--- a/pkgs/applications/science/misc/foldingathome/client.nix
+++ b/pkgs/applications/science/misc/foldingathome/client.nix
@@ -10,7 +10,7 @@
 }:
 let
   majMin = stdenv.lib.versions.majorMinor version;
-  version = "7.6.9";
+  version = "7.6.13";
 
   fahclient = stdenv.mkDerivation rec {
     inherit version;
@@ -18,7 +18,7 @@ let
 
     src = fetchurl {
       url = "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v${majMin}/fahclient_${version}_amd64.deb";
-      sha256 = "1v4yijjjdq9qx1fp60flp9ya6ywl9qdsgkzwmzjzp8sd5gfvhyr6";
+      sha256 = "1j2cnsyassvifp6ymwd9kxwqw09hks24834gf7nljfncyy9g4g0i";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
@r-ryantm apparently missed the client

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
`/nix/store/rjgvcgry7j78h55z6lpxfd13bb40ayp8-fahclient-7.6.9	  370524984`
`/nix/store/q8jd1574izqnci0g8ga7x49j1a5rvg7v-fahclient-7.6.13	  370522632`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ping @zimbatm who merged the other 7.6.13 updates
