### PR TITLE
notmuch: 0.30.1c80020 -> 0.31

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -12,7 +12,7 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "0.30.1c80020";
+  version = "0.31";
   pname = "notmuch";
 
   passthru = {
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = "https://git.notmuchmail.org/git/notmuch";
-    sha256 = "0xj944c4ayps1bg21pksjih3y9v6lb34dd582df14i14q0yzji51";
-    rev = "1c80020e701c7323de137c0616fc8864443d7bd3";
+    sha256 = "0f9d9k9avb46yh2r8fvijvw7bryqwckvyzc68f9phax2g4c99x4x";
+    rev = version;
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

New upstream release: https://notmuchmail.org/news/release-0.31/

ZHF: #97479 

Fixes notmuch build errors during tests (segfaults) https://hydra.nixos.org/build/128029286/nixlog/1
```
T568-lib-thread: Testing API tests for notmuch_thread_*
 PASS   building database
 FAIL   get thread-id from closed database
        --- T568-lib-thread.2.EXPECTED  2020-10-01 20:31:15.076653846 +0000
        +++ T568-lib-thread.2.OUTPUT    2020-10-01 20:31:15.078653857 +0000
        @@ -1,4 +1,2 @@
         == stdout ==
        -1
        -0000000000000009
         == stderr ==
In file included from /nix/store/4wy9j24psf9ny4di3anjs7yk2fvfb0gq-glibc-2.31-dev/include/bits/libc-header-start.h:33,
                 from /nix/store/4wy9j24psf9ny4di3anjs7yk2fvfb0gq-glibc-2.31-dev/include/stdio.h:27,
                 from test1.c:1:
/nix/store/4wy9j24psf9ny4di3anjs7yk2fvfb0gq-glibc-2.31-dev/include/features.h:397:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
  397 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
/build/notmuch-1c80020/test/test-lib.sh: line 1094: 17263 Segmentation fault      (core dumped) ./${exec_file} "$@" >> OUTPUT.stdout 2>> OUTPUT.stderr
```
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
