### PR TITLE
datagrip: remove loskutov from maintainers

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -90,7 +90,7 @@ let
           It allows you to quickly migrate and refactor relational databases,
           construct efficient, statically checked SQL queries and much more.
         '';
-        maintainers = with maintainers; [ loskutov ];
+        maintainers = with maintainers; [ ];
         platforms = platforms.linux;
       };
     });


### PR DESCRIPTION
I haven't been actively maintaining this derivation; provided that updates are made by scripts, it looks like it's time to finally abandon it.