### PR TITLE
nextcloud20: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -75,7 +75,16 @@
 
   <itemizedlist>
    <listitem>
-    <para />
+    <para>
+     The default-version of <literal>nextcloud</literal> is <package>nextcloud20</package>.
+     Please note that it's <emphasis>not</emphasis> possible to upgrade <literal>nextcloud</literal>
+     across multiple major versions! This means that it's e.g. not possible to upgrade
+     from <package>nextcloud18</package> to <package>nextcloud20</package> in a single deploy.
+    </para>
+    <para>
+     The package can be manually upgraded by setting <xref linkend="opt-services.nextcloud.package" />
+     to <package>nextcloud20</package>.
+    </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -427,7 +427,7 @@ in {
               then ''"$(<"${toString c.dbpassFile}")"''
               else if c.dbpass != null
               then ''"${toString c.dbpass}"''
-              else null;
+              else ''""'';
             adminpass = if c.adminpassFile != null
               then ''"$(<"${toString c.adminpassFile}")"''
               else ''"${toString c.adminpass}"'';
@@ -441,8 +441,7 @@ in {
               ${if c.dbhost != null then "--database-host" else null} = ''"${c.dbhost}"'';
               ${if c.dbport != null then "--database-port" else null} = ''"${toString c.dbport}"'';
               ${if c.dbuser != null then "--database-user" else null} = ''"${c.dbuser}"'';
-              ${if (any (x: x != null) [c.dbpass c.dbpassFile])
-                 then "--database-pass" else null} = dbpass;
+              "--database-pass" = dbpass;
               ${if c.dbtableprefix != null
                 then "--database-table-prefix" else null} = ''"${toString c.dbtableprefix}"'';
               "--admin-user" = ''"${c.adminuser}"'';

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -330,37 +330,28 @@ in {
         }
       ];
 
-      warnings = []
-        ++ (optional (cfg.poolConfig != null) ''
+      warnings = let
+        latest = 20;
+        upgradeWarning = major: nixos:
+          ''
+            A legacy Nextcloud install (from before NixOS ${nixos}) may be installed.
+
+            After nextcloud${toString major} is installed successfully, you can safely upgrade
+            to ${toString (major + 1)}. The latest version available is nextcloud${toString latest}.
+
+            Please note that Nextcloud doesn't support upgrades across multiple major versions
+            (i.e. an upgrade from 16 is possible to 17, but not 16 to 18).
+
+            The package can be upgraded by explicitly declaring the service-option
+            `services.nextcloud.package`.
+          '';
+      in (optional (cfg.poolConfig != null) ''
           Using config.services.nextcloud.poolConfig is deprecated and will become unsupported in a future release.
           Please migrate your configuration to config.services.nextcloud.poolSettings.
         '')
-        ++ (optional (versionOlder cfg.package.version "18") ''
-          A legacy Nextcloud install (from before NixOS 20.03) may be installed.
-
-          You're currently deploying an older version of Nextcloud. This may be needed
-          since Nextcloud doesn't allow major version upgrades that skip multiple
-          versions (i.e. an upgrade from 16 is possible to 17, but not 16 to 18).
-
-          It is assumed that Nextcloud will be upgraded from version 16 to 17.
-
-           * If this is a fresh install, there will be no upgrade to do now.
-
-           * If this server already had Nextcloud installed, first deploy this to your
-             server, and wait until the upgrade to 17 is finished.
-
-          Then, set `services.nextcloud.package` to `pkgs.nextcloud18` to upgrade to
-          Nextcloud version 18. Please note that Nextcloud 19 is already out and it's
-          recommended to upgrade to nextcloud19 after that.
-        '')
-        ++ (optional (versionOlder cfg.package.version "19") ''
-          A legacy Nextcloud install (from before NixOS 20.09) may be installed.
-
-          If/After nextcloud18 is installed successfully, you can safely upgrade to
-          nextcloud19. If not, please upgrade to nextcloud18 first since Nextcloud doesn't
-          support upgrades that skip multiple versions (i.e. an upgrade from 17 to 19 isn't
-          possible, but an upgrade from 18 to 19).
-        '');
+        ++ (optional (versionOlder cfg.package.version "18") (upgradeWarning 17 "20.03"))
+        ++ (optional (versionOlder cfg.package.version "19") (upgradeWarning 18 "20.09"))
+        ++ (optional (versionOlder cfg.package.version "20") (upgradeWarning 19 "21.03"));
 
       services.nextcloud.package = with pkgs;
         mkDefault (
@@ -372,7 +363,8 @@ in {
             ''
           else if versionOlder stateVersion "20.03" then nextcloud17
           else if versionOlder stateVersion "20.09" then nextcloud18
-          else nextcloud19
+          else if versionOlder stateVersion "21.03" then nextcloud19
+          else nextcloud20
         );
     }
 

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -85,7 +85,7 @@ in {
     package = mkOption {
       type = types.package;
       description = "Which package to use for the Nextcloud instance.";
-      relatedPackages = [ "nextcloud18" "nextcloud19" ];
+      relatedPackages = [ "nextcloud18" "nextcloud19" "nextcloud20" ];
     };
 
     maxUploadSize = mkOption {

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -49,4 +49,9 @@ in {
     version = "19.0.3";
     sha256 = "0sc9cnsdh8kj60h7i3knh40ngdz1w1wmdqw2v2axfkmax22kjl7w";
   };
+
+  nextcloud20 = generic {
+    version = "20.0.0";
+    sha256 = "1n2cv1i56g6qpzkbl5xaf420zzr4y7isg0lskmr7ymk83way0wx2";
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5720,7 +5720,7 @@ in
   grocy = callPackage ../servers/grocy { };
 
   inherit (callPackage ../servers/nextcloud {})
-    nextcloud17 nextcloud18 nextcloud19;
+    nextcloud17 nextcloud18 nextcloud19 nextcloud20;
 
   nextcloud-client = libsForQt514.callPackage ../applications/networking/nextcloud-client { };
 


### PR DESCRIPTION
###### Motivation for this change

Adds [`nextcloud20`](https://github.com/nextcloud/server/releases/tag/v20.0.0) to our package-set. For this change, a few customizations were needed. Please review this commit-by-commit for more details.

To allow users to upgrade to the latest major (even on stable NixOS), the addition of the package (and the `nginx` changes) **should be backported** to 20.09 (cc @NixOS/backports ), the changes to the upgrade-path should be left out though[1].

[1] https://nixos.org/manual/nixos/stable/index.html#module-services-nextcloud-maintainer-info

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
