### PR TITLE
codeowners: add cprussin as a codeowner for nodejs & deno

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -208,3 +208,8 @@
 /pkgs/development/compilers/go @kalbasit @Mic92 @zowoq
 /pkgs/development/go-modules   @kalbasit @Mic92 @zowoq
 /pkgs/development/go-packages  @kalbasit @Mic92 @zowoq
+
+# Nodejs & Deno
+/pkgs/development/node-packages @cprussin
+/pkgs/development/web/nodejs @cprussin
+/pkgs/development/web/deno @cprussin


### PR DESCRIPTION
###### Motivation for this change

Adding myself as a codeowner so I can start helping maintain nodejs/deno/node modules.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
