### PR TITLE
horizon-eda: init at 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3319,6 +3319,12 @@
     githubId = 10654650;
     name = "Guillaume Koenig";
   };
+  guserav = {
+    email = "guserav@users.noreply.github.com";
+    github = "guserav";
+    githubId = 28863828;
+    name = "guserav";
+  };
   guyonvarch = {
     email = "joris@guyonvarch.me";
     github = "guyonvarch";

--- a/pkgs/applications/science/electronics/horizon-eda/default.nix
+++ b/pkgs/applications/science/electronics/horizon-eda/default.nix
@@ -1,0 +1,75 @@
+{ stdenv
+, boost
+, coreutils
+, cppzmq
+, curl
+, epoxy
+, fetchFromGitHub
+, glm
+, gnome3
+, lib
+, libgit2
+, librsvg
+, libuuid
+, libzip
+, opencascade
+, pkgconfig
+, podofo
+, python3
+, sqlite
+, wrapGAppsHook
+, zeromq
+}:
+
+stdenv.mkDerivation rec {
+  pname = "horizon-eda";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "horizon-eda";
+    repo = "horizon";
+    rev = "v${version}";
+    sha256 = "0b1bi99xdhbkb2vdb9y6kyqm0h8y0q168jf2xi8kd0z7kww8li2p";
+  };
+
+  buildInputs = [
+    cppzmq
+    curl
+    epoxy
+    glm
+    gnome3.gtkmm
+    libgit2
+    librsvg
+    libuuid
+    libzip
+    opencascade
+    podofo
+    python3
+    sqlite
+    zeromq
+  ];
+
+  nativeBuildInputs = [
+    boost.dev
+    pkgconfig
+    wrapGAppsHook
+  ];
+
+  CASROOT = opencascade;
+
+  installFlags = [
+    "INSTALL=${coreutils}/bin/install"
+    "DESTDIR=$(out)"
+    "PREFIX="
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "A free EDA software to develop printed circuit boards";
+    homepage = "https://horizon-eda.org";
+    maintainers = with maintainers; [ guserav ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26573,6 +26573,8 @@ in
 
   fped = callPackage ../applications/science/electronics/fped { };
 
+  horizon-eda = callPackage ../applications/science/electronics/horizon-eda {};
+
   # this is a wrapper for kicad.base and kicad.libraries
   kicad = callPackage ../applications/science/electronics/kicad { };
   kicad-small = kicad.override { pname = "kicad-small"; with3d = false; };


### PR DESCRIPTION
Mostly based on #86694 by yrashk

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
