### PR TITLE
python: gatt: new package

### DIFF
--- a/pkgs/development/python-modules/gatt-python/default.nix
+++ b/pkgs/development/python-modules/gatt-python/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, pythonOlder
+, dbus-python
+, pygobject3
+}:
+
+buildPythonPackage rec {
+  pname = "gatt-python";
+  version = "0.2.7";
+  disabled = pythonOlder "3.4";
+
+  # there's no 0.2.7 tag on GitHub, which is what fetchPypi would do, so fetch manually
+  src = fetchTarball {
+    name = "gatt-0.2.7.tar.gz";
+    url = "https://files.pythonhosted.org/packages/96/d0/d66154053d5b47996731d80ee66f65bdf7b790258addc0b6a5f50bcc3579/gatt-0.2.7.tar.gz";
+    sha256 = "06y9k5gc2r1nh38z21n7w5d1xrwd230avj03l1bm2grfcxxxf1ig";
+  };
+
+  propagatedBuildInputs = [
+    dbus-python
+    pygobject3
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Bluetooth GATT SDK for Python";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2279,6 +2279,8 @@ in {
 
   gateone = callPackage ../development/python-modules/gateone { };
 
+  gatt-python = callPackage ../development/python-modules/gatt-python { };
+
   gcovr = callPackage ../development/python-modules/gcovr { };
 
   gdal = toPythonModule (pkgs.gdal.override { pythonPackages = self; });


### PR DESCRIPTION
For some reason the upstream git repo is missing the tag for the latest
release that is available on pypi. However, the soucre tarball *is*
available for downlaod from pypi, so let's use that one.

###### Motivation for this change

I wanted to use [a simple Python app for Bluetooth control of my IKEA Idasen sit-stand desk](https://github.com/rhyst/idasen-controller) on my new NixOS installation. That application uses some Python modules that require C extensions (GLib introspection, dbus,...), and it was painful to install that on NixOS via `pip`. The only package that was not in NixOS already is this one, so here we go.

###### Things done

After configuring the app, I can now run it like this: `nix-shell -p 'python3.withPackages (ps: with ps; [ gatt-python pyaml ])' --run 'python main.py --sit'`, which is awesome.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
  - ~~sorry, just starting with nix~~ on by default
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - n/a I believe
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - there are none
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - It isn't a binary, instead it's a Python script, but `nix-shell -p 'python3.withPackages (ps: with ps; [ gatt-python ])' --run 'gattctl --discover'` works
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - the dir contents looks sane
- [x] Ensured that relevant documentation is up to date
  - there's none, it's a python library package
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
 - I'm not adding myself as a maintainer because I don't know how that works.