### PR TITLE
find-cursor: init at 1.6

### DIFF
--- a/pkgs/tools/X11/find-cursor/default.nix
+++ b/pkgs/tools/X11/find-cursor/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, libX11, libXdamage, libXrender, libXcomposite, libXext, installShellFiles, git }:
+
+stdenv.mkDerivation rec {
+  pname = "find-cursor";
+  version = "1.6";
+
+  src = fetchFromGitHub {
+    owner = "arp242";
+    repo = "find-cursor";
+    rev = "v${version}";
+    sha256 = "13lpcxklv9ayqapyk9pmwxkinhxah5hkr6n0jc2m5hm68nh220w1";
+  };
+
+  nativeBuildInputs = [ installShellFiles git ];
+  buildInputs = [ libX11 libXdamage libXrender libXcomposite libXext ];
+  preInstall = "mkdir -p $out/share/man/man1";
+  installFlags = "PREFIX=${placeholder "out"}";
+
+  meta = with stdenv.lib; {
+    description = "Simple XLib program to highlight the cursor position";
+    homepage = "https://github.com/arp242/find-cursor";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.yanganto ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -321,6 +321,8 @@ in
 
   fetchMavenArtifact = callPackage ../build-support/fetchmavenartifact { };
 
+  find-cursor = callPackage ../tools/X11/find-cursor { };
+
   prefer-remote-fetch = import ../build-support/prefer-remote-fetch;
 
   global-platform-pro = callPackage ../development/tools/global-platform-pro/default.nix { };


### PR DESCRIPTION
###### Motivation for this change
This X11 tool helps me find the cursor when using 4 screens.
It is good and usable, so I package this on NixOS.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
