### PR TITLE
caffeine-ng: add missing dependencies, fix bin paths

### DIFF
--- a/pkgs/tools/X11/caffeine-ng/default.nix
+++ b/pkgs/tools/X11/caffeine-ng/default.nix
@@ -1,5 +1,5 @@
 { gdk-pixbuf, glib, gobject-introspection, gtk3, lib, libnotify,
-  python3Packages, wrapGAppsHook
+  procps, xset, xautolock, xscreensaver, python3Packages, wrapGAppsHook
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -12,16 +12,24 @@ python3Packages.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [ wrapGAppsHook glib ];
-  buildInputs = [ 
-    gdk-pixbuf gobject-introspection libnotify gtk3 
+  buildInputs = [
+    gdk-pixbuf gobject-introspection libnotify gtk3
     python3Packages.setuptools_scm
   ];
   pythonPath = with python3Packages; [
     dbus-python docopt ewmh pygobject3 pyxdg
-    setproctitle 
+    setproctitle
   ];
 
   doCheck = false; # There are no tests.
+
+  postPatch = ''
+    substituteInPlace caffeine/inhibitors.py \
+      --replace 'os.system("xset' 'os.system("${xset}/bin/xset' \
+      --replace 'os.system("xautolock' 'os.system("${xautolock}/bin/xautolock' \
+      --replace 'os.system("pgrep' 'os.system("${procps}/bin/pgrep' \
+      --replace 'os.system("xscreensaver-command' 'os.system("${xscreensaver}/bin/xscreensaver-command'
+  '';
 
   postInstall = ''
     mkdir -p $out/share


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
caffeine-ng makes `os.system` calls expecting some binaries in the path, see [inhibitors.py](https://github.com/caffeine-ng/caffeine-ng/blob/master/caffeine/inhibitors.py) file. This PR adds missing dependencies and patches mentioned file to use binaries from the nix store.

Closure size change: 376.3M -> 509.3M

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
