### PR TITLE
firefox: add ltoSupport and enable it by default

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -253,14 +253,15 @@ buildStdenv.mkDerivation ({
   ]
   ++ lib.optional (buildStdenv.isDarwin) "--disable-xcode-checks"
   ++ lib.optional (!ltoSupport) "--with-clang-path=${llvmPackages.clang}/bin/clang"
-  # LTO is done using clang and lld.
+  # LTO is done using clang and lld on Linux.
+  # Darwin needs to use the default linker as lld is not supported (yet?):
+  #   https://bugzilla.mozilla.org/show_bug.cgi?id=1538724
   # elf-hack is broken when using clang:
-  # https://bugzilla.mozilla.org/show_bug.cgi?id=1482204
+  #   https://bugzilla.mozilla.org/show_bug.cgi?id=1482204
   ++ lib.optionals ltoSupport [
     "--enable-lto"
-    "--enable-linker=lld"
     "--disable-elf-hack"
-  ]
+  ] ++ lib.optional (ltoSupport && !buildStdenv.isDarwin) "--enable-linker=lld"
 
   ++ flag alsaSupport "alsa"
   ++ flag pulseaudioSupport "pulseaudio"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Build Firefox with LTO support as upstream does. This change switches the compiler to clang and linker to lld.

The closure size increased by ~1% (586.6M -> 592.9M).

The resulting directory of interest did decrease in size (181M -> 179M).

```
# Non-LTO build
$ du -sh /nix/store/q4295z228mic5c062ha6v6dyzjnf78vd-firefox-unwrapped-81.0/lib/firefox
181M    /nix/store/q4295z228mic5c062ha6v6dyzjnf78vd-firefox-unwrapped-81.0/lib/firefox

# LTO build
$ du -sh /nix/store/7qi4yl0f44zxd3lmka6yba0f2wdxa4nd-firefox-unwrapped-81.0/lib/firefox
179M    /nix/store/7qi4yl0f44zxd3lmka6yba0f2wdxa4nd-firefox-unwrapped-81.0/lib/firefox
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
