### PR TITLE
mblaze: 0.5.1 -> 1.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/mblaze/default.nix
+++ b/pkgs/applications/networking/mailreaders/mblaze/default.nix
@@ -1,36 +1,30 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, libiconv, ruby ? null }:
+{ stdenv, lib, fetchFromGitHub, installShellFiles, libiconv, ruby ? null }:
 
 stdenv.mkDerivation rec {
   pname = "mblaze";
-  version = "0.5.1";
+  version = "1.0";
 
+  nativeBuildInputs = [ installShellFiles ];
   buildInputs = [ ruby ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   src = fetchFromGitHub {
-    owner = "chneukirchen";
+    owner = "leahneukirchen";
     repo = "mblaze";
     rev = "v${version}";
-    sha256 = "11x548dl2jy9cmgsakqrzfdq166whhk4ja7zkiaxrapkjmkf6pbh";
+    sha256 = "0hxy3mjjv4hg856sl1r15fdmqaw4s9c26b3lidsd5x0kpqy601ai";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/leahneukirchen/mblaze/commit/53151f4f890f302291eb8d3375dec4f8ecb66ed7.patch";
-      sha256 = "1mcyrh053iiyzdhgm09g5h3a77np496whnc7jr4agpk1nkbcpfxc";
-    })
-  ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 
   postInstall = ''
-    install -Dm644 -t $out/share/zsh/site-functions contrib/_mblaze
+    installShellCompletion contrib/_mblaze
   '' + lib.optionalString (ruby != null) ''
     install -Dt $out/bin contrib/msuck contrib/mblow
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/chneukirchen/mblaze";
-    description = "Unix utilities to deal with Maildir";
+    homepage = "https://github.com/leahneukirchen/mblaze";
+    description = "Unix utilities for processing and interacting with mail messages which are stored in maildir folders";
     license = licenses.cc0;
     platforms = platforms.all;
     maintainers = [ maintainers.ajgrf ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update mblaze. It has since changed owner and was very out of date.

The patch is no longer necessary.

I also took the liberty of updating shell completion installation to use `installShellCompletion`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of *most* binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
