### PR TITLE
python3Packages.nipype: disable neurdflib by default to avoid package collision

### DIFF
--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -21,6 +21,7 @@
 , pytest
 , pytest_xdist
 , pytest-forked
+, rdflib
 , scipy
 , simplejson
 , traits
@@ -33,6 +34,10 @@
 , bash
 , glibcLocales
 , callPackage
+# causes Python packaging conflict with any package requiring rdflib,
+# so use the unpatched rdflib by default (disables Nipype provenance tracking);
+# see https://github.com/nipy/nipype/issues/2888:
+, useNeurdflib ? false
 }:
 
 let
@@ -69,7 +74,6 @@ buildPythonPackage rec {
     funcsigs
     future
     networkx
-    neurdflib
     nibabel
     numpy
     packaging
@@ -80,7 +84,7 @@ buildPythonPackage rec {
     simplejson
     traits
     xvfbwrapper
-  ];
+  ] ++ [ (if useNeurdflib then neurdflib else rdflib) ];
 
   checkInputs = [
     pybids

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -1,23 +1,19 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, isPy3k
-, isPy38
+, isPy27
 # python dependencies
 , click
-, configparser ? null
 , dateutil
 , etelemetry
 , filelock
 , funcsigs
 , future
-, futures
 , mock
 , networkx
 , nibabel
 , numpy
 , packaging
-, pathlib2
 , prov
 , psutil
 , pybids
@@ -39,8 +35,6 @@
 , callPackage
 }:
 
-assert !isPy3k -> configparser != null;
-
 let
 
  # This is a temporary convenience package for changes waiting to be merged into the primary rdflib repo.
@@ -51,6 +45,7 @@ in
 buildPythonPackage rec {
   pname = "nipype";
   version = "1.5.1";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
@@ -85,10 +80,6 @@ buildPythonPackage rec {
     simplejson
     traits
     xvfbwrapper
-  ] ++ stdenv.lib.optionals (!isPy3k) [
-    configparser
-    futures
-    pathlib2 # darwin doesn't receive this transitively, but it is in install_requires
   ];
 
   checkInputs = [


### PR DESCRIPTION
Prior to this change, any closure containing python3Packages.rdflib causes a conflict with NIpype.  Additionally, the patched rdflib (neurdflib) is an optional dependency of Nipype anyway (see https://github.com/nipy/nipype/issues/2888) and our policy is not to include optdepends by default.

I also removed Python 2 support since Nipype doesn't support Python 2 (and python2Packages.nipype wouldn't even be attempted since dependency `nibabel` is disabled for that interpreter anyway).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
