### PR TITLE
ttf-tw-moe: first version

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3951,6 +3951,12 @@
     githubId = 2502736;
     name = "James Hillyerd";
   };
+  jiehong = {
+    email = "nixos@majiehong.com";
+    github = "Jiehong";
+    githubId = 1061229;
+    name = "Jiehong Ma";
+  };
   jirkamarsik = {
     email = "jiri.marsik89@gmail.com";
     github = "jirkamarsik";

--- a/pkgs/data/fonts/ttf-tw-moe/default.nix
+++ b/pkgs/data/fonts/ttf-tw-moe/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchzip }:
+
+fetchzip {
+  name = "ttf-tw-moe";
+
+  url = "https://github.com/Jiehong/TW-fonts/archive/b30ae75e9dc299afd61e31cfd43f7a0a157dfb1f.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile TW-fonts-b30ae75e9dc299afd61e31cfd43f7a0a157dfb1f/\*.ttf -d $out/share/fonts/truetype
+  '';
+
+  sha256 = "0khgxih9z6pqf7pdp21xjp24wb9ygsrdcmzpjb7vr9x8n78i1fbs";
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.moe.gov.tw/";
+    description = "Set of KAI and SONG fonts from the Ministry of Education of Taiwan";
+    longDescription = ''
+      Installs 2 TTF fonts: MOESongUN and TW-MOE-Std-Kai.
+      Both are provided by the Ministry of Education of Taiwan; each character's shape
+      closely follows the official recommendation, and can be used as for teaching purposes.
+    '';
+    license = licenses.cc-by-nd-30;
+    maintainers = [ maintainers.jiehong ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19476,6 +19476,8 @@ in
 
   ttf-envy-code-r = callPackage ../data/fonts/ttf-envy-code-r {};
 
+  ttf-tw-moe = callPackage ../data/fonts/ttf-tw-moe { };
+
   twemoji-color-font = callPackage ../data/fonts/twemoji-color-font {
     inherit (nodePackages) svgo;
   };


### PR DESCRIPTION
###### Motivation for this change
Add a pack of 2 fonts used as referenced for teaching in Taiwan.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
