### PR TITLE
xsel: 2019-08-21 -> 2020-05-27

### DIFF
--- a/pkgs/tools/misc/xsel/default.nix
+++ b/pkgs/tools/misc/xsel/default.nix
@@ -1,15 +1,14 @@
-{stdenv, lib, fetchFromGitHub, libX11, autoreconfHook }:
+{ stdenv, lib, fetchFromGitHub, libX11, autoreconfHook }:
 
 stdenv.mkDerivation {
   pname = "xsel-unstable";
-
-  version = "2019-08-21";
+  version = "2020-05-27";
 
   src = fetchFromGitHub {
     owner = "kfish";
     repo = "xsel";
-    rev = "ef01f3c72a195dbce682184c842b81b17d7d7ad1";
-    sha256 = "191qa6022b7nww3bicfxpgp4d9x6c8s3sgixi780383ghkxds08c";
+    rev = "062e6d373537c60829fa9b5dcddbcd942986b3c3";
+    sha256 = "0fbf80zsc22vcqp59r9fdx4icxhrkv7l3lphw83326jrmkzy6kri";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change
Result of `nixpkgs-review pr 100032` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>14 packages built:</summary>
  <ul>
    <li>_0x0</li>
    <li>cht-sh</li>
    <li>clipmenu</li>
    <li>gnvim</li>
    <li>imgurbash2</li>
    <li>keepass</li>
    <li>kitty</li>
    <li>neovim-qt</li>
    <li>neovim-unwrapped</li>
    <li>pws</li>
    <li>rofi-emoji</li>
    <li>rofimoji</li>
    <li>xsel</li>
    <li>yank</li>
  </ul>
</details>


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
