### PR TITLE
envchain: init at 1.0.1

### DIFF
--- a/pkgs/tools/misc/envchain/default.nix
+++ b/pkgs/tools/misc/envchain/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, libedit, libsecret, ncurses, pkg-config, readline, Security }:
+
+stdenv.mkDerivation rec {
+  pname = "envchain";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "sorah";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0qxwiqhb8cg0zbn5p0mvnbyxx1xwvgiricrkjlvxz13sf2ngq87p";
+  };
+
+  postPatch = ''
+    sed -i -e "s|-ltermcap|-lncurses|" Makefile
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libsecret readline ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ libedit ncurses Security ];
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Set environment variables with macOS keychain or D-Bus secret service";
+    homepage = "https://github.com/sorah/envchain";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ bbigras ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3510,6 +3510,8 @@ in
 
   entr = callPackage ../tools/misc/entr { };
 
+  envchain = callPackage ../tools/misc/envchain { inherit (pkgs.darwin.apple_sdk.frameworks) Security; };
+
   eot_utilities = callPackage ../tools/misc/eot-utilities { };
 
   eplot = callPackage ../tools/graphics/eplot { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This tool is to avoid having sensible things in `.env` files.

###### Things done

Note that 1.0.1 is 4 years old.

The last commit in the repo is about 5 months old.

Tested saving a secret on Gnome. Didn't test it with envrc yet.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).