### PR TITLE
pythonPackages.python-csxcad: init at unstable-2020-02-18

### DIFF
--- a/pkgs/development/python-modules/python-csxcad/default.nix
+++ b/pkgs/development/python-modules/python-csxcad/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cython
+, openems
+, csxcad
+, numpy
+, matplotlib
+}:
+
+buildPythonPackage rec {
+  pname = "python-csxcad";
+  version = "unstable-2020-02-18";
+
+  src = fetchFromGitHub {
+    owner = "thliebig";
+    repo = "CSXCAD";
+    rev = "ef6e40931dbd80e0959f37c8e9614c437bf7e518";
+    sha256 = "072s765jyzpdq8qqysdy0dld17m6sr9zfcs0ip2zk8c4imxaysnb";
+  };
+
+  sourceRoot = "source/python";
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    openems
+    csxcad
+    numpy
+    matplotlib
+  ];
+
+  setupPyBuildFlags = "-I${openems}/include -L${openems}/lib -R${openems}/lib";
+
+  meta = with lib; {
+    description = "Python interface to CSXCAD";
+    homepage = http://openems.de/index.php/Main_Page.html;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ matthuszagh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4498,6 +4498,8 @@ in {
 
   pkuseg = callPackage ../development/python-modules/pkuseg { };
 
+  python-csxcad = callPackage ../development/python-modules/python-csxcad { };
+
   pkutils = callPackage ../development/python-modules/pkutils { };
 
   plac = callPackage ../development/python-modules/plac { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Adds python bindings for [CSXCAD](https://github.com/thliebig/CSXCAD). @jonringer this is the 2nd last PR related to [this PR](https://github.com/NixOS/nixpkgs/pull/69262).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
