### PR TITLE
[20.09] python3Packages.alerta-server: fix build

### DIFF
--- a/pkgs/development/python-modules/alerta-server/default.nix
+++ b/pkgs/development/python-modules/alerta-server/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, pyyaml
-, python-dateutil, requests, pymongo, raven, bcrypt, flask, pyjwt, flask-cors, psycopg2, pytz, flask-compress, jinja2
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder
+, bcrypt, blinker, flask, flask-compress, flask-cors, mohawk, psycopg2, pyjwt, pymongo, python-dateutil, pytz, pyyaml, requests, requests-hawk, sentry-sdk
 }:
 
 buildPythonPackage rec {
@@ -11,7 +11,23 @@ buildPythonPackage rec {
     sha256 = "894d240c51428225264867a80094b9743d71272635a18ddfefa5832b61fed2c6";
   };
 
-  propagatedBuildInputs = [ python-dateutil requests pymongo raven bcrypt flask pyjwt flask-cors psycopg2 pytz flask-compress jinja2 pyyaml];
+  propagatedBuildInputs = [
+    bcrypt
+    blinker
+    flask
+    flask-compress
+    flask-cors
+    mohawk
+    psycopg2
+    pyjwt
+    pymongo
+    python-dateutil
+    pytz
+    pyyaml  
+    requests
+    requests-hawk
+    sentry-sdk
+  ];
 
   doCheck = false; # We can't run the tests from Nix, because they rely on the presence of a working MongoDB server
 


### PR DESCRIPTION
###### Motivation for this change

Backport of: https://github.com/NixOS/nixpkgs/pull/99694

ZHF: https://github.com/NixOS/nixpkgs/issues/97479
https://hydra.nixos.org/build/127938022/nixlog/

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).