### PR TITLE
python3Packages.azure-servicemanagement-legacy: use fetchPypi

### DIFF
--- a/pkgs/development/python-modules/azure-servicemanagement-legacy/default.nix
+++ b/pkgs/development/python-modules/azure-servicemanagement-legacy/default.nix
@@ -1,32 +1,29 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , azure-common
 , requests
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   version = "0.20.7";
   pname = "azure-servicemanagement-legacy";
 
-  src = fetchFromGitHub {
-    owner = "Azure";
-    repo = "azure-sdk-for-python";
-    rev = "ab01fc1f23462f130c69f46505524b88101023dc";
-    sha256 = "0w2bm9hkwy1m94l8r2klnpqn4192y8bir3z8bymxgfx9y0b1mn2q";
+  src = fetchPypi {
+    inherit version pname;
+    extension = "zip";
+    sha256 = "1kcibw17qm8c02y28xabm3k1zrawi6g4q8kzc751l5l3vagqnf2x";
   };
-
-  preBuild = ''
-    cd ./azure-servicemanagement-legacy
-  '';
 
   propagatedBuildInputs = [
     azure-common
     requests
   ];
 
+  pythonNamespaces = [ "azure" ];
   # has no tests
   doCheck = false;
+  pythonImportsCheck = [ "azure.servicemanagement" ];
 
   meta = with lib; {
     description = "This is the Microsoft Azure Service Management Legacy Client Library";


### PR DESCRIPTION

###### Motivation for this change
as noted in #99636 (comment) , using the previous source would cause issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
3 packages built:
python27Packages.azure-servicemanagement-legacy python37Packages.azure-servicemanagement-legacy python38Packages.azure-servicemanagement-legacy
```