### PR TITLE
python3Packages.localzone: 0.9.6 -> 0.9.7

### DIFF
--- a/pkgs/development/python-modules/localzone/default.nix
+++ b/pkgs/development/python-modules/localzone/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "localzone";
-  version = "0.9.6";
+  version = "0.9.7";
 
   src = fetchFromGitHub {
     owner = "ags-slc";
     repo = pname;
     rev = "v${version}";
-    sha256 = "154l7qglsm4jrhqddvlas8cgl9qm2z4dzihv05jmsyqjikcmfwk8";
+    sha256 = "1vzn1vm3zf86l7qncbmghjrwyvla9dc2v8abn8jajbl47gm7r5f7";
   };
 
   propagatedBuildInputs = [ dnspython sphinx ];
@@ -30,6 +30,5 @@ buildPythonPackage rec {
     homepage = "https://localzone.iomaestro.com";
     license = licenses.bsd3;
     maintainers = with maintainers; [ flyfloh ];
-    broken = true; # incompatible with dnspython>=2.0.0
   };
 }


### PR DESCRIPTION
###### Motivation for this change
fixes build with dnspython >= 2

related: #99567 https://github.com/ags-slc/localzone/issues/1 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
