### PR TITLE
libcint: 3.1.1 -> 4.0.2

### DIFF
--- a/pkgs/development/libraries/libcint/default.nix
+++ b/pkgs/development/libraries/libcint/default.nix
@@ -4,18 +4,18 @@
 , cmake
 , blas
   # Check Inputs
-, python2
+, python
 }:
 
 stdenv.mkDerivation rec {
   pname = "libcint";
-  version = "3.1.1";
+  version = "4.0.2";
 
   src = fetchFromGitHub {
     owner = "sunqm";
     repo = "libcint";
     rev = "v${version}";
-    sha256 = "0z1gavi7aacx68fmyzy90vzv5kff844lnxc6habs6y377dr3rwwy";
+    sha256 = "0j8fkkp3vb1936qy80sc08c327b47qxh0x2aadd1225jjq6xqxmn";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -27,8 +27,7 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
-  # Test syntax (like print statements) is written in python2. Fixed when #33 merged: https://github.com/sunqm/libcint/pull/33
-  checkInputs = [ python2.pkgs.numpy ];
+  checkInputs = [ python.pkgs.numpy ];
 
   meta = with lib; {
     description = "General GTO integrals for quantum chemistry";
@@ -39,6 +38,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://wiki.sunqm.net/libcint";
     downloadPage = "https://github.com/sunqm/libcint";
+    changelog = "https://github.com/sunqm/libcint/blob/master/ChangeLog";
     license = licenses.bsd2;
     maintainers = with maintainers; [ drewrisinger ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bump for new release: https://github.com/sunqm/libcint/releases/tag/v4.0.2
Add changelog.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
