### PR TITLE
hpmyroom: 12.0.0.0220 -> 12.1.1.0257

### DIFF
--- a/pkgs/applications/networking/hpmyroom/default.nix
+++ b/pkgs/applications/networking/hpmyroom/default.nix
@@ -4,11 +4,11 @@
 }:
 mkDerivation rec {
   pname = "hpmyroom";
-  version = "12.0.0.0220";
+  version = "12.1.1.0257";
 
   src = fetchurl {
     url = "https://www.myroom.hpe.com/downloadfiles/${pname}-${version}.x86_64.rpm";
-    sha256 = "0gajj2s6l7jj8520agrv2dyisg7hhacbwzqlsp9a0xdxr0v71jhr";
+    sha256 = "1xm41v324zq1x5awgb7fr238f7ml7vq6jrfh84358i5shgha1g2k";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
A few new releases in the meantime.
See https://www.myroom.hpe.com/Support/WhatsNew

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
