### PR TITLE
lazarus-qt5: init at 2.0.10

### DIFF
--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -1,53 +1,107 @@
-{ stdenv, fetchurl, makeWrapper
+{ stdenv, lib, fetchurl, makeWrapper, writeText
 , fpc, gtk2, glib, pango, atk, gdk-pixbuf
 , libXi, xorgproto, libX11, libXext
 , gdb, gnumake, binutils
+, withQt ? false, qtbase ? null, libqt5pas ? null, wrapQtAppsHook ? null
 }:
+
+# TODO:
+#  1. the build date is embedded in the binary through `$I %DATE%` - we should dump that
+
+let
+  version = "2.0.10-2";
+
+  # as of 2.0.10 a suffix is being added. That may or may not disappear and then
+  # come back, so just leave this here.
+  majorMinorPatch = v:
+    builtins.concatStringsSep "." (lib.take 3 (lib.splitVersion v));
+
+  overrides = writeText "revision.inc" (lib.concatStringsSep "\n" (lib.mapAttrsToList (k: v:
+    "const ${k} = '${v}';") {
+      # this is technically the SVN revision but as we don't have that replace
+      # it with the version instead of showing "Unknown"
+      RevisionStr = version;
+    }));
+
+in
 stdenv.mkDerivation rec {
-  pname = "lazarus";
-  version = "2.0.8";
+  pname = "lazarus-${LCL_PLATFORM}";
+  inherit version;
 
   src = fetchurl {
-    url = "mirror://sourceforge/lazarus/Lazarus%20Zip%20_%20GZip/Lazarus%20${version}/lazarus-${version}.tar.gz";
-    sha256 = "1iciqydb0miqdrh89aj59gy7kfcwikkycqssq9djcqsw1ql3gc4h";
+    url = "mirror://sourceforge/lazarus/Lazarus%20Zip%20_%20GZip/Lazarus%20${majorMinorPatch version}/lazarus-${version}.tar.gz";
+    sha256 = "sha256-ZNViZGjdJKMzKyBfOr0KWBq33hsGCi1X4hhkBmz9Q7c=";
   };
 
+  postPatch = ''
+    cp ${overrides} ide/${overrides.name}
+  '';
+
   buildInputs = [
+    # we need gtk2 unconditionally as that is the default target when building applications with lazarus
     fpc gtk2 glib libXi xorgproto
     libX11 libXext pango atk
-    stdenv.cc makeWrapper gdk-pixbuf
-  ];
+    stdenv.cc gdk-pixbuf
+  ]
+  ++ lib.optionals withQt [ libqt5pas qtbase ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ] ++ lib.optional withQt wrapQtAppsHook;
 
   makeFlags = [
     "FPC=fpc"
     "PP=fpc"
+    "LAZARUS_INSTALL_DIR=${placeholder "out"}/share/lazarus/"
+    "INSTALL_PREFIX=${placeholder "out"}/"
     "REQUIRE_PACKAGES+=tachartlazaruspkg"
     "bigide"
   ];
 
+  LCL_PLATFORM = if withQt then "qt5" else "gtk2";
+
+  NIX_LDFLAGS = lib.concatStringsSep " " ([
+    "-L${stdenv.cc.cc.lib}/lib"
+    "-lX11"
+    "-lXext"
+    "-lXi"
+    "-latk-1.0"
+    "-lc"
+    "-lcairo"
+    "-lgcc_s"
+    "-lgdk-x11-2.0"
+    "-lgdk_pixbuf-2.0"
+    "-lglib-2.0"
+    "-lgtk-x11-2.0"
+    "-lpango-1.0"
+  ]
+  ++ lib.optionals withQt [
+    "-L${lib.getLib libqt5pas}/lib"
+    "-lQt5Pas"
+  ]);
+
   preBuild = ''
-    export makeFlags="$makeFlags LAZARUS_INSTALL_DIR=$out/share/lazarus/ INSTALL_PREFIX=$out/"
-    export NIX_LDFLAGS="$NIX_LDFLAGS -L${stdenv.cc.cc.lib}/lib -lXi -lX11 -lglib-2.0 -lgtk-x11-2.0 -lgdk-x11-2.0 -lc -lXext -lpango-1.0 -latk-1.0 -lgdk_pixbuf-2.0 -lcairo -lgcc_s"
-    export LCL_PLATFORM=gtk2
     mkdir -p $out/share "$out/lazarus"
     tar xf ${fpc.src} --strip-components=1 -C $out/share -m
-    sed -e 's@/usr/fpcsrc@'"$out/share/fpcsrc@" -i ide/include/unix/lazbaseconf.inc
+    substituteInPlace ide/include/unix/lazbaseconf.inc \
+      --replace '/usr/fpcsrc' "$out/share/fpcsrc"
   '';
 
-  postInstall = ''
-    wrapProgram $out/bin/startlazarus --prefix NIX_LDFLAGS ' ' \
-      "$(echo "$NIX_LDFLAGS" | sed -re 's/-rpath [^ ]+//g')" \
-      --prefix NIX_LDFLAGS_${binutils.suffixSalt} ' ' \
-      "$(echo "$NIX_LDFLAGS" | sed -re 's/-rpath [^ ]+//g')" \
+  postInstall = let
+    ldFlags = ''$(echo "$NIX_LDFLAGS" | sed -re 's/-rpath [^ ]+//g')'';
+  in ''
+    wrapProgram $out/bin/startlazarus \
+      --prefix NIX_LDFLAGS ' ' "${ldFlags}" \
+      --prefix NIX_LDFLAGS_${binutils.suffixSalt} ' ' "${ldFlags}" \
       --prefix LCL_PLATFORM ' ' "$LCL_PLATFORM" \
-      --prefix PATH ':' "${fpc}/bin:${gdb}/bin:${gnumake}/bin:${binutils}/bin"
+      --prefix PATH ':' "${lib.makeBinPath [ fpc gdb gnumake binutils ]}"
   '';
 
   meta = with stdenv.lib; {
-    description = "Lazarus graphical IDE for FreePascal language";
-    homepage = "http://www.lazarus.freepascal.org";
+    description = "Lazarus graphical IDE for the FreePascal language";
+    homepage = "https://www.lazarus.freepascal.org";
     license = licenses.gpl2Plus ;
+    maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
-    maintainers = [ maintainers.raskin ];
   };
 }

