### PR TITLE
[20.09] nixos/installer: drop the extra nixUnstable in nixos-install

### DIFF
--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -22,10 +22,9 @@ let
     src = ./nixos-install.sh;
     inherit (pkgs) runtimeShell;
     nix = config.nix.package.out;
-    path = makeBinPath [ 
-      pkgs.nixUnstable 
+    path = makeBinPath [
       pkgs.jq
-      nixos-enter 
+      nixos-enter
     ];
   };
 


### PR DESCRIPTION
###### Motivation for this change
(Backport of #99615, cc @worldofpeace )

The only nix version available in the installer should be the version
configure in the module system. If someone needs `nixUnstable` in their
`nixos-install` they should probably set the module option and not just
add it to the closure.

(cherry picked from commit 544059b01f30d7d00939b27b82bb5bd4a974d45a)
