### PR TITLE
[20.09] jwm: fix gettext requirement

### DIFF
--- a/pkgs/applications/window-managers/jwm/0001-Fix-Gettext-Requirement.patch
+++ b/pkgs/applications/window-managers/jwm/0001-Fix-Gettext-Requirement.patch
@@ -1,0 +1,14 @@
+diff --git a/configure.ac b/configure.ac
+index 347d325..dce95a0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -489,7 +489,8 @@ fi
+ ############################################################################
+ AM_ICONV
+ AM_GNU_GETTEXT([external])
+-AM_GNU_GETTEXT_VERSION([0.19])
++AM_GNU_GETTEXT_VERSION([0.19.6])
++AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.6])
+ LDFLAGS="$LDFLAGS $LIBINTL $LIBICONV"
+ 
+ ############################################################################

--- a/pkgs/applications/window-managers/jwm/default.nix
+++ b/pkgs/applications/window-managers/jwm/default.nix
@@ -1,12 +1,11 @@
-{ stdenv, fetchFromGitHub, pkgconfig, automake, autoconf, libtool,
-  gettext, which, xorg, libX11, libXext, libXinerama, libXpm, libXft,
-  libXau, libXdmcp, libXmu, libpng, libjpeg, expat, xorgproto,
-  librsvg, freetype, fontconfig }:
+{ stdenv, fetchFromGitHub, pkgconfig, automake, autoconf, libtool, gettext
+, which, xorg, libX11, libXext, libXinerama, libXpm, libXft, libXau, libXdmcp
+, libXmu, libpng, libjpeg, expat, xorgproto, librsvg, freetype, fontconfig }:
 
 stdenv.mkDerivation rec {
   pname = "jwm";
   version = "1685";
-  
+
   src = fetchFromGitHub {
     owner = "joewing";
     repo = "jwm";
@@ -14,11 +13,28 @@ stdenv.mkDerivation rec {
     sha256 = "1kyvy022sij898g2hm5spy5vq0kw6aqd7fsnawl2xyh06gwh29wg";
   };
 
+  patches = [ ./0001-Fix-Gettext-Requirement.patch ];
+
   nativeBuildInputs = [ pkgconfig automake autoconf libtool gettext which ];
 
-  buildInputs = [ libX11 libXext libXinerama libXpm libXft xorg.libXrender
-    libXau libXdmcp libXmu libpng libjpeg expat xorgproto
-    librsvg freetype fontconfig ];
+  buildInputs = [
+    libX11
+    libXext
+    libXinerama
+    libXpm
+    libXft
+    xorg.libXrender
+    libXau
+    libXdmcp
+    libXmu
+    libpng
+    libjpeg
+    expat
+    xorgproto
+    librsvg
+    freetype
+    fontconfig
+  ];
 
   enableParallelBuilding = true;
 
@@ -28,7 +44,7 @@ stdenv.mkDerivation rec {
     homepage = "http://joewing.net/projects/jwm/";
     description = "Joe's Window Manager is a light-weight X11 window manager";
     license = stdenv.lib.licenses.gpl2;
-    platforms   = stdenv.lib.platforms.unix;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.romildo ];
   };
 }


### PR DESCRIPTION
Jwm requests a specific version of gettext. Since the current version
of gettext is higher, the build fails. Gettext supports to request
a minimum version (since 0.19.6). A patch is introduces which requests
the minimum version 0.19.6.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF: #97479

Backport of https://github.com/NixOS/nixpkgs/pull/99554

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
