### PR TITLE
cudatext: 1.111.0 -> 1.115.0

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -30,22 +30,21 @@ let
   deps = lib.mapAttrs
     (name: spec:
       fetchFromGitHub {
-        owner = "Alexey-T";
         repo = name;
-        inherit (spec) rev sha256;
+        inherit (spec) owner rev sha256;
       }
     )
     (builtins.fromJSON (builtins.readFile ./deps.json));
 in
 stdenv.mkDerivation rec {
   pname = "cudatext";
-  version = "1.111.0";
+  version = "1.115.0";
 
   src = fetchFromGitHub {
     owner = "Alexey-T";
     repo = "CudaText";
     rev = version;
-    sha256 = "1ai0g8fmw4m237dqh5dkr8w9qqricyvp49ijz2ivvmg9dsdfzjfp";
+    sha256 = "0q7gfpzc97fvyvabjdb9a4d3c2qhm4zf5bqgnsj73vkly80kgww8";
   };
 
   patches = [
@@ -74,6 +73,7 @@ stdenv.mkDerivation rec {
     cp -r --no-preserve=mode ${dep} ${name}
   '') deps) + ''
     lazbuild --lazarusdir=${lazarus}/share/lazarus --pcp=./lazarus --ws=${widgetset} \
+      bgrabitmap/bgrabitmap/bgrabitmappack.lpk \
       EncConv/encconv/encconv_package.lpk \
       ATBinHex-Lazarus/atbinhex/atbinhex_package.lpk \
       ATFlatControls/atflatcontrols/atflatcontrols_package.lpk \

--- a/pkgs/applications/editors/cudatext/deps.json
+++ b/pkgs/applications/editors/cudatext/deps.json
@@ -1,42 +1,57 @@
 {
   "EncConv": {
+    "owner": "Alexey-T",
     "rev": "2020.06.15",
     "sha256": "07dpvq3ppfq3b70i1smkf7vwdlzq8qnxs3fk94hi9h1z36bz2rw3"
   },
   "ATBinHex-Lazarus": {
+    "owner": "Alexey-T",
     "rev": "2020.09.05",
     "sha256": "022yx5vic4hnc9lz53wvr4h7hf0h71801dzlilj55x5mf8p59072"
   },
   "ATFlatControls": {
-    "rev": "2020.08.23",
-    "sha256": "1axzwiz5h62v11ncynxcg431dfbky9pwyha7cd6kpizjdjagfklw"
+    "owner": "Alexey-T",
+    "rev": "2020.09.20",
+    "sha256": "09svn8yyqp6znvfpcxrsybkclh828h5rvah7nhbhk7nrfzj8i63x"
   },
   "ATSynEdit": {
-    "rev": "2020.09.05",
-    "sha256": "0qn0fp7rbi48f3nrysb0knkd7a3a6pl5w72yf95g5iibal4zrib2"
+    "owner": "Alexey-T",
+    "rev": "2020.10.12",
+    "sha256": "07vznwwfa3c1jr1cd32yppw0mmmm1ja9bmsxhxlcbnc2nb30n9zr"
   },
   "ATSynEdit_Cmp": {
-    "rev": "2020.09.05",
-    "sha256": "1bd25zc97001b7lg0bvi8va9mazkr6jih6d2ddkabcxcnsj0dxnq"
+    "owner": "Alexey-T",
+    "rev": "2020.10.11",
+    "sha256": "11vx685i85izp7wzb34dalcwlkmkbz1vzva5j9cf2yz1jff1v4qw"
   },
   "EControl": {
-    "rev": "2020.09.05",
-    "sha256": "1n7s1zkhrr216gqdqvq6wq0n3jq7s78mwpi5s5j8054p0fak1ywi"
+    "owner": "Alexey-T",
+    "rev": "2020.10.04",
+    "sha256": "0ypbaca3y5biw2207yh3x5p28gm8g51qf7glm5622w3cgbrf9mdq"
   },
   "ATSynEdit_Ex": {
-    "rev": "2020.09.05",
-    "sha256": "17y2cx5syj3jvrszjgdyf1p6vilp2qgaggz4y8yqnz99cvd0shs7"
+    "owner": "Alexey-T",
+    "rev": "2020.10.04",
+    "sha256": "0z66cm9pgdi7whqaim6hva4aa08zrr1881n1fal7lnz6wlla824k"
   },
   "Python-for-Lazarus": {
+    "owner": "Alexey-T",
     "rev": "2020.07.31",
     "sha256": "0qbs51h6gw8qd3h06kwy1j7db35shbg7r2rayrhvvw0vzr9n330j"
   },
   "Emmet-Pascal": {
+    "owner": "Alexey-T",
     "rev": "2020.09.05",
     "sha256": "0qfiirxnk5g3whx8y8hp54ch3h6gkkd01yf79m95bwar5qvdfybg"
   },
   "CudaText-lexers": {
+    "owner": "Alexey-T",
     "rev": "2020.08.10",
     "sha256": "1gzs2psyfhb9si1qyacxzfjb3dz2v255hv7y4jlkbxdxv0kckqr6"
+  },
+  "bgrabitmap": {
+    "owner": "bgrabitmap",
+    "rev": "v11.2.4",
+    "sha256": "1zk88crfn07md16wg6af4i8nlx4ikkhxq9gfk49jirwimgwbf1md"
   }
 }

--- a/pkgs/applications/editors/cudatext/dont-check-update.patch
+++ b/pkgs/applications/editors/cudatext/dont-check-update.patch
@@ -1,8 +1,8 @@
 diff --git i/app/formmain.pas w/app/formmain.pas
-index 8c1131680..6c6c0043f 100644
+index f6f37febb..cf993d75e 100644
 --- i/app/formmain.pas
 +++ w/app/formmain.pas
-@@ -2135,6 +2135,7 @@ begin
+@@ -2156,6 +2156,7 @@ begin
      false
      {$endif};
      *)


### PR DESCRIPTION
###### Motivation for this change
[Changelog](http://uvviewsoft.com/cudatext/history.txt)

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
