### PR TITLE
spasm-ng: init at unstable-2020-08-03

### DIFF
--- a/pkgs/development/compilers/spasm-ng/default.nix
+++ b/pkgs/development/compilers/spasm-ng/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, gcc, gmp, openssl, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "spasm-ng";
+
+  version = "unstable-2020-08-03";
+
+  src = fetchFromGitHub {
+    owner = "alberthdev";
+    repo = "spasm-ng";
+    rev = "221898beff2442f459b80ab89c8e1035db97868e";
+    sha256 = "0xspxmp2fir604b4xsk4hi1gjv61rnq2ypppr7cj981jlhicmvjj";
+  };
+
+  nativeBuildInputs = [ gcc ];
+
+  buildInputs = [ gmp openssl zlib ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    install -Dm755 spasm -t $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage    = "https://github.com/alberthdev/spasm-ng";
+    description = "Z80 assembler with extra features to support development for TI calculators";
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ siraben ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9789,6 +9789,8 @@ in
 
   souffle = callPackage ../development/compilers/souffle { };
 
+  spasm-ng = callPackage ../development/compilers/spasm-ng { };
+
   spirv-llvm-translator = callPackage ../development/compilers/spirv-llvm-translator { };
 
   sqldeveloper = callPackage ../development/tools/database/sqldeveloper {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
