### PR TITLE
monero{,-gui}: 0.16.0.3 -> 0.17.0.1

### DIFF
--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -57,8 +57,9 @@ stdenv.mkDerivation rec {
     # set monero-gui version
     substituteInPlace src/version.js.in \
        --replace '@VERSION_TAG_GUI@' '${version}'
-    substituteInPlace monero/src/version.cpp.in \
-      --replace '@VERSION_IS_RELEASE@' 'true'
+
+    # remove this line on the next release
+    rm cmake/Version.cmake
 
     # use monerod from the monero package
     substituteInPlace src/daemon/DaemonManager.cpp \

--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -18,6 +18,13 @@ with stdenv.lib;
 
 assert trezorSupport -> all (x: x!=null) [ libusb1 protobuf python3 ];
 
+let
+  arch = if stdenv.isx86_64  then "x86-64"
+    else if stdenv.isi686    then "i686"
+    else if stdenv.isAarch64 then "armv8-a"
+    else throw "unsupported architecture";
+in
+
 stdenv.mkDerivation rec {
   pname = "monero-gui";
   version = "0.17.0.1";
@@ -71,7 +78,10 @@ stdenv.mkDerivation rec {
                 'add_subdirectory(monero EXCLUDE_FROM_ALL)'
   '';
 
-  cmakeFlags = [ "-DCMAKE_INSTALL_PREFIX=$out/bin" ];
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=$out/bin"
+    "-DARCH=${arch}"
+  ];
 
   desktopItem = makeDesktopItem {
     name = "monero-wallet-gui";

--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -1,14 +1,22 @@
 { stdenv, wrapQtAppsHook, makeDesktopItem
-, fetchFromGitHub, qmake, qttools, pkgconfig
+, fetchFromGitHub
+, cmake, qttools, pkgconfig
 , qtbase, qtdeclarative, qtgraphicaleffects
 , qtmultimedia, qtxmlpatterns
 , qtquickcontrols, qtquickcontrols2
-, monero, unbound, readline, boost, libunwind
-, libsodium, pcsclite, zeromq, libgcrypt, libgpgerror
-, hidapi, libusb-compat-0_1, protobuf, randomx
+, monero, miniupnpc, unbound, readline
+, boost, libunwind, libsodium, pcsclite
+, randomx, zeromq, libgcrypt, libgpgerror
+, hidapi, rapidjson
+, trezorSupport ? true
+,   libusb1  ? null
+,   protobuf ? null
+,   python3  ? null
 }:
 
 with stdenv.lib;
+
+assert trezorSupport -> all (x: x!=null) [ libusb1 protobuf python3 ];
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
@@ -21,42 +29,48 @@ stdenv.mkDerivation rec {
     sha256 = "1i9a3ampppyzsl4sllbqlr3w43sjpb3fdfxhb1j4n49p8g0jzmf3";
   };
 
-  nativeBuildInputs = [ qmake pkgconfig wrapQtAppsHook ];
+  nativeBuildInputs = [
+    cmake pkgconfig wrapQtAppsHook
+    (getDev qttools)
+  ];
 
   buildInputs = [
     qtbase qtdeclarative qtgraphicaleffects
     qtmultimedia qtquickcontrols qtquickcontrols2
     qtxmlpatterns
-    monero unbound readline libgcrypt libgpgerror
-    boost libunwind libsodium pcsclite zeromq
-    hidapi libusb-compat-0_1 protobuf randomx
-  ];
+    monero miniupnpc unbound readline
+    randomx libgcrypt libgpgerror
+    boost libunwind libsodium pcsclite
+    zeromq hidapi rapidjson
+  ] ++ optionals trezorSupport [ libusb1 protobuf python3 ];
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=format-security" ];
+  postUnpack = ''
+    # copy monero sources here
+    # (needs to be writable)
+    cp -r ${monero.source}/* source/monero
+    chmod -R +w source/monero
+  '';
 
   patches = [ ./move-log-file.patch ];
 
   postPatch = ''
-    echo '
-      var GUI_VERSION = "${version}";
-      var GUI_MONERO_VERSION = "${getVersion monero}";
-    ' > version.js
-    substituteInPlace monero-wallet-gui.pro \
-      --replace '$$[QT_INSTALL_BINS]/lrelease' '${getDev qttools}/bin/lrelease'
+    # set monero-gui version
+    substituteInPlace src/version.js.in \
+       --replace '@VERSION_TAG_GUI@' '${version}'
+    substituteInPlace monero/src/version.cpp.in \
+      --replace '@VERSION_IS_RELEASE@' 'true'
+
+    # use monerod from the monero package
     substituteInPlace src/daemon/DaemonManager.cpp \
       --replace 'QApplication::applicationDirPath() + "' '"${monero}/bin'
+
+    # only build external deps, *not* the full monero
+    substituteInPlace CMakeLists.txt \
+      --replace 'add_subdirectory(monero)' \
+                'add_subdirectory(monero EXCLUDE_FROM_ALL)'
   '';
 
-  makeFlags = [ "INSTALL_ROOT=$(out)" ];
-
-  preBuild = ''
-    sed -i s#/opt/monero-wallet-gui##g Makefile
-    make -C src/zxcvbn-c
-
-    # use nixpkgs monero sources
-    rmdir monero
-    ln -s "${monero.src}" monero
-  '';
+  cmakeFlags = [ "-DCMAKE_INSTALL_PREFIX=$out/bin" ];
 
   desktopItem = makeDesktopItem {
     name = "monero-wallet-gui";
@@ -69,15 +83,15 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     # install desktop entry
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications
+    install -Dm644 -t $out/share/applications \
+      ${desktopItem}/share/applications/*
 
     # install icons
     for n in 16 24 32 48 64 96 128 256; do
       size=$n"x"$n
-      mkdir -p $out/share/icons/hicolor/$size/apps
-      cp $src/images/appicons/$size.png \
-         $out/share/icons/hicolor/$size/apps/monero.png
+      install -Dm644 \
+        -t $out/share/icons/hicolor/$size/apps/monero.png \
+        $src/images/appicons/$size.png
     done;
   '';
 

--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -12,13 +12,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.16.0.3";
+  version = "0.17.0.1";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "0iwjp8x5swy8i8pzrlm5v55awhm54cf48pm1vz98lcq361lhfzk6";
+    sha256 = "1i9a3ampppyzsl4sllbqlr3w43sjpb3fdfxhb1j4n49p8g0jzmf3";
   };
 
   nativeBuildInputs = [ qmake pkgconfig wrapQtAppsHook ];

--- a/pkgs/applications/blockchains/monero/default.nix
+++ b/pkgs/applications/blockchains/monero/default.nix
@@ -5,9 +5,9 @@
 , randomx, rapidjson
 , CoreData, IOKit, PCSC
 , trezorSupport ? true
-  , libusb1  ? null
-  , protobuf ? null
-  , python3  ? null
+,   libusb1  ? null
+,   protobuf ? null
+,   python3  ? null
 }:
 
 with stdenv.lib;
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # remove vendored libraries
     rm -r external/{miniupnp,randomx,rapidjson,unbound}
+    # export patched source for monero-gui
+    cp -r . $source
   '';
 
   nativeBuildInputs = [ cmake pkgconfig ];
@@ -51,6 +53,8 @@ stdenv.mkDerivation rec {
     "-DReadline_ROOT_DIR=${readline.dev}"
     "-DRandomX_ROOT_DIR=${randomx}"
   ] ++ optional stdenv.isDarwin "-DBoost_USE_MULTITHREADED=OFF";
+
+  outputs = [ "out" "source" ];
 
   meta = with stdenv.lib; {
     description = "Private, secure, untraceable currency";

--- a/pkgs/applications/blockchains/monero/default.nix
+++ b/pkgs/applications/blockchains/monero/default.nix
@@ -2,11 +2,18 @@
 , cmake, pkgconfig
 , boost, miniupnpc, openssl, unbound
 , zeromq, pcsclite, readline, libsodium, hidapi
-, protobuf, randomx, rapidjson, libusb-compat-0_1
+, randomx, rapidjson
 , CoreData, IOKit, PCSC
+, trezorSupport ? true
+  , libusb1  ? null
+  , protobuf ? null
+  , python3  ? null
 }:
 
+with stdenv.lib;
+
 assert stdenv.isDarwin -> IOKit != null;
+assert trezorSupport -> all (x: x!=null) [ libusb1 protobuf python3 ];
 
 stdenv.mkDerivation rec {
   pname = "monero";
@@ -20,21 +27,30 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [ ./use-system-libraries.patch ];
+
+  postPatch = ''
+    # remove vendored libraries
+    rm -r external/{miniupnp,randomx,rapidjson,unbound}
+  '';
+
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
     boost miniupnpc openssl unbound
     zeromq pcsclite readline
     libsodium hidapi randomx rapidjson
-    protobuf libusb-compat-0_1
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit CoreData PCSC ];
+    protobuf
+  ] ++ optionals stdenv.isDarwin [ IOKit CoreData PCSC ]
+    ++ optionals trezorSupport [ libusb1 protobuf python3 ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
     "-DUSE_DEVICE_TREZOR=ON"
     "-DBUILD_GUI_DEPS=ON"
     "-DReadline_ROOT_DIR=${readline.dev}"
-  ] ++ stdenv.lib.optional stdenv.isDarwin "-DBoost_USE_MULTITHREADED=OFF";
+    "-DRandomX_ROOT_DIR=${randomx}"
+  ] ++ optional stdenv.isDarwin "-DBoost_USE_MULTITHREADED=OFF";
 
   meta = with stdenv.lib; {
     description = "Private, secure, untraceable currency";

--- a/pkgs/applications/blockchains/monero/default.nix
+++ b/pkgs/applications/blockchains/monero/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, fetchFromGitHub, fetchpatch
 , cmake, pkgconfig
 , boost, miniupnpc, openssl, unbound
 , zeromq, pcsclite, readline, libsodium, hidapi
@@ -27,7 +27,16 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  patches = [ ./use-system-libraries.patch ];
+  patches = [
+    ./use-system-libraries.patch
+
+    # This fixes a bug in the monero-gui build system,
+    # remove it once the PR has been merged
+    (fetchpatch {
+      url = "https://github.com/monero-project/monero/pull/6867.patch";
+      sha256 = "0nxa6861df1fadrm9bmhqf2g6mljgr4jndsbxqp7g501hv9z51j3";
+    })
+  ];
 
   postPatch = ''
     # remove vendored libraries

--- a/pkgs/applications/blockchains/monero/default.nix
+++ b/pkgs/applications/blockchains/monero/default.nix
@@ -10,13 +10,13 @@ assert stdenv.isDarwin -> IOKit != null;
 
 stdenv.mkDerivation rec {
   pname = "monero";
-  version = "0.16.0.3";
+  version = "0.17.0.1";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    sha256 = "1r9x3712vhb24dxxirfiwj5f9x0h4m7x0ngiiavf5983dfdlgz33";
+    sha256 = "1v0phvg5ralli4dr09a60nq032xqlci5d6v4zfq8304vgrn1ffgp";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/blockchains/monero/use-system-libraries.patch
+++ b/pkgs/applications/blockchains/monero/use-system-libraries.patch
@@ -1,0 +1,69 @@
+diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
+index a8916a7d0..39ec7747b 100644
+--- a/external/CMakeLists.txt
++++ b/external/CMakeLists.txt
+@@ -37,34 +37,16 @@
+ 
+ find_package(Miniupnpc REQUIRED)
+ 
+-message(STATUS "Using in-tree miniupnpc")
+-add_subdirectory(miniupnp/miniupnpc)
+-set_property(TARGET libminiupnpc-static PROPERTY FOLDER "external")
+-if(MSVC)
+-  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -wd4244 -wd4267")
+-elseif(NOT MSVC)
+-  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-undef -Wno-unused-result -Wno-unused-value")
+-endif()
+-if(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+-	set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -D_NETBSD_SOURCE")
+-endif()
+-
+-set(UPNP_LIBRARIES "libminiupnpc-static" PARENT_SCOPE)
++set(UPNP_STATIC false PARENT_SCOPE)
++set(UPNP_INCLUDE ${MINIUPNP_INCLUDE_DIR} PARENT_SCOPE)
++set(UPNP_LIBRARIES ${MINIUPNP_LIBRARY} PARENT_SCOPE)
+ 
+ find_package(Unbound)
+ 
+ if(NOT UNBOUND_INCLUDE_DIR OR STATIC)
+-  # NOTE: If STATIC is true, CMAKE_FIND_LIBRARY_SUFFIXES has been reordered.
+-  # unbound has config tests which used OpenSSL libraries, so -ldl may need to
+-  # be set in this case.
+-  # The unbound CMakeLists.txt can set it, since it's also needed for the
+-  # static OpenSSL libraries set up there after with target_link_libraries.
+-  add_subdirectory(unbound)
+-
+-  set(UNBOUND_STATIC true PARENT_SCOPE)
+-  set(UNBOUND_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/unbound/libunbound" PARENT_SCOPE)
+-  set(UNBOUND_LIBRARY "unbound" PARENT_SCOPE)
+-  set(UNBOUND_LIBRARY_DIRS "${LIBEVENT2_LIBDIR}" PARENT_SCOPE)
++  set(UNBOUND_STATIC false PARENT_SCOPE)
++  set(UPNP_INCLUDE ${MINIUPNP_INCLUDE_DIR} PARENT_SCOPE)
++  set(UPNP_LIBRARIES ${MINIUPNP_LIBRARY} PARENT_SCOPE)
+ else()
+   message(STATUS "Found libunbound include (unbound.h) in ${UNBOUND_INCLUDE_DIR}")
+   if(UNBOUND_LIBRARIES)
+@@ -81,4 +63,5 @@ endif()
+ add_subdirectory(db_drivers)
+ add_subdirectory(easylogging++)
+ add_subdirectory(qrcodegen)
+-add_subdirectory(randomx EXCLUDE_FROM_ALL)
++
++find_library(RANDOMX_LIBRARIES NAMES RandomX)
+diff --git a/src/p2p/net_node.inl b/src/p2p/net_node.inl
+index 175741146..088b582f7 100644
+--- a/src/p2p/net_node.inl
++++ b/src/p2p/net_node.inl
+@@ -60,9 +60,9 @@
+ #include "cryptonote_core/cryptonote_core.h"
+ #include "net/parse.h"
+ 
+-#include <miniupnp/miniupnpc/miniupnpc.h>
+-#include <miniupnp/miniupnpc/upnpcommands.h>
+-#include <miniupnp/miniupnpc/upnperrors.h>
++#include <miniupnpc/miniupnpc.h>
++#include <miniupnpc/upnpcommands.h>
++#include <miniupnpc/upnperrors.h>
+ 
+ #undef MONERO_DEFAULT_LOG_CATEGORY
+ #define MONERO_DEFAULT_LOG_CATEGORY "net.p2p"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Version update to support the upcoming hard-fork (October 17th)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
