### PR TITLE
i3status-rust: parameterise optional features (pulseaudio, notmuch)

### DIFF
--- a/pkgs/applications/window-managers/i3/status-rust.nix
+++ b/pkgs/applications/window-managers/i3/status-rust.nix
@@ -1,4 +1,11 @@
-{ stdenv, rustPlatform, fetchFromGitHub, pkgconfig, dbus, libpulseaudio }:
+{ lib, rustPlatform, fetchFromGitHub, pkgconfig, dbus
+, withPulseaudio ? true, libpulseaudio ? null
+, withNotmuch ? false, notmuch ? null }:
+
+assert withPulseaudio -> libpulseaudio != null;
+assert withNotmuch -> notmuch != null;
+
+with lib;
 
 rustPlatform.buildRustPackage rec {
   pname = "i3status-rust";
@@ -13,14 +20,24 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "0jmmxld4rsjj6p5nazi3d8j1hh7r34q6kyfqq4wv0sjc77gcpaxd";
 
+  cargoBuildFlags = [
+    "--no-default-features"
+    "--features" (escapeShellArg (concatStringsSep " " (
+      optional withPulseaudio "pulseaudio" ++
+      optional withNotmuch "notmuch"
+    )))
+  ];
+
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ dbus libpulseaudio ];
+  buildInputs = [ dbus ]
+    ++ optional withPulseaudio libpulseaudio
+    ++ optional withNotmuch notmuch;
 
   # Currently no tests are implemented, so we avoid building the package twice
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "Very resource-friendly and feature-rich replacement for i3status";
     homepage = "https://github.com/greshake/i3status-rust";
     license = licenses.gpl3;


### PR DESCRIPTION
###### Motivation for this change

This exposes optional feature flags (`withPulseaudio` and `withNotmuch`) as parameters for the package.
The first one was already and is still enabled by default.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
