### PR TITLE
ocenaudio: init at 3.9.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6090,6 +6090,12 @@
     githubId = 1538622;
     name = "Michael Reilly";
   };
+  onny = {
+    email = "onny@project-insanity.org";
+    github = "onny";
+    githubId = 757752;
+    name = "Jonas Heinrich";
+  };
   OPNA2608 = {
     email = "christoph.neidahl@gmail.com";
     github = "OPNA2608";

--- a/pkgs/applications/audio/ocenaudio/default.nix
+++ b/pkgs/applications/audio/ocenaudio/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, qt5
+, libjack2
+, alsaLib
+, bzip2
+, libpulseaudio }:
+
+stdenv.mkDerivation rec {
+  pname = "ocenaudio";
+  version = "3.9.2";
+
+  src = fetchurl {
+    url = "https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian9_64.deb?version=${version}";
+    sha256 = "1fvpba3dnzb7sm6gp0znbrima02ckfiy2zwb66x1gr05y9a56inv";
+  };
+
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    qt5.qtbase
+    libjack2
+    libpulseaudio
+    bzip2
+    alsaLib
+  ];
+
+  buildInputs = [ dpkg ];
+
+  dontUnpack = true;
+  dontBuild = true;
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out
+    dpkg -x $src $out
+    cp -av $out/opt/ocenaudio/* $out
+    rm -rf $out/opt
+
+    # Create symlink bzip2 library
+    ln -s ${bzip2.out}/lib/libbz2.so.1 $out/libbz2.so.1.0
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cross-platform, easy to use, fast and functional audio editor";
+    homepage = "https://www.ocenaudio.com";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21527,6 +21527,8 @@ in
 
   nwg-launchers = callPackage ../applications/misc/nwg-launchers { };
 
+  ocenaudio = callPackage ../applications/audio/ocenaudio { };
+
   open-policy-agent = callPackage ../development/tools/open-policy-agent { };
 
   openshift = callPackage ../applications/networking/cluster/openshift { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Packages the audio editor [ocenaudio](https://www.ocenaudio.com/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
