### PR TITLE
pythonPackages.pyotp: Disable on Python27

### DIFF
--- a/pkgs/development/python-modules/pyotp/default.nix
+++ b/pkgs/development/python-modules/pyotp/default.nix
@@ -1,13 +1,16 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchPypi, isPy27 }:
 
 buildPythonPackage rec {
   pname = "pyotp";
   version = "2.4.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "01eceab573181188fe038d001e42777884a7f5367203080ef5bda0e30fe82d28";
   };
+
+  pythonImportsCheck = [ "pyotp" ];
 
   meta = with lib; {
     description = "Python One Time Password Library";


### PR DESCRIPTION
###### Motivation for this change
This disables tests for python27, as they import urllib in an unsupported way. 

ZHF: #97479 

Result of `nixpkgs-review pr 100023` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>home-assistant</li>
    <li>python27Packages.pyotp</li>
    <li>python37Packages.pyotp</li>
    <li>python38Packages.pyotp</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https1://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
