### PR TITLE
ruby_3_0: init at 3.0.0-preview1

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -27,6 +27,7 @@ let
     ver = version;
     tag = ver.gitTag;
     atLeast27 = lib.versionAtLeast ver.majMin "2.7";
+    atLeast30 = lib.versionAtLeast ver.majMin "3.0";
     baseruby = self.override {
       useRailsExpress = false;
       docSupport = false;
@@ -132,6 +133,11 @@ let
         preConfigure = opString docSupport ''
           configureFlagsArray+=("--with-ridir=$devdoc/share/ri")
         '';
+
+        NIX_CFLAGS_COMPILE =
+          if atLeast30 && stdenv.cc.isClang
+          then "-Wno-error=implicit-function-declaration"
+          else null;
 
         # fails with "16993 tests, 2229489 assertions, 105 failures, 14 errors, 89 skips"
         # mostly TZ- and patch-related tests
@@ -244,6 +250,14 @@ in {
     sha256 = {
       src = "1m63461mxi3fg4y3bspbgmb0ckbbb1ldgf9xi0piwkpfsk80cmvf";
       git = "0kbgznf1yprfp9645k31ra5f4757b7fichzi0hdg6nxkj90853s0";
+    };
+  };
+
+  ruby_3_0 = generic {
+    version = rubyVersion "3" "0" "0" "preview1";
+    sha256 = {
+      src = "019i4n2mgvnv088zlzbbsyrfbfz943m4a8adn9qaihky9r9xg2yf";
+      git = "04cm1c9am7955rxg9vb1qrqz9i38y4h93ad9acflia0c7k037sif";
     };
   };
 }

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -16,4 +16,6 @@
     "${patchSet}/patches/ruby/2.7/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.7/head/railsexpress/03-more-detailed-stacktrace.patch"
   ];
+  "3.0.0" = ops useRailsExpress [ # no patches yet (2020-10-04)
+  ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10328,7 +10328,8 @@ in
   })
     ruby_2_5
     ruby_2_6
-    ruby_2_7;
+    ruby_2_7
+    ruby_3_0;
 
   rubyMinimal = ruby.override {
     # gem support is minimal overhead


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
