### PR TITLE
pineapple: init at 1174

### DIFF
--- a/pkgs/misc/emulators/pineapple/default.nix
+++ b/pkgs/misc/emulators/pineapple/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, appimageTools, fetchurl }:
+let
+  pname = "pineapple";
+  version = "1180";
+  name = "Yuzu-EA-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/pineappleEA/pineappleEA.github.io/releases/download/EA-${version}/${name}.AppImage";
+    sha256 = "0i33mfk854ds566kyy9k9lmjli8f06g1si8rq0qlwipbhmprvm1d";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit name src; };
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/yuzu
+    install -m 444 -D ${appimageContents}/yuzu.desktop $out/share/applications/yuzu.desktop
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Early Access builds for yuzu";
+    homepage = "https://pineappleEA.github.io";
+    license = with licenses; [
+      gpl2Only
+      # Icons
+      cc-by-nd-30 cc0
+    ];
+    maintainers = [ maintainers.ivar ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6488,6 +6488,8 @@ in
 
   pim6sd = callPackage ../servers/pim6sd { };
 
+  pineapple = callPackage ../misc/emulators/pineapple { };
+
   pinentry = libsForQt5.callPackage ../tools/security/pinentry {
     libcap = if stdenv.isDarwin then null else libcap;
   };


### PR DESCRIPTION
###### Motivation for this change
Adds [pineappleEA](https://pineappleea.github.io/).

Building from source proved to be too much of a hastle, so for now I've just used the provided appimage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
