### PR TITLE
asterisk: Bump all packages

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -24,9 +24,8 @@ let
       ./runtime-vardirs.patch
     ];
 
-    # Disable MD5 verification for pjsip
     postPatch = ''
-      sed -i 's|$(verify_tarball)|true|' third-party/pjproject/Makefile
+      echo "PJPROJECT_CONFIG_OPTS += --prefix=$out" >> third-party/pjproject/Makefile.rules
     '';
 
     src = fetchurl {
@@ -51,6 +50,7 @@ let
 
       chmod -w externals_cache
     '';
+
     configureFlags = [
       "--libdir=\${out}/lib"
       "--with-lua=${lua}/lib"
@@ -68,6 +68,7 @@ let
     postInstall = ''
       # Install sample configuration files for this version of Asterisk
       make samples
+      ${lib.optionalString (lib.versionAtLeast version "17.0.0") "make install-headers"}
     '';
 
     meta = with stdenv.lib; {
@@ -78,14 +79,9 @@ let
     };
   };
 
-  pjproject_2_7_1 = fetchurl {
-    url = "https://www.pjsip.org/release/2.7.1/pjproject-2.7.1.tar.bz2";
-    sha256 = "09ii5hgl5s7grx4fiimcl3s77i385h7b3kwpfa2q0arbl1ibryjr";
-  };
-
-  pjproject_2_8 = fetchurl {
-    url = "https://www.pjsip.org/release/2.8/pjproject-2.8.tar.bz2";
-    sha256 = "0ybg0113rp3fk49rm2v0pcgqb28h3dv1pdy9594w2ggiz7bhngah";
+  pjproject_2_10 = fetchurl {
+    url = "https://raw.githubusercontent.com/asterisk/third-party/master/pjproject/2.10/pjproject-2.10.tar.bz2";
+    sha256 = "14qmddinm4bv51rl0wwg5133r64x5bd6inwbx27ahb2n0151m2if";
   };
 
   mp3-202 = fetchsvn {
@@ -95,61 +91,42 @@ let
   };
 
 in rec {
-  # Supported releases (as of 2018-11-20).
+  # Supported releases (as of 2020-10-07).
+  # Source: https://wiki.asterisk.org/wiki/display/AST/Asterisk+Versions
+  # Exact version can be found at https://www.asterisk.org/downloads/asterisk/all-asterisk-versions/
   #
   # Series  Type       Rel. Date   Sec. Fixes  EOL
   # 13.x    LTS        2014-10-24  2020-10-24  2021-10-24
-  # 15.x    Standard   2017-10-03  2018-10-03  2019-10-03
-  asterisk-stable = asterisk_15;
   # 16.x    LTS        2018-10-09  2022-10-09  2023-10-09
   asterisk-lts = asterisk_16;
-  asterisk = asterisk_16;
+  # 17.x    Standard   2019-10-28  2020-10-28  2021-10-28
+  asterisk-stable = asterisk_17;
+  asterisk = asterisk_17;
 
   asterisk_13 = common {
-    version = "13.24.1";
-    sha256 = "1mclpk7knqjl6jr6mpvhb17wsjah4bk2xqhb3shpx1j4z19xkmm3";
+    version = "13.36.0";
+    sha256 = "1p41xrxmzpqmjgvrl7f4vbigiqpmg60fd8bqg5rxbf4lxzpvknnp";
     externals = {
-      "externals_cache/pjproject-2.7.1.tar.bz2" = pjproject_2_7_1;
-      "addons/mp3" = mp3-202;
-    };
-  };
-
-  asterisk_15 = common {
-    version = "15.7.0";
-    sha256 = "1ngs73h4lz94b4f3shy1yb5laqy0z03zf451xa1nihrgp1h3ilyv";
-    externals = {
-      "externals_cache/pjproject-2.8.tar.bz2" = pjproject_2_8;
+      "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
       "addons/mp3" = mp3-202;
     };
   };
 
   asterisk_16 = common {
-    version = "16.1.1";
-    sha256 = "19bfvqmxphk2608jx7jghfy7rdbj1qj5vw2fyb0fq4xjvx919wmv";
+    version = "16.13.0";
+    sha256 = "01nja8hd6jk1966awc2vcz3hl46pvhi797k515q87vzmap1khlp9";
     externals = {
-      "externals_cache/pjproject-2.8.tar.bz2" = pjproject_2_8;
+      "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
       "addons/mp3" = mp3-202;
     };
   };
 
-  #asterisk-git = common {
-  #  version = "15-pre";
-  #  sha256 = "...";
-  #  externals = {
-  #    "externals_cache/pjproject-2.5.5.tar.bz2" = pjproject-255;
-  #    # Note that these sounds are included with the release tarball. They are
-  #    # provided here verbatim for the convenience of anyone wanting to build
-  #    # Asterisk from other sources. Include in externals.
-  #    "sounds/asterisk-core-sounds-en-gsm-1.5.tar.gz" = fetchurl {
-  #      url = "http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-core-sounds-en-gsm-1.5.tar.gz";
-  #      sha256 = "01xzbg7xy0c5zg7sixjw5025pvr4z64kfzi9zvx19im0w331h4cd";
-  #    };
-  #    "sounds/asterisk-moh-opsound-wav-2.03.tar.gz" = fetchurl {
-  #      url = "http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-moh-opsound-wav-2.03.tar.gz";
-  #      sha256 = "449fb810d16502c3052fedf02f7e77b36206ac5a145f3dacf4177843a2fcb538";
-  #    };
-  #    # TODO: Sounds for other languages could be added here
-  #  }
-  #}.overrideDerivation (_: {src = fetchgit {...}})
-
+  asterisk_17 = common {
+    version = "17.7.0";
+    sha256 = "0lsglrh3l823200rmkay3pgy42k0fsij610s3s4vd3zv4jjb1g0s";
+    externals = {
+      "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
+      "addons/mp3" = mp3-202;
+    };
+  };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -46,6 +46,7 @@ mapAliases ({
   arduino_core = arduino-core;  # added 2015-02-04
   arora = throw "arora has been removed."; # added 2020-09-09
   asciidocFull = asciidoc-full;  # added 2014-06-22
+  asterisk_15 = throw "Asterisk 15 is end of life and has been removed."; # added 2020-10-07
   at_spi2_atk = at-spi2-atk; # added 2018-02-25
   at_spi2_core = at-spi2-core; # added 2018-02-25
   avldrums-lv2 = x42-avldrums; # added 2020-03-29

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16361,7 +16361,7 @@ in
 
   inherit (callPackages ../servers/asterisk { })
     asterisk asterisk-stable asterisk-lts
-    asterisk_13 asterisk_15 asterisk_16;
+    asterisk_13 asterisk_16 asterisk_17;
 
   asterisk-module-sccp = callPackage ../servers/asterisk/sccp { };
 


### PR DESCRIPTION
All packages were outdated.
Asterisk 15 is not supported anymore, but there is 17 now.

All versions bumped pjproject to 2.10 which requires overriding the
prefix.

Since Asterisk 17, `make install-headers` seems to be needed.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
