### PR TITLE
mas: init at 1.8.1

### DIFF
--- a/pkgs/os-specific/darwin/mas/default.nix
+++ b/pkgs/os-specific/darwin/mas/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchurl
+, libarchive
+, p7zip
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mas";
+  version = "1.8.1";
+
+  src = fetchurl {
+    url = "https://github.com/mas-cli/mas/releases/download/v${version}/mas.pkg";
+    sha256 = "W/wgg+ETeJPoZ7MoVGH2uJzQiZMLIy3n1JYKUloc3ZU=";
+  };
+
+  nativeBuildInputs = [ libarchive p7zip ];
+
+  unpackPhase = ''
+    7z x $src
+    bsdtar -xf Payload~
+  '';
+
+  doBuild = false;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r ./bin $out
+    cp -r ./Frameworks $out
+  '';
+
+  postFixup = ''
+    install_name_tool -change @rpath/MasKit.framework/Versions/A/MasKit $out/Frameworks/MasKit.framework/Versions/A/MasKit $out/bin/mas
+    install_name_tool -change @rpath/Commandant.framework/Commandant $out/Frameworks/MasKit.framework/Versions/A/Frameworks/Commandant.framework/Versions/A/Commandant $out/bin/mas
+  '';
+
+  meta = with lib; {
+    description = "Mac App Store command line interface";
+    homepage = "https://github.com/mas-cli/mas";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zachcoyle ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29382,6 +29382,8 @@ in
 
   martyr = callPackage ../development/libraries/martyr { };
 
+  mas = callPackage ../os-specific/darwin/mas { };
+
   moltengamepad = callPackage ../misc/drivers/moltengamepad { };
 
   openzwave = callPackage ../development/libraries/openzwave { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
mas is a command line interface to the Mac App store, and having this package available will allow automation of interactions with the App Store

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
