### PR TITLE
zeromq: 4.3.2 -> 4.3.3

### DIFF
--- a/pkgs/development/libraries/zeromq/4.x.nix
+++ b/pkgs/development/libraries/zeromq/4.x.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchFromGitHub, cmake, asciidoc, enableDrafts ? false }:
+{ stdenv, fetchFromGitHub, cmake, asciidoc, pkg-config, libsodium
+, enableDrafts ? false }:
 
 stdenv.mkDerivation rec {
   pname = "zeromq";
-  version = "4.3.2";
+  version = "4.3.3";
 
   src = fetchFromGitHub {
     owner = "zeromq";
     repo = "libzmq";
     rev = "v${version}";
-    sha256 = "1q37z05i76ili31j6jlw8988iy6vxadlmd306f99phxfdpqa6bn9";
+    sha256 = "155kb0ih0xj4jvd39bq8d04bgvhy9143r3632ks1m04455z4qdzd";
   };
 
-  nativeBuildInputs = [ cmake asciidoc ];
+  nativeBuildInputs = [ cmake asciidoc pkg-config ];
+  buildInputs = [ libsodium ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Release version bump. Note that 4.3.3 now requires pkg-config to find libsodium, otherwise it defaults to a statically linked vendored implementation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
