### PR TITLE
google-re2: init at 0.1.20210601

### DIFF
--- a/pkgs/development/python-modules/google-re2/default.nix
+++ b/pkgs/development/python-modules/google-re2/default.nix
@@ -1,9 +1,9 @@
-{ lib, buildPythonPackage, pythonAtLeast, fetchPypi, pybind11, re2, six }:
+{ lib, buildPythonPackage, pythonOlder, fetchPypi, pybind11, re2, six }:
 
 buildPythonPackage rec {
   pname = "google-re2";
   version = "0.1.20210601";
-  disabled = !pythonAtLeast "3.6";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/google-re2/default.nix
+++ b/pkgs/development/python-modules/google-re2/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, pythonAtLeast, fetchPypi, pybind11, re2, six }:
+
+buildPythonPackage rec {
+  pname = "google-re2";
+  version = "0.1.20210601";
+  disabled = !pythonAtLeast "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1f1ql95f97ss8i0rn1c37kgi0qrf1nq9b3q8xbq9x3gwg7xgzi71";
+  };
+
+  propagatedBuildInputs = [
+    pybind11 re2 six
+  ];
+
+  meta = with lib; {
+    description = "RE2 Python bindings";
+    homepage    = "https://github.com/google/re2";
+    license     = licenses.bsd3;
+    maintainers = with maintainers; [ alexbakker ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2937,6 +2937,8 @@ in {
 
   google-pasta = callPackage ../development/python-modules/google-pasta { };
 
+  google-re2 = callPackage ../development/python-modules/google-re2 { };
+
   google-resumable-media = callPackage ../development/python-modules/google-resumable-media { };
 
   googletrans = callPackage ../development/python-modules/googletrans { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New package. Depends on #99647.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
