### PR TITLE
amule: 2.3.2 -> unstable-20201006

### DIFF
--- a/pkgs/tools/networking/p2p/amule/default.nix
+++ b/pkgs/tools/networking/p2p/amule/default.nix
@@ -10,27 +10,14 @@ assert client -> libX11 != null;
 
 stdenv.mkDerivation rec {
   pname = "amule";
-  version = "2.3.2";
+  version = "unstable-20201006";
 
   src = fetchFromGitHub {
     owner = "amule-project";
     repo = "amule";
-    rev = version;
-    sha256 = "010wxm6g9f92x6fympj501zbnjka32rzbx0sk3a2y4zpih5d2nsn";
+    rev = "6f8951527eda670c7266984ce476061bfe8867fc";
+    sha256 = "12b44b6hz3mb7nsn6xhzvm726xs06xcim013i1appif4dr8njbx1";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/amule-project/amule/pull/135.patch";
-      sha256 = "1n24r1j28083b8ipbnh1nf6i4j6vx59pdkfl1c0g6bb4psx9wvvi";
-      name = "libupnp_18.patch";
-    })
-    (fetchpatch {
-      name = "amule-cryptopp_6.patch";
-      url = "https://github.com/amule-project/amule/commit/27c13f3e622b8a3eaaa05bb62b0149604bdcc9e8.patch";
-      sha256 = "0kq095gi3xl665wr864zlhp5f3blk75pr725yany8ilzcwrzdrnm";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace src/libs/ec/file_generator.pl \


### PR DESCRIPTION
There has been no new release since 2.3.2 for some years now (around 2016) [1]

The most recent master branch for the amule project includes a commit [2] which
fixes compilation breakage with the next libupnp version [3].

So this bumps the amule version to the latest commit of that repository.

[1] https://github.com/amule-project/amule/issues/219

[2] https://github.com/amule-project/amule/commit/8784480c79680df5c224d6886a8b4cd3dc1d1801

[3] #93048 

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions: nix on debian
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nixpkgs-review pr 99893` [2]
- [x] Tested execution of all binary files (usually in `./result/bin/`) ~> amule starts and can connect to some kadmelia networks
- [x] Impact on package closure size: -58968 [1]
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

[1] 

```
before: /nix/store/zsw4nifqvr7gl7is6ym0pmwdvyw969a9-amule-2.3.2   288470680
now: /nix/store/0kpzc5vi9vwn0y5w3ncpa5fr1jyv3mlm-amule-2.3.2      288529648
```

[2] 
```
$ nixpkgs-review pr 99893
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0 pull/99893/head:refs/nixpkgs-review/1
From https://github.com/NixOS/nixpkgs
 + 98e5369bafa...1f7cf962918 refs/pull/99893/head -> refs/nixpkgs-review/1  (forced update)
$ git worktree add /home/tony/.cache/nixpkgs-review/pr-99893/nixpkgs 9ae60c874749f2bdbfb1ffb1249621f050410ad7
Preparing worktree (detached HEAD 9ae60c87474)
Updating files: 100% (22850/22850), done.
HEAD is now at 9ae60c87474 act: build with go 1.15 on darwin
$ git merge --no-commit 1f7cf9629180506f6f651d835c9ed3e428b3811f
Automatic merge went well; stopped before committing as requested
$ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/tony/.cache/nixpkgs-review/pr-99893/build.nix
building '/nix/store/7q7ic26fdaacnjsz8f06cwiydfjrxxrx-amule-unstable-20201006.drv'...
building '/nix/store/f20s02hml0hsw1pgyv08440akznw13x3-amule-unstable-20201006.drv'...
building '/nix/store/9xys7s31kyxkrc40kh718cl4v4m7mnkk-env.drv'...
[3 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/99893
3 packages built:
amule amuleDaemon amuleGui

$ nix-shell /home/tony/.cache/nixpkgs-review/pr-99893/shell.nix
```