### PR TITLE
ocamlPackages.secp256k1: 0.4.0 → 0.4.1

### DIFF
--- a/pkgs/development/ocaml-modules/secp256k1/default.nix
+++ b/pkgs/development/ocaml-modules/secp256k1/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, base, stdio, configurator, secp256k1 }:
+{ stdenv, fetchFromGitHub, buildDunePackage, base, stdio, dune-configurator, secp256k1 }:
 
-buildDunePackage {
+buildDunePackage rec {
   pname = "secp256k1";
-  version = "0.4.0";
+  version = "0.4.1";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "dakk";
     repo = "secp256k1-ml";
-    rev = "42c04c93e2ed9596f6378676e944c8cfabfa69d7";
-    sha256 = "1zw2kgg181a9lj1m8z0ybijs8gw9w1kk990avh1bp9x8kc1asffg";
+    rev = version;
+    sha256 = "0jkd7mc5kynhg0b76dfk70pww97qsq2jbd991634i16xf8qja9fj";
   };
 
-  buildInputs = [ base stdio configurator secp256k1 ];
+  buildInputs = [ base stdio dune-configurator secp256k1 ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/dakk/secp256k1-ml";


### PR DESCRIPTION
###### Motivation for this change

Drop dependency on `configurator`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc/ maintainer @vyorkin 