### PR TITLE
[20.09] electricsheep: 2.7b33-2017-10-20 -> 3.0.2-2019-10-05, fix build

### DIFF
--- a/pkgs/misc/screensavers/electricsheep/default.nix
+++ b/pkgs/misc/screensavers/electricsheep/default.nix
@@ -4,12 +4,12 @@
 
 stdenv.mkDerivation rec {
   pname = "electricsheep";
-  version = "2.7b33-2017-10-20";
+  version = "3.0.2-2019-10-05";
 
   src = fetchFromGitHub {
     owner = "scottdraves";
     repo = pname;
-    rev = "c02c19b9364733fc73826e105fc983a89a8b4f40";
+    rev = "37ba0fd692d6581f8fe009ed11c9650cd8174123";
     sha256 = "1z49l53j1lhk7ahdy96lm9r0pklwpf2i5s6y2l2rn6l4z8dxkjmk";
   };
 
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "CPPFLAGS=-I${glee}/include/GL"
+  ];
+
+  makeFlags = [
+    ''CXXFLAGS+="-DGL_GLEXT_PROTOTYPES"''
   ];
 
   preBuild = ''


### PR DESCRIPTION

###### Motivation for this change

ZHF: #97479

backport of https://github.com/NixOS/nixpkgs/pull/99131

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
