### PR TITLE
xmlsec: 1.2.28 -> 1.2.30

### DIFF
--- a/pkgs/development/libraries/xmlsec/default.nix
+++ b/pkgs/development/libraries/xmlsec/default.nix
@@ -3,7 +3,7 @@
 
 lib.fix (self:
 let
-  version = "1.2.28";
+  version = "1.2.30";
 in
 stdenv.mkDerivation {
   pname = "xmlsec";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.aleksey.com/xmlsec/download/xmlsec1-${version}.tar.gz";
-    sha256 = "1m12caglhyx08g8lh2sl3nkldlpryzdx2d572q73y3m33s0w9vhk";
+    sha256 = "1j5bf7ni45jghyrbf7a14wx2pvfara557zyry7g7h8840c5kd11d";
   };
 
   patches = [
@@ -29,6 +29,7 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
   doCheck = true;
+  checkInputs = [ nss.tools ];
 
   # enable deprecated soap headers required by lasso
   # https://dev.entrouvert.org/issues/18771


### PR DESCRIPTION

###### Motivation for this change
fixes the .pc's not being installed

https://discourse.nixos.org/t/pkg-config-pkgconfig-and-python/9331/2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
