### PR TITLE
smos: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6255,6 +6255,12 @@
     githubId = 40049608;
     name = "Andy Chun";
   };
+  norfair = {
+    email = "syd@cs-syd.eu";
+    github = "NorfairKing";
+    githubId = 3521180;
+    name = "Tom Sydney Kerckhove";
+  };
   notthemessiah = {
     email = "brian.cohen.88@gmail.com";
     github = "notthemessiah";

--- a/pkgs/applications/misc/smos/default.nix
+++ b/pkgs/applications/misc/smos/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, fetchurl
+, unzip
+}:
+
+stdenv.mkDerivation rec {
+  name = "smos-${version}";
+  version = "0.1.0";
+
+  src = fetchurl {
+    url = "https://github.com/NorfairKing/smos/releases/download/v${version}/smos-release.zip";
+    sha256 = "sha256:07yavk7xl92yjwwjdig90yq421n8ldv4fjfw7izd4hfpzw849a12";
+  };
+
+  phases = [ "unpackPhase" ];
+  unpackCmd = "${unzip}/bin/unzip -d $out $curSrc";
+  sourceRoot = ".";
+
+  meta = with stdenv.lib; {
+    description = "A comprehensive self-management system";
+    homepage = https://smos.online;
+    license = licenses.mit;
+    maintainers = with maintainers; [ norfair ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21266,6 +21266,8 @@ in
 
   smallwm = callPackage ../applications/window-managers/smallwm { };
 
+  smos = callPackage ../applications/misc/smos { };
+
   spectrwm = callPackage ../applications/window-managers/spectrwm { };
 
   spectral = qt5.callPackage ../applications/networking/instant-messengers/spectral { };


### PR DESCRIPTION
I wrote smos at 
https://github.com/NorfairKing/smos
and I use it on NixOS so I know that this works.

The zip file that's being downloaded is the zipped-up version for a nix-expression at `https://github.com/NorfairKing/smos/blob/development/ci.nix` attribute `release-static`.
These are static executables, so they should have no runtime dependencies.
The zip file also contains `bash`, `zsh` and `fish`  completions, as well as a new `mime` type` and a `.desktop` file.


Some questions:

- Should I import the nix file in the smos repo instead?
- There is a module at https://github.com/NorfairKing/smos/blob/development/nix/module.nix, can I somehow add it to nixpkgs without moving it out of the smos repo?
- Same question for the home manager module at https://github.com/NorfairKing/smos/blob/development/nix/program.nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
