### PR TITLE
pythonPackages: use latest qt version instead of 5.14

### DIFF
--- a/pkgs/applications/audio/carla/default.nix
+++ b/pkgs/applications/audio/carla/default.nix
@@ -15,13 +15,13 @@ assert withGtk3 -> gtk3 != null;
 
 stdenv.mkDerivation rec {
   pname = "carla";
-  version = "2.1.1";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "falkTX";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0c3y4a6cgi4bv1mg57i3qn5ia6pqjqlaylvkapj6bmpsw71ig22g";
+    sha256 = "B4xoRuNEW4Lz9haP8fqxOTcysGTNEXFOq9UXqUJLSFw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/audio/friture/default.nix
+++ b/pkgs/applications/audio/friture/default.nix
@@ -32,9 +32,8 @@ in py.buildPythonApplication rec {
     ./unlock_constraints.patch
   ];
 
-  postFixup = ''
-    wrapQtApp $out/bin/friture
-    wrapQtApp $out/bin/.friture-wrapped
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
 
   meta = with lib; {

--- a/pkgs/applications/audio/puddletag/default.nix
+++ b/pkgs/applications/audio/puddletag/default.nix
@@ -30,5 +30,6 @@ python3Packages.buildPythonApplication rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.linux;
+    broken = true; # Needs Qt wrapping
   };
 }

