### PR TITLE
shattered-pixel-dungeon: 0.8.2d -> 0.9.0b

### DIFF
--- a/pkgs/games/shattered-pixel-dungeon/default.nix
+++ b/pkgs/games/shattered-pixel-dungeon/default.nix
@@ -10,13 +10,13 @@
 
 let
   pname = "shattered-pixel-dungeon";
-  version = "0.8.2d";
+  version = "0.9.0b";
 
   src = fetchFromGitHub {
     owner = "00-Evan";
     repo = "shattered-pixel-dungeon";
     rev = "v${version}";
-    sha256 = "11lgalam1aacw01ar7nawiim4pbxqzrdrnxvj6wq9mg83hgsz65l";
+    sha256 = "1cjrs1k2wkhaby8qprx2m9nhlcmnbrjlalsaj9vwgq1s7szzl2w4";
   };
 
   postPatch = ''

--- a/pkgs/games/shattered-pixel-dungeon/default.nix
+++ b/pkgs/games/shattered-pixel-dungeon/default.nix
@@ -34,6 +34,8 @@ let
     nativeBuildInputs = [ gradle_5 perl ];
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d)
+      # https://github.com/gradle/gradle/issues/4426
+      ${stdenv.lib.optionalString stdenv.isDarwin "export TERM=dumb"}
       gradle --no-daemon desktop:release
     '';
     # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
@@ -54,6 +56,8 @@ in stdenv.mkDerivation rec {
 
   buildPhase = ''
     export GRADLE_USER_HOME=$(mktemp -d)
+    # https://github.com/gradle/gradle/issues/4426
+    ${stdenv.lib.optionalString stdenv.isDarwin "export TERM=dumb"}
     # point to offline repo
     sed -ie "s#repositories {#repositories { maven { url '${deps}' };#g" build.gradle
     gradle --offline --no-daemon desktop:release
@@ -78,6 +82,8 @@ in stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
+    # https://github.com/NixOS/nixpkgs/pull/99885#issuecomment-740065005
+    broken = stdenv.isDarwin;
   };
 }
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
