### PR TITLE
python3Packages.qiskit: 0.20.0 -> 0.23.1, update dependencies & subpackages

### DIFF
--- a/pkgs/development/python-modules/docplex/default.nix
+++ b/pkgs/development/python-modules/docplex/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage rec {
   pname = "docplex";
-  version = "2.15.194";
+  version = "2.16.196";
 
   # No source available from official repo
   src = fetchPypi {
     inherit pname version;
-    sha256 = "976e9b4e18bccbabae04149c33247a795edb1f00110f1b511c5517ac6ac353bb";
+    sha256 = "8fd96e3586444e577b356c0ac62511414e76027ff159ebe0d0b3e44b881406d1";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/fastjsonschema/default.nix
+++ b/pkgs/development/python-modules/fastjsonschema/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "fastjsonschema";
-  version = "2.14.4";
+  version = "2.14.5";
 
   disabled = pythonOlder "3.3";
 
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     repo = "python-fastjsonschema";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "0c3q31lqzrc52gacnqc271k5952qbyl0z4kagsqvl7fiwk84hqlz";
+    sha256 = "1hgzafswdw5zqrd8qhdxa43crzfy7lrlifdn90133a0h3psr7qs1";
   };
 
   checkInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/pproxy/default.nix
+++ b/pkgs/development/python-modules/pproxy/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "pproxy";
-  version = "2.3.2";
+  version = "2.3.7";
 
   disabled = isPy27;
 
@@ -16,8 +16,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "qwj";
     repo = "python-proxy";
-    rev = "818ab9cc10565789fe429a7be50ddefb9c583781";
-    sha256 = "0g3cyi5lzakhs5p3fpwywbl8jpapnr8890zw9w45dqg8k0svc1fi";
+    rev = "7fccf8dd62204f34b0aa3a70fc568fd6ddff7728";
+    sha256 = "1sl2i0kymnbsk49ina81yjnkxjy09541f7pmic8r6rwsv1s87skc";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pylatexenc/default.nix
+++ b/pkgs/development/python-modules/pylatexenc/default.nix
@@ -6,23 +6,23 @@
 
 buildPythonPackage rec {
   pname = "pylatexenc";
-  version = "2.7";
+  version = "2.8";
 
   src = fetchFromGitHub {
     owner = "phfaist";
     repo = "pylatexenc";
     rev = "v${version}";
-    sha256 = "1hpcwbknfah3mky2m4asw15b9qdvv4k5ni0js764n1jpi83m1zgk";
+    sha256 = "0m9vrbh1gmbgq6dqm7xzklar3accadw0pn896rqsdi5jbgd3w0mh";
   };
 
   pythonImportsCheck = [ "pylatexenc" ];
-  dontUseSetuptoolsCheck = true;
   checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Simple LaTeX parser providing latex-to-unicode and unicode-to-latex conversion";
     homepage = "https://pylatexenc.readthedocs.io";
     downloadPage = "https://www.github.com/phfaist/pylatexenc/releases";
+    changelog = "https://pylatexenc.readthedocs.io/en/latest/changes/";
     license = licenses.mit;
     maintainers = with maintainers; [ drewrisinger ];
   };

--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -3,34 +3,38 @@
 , buildPythonPackage
 , fetchFromGitHub
 , fetchpatch
+  # C Inputs
+, blas
+, catch2
 , cmake
-, cvxpy
 , cython
 , muparserx
 , ninja
 , nlohmann_json
+, spdlog
+  # Python Inputs
+, cvxpy
 , numpy
-, openblas
 , pybind11
 , scikit-build
-, spdlog
   # Check Inputs
-, qiskit-terra
 , pytestCheckHook
-, python
+, ddt
+, fixtures
+, qiskit-terra
 }:
 
 buildPythonPackage rec {
   pname = "qiskit-aer";
-  version = "0.6.1";
+  version = "0.7.1";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "Qiskit";
     repo = "qiskit-aer";
     rev = version;
-    sha256 = "1fnv11diis0as8zcc57mamz0gbjd6vj7nw3arxzvwa77ja803sr4";
+    sha256 = "07l0wavdknx0y4vy0hwgw24365sg4nb6ygl3lpa098np85qgyn4y";
   };
 
   nativeBuildInputs = [
@@ -40,10 +44,11 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [
-    openblas
-    spdlog
-    nlohmann_json
+    blas
+    catch2
     muparserx
+    nlohmann_json
+    spdlog
   ];
 
   propagatedBuildInputs = [
@@ -60,11 +65,6 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
-  cmakeFlags = [
-    "-DBUILD_TESTS=True"
-    "-DAER_THRUST_BACKEND=OMP"
-  ];
-
   # *** Testing ***
 
   pythonImportsCheck = [
@@ -72,11 +72,17 @@ buildPythonPackage rec {
     "qiskit.providers.aer.backends.qasm_simulator"
     "qiskit.providers.aer.backends.controller_wrappers" # Checks C++ files built correctly. Only exists if built & moved to output
   ];
-  checkInputs = [
-    qiskit-terra
-    pytestCheckHook
+  # Slow tests
+  disabledTests = [
+    "test_paulis_1_and_2_qubits"
+    "test_3d_oscillator"
   ];
-  dontUseSetuptoolsCheck = true;  # Otherwise runs tests twice
+  checkInputs = [
+    pytestCheckHook
+    ddt
+    fixtures
+    qiskit-terra
+  ];
 
   preCheck = ''
     # Tests include a compiled "circuit" which is auto-built in $HOME
@@ -87,9 +93,7 @@ buildPythonPackage rec {
     # Add qiskit-aer compiled files to cython include search
     pushd $HOME
   '';
-  postCheck = ''
-    popd
-  '';
+  postCheck = "popd";
 
   meta = with lib; {
     description = "High performance simulators for Qiskit";

--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -21,6 +21,7 @@
 , pytestCheckHook
 , ddt
 , fixtures
+, pytest-timeout
 , qiskit-terra
 }:
 
@@ -81,7 +82,12 @@ buildPythonPackage rec {
     pytestCheckHook
     ddt
     fixtures
+    pytest-timeout
     qiskit-terra
+  ];
+  pytestFlagsArray = [
+    "--timeout=30"
+    "--durations=10"
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/qiskit-aqua/default.nix
+++ b/pkgs/development/python-modules/qiskit-aqua/default.nix
@@ -28,6 +28,7 @@
   # Check Inputs
 , ddt
 , pytestCheckHook
+, pytest-timeout
 , qiskit-aer
 }:
 
@@ -100,6 +101,7 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
     ddt
+    pytest-timeout
     qiskit-aer
   ];
   pythonImportsCheck = [
@@ -110,7 +112,10 @@ buildPythonPackage rec {
     "qiskit.ml"
     "qiskit.optimization"
   ];
-  pytestFlagsArray = lib.optionals (!withPyscf) [
+  pytestFlagsArray = [
+    "--timeout=30"
+    "--durations=10"
+  ] ++ lib.optionals (!withPyscf) [
     "--ignore=test/chemistry/test_qeom_ee.py"
     "--ignore=test/chemistry/test_qeom_vqe.py"
     "--ignore=test/chemistry/test_vqe_uccsd_adapt.py"

--- a/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
+++ b/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-ibmq-provider";
-  version = "0.8.0";
+  version = "0.11.1";
 
   disabled = pythonOlder "3.6";
 
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "0rrpwr4a82j69j5ibl2g0nw8wbpg201cfz6f234k2v6pj500x9nl";
+    sha256 = "0b5mnq8f5844idnsmp84lpkvlpszfwwi998yvggcgaayw1dbk53h";
   };
 
   propagatedBuildInputs = [
@@ -56,19 +56,12 @@ buildPythonPackage rec {
     seaborn
   ];
 
-  # websockets seems to be pinned b/c in v8+ it drops py3.5 support. Not an issue here (usually py3.7+, and disabled for older py3.6)
-  postPatch = ''
-    substituteInPlace requirements.txt --replace "websockets>=7,<8" "websockets"
-    substituteInPlace setup.py --replace "websockets>=7,<8" "websockets"
-  '';
-
   # Most tests require credentials to run on IBMQ
   checkInputs = [
     pytestCheckHook
     pproxy
     vcrpy
   ];
-  dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [ "qiskit.providers.ibmq" ];
   # These disabled tests require internet connection, aren't skipped elsewhere
@@ -76,6 +69,10 @@ buildPythonPackage rec {
     "test_old_api_url"
     "test_non_auth_url"
     "test_non_auth_url_with_hub"
+
+    # slow tests
+    "test_websocket_retry_failure"
+    "test_invalid_url"
   ];
 
   # Skip tests that rely on internet access (mostly to IBM Quantum Experience cloud).

--- a/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
+++ b/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
@@ -9,21 +9,33 @@
 , requests_ntlm
 , websockets
   # Visualization inputs
-, ipykernel
+, withVisualization ? false
+, ipython
 , ipyvuetify
 , ipywidgets
 , matplotlib
-, nbconvert
-, nbformat
 , plotly
 , pyperclip
 , seaborn
   # check inputs
 , pytestCheckHook
+, nbconvert
+, nbformat
 , pproxy
 , vcrpy
 }:
 
+let
+  visualizationPackages = [
+    ipython
+    ipyvuetify
+    ipywidgets
+    matplotlib
+    plotly
+    pyperclip
+    seaborn
+  ];
+in
 buildPythonPackage rec {
   pname = "qiskit-ibmq-provider";
   version = "0.11.1";
@@ -44,24 +56,16 @@ buildPythonPackage rec {
     requests
     requests_ntlm
     websockets
-    # Visualization/Jupyter inputs
-    ipykernel
-    ipyvuetify
-    ipywidgets
-    matplotlib
-    nbconvert
-    nbformat
-    plotly
-    pyperclip
-    seaborn
-  ];
+  ] ++ lib.optionals withVisualization visualizationPackages;
 
   # Most tests require credentials to run on IBMQ
   checkInputs = [
     pytestCheckHook
+    nbconvert
+    nbformat
     pproxy
     vcrpy
-  ];
+  ] ++ lib.optionals (!withVisualization) visualizationPackages;
 
   pythonImportsCheck = [ "qiskit.providers.ibmq" ];
   # These disabled tests require internet connection, aren't skipped elsewhere

--- a/pkgs/development/python-modules/qiskit-ignis/default.nix
+++ b/pkgs/development/python-modules/qiskit-ignis/default.nix
@@ -8,6 +8,13 @@
 , qiskit-terra
 , scikitlearn
 , scipy
+  # Optional package inputs
+, withVisualization ? false
+, matplotlib
+, withCvx ? false
+, cvxpy
+, withJit ? false
+, numba
   # Check Inputs
 , pytestCheckHook
 , ddt
@@ -17,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-ignis";
-  version = "0.4.0";
+  version = "0.5.1";
 
   disabled = pythonOlder "3.6";
 
@@ -26,16 +33,24 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-ignis";
     rev = version;
-    sha256 = "07mxhaknkp121xm6mgrpcrbj9qw6j924ra3k0s6vr8qgvfcxvh0y";
+    sha256 = "17kplmi17axcbbgw35dzfr3d5bzfymxfni9sf6v14223c5674p4y";
   };
+
+  # hacky, fix https://github.com/Qiskit/qiskit-ignis/issues/532.
+  # TODO: remove on qiskit-ignis v0.5.1
+  postPatch = ''
+    substituteInPlace qiskit/ignis/mitigation/expval/base_meas_mitigator.py --replace "plt.axes" "'plt.axes'"
+  '';
 
   propagatedBuildInputs = [
     numpy
     qiskit-terra
     scikitlearn
     scipy
-  ];
-  postInstall = "rm -rf $out/${python.sitePackages}/docs";  # this dir can create conflicts
+  ] ++ lib.optionals (withCvx) [ cvxpy ]
+  ++ lib.optionals (withVisualization) [ matplotlib ]
+  ++ lib.optionals (withJit) [ numba ];
+  postInstall = "rm -rf $out/${python.sitePackages}/docs"; # this dir can create conflicts
 
   # Tests
   pythonImportsCheck = [ "qiskit.ignis" ];
@@ -49,7 +64,7 @@ buildPythonPackage rec {
   ];
   disabledTests = [
     "test_tensored_meas_cal_on_circuit" # Flaky test, occasionally returns result outside bounds
-    "test_qv_fitter"  # execution hangs, ran for several minutes
+    "test_qv_fitter" # execution hangs, ran for several minutes
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -35,15 +35,15 @@
 
 buildPythonPackage rec {
   pname = "qiskit-terra";
-  version = "0.15.1";
+  version = "0.16.1";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "1p7y36gj3675dmp05nwi0m9nc7h0bwyimir3ncf9wbkx3crrh99c";
+    sha256 = "0007glsbrvq9swamvz8r76z9nzh46b388y0ds1dypczxpwlp9xcq";
   };
 
   nativeBuildInputs = [ cython ];
@@ -81,7 +81,6 @@ buildPythonPackage rec {
     nbconvert
     pytestCheckHook
   ];
-  dontUseSetuptoolsCheck = true;  # can't find setup.py, so fails. tested by pytest
 
   pythonImportsCheck = [
     "qiskit"
@@ -90,6 +89,7 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "--ignore=test/randomized/test_transpiler_equivalence.py" # collection requires qiskit-aer, which would cause circular dependency
+    "--ignore=test/python/classical_function_compiler/"
   ];
 
   # Moves tests to $PACKAGEDIR/test. They can't be run from /build because of finding

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -105,6 +105,32 @@ buildPythonPackage rec {
   ] ++ lib.optionals (!withClassicalFunctionCompiler ) [
     "--ignore=test/python/classical_function_compiler/"
   ];
+  disabledTests = [
+    # Flaky tests
+    "test_cx_equivalence"
+    "test_pulse_limits"
+  ]
+  # Disabling slow tests for build constraints
+  ++ [
+    "test_all_examples"
+    "test_controlled_random_unitary"
+    "test_controlled_standard_gates_1"
+    "test_jupyter_jobs_pbars"
+    "test_lookahead_swap_higher_depth_width_is_better"
+    "test_move_measurements"
+    "test_job_monitor"
+    "test_wait_for_final_state"
+    "test_multi_controlled_y_rotation_matrix_basic_mode"
+    "test_two_qubit_weyl_decomposition_abc"
+    "test_isometry"
+    "test_parallel"
+    "test_random_state"
+    "test_random_clifford_valid"
+    "test_to_matrix"
+    "test_block_collection_reduces_1q_gate"
+    "test_multi_controlled_rotation_gate_matrices"
+    "test_block_collection_runs_for_non_cx_bases"
+  ];
 
   # Moves tests to $PACKAGEDIR/test. They can't be run from /build because of finding
   # cythonized modules and expecting to find some resource files in the test directory.

--- a/pkgs/development/python-modules/qiskit/default.nix
+++ b/pkgs/development/python-modules/qiskit/default.nix
@@ -15,15 +15,15 @@
 buildPythonPackage rec {
   pname = "qiskit";
   # NOTE: This version denotes a specific set of subpackages. See https://qiskit.org/documentation/release_notes.html#version-history
-  version = "0.20.0";
+  version = "0.23.1";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
-    owner = "Qiskit";
+    owner = "qiskit";
     repo = "qiskit";
     rev = version;
-    sha256 = "1r23pjnql49gczf4k4m6ir5rr95gqdxjrks60p8a93d243mxx3c9";
+    sha256 = "0x4cqx1wqqj7h5g3vdag694qjzsmvhpw25yrlcs70mh5ywdp28x1";
   };
 
   propagatedBuildInputs = [
@@ -35,7 +35,6 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [ pytestCheckHook ];
-  dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [
     "qiskit"
@@ -43,6 +42,7 @@ buildPythonPackage rec {
     "qiskit.circuit"
     "qiskit.ignis"
     "qiskit.providers.aer"
+    "qiskit.providers.ibmq"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/retworkx/default.nix
+++ b/pkgs/development/python-modules/retworkx/default.nix
@@ -1,7 +1,6 @@
 { lib
 , rustPlatform
 , python
-, fetchpatch
 , fetchFromGitHub
 , pipInstallHook
 , maturin
@@ -13,35 +12,30 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "retworkx";
-  version = "0.4.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "Qiskit";
     repo = "retworkx";
     rev = version;
-    sha256 = "1xqp6d39apkjvd0ad9vw81cp2iqzhpagfa4p171xqm3bwfn2imdc";
+    sha256 = "11n30ldg3y3y6qxg3hbj837pnbwjkqw3nxq6frds647mmmprrd20";
   };
 
-  cargoSha256 = "0bma0l14jv5qhcsxck7vw3ak1w3c8v84cq4hii86i4iqk523zns5";
-  cargoPatches = [
-      ( fetchpatch {
-        name = "retworkx-cargo-lock.patch";
-        url = "https://github.com/Qiskit/retworkx/commit/a02fd33d357a92dbe9530696a6d85aa59fe8a5b9.patch";
-        sha256 = "0gvxr1nqp9ll4skfks4p4d964pshal25kb1nbfzhpyipnzddizr5";
-      } )
-  ];
+  cargoSha256 = "1vg4yf0k6yypqf9z46zz818mz7fdrgxj7zl6zjf7pnm2r8mq3qw5";
 
   propagatedBuildInputs = [ python ];
 
   nativeBuildInputs = [ pipInstallHook maturin pip ];
 
-  # Need to check AFTER python wheel is installed (b/c using Rust Build, not buildPythonPackage)
+  # Needed b/c need to check AFTER python wheel is installed (using Rust Build, not buildPythonPackage)
   doCheck = false;
   doInstallCheck = true;
 
+  installCheckInputs = [ pytestCheckHook numpy ];
+
   buildPhase = ''
     runHook preBuild
-    maturin build --release --manylinux off --strip --interpreter ${python.interpreter}
+    maturin build --release --manylinux off --strip
     runHook postBuild
   '';
 
@@ -50,10 +44,9 @@ rustPlatform.buildRustPackage rec {
     pipInstallPhase
   '';
 
-  installCheckInputs = [ pytestCheckHook numpy ];
   preCheck = ''
     export TESTDIR=$(mktemp -d)
-    cp -r $TMP/$sourceRoot/tests $TESTDIR
+    cp -r tests/ $TESTDIR
     pushd $TESTDIR
   '';
   postCheck = "popd";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
* Update to latest version of qiskit.
* Update qiskit dependencies: ``fastjsonschema, pproxy``.
* Turn off optional visualization packages by default: reduce runtime closure & improve import speed (https://github.com/Qiskit/qiskit-terra/issues/5100)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
