### PR TITLE
[20.09] pythonPackages.sievelib: fix build by adding patch

### DIFF
--- a/pkgs/development/python-modules/sievelib/default.nix
+++ b/pkgs/development/python-modules/sievelib/default.nix
@@ -12,8 +12,14 @@ buildPythonPackage rec {
 
   patches = [
     (fetchpatch {
+      name = "pip-10-pip-req.patch";
       url = "https://github.com/tonioo/sievelib/commit/1deef0e2bf039a0e817ea6f19aaf1947dc9fafbc.patch";
       sha256 = "0vaj73mcij9dism8vfaai82irh8j1b2n8gf9jl1a19d2l26jrflk";
+    })
+    (fetchpatch {
+      name = "requirements-in-setup-py.patch";
+      url = "https://github.com/tonioo/sievelib/commit/91f40ec226ea288e98379da01672a46dabd89fc9.patch";
+      sha256 = "0hph89xn16r353rg6f05bh0cgigmwdc736bya089qc03jhssrgns";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of #98016

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
