### PR TITLE
Drop spidermonkey from aliases

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -661,7 +661,6 @@ mapAliases ({
   youtubeDL = youtube-dl;  # added 2014-10-26
   zdfmediathk = mediathekview; # added 2019-01-19
   gnome_user_docs = gnome-user-docs; # added 2019-11-20
-  spidermonkey = spidermonkey_68; # added 2020-09-30
 
   # TODO(ekleog): add ‘wasm’ alias to ‘ocamlPackages.wasm’ after 19.03
   # branch-off

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10364,7 +10364,7 @@ in
   spidermonkey_60 = callPackage ../development/interpreters/spidermonkey/60.nix { };
   spidermonkey_68 = callPackage ../development/interpreters/spidermonkey/68.nix { };
   spidermonkey_78 = callPackage ../development/interpreters/spidermonkey/78.nix { };
-  spidermonkey = spidermonkey_38;
+  spidermonkey = spidermonkey_68;
 
   ssm-agent = callPackage ../applications/networking/cluster/ssm-agent { };
   ssm-session-manager-plugin = callPackage ../applications/networking/cluster/ssm-session-manager-plugin { };


### PR DESCRIPTION
It's already aliased in all-packages.

This creates issues at least for the mediatomb build.

Related to #93450#issuecomment-705408544

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs: `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 100026"` [1]
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

[1] 
```
nixpkgs-review pr 100026
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0 pull/100026/head:refs/nixpkgs-review/1
From https://github.com/NixOS/nixpkgs
 + 2c4cf27d61b...b1062d4dcda refs/pull/100026/head -> refs/nixpkgs-review/1  (forced update)
$ git worktree add /home/tony/.cache/nixpkgs-review/pr-100026/nixpkgs b50ef4e3f226dde6c34817e3f92ca0aa3e18a72e
Preparing worktree (detached HEAD b50ef4e3f22)
Updating files: 100% (22856/22856), done.
HEAD is now at b50ef4e3f22 ocamlPackages.fmt: 0.8.8 -> 0.8.9
$ nix-env -f /home/tony/.cache/nixpkgs-review/pr-100026/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit b1062d4dcdafdcdb36ad5939f2c3a438eb02e902
Auto-merging pkgs/top-level/all-packages.nix
Automatic merge went well; stopped before committing as requested
$ nix-env -f /home/tony/.cache/nixpkgs-review/pr-100026/nixpkgs -qaP --xml --out-path --show-trace --meta
2 packages added:
mediatomb (init at 0.12.1) spidermonkey (init at 68.10.0)

1 package removed:
spidermonkey (†68.10.0)

$ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/tony/.cache/nixpkgs-review/pr-100026/build.nix
building '/nix/store/h5ccfai75h93jjw47wm02spnlba9kqlp-env.drv'...
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/100026
2 packages built:
mediatomb spidermonkey

[0.0 MiB DL]
error: build log of '/nix/store/2k0v219m2ilrq7y1g559mpvffxn15ypl-spidermonkey-68.10.0.drv' is not available
$ nix-shell /home/tony/.cache/nixpkgs-review/pr-100026/shell.nix
```