### PR TITLE
gnupg: put libexec tools (eg. gpg-preset-passphrase) in PATH

### DIFF
--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -69,6 +69,9 @@ stdenv.mkDerivation rec {
 
     # add gpg2 symlink to make sure git does not break when signing commits
     ln -s $out/bin/gpg $out/bin/gpg2
+
+    # Make libexec tools available in PATH
+    ln -s -t $out/bin $out/libexec/*
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
This is extracted from https://github.com/NixOS/nixpkgs/pull/93659 as suggested in https://github.com/NixOS/nixpkgs/pull/93659#discussion_r500631930

###### Motivation for this change
Use `gpg-preset-passphrase`.

###### Things done
Symlink `$out/libexec/*` into `$out/bin`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
