### PR TITLE
embree: 3.11.0 -> 3.12.0

### DIFF
--- a/pkgs/development/libraries/embree/default.nix
+++ b/pkgs/development/libraries/embree/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, ispc, tbb, glfw,
-  openimageio, libjpeg, libpng, libpthreadstubs, libX11 }:
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig, ispc, tbb, glfw,
+  openimageio, libjpeg, libpng, libpthreadstubs, libX11, glib }:
 
 stdenv.mkDerivation rec {
   pname = "embree";
-  version = "3.11.0";
+  version = "3.12.0";
 
   src = fetchFromGitHub {
     owner = "embree";
     repo = "embree";
     rev = "v${version}";
-    sha256 = "0v5gqi8jp09xxcbyyknji83412bq4l0w35b6hnrqxycgdrnf7hkr";
+    sha256 = "1q06fkfww8z8pcnhaqc4d2zi8hn620i9h9dmpnrfy3azalvizhkq";
   };
 
   postPatch = ''
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     sed -i "s|SET(EMBREE_ROOT_DIR .*)|set(EMBREE_ROOT_DIR $out)|" \
       common/cmake/embree-config.cmake
     sed -i "s|$""{EMBREE_ROOT_DIR}/||" common/cmake/embree-config.cmake
+    substituteInPlace common/math/math.h --replace 'defined(__MACOSX__) && !defined(__INTEL_COMPILER)' 0
+    substituteInPlace common/math/math.h --replace 'defined(__WIN32__) || defined(__FreeBSD__)' 'defined(__WIN32__) || defined(__FreeBSD__) || defined(__MACOSX__)'
   '';
 
   cmakeFlags = [
@@ -24,8 +26,10 @@ stdenv.mkDerivation rec {
     "-DEMBREE_RAY_MASK=ON"
   ];
 
+
   nativeBuildInputs = [ ispc pkgconfig cmake ];
-  buildInputs = [ tbb glfw openimageio libjpeg libpng libX11 libpthreadstubs ];
+  buildInputs = [ tbb glfw openimageio libjpeg libpng libX11 libpthreadstubs ]
+                ++ lib.optionals stdenv.isDarwin [ glib ];
 
   meta = with stdenv.lib; {
     description = "High performance ray tracing kernels from Intel";


### PR DESCRIPTION
###### Motivation for this change

Addresses #99049 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
