### PR TITLE
nixos/plasma: use upstream xsession/wayland files

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -18,10 +18,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - Activation scripts can now opt int to be run when running `nixos-rebuild dry-activate` and detect the dry activation by reading `$NIXOS_ACTION`.
   This allows activation scripts to output what they would change if the activation was really run.
+  The users/modules activation script supports this and outputs some of is actions.
 
 - KDE Plasma now finally works on Wayland.
-
-  The users/modules activation script supports this and outputs some of is actions.
 
 - bash now defaults to major version 5.
 

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -18,6 +18,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - Activation scripts can now opt int to be run when running `nixos-rebuild dry-activate` and detect the dry activation by reading `$NIXOS_ACTION`.
   This allows activation scripts to output what they would change if the activation was really run.
+
+- We can now finally use Plasma on Wayland.
+
   The users/modules activation script supports this and outputs some of is actions.
 
 - bash now defaults to major version 5.
@@ -338,6 +341,7 @@ In addition to numerous new and upgraded packages, this release has the followin
   configuration file. For details, see the [upstream changelog](https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst).
 
 - `opencv2` no longer includes the non-free libraries by default, and consequently `pfstools` no longer includes OpenCV support by default.  Both packages now support an `enableUnfree` option to re-enable this functionality.
+- `services.xserver.displayManager.defaultSession = "plasma5"` does not work anymore, instead use either `"plasma"` for the Plasma X11 session or `"plasmawayland"` for the Plasma Wayland sesison.
 
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -19,7 +19,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 - Activation scripts can now opt int to be run when running `nixos-rebuild dry-activate` and detect the dry activation by reading `$NIXOS_ACTION`.
   This allows activation scripts to output what they would change if the activation was really run.
 
-- We can now finally use Plasma on Wayland.
+- KDE Plasma now finally works on Wayland.
 
   The users/modules activation script supports this and outputs some of is actions.
 

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -13,7 +13,6 @@ let
 
   pulseaudio = config.hardware.pulseaudio;
   pactl = "${getBin pulseaudio.package}/bin/pactl";
-  startplasma-x11 = "${getBin plasma5.plasma-workspace}/bin/startplasma-x11";
   sed = "${getBin pkgs.gnused}/bin/sed";
 
   gtkrc2 = writeText "gtkrc-2.0" ''

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -136,9 +136,6 @@ let
           fi
       fi
 
-    ''
-    + ''
-      exec "${startplasma-x11}"
     '';
 
 in
@@ -183,6 +180,7 @@ in
 
   config = mkMerge [
     (mkIf cfg.enable {
+
       # Seed our configuration into nixos-generate-config
       system.nixos-generate-config.desktopConfiguration = [''
         # Enable the Plasma 5 Desktop Environment.
@@ -190,11 +188,7 @@ in
         services.xserver.desktopManager.plasma5.enable = true;
       ''];
 
-      services.xserver.desktopManager.session = singleton {
-        name = "plasma5";
-        bgSupport = true;
-        start = startplasma;
-      };
+      services.xserver.displayManager.sessionPackages = [ pkgs.libsForQt5.plasma5.plasma-workspace ];
 
       security.wrappers = {
         kcheckpass =
@@ -389,6 +383,7 @@ in
 
       # Update the start menu for each user that is currently logged in
       system.userActivationScripts.plasmaSetup = activationScript;
+      services.xserver.displayManager.setupCommands = startplasma;
 
       nixpkgs.config.firefox.enablePlasmaBrowserIntegration = true;
     })

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -12,7 +12,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
     services.xserver.displayManager.sddm.enable = true;
-    services.xserver.displayManager.defaultSession = "plasma5";
+    services.xserver.displayManager.defaultSession = "plasma";
     services.xserver.desktopManager.plasma5.enable = true;
     services.xserver.displayManager.autoLogin = {
       enable = true;

--- a/pkgs/desktops/plasma-5/plasma-workspace/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-workspace/default.nix
@@ -24,6 +24,7 @@ let inherit (lib) getBin getLib; in
 
 mkDerivation {
   name = "plasma-workspace";
+  passthru.providedSessions = [ "plasma" "plasmawayland" ];
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
An updated version of https://github.com/NixOS/nixpkgs/pull/56988
Wayland still does not work and `~/.local/share/sddm/wayland-session.log` is empty after a failed Wayland login,as `journalctl -u display-manager`.

I will fix the override after making Wayland work

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
