### PR TITLE
haskell-language-server: c476992f43 -> 93a3b53b6c

### DIFF
--- a/pkgs/development/tools/haskell/haskell-language-server/default.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/default.nix
@@ -11,11 +11,11 @@
 }:
 mkDerivation {
   pname = "haskell-language-server";
-  version = "0.4.0.0";
+  version = "0.5.0.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "1fh9k9b3880m6ql4i10yn2yanskk9xhrakrrddqvainhcf2ik8hl";
-    rev = "c4576992f443a9abe48ffcfa0e2d2b9bce15d7ae";
+    sha256 = "0dxhxm0fnvkxhkxwjjqa80y5whw2bmynxlhmkw4fa2bj7m09whvl";
+    rev = "93a3b53b6cb0a1bb7451b1e072b0621ef1346eb7;
     fetchSubmodules = true;
   };
   isLibrary = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Version 0.5.0 of `haskell-language-server` was recently [released](https://github.com/haskell/haskell-language-server/releases/tag/0.5.0) so updating package to match.

This could also be a used with #99519 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
