### PR TITLE
buildGoModule: check go.sum is up-to-date

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -34,6 +34,9 @@
 # IE: programs coupled with the compiler
 , allowGoReference ? false
 
+# Verify go.sum is up-to-date (not modified by "go mod vendor")
+, checkGoSum ? false
+
 , meta ? {}
 
 , ... }@args':
@@ -100,7 +103,15 @@ let
         echo running vend to rewrite vendor folder
         ${vendCommand}
       else
+        if [ ${checkGoSum} == "true" ]; then
+          # verify go.sum is not modified (up-to-date)
+          GOSUM=$(sha256sum go.sum)
+        fi
         go mod vendor
+        if [ ${checkGoSum} == "true" && "$(sha256sum go.sum)" != "$GOSUM" ]; then
+          echo "go.sum is not up to date"
+          exit 10
+        fi
       fi
       mkdir -p vendor
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

`go mod vendor` will modify `go.sum` file implicitly, so even if `go.sum` file is not up to date, it still runs fine, and that's not good.

###### Things done

We are supposed to use a readonly version of `go mod vendor` here if there is one, but there isn't, so the best we can do is check the `go.sum` is not modified after `go mod vendor`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
