### PR TITLE
sentencepiece: remove static library from the output

### DIFF
--- a/pkgs/development/libraries/sentencepiece/default.nix
+++ b/pkgs/development/libraries/sentencepiece/default.nix
@@ -18,7 +18,9 @@ stdenv.mkDerivation rec {
     sha256 = "1yg55h240iigjaii0k70mjb4sh3mgg54rp2sz8bx5glnsjwys5s3";
   };
 
-  nativeBuildInputs = [ cmake ] ++ stdenv.lib.optional withGPerfTools gperftools;
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = stdenv.lib.optional withGPerfTools gperftools;
 
   cmakeFlags = [
     "-DSPM_ENABLE_SHARED=${if enableStatic then "OFF" else "ON"}"

--- a/pkgs/development/libraries/sentencepiece/default.nix
+++ b/pkgs/development/libraries/sentencepiece/default.nix
@@ -1,9 +1,9 @@
-{ lib
+{ stdenv
 , fetchFromGitHub
-, stdenv
 , cmake
 , gperftools
 
+, enableStatic ? false
 , withGPerfTools ? true
 }:
 
@@ -18,7 +18,15 @@ stdenv.mkDerivation rec {
     sha256 = "1yg55h240iigjaii0k70mjb4sh3mgg54rp2sz8bx5glnsjwys5s3";
   };
 
-  nativeBuildInputs = [ cmake ] ++ lib.optional withGPerfTools gperftools;
+  nativeBuildInputs = [ cmake ] ++ stdenv.lib.optional withGPerfTools gperftools;
+
+  cmakeFlags = [
+    "-DSPM_ENABLE_SHARED=${if enableStatic then "OFF" else "ON"}"
+  ];
+
+  postInstall = stdenv.lib.optionalString (!enableStatic) ''
+    rm $out/lib/*.a
+  '';
 
   outputs = [ "bin" "dev" "out" ];
 

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -281,6 +281,9 @@ in {
   python39 = super.python39.override { static = true; };
   python3Minimal = super.python3Minimal.override { static = true; };
 
+  sentencepiece = super.sentencepiece.override {
+    enableStatic =  true;
+  };
 
   libev = super.libev.override { static = true; };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Unfortunately, sentencepiece does provide a CMake option to disable
static builds. So just remove it from the output, unless static builds
are enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).