### PR TITLE
iconnconfig: init at 0.5.2-beta

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2843,6 +2843,12 @@
     githubId = 25955146;
     name = "eyJhb";
   };
+  ezemtsov = {
+    email = "eugene.zemtsov@gmail.com";
+    github = "ezemtsov";
+    githubId = 21081069;
+    name = "Evgeny Zemtsov";
+  };
   f--t = {
     email = "git@f-t.me";
     github = "f--t";

--- a/pkgs/applications/audio/iconnconfig/default.nix
+++ b/pkgs/applications/audio/iconnconfig/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, mkDerivation
+, fetchgit
+, qmake
+, alsaLib
+, libusb1
+}:
+
+mkDerivation rec {
+  pname = "IConnConfig";
+  version = "0.5.2-beta";
+  src = fetchgit {
+    url = "https://codeberg.org/dehnhardt/IConnConfig";
+    rev = "v${version}";
+    sha256 = "10g0cgqkpqgwnbjdndhmyk4h680kbmlws3mc678fmgjy75qvbfmj";
+  };
+
+  PKControls = fetchgit {
+    url = "https://codeberg.org/dehnhardt/PKControls.git";
+    rev = "f49a0105b65c19e3f63962a1e242839be15bc6b6";
+    sha256 = "1n6lkqy9ihqffs1s2ihdzzhk7dxi1cjj4igs3m00m8h0b5g78gga";
+  };
+
+  sourceRoot = "source/iconnconfig";
+
+  unpackPhase = ''
+    mkdir -p ${sourceRoot} source/PKControls
+    cp -r ${src}/* ${sourceRoot}
+    cp -r ${PKControls}/* source/PKControls
+  '';
+
+  nativeBuildInputs = [ qmake ];
+  buildInputs = [ alsaLib libusb1 ];
+
+  qmakeFlags = [ "iConnConfig.pro" "CONFIG+=build_deb" ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://codeberg.org/dehnhardt/IConnConfig";
+    description = "Linux based configuration utility for IConnectivity interfaces";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ezemtsov ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/audio/iconnconfig/default.nix
+++ b/pkgs/applications/audio/iconnconfig/default.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation rec {
-  pname = "IConnConfig";
+  pname = "iconnconfig";
   version = "0.5.2-beta";
   src = fetchgit {
     url = "https://codeberg.org/dehnhardt/IConnConfig";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27488,6 +27488,8 @@ in
 
   utsushi = callPackage ../misc/drivers/utsushi { };
 
+  iconnconfig = libsForQt5.callPackage ../applications/audio/iconnconfig { };
+
   idsk = callPackage ../tools/filesystems/idsk { };
 
   logtop = callPackage ../tools/misc/logtop { };


### PR DESCRIPTION
##### Motivation for this change

iConnConfig - an open source version of control software for iConnectivity devices.
Tested with my iConnectMidi4+

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
