### PR TITLE
nixos/installer: use the configured nix package for nixos-install

### DIFF
--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -23,7 +23,6 @@ let
     inherit (pkgs) runtimeShell;
     nix = config.nix.package.out;
     path = makeBinPath [
-      pkgs.nixUnstable
       pkgs.jq
       nixos-enter
     ];


### PR DESCRIPTION
###### Motivation for this change

The current state lead to having two version of Nix in each system
closure unless someone defaulted to `nixUnstable`. We should probably
only pick the package that is actually desired by the user.

If someone needs an exotic installer with `nixUnstable` then they should
probably build an image with it for their exotic use case.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - all the installer tests succeeded
