### PR TITLE
starship: 0.45.2 -> 0.46.0

### DIFF
--- a/pkgs/tools/misc/starship/default.nix
+++ b/pkgs/tools/misc/starship/default.nix
@@ -10,13 +10,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "starship";
-  version = "0.45.2";
+  version = "0.46.2";
 
   src = fetchFromGitHub {
     owner = "starship";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0kxmgx4pnayp3jf6cgmka05x3aymxr79rim5nff6k3cg5zaqrz59";
+    sha256 = "092nqxl3vdk8k589bv3g05c598k77f4wsxcgymfb1h1fc0lfzqs4";
   };
 
   nativeBuildInputs = [ installShellFiles ] ++ stdenv.lib.optionals stdenv.isLinux [ pkg-config ];
@@ -31,14 +31,17 @@ rustPlatform.buildRustPackage rec {
     done
   '';
 
-  cargoSha256 = "0x9a322anwrgpxfqrvqb1ikavp8qffa93wdvj5kln1d2rgmxr2sy";
+  cargoSha256 = "1smz7084ppz79p8migpy0cqp6azf7sixv9ga65l2f3zfna7kbk78";
 
   checkFlags = [
     "--skip=directory_in_home"
-    "--skip=fish_directory_in_home"
     "--skip=home_directory"
-    "--skip=truncated_directory_in_home"
     "--skip=directory_in_root"
+    "--skip=truncation_symbol_not_truncated_home"
+    "--skip=truncation_symbol_truncated_home"
+    "--skip=folder_with_glide_yaml"
+    "--skip=shows_multiple_tfms"
+    "--skip=shows_pinned_in_project_below_root_with_global_json"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/starship/starship/releases/tag/v0.46.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
