### PR TITLE
ogre: 1.12.1 -> 1.12.9, cegui: enable build on darwin

### DIFF
--- a/pkgs/development/libraries/cegui/default.nix
+++ b/pkgs/development/libraries/cegui/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, cmake, ogre, freetype, boost, expat }:
+{ lib, stdenv, fetchurl, cmake, ogre, freetype, boost, expat, libiconv}:
 
 stdenv.mkDerivation rec {
   pname = "cegui";
@@ -10,12 +10,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ ogre freetype boost expat ];
+
+  buildInputs = [ ogre freetype boost expat ]
+    ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   meta = with lib; {
     homepage = "http://cegui.org.uk/";
     description = "C++ Library for creating GUIs";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19496,7 +19496,11 @@ with pkgs;
 
   ode = callPackage ../development/libraries/ode { };
 
-  ogre = callPackage ../development/libraries/ogre {};
+  ogre = callPackage ../development/libraries/ogre {
+    inherit (darwin.apple_sdk.frameworks) Foundation AppKit Cocoa AGL;
+    inherit (darwin) libobjc;
+  };
+
   ogre1_9 = callPackage ../development/libraries/ogre/1.9.x.nix {};
   ogre1_10 = callPackage ../development/libraries/ogre/1.10.x.nix {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19502,7 +19502,10 @@ with pkgs;
   };
 
   ogre1_9 = callPackage ../development/libraries/ogre/1.9.x.nix {};
-  ogre1_10 = callPackage ../development/libraries/ogre/1.10.x.nix {};
+  ogre1_10 = callPackage ../development/libraries/ogre/1.10.x.nix {
+    inherit (darwin.apple_sdk.frameworks) Foundation AppKit Cocoa AGL;
+    inherit (darwin) libobjc;
+  };
 
   ogrepaged = callPackage ../development/libraries/ogrepaged { };
 


### PR DESCRIPTION
###### Description of changes
Update and fix darwin build.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).