### PR TITLE
nixos/grub-install: execute prepare commands earlier

### DIFF
--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -484,6 +484,13 @@ sub addEntry {
     }
 }
 
+# extraPrepareConfig could refer to @bootPath@, which we have to substitute
+$extraPrepareConfig =~ s/\@bootPath\@/$bootPath/g;
+
+# Run extraPrepareConfig in sh
+if ($extraPrepareConfig ne "") {
+  system((get("shell"), "-c", $extraPrepareConfig));
+}
 
 # Add default entries.
 $conf .= "$extraEntries\n" if $extraEntriesBeforeNixOS;
@@ -561,13 +568,6 @@ if ($grubVersion == 2) {
     }
 }
 
-# extraPrepareConfig could refer to @bootPath@, which we have to substitute
-$extraPrepareConfig =~ s/\@bootPath\@/$bootPath/g;
-
-# Run extraPrepareConfig in sh
-if ($extraPrepareConfig ne "") {
-  system((get("shell"), "-c", $extraPrepareConfig));
-}
 
 # write the GRUB config.
 my $confFile = $grubVersion == 1 ? "$bootPath/grub/menu.lst" : "$bootPath/grub/grub.cfg";


### PR DESCRIPTION
###### Motivation for this change
Previously the extraPrepareConfig commands where exectued after the grub
entries were generated. With this new location we can run commands
before the initrd appender scripts is executed. This is especially
helpful with the recent change to the sshd host keys of openssh in the
initrd. In the old setup you did not have to provision host keys (and
you might not even have cared about them) but with the new setup you
must always provide host keys even if you do not care about them.

In my personal setup I have everything encrypted except that initrd. The
initrd is basically public knowledge as anyone (on the hosting provider)
will be able to read that key from the initrd.


cc @mweinelt  #98100
