### PR TITLE
rtl88x2bu: 2020-05-19 -> 2020-08-20

### DIFF
--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -1,15 +1,23 @@
-{ stdenv, fetchFromGitHub, kernel, bc }:
+{ stdenv, fetchFromGitHub, fetchpatch, kernel, bc }:
 
 stdenv.mkDerivation rec {
   name = "rtl88x2bu-${kernel.version}-${version}";
-  version = "unstable-2020-05-19";
+  version = "unstable-2020-08-20";
 
   src = fetchFromGitHub {
     owner = "cilynx";
     repo = "rtl88x2BU";
-    rev = "0f159d7cd937a12b818121cb1f1c4910bd1adc72";
-    sha256 = "0flqnvzfdb4wsiiqv9vf5gfwd5fgpjvhs9zhqknnv1cmp8msgw6y";
+    rev = "a1c53f43fb9995fbe3ad26567079d6384626d350";
+    sha256 = "1cby66jg511zxs1i535mflafhryla9764mnrzacxppimxpancv3s";
   };
+
+  patches = [
+    # https://github.com/cilynx/rtl88x2bu/pull/58
+    (fetchpatch {
+      url = "https://github.com/cilynx/rtl88x2bu/pull/58.patch";
+      sha256 = "0md9cv61nx85pk3v60y9wviyb9fgj54q9m26wiv3dc7smr70h8l6";
+    })
+  ];
 
   hardeningDisable = [ "pic" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


I do not have this hardware but the build works now :)

Ping @NixOS/nixos-release-managers 