### PR TITLE
[20.09] python.pkgs.scikit-optimize: 0.6 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/scikit-optimize/default.nix
+++ b/pkgs/development/python-modules/scikit-optimize/default.nix
@@ -1,25 +1,29 @@
 { lib
+, isPy27
 , buildPythonPackage
 , fetchFromGitHub
+, matplotlib
 , numpy
 , scipy
 , scikitlearn
 , pyaml
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "scikit-optimize";
-  version = "0.6";
+  version = "0.8.1";
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "scikit-optimize";
     repo = "scikit-optimize";
     rev = "v${version}";
-    sha256 = "1srbb20k8ddhpcfxwdflapfh6xfyrd3dnclcg3bsfq1byrcmv0d4";
+    sha256 = "1bz8gxccx8n99abw49j8h5zf3i568g5hcf8nz1yinma8jqhxjkjh";
   };
 
   propagatedBuildInputs = [
+    matplotlib
     numpy
     scipy
     scikitlearn
@@ -27,13 +31,8 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
   ];
-
-  # remove --ignore at next release > 0.6
-  checkPhase = ''
-    pytest skopt --ignore skopt/tests/test_searchcv.py
-  '';
 
   meta = with lib; {
     description = "Sequential model-based optimization toolbox";


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of  #97990

Fails on macos, but that should be fixed in `master` first.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
