### PR TITLE
nixos/mediatomb: fix doc errors

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -228,9 +228,8 @@ GRANT ALL PRIVILEGES ON *.* TO 'mysql'@'localhost' WITH GRANT OPTION;
    </listitem>
    <listitem>
      <para>
-       The <link linked="opt-services.mediatomb">mediatomb service</link>
-       declares new options. It also adapts existing options so the
-       configuration generation is now lazy. The existing option
+       The Mediatomb service declares new options. It also adapts existing
+       options to make the configuration generation lazy. The existing option
        <literal>customCfg</literal> (defaults to false), when enabled, stops
        the service configuration generation completely. It then expects the
        users to provide their own correct configuration at the right location
@@ -886,17 +885,17 @@ CREATE ROLE postgres LOGIN SUPERUSER;
       </listitem>
      </itemizedlist>
     </para>
+   </listitem>
    <listitem>
      <para>
-       The <link linked="opt-services.mediatomb">mediatomb service</link> is
-       now using by default the new and maintained fork
-       <literal>gerbera</literal> package instead of the unmaintained
+       The mediatomb service is now using the new and maintained <literal>gerbera</literal>
+       <literal>gerbera</literal> fork instead of the unmaintained
        <literal>mediatomb</literal> package. If you want to keep the old
        behavior, you must declare it with:
        <programlisting>
        services.mediatomb.package = pkgs.mediatomb;
        </programlisting>
-       One new option <literal>openFirewall<literal> has been introduced which
+       One new option <literal>openFirewall</literal> has been introduced which
        defaults to false. If you relied on the service declaration to add the
        firewall rules itself before, you should now declare it with:
        <programlisting>

--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -261,7 +261,7 @@ in {
         type = types.path;
         default = "/var/lib/${name}";
         description = ''
-          The directory where ${cfg.serverName} stores its state, data, etc.
+          The directory where Gerbera/Mediatomb stores its state, data, etc.
         '';
       };
 
@@ -306,10 +306,12 @@ in {
         default = false;
         description = ''
           If false (the default), this is up to the user to declare the firewall rules.
-          If true, this opens the 1900 (tcp and udp) and ${toString cfg.port} (tcp) ports.
-          If the option cfg.interface is set, the firewall rules opened are
-          dedicated to that interface. Otherwise, those rules are opened
-          globally.
+          If true, this opens port 1900 (tcp and udp) and the port specified by
+          <option>sercvices.mediatomb.port</option>.
+
+          If the option <option>services.mediatomb.interface</option> is set,
+          the firewall rules opened are dedicated to that interface. Otherwise,
+          those rules are opened globally.
         '';
       };
 
@@ -337,10 +339,12 @@ in {
         type = types.bool;
         default = false;
         description = ''
-          Allow ${name} to create and use its own config file inside ${cfg.dataDir}.
+          Allow ${name} to create and use its own config file inside the <literal>dataDir</literal> as
+          configured by <option>services.mediatomb.dataDir</option>.
           Deactivated by default, the service then runs with the configuration generated from this module.
           Otherwise, when enabled, no service configuration is generated. Gerbera/Mediatomb then starts using
-          ${cfg.dataDir}/config.xml. It's up to the user to make a correct configuration file.
+          config.xml within the configured <literal>dataDir</literal>. It's up to the user to make a correct
+          configuration file.
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

Fix the manual build.

https://github.com/NixOS/nixpkgs/pull/93450#issuecomment-705565019

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
