### PR TITLE
gnomeExtensions.freon: init at 40

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4268,6 +4268,12 @@
     githubId = 39434424;
     name = "Felix Springer";
   };
+  justinas = {
+    email = "justinas@justinas.org";
+    github = "justinas";
+    githubId = 662666;
+    name = "Justinas Stankevičius";
+  };
   justinlovinger = {
     email = "git@justinlovinger.com";
     github = "JustinLovinger";

--- a/pkgs/desktops/gnome-3/extensions/freon/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/freon/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-freon";
+  version = "40";
+
+  uuid = "freon@UshakovVasilii_Github.yahoo.com";
+
+  src = fetchFromGitHub {
+    owner = "UshakovVasilii";
+    repo = "gnome-shell-extension-freon";
+    rev = "EGO-${version}";
+    sha256 = "0ak6f5dds9kk3kqww681gs3l1mj3vf22icrvb5m257s299rq8yzl";
+  };
+
+  nativeBuildInputs = [ glib ];
+
+  buildPhase = ''
+    runHook preBuild
+    glib-compile-schemas --strict --targetdir=${uuid}/schemas ${uuid}/schemas
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -r ${uuid} $out/share/gnome-shell/extensions
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GNOME Shell extension for displaying CPU, GPU, disk temperatures, voltage and fan RPM in the top panel";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ justinas ];
+    homepage = "https://github.com/UshakovVasilii/gnome-shell-extension-freon";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25777,6 +25777,7 @@ in
     draw-on-your-screen = callPackage ../desktops/gnome-3/extensions/draw-on-your-screen { };
     drop-down-terminal = callPackage ../desktops/gnome-3/extensions/drop-down-terminal { };
     emoji-selector = callPackage ../desktops/gnome-3/extensions/emoji-selector { };
+    freon = callPackage ../desktops/gnome-3/extensions/freon { };
     gsconnect = callPackage ../desktops/gnome-3/extensions/gsconnect { };
     icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };
     impatience = callPackage ../desktops/gnome-3/extensions/impatience { };


### PR DESCRIPTION
##### Motivation for this change
[freon](https://github.com/UshakovVasilii/gnome-shell-extension-freon) is a more up-to-date fork of the [Sensors](https://github.com/xtranophilist/gnome-shell-extension-sensors) gnome extension. It lets one monitor temperatures provided via `lm_sensors` as well as through `nvidia-smi` and `bumblebee`.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
