### PR TITLE
python3Packages.skidl: init at unstable-2020-09-15

### DIFF
--- a/pkgs/development/python-modules/skidl/default.nix
+++ b/pkgs/development/python-modules/skidl/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+, future
+, kinparse
+, enum34
+, pyspice
+, graphviz
+, pillow
+, cffi
+}:
+
+buildPythonPackage rec {
+  pname = "skidl";
+  version = "unstable-2020-09-15";
+
+  src = fetchFromGitHub {
+    owner = "xesscorp";
+    repo = "skidl";
+    rev = "551bdb92a50c0894b0802c0a89b4cb62a5b4038f";
+    sha256 = "1g65cyxpkqshgsggav2q3f76rbj5pzh7sacyhmhzvfz4zfarkcxk";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    future
+    kinparse
+    enum34
+    pyspice
+    graphviz
+    pillow
+    cffi
+  ];
+
+  # Checks require availability of the kicad symbol libraries.
+  doCheck = false;
+  pythonImportsCheck = [ "skidl" ];
+
+  meta = with lib; {
+    description = "SKiDL is a module that extends Python with the ability to design electronic circuits";
+    homepage = "https://xesscorp.github.io/skidl/docs/_site/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthuszagh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6542,6 +6542,8 @@ in {
     jre = pkgs.jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };
 
+  skidl = callPackage ../development/python-modules/skidl { };
+
   sklearn-deap = callPackage ../development/python-modules/sklearn-deap { };
 
   skorch = callPackage ../development/python-modules/skorch { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adds [skidl](https://github.com/xesscorp/skidl).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
