### PR TITLE
flutter: Bump and add dart cache to flutter

### DIFF
--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -1,6 +1,9 @@
-{ callPackage }:
+{ callPackage, dart }:
 
 let
+  dart_stable = dart.override { version = "2.10.0"; };
+  dart_beta = dart.override { version = "2.10.0"; };
+  dart_dev = dart.override { version = "2.11.0-161.0.dev"; };
   mkFlutter = opts: callPackage (import ./flutter.nix opts) { };
   getPatches = dir:
     let files = builtins.attrNames (builtins.readDir dir);
@@ -10,25 +13,28 @@ in {
   stable = mkFlutter rec {
     pname = "flutter";
     channel = "stable";
-    version = "1.17.5";
+    version = "1.22.0";
     filename = "flutter_linux_${version}-${channel}.tar.xz";
-    sha256Hash = "0kapja3nh7dfhjbn2np02wghijrjnpzsv4hz10fj54hs8hdx19di";
+    sha256Hash = "0ryrx458ss8ryhmspcfrhjvad2pl46bxh1qk5vzwzhxiqdc79vm8";
     patches = getPatches ./patches/stable;
+    dart = dart_stable;
   };
   beta = mkFlutter rec {
-    pname = "flutter-beta";
+    pname = "flutter";
     channel = "beta";
-    version = "1.20.0-7.2.pre";
+    version = "1.22.0-12.3.pre";
     filename = "flutter_linux_${version}-${channel}.tar.xz";
-    sha256Hash = "0w89ig5vi4spa95mf08r4vvwni7bzzdlyhvr9sy1a35qmf7j9s6f";
-    patches = getPatches ./patches/beta;
+    sha256Hash = "1axzz137z4lgpa09h7bjf52i6dij6a9wmjbha1182db23r09plzh";
+    patches = getPatches ./patches/stable;
+    dart = dart_beta;
   };
   dev = mkFlutter rec {
-    pname = "flutter-dev";
+    pname = "flutter";
     channel = "dev";
-    version = "1.21.0-1.0.pre";
+    version = "1.23.0-7.0.pre";
     filename = "flutter_linux_${version}-${channel}.tar.xz";
-    sha256Hash = "14rx89jp6ivk3ai7iwbznkr5q445ndh8fppzbxg520kq10s2208r";
-    patches = getPatches ./patches/beta;
+    sha256Hash = "166qb4qbv051bc71yj7c0vrkamhvzz3fp3mz318qzm947mydwjj5";
+    patches = getPatches ./patches/dev;
+    dart = dart_dev;
   };
 }

--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -1,5 +1,5 @@
-{ channel, pname, version, sha256Hash, patches
-, filename ? "flutter_linux_v${version}-${channel}.tar.xz" }:
+{ channel, pname, version, sha256Hash, patches, dart
+, filename ? "flutter_linux_${version}-${channel}.tar.xz"}:
 
 { bash, buildFHSUserEnv, cacert, coreutils, git, makeWrapper, runCommand, stdenv
 , fetchurl, alsaLib, dbus, expat, libpulseaudio, libuuid, libX11, libxcb
@@ -72,6 +72,7 @@ let
       with pkgs; [
         bash
         curl
+        dart
         git
         unzip
         which
@@ -119,11 +120,15 @@ in runCommand drvName {
     homepage = "https://flutter.dev";
     license = licenses.bsd3;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ babariviere ];
+    maintainers = with maintainers; [ babariviere ericdallo ];
   };
 } ''
   mkdir -p $out/bin
 
   echo -n "$startScript" > $out/bin/${pname}
   chmod +x $out/bin/${pname}
