### PR TITLE
tests/hardened: Fix usage with 5.8

### DIFF
--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -67,7 +67,10 @@ import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... } : {
 
       # Test hidepid
       with subtest("hidepid=2 option is applied and works"):
-          machine.succeed("grep -Fq hidepid=2 /proc/mounts")
+          # Linux >= 5.8 shows "invisible"
+          machine.succeed(
+              "grep -Fq hidepid=2 /proc/mounts || grep -Fq hidepid=invisible /proc/mounts"
+          )
           # cannot use pgrep -u here, it segfaults when access to process info is denied
           machine.succeed("[ `su - sybil -c 'ps --no-headers --user root | wc -l'` = 0 ]")
           machine.succeed("[ `su - alice -c 'ps --no-headers --user root | wc -l'` != 0 ]")


### PR DESCRIPTION
Linux >= 5.8 improved /proc mount options. `hidepid=2` is now
displayed as `hidepid=invisible`

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix hardened test, address comments in 4712b946e40f99d1b9b3e1cc781b0a95f67087a0
Will allow `release-20.09` to revert ad3a5d5092eb24c525d6dd1f8035cf2ec0c5b0b2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Fixes #99600
