### PR TITLE
sudo: 1.8.31p1 -> 1.9.3p1 + adding myself as maintainer

### DIFF
--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
 
     license = "https://www.sudo.ws/sudo/license.html";
 
-    maintainers = [ stdenv.lib.maintainers.eelco ];
+    maintainers = with stdenv.lib.maintainers; [ eelco delroth ];
 
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, coreutils, pam, groff, sssd
+{ stdenv, fetchurl, coreutils, pam, groff, sssd, nixosTests
 , sendmailPath ? "/run/wrappers/bin/sendmail"
 , withInsults ? false
 , withSssd ? false
@@ -60,6 +60,8 @@ stdenv.mkDerivation rec {
     ''
     rm -f $out/share/doc/sudo/ChangeLog
     '';
+
+  passthru.tests = { inherit (nixosTests) sudo; };
 
   meta = {
     description = "A command to run commands as root";

--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   pname = "sudo";
-  version = "1.8.31p1";
+  version = "1.9.3p1";
 
   src = fetchurl {
     url = "https://www.sudo.ws/dist/${pname}-${version}.tar.gz";
-    sha256 = "1n0mdmgcs92af34xxsnsh1arrngymhdmwd9srjgjbk65q7xzsg67";
+    sha256 = "17mldsg5d08s23cskmjxfa81ibnqw3slgf3l4023j72ywi9xxffw";
   };
 
   prePatch = ''


### PR DESCRIPTION
###### Motivation for this change

`sudo` in nixpkgs is currently lagging several versions behind, and it seems to be solely due to maintainer bandwidth (no reply on the last two pull requests bumping the package, #93100 and #88768). We're currently stuck on a release from 5 months ago, which isn't ideal for such a core package.

This PR bumps to the newest release, and adds myself as a maintainer for `sudo` so I can help with keeping this up to date in the future.

Closes #93100 
Closes #88768

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
