### PR TITLE
pythonPackages.sip: do not build tools for non-default sip module

### DIFF
--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -13,9 +13,9 @@
 
 let
 
-  inherit (pythonPackages) buildPythonPackage python isPy3k dbus-python enum34;
+  inherit (pythonPackages) buildPythonPackage python isPy3k dbus-python enum34 sip;
 
-  sip = (pythonPackages.sip.override { sip-module = "PyQt5.sip"; }).overridePythonAttrs(oldAttrs: {
+  pyqt5-sip = (sip.override { sipModule = "PyQt5.sip"; }).overridePythonAttrs(oldAttrs: {
     # If we install sip in another folder, then we need to create a __init__.py as well
     # if we want to be able to import it with Python 2.
     # Python 3 could rely on it being an implicit namespace package, however,
@@ -104,7 +104,7 @@ in buildPythonPackage rec {
   '';
 
   postInstall = ''
-    ln -s ${sip}/${python.sitePackages}/PyQt5/sip.* $out/${python.sitePackages}/PyQt5/
+    ln -s ${pyqt5-sip}/${python.sitePackages}/PyQt5/* $out/${python.sitePackages}/PyQt5/
     for i in $out/bin/*; do
       wrapProgram $i --prefix PYTHONPATH : "$PYTHONPATH"
     done


### PR DESCRIPTION
This ensures that the default sip and alternative sips do not have common files.

Rebased https://github.com/NixOS/nixpkgs/pull/52968.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
