### PR TITLE
python3Packages.rarfile: 3.0 -> 4.0

### DIFF
--- a/pkgs/development/python-modules/rarfile/default.nix
+++ b/pkgs/development/python-modules/rarfile/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, pytest, nose, libarchive, glibcLocales
+{ stdenv, buildPythonPackage, fetchFromGitHub, pytestCheckHook, nose, libarchive, glibcLocales, isPy27
 # unrar is non-free software
 , useUnrar ? false, unrar
 }:
@@ -6,17 +6,19 @@
 assert useUnrar -> unrar != null;
 assert !useUnrar -> libarchive != null;
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "rarfile";
-  version = "3.0";
+  version = "4.0";
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "markokr";
     repo = "rarfile";
-    rev = "rarfile_3_0";
-    sha256 = "07yliz6p1bxzhipnrgz133gl8laic35gl4rqfay7f1vc384ch7sn";
+    rev = "v${version}";
+    sha256 = "0gpriqkvcb6bsccvq8b099xjv5fkjs0d7g4636d5jphy417jxk5m";
   };
-  buildInputs = [ pytest nose glibcLocales ];
+
+  checkInputs = [ pytestCheckHook nose glibcLocales ];
 
   prePatch = ''
     substituteInPlace rarfile.py \
@@ -31,9 +33,7 @@ buildPythonPackage {
   # the tests only work with the standard unrar package
   doCheck = useUnrar;
   LC_ALL = "en_US.UTF-8";
-  checkPhase = ''
-    py.test test -k "not test_printdir"
-  '';
+  pythonImportsCheck = [ "rarfile" ];
 
   meta = with stdenv.lib; {
     description = "RAR archive reader for Python";


### PR DESCRIPTION
###### Motivation for this change

as noted in #99636 (comment) , using the previous source would cause issues.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
