### PR TITLE
python3Packages.cirq: 0.8.2 -> 0.9.1

### DIFF
--- a/pkgs/development/python-modules/cirq/default.nix
+++ b/pkgs/development/python-modules/cirq/default.nix
@@ -28,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "cirq";
-  version = "0.8.2";
+  version = "0.9.1";
 
   disabled = pythonOlder "3.6";
 
@@ -36,25 +36,20 @@ buildPythonPackage rec {
     owner = "quantumlib";
     repo = "cirq";
     rev = "v${version}";
-    sha256 = "0xs46s19idh8smf80zhgraxwh3lphcdbljdrhxwhi5xcc41dfsmf";
+    sha256 = "0mygvpq7kzga8l1w2jvwv9a2n3akpss45hrx250gdrnqjp6xrw64";
   };
-
-  patches = [
-    (fetchpatch {
-      # Fixes serialization issues on certain versions of protobuf & numpy.
-      name = "cirq-pr-2986-protobuf-bools.patch";
-      url = "https://github.com/quantumlib/Cirq/commit/78ddfb574c0f3936f713613bf4ba102163efb7b3.patch";
-      sha256 = "0hmad9ndsqf5ci7shvd924d2rv4k9pzx2r2cl1bm5w91arzz9m18";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace requirements.txt \
       --replace "freezegun~=0.3.15" "freezegun" \
       --replace "matplotlib~=3.0" "matplotlib" \
       --replace "networkx~=2.4" "networkx" \
-      --replace "numpy~=1.16, < 1.19" "numpy" \
+      --replace "numpy~=1.16" "numpy" \
       --replace "protobuf~=3.12.0" "protobuf"
+
+    # Fix serialize_sympy_constants test by allowing small errors in pi
+    substituteInPlace cirq/google/arg_func_langs_test.py \
+      --replace "'float_value': float(str(np.float32(sympy.pi)))" "'float_value': pytest.approx(float(str(np.float32(sympy.pi))))"
   '';
 
   propagatedBuildInputs = [
@@ -87,6 +82,7 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "--ignore=dev_tools"  # Only needed when developing new code, which is out-of-scope
+    "--ignore=cirq/contrib/"  # requires external (unpackaged) python packages, so untested.
     "--benchmark-disable" # Don't need to run benchmarks when packaging.
   ];
   disabledTests = [
@@ -95,6 +91,25 @@ buildPythonPackage rec {
     # Seem to fail due to math issues on aarch64?
     "expectation_from_wavefunction"
     "test_single_qubit_op_to_framed_phase_form_output_on_example_case"
+  ] ++ [
+    # slow tests, for quicker building
+    "test_anneal_search_method_calls"
+    "test_density_matrix_from_state_tomography_is_correct"
+    "test_example_runs_qubit_characterizations"
+    "test_example_runs_hello_line_perf"
+    "test_example_runs_bc_mean_field_perf"
+    "test_main_loop"
+    "test_clifford_circuit_2"
+    "test_decompose_specific_matrices"
+    "test_two_qubit_randomized_benchmarking"
+    "test_kak_decomposition_perf"
+    "test_example_runs_simon"
+    "test_decompose_random_unitary"
+    "test_decompose_size_special_unitary"
+    "test_api_retry_5xx_errors"
+    "test_xeb_fidelity"
+    "test_example_runs_phase_estimator_perf"
+    "test_cross_entropy_benchmarking"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
New minor version (feature update).
https://github.com/quantumlib/Cirq/releases/tag/v0.9.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
