### PR TITLE
cagebreak: init at 1.4.2

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -44,6 +44,7 @@ in
   caddy = handleTest ./caddy.nix {};
   cadvisor = handleTestOn ["x86_64-linux"] ./cadvisor.nix {};
   cage = handleTest ./cage.nix {};
+  cagebreak = handleTest ./cagebreak.nix {};
   cassandra = handleTest ./cassandra.nix {};
   ceph-single-node = handleTestOn ["x86_64-linux"] ./ceph-single-node.nix {};
   ceph-multi-node = handleTestOn ["x86_64-linux"] ./ceph-multi-node.nix {};

--- a/nixos/tests/cagebreak.nix
+++ b/nixos/tests/cagebreak.nix
@@ -1,0 +1,98 @@
+import ./make-test-python.nix ({ pkgs, lib, ...} :
+
+let
+  cagebreakConfigfile = pkgs.writeText "config" ''
+    workspaces 1
+    escape C-t
+    bind t exec env DISPLAY=:0 ${pkgs.xterm}/bin/xterm -cm -pc
+    bind a exec ${pkgs.alacritty}/bin/alacritty
+  '';
+in
+{
+  name = "cagebreak";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ berbiche ];
+  };
+
+  machine = { config, ... }:
+  let
+    alice = config.users.users.alice;
+  in {
+    imports = [ ./common/user-account.nix ];
+
+    environment.systemPackages = [ pkgs.cagebreak ];
+    services.xserver = {
+      enable = true;
+      displayManager.autoLogin = {
+        enable = true;
+        user = alice.name;
+      };
+    };
+    services.xserver.windowManager.session = lib.singleton {
+      manage = "desktop";
+      name = "cagebreak";
+      start = ''
+        export XDG_RUNTIME_DIR=/run/user/${toString alice.uid}
+        ${pkgs.cagebreak}/bin/cagebreak &
+        waitPID=$!
+      '';
+    };
+
+    systemd.services.setupCagebreakConfig = {
+      wantedBy = [ "multi-user.target" ];
+      before = [ "multi-user.target" ];
+      environment = {
+        HOME = alice.home;
+      };
+      unitConfig = {
+        type = "oneshot";
+        RemainAfterExit = true;
+        user = alice.name;
+      };
+      script = ''
+        cd $HOME
+        CONFFILE=$HOME/.config/cagebreak/config
+        mkdir -p $(dirname $CONFFILE)
+        cp ${cagebreakConfigfile} $CONFFILE
+      '';
+    };
+
+    # Copied from cage:
+    # this needs a fairly recent kernel, otherwise:
+    #   [backend/drm/util.c:215] Unable to add DRM framebuffer: No such file or directory
+    #   [backend/drm/legacy.c:15] Virtual-1: Failed to set CRTC: No such file or directory
+    #   [backend/drm/util.c:215] Unable to add DRM framebuffer: No such file or directory
+    #   [backend/drm/legacy.c:15] Virtual-1: Failed to set CRTC: No such file or directory
+    #   [backend/drm/drm.c:618] Failed to initialize renderer on connector 'Virtual-1': initial page-flip failed
+    #   [backend/drm/drm.c:701] Failed to initialize renderer for plane
+    boot.kernelPackages = pkgs.linuxPackages_latest;
+
+    virtualisation.memorySize = 1024;
+  };
+
+  enableOCR = true;
+
+  testScript = { nodes, ... }: let
+    user = nodes.machine.config.users.users.alice;
+  in ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_file("/run/user/${toString user.uid}/wayland-0")
+
+    with subtest("ensure wayland works with alacritty"):
+        machine.send_key("ctrl-t")
+        machine.send_key("a")
+        machine.wait_until_succeeds("pgrep alacritty")
+        machine.wait_for_text("alice@machine")
+        machine.screenshot("screen")
+        machine.send_key("ctrl-d")
+
+    with subtest("ensure xwayland works with xterm"):
+        machine.send_key("ctrl-t")
+        machine.send_key("t")
+        machine.wait_until_succeeds("pgrep xterm")
+        machine.wait_for_text("alice@machine")
+        machine.screenshot("screen")
+        machine.send_key("ctrl-d")
+  '';
+})

--- a/pkgs/applications/window-managers/cagebreak/default.nix
+++ b/pkgs/applications/window-managers/cagebreak/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchFromGitHub
+, meson, ninja, pkg-config, wayland, scdoc, makeWrapper
+, wlroots, wayland-protocols, pixman, libxkbcommon
+, cairo , pango, fontconfig, pandoc, systemd
+, withXwayland ? true, xwayland
+, nixosTests
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cagebreak";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "project-repo";
+    repo = "cagebreak";
+    rev = version;
+    hash = "sha256-+Ww1rsUR7qe/BixLPR8GiRc3C6QmpLzWpT2wym8b4/M=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config wayland scdoc makeWrapper ];
+
+  buildInputs = [
+    wlroots wayland wayland-protocols pixman libxkbcommon cairo
+    pango fontconfig pandoc systemd
+  ];
+
+  outputs = [ "out" "contrib" ];
+
+  mesonFlags = [
+    "-Dxwayland=${stdenv.lib.boolToString withXwayland}"
+    "-Dversion_override=${version}"
+  ];
+
+  postInstall = ''
+    mkdir -p $contrib/share/cagebreak
+    cp $src/examples/config $contrib/share/cagebreak/config
+  '';
+
+  postFixup = stdenv.lib.optionalString withXwayland ''
+    wrapProgram $out/bin/cagebreak --prefix PATH : "${xwayland}/bin"
+  '';
+
+  passthru.tests.basic = nixosTests.cagebreak;
+
+  meta = with stdenv.lib; {
+    description = "A Wayland tiling compositor inspired by ratpoison";
+    homepage = "https://github.com/project-repo/cagebreak";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ berbiche ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28209,4 +28209,6 @@ in
 
   bottom = callPackage ../tools/system/bottom {};
 
+  cagebreak = callPackage ../applications/window-managers/cagebreak/default.nix {};
+
 }


### PR DESCRIPTION
##### Motivation for this change

[Cagebreak](https://github.com/project-repo/cagebreak) is a Wayland tiling compositor inspired by ratpoison and based on wlroots.

In order to test the binary, the user **MUST** create the file `$XDG_CONFIG_HOME/cagebreak/config` otherwise the program segfaults.
The upstream example configuration is made available in `"${cagebreak.contrib}/share/cagebreak/config"`.

``` console
$ nix path-info -Sh '.#cagebreak'
/nix/store/zb3hh4pklhd6h5symq3nfp7hzg178bc4-cagebreak-1.4.2	 205.6M
```

I am neither a ratpoison user nor a cagebreak user (yet).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
