### PR TITLE
kube3d: 3.0.2 -> 3.1.0 -> 3.1.1 -> 3.1.2 -> 3.1.3 -> 3.1.4 -> 3.1.5

### DIFF
--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "kube3d";
-  version = "3.1.4";
+  version = "3.1.5";
   k3sVersion = "1.18.9-k3s1";
 
   excludedPackages = ''tools'';
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner  = "rancher";
     repo   = "k3d";
     rev    = "v${version}";
-    sha256 = "05895wgikjqs8myn6qachwjapxbra0n4h5n8a05519hvmniv7fnv";
+    sha256 = "0aspkar9im323d8117k48fvh1yylyspi2p2l2f5rdg1ilpa6hm53";
   };
 
   buildFlagsArray = ''

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "kube3d";
-  version = "3.1.3";
+  version = "3.1.4";
   k3sVersion = "1.18.9-k3s1";
 
   excludedPackages = ''tools'';
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner  = "rancher";
     repo   = "k3d";
     rev    = "v${version}";
-    sha256 = "1qwy5h2kgqmyffvnb6q4l4jbavj0lacp46mm2wxrixspadkxg3wm";
+    sha256 = "05895wgikjqs8myn6qachwjapxbra0n4h5n8a05519hvmniv7fnv";
   };
 
   buildFlagsArray = ''

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -2,8 +2,8 @@
 
 buildGoModule rec {
   pname = "kube3d";
-  version = "3.0.2";
-  k3sVersion = "1.18.6-k3s1";
+  version = "3.1.0";
+  k3sVersion = "1.18.9-k3s1";
 
   excludedPackages = ''tools'';
 
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner  = "rancher";
     repo   = "k3d";
     rev    = "v${version}";
-    sha256 = "182n4kggwr6z75vsagfd0rl89ixcw5h13whf56jh4cd38dj8is5l";
+    sha256 = "1a3xspyyjp4vgh461q2l30i04ln2l2f7h46dxjrf25ysmlddq2za";
   };
 
   buildFlagsArray = ''

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -40,6 +40,6 @@ buildGoModule rec {
     description = "A helper to run k3s (Lightweight Kubernetes. 5 less than k8s) in a docker container";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ kuznero jlesquembre ngerstle ];
+    maintainers = with maintainers; [ kuznero jlesquembre ngerstle jk ];
   };
 }

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "kube3d";
-  version = "3.1.0";
+  version = "3.1.1";
   k3sVersion = "1.18.9-k3s1";
 
   excludedPackages = ''tools'';
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner  = "rancher";
     repo   = "k3d";
     rev    = "v${version}";
-    sha256 = "1a3xspyyjp4vgh461q2l30i04ln2l2f7h46dxjrf25ysmlddq2za";
+    sha256 = "08ia6qxzdm9snqkcy6g4l7m81yk5k8k940lyfq3czc62i0zc8vg3";
   };
 
   buildFlagsArray = ''

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -22,11 +22,13 @@ buildGoModule rec {
   '';
 
   nativeBuildInputs = [ installShellFiles ];
+
+  # TODO: Move to enhanced installShellCompletion when in master: PR #83630
   postInstall = ''
-   for shell in bash zsh; do
-     $out/bin/k3d completion $shell > k3d.$shell
-     installShellCompletion k3d.$shell
-   done
+    $out/bin/k3d completion bash > k3d.bash
+    $out/bin/k3d completion fish > k3d.fish
+    $out/bin/k3d completion zsh  > _k3d
+    installShellCompletion k3d.{bash,fish} --zsh _k3d
   '';
 
   vendorSha256 = null;

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "kube3d";
-  version = "3.1.2";
+  version = "3.1.3";
   k3sVersion = "1.18.9-k3s1";
 
   excludedPackages = ''tools'';
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner  = "rancher";
     repo   = "k3d";
     rev    = "v${version}";
-    sha256 = "1qfmmglx57yhrrainxfrmmba54sgxj4is9fgpc3p5sr2babxqgnp";
+    sha256 = "1qwy5h2kgqmyffvnb6q4l4jbavj0lacp46mm2wxrixspadkxg3wm";
   };
 
   buildFlagsArray = ''

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "kube3d";
-  version = "3.1.1";
+  version = "3.1.2";
   k3sVersion = "1.18.9-k3s1";
 
   excludedPackages = ''tools'';
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner  = "rancher";
     repo   = "k3d";
     rev    = "v${version}";
-    sha256 = "08ia6qxzdm9snqkcy6g4l7m81yk5k8k940lyfq3czc62i0zc8vg3";
+    sha256 = "1qfmmglx57yhrrainxfrmmba54sgxj4is9fgpc3p5sr2babxqgnp";
   };
 
   buildFlagsArray = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Bump kube3d/k3d to ~`3.1.0`~ ~`3.1.1`~ ~`3.1.2`~ ~`3.1.3`~ ~`3.1.4`~ `3.1.5`

###### Things done

Updated version, k3s version, and src sha256
I matched the k3s version to the one output by the GH release binary, hopefully that's correct.

@kuznero @jlesquembre @ngerstle 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
