### PR TITLE
multilockscreen: init at 1.0.0

### DIFF
--- a/pkgs/misc/screensavers/multilockscreen/default.nix
+++ b/pkgs/misc/screensavers/multilockscreen/default.nix
@@ -1,0 +1,47 @@
+{
+  stdenv, makeWrapper, fetchFromGitHub, writeShellScriptBin,
+  imagemagick, i3lock-color, xdpyinfo, xrandr, bc, feh, procps, xrdb, xset,
+  gnused, gnugrep, coreutils
+}:
+let
+  i3lock = writeShellScriptBin "i3lock" ''
+    ${i3lock-color}/bin/i3lock-color "$@"
+  '';
+  binPath = stdenv.lib.makeBinPath [
+    imagemagick i3lock
+    xdpyinfo xrandr xset
+    bc feh procps xrdb
+    gnused gnugrep coreutils
+  ];
+in
+stdenv.mkDerivation rec {
+  pname = "multilockscreen";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "jeffmhubbard";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0gmnrq7ibbhiwsn7mfi2r71fwm6nvhiwf4wsyz44cscm474z83p0";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp multilockscreen $out/bin/multilockscreen
+    wrapProgram "$out/bin/multilockscreen" --prefix PATH : "${binPath}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Wrapper script for i3lock-color";
+    longDescription = ''
+      multilockscreen is a wrapper script for i3lock-color.
+      It allows you to cache background images for i3lock-color with a variety of different effects and adds a stylish indicator.
+    '';
+    homepage = "https://github.com/jeffmhubbard/multilockscreen";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kylesferrazza ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21367,6 +21367,8 @@ in
     inherit (xorg) xrdb;
   };
 
+  multilockscreen = callPackage ../misc/screensavers/multilockscreen { };
+
   i3minator = callPackage ../tools/misc/i3minator { };
 
   i3pystatus = callPackage ../applications/window-managers/i3/pystatus.nix { };


### PR DESCRIPTION
closes #99637

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The aforementioned issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
