### PR TITLE
[20.09] python3Packages.localzone: 0.9.6 -> 0.9.7

### DIFF
--- a/pkgs/applications/misc/ape/apeclex.nix
+++ b/pkgs/applications/misc/ape/apeclex.nix
@@ -2,7 +2,7 @@
 
 callPackage ./. {
   pname = "ape-clex";
-  lexicon = "${attemptoClex}/clex_lexicon.pl";
+  lexiconPath = "${attemptoClex}/clex_lexicon.pl";
   description = "Parser for Attempto Controlled English (ACE) with a large lexicon (~100,000 entries)";
   license = with stdenv.lib; [ licenses.lgpl3 licenses.gpl3 ];
 }

--- a/pkgs/applications/misc/ape/default.nix
+++ b/pkgs/applications/misc/ape/default.nix
@@ -1,10 +1,10 @@
 { stdenv, swiProlog, makeWrapper,
   fetchFromGitHub,
-  lexicon ? "prolog/lexicon/clex_lexicon.pl",
+  lexiconPath ? "prolog/lexicon/clex_lexicon.pl",
   pname ? "ape",
   description ? "Parser for Attempto Controlled English (ACE)",
   license ? with stdenv.lib; licenses.lgpl3
-  }:
+}:
 
 stdenv.mkDerivation rec {
   inherit pname;
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     # We move the file first to avoid "same file" error in the default case
-    cp ${lexicon} new_lexicon.pl
+    cp ${lexiconPath} new_lexicon.pl
     rm prolog/lexicon/clex_lexicon.pl
     cp new_lexicon.pl prolog/lexicon/clex_lexicon.pl
   '';

--- a/pkgs/development/python-modules/localzone/default.nix
+++ b/pkgs/development/python-modules/localzone/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "localzone";
-  version = "0.9.6";
+  version = "0.9.7";
 
   src = fetchFromGitHub {
     owner = "ags-slc";
     repo = pname;
     rev = "v${version}";
-    sha256 = "154l7qglsm4jrhqddvlas8cgl9qm2z4dzihv05jmsyqjikcmfwk8";
+    sha256 = "1vzn1vm3zf86l7qncbmghjrwyvla9dc2v8abn8jajbl47gm7r5f7";
   };
 
   propagatedBuildInputs = [ dnspython sphinx ];


### PR DESCRIPTION
###### Motivation for this change
(cherry picked from commit 0093e4e6a9998f1ff59e79ec31f2341770b7bebb)

backport #99571 
backport #99886

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
