### PR TITLE
gmrender-resurrect: Make build against libupnp 1.14 ok

### DIFF
--- a/pkgs/tools/networking/gmrender-resurrect/default.nix
+++ b/pkgs/tools/networking/gmrender-resurrect/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, makeWrapper, gstreamer
+{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, pkgconfig, makeWrapper, gstreamer
 , gst-plugins-base, gst-plugins-good, gst-plugins-bad, gst-plugins-ugly, gst-libav, libupnp }:
 
 let
@@ -18,6 +18,14 @@ in
       rev = "v${version}";
       sha256 = "14i5jrry6qiap5l2x2jqj7arymllajl3wgnk29ccvr8d45zp4jn1";
     };
+
+    patches = [
+      (fetchpatch {
+        url = "https://github.com/hzeller/gmrender-resurrect/commit/dc8c4d4dc234311b3099e7f1efadf5d9733c81e9.patch";
+        sha256 = "0fqi58viaq9jg5h5j1725qrach4c3wmfmh0q43q4r8az2pn7dszw";
+        name = "libupnp.patch";
+      })
+    ];
 
     buildInputs = [ gstreamer libupnp ];
     nativeBuildInputs = [ autoreconfHook pkgconfig makeWrapper ];


### PR DESCRIPTION
Related to #93048

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions: debian with nix
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nixpkgs-review pr 99899` [2]
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size: -1136 [1]
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

[1]
```
before /nix/store/vmr8ny2pwaa6jdnrq14yml0b58cbs0xi-gmrender-resurrect-0.0.8      813998272
after  /nix/store/m8vmfyly18zx3wzx881fmhx7v2wkvqgc-gmrender-resurrect-0.0.8      813999408
```

[2]
```
$ nixpkgs-review pr 99899
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0 pull/99899/head:refs/nixpkgs-review/1
remote: Enumerating objects: 59, done.
remote: Counting objects: 100% (59/59), done.
remote: Total 101 (delta 59), reused 59 (delta 59), pack-reused 42
Receiving objects: 100% (101/101), 190.48 KiB | 241.00 KiB/s, done.
Resolving deltas: 100% (72/72), completed with 50 local objects.
From https://github.com/NixOS/nixpkgs
   0093e4e6a99..9ae60c87474  master               -> refs/nixpkgs-review/0
 + 024ad57ed18...98e5369bafa refs/pull/99899/head -> refs/nixpkgs-review/1  (forced update)
$ git worktree add /home/tony/.cache/nixpkgs-review/pr-99899/nixpkgs 9ae60c874749f2bdbfb1ffb1249621f050410ad7
Preparing worktree (detached HEAD 9ae60c87474)
Updating files: 100% (22850/22850), done.
HEAD is now at 9ae60c87474 act: build with go 1.15 on darwin
$ git merge --no-commit 98e5369bafacf919982813d86e5dc99095d5d3d0
Automatic merge went well; stopped before committing as requested
$ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/tony/.cache/nixpkgs-review/pr-99899/build.nix
building '/nix/store/97ijw7dfydq4npnv8hc6b13fdvm72hl4-env.drv'...
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/99899
1 package built:
gmrender-resurrect

$ nix-shell /home/tony/.cache/nixpkgs-review/pr-99899/shell.nix

[nix-shell:~/.cache/nixpkgs-review/pr-99899]$ exit
$ git worktree prune
```