### PR TITLE
nodePackages.expo-cli: use .override

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -59,8 +59,7 @@ let
       buildInputs = [ pkgs.phantomjs2 ];
     };
 
-    expo-cli = super."expo-cli".overrideNodeAttrs (attrs: {
-      __acceptOverrideNodeAttrsCanBeDroppedAnytime = true;
+    expo-cli = super."expo-cli".override (attrs: {
       # The traveling-fastlane-darwin optional dependency aborts build on Linux.
       dependencies = builtins.filter (d: d.packageName != "@expo/traveling-fastlane-${if stdenv.isLinux then "darwin" else "linux"}") attrs.dependencies;
     });

--- a/pkgs/development/node-packages/node-env.nix
+++ b/pkgs/development/node-packages/node-env.nix
@@ -372,37 +372,8 @@ let
         fi
     '';
 
-  # Derivations built with `buildNodePackage` can already be overriden with `override`, `overrideAttrs`, and `overrideDerivation`.
-  # This function introduces `overrideNodeAttrs` and it overrides the call to `buildNodePackage`.
-  #
-  # THIS FUNCTION IS TEMPORARY until we have a better mechanism in place:
-  # https://github.com/NixOS/nixpkgs/pull/96509#issuecomment-682381592
-  # YOU SHOULD NOT USE IT UNLESS YOU ACCEPT THAT.
-  makeOverridableNodePackage = f: origArgs:
-    let
-      ff = f origArgs;
-      overrideWith = newArgs: origArgs // (
-        let args = if stdenv.lib.isFunction newArgs then newArgs origArgs else newArgs;
-        in
-          assert stdenv.lib.assertMsg (args.__acceptOverrideNodeAttrsCanBeDroppedAnytime or false) ''
-            overrideNodeAttrs is temporary function that will be removed once a better mechanism exists.
-            Pass it `__acceptOverrideNodeAttrsCanBeDroppedAnytime = true;` to aknowledge the fact.
-          '';
-          builtins.removeAttrs args [ "__acceptOverrideNodeAttrsCanBeDroppedAnytime" ]
-      );
-    in
-      if builtins.isAttrs ff then (ff // {
-        overrideNodeAttrs = newArgs: makeOverridableNodePackage f (overrideWith newArgs);
-      })
-      else if builtins.isFunction ff then {
-        overrideNodeAttrs = newArgs: makeOverridableNodePackage f (overrideWith newArgs);
-        __functor = self: ff;
-      }
-      else ff;
-
-
   # Builds and composes an NPM package including all its dependencies
-  buildNodePackage = makeOverridableNodePackage (
+  buildNodePackage =
     { name
     , packageName
     , version
@@ -472,7 +443,7 @@ let
         # Run post install hook, if provided
         runHook postInstall
       '';
-    } // extraArgs));
+    } // extraArgs);
 
   # Builds a development shell
   buildNodeShell =


### PR DESCRIPTION
generate.sh seems to remove changes to node-env.nix, fortunately
.override seems to work so .overrideNodeAttrs does not actually
seem necessary. Not sure why I did not use it before.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
