### PR TITLE
rtl8812au: 5.6.4.2_35491.20200318 -> 5.6.4.2_35491.20200702

### DIFF
--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "rtl8812au-${kernel.version}-${version}";
-  version = "5.6.4.2_35491.20200318";
+  version = "5.6.4.2_35491.20200702";
 
   src = fetchFromGitHub {
     owner = "gordboy";
     repo = "rtl8812au-5.6.4.2";
-    rev = "49e98ff9bfdbe2ddce843808713de383132002e0";
-    sha256 = "0f4isqasm9rli5v6a7xpphyh509wdxs1zcfvgdsnyhnv8amhqxgs";
+    rev = "3110ad65d0f03532bd97b1017cae67ca86dd34f6";
+    sha256 = "0p0cv67dfr41npxn0c1frr0k9wiv0pdbvlzlmclgixn39xc6n5qz";
   };
 
   nativeBuildInputs = [ bc nukeReferences ];
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Driver for Realtek 802.11ac, rtl8812au, provides the 8812au mod";
-    homepage = "https://github.com/zebulon2/rtl8812au-driver-5.2.20";
+    homepage = "https://github.com/gordboy/rtl8812au-5.6.4.2";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ danielfullmer ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


I do not have this hardware but the build works now :)

Ping @NixOS/nixos-release-managers 