### PR TITLE
rtl8821cu: 2020-05-16 -> 2020-08-21

### DIFF
--- a/pkgs/os-specific/linux/rtl8821cu/default.nix
+++ b/pkgs/os-specific/linux/rtl8821cu/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, kernel, bc }:
 stdenv.mkDerivation rec {
   name = "rtl8821cu-${kernel.version}-${version}";
-  version = "unstable-2020-05-16";
+  version = "unstable-2020-08-21";
 
   src = fetchFromGitHub {
     owner = "brektrou";
     repo = "rtl8821cu";
-    rev = "5c510c9f14352fed4906a10921040b9e46b58346";
-    sha256 = "1n74h1m3l2dj35caswaghzcjwcv5qlv3gj6j1rqdddbyg5khl4ag";
+    rev = "45a8b4393e3281b969822c81bd93bdb731d58472";
+    sha256 = "1995zs1hvlxjhbh2w7zkwr824z19cgc91s00g7yhm5d7zjav14rd";
   };
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


I do not have this hardware but the build works now :)

Ping @NixOS/nixos-release-managers 