### PR TITLE
python2Packages.pyspice: disable python<3.6

### DIFF
--- a/pkgs/development/python-modules/pyspice/default.nix
+++ b/pkgs/development/python-modules/pyspice/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , buildPythonPackage
+, pythonOlder
 , fetchPypi
 , libngspice
 , numpy
@@ -15,6 +16,7 @@
 buildPythonPackage rec {
   pname = "PySpice";
   version = "1.4.3";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change
follow up to: #99634

```
builder for '/nix/store/mr29wsg5hzvn22gicqwac3ci1xyd9a0g-python2.7-PySpice-1.4.3.drv' failed with exit code 1; last 10 log lines:
  unpacking sources
  unpacking source archive /nix/store/d2cp7aq5mpks8c1hyfw45hviw7r25f35-PySpice-1.4.3.tar.gz
  source root is PySpice-1.4.3
  setting SOURCE_DATE_EPOCH to timestamp 1593798877 of file PySpice-1.4.3/setup.cfg
  patching sources
  configuring
  no configure script, doing nothing
  building
  Executing setuptoolsBuildPhase
  ERROR: PySpice requires Python 3.6
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
$ nix-env -f /home/jon/.cache/nixpkgs-review/pr-99675/nixpkgs -qaP --xml --out-path --show-trace --meta
2 packages removed:
python2.7-PySpice (†1.4.3) python2.7-skidl-unstable (†2020-09-15)
```