### PR TITLE
material-shell: add patch to fix font scaling

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/material-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/material-shell/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, gnome3 }:
+{ stdenv, lib, fetchFromGitHub, gnome3, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-material-shell";
@@ -10,6 +10,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "076cv1l5qr5x71przjwvbzx0m91n4z0byc2gc3r48l8vsr2d0hwf";
   };
+
+  patches = [
+    # Fix for https://github.com/material-shell/material-shell/issues/284
+    # (Remove this patch when updating to version >= 8)
+    (fetchpatch {
+      url = "https://github.com/material-shell/material-shell/commit/fc27489a1ec503a4a5c7cb2f4e1eefa84a7ea2f1.patch";
+      sha256 = "0x2skg955c4jqgwbkfhk7plm8bh1qnk66cdds796bzkp3hb5syw8";
+    })
+  ];
 
   # This package has a Makefile, but it's used for building a zip for
   # publication to extensions.gnome.org. Disable the build phase so


### PR DESCRIPTION
###### Motivation for this change

Fixes font sizes on displays with non-default DPI scaling

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
