### PR TITLE
tox-node: 0.0.8 -> 0.1.0

### DIFF
--- a/pkgs/tools/networking/tox-node/default.nix
+++ b/pkgs/tools/networking/tox-node/default.nix
@@ -7,13 +7,13 @@ with rustPlatform;
 
 buildRustPackage rec {
   pname = "tox-node";
-  version = "0.0.8";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "tox-rs";
     repo = "tox-node";
     rev = "v${version}";
-    sha256 = "0vnjbhz74d4s6701xsd46ygx0kq8wd8xwpajvkhdivc042mw9078";
+    sha256 = "0bar42nigjwn7dq48rmg74sm3gnfqvb6gnd9g1n0i8nmynd00wvn";
   };
 
   buildInputs = [ libsodium openssl ];
@@ -31,12 +31,12 @@ buildRustPackage rec {
 
   doCheck = false;
 
-  cargoSha256 = "1ka22krw8s05vpamg9naqqf7vv5h8dkpfdik0wy8nispkrxzgb92";
+  cargoSha256 = "087ccb824hmmxmnn5c2bzww2q888a8zy6y7rwgsdfr8rbay2c909";
 
   meta = with stdenv.lib; {
     description = "A server application to run tox node written in pure Rust";
     homepage = "https://github.com/tox-rs/tox-node";
-    license = [ licenses.mit ];
+    license = [ licenses.gpl3Plus ];
     platforms = platforms.linux;
     maintainers = with maintainers; [ suhr ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
