### PR TITLE
blackfire: init at 1.44.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -331,6 +331,7 @@
   ./services/desktops/tumbler.nix
   ./services/desktops/zeitgeist.nix
   ./services/development/bloop.nix
+  ./services/development/blackfire.nix
   ./services/development/hoogle.nix
   ./services/development/jupyter/default.nix
   ./services/development/jupyterhub/default.nix

--- a/nixos/modules/services/development/blackfire.nix
+++ b/nixos/modules/services/development/blackfire.nix
@@ -1,0 +1,65 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.blackfire-agent;
+
+  agentConfigFile = lib.generators.toINI {} {
+    blackfire =  cfg.settings;
+  };
+
+  agentSock = "blackfire/agent.sock";
+in {
+  meta = {
+    maintainers = pkgs.blackfire.meta.maintainers;
+    doc = ./blackfire.xml;
+  };
+
+  options = {
+    services.blackfire-agent = {
+      enable = lib.mkEnableOption "Blackfire profiler agent";
+      settings = lib.mkOption {
+        description = ''
+          See https://blackfire.io/docs/configuration/agent
+        '';
+        type = lib.types.submodule {
+          freeformType = with lib.types; attrsOf str;
+
+          options = {
+            server-id = lib.mkOption {
+              type = lib.types.str;
+              description = ''
+                Sets the server id used to authenticate with Blackfire
+
+                You can find your personal server-id at https://blackfire.io/my/settings/credentials
+              '';
+            };
+
+            server-token = lib.mkOption {
+              type = lib.types.str;
+              description = ''
+                Sets the server token used to authenticate with Blackfire
+
+                You can find your personal server-token at https://blackfire.io/my/settings/credentials
+              '';
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.etc."blackfire/agent".text = agentConfigFile;
+
+    services.blackfire-agent.settings.socket = "unix:///run/${agentSock}";
+
+    systemd.services.blackfire-agent = {
+      description = "Blackfire agent";
+
+      serviceConfig = {
+        ExecStart = "${pkgs.blackfire}/bin/blackfire-agent";
+        RuntimeDirectory = "blackfire";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/development/blackfire.xml
+++ b/nixos/modules/services/development/blackfire.xml
@@ -1,0 +1,45 @@
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="module-services-blackfire">
+ <title>Blackfire profiler</title>
+ <para>
+  <emphasis>Source:</emphasis>
+  <filename>modules/services/development/blackfire.nix</filename>
+ </para>
+ <para>
+  <emphasis>Upstream documentation:</emphasis>
+  <link xlink:href="https://blackfire.io/docs/introduction"/>
+ </para>
+ <para>
+  <link xlink:href="https://blackfire.io">Blackfire</link> is a proprietary tool for profiling applications. There are several languages supported by the product but currently only PHP support is packaged in Nixpkgs. The back-end consists of a module that is loaded into the language runtime (called <firstterm>probe</firstterm>) and a service (<firstterm>agent</firstterm>) that the probe connects to and that sends the profiles to the server.
+ </para>
+ <para>
+  To use it, you will need to enable the agent and the probe on your server. The exact method will depend on the way you use PHP but here is an example of NixOS configuration for PHP-FPM:
+<programlisting>let
+  php = pkgs.php.withExtensions ({ enabled, all }: enabled ++ (with all; [
+    blackfire
+  ]));
+in {
+  # Enable the probe extension for PHP-FPM.
+  services.phpfpm = {
+    phpPackage = php;
+  };
+
+  # Enable and configure the agent.
+  services.blackfire-agent = {
+    enable = true;
+    settings = {
+      # You will need to get credentials at https://blackfire.io/my/settings/credentials
+      # You can also use other options described in https://blackfire.io/docs/configuration/agent
+      server-id = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX";
+      server-token = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    };
+  };
+
+  # Make the agent run on start-up.
+  # Alternately, you can start it manually with `systemctl start blackfire-agent`.
+  systemd.services.blackfire-agent.wantedBy = [ "phpfpm-foo.service" ];
+}</programlisting>
+ </para>
+ <para>
+  On your developer machine, you will also want to install <link xlink:href="https://blackfire.io/docs/up-and-running/installation#install-a-profiling-client">the client</link> (see <package>blackfire</package> package) or the browser extension to actually trigger the profiling.
+ </para>
+</chapter>

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -106,7 +106,7 @@ let
                 name = "php-with-extensions-${version}";
                 inherit (php) version;
                 nativeBuildInputs = [ makeWrapper ];
-                passthru = {
+                passthru = php.passthru // {
                   buildEnv = mkBuildEnv allArgs allExtensionFunctions;
                   withExtensions = mkWithExtensions allArgs allExtensionFunctions;
                   phpIni = "${phpWithExtensions}/lib/php.ini";
@@ -259,6 +259,7 @@ let
           passthru = {
             buildEnv = mkBuildEnv {} [];
             withExtensions = mkWithExtensions {} [];
+            inherit ztsSupport;
           };
 
           meta = with stdenv.lib; {

--- a/pkgs/development/tools/misc/blackfire/default.nix
+++ b/pkgs/development/tools/misc/blackfire/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, writeShellScript
+, curl
+, jq
+, common-updater-scripts
+}:
+
+stdenv.mkDerivation rec {
+  pname = "blackfire-agent";
+  version = "1.44.1";
+
+  src = fetchurl {
+    url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire-php/blackfire-agent_${version}_amd64.deb";
+    sha256 = "1p00flipm5x6r36gblfrfrd14byipilybrhfzv8rzpahz2b7r5hb";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    dpkg-deb -x $src $out
+    mv $out/usr/* $out
+    rmdir $out/usr
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = writeShellScript "update-${pname}" ''
+      export PATH="${lib.makeBinPath [ curl jq common-updater-scripts ]}"
+      update-source-version "$UPDATE_NIX_ATTR_PATH" "$(curl https://blackfire.io/api/v1/releases | jq .agent --raw-output)"
+    '';
+  };
+
+  meta = with lib; {
+    description = "Blackfire Profiler agent and client";
+    homepage = "https://blackfire.io/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/tools/misc/blackfire/php-probe.nix
+++ b/pkgs/development/tools/misc/blackfire/php-probe.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, php
+, writeShellScript
+, curl
+, jq
+, common-updater-scripts
+}:
+
+let
+  soFile = {
+    "7.3" = "blackfire-20180731";
+    "7.4" = "blackfire-20190902";
+  }.${lib.versions.majorMinor php.version} or (throw "Unsupported PHP version.");
+in stdenv.mkDerivation rec {
+  pname = "php-blackfire";
+  version = "1.41.0";
+
+  src = fetchurl {
+    url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire-php/blackfire-php_${version}_amd64.deb";
+    sha256 = "0vbl48bccswk9ygb4sshn24cl33fk0xg8d1bcg7ihvdc45any9ww";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    dpkg-deb -x $src pkg
+    sourceRoot=pkg
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D usr/lib/blackfire-php/amd64/${soFile}${lib.optionalString php.ztsSupport "-zts"}.so $out/lib/php/extensions/blackfire.so
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = writeShellScript "update-${pname}" ''
+      export PATH="${lib.makeBinPath [ curl jq common-updater-scripts ]}"
+      update-source-version "$UPDATE_NIX_ATTR_PATH" "$(curl https://blackfire.io/api/v1/releases | jq .probe.php --raw-output)"
+    '';
+  };
+
+  meta = with lib; {
+    description = "Blackfire Profiler PHP module";
+    homepage = "https://blackfire.io/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10674,6 +10674,8 @@ in
 
   black = with python3Packages; toPythonApplication black;
 
+  blackfire = callPackage ../development/tools/misc/blackfire { };
+
   black-macchiato = with python3Packages; toPythonApplication black-macchiato;
 
   blackmagic = callPackage ../development/tools/misc/blackmagic { };

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -399,6 +399,8 @@ in
       meta.maintainers = lib.teams.php.members;
     };
 
+    blackfire = pkgs.callPackage ../development/tools/misc/blackfire/php-probe.nix { inherit php; };
+
     couchbase = buildPecl rec {
       version = "2.6.1";
       pname = "couchbase";


### PR DESCRIPTION
###### Motivation for this change
Adds [Blackfire](https://blackfire.io), a proprietary profiler for PHP and other languages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