+
+  mkdir -p $out/bin/cache/dart-sdk/
+  cp -r ${dart}/* $out/bin/cache/dart-sdk/
+  ln $out/bin/cache/dart-sdk/bin/dart $out/bin/dart
 ''

--- a/pkgs/development/compilers/flutter/patches/dev/disable-auto-update.patch
+++ b/pkgs/development/compilers/flutter/patches/dev/disable-auto-update.patch
@@ -1,8 +1,8 @@
 diff --git a/bin/internal/shared.sh b/bin/internal/shared.sh
-index 702bd9ed5..4d4dc94c6 100755
+index 22efe87443..c6954575c5 100644
 --- a/bin/internal/shared.sh
 +++ b/bin/internal/shared.sh
-@@ -204,8 +204,6 @@ function shared::execute() {
+@@ -212,8 +212,6 @@ function shared::execute() {
    # FLUTTER_TOOL_ARGS="--enable-asserts $FLUTTER_TOOL_ARGS"
    # FLUTTER_TOOL_ARGS="$FLUTTER_TOOL_ARGS --observe=65432"
  
@@ -12,10 +12,10 @@ index 702bd9ed5..4d4dc94c6 100755
    case "$BIN_NAME" in
      flutter*)
 diff --git a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
-index 21be933e1..2ea73c4c0 100644
+index fb1616ba96..b973b3fd58 100644
 --- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
 +++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
-@@ -294,13 +294,6 @@ class FlutterCommandRunner extends CommandRunner<void> {
+@@ -291,13 +291,6 @@ class FlutterCommandRunner extends CommandRunner<void> {
            globals.flutterUsage.suppressAnalytics = true;
          }
  

--- a/pkgs/development/compilers/flutter/patches/dev/move-cache.patch
+++ b/pkgs/development/compilers/flutter/patches/dev/move-cache.patch
@@ -1,21 +1,21 @@
 diff --git a/dev/devicelab/lib/framework/runner.dart b/dev/devicelab/lib/framework/runner.dart
-index 8e511eefd..fef3cca8b 100644
+index a059a8e992..b664a7070c 100644
 --- a/dev/devicelab/lib/framework/runner.dart
 +++ b/dev/devicelab/lib/framework/runner.dart
-@@ -126,7 +126,7 @@ Future<void> cleanupSystem() async {
-     print('\nTelling Gradle to shut down (JAVA_HOME=$javaHome)');
-     final String gradlewBinaryName = Platform.isWindows ? 'gradlew.bat' : 'gradlew';
-     final Directory tempDir = Directory.systemTemp.createTempSync('flutter_devicelab_shutdown_gradle.');
--    recursiveCopy(Directory(path.join(flutterDirectory.path, 'bin', 'cache', 'artifacts', 'gradle_wrapper')), tempDir);
-+    recursiveCopy(Directory(path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter', 'artifacts', 'gradle_wrapper')), tempDir);
-     copy(File(path.join(path.join(flutterDirectory.path, 'packages', 'flutter_tools'), 'templates', 'app', 'android.tmpl', 'gradle', 'wrapper', 'gradle-wrapper.properties')), Directory(path.join(tempDir.path, 'gradle', 'wrapper')));
-     if (!Platform.isWindows) {
-       await exec(
+@@ -137,7 +137,7 @@ Future<void> cleanupSystem() async {
+       print('\nTelling Gradle to shut down (JAVA_HOME=$javaHome)');
+       final String gradlewBinaryName = Platform.isWindows ? 'gradlew.bat' : 'gradlew';
+       final Directory tempDir = Directory.systemTemp.createTempSync('flutter_devicelab_shutdown_gradle.');
+-      recursiveCopy(Directory(path.join(flutterDirectory.path, 'bin', 'cache', 'artifacts', 'gradle_wrapper')), tempDir);
++      recursiveCopy(Directory(path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter', 'artifacts', 'gradle_wrapper')), tempDir);
+       copy(File(path.join(path.join(flutterDirectory.path, 'packages', 'flutter_tools'), 'templates', 'app', 'android.tmpl', 'gradle', 'wrapper', 'gradle-wrapper.properties')), Directory(path.join(tempDir.path, 'gradle', 'wrapper')));
+       if (!Platform.isWindows) {
+         await exec(
 diff --git a/packages/flutter_tools/lib/src/asset.dart b/packages/flutter_tools/lib/src/asset.dart
-index c680de599..480abfb77 100644
+index 36714c5fb4..c0cc049ee1 100644
 --- a/packages/flutter_tools/lib/src/asset.dart
 +++ b/packages/flutter_tools/lib/src/asset.dart
-@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
+@@ -6,6 +6,7 @@ import 'package:meta/meta.dart';
  import 'package:package_config/package_config.dart';
  import 'package:yaml/yaml.dart';
  
@@ -23,20 +23,20 @@ index c680de599..480abfb77 100644
  import 'base/context.dart';
  import 'base/file_system.dart';
  import 'base/utils.dart';
-@@ -392,7 +393,7 @@ List<_Asset> _getMaterialAssets(String fontSet) {
+@@ -397,7 +398,7 @@ List<_Asset> _getMaterialAssets(String fontSet) {
      for (final Map<dynamic, dynamic> font in (family['fonts'] as List<dynamic>).cast<Map<dynamic, dynamic>>()) {
        final Uri entryUri = globals.fs.path.toUri(font['asset'] as String);
        result.add(_Asset(
 -        baseDir: globals.fs.path.join(Cache.flutterRoot, 'bin', 'cache', 'artifacts', 'material_fonts'),
-+	baseDir: globals.fs.path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter', 'artifacts', 'material_fonts'),
++        baseDir: globals.fs.path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter', 'artifacts', 'material_fonts'),
          relativeUri: Uri(path: entryUri.pathSegments.last),
          entryUri: entryUri,
          package: null,
 diff --git a/packages/flutter_tools/lib/src/cache.dart b/packages/flutter_tools/lib/src/cache.dart
-index c0946782c..bdbc35cb8 100644
+index aaca036d78..43ff428f8d 100644
 --- a/packages/flutter_tools/lib/src/cache.dart
 +++ b/packages/flutter_tools/lib/src/cache.dart
-@@ -202,8 +202,15 @@ class Cache {
+@@ -226,8 +226,15 @@ class Cache {
        return;
      }
      assert(_lock == null);
@@ -53,7 +53,7 @@ index c0946782c..bdbc35cb8 100644
      try {
        _lock = lockFile.openSync(mode: FileMode.write);
      } on FileSystemException catch (e) {
-@@ -306,7 +313,7 @@ class Cache {
+@@ -330,7 +337,7 @@ class Cache {
      if (_rootOverride != null) {
        return _fileSystem.directory(_fileSystem.path.join(_rootOverride.path, 'bin', 'cache'));
      } else {

--- a/pkgs/development/compilers/flutter/patches/stable/disable-auto-update.patch
+++ b/pkgs/development/compilers/flutter/patches/stable/disable-auto-update.patch
@@ -1,24 +1,24 @@
-diff --git a/bin/flutter b/bin/flutter
-index cdf974233..1f7de1c1b 100755
---- a/bin/flutter
-+++ b/bin/flutter
-@@ -185,8 +185,6 @@ fi
- # FLUTTER_TOOL_ARGS="--enable-asserts $FLUTTER_TOOL_ARGS"
- # FLUTTER_TOOL_ARGS="$FLUTTER_TOOL_ARGS --observe=65432"
+diff --git a/bin/internal/shared.sh b/bin/internal/shared.sh
+index 8d613de739..a673466726 100644
+--- a/bin/internal/shared.sh
++++ b/bin/internal/shared.sh
+@@ -204,8 +204,6 @@ function shared::execute() {
+   # FLUTTER_TOOL_ARGS="--enable-asserts $FLUTTER_TOOL_ARGS"
+   # FLUTTER_TOOL_ARGS="$FLUTTER_TOOL_ARGS --observe=65432"
  
--(upgrade_flutter) 3< "$PROG_NAME"
+-  upgrade_flutter 7< "$PROG_NAME"
 -
- # FLUTTER_TOOL_ARGS isn't quoted below, because it is meant to be considered as
- # separate space-separated args.
- "$DART" --packages="$FLUTTER_TOOLS_DIR/.packages" $FLUTTER_TOOL_ARGS "$SNAPSHOT_PATH" "$@"
+   BIN_NAME="$(basename "$PROG_NAME")"
+   case "$BIN_NAME" in
+     flutter*)
 diff --git a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
-index b3e69714f..a9eb76234 100644
+index 8a1a1e29da..778f253358 100644
 --- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
 +++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
-@@ -301,13 +301,6 @@ class FlutterCommandRunner extends CommandRunner<void> {
+@@ -293,13 +293,6 @@ class FlutterCommandRunner extends CommandRunner<void> {
+           globals.flutterUsage.suppressAnalytics = true;
          }
  
-         _checkFlutterCopy();
 -        try {
 -          await globals.flutterVersion.ensureVersionFile();
 -        } on FileSystemException catch (e) {

--- a/pkgs/development/compilers/flutter/patches/stable/move-cache.patch
+++ b/pkgs/development/compilers/flutter/patches/stable/move-cache.patch
@@ -1,8 +1,8 @@
 diff --git a/dev/devicelab/lib/framework/runner.dart b/dev/devicelab/lib/framework/runner.dart
-index 8e511eefd..fef3cca8b 100644
+index d045c83f04..d51973020b 100644
 --- a/dev/devicelab/lib/framework/runner.dart
 +++ b/dev/devicelab/lib/framework/runner.dart
-@@ -126,7 +126,7 @@ Future<void> cleanupSystem() async {
+@@ -136,7 +136,7 @@ Future<void> cleanupSystem() async {
      print('\nTelling Gradle to shut down (JAVA_HOME=$javaHome)');
      final String gradlewBinaryName = Platform.isWindows ? 'gradlew.bat' : 'gradlew';
      final Directory tempDir = Directory.systemTemp.createTempSync('flutter_devicelab_shutdown_gradle.');
@@ -12,7 +12,7 @@ index 8e511eefd..fef3cca8b 100644
      if (!Platform.isWindows) {
        await exec(
 diff --git a/packages/flutter_tools/lib/src/asset.dart b/packages/flutter_tools/lib/src/asset.dart
-index c680de599..480abfb77 100644
+index 8da01315ae..bb8d61d7f2 100644
 --- a/packages/flutter_tools/lib/src/asset.dart
 +++ b/packages/flutter_tools/lib/src/asset.dart
 @@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
@@ -23,20 +23,20 @@ index c680de599..480abfb77 100644
  import 'base/context.dart';
  import 'base/file_system.dart';
  import 'base/utils.dart';
-@@ -392,7 +393,7 @@ List<_Asset> _getMaterialAssets(String fontSet) {
+@@ -399,7 +400,7 @@ List<_Asset> _getMaterialAssets(String fontSet) {
      for (final Map<dynamic, dynamic> font in (family['fonts'] as List<dynamic>).cast<Map<dynamic, dynamic>>()) {
        final Uri entryUri = globals.fs.path.toUri(font['asset'] as String);
        result.add(_Asset(
 -        baseDir: globals.fs.path.join(Cache.flutterRoot, 'bin', 'cache', 'artifacts', 'material_fonts'),
-+	baseDir: globals.fs.path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter', 'artifacts', 'material_fonts'),
++        baseDir: globals.fs.path.join(globals.fsUtils.homeDirPath, '.cache', 'flutter', 'artifacts', 'material_fonts'),
          relativeUri: Uri(path: entryUri.pathSegments.last),
          entryUri: entryUri,
          package: null,
 diff --git a/packages/flutter_tools/lib/src/cache.dart b/packages/flutter_tools/lib/src/cache.dart
-index c0946782c..bdbc35cb8 100644
+index a35d8f87d0..a40027dc74 100644
 --- a/packages/flutter_tools/lib/src/cache.dart
 +++ b/packages/flutter_tools/lib/src/cache.dart
-@@ -202,8 +202,15 @@ class Cache {
+@@ -215,8 +215,15 @@ class Cache {
        return;
      }
      assert(_lock == null);
@@ -53,7 +53,7 @@ index c0946782c..bdbc35cb8 100644
      try {
        _lock = lockFile.openSync(mode: FileMode.write);
      } on FileSystemException catch (e) {
-@@ -306,7 +313,7 @@ class Cache {
+@@ -319,7 +326,7 @@ class Cache {
      if (_rootOverride != null) {
        return _fileSystem.directory(_fileSystem.path.join(_rootOverride.path, 'bin', 'cache'));
      } else {

--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -36,6 +36,10 @@ let
       url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
       sha256 = "1p66fkdh1kv0ypmadmg67c3y3li3aaf1lahqh2g6r6qrzbh5da2p";
     };
+    "2.10.0-x86_64-linux" = fetchurl {
+      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
+      sha256 = "0dncmsfbwcn3ygflhp83i6z4bvc02fbpaq1vzdzw8xdk3sbynchb";
+    };
     "2.9.0-4.0.dev-x86_64-linux" = fetchurl {
       url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
       sha256 = "16d9842fb3qbc0hy0zmimav9zndfkq96glgykj20xssc88qpjk2r";
@@ -47,6 +51,10 @@ let
     "2.9.0-4.0.dev-aarch64-linux" = fetchurl {
       url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
       sha256 = "1x6mlmc4hccmx42k7srhma18faxpxvghjwqahna80508rdpljwgc";
+    };
+    "2.11.0-161.0.dev-x86_64-linux" = fetchurl {
+      url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
+      sha256 = "05difz4w2fyh2yq5p5pkrqk59jqljlxhc1i6lmy5kihh6z69r12i";
     };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8636,6 +8636,8 @@ in
   flutterPackages =
     recurseIntoAttrs (callPackage ../development/compilers/flutter { });
   flutter = flutterPackages.stable;
+  flutter-beta = flutterPackages.beta;
+  flutter-dev = flutterPackages.dev;
 
   fpc = callPackage ../development/compilers/fpc { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
* Flutter requires dart-sdk cache to work propertly
* bump flutter version to latest

Fixes #98405

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
