### PR TITLE
coqPackages.paco: 4.0.0 → 4.0.2

### DIFF
--- a/pkgs/development/coq-modules/paco/default.nix
+++ b/pkgs/development/coq-modules/paco/default.nix
@@ -9,8 +9,8 @@ let
     };
     post_8_6 = rec {
       rev = "v${version}";
-      version = "4.0.0";
-      sha256 = "1ncrdyijkgf0s2q4rg1s9r2nrcb17gq3jz63iqdlyjq3ylv8gyx0";
+      version = "4.0.2";
+      sha256 = "1q96bsxclqx84xn5vkid501jkwlc1p6fhb8szrlrp82zglj58b0b";
     };
   };
   params = {
@@ -36,8 +36,7 @@ stdenv.mkDerivation rec {
     repo = "paco";
   };
 
-  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 unzip ];
-  propagatedBuildInputs = [ coq ];
+  buildInputs = [ coq ];
 
   preBuild = "cd src";
 


### PR DESCRIPTION
###### Motivation for this change

Improvements: https://github.com/snu-sf/paco/releases

Also removes the spurious dependencies.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
