### PR TITLE
[20.09] pythonPackages.pyotp: fix tests

### DIFF
--- a/pkgs/development/python-modules/pyotp/default.nix
+++ b/pkgs/development/python-modules/pyotp/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchPypi, isPy27, urllib3 }:
 
 buildPythonPackage rec {
   pname = "pyotp";
@@ -8,6 +8,10 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "01eceab573181188fe038d001e42777884a7f5367203080ef5bda0e30fe82d28";
   };
+
+  doCheck = (!isPy27); # Tests import urllib3 in a way python27 does not support
+
+  checkInputs = [ urllib3 ];
 
   meta = with lib; {
     description = "Python One Time Password Library";


### PR DESCRIPTION
(cherry picked from commit ae23d0bf634d460be9e75702f369a08c1c2e64ba)

ZHF: #97479 

PR to master: #100023 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
