### PR TITLE
orpie: 1.5.2 → 1.6.1

### DIFF
--- a/pkgs/applications/misc/orpie/default.nix
+++ b/pkgs/applications/misc/orpie/default.nix
@@ -1,21 +1,30 @@
-{ stdenv, fetchurl, ocamlPackages, ncurses, gsl }:
+{ lib, fetchFromGitHub, ocamlPackages }:
 
-stdenv.mkDerivation rec {
+ocamlPackages.buildDunePackage rec {
   pname = "orpie";
-  version = "1.5.2";
+  version = "1.6.1";
 
-  src = fetchurl {
-    url = "http://pessimization.com/software/orpie/${pname}-${version}.tar.gz";
-    sha256 = "0v9xgpcf186ni55rkmx008msyszw0ypd6rd98hgwpih8yv3pymfy";
+  src = fetchFromGitHub {
+    owner = "pelzlpj";
+    repo = pname;
+    rev = "release-${version}";
+    sha256 = "1rx2nl6cdv609pfymnbq53pi3ql5fr4kda8x10ycd9xq2gc4f21g";
   };
 
-  buildInputs = [ ncurses gsl ] ++ (with ocamlPackages; [ ocaml camlp4 ]);
+  preConfigure = ''
+    patchShebangs scripts
+    substituteInPlace scripts/compute_prefix \
+      --replace '"topfind"' \
+      '"${ocamlPackages.findlib}/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib/topfind"'
+    export PREFIX=$out
+  '';
+
+  buildInputs = with ocamlPackages; [ curses camlp5 num gsl ];
 
   meta = {
-    homepage = "https://github.com/pelzlpj/orpie";
-    description = "A fullscreen RPN calculator for the console";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.all;
-    maintainers = with stdenv.lib.maintainers; [ obadz ];
+    inherit (src.meta) homepage;
+    description = "A Curses-based RPN calculator";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ obadz ];
   };
 }

--- a/pkgs/development/ocaml-modules/gsl/default.nix
+++ b/pkgs/development/ocaml-modules/gsl/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchurl, buildDunePackage, pkg-config, gsl
+, dune-configurator
+}:
+
+buildDunePackage rec {
+  pname = "gsl";
+  version = "1.24.3";
+
+  minimumOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/mmottl/gsl-ocaml/releases/download/${version}/gsl-${version}.tbz";
+    sha256 = "1mpzcgbrha2l8iikqbmn32668v2mnnsykxg5n5jgs0qnskn2nvrn";
+  };
+
+  buildInputs = [ dune-configurator gsl pkg-config ];
+
+  meta = {
+    homepage = "https://mmottl.github.io/gsl-ocaml/";
+    description = "OCaml bindings to the GNU Scientific Library";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22588,10 +22588,7 @@ in
 
   opusTools = callPackage ../applications/audio/opus-tools { };
 
-  orpie = callPackage ../applications/misc/orpie {
-    gsl = gsl_1;
-    ocamlPackages = ocaml-ng.ocamlPackages_4_02;
-  };
+  orpie = callPackage ../applications/misc/orpie { };
 
   osmo = callPackage ../applications/office/osmo { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -322,6 +322,10 @@ let
       inherit (pkgs) gnuplot;
     };
 
+    gsl = callPackage ../development/ocaml-modules/gsl {
+      inherit (pkgs) gsl;
+    };
+
     hacl_x25519 = callPackage ../development/ocaml-modules/hacl_x25519 { };
 
     herelib = callPackage ../development/ocaml-modules/herelib { };


### PR DESCRIPTION
###### Motivation for this change

Compatibility with recent OCaml and GSL

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc/ @obadz maintainer