### PR TITLE
qt5.qtwebengine: Sessions restore patch

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -47,6 +47,15 @@ qtModule {
       stripLen = 1;
       extraPrefix = "src/3rdparty/";
     })
+    # Manual backport of patch originally reviewed on
+    # https://chromium-review.googlesource.com/c/chromium/src/+/2153325:
+    # Downstream reference: https://github.com/NixOS/nixpkgs/pull/99456#issuecomment-703523943
+    (fetchpatch {
+      url = "https://code.qt.io/cgit/qt/qtwebengine-chromium.git/patch/?id=4e828b3b";
+      sha256 = "1lzqa7hlw2yns86vq4zz270vf77zk8yql080a0xryw0lds83jviv";
+      stripLen = 1;
+      extraPrefix = "src/3rdparty/";
+    })
   ];
 
   postPatch =


### PR DESCRIPTION
Per https://github.com/NixOS/nixpkgs/pull/99456#issuecomment-703523943

cc @ttuegel .

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