--- a/pkgs/development/compilers/fpc/libqt5pas.nix
+++ b/pkgs/development/compilers/fpc/libqt5pas.nix
@@ -1,6 +1,6 @@
-{ stdenv, lazarus, qt5 }:
+{ mkDerivation, lib, lazarus, qmake, qtbase, qtx11extras }:
 
-stdenv.mkDerivation {
+mkDerivation {
   pname = "libqt5pas";
   inherit (lazarus) version src;
 
@@ -8,14 +8,14 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace Qt5Pas.pro \
-      --replace "target.path = \$\$[QT_INSTALL_LIBS]" "target.path = $out/lib"
+      --replace 'target.path = $$[QT_INSTALL_LIBS]' "target.path = $out/lib"
   '';
 
-  nativeBuildInputs = with qt5; [ qmake ];
+  nativeBuildInputs = [ qmake ];
 
-  buildInputs = with qt5; [ qtbase qtx11extras ];
+  buildInputs = [ qtbase qtx11extras ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Free Pascal Qt5 binding library";
     homepage = "https://wiki.freepascal.org/Qt5_Interface#libqt5pas";
     maintainers = with maintainers; [ sikmir ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9377,6 +9377,11 @@ in
     fpc = fpc;
   };
 
+  lazarus-qt = libsForQt5.callPackage ../development/compilers/fpc/lazarus.nix {
+    fpc = fpc;
+    withQt = true;
+  };
+
   lessc = nodePackages.less;
 
   liquibase = callPackage ../development/tools/database/liquibase { };
@@ -14079,7 +14084,7 @@ in
 
   libqalculate = callPackage ../development/libraries/libqalculate { };
 
-  libqt5pas = callPackage ../development/compilers/fpc/libqt5pas.nix { };
+  libqt5pas = libsForQt5.callPackage ../development/compilers/fpc/libqt5pas.nix { };
 
   libroxml = callPackage ../development/libraries/libroxml { };
 


### PR DESCRIPTION
###### Motivation for this change

Includes the following changes:

1. lazarus: 2.0.8 -> 2.0.10 (built with gtk2)
2. lots of cleanups
3. minor libqt5pas cleanups

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).