### PR TITLE
terraform-providers.cloudfoundry: init at 0.12.4

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/cloudfoundry/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/cloudfoundry/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "terraform-provider-cloudfoundry";
+  version = "0.12.6";
+
+  src = fetchFromGitHub {
+    owner = "cloudfoundry-community";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0n5ybpzk6zkrnd9vpmbjlkm8fdp7nbfr046wih0jk72pmiyrcygi";
+  };
+
+  vendorSha256 = "01lfsd9aw9w3kr1a2a5b7ac6d8jaij83lhxl4y4qsnjlqk86fbxq";
+
+  # needs a running cloudfoundry
+  doCheck = false;
+
+  postInstall = "mv $out/bin/terraform-provider-cloudfoundry{,_v${version}}";
+
+  passthru = { provider-source-address = "registry.terraform.io/cloudfoundry-community/cloudfoundry"; };
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry";
+    description = "Terraform provider for cloudfoundry";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -142,6 +142,7 @@ let
 
     # Packages that don't fit the default model
     ansible = callPackage ./ansible {};
+    cloudfoundry = callPackage ./cloudfoundry {};
     elasticsearch = callPackage ./elasticsearch {};
     gandi = callPackage ./gandi {};
     keycloak = callPackage ./keycloak {};


### PR DESCRIPTION
###### Motivation for this change
Adds cloudfoundry terraform provider.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
