### PR TITLE
c3d: unstable-2019-10-22 -> unstable-2020-10-05

### DIFF
--- a/pkgs/applications/graphics/c3d/default.nix
+++ b/pkgs/applications/graphics/c3d/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchgit, cmake, itk4, Cocoa }:
+{ stdenv, fetchFromGitHub, cmake, itk4, Cocoa }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname   = "c3d";
-  version = "unstable-2019-10-22";
+  version = "unstable-2020-10-05";
 
-  src = fetchgit {
-    url    = "https://github.com/pyushkevich/c3d";
-    rev    = "c04e2b84568654665c64d8843378c8bbd58ba9b0";
-    sha256 = "0lzldxvshl9q362mg76byc7s5zc9qx7mxf2wgyij5vysx8mihx3q";
+  src = fetchFromGitHub {
+    owner = "pyushkevich";
+    repo = pname;
+    rev = "0a87e3972ea403babbe2d05ec6d50855e7c06465";
+    sha256 = "0wsmkifqrcfy13fnwvinmnq1m0lkqmpyg7bgbwnb37mbrlbq06wf";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -15,11 +16,11 @@ stdenv.mkDerivation {
     ++ stdenv.lib.optional stdenv.isDarwin Cocoa;
 
   meta = with stdenv.lib; {
-    homepage = "http://www.itksnap.org/c3d";
+    homepage = "https://github.com/pyushkevich/c3d";
     description = "Medical imaging processing tool";
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.unix;
-    license = licenses.gpl2;
+    license = licenses.gpl3;
     broken = stdenv.isAarch64;
     # /build/git-3453f61/itkextras/OneDimensionalInPlaceAccumulateFilter.txx:311:10: fatal error: xmmintrin.h: No such file or directory
   };


### PR DESCRIPTION

###### Motivation for this change

Routine update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
