### PR TITLE
gamehub: init at 0.16.0-1

### DIFF
--- a/pkgs/games/gamehub/default.nix
+++ b/pkgs/games/gamehub/default.nix
@@ -1,6 +1,6 @@
 { stdenv ,fetchFromGitHub ,
   meson ,ninja ,vala ,pkg-config ,desktop-file-utils ,
-  glib ,gtk3 ,libgee ,libsoup ,json-glib ,sqlite ,webkitgtk ,libmanette ,libXtst
+  glib ,gtk3 ,libgee ,libsoup ,json-glib ,sqlite ,webkitgtk ,libmanette ,libXtst ,wrapGAppsHook
 }:
 stdenv.mkDerivation rec {
   pname = "GameHub";
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-QcpqGydNkmAPrPxp/52+D6MS1I7k+CKHxr3/tpCukP8=";
   };
   nativeBuildInputs = [
-    meson ninja vala pkg-config desktop-file-utils
+    meson ninja vala pkg-config
+    desktop-file-utils wrapGAppsHook
 
   ];
   propagatedBuildInputs = [

--- a/pkgs/games/gamehub/default.nix
+++ b/pkgs/games/gamehub/default.nix
@@ -1,0 +1,22 @@
+{ stdenv ,fetchFromGitHub ,
+  meson ,ninja ,vala ,pkg-config ,desktop-file-utils ,
+  glib ,gtk3 ,libgee ,libsoup ,json-glib ,sqlite ,webkitgtk ,libmanette ,libXtst
+}:
+stdenv.mkDerivation rec {
+  pname = "GameHub";
+  version = "0.16.0-1";
+  src = fetchFromGitHub {
+    owner = "tkashkin";
+    repo = pname;
+    rev = "${version}-master";
+    sha256 = "sha256-QcpqGydNkmAPrPxp/52+D6MS1I7k+CKHxr3/tpCukP8=";
+  };
+  nativeBuildInputs = [
+    meson ninja vala pkg-config desktop-file-utils
+
+  ];
+  propagatedBuildInputs = [
+    glib gtk3 libgee libsoup
+    json-glib sqlite webkitgtk libmanette libXtst
+  ];
+}

--- a/pkgs/games/gamehub/default.nix
+++ b/pkgs/games/gamehub/default.nix
@@ -20,4 +20,11 @@ stdenv.mkDerivation rec {
     glib gtk3 libgee libsoup
     json-glib sqlite webkitgtk libmanette libXtst
   ];
+  meta = with stdenv.lib;{
+    description = "All your games in one place";
+    homepage = "https://tkashkin.tk/projects/gamehub/";
+    mantainers = with mantainers;[ pasqui23 ];
+    license = with licenses;[ gpl3Only ];
+    platforms = with platforms;[ linux ];
+  };
 }

--- a/pkgs/games/gamehub/default.nix
+++ b/pkgs/games/gamehub/default.nix
@@ -17,15 +17,18 @@
 , libXtst
 , wrapGAppsHook
 }:
+
 stdenv.mkDerivation rec {
   pname = "GameHub";
   version = "0.16.0-1";
+
   src = fetchFromGitHub {
     owner = "tkashkin";
     repo = pname;
     rev = "${version}-master";
     sha256 = "sha256-QcpqGydNkmAPrPxp/52+D6MS1I7k+CKHxr3/tpCukP8=";
   };
+
   nativeBuildInputs = [
     meson
     ninja
@@ -46,11 +49,12 @@ stdenv.mkDerivation rec {
     libmanette
     libXtst
   ];
-  meta = with lib;{
+
+  meta = with lib; {
     description = "All your games in one place";
     homepage = "https://tkashkin.tk/projects/gamehub/";
-    mantainers = with mantainers;[ pasqui23 ];
-    license = with licenses;[ gpl3Only ];
-    platforms = with platforms;[ linux ];
+    mantainers = with mantainers; [ pasqui23 ];
+    license = with licenses; [ gpl3Only ];
+    platforms = with platforms; [ linux ];
   };
 }

--- a/pkgs/games/gamehub/default.nix
+++ b/pkgs/games/gamehub/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , fetchFromGitHub
 , meson
 , ninja
@@ -45,7 +46,7 @@ stdenv.mkDerivation rec {
     libmanette
     libXtst
   ];
-  meta = with stdenv.lib;{
+  meta = with lib;{
     description = "All your games in one place";
     homepage = "https://tkashkin.tk/projects/gamehub/";
     mantainers = with mantainers;[ pasqui23 ];

--- a/pkgs/games/gamehub/default.nix
+++ b/pkgs/games/gamehub/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "All your games in one place";
     homepage = "https://tkashkin.tk/projects/gamehub/";
-    mantainers = with mantainers; [ pasqui23 ];
+    mantainers = with maintainers; [ pasqui23 ];
     license = with licenses; [ gpl3Only ];
     platforms = with platforms; [ linux ];
   };

--- a/pkgs/games/gamehub/default.nix
+++ b/pkgs/games/gamehub/default.nix
@@ -1,6 +1,20 @@
-{ stdenv ,fetchFromGitHub ,
-  meson ,ninja ,vala ,pkg-config ,desktop-file-utils ,
-  glib ,gtk3 ,libgee ,libsoup ,json-glib ,sqlite ,webkitgtk ,libmanette ,libXtst ,wrapGAppsHook
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, vala
+, pkg-config
+, desktop-file-utils
+, glib
+, gtk3
+, libgee
+, libsoup
+, json-glib
+, sqlite
+, webkitgtk
+, libmanette
+, libXtst
+, wrapGAppsHook
 }:
 stdenv.mkDerivation rec {
   pname = "GameHub";
@@ -12,13 +26,24 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-QcpqGydNkmAPrPxp/52+D6MS1I7k+CKHxr3/tpCukP8=";
   };
   nativeBuildInputs = [
-    meson ninja vala pkg-config
-    desktop-file-utils wrapGAppsHook
+    meson
+    ninja
+    vala
+    pkg-config
+    desktop-file-utils
+    wrapGAppsHook
 
   ];
   propagatedBuildInputs = [
-    glib gtk3 libgee libsoup
-    json-glib sqlite webkitgtk libmanette libXtst
+    glib
+    gtk3
+    libgee
+    libsoup
+    json-glib
+    sqlite
+    webkitgtk
+    libmanette
+    libXtst
   ];
   meta = with stdenv.lib;{
     description = "All your games in one place";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18007,6 +18007,8 @@ in
   };
 
   fusionInventory = callPackage ../servers/monitoring/fusion-inventory { };
+  
+  gamehub = callPackage ../games/gamehub { };
 
   gatling = callPackage ../servers/http/gatling { };
 


### PR DESCRIPTION


###### Motivation for this change
Gamehub is a game launcher supporting Steam,GOG and Humble Bundle

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Compiles,but it cores dump with:
```
nix shell .#gamehub -c gamehub   
Gtk-Message: 16:03:18.564: Failed to load module "appmenu-gtk-module"
zsh: trace trap (core dumped)  nix shell .#gamehub -c gamehub
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
