### PR TITLE
sbt: 1.3.13 -> 1.4.0

### DIFF
--- a/pkgs/development/tools/build-managers/sbt/default.nix
+++ b/pkgs/development/tools/build-managers/sbt/default.nix
@@ -1,25 +1,27 @@
-{ stdenv, fetchurl, jre }:
+{ stdenv, fetchurl, jre, autoPatchelfHook, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "sbt";
-  version = "1.3.13";
+  version = "1.4.0";
 
   src = fetchurl {
-    urls = [
-      "https://piccolo.link/sbt-${version}.tgz"
-      "https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.tgz"
-    ];
-    sha256 = "08mx84kzpm750zjxm225nh9wqm7js5y2k6hgb8xw3n574zg58hc5";
+    url = "https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.tgz";
+    sha256 = "1mgfs732w1c1p7dna7h47x8h073lvjs224fqlpkkvq10153mnxxl";
   };
 
   patchPhase = ''
     echo -java-home ${jre.home} >>conf/sbtopts
   '';
 
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [ zlib ];
+
   installPhase = ''
     mkdir -p $out/share/sbt $out/bin
     cp -ra . $out/share/sbt
-    ln -s $out/share/sbt/bin/sbt $out/bin/
+    ln -sT ../share/sbt/bin/sbt $out/bin/sbt
+    ln -sT ../share/sbt/bin/sbtn-x86_64-${ if (stdenv.isDarwin) then "apple-darwin" else "pc-linux"} $out/bin/sbtn
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

New upstream release: https://github.com/sbt/sbt/releases/tag/v1.4.0

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Previously: #99612
