### PR TITLE
[20.09] matplotlib: Disable LTO on darwin.

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ]
     ++ stdenv.lib.optionals enableQt [ pyqt5 ];
 
-  setup_cfg = ./setup.cfg;
+  setup_cfg = if stdenv.isDarwin then ./setup-darwin.cfg else ./setup.cfg;
   preBuild = ''
     cp "$setup_cfg" ./setup.cfg
   '';

--- a/pkgs/development/python-modules/matplotlib/setup-darwin.cfg
+++ b/pkgs/development/python-modules/matplotlib/setup-darwin.cfg
@@ -1,0 +1,7 @@
+[directories]
+basedirlist = .
+
+[libs]
+system_freetype = true
+# LTO not working in darwin stdenv, see #19312
+enable_lto = false


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

This is a backport of 31579c6b0a643742d6ac6157d002de1e730a83cb that makes `matplotlib` actually _work_ again on darwin. This will also get e.g. `scikit-optimize`'s tests passing on darwin too.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