--- a/pkgs/applications/backup/vorta/default.nix
+++ b/pkgs/applications/backup/vorta/default.nix
@@ -28,8 +28,8 @@ buildPythonApplication rec {
   # QT setup in tests broken.
   doCheck = false;
 
-  postFixup = ''
-    wrapQtApp $out/bin/vorta
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
 
   meta = with lib; {

--- a/pkgs/applications/editors/retext/default.nix
+++ b/pkgs/applications/editors/retext/default.nix
@@ -46,11 +46,13 @@ in python.pkgs.buildPythonApplication {
   propagatedBuildInputs = [ pythonEnv ];
 
   postInstall = ''
-    wrapQtApp "$out/bin/retext" \
-      --set ASPELL_CONF "dict-dir ${buildEnv {
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+    makeWrapperArgs+=(
+      "--set" "ASPELL_CONF" "dict-dir ${buildEnv {
         name = "aspell-all-dicts";
         paths = map (path: "${path}/lib/aspell") enchantAspellDicts;
       }}"
+    )
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -10,7 +10,7 @@ let
     [ qscintilla-qt5 gdal jinja2 numpy psycopg2
       chardet dateutil pyyaml pytz requests urllib3 pygments pyqt5 sip owslib six ];
 in mkDerivation rec {
-  version = "3.10.9";
+  version = "3.10.10";
   pname = "qgis";
   name = "${pname}-unwrapped-${version}";
 
@@ -18,7 +18,7 @@ in mkDerivation rec {
     owner = "qgis";
     repo = "QGIS";
     rev = "final-${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "0d646hvrhhgsw789qc2g3iblmsvr64qh15jck1jkaljzrj3qbml6";
+    sha256 = "yZBG+bpJA7iKkUEjVo45d+bmRp9WS7mk8z96FLf0ZQ0=";
   };
 
   passthru = {

--- a/pkgs/applications/graphics/cq-editor/default.nix
+++ b/pkgs/applications/graphics/cq-editor/default.nix
@@ -2,6 +2,7 @@
 , mkDerivationWith
 , python3Packages
 , fetchFromGitHub
+, wrapQtAppsHook
 }:
 
 mkDerivationWith python3Packages.buildPythonApplication rec {
@@ -27,8 +28,9 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     requests
   ];
 
-  postFixup = ''
-    wrapQtApp "$out/bin/cq-editor"
+  nativeBuildInputs = [ wrapQtAppsHook ];
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
 
   checkInputs = with python3Packages; [

--- a/pkgs/applications/misc/dupeguru/default.nix
+++ b/pkgs/applications/misc/dupeguru/default.nix
@@ -58,5 +58,6 @@ python3Packages.buildPythonApplication rec {
     license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = [ maintainers.novoxudonoser ];
+    broken = true; # mv: cannot stat '_block.cpython-38m*.so': No such file or directory
   };
 }

--- a/pkgs/applications/misc/dupeguru/default.nix
+++ b/pkgs/applications/misc/dupeguru/default.nix
@@ -40,15 +40,15 @@ python3Packages.buildPythonApplication rec {
   # Avoid double wrapping Python programs.
   dontWrapQtApps = true;
 
+  # TODO: A bug in python wrapper
+  # see https://github.com/NixOS/nixpkgs/pull/75054#discussion_r357656916
   preFixup = ''
-    # TODO: A bug in python wrapper
-    # see https://github.com/NixOS/nixpkgs/pull/75054#discussion_r357656916
     makeWrapperArgs="''${qtWrapperArgs[@]}"
   '';
 
+  # Executable in $out/bin is a symlink to $out/share/dupeguru/run.py
+  # so wrapPythonPrograms hook does not handle it automatically.
   postFixup = ''
-    # Executable in $out/bin is a symlink to $out/share/dupeguru/run.py
-    # so wrapPythonPrograms hook does not handle it automatically.
     wrapPythonProgramsIn "$out/share/dupeguru" "$out $pythonPath"
   '';
 

--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -3,13 +3,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "electron-cash";
-  version = "4.1.0";
+  version = "4.1.1";
 
   src = fetchFromGitHub {
     owner = "Electron-Cash";
     repo = "Electron-Cash";
     rev = version;
-    sha256 = "1ccfm6kkmbkvykfdzrisxvr0lx9kgq4l43ixk6v3xnvhnbfwz4s2";
+    sha256 = "1fllz2s20lg4hrppzmnlgjy9mrq7gaq66l2apb3vz1avzvsjw3gm";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -36,15 +36,6 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [ wrapQtAppsHook ];
 
-  patches = [
-    # Patch a failed test, this can be removed in next version
-    (fetchpatch {
-      url =
-        "https://github.com/Electron-Cash/Electron-Cash/commit/1a9122d59be0c351b14c174a60880c2e927e6168.patch";
-      sha256 = "0zw629ypn9jxb1y124s3dkbbf2q3wj1i97j16lzdxpjy3sk0p5hk";
-    })
-  ];
-
   postPatch = ''
     substituteInPlace contrib/requirements/requirements.txt \
       --replace "qdarkstyle==2.6.8" "qdarkstyle<3"
@@ -70,9 +61,11 @@ python3Packages.buildPythonApplication rec {
   #   Electron Cash was unable to find the secp256k1 library on this system.
   #   Elliptic curve cryptography operations will be performed in slow
   #   Python-only mode.
-  postFixup = ''
-    wrapQtApp $out/bin/electron-cash \
-      --prefix LD_LIBRARY_PATH : ${secp256k1}/lib
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+    makeWrapperArgs+=(
+      "--prefix" "LD_LIBRARY_PATH" ":" "${secp256k1}/lib"
+    )
   '';
 
   doInstallCheck = true;

--- a/pkgs/applications/misc/electrum/ltc.nix
+++ b/pkgs/applications/misc/electrum/ltc.nix
@@ -36,8 +36,8 @@ python3Packages.buildPythonApplication rec {
     sed -i '/Created: .*/d' gui/qt/icons_rc.py
   '';
 
-  postFixup = ''
-    wrapQtApp $out/bin/electrum-ltc
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
 
   checkPhase = ''

--- a/pkgs/applications/misc/kdeconnect/default.nix
+++ b/pkgs/applications/misc/kdeconnect/default.nix
@@ -1,6 +1,7 @@
 { mkDerivation
 , lib
 , fetchurl
+, fetchpatch
 , extra-cmake-modules
 , kcmutils
 , kconfigwidgets
@@ -13,25 +14,55 @@
 , libfakekey
 , libXtst
 , qtx11extras
+, qtmultimedia
+, qtgraphicaleffects
 , sshfs
 , makeWrapper
 , kwayland
 , kio
+, kpeoplevcard
+, kpeople
+, kirigami2
+, pulseaudio-qt
 }:
 
 mkDerivation rec {
   pname = "kdeconnect";
-  version = "1.3.5";
+  version = "20.08.1";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${version}/${pname}-kde-${version}.tar.xz";
-    sha256 = "02lr3xx5s2mgddac4n3lkgr7ppf1z5m6ajs90rjix0vs8a271kp5";
+    url = "https://download.kde.org/stable/release-service/${version}/src/${pname}-kde-${version}.tar.xz";
+    sha256 = "0s76djgpx08jfmh99c7kx18mnr3w7bv4hdra120nicq89mmy7gwf";
   };
 
+  patches = [
+    # https://invent.kde.org/network/kdeconnect-kde/-/merge_requests/328
+    (fetchpatch {
+      url = "https://invent.kde.org/network/kdeconnect-kde/-/commit/6101ef3ad07d865958d58a3d2736f5536f1c5719.diff";
+      sha256 = "17mr7k13226vzcgxlmfs6q2mdc5j7vwp4iri9apmh6xlf6r591ac";
+    })
+  ];
+
   buildInputs = [
-    libfakekey libXtst
-    ki18n kiconthemes kcmutils kconfigwidgets kdbusaddons knotifications
-    qca-qt5 qtx11extras makeWrapper kwayland kio
+    libfakekey
+    libXtst
+    qtmultimedia
+    qtgraphicaleffects
+    pulseaudio-qt
+    kpeoplevcard
+    kpeople
+    kirigami2
+    ki18n
+    kiconthemes
+    kcmutils
+    kconfigwidgets
+    kdbusaddons
+    knotifications
+    qca-qt5
+    qtx11extras
+    makeWrapper
+    kwayland
+    kio
   ];
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];

--- a/pkgs/applications/networking/flent/default.nix
+++ b/pkgs/applications/networking/flent/default.nix
@@ -25,10 +25,8 @@ buildPythonApplication rec {
     xvfb-run -s '-screen 0 800x600x24' ./test-runner
   '';
 
-  postInstall = ''
-    for program in $out/bin/*; do
-      wrapQtApp $program --prefix PYTHONPATH : $PYTHONPATH
-    done
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/git-and-tools/git-annex-metadata-gui/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-annex-metadata-gui/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonApplication, fetchFromGitHub, pyqt5, git-annex-adapter }:
+{ stdenv, buildPythonApplication, fetchFromGitHub, pyqt5, qt5, git-annex-adapter }:
 
 buildPythonApplication rec {
   pname = "git-annex-metadata-gui";
@@ -13,6 +13,12 @@ buildPythonApplication rec {
 
   prePatch = ''
     substituteInPlace setup.py --replace "'PyQt5', " ""
+  '';
+
+  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
 
   propagatedBuildInputs = [ pyqt5 git-annex-adapter ];

--- a/pkgs/development/libraries/kpeoplevcard/default.nix
+++ b/pkgs/development/libraries/kpeoplevcard/default.nix
@@ -1,0 +1,40 @@
+{ mkDerivation
+, lib
+, fetchurl
+, cmake
+, extra-cmake-modules
+, pkg-config
+, kcoreaddons
+, kpeople
+, kcontacts
+}:
+
+mkDerivation rec {
+  pname = "kpeoplevcard";
+  version = "0.1";
+
+  src = fetchurl {
+    url = "https://download.kde.org/stable/${pname}/${version}/${pname}-${version}.tar.xz";
+    sha256 = "1hv3fq5k0pps1wdvq9r1zjnr0nxf8qc3vwsnzh9jpvdy79ddzrcd";
+  };
+
+  buildInputs = [
+    kcoreaddons
+    kpeople
+    kcontacts
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    extra-cmake-modules
+  ];
+
+  meta = with lib; {
+    description = "Pulseaudio bindings for Qt";
+    homepage    = "KPeople VCard Support";
+    license     = with licenses; [ lgpl2 ];
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}
+

--- a/pkgs/development/libraries/pulseaudio-qt/default.nix
+++ b/pkgs/development/libraries/pulseaudio-qt/default.nix
@@ -1,0 +1,35 @@
+{ mkDerivation
+, lib
+, fetchurl
+, cmake
+, extra-cmake-modules
+, pkg-config
+, pulseaudio
+}:
+
+mkDerivation rec {
+  pname = "pulseaudio-qt";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/${pname}/${pname}-${lib.versions.majorMinor version}.tar.xz";
+    sha256 = "1i0ql68kxv9jxs24rsd3s7jhjid3f2fq56fj4wbp16zb4wd14099";
+  };
+
+  buildInputs = [
+    pulseaudio
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    extra-cmake-modules
+  ];
+
+  meta = with lib; {
+    description = "Pulseaudio bindings for Qt";
+    homepage    = "https://invent.kde.org/libraries/pulseaudio-qt";
+    license     = with licenses; [ lgpl2 ];
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -6,17 +6,17 @@
 
 let
   pname = "qscintilla-qt${if withQt5 then "5" else "4"}";
-  version = "2.11.2";
+  version = "2.11.5";
 
 in stdenv.mkDerivation rec {
   inherit pname version;
 
   src = fetchurl {
-    url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/${version}/QScintilla_gpl-${version}.tar.gz";
-    sha256 = "18glb2v07mwfz6p8qmwhzcaaczyc36x3gn9wx8ndm7q6d93xr6q2";
+    url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/${version}/QScintilla-${version}.tar.gz";
+    sha256 = "k2Hib9f7e1gZp+uSxcGIChjem9PtndLrAI5XOIaWcWs=";
   };
 
-  sourceRoot = "QScintilla_gpl-${version}/Qt4Qt5";
+  sourceRoot = "QScintilla-${version}/Qt4Qt5";
 
   buildInputs = [ (if withQt5 then qtbase else qt4) ];
 
@@ -63,7 +63,7 @@ in stdenv.mkDerivation rec {
       background colours and multiple fonts.
     '';
     homepage = "https://www.riverbankcomputing.com/software/qscintilla/intro";
-    license = with licenses; [ gpl2 gpl3 ]; # and commercial
+    license = with licenses; [ gpl3 ]; # and commercial
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/python-modules/nose-timer/default.nix
+++ b/pkgs/development/python-modules/nose-timer/default.nix
@@ -1,0 +1,20 @@
+{ buildPythonPackage, fetchPypi, lib, nose, }:
+
+buildPythonPackage rec {
+  pname = "nose-timer";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09hwjwbczi06bfqgiylb2yxs5h88jdl26zi1fdqxdzvamrkksf2c";
+  };
+
+  propagatedBuildInputs = [ nose ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mahmoudimus/nose-timer";
+    license = licenses.mit;
+    description = "A timer plugin for nosetests (how much time does every test take?)";
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -30,12 +30,12 @@ let
 
 in buildPythonPackage rec {
   pname = "PyQt5";
-  version = "5.14.2";
+  version = "5.15.1";
   format = "other";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "1c4y4qi1l540gd125ikj0al00k5pg65kmqaixcfbzslrsrphq8xx";
+    sha256 = "18grs2p698ihjgi8agksv6sajakciywyr29ihslqvl260a2np9yr";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -7,6 +7,10 @@ let
 
   inherit (pythonPackages) buildPythonPackage python isPy3k pyqt5 enum34;
   inherit (pyqt5) sip;
+  # source: https://www.riverbankcomputing.com/pipermail/pyqt/2020-June/042985.html
+  patches = lib.optional (lib.hasPrefix "5.14" pyqt5.version)
+    [ ./fix-build-with-qt-514.patch ]
+  ;
 
 in buildPythonPackage rec {
   pname = "PyQtWebEngine";
@@ -18,10 +22,7 @@ in buildPythonPackage rec {
     sha256 = "0xdzhl07x3mzfnr5cf4d640168vxi7fyl0fz1pvpbgs0irl14237";
   };
 
-  patches = [
-    # source: https://www.riverbankcomputing.com/pipermail/pyqt/2020-June/042985.html
-    ./fix-build-with-qt-514.patch
-  ];
+  inherit patches;
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = sip-module;
-  version = "4.19.22";
+  version = "4.19.24";
   format = "other";
 
   disabled = isPyPy;
 
   src = fetchurl {
     url = "https://www.riverbankcomputing.com/static/Downloads/sip/${version}/sip-${version}.tar.gz";
-    sha256 = "0idywc326l8v1m3maprg1aq2gph67mmnnsskvlwfx8n19s16idz1";
+    sha256 = "1ra15vb5i9gkg2vdvh16cq9x2mmzw1yi3xphxs8q34q1pf83gkgd";
   };
 
   configurePhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2061,8 +2061,10 @@ in
 
   gmic = callPackage ../tools/graphics/gmic { };
 
-  gmic-qt = libsForQt514.callPackage ../tools/graphics/gmic-qt { };
+  gmic-qt = libsForQt5.callPackage ../tools/graphics/gmic-qt { };
 
+  # NOTE: If overriding qt version, krita needs to use the same qt version as
+  # well.
   gmic-qt-krita = gmic-qt.override {
     variant = "krita";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6493,7 +6493,7 @@ in
     jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };
 
-  qarte = libsForQt514.callPackage ../applications/video/qarte { };
+  qarte = libsForQt5.callPackage ../applications/video/qarte { };
 
   qlcplus = libsForQt512.callPackage ../applications/misc/qlcplus { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6595,7 +6595,7 @@ in
 
   reredirect = callPackage ../tools/misc/reredirect { };
 
-  retext = libsForQt514.callPackage ../applications/editors/retext { };
+  retext = libsForQt5.callPackage ../applications/editors/retext { };
 
   richgo = callPackage ../development/tools/richgo {  };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -278,7 +278,7 @@ in
 
   dispad = callPackage ../tools/X11/dispad { };
 
-  dupeguru = callPackage ../applications/misc/dupeguru { qt5 = qt514; };
+  dupeguru = callPackage ../applications/misc/dupeguru { };
 
   dump1090 = callPackage ../applications/radio/dump1090 { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3703,7 +3703,7 @@ in
 
   flashrom = callPackage ../tools/misc/flashrom { };
 
-  flent = python3Packages.callPackage ../applications/networking/flent { qt5 = qt514; };
+  flent = python3Packages.callPackage ../applications/networking/flent { };
 
   flpsed = callPackage ../applications/editors/flpsed { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9266,7 +9266,18 @@ in
     graalvm8-ee
     graalvm11-ee;
 
-  openshot-qt = libsForQt514.callPackage ../applications/video/openshot-qt { };
+  openshot-qt = let
+    # Cannot use a newer Qt (5.15) version because it requires qtwebkit
+    # and our qtwebkit fails to build with 5.15. 01bcfd3579219d60e5d07df309a000f96b2b658b
+    pkgs_ = pkgs.extend(_: prev: {
+      pythonInterpreters = prev.pythonInterpreters.override(oldAttrs: {
+        pkgs = oldAttrs.pkgs.extend(_: _: {
+          qt5 = pkgs.qt514;
+          libsForQt5 = pkgs.libsForQt514;
+        });
+      });
+    });
+  in pkgs_.libsForQt514.callPackage ../applications/video/openshot-qt { };
 
   openspin = callPackage ../development/compilers/openspin { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21586,7 +21586,7 @@ in
 
   k4dirstat = libsForQt5.callPackage ../applications/misc/k4dirstat { };
 
-  kdeconnect = libsForQt514.callPackage ../applications/misc/kdeconnect { };
+  kdeconnect = libsForQt5.callPackage ../applications/misc/kdeconnect { };
 
   inherit (kdeFrameworks) kdesu;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20314,7 +20314,7 @@ in
 
   electrum-dash = callPackage ../applications/misc/electrum/dash.nix { };
 
-  electrum-ltc = libsForQt514.callPackage ../applications/misc/electrum/ltc.nix { };
+  electrum-ltc = libsForQt5.callPackage ../applications/misc/electrum/ltc.nix { };
 
   elementary-planner = callPackage ../applications/office/elementary-planner { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20308,7 +20308,7 @@ in
 
   ekho = callPackage ../applications/audio/ekho { };
 
-  electron-cash = libsForQt514.callPackage ../applications/misc/electron-cash { };
+  electron-cash = libsForQt5.callPackage ../applications/misc/electron-cash { };
 
   electrum = libsForQt5.callPackage ../applications/misc/electrum { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23325,11 +23325,11 @@ in
 
   curaengine = callPackage ../applications/misc/curaengine { inherit (python3.pkgs) libarcus; };
 
-  cura = libsForQt514.callPackage ../applications/misc/cura { };
+  cura = libsForQt5.callPackage ../applications/misc/cura { };
 
   curaPlugins = callPackage ../applications/misc/cura/plugins.nix { };
 
-  curaLulzbot = libsForQt514.callPackage ../applications/misc/cura/lulzbot/default.nix { };
+  curaLulzbot = libsForQt5.callPackage ../applications/misc/cura/lulzbot/default.nix { };
 
   curaByDagoma = callPackage ../applications/misc/curabydagoma { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15066,6 +15066,8 @@ in
 
     kproperty = callPackage ../development/libraries/kproperty { };
 
+    kpeoplevcard = callPackage ../development/libraries/kpeoplevcard { };
+
     kreport = callPackage ../development/libraries/kreport { };
 
     libcommuni = callPackage ../development/libraries/libcommuni { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19741,7 +19741,17 @@ in
 
   bambootracker = libsForQt5.callPackage ../applications/audio/bambootracker { };
 
-  cadence = libsForQt514.callPackage ../applications/audio/cadence { };
+  cadence = let
+    # Use Qt 5.14 consistently
+    pkgs_ = pkgs.extend(_: prev: {
+      pythonInterpreters = prev.pythonInterpreters.override(oldAttrs: {
+        pkgs = oldAttrs.pkgs.extend(_: _: {
+          qt5 = pkgs.qt514;
+          libsForQt5 = pkgs.libsForQt514;
+        });
+      });
+    });
+  in pkgs_.libsForQt514.callPackage ../applications/audio/cadence { };
 
   cheesecutter = callPackage ../applications/audio/cheesecutter { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23025,17 +23025,7 @@ in
 
   quodlibet-xine-full = quodlibet-full.override { xineBackend = true; tag = "-xine-full"; };
 
-  qutebrowser = let
-    pkgs_ = pkgs.extend(_: prev: {
-      pythonInterpreters = prev.pythonInterpreters.override(oldAttrs: {
-        pkgs = oldAttrs.pkgs.extend(_: _: {
-          # Use 5.14 https://github.com/NixOS/nixpkgs/commit/3fafb021256bc594cecd949b3edc5bc480fc721f
-          qt5 = pkgs.qt514;
-          libsForQt5 = pkgs.libsForQt514;
-        });
-      });
-    });
-  in pkgs_.libsForQt514.callPackage ../applications/networking/browsers/qutebrowser { };
+  qutebrowser = libsForQt5.callPackage ../applications/networking/browsers/qutebrowser { };
 
   qxw = callPackage ../applications/editors/qxw {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17512,7 +17512,7 @@ in
 
   fatrace = callPackage ../os-specific/linux/fatrace { };
 
-  ffado = libsForQt514.callPackage ../os-specific/linux/ffado {
+  ffado = libsForQt5.callPackage ../os-specific/linux/ffado {
     inherit (pkgs.linuxPackages) kernel;
   };
   libffado = ffado;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16766,7 +16766,7 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
   };
 
-  qpaeq = libsForQt514.callPackage ../servers/pulseaudio/qpaeq.nix { };
+  qpaeq = libsForQt5.callPackage ../servers/pulseaudio/qpaeq.nix { };
 
   pulseaudioFull = pulseaudio.override {
     x11Support = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20936,7 +20936,7 @@ in
     opencv = python37Packages.opencv3;
   };
 
-  manuskript = libsForQt514.callPackage ../applications/editors/manuskript { };
+  manuskript = libsForQt5.callPackage ../applications/editors/manuskript { };
 
   manul = callPackage ../development/tools/manul { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21399,7 +21399,7 @@ in
   # Impressive, formerly known as "KeyJNote".
   impressive = callPackage ../applications/office/impressive { };
 
-  inkcut = libsForQt514.callPackage ../applications/misc/inkcut { };
+  inkcut = libsForQt5.callPackage ../applications/misc/inkcut { };
 
   inkscape = callPackage ../applications/graphics/inkscape {
     lcms = lcms2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20836,7 +20836,7 @@ in
 
   freerdpUnstable = freerdp;
 
-  friture = libsForQt514.callPackage ../applications/audio/friture { };
+  friture = libsForQt5.callPackage ../applications/audio/friture { };
 
   fte = callPackage ../applications/editors/fte { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10217,10 +10217,9 @@ in
   python3Packages = python3.pkgs;
 
   pythonInterpreters = callPackage ./../development/interpreters/python {
-    # Overrides that apply to all Python interpreters
+    # Overrides that apply to all Python interpreters and their packages
+    # Generally, this should be avoided.
     pkgs = pkgs.extend (final: _: {
-      qt5 = final.qt514;
-      libsForQt5 = final.libsForQt514;
     });
   };
   inherit (pythonInterpreters) python27 python36 python37 python38 python39 python3Minimal pypy27 pypy36;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23002,7 +23002,9 @@ in
     pkgs_ = pkgs.extend(_: prev: {
       pythonInterpreters = prev.pythonInterpreters.override(oldAttrs: {
         pkgs = oldAttrs.pkgs.extend(_: _: {
-          inherit (pkgs) qt5 libsForQt514;
+          # Use 5.14 https://github.com/NixOS/nixpkgs/commit/3fafb021256bc594cecd949b3edc5bc480fc721f
+          qt5 = pkgs.qt514;
+          libsForQt5 = pkgs.libsForQt514;
         });
       });
     });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21723,7 +21723,7 @@ in
 
   legit = gitAndTools.legit;
 
-  leo-editor = libsForQt514.callPackage ../applications/editors/leo-editor { };
+  leo-editor = libsForQt5.callPackage ../applications/editors/leo-editor { };
 
   libowfat = callPackage ../development/libraries/libowfat { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22878,7 +22878,18 @@ in
 
   qemu-utils = callPackage ../applications/virtualization/qemu/utils.nix {};
 
-  qgis-unwrapped = libsForQt514.callPackage ../applications/gis/qgis/unwrapped.nix {
+  # Our 3.10 LTS cannot use a newer Qt (5.15) version because it requires qtwebkit
+  # and our qtwebkit fails to build with 5.15. 01bcfd3579219d60e5d07df309a000f96b2b658b
+  qgis-unwrapped = let
+    pkgs_ = pkgs.extend(_: prev: {
+      pythonInterpreters = prev.pythonInterpreters.override(oldAttrs: {
+        pkgs = oldAttrs.pkgs.extend(_: _: {
+          qt5 = pkgs.qt514;
+          libsForQt5 = pkgs.libsForQt514;
+        });
+      });
+    });
+  in pkgs_.libsForQt514.callPackage ../applications/gis/qgis/unwrapped.nix {
       withGrass = false;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11218,7 +11218,7 @@ in
 
   kati = callPackage ../development/tools/build-managers/kati { };
 
-  kcc = libsForQt514.callPackage ../applications/graphics/kcc { };
+  kcc = libsForQt5.callPackage ../applications/graphics/kcc { };
 
   kconfig-frontends = callPackage ../development/tools/misc/kconfig-frontends {
     gperf = gperf_3_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15110,6 +15110,8 @@ in
       suffix = "qt5";
     };
 
+    pulseaudio-qt = callPackage ../development/libraries/pulseaudio-qt { };
+
     qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
 
     qmltermwidget = callPackage ../development/libraries/qmltermwidget {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24055,7 +24055,7 @@ in
 
   webcamoid = libsForQt514.callPackage ../applications/video/webcamoid { };
 
-  webmacs = libsForQt514.callPackage ../applications/networking/browsers/webmacs {};
+  webmacs = libsForQt5.callPackage ../applications/networking/browsers/webmacs {};
 
   webtorrent_desktop = callPackage ../applications/video/webtorrent_desktop {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20098,7 +20098,7 @@ in
 
   coyim = callPackage ../applications/networking/instant-messengers/coyim {};
 
-  cq-editor = libsForQt514.callPackage ../applications/graphics/cq-editor {
+  cq-editor = libsForQt5.callPackage ../applications/graphics/cq-editor {
     python3Packages = python37Packages;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22910,7 +22910,7 @@ in
 
   qmmp = libsForQt5.callPackage ../applications/audio/qmmp { };
 
-  qnotero = libsForQt514.callPackage ../applications/office/qnotero { };
+  qnotero = libsForQt5.callPackage ../applications/office/qnotero { };
 
   qrcode = callPackage ../tools/graphics/qrcode {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23036,7 +23036,7 @@ in
 
   rapcad = libsForQt514.callPackage ../applications/graphics/rapcad { boost = boost159; };
 
-  rapid-photo-downloader = libsForQt514.callPackage ../applications/graphics/rapid-photo-downloader { };
+  rapid-photo-downloader = libsForQt5.callPackage ../applications/graphics/rapid-photo-downloader { };
 
   rapidsvn = callPackage ../applications/version-management/rapidsvn { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19951,7 +19951,7 @@ in
 
   carddav-util = callPackage ../tools/networking/carddav-util { };
 
-  carla = libsForQt514.callPackage ../applications/audio/carla { };
+  carla = libsForQt5.callPackage ../applications/audio/carla { };
 
   castor = callPackage ../applications/networking/browsers/castor { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21626,7 +21626,7 @@ in
 
   kmplayer = libsForQt5.callPackage ../applications/video/kmplayer { };
 
-  kmymoney = libsForQt514.callPackage ../applications/office/kmymoney {
+  kmymoney = libsForQt5.callPackage ../applications/office/kmymoney {
     inherit (kdeApplications) kidentitymanagement;
     inherit (kdeFrameworks) kdewebkit;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20802,10 +20802,10 @@ in
 
   fractal = callPackage ../applications/networking/instant-messengers/fractal { };
 
-  freecad = libsForQt514.callPackage ../applications/graphics/freecad {
+  freecad = libsForQt5.callPackage ../applications/graphics/freecad {
     mpi = openmpi;
   };
-  freecadStable = libsForQt514.callPackage ../applications/graphics/freecad/stable.nix {
+  freecadStable = libsForQt5.callPackage ../applications/graphics/freecad/stable.nix {
     mpi = openmpi;
     opencascade-occt = opencascade-occt730;
     python3Packages = python37Packages;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19931,9 +19931,9 @@ in
 
   calculix = callPackage ../applications/science/math/calculix {};
 
-  calibre-py2 = libsForQt514.callPackage ../applications/misc/calibre { pythonPackages = python2Packages; };
+  calibre-py2 = libsForQt5.callPackage ../applications/misc/calibre { pythonPackages = python2Packages; };
 
-  calibre-py3 = libsForQt514.callPackage ../applications/misc/calibre { pythonPackages = python3Packages; };
+  calibre-py3 = libsForQt5.callPackage ../applications/misc/calibre { pythonPackages = python3Packages; };
 
   calibre = calibre-py3;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21639,7 +21639,7 @@ in
 
   kpt = callPackage ../applications/networking/cluster/kpt { };
 
-  krita = libsForQt514.callPackage ../applications/graphics/krita {
+  krita = libsForQt5.callPackage ../applications/graphics/krita {
     openjpeg = openjpeg_1;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10834,7 +10834,7 @@ in
   };
 
   # Does not actually depend on Qt 5
-  inherit (kdeFrameworks) extra-cmake-modules kapidox kdoctools;
+  inherit (kdeFrameworks) extra-cmake-modules;
 
   coccinelle = callPackage ../development/tools/misc/coccinelle {
     ocamlPackages = ocaml-ng.ocamlPackages_4_05;
@@ -15043,7 +15043,7 @@ in
       kwidgetsaddons kwindowsystem kxmlgui kxmlrpcclient modemmanager-qt
       networkmanager-qt plasma-framework prison qqc2-desktop-style solid sonnet
       syntax-highlighting syndication threadweaver kirigami2 kholidays kpurpose
-      kcontacts kquickcharts;
+      kcontacts kquickcharts kdoctools kapidox;
 
     ### KDE PLASMA 5
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4050,6 +4050,8 @@ in {
 
   nose-focus = callPackage ../development/python-modules/nose-focus { };
 
+  nose-timer = callPackage ../development/python-modules/nose-timer { };
+
   nosejs = callPackage ../development/python-modules/nosejs { };
 
   nose-of-yeti = callPackage ../development/python-modules/nose-of-yeti { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

In https://github.com/NixOS/nixpkgs/commit/3cbcc14eef897607c50be4a9918d88614ea9881e the Qt version used in Python packages was pinned to 5.14. This was done because certain *applications* were not compatible. In principle, we should try to have the same Qt version in the Python packages set as in the top-level set, and override applications in case they're not compatible.

There were some problems with how the pinning to 5.14 was done, which eventually led to https://github.com/NixOS/nixpkgs/pull/98197.

This PR now unpins the Qt version. Applications are going to need some fixing, as is done for Qutebrowser in https://github.com/NixOS/nixpkgs/pull/98197.

This fixes https://github.com/NixOS/nixpkgs/issues/99937 + fixes https://github.com/NixOS/nixpkgs/issues/99982 + fixes #99951 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


# Packages

Just to note anyone wishing to help, these are the affected packages, filtered from ofborg's eval:

- [x] aj-snapshot
- [x] anki
- [x] ankisyncd
- [x] appleseed
- [x] asymptote
- [x] audiality2
- [x] backintime
- [x] backintime-qt4
- [x] cadence
- [x] calibre
- [x] calibre-py2 - build and run with `libsForQt5.callPackage` (instead of `libsForQt514.callPackage`) - not sure if this needs to be committed, considering https://github.com/NixOS/nixpkgs/commit/22167ae45fb27fac1e6aec7d1bf6ce82516fcb12 .
- [x] calibre-py3 - build and run with `libsForQt5.callPackage` (instead of `libsForQt514.callPackage`) - not sure if this needs to be committed, considering https://github.com/NixOS/nixpkgs/commit/22167ae45fb27fac1e6aec7d1bf6ce82516fcb12 .
- [x] carla
- [x] cq-editor
- [x] cura - The gui seems to work, though it segfaulted when I quit the program, and the console showed lots of deprecation warning. If qt5.14 will be desired for it, it will need a big diff for an override.
- [x] curaengine
- [x] curaLulzbot - same as cura
- [ ] dupeguru - fails to build from before this change ([example](https://hydra.nixos.org/build/127857616)).
- [x] electron-cash
- [x] electrum
- [x] electrum-ltc
- [x] faust2jack - only affected by sip patch, should be find if it builds.
- [x] faust2jaqt - only affected by sip patch, should be find if it builds.
- [x] fdroidserver
- [x] ffado - only affected by sip patch, should be find if it builds.
- [x] flatcam
- [x] flent
- [x] freecad
- [x] freecadStable
- [x] frescobaldi
- [x] friture - runs fine sort of, no qt related errors but does print opengl related errors.
- [x] giada
- [x] gitAndTools.git-annex-metadata-gui
- [x] gitAndTools.git-cola
- [x] git-cola
- [x] gmic-qt-krita
- [ ] gns3-gui - should be OK, as it's only pyqt5 that was upgraded for it.
- [x] gnss-sdr - should be tested with https://github.com/NixOS/nixpkgs/pull/99685
- [x] gnuradio - should be tested with https://github.com/NixOS/nixpkgs/pull/99685
- [x] gnuradio-with-packages - should be unaffected with https://github.com/NixOS/nixpkgs/pull/99685
- [x] gqrx - should be unaffected with https://github.com/NixOS/nixpkgs/pull/99685
- [x] gr-ais - should be unaffected with https://github.com/NixOS/nixpkgs/pull/99685
- [x] gr-gsm - should be unaffected with https://github.com/NixOS/nixpkgs/pull/99685
- [x] gr-limesdr - should be unaffected with https://github.com/NixOS/nixpkgs/pull/99685
- [x] gr-nacl - should be unaffected with https://github.com/NixOS/nixpkgs/pull/99685
- [x] gr-osmosdr - should be unaffected with https://github.com/NixOS/nixpkgs/pull/99685
- [x] gr-rds - should be unaffected with https://github.com/NixOS/nixpkgs/pull/99685
- [x] hplip
- [ ] hplip_3_16_11
- [ ] hplip_3_18_5
- [x] hplipWithPlugin
- [ ] hplipWithPlugin_3_16_11
- [ ] hplipWithPlugin_3_18_5
- [ ] ihaskell
- [x] inkcut
- [x] inspectrum - should be unaffected with https://github.com/NixOS/nixpkgs/pull/99685
- [ ] jack1
- [ ] jack2
- [ ] jack2Full
- [ ] jackmix_jack1
- [x] kcc
- [x] kmymoney
- [ ] koboredux
- [ ] koboredux-free
- [x] krita
- [x] krop
- [ ] labelImg - - should be OK, as it's only pyqt5 that was upgraded for it.
- [x] leo-editor
- [x] libffado
- [x] littlegptracker
- [x] lsp-plugins
- [x] ltc-tools
- [x] luppp
- [x] maestral-gui (https://github.com/NixOS/nixpkgs/pull/99589)
- [x] manuskript
- [ ] mnemosyne
- [ ] mooSpace
- [ ] multibootusb
- [ ] nagstamon
- [x] onionshare
- [x] onionshare-gui
- [x] openshot-qt
- [x] persepolis
- [X] picard - should be OK
- [ ] plover.dev
- [x] puddletag (`qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
`)
- [x] pulseeffects
- [x] python27Packages.androguard
- [ ] python27Packages.appleseed
- [ ] python27Packages.binwalk-full
- [ ] python27Packages.jupyter
- [ ] python27Packages.pivy
- [ ] python27Packages.poppler-qt5
- [ ] python27Packages.pykdl
- [ ] python27Packages.pyqt4
- [x] python27Packages.pyqt5
- [x] python27Packages.pyqt5_with_qtmultimedia
- [ ] python27Packages.pyqt5_with_qtwebkit
- [ ] python27Packages.pyqtgraph
- [ ] python27Packages.pyqtwebengine
- [ ] python27Packages.pyside2
- [ ] python27Packages.pyside2-tools
- [ ] python27Packages.qscintilla
- [x] python27Packages.qscintilla-qt4
- [ ] python27Packages.qscintilla-qt5
- [ ] python27Packages.qtconsole
- [ ] python27Packages.shiboken2
- [x] python27Packages.sip
- [ ] python27Packages.subdownloader
- [x] python3Packages.androguard
- [ ] python3Packages.ansible-kernel
- [ ] python3Packages.binwalk-full
- [ ] python3Packages.enaml
- [ ] python3Packages.enamlx
- [ ] python3Packages.jupyter
- [ ] python3Packages.libarcus
- [ ] python3Packages.libsavitar
- [ ] python3Packages.lightparam
- [ ] python3Packages.mayavi
- [ ] python3Packages.pivy
- [ ] python3Packages.poppler-qt5
- [ ] python3Packages.pykdl
- [x] python3Packages.pyqt4
- [x] python3Packages.pyqt5
- [x] python3Packages.pyqt5_with_qtmultimedia
- [x] python3Packages.pyqt5_with_qtwebkit
- [ ] python3Packages.pyqtgraph
- [ ] python3Packages.pyqtwebengine
- [ ] python3Packages.pyside2
- [ ] python3Packages.pyside2-tools
- [ ] python3Packages.qimage2ndarray
- [ ] python3Packages.qreactor
- [ ] python3Packages.qscintilla-qt5
- [ ] python3Packages.qtconsole
- [ ] python3Packages.quamash
- [ ] python3Packages.roboschool
- [ ] python3Packages.shiboken2
- [x] python3Packages.sip
- [ ] python3Packages.skein
- [x] python3Packages.spyder
- [ ] python3Packages.spyder_3 (`qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.`, old version, probably best removed)
- [ ] python3Packages.stytra
- [ ] python3Packages.trezor_agent
- [ ] python3Packages.uranium
- [ ] python3Packages.vega
- [x] python3Packages.weboob - builds, but I couldn't find a single binary that should launch a gui there.
- [x] qarte
- [x] qgis (`error: no matching function for call to ‘QsciAPIs::QsciAPIs()’`)
- [x] qgis-unwrapped
- [x] qnotero
- [x] qpaeq
- [x] qradiolink - should be unaffected / tested along with https://github.com/NixOS/nixpkgs/pull/99685
- [x] qutebrowser - Should work, given that qt is not updated for it ([commit](https://github.com/NixOS/nixpkgs/pull/99956/commits/2667af4062ef0710b486fbae3108e0141aecb0fc)).
- [x] rapid-photo-downloader
- [x] retext
- [ ] scudcloud
- [ ] seexpr
- [ ] shotcut
- [ ] sl1-to-photon
- [ ] sonic-pi
- [x] soundtracker
- [x] spyder
- [x] sumorobot-manager
- [x] syncplay
- [ ] tambura
- [ ] tetraproc
- [x] tortoisehg
- [ ] trezor_agent
- [ ] tribler
- [x] tuxguitar
- [ ] urh
- [ ] virtscreen
- [x] vorta
- [x] webbrowser
- [ ] webcamoid
- [x] webmacs