### PR TITLE
vscode.fhs: add buildFHSUserEnv wrapped version

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -1,7 +1,8 @@
 { stdenv, lib, makeDesktopItem
 , unzip, libsecret, libXScrnSaver, libxshmfence, wrapGAppsHook
 , gtk2, atomEnv, at-spi2-atk, autoPatchelfHook
-, systemd, fontconfig, libdbusmenu
+, systemd, fontconfig, libdbusmenu, buildFHSUserEnvBubblewrap
+, writeShellScriptBin
 
 # Populate passthru.tests
 , tests
@@ -13,13 +14,14 @@
 
 let
   inherit (stdenv.hostPlatform) system;
-in
-  stdenv.mkDerivation {
+  unwrapped = stdenv.mkDerivation {
 
     inherit pname version src sourceRoot;
 
     passthru = {
       inherit executableName tests;
+      fhs = fhs {};
+      fhsWithPackages = f: fhs { additionalPkgs = f; };
     };
 
     desktopItem = makeDesktopItem {
@@ -97,4 +99,59 @@ in
     '';
 
     inherit meta;
-  }
+  };
+
+  # Vscode and variants allow for users to download and use extensions
+  # which often include the usage of pre-built binaries.
+  # This has been an on-going painpoint for many users, as
+  # a full extension update cycle has to be done through nixpkgs
+  # in order to create or update extensions.
+  # See: #83288 #91179 #73810 #41189
+  #
+  # buildFHSUserEnv allows for users to use the existing vscode
+  # extension tooling without significant pain.
+  fhs = { additionalPkgs ? pkgs: [] }: buildFHSUserEnvBubblewrap {
+    # also determines the name of the wrapped command
+    name = executableName;
+
+    # additional libraries which are commonly needed for extensions
+    targetPkgs = pkgs: (with pkgs; [
+      # ld-linux-x86-64-linux.so.2 and others
+      glibc
+
+      # dotnet
+      curl
+      icu
+      libunwind
+      libuuid
+      openssl
+      zlib
+
+      # mono
+      krb5
+    ]) ++ additionalPkgs pkgs;
+
+    # restore desktop item icons
+    extraInstallCommands = ''
+      mkdir -p $out/share/applications
+      for item in ${unwrapped}/share/applications/*.desktop; do
+        ln -s $item $out/share/applications/
+      done
+    '';
+
+    runScript = "${unwrapped}/bin/${executableName}";
+
+    # vscode likes to kill the parent so that the
+    # gui application isn't attached to the terminal session
+    dieWithParent = false;
+
+    passthru = {
+      inherit executableName;
+      inherit (unwrapped) pname version; # for home-manager module
+    };
+
+    inherit meta;
+  };
+in
+  unwrapped
+

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -150,7 +150,12 @@ let
       inherit (unwrapped) pname version; # for home-manager module
     };
 
-    inherit meta;
+    meta = meta // {
+      description = ''
+        Wrapped variant of ${pname} which launches in a FHS compatible envrionment.
+        Should allow for easy usage of extensions without nix-specific modifications.
+      '';
+    };
   };
 in
   unwrapped

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -14,6 +14,7 @@ args @ {
 , unshareNet ? false
 , unshareUts ? true
 , unshareCgroup ? true
+, dieWithParent ? true
 , ...
 }:
 
@@ -22,7 +23,7 @@ let
   buildFHSEnv = callPackage ./env.nix { };
 
   env = buildFHSEnv (removeAttrs args [
-    "runScript" "extraInstallCommands" "meta" "passthru"
+    "runScript" "extraInstallCommands" "meta" "passthru" "dieWithParent"
     "unshareUser" "unshareCgroup" "unshareUts" "unshareNet" "unsharePid" "unshareIpc"
   ]);
 
@@ -30,6 +31,13 @@ let
     files = [
       # NixOS Compatibility
       "static"
+      "nix" # mainly for nixUnstable users, but also for access to nix/netrc
+      # Shells
+      "bashrc"
+      "zshenv"
+      "zshrc"
+      "zinputrc"
+      "zprofile"
       # Users, Groups, NSS
       "passwd"
       "group"
@@ -136,7 +144,7 @@ let
       ${lib.optionalString unshareNet "--unshare-net"}
       ${lib.optionalString unshareUts "--unshare-uts"}
       ${lib.optionalString unshareCgroup "--unshare-cgroup"}
-      --die-with-parent
+      ${lib.optionalString dieWithParent "--die-with-parent"}
       --ro-bind /nix /nix
       # Our glibc will look for the cache in its own path in `/nix/store`.
       # As such, we need a cache to exist there, because pressure-vessel

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26652,6 +26652,8 @@ in
   };
 
   vscode = callPackage ../applications/editors/vscode/vscode.nix { };
+  vscode-fhs = vscode.fhs;
+  vscode-fhsWithPackages = vscode.fhsWithPackages;
 
   vscode-with-extensions = callPackage ../applications/editors/vscode/with-extensions.nix {};
 
@@ -26660,6 +26662,8 @@ in
   vscode-extensions = recurseIntoAttrs (callPackage ../misc/vscode-extensions {});
 
   vscodium = callPackage ../applications/editors/vscode/vscodium.nix { };
+  vscodium-fhs = vscodium.fhs;
+  vscodium-fhsWithPackages = vscodium.fhsWithPackages;
 
   code-server = callPackage ../servers/code-server {
     inherit (darwin.apple_sdk.frameworks) AppKit Cocoa Security;


### PR DESCRIPTION
###### Motivation for this change
Extensions commonly use pre-compiled binaries which aren't
aware of the nix store. Using buildFHSUserEnv will allow
for a more "natural" usage of vscode.

EDIT:
To not break users due to FHSUser regressions, I'm instead adding this as a passthru to the original vscode/vscodium flavors.

closes: #73810
closes: #91179

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
