### PR TITLE
WIP: reintroduce the systemd lib output

### DIFF
--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -17,9 +17,9 @@ rec {
   inherit pkgs;
 
 
-  testDriver = let
+  mkTestDriver = let
     testDriverScript = ./test-driver/test-driver.py;
-  in stdenv.mkDerivation {
+  in qemu_pkg: stdenv.mkDerivation {
     name = "nixos-test-driver";
 
     nativeBuildInputs = [ makeWrapper ];
@@ -47,10 +47,12 @@ rec {
         # TODO: copy user script part into this file (append)
 
         wrapProgram $out/bin/nixos-test-driver \
-          --prefix PATH : "${lib.makeBinPath [ qemu_test vde2 netpbm coreutils ]}" \
+          --prefix PATH : "${lib.makeBinPath [ qemu_pkg vde2 netpbm coreutils ]}" \
       '';
   };
 
+  testDriver = mkTestDriver qemu_test;
+  testDriverInteractive = mkTestDriver qemu_kvm;
 
   # Run an automated test suite in the given virtual network.
   # `driver' is the script that runs the network.
@@ -113,7 +115,11 @@ rec {
       # Generate convenience wrappers for running the test driver
       # interactively with the specified network, and for starting the
       # VMs from the command line.
-      driver = let warn = if skipLint then lib.warn "Linting is disabled!" else lib.id; in warn (runCommand testDriverName
+      driver = testDriver:
+        let
+          warn = if skipLint then lib.warn "Linting is disabled!" else lib.id;
+        in
+        warn (runCommand testDriverName
         { buildInputs = [ makeWrapper];
           testScript = testScript';
           preferLocalBuild = true;
@@ -148,7 +154,7 @@ rec {
         meta = (drv.meta or {}) // t.meta;
       };
 
-      test = passMeta (runTests driver);
+      test = passMeta (runTests (driver testDriver));
 
       nodeNames = builtins.attrNames nodes;
       invalidNodeNames = lib.filter
@@ -165,7 +171,8 @@ rec {
         ''
       else
         test // {
-          inherit nodes driver test;
+          inherit nodes test;
+          driver = driver testDriverInteractive;
         };
 
   runInMachine =

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -6,12 +6,12 @@
 , CoreServices, Cocoa, Hypervisor, rez, setfile
 , numaSupport ? stdenv.isLinux && !stdenv.isAarch32, numactl
 , seccompSupport ? stdenv.isLinux, libseccomp
-, pulseSupport ? !stdenv.isDarwin, libpulseaudio
-, sdlSupport ? !stdenv.isDarwin, SDL2
-, gtkSupport ? !stdenv.isDarwin && !xenSupport, gtk3, gettext, vte, wrapGAppsHook
-, vncSupport ? true, libjpeg, libpng
-, smartcardSupport ? true, libcacard
-, spiceSupport ? !stdenv.isDarwin, spice, spice-protocol
+, pulseSupport ? !stdenv.isDarwin && !nixosTestRunner, libpulseaudio
+, sdlSupport ? !stdenv.isDarwin && !nixosTestRunner, SDL2
+, gtkSupport ? !stdenv.isDarwin && !xenSupport && !nixosTestRunner, gtk3, gettext, vte, wrapGAppsHook
+, vncSupport ? !nixosTestRunner, libjpeg, libpng
+, smartcardSupport ? !nixosTestRunner, libcacard
+, spiceSupport ? !stdenv.isDarwin && !nixosTestRunner, spice, spice-protocol
 , usbredirSupport ? spiceSupport, usbredir
 , xenSupport ? false, xen
 , cephSupport ? false, ceph

--- a/pkgs/os-specific/linux/systemd/0020-NIXOS-use-different-values-for-runtime-dir-in-the-bi.patch
+++ b/pkgs/os-specific/linux/systemd/0020-NIXOS-use-different-values-for-runtime-dir-in-the-bi.patch
@@ -1,0 +1,137 @@
+From 2d0b9e25f92e0f25fd54f6562b96254d189bab9a Mon Sep 17 00:00:00 2001
+From: Andreas Rammhold <andreas@rammhold.de>
+Date: Mon, 5 Oct 2020 14:31:54 +0200
+Subject: [PATCH] NIXOS: use different values for runtime dir in the binaries
+
+---
+ meson.build | 58 ++++++++++++++++++++++++++++++++---------------------
+ 1 file changed, 35 insertions(+), 23 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index b841b8031a..d20689c798 100644
+--- a/meson.build
++++ b/meson.build
+@@ -85,6 +85,11 @@ if rootprefixdir == ''
+ endif
+ rootprefixdir_noslash = rootprefixdir == '/' ? '' : rootprefixdir
+ 
++nixos_rootprefixdir = '/run/current-system/systemd/'
++nixos_rootprefixdir_noslash = '/run/current-system/systemd'
++nixos_rootlibexecdir = join_paths(nixos_rootprefixdir, 'lib/systemd')
++
++
+ have_standalone_binaries = get_option('standalone-binaries')
+ 
+ sysvinit_path = get_option('sysvinit-path')
+@@ -115,6 +120,7 @@ datadir = join_paths(prefixdir, get_option('datadir'))
+ localstatedir = join_paths('/', get_option('localstatedir'))
+ 
+ rootbindir = join_paths(rootprefixdir, 'bin')
++nixos_rootbindir = join_paths(nixos_rootprefixdir, 'bin')
+ rootsbindir = join_paths(rootprefixdir, split_bin ? 'sbin' : 'bin')
+ rootlibexecdir = join_paths(rootprefixdir, 'lib/systemd')
+ 
+@@ -141,6 +147,7 @@ pkgdatadir = join_paths(datadir, 'systemd')
+ environmentdir = join_paths(prefixdir, 'lib/environment.d')
+ pkgsysconfdir = join_paths(sysconfdir, 'systemd')
+ userunitdir = join_paths(prefixdir, 'lib/systemd/user')
++nixos_userunitdir = join_paths(nixos_rootprefixdir, 'lib/systemd/user')
+ userpresetdir = join_paths(prefixdir, 'lib/systemd/user-preset')
+ tmpfilesdir = join_paths(prefixdir, 'lib/tmpfiles.d')
+ sysusersdir = join_paths(prefixdir, 'lib/sysusers.d')
+@@ -150,12 +157,17 @@ modulesloaddir = join_paths(prefixdir, 'lib/modules-load.d')
+ networkdir = join_paths(rootprefixdir, 'lib/systemd/network')
+ pkgincludedir = join_paths(includedir, 'systemd')
+ systemgeneratordir = join_paths(rootlibexecdir, 'system-generators')
++nixos_systemgeneratordir = join_paths(nixos_rootlibexecdir, 'system-generators')
+ usergeneratordir = join_paths(prefixdir, 'lib/systemd/user-generators')
++nixos_usergeneratordir = join_paths(nixos_rootprefixdir, 'lib/systemd/user-generators')
+ systemenvgeneratordir = join_paths(prefixdir, 'lib/systemd/system-environment-generators')
++nixos_systemenvgeneratordir = join_paths(nixos_rootprefixdir, 'lib/systemd/system-environment-generators')
+ userenvgeneratordir = join_paths(prefixdir, 'lib/systemd/user-environment-generators')
++nixos_userenvgeneratordir = join_paths(nixos_rootprefixdir, 'lib/systemd/user-environment-generators')
+ systemshutdowndir = join_paths(rootlibexecdir, 'system-shutdown')
+ systemsleepdir = join_paths(rootlibexecdir, 'system-sleep')
+ systemunitdir = join_paths(rootprefixdir, 'lib/systemd/system')
++nixos_systemunitdir = join_paths(nixos_rootprefixdir, 'lib/systemd/system')
+ systempresetdir = join_paths(rootprefixdir, 'lib/systemd/system-preset')
+ udevlibexecdir = join_paths(rootprefixdir, 'lib/udev')
+ udevrulesdir = join_paths(udevlibexecdir, 'rules.d')
+@@ -209,7 +221,7 @@ status_unit_format_default = get_option('status-unit-format-default')
+ 
+ conf.set_quoted('PKGSYSCONFDIR',                              pkgsysconfdir)
+ conf.set_quoted('SYSTEM_CONFIG_UNIT_DIR',                     join_paths(pkgsysconfdir, 'system'))
+-conf.set_quoted('SYSTEM_DATA_UNIT_PATH',                      systemunitdir)
++conf.set_quoted('SYSTEM_DATA_UNIT_PATH',                      nixos_systemunitdir)
+ conf.set_quoted('SYSTEM_SYSVINIT_PATH',                       sysvinit_path)
+ conf.set_quoted('SYSTEM_SYSVRCND_PATH',                       sysvrcnd_path)
+ conf.set_quoted('RC_LOCAL_PATH',                              get_option('rc-local'))
+@@ -217,27 +229,27 @@ conf.set_quoted('RC_LOCAL_PATH',                              get_option('rc-loc
+ conf.set('ANSI_OK_COLOR',                                     'ANSI_' + get_option('ok-color').underscorify().to_upper())
+ 
+ conf.set_quoted('USER_CONFIG_UNIT_DIR',                       join_paths(pkgsysconfdir, 'user'))
+-conf.set_quoted('USER_DATA_UNIT_DIR',                         userunitdir)
++conf.set_quoted('USER_DATA_UNIT_DIR',                         nixos_userunitdir)
+ conf.set_quoted('CERTIFICATE_ROOT',                           get_option('certificate-root'))
+ conf.set_quoted('CATALOG_DATABASE',                           join_paths(catalogstatedir, 'database'))
+-conf.set_quoted('SYSTEMD_CGROUP_AGENT_PATH',                  join_paths(rootlibexecdir, 'systemd-cgroups-agent'))
+-conf.set_quoted('SYSTEMD_BINARY_PATH',                        join_paths(rootlibexecdir, 'systemd'))
+-conf.set_quoted('SYSTEMD_FSCK_PATH',                          join_paths(rootlibexecdir, 'systemd-fsck'))
+-conf.set_quoted('SYSTEMD_MAKEFS_PATH',                        join_paths(rootlibexecdir, 'systemd-makefs'))
+-conf.set_quoted('SYSTEMD_GROWFS_PATH',                        join_paths(rootlibexecdir, 'systemd-growfs'))
+-conf.set_quoted('SYSTEMD_SHUTDOWN_BINARY_PATH',               join_paths(rootlibexecdir, 'systemd-shutdown'))
+-conf.set_quoted('SYSTEMCTL_BINARY_PATH',                      join_paths(rootbindir, 'systemctl'))
+-conf.set_quoted('SYSTEMD_TTY_ASK_PASSWORD_AGENT_BINARY_PATH', join_paths(rootbindir, 'systemd-tty-ask-password-agent'))
++conf.set_quoted('SYSTEMD_CGROUP_AGENT_PATH',                  join_paths(nixos_rootlibexecdir, 'systemd-cgroups-agent'))
++conf.set_quoted('SYSTEMD_BINARY_PATH',                        join_paths(nixos_rootlibexecdir, 'systemd'))
++conf.set_quoted('SYSTEMD_FSCK_PATH',                          join_paths(nixos_rootlibexecdir, 'systemd-fsck'))
++conf.set_quoted('SYSTEMD_MAKEFS_PATH',                        join_paths(nixos_rootlibexecdir, 'systemd-makefs'))
++conf.set_quoted('SYSTEMD_GROWFS_PATH',                        join_paths(nixos_rootlibexecdir, 'systemd-growfs'))
++conf.set_quoted('SYSTEMD_SHUTDOWN_BINARY_PATH',               join_paths(nixos_rootlibexecdir, 'systemd-shutdown'))
++conf.set_quoted('SYSTEMCTL_BINARY_PATH',                      join_paths(nixos_rootbindir, 'systemctl'))
++conf.set_quoted('SYSTEMD_TTY_ASK_PASSWORD_AGENT_BINARY_PATH', join_paths(nixos_rootbindir, 'systemd-tty-ask-password-agent'))
+ conf.set_quoted('SYSTEMD_STDIO_BRIDGE_BINARY_PATH',           join_paths(bindir, 'systemd-stdio-bridge'))
+-conf.set_quoted('ROOTPREFIX',                                 rootprefixdir)
+-conf.set_quoted('ROOTPREFIX_NOSLASH',                         rootprefixdir_noslash)
++conf.set_quoted('ROOTPREFIX',                                 nixos_rootprefixdir)
++conf.set_quoted('ROOTPREFIX_NOSLASH',                         nixos_rootprefixdir_noslash)
+ conf.set_quoted('RANDOM_SEED_DIR',                            randomseeddir)
+ conf.set_quoted('RANDOM_SEED',                                join_paths(randomseeddir, 'random-seed'))
+ conf.set_quoted('SYSTEMD_CRYPTSETUP_PATH',                    join_paths(rootlibexecdir, 'systemd-cryptsetup'))
+-conf.set_quoted('SYSTEM_GENERATOR_DIR',                       systemgeneratordir)
+-conf.set_quoted('USER_GENERATOR_DIR',                         usergeneratordir)
+-conf.set_quoted('SYSTEM_ENV_GENERATOR_DIR',                   systemenvgeneratordir)
+-conf.set_quoted('USER_ENV_GENERATOR_DIR',                     userenvgeneratordir)
++conf.set_quoted('SYSTEM_GENERATOR_DIR',                       nixos_systemgeneratordir)
++conf.set_quoted('USER_GENERATOR_DIR',                         nixos_usergeneratordir)
++conf.set_quoted('SYSTEM_ENV_GENERATOR_DIR',                   nixos_systemenvgeneratordir)
++conf.set_quoted('USER_ENV_GENERATOR_DIR',                     nixos_userenvgeneratordir)
+ conf.set_quoted('SYSTEM_SHUTDOWN_PATH',                       systemshutdowndir)
+ conf.set_quoted('SYSTEM_SLEEP_PATH',                          systemsleepdir)
+ conf.set_quoted('SYSTEMD_KBD_MODEL_MAP',                      join_paths(pkgdatadir, 'kbd-model-map'))
+@@ -250,15 +262,15 @@ conf.set_quoted('LIBDIR',                                     libdir)
+ conf.set_quoted('ROOTLIBDIR',                                 rootlibdir)
+ conf.set_quoted('ROOTLIBEXECDIR',                             rootlibexecdir)
+ conf.set_quoted('BOOTLIBDIR',                                 bootlibdir)
+-conf.set_quoted('SYSTEMD_PULL_PATH',                          join_paths(rootlibexecdir, 'systemd-pull'))
+-conf.set_quoted('SYSTEMD_IMPORT_PATH',                        join_paths(rootlibexecdir, 'systemd-import'))
+-conf.set_quoted('SYSTEMD_IMPORT_FS_PATH',                     join_paths(rootlibexecdir, 'systemd-import-fs'))
+-conf.set_quoted('SYSTEMD_EXPORT_PATH',                        join_paths(rootlibexecdir, 'systemd-export'))
+-conf.set_quoted('VENDOR_KEYRING_PATH',                        join_paths(rootlibexecdir, 'import-pubring.gpg'))
++conf.set_quoted('SYSTEMD_PULL_PATH',                          join_paths(nixos_rootlibexecdir, 'systemd-pull'))
++conf.set_quoted('SYSTEMD_IMPORT_PATH',                        join_paths(nixos_rootlibexecdir, 'systemd-import'))
++conf.set_quoted('SYSTEMD_IMPORT_FS_PATH',                     join_paths(nixos_rootlibexecdir, 'systemd-import-fs'))
++conf.set_quoted('SYSTEMD_EXPORT_PATH',                        join_paths(nixos_rootlibexecdir, 'systemd-export'))
++conf.set_quoted('VENDOR_KEYRING_PATH',                        join_paths(nixos_rootlibexecdir, 'import-pubring.gpg'))
+ conf.set_quoted('USER_KEYRING_PATH',                          join_paths(pkgsysconfdir, 'import-pubring.gpg'))
+ conf.set_quoted('DOCUMENT_ROOT',                              join_paths(pkgdatadir, 'gatewayd'))
+-conf.set_quoted('SYSTEMD_HOMEWORK_PATH',                      join_paths(rootlibexecdir, 'systemd-homework'))
+-conf.set_quoted('SYSTEMD_USERWORK_PATH',                      join_paths(rootlibexecdir, 'systemd-userwork'))
++conf.set_quoted('SYSTEMD_HOMEWORK_PATH',                      join_paths(nixos_rootlibexecdir, 'systemd-homework'))
++conf.set_quoted('SYSTEMD_USERWORK_PATH',                      join_paths(nixos_rootlibexecdir, 'systemd-userwork'))
+ conf.set10('MEMORY_ACCOUNTING_DEFAULT',                       memory_accounting_default)
+ conf.set_quoted('MEMORY_ACCOUNTING_DEFAULT_YES_NO',           memory_accounting_default ? 'yes' : 'no')
+ conf.set('STATUS_UNIT_FORMAT_DEFAULT',                        'STATUS_UNIT_FORMAT_' + status_unit_format_default.to_upper())
+-- 
+2.28.0
+

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -55,10 +55,11 @@ in stdenv.mkDerivation {
     ./0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
     ./0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
     ./0019-revert-get-rid-of-seat_can_multi_session.patch
+    ./0020-NIXOS-use-different-values-for-runtime-dir-in-the-bi.patch
   ];
 
   postPatch = ''
-    substituteInPlace src/basic/path-util.h --replace "@defaultPathNormal@" "${placeholder "out"}/bin/"
+    substituteInPlace src/basic/path-util.h --replace "@defaultPathNormal@" "/run/current-system/systemd/bin/"
     substituteInPlace src/boot/efi/meson.build \
       --replace \
       "find_program('ld'" \

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -68,7 +68,7 @@ in stdenv.mkDerivation {
       "find_program('${stdenv.cc.bintools.targetPrefix}objcopy'"
   '';
 
-  outputs = [ "out" "man" "dev" ];
+  outputs = [ "out" "lib" "man" "dev" ];
 
   nativeBuildInputs =
     [ pkgconfig intltool gperf libxslt gettext docbook_xsl docbook_xml_dtd_42 docbook_xml_dtd_45
@@ -98,6 +98,7 @@ in stdenv.mkDerivation {
     "-Ddbussystemservicedir=${placeholder "out"}/share/dbus-1/system-services"
     "-Dpamconfdir=${placeholder "out"}/etc/pam.d"
     "-Drootprefix=${placeholder "out"}"
+    "-Drootlibdir=${placeholder "lib"}/lib"
     "-Dpkgconfiglibdir=${placeholder "dev"}/lib/pkgconfig"
     "-Dpkgconfigdatadir=${placeholder "dev"}/share/pkgconfig"
     "-Dloadkeys-path=${kbd}/bin/loadkeys"
@@ -266,9 +267,38 @@ in stdenv.mkDerivation {
 
     # "kernel-install" shouldn't be used on NixOS.
     find $out -name "*kernel-install*" -exec rm {} \;
+
+    # Keep only libudev and libsystemd in the lib output.
+    mkdir -p $out/lib
+    mv $lib/lib/security $lib/lib/libnss* $out/lib/
   ''; # */
 
   enableParallelBuilding = true;
+
+  # On aarch64 we "leak" a reference to $out/lib/systemd/catalog in the lib
+  # output. The result of that is a dependency cycle between $out and $lib.
+  # Thus nix (rightfully) marks the build as failed. That reference originates
+  # from an array of strings (catalog_file_dirs) in systemd
+  # (src/src/journal/catalog.{c,h}).  The only consumer (as of v242) of the
+  # symbol is the main function of journalctl.  Still libsystemd.so contains
+  # the VALUE but not the symbol.  Systemd seems to be properly using function
+  # & data sections together with the linker flags to garbage collect unused
+  # sections (-Wl,--gc-sections).  For unknown reasons those flags do not
+  # eliminate the unused string constants, in this case on aarch64-linux. The
+  # hacky way is to just remove the reference after we finished compiling.
+  # Since it can not be used (there is no symbol to actually refer to it) there
+  # should not be any harm.  It is a bit odd and I really do not like starting
+  # these kind of hacks but there doesn't seem to be a straight forward way at
+  # this point in time.
+  # The reference will be replaced by the same reference the usual nukeRefs
+  # tooling uses.  The standard tooling can not / should not be uesd since it
+  # is a bit too excessive and could potentially do us some (more) harm.
+  postFixup = ''
+    nukedRef=$(echo $out | sed -e "s,$NIX_STORE/[^-]*-\(.*\),$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-\1,")
+    cat $lib/lib/libsystemd.so | perl -pe "s|$out/lib/systemd/catalog|$nukedRef/lib/systemd/catalog|" > $lib/lib/libsystemd.so.tmp
+    mv $lib/lib/libsystemd.so.tmp $(readlink -f $lib/lib/libsystemd.so)
+  '';
+
 
   # The interface version prevents NixOS from switching to an
   # incompatible systemd at runtime.  (Switching across reboots is


### PR DESCRIPTION
##### Motivation for this change

Yesterday I started hacking on some changes for systemd and I think the approach might be suitable for one of our current problems with closure bloat (due to not having a `lib` output) anymore.

The basic idea is to distinguish between build-time and run-time paths in the meson world. There are paths where build results should be installed to but those aren't always the same during runtime.

One concern, to this approach, was that we must always popluate `/run/current-system/systemd` before stage-2. That is currently the case and not a reason to worry. It will be more difficult once we migrate to initrd in stage-1 but for that to happen we should probably start cleaning up a lot of other things first.

Right now I also have some changes in here that cut down on the test closure size of NixOS tests. I'm willing to file them as another PR if you do not want to mix these things.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
   - I did run the entire `small` release set and most of the "normal" NixOS tests. Haven't seen any new issues that do not look like normal test flakiness.
- [ ] check if we still need the aarch64 hack