### PR TITLE
sublime-music: 0.11.7 -> 0.11.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9087,6 +9087,12 @@
     githubId = 65870;
     name = "Сухарик";
   };
+  sumnerevans = {
+    email = "me@sumnerevans.com";
+    github = "sumnerevans";
+    githubId = 16734772;
+    name = "Sumner Evans";
+  };
   superbo = {
     email = "supernbo@gmail.com";
     github = "SuperBo";

--- a/pkgs/applications/audio/sublime-music/default.nix
+++ b/pkgs/applications/audio/sublime-music/default.nix
@@ -71,6 +71,6 @@ python3Packages.buildPythonApplication rec {
     description = "GTK3 Subsonic/Airsonic client";
     homepage = "https://sublimemusic.app/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ albakham ];
+    maintainers = with maintainers; [ albakham sumnerevans ];
   };
 }

--- a/pkgs/applications/audio/sublime-music/default.nix
+++ b/pkgs/applications/audio/sublime-music/default.nix
@@ -57,6 +57,16 @@ python3Packages.buildPythonApplication rec {
   doCheck = false;
   pythonImportsCheck = [ "sublime_music" ];
 
+  postInstall = ''
+    install -Dm444 sublime-music.desktop      -t $out/share/applications
+    install -Dm444 sublime-music.metainfo.xml -t $out/share/metainfo
+
+    for size in 16 22 32 48 64 72 96 128 192 512 1024; do
+        install -Dm444 logo/rendered/"$size".png \
+          $out/share/icons/hicolor/"$size"x"$size"/apps/sublime-music.png
+    done
+  '';
+
   meta = with lib; {
     description = "GTK3 Subsonic/Airsonic client";
     homepage = "https://sublimemusic.app/";

--- a/pkgs/applications/audio/sublime-music/default.nix
+++ b/pkgs/applications/audio/sublime-music/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, gobject-introspection, gtk3, pango, wrapGAppsHook
+{ fetchFromGitLab, lib, python3Packages, gobject-introspection, gtk3, pango, wrapGAppsHook
 , chromecastSupport ? false
 , serverSupport ? false
 , keyringSupport ? true
@@ -8,11 +8,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "sublime-music";
-  version = "0.11.7";
+  version = "0.11.10";
 
-  src = python3Packages.fetchPypi {
-    inherit pname version;
-    sha256 = "1x6b02gw46gp6qcgv67j7k3gr1dpfczbyma6dxanag8pnpqrj8qi";
+  src = fetchFromGitLab {
+    owner = "sublime-music";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1g78gmiywg07kaywfc9q0yab2bzxs936vb3157ni1z0flbmcwrry";
   };
 
   nativeBuildInputs = [
@@ -30,6 +32,7 @@ python3Packages.buildPythonApplication rec {
   ;
 
   propagatedBuildInputs = with python3Packages; [
+    bleach
     dataclasses-json
     deepdiff
     fuzzywuzzy
@@ -52,7 +55,7 @@ python3Packages.buildPythonApplication rec {
 
   # no tests
   doCheck = false;
-  pythonImportsCheck = [ "sublime" ];
+  pythonImportsCheck = [ "sublime_music" ];
 
   meta = with lib; {
     description = "GTK3 Subsonic/Airsonic client";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This PR

* Updates Sublime Music to v0.11.10
* Adds functionality to install the `.desktop` and `.metainfo.xml` files as well as the icon for Sublime Music. I had to change the source to use the `.tar.gz` from the Releases page instead of the source from PyPi because the tar file has those additional resources.
* Adds me (@sumnerevans) as a maintainer for the `sublime-music` package. I'm the creator of Sublime Music, and I recently switched to NixOS, so I figured it would be good to add myself to the maintainers list.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
