### PR TITLE
[20.09] python3Packages.toggl-cli: 2.1.0 -> 2.2.1

### DIFF
--- a/pkgs/development/python-modules/blessed/default.nix
+++ b/pkgs/development/python-modules/blessed/default.nix
@@ -2,35 +2,21 @@
 , wcwidth, pytest, mock, glibcLocales
 }:
 
-let
-
-  fixTestSuiteFailure_1 = fetchpatch {
-    url = "https://github.com/jquast/blessed/pull/108/commits/76a54d39b0f58bfc71af04ee143459eefb0e1e7b.patch";
-    sha256 = "1higmv4c03ly7ywac1d7s71f3hrl531vj16nsfl9xh6zh9c47qcg";
-  };
-
-  fixTestSuiteFailure_2 = fetchpatch {
-    url = "https://github.com/jquast/blessed/pull/108/commits/aa94e01aed745715e667601fb674844b257cfcc9.patch";
-    sha256 = "1frygr6sc1vakdfx1hf6jj0dbwibiqz8hw9maf1b605cbslc9nay";
-  };
-
-in
-
 buildPythonPackage rec {
   pname = "blessed";
-  version = "1.15.0";
+  version = "1.17.10";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "777b0b6b5ce51f3832e498c22bc6a093b6b5f99148c7cbf866d26e2dec51ef21";
+    sha256 = "09kcz6w87x34a3h4r142z3zgw0av19cxn9jrbz52wkpm1534dfaq";
   };
-
-  patches = [ fixTestSuiteFailure_1 fixTestSuiteFailure_2 ];
 
   checkInputs = [ pytest mock glibcLocales ];
 
+  # Default tox.ini parameters not needed
   checkPhase = ''
-    LANG=en_US.utf-8 py.test blessed/tests
+    rm tox.ini
+    pytest
   '';
 
   propagatedBuildInputs = [ wcwidth six ];

--- a/pkgs/development/python-modules/inquirer/default.nix
+++ b/pkgs/development/python-modules/inquirer/default.nix
@@ -1,20 +1,23 @@
-{ stdenv, buildPythonPackage, fetchPypi, python-editor, readchar, blessings, pytest, pytestcov, pexpect, pytest-mock }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, python-editor, readchar, blessed, pytest, pytestcov, pexpect, pytest-mock }:
 
 buildPythonPackage rec {
   pname = "inquirer";
   version = "2.7.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "e819188de0ca7985a99c282176c6f50fb08b0d33867fd1965d3f3e97d6c8f83f";
+  # PyPi archive currently broken: https://github.com/magmax/python-inquirer/issues/106
+  src = fetchFromGitHub rec {
+    owner = "magmax";
+    repo = "python-inquirer";
+    rev = version;
+    sha256 = "152l5qjgkag8zkr69ax2i5s8xcac1qvyngisrplbnbzwbpf77d0d";
   };
 
-  propagatedBuildInputs = [ python-editor readchar blessings ];
+  propagatedBuildInputs = [ blessed python-editor readchar ];
 
-  # No real changes in 2.0.0...e0edfa3
   postPatch = ''
-   substituteInPlace setup.py \
-     --replace "readchar == 2.0.1" "readchar >= 2.0.0"
+   substituteInPlace requirements.txt \
+     --replace "blessed==1.17.6" "blessed~=1.17" \
+     --replace "readchar==2.0.1" "readchar>=2.0.0"
   '';
 
   checkInputs = [ pytest pytestcov pexpect pytest-mock ];

--- a/pkgs/development/python-modules/notify-py/default.nix
+++ b/pkgs/development/python-modules/notify-py/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k, alsaUtils, libnotify, which, loguru, pytest }:
+
+buildPythonPackage rec {
+  pname = "notify_py";
+  version = "0.2.3";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1i209xsff54hipdk9cg6va60fl33swg126yfgkg3wsgjmi6s07ca";
+  };
+
+  postPatch = ''
+   substituteInPlace setup.py \
+     --replace "loguru==0.4.1" "loguru~=0.5.0"
+  '';
+
+  propagatedBuildInputs = [ alsaUtils libnotify loguru which ];
+
+  checkInputs = [ alsaUtils libnotify pytest which ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  pythonImportsCheck = [ "notifypy" ];
+
+  meta = with lib; {
+    description = " Python Module for sending cross-platform desktop notifications on Windows, macOS, and Linux.";
+    homepage = "https://github.com/ms7m/notify-py/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/development/python-modules/toggl-cli/default.nix
+++ b/pkgs/development/python-modules/toggl-cli/default.nix
@@ -4,6 +4,7 @@
 , factory_boy
 , faker
 , inquirer
+, notify-py
 , pbr
 , pendulum
 , ptable
@@ -11,7 +12,6 @@
 , pytestcov
 , pytest-mock
 , requests
-, setuptools
 , twine
 , validate-email
 }:
@@ -19,22 +19,19 @@
 
 buildPythonPackage rec {
   pname = "toggl-cli";
-  version = "2.1.0";
-  disabled = pythonOlder "3.5" || pythonAtLeast "3.8";
+  version = "2.2.1";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     pname = "togglCli";
     inherit version;
-    sha256 = "0iirvvb8772569v28d36bnryksm1qkkw48d48fw26j7ka01qq6mm";
+    sha256 = "1izsxag98lvivkwf7724g2ak6icjak9jdqphaq1a79kwdnqprx1m";
   };
 
   postPatch = ''
    substituteInPlace requirements.txt \
-     --replace "pendulum==2.0.4" "pendulum>=2.0.4" \
-     --replace "click-completion==0.5.0" "click-completion>=0.5.0" \
-     --replace "click==7.0" "click>=7.0" \
-     --replace "pbr==5.1.2" "pbr>=5.1.2" \
-     --replace "inquirer==2.5.1" "inquirer>=2.5.1"
+     --replace "inquirer==2.6.3" "inquirer>=2.6.3" \
+     --replace "notify-py==0.2.2" "notify-py>=0.2.2"
   '';
 
   nativeBuildInputs = [ pbr twine ];
@@ -53,15 +50,15 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
-    setuptools
     click
     click-completion
-    validate-email
+    inquirer
+    notify-py
     pendulum
     ptable
     requests
-    inquirer
     pbr
+    validate-email
   ];
 
   meta = with stdenv.lib; {
@@ -71,4 +68,3 @@ buildPythonPackage rec {
     maintainers = [ maintainers.mmahut ];
   };
 }
-

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4011,6 +4011,8 @@ in {
 
   notify = callPackage ../development/python-modules/notify { };
 
+  notify-py = callPackage ../development/python-modules/notify-py { };
+
   notmuch = callPackage ../development/python-modules/notmuch { inherit (pkgs) notmuch; };
 
   nototools = callPackage ../data/fonts/noto-fonts/tools.nix { };


### PR DESCRIPTION
###### Motivation for this change

Backport of: https://github.com/NixOS/nixpkgs/pull/99607

ZHF: #97479
https://hydra.nixos.org/build/128023281
https://hydra.nixos.org/build/127640071

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).