### PR TITLE
powerdns: update configure flags

### DIFF
--- a/pkgs/servers/dns/powerdns/default.nix
+++ b/pkgs/servers/dns/powerdns/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig
-, boost, libyamlcpp, libsodium, sqlite, protobuf, botan2, openssl
+, boost, libyamlcpp, libsodium, sqlite, protobuf, openssl
 , mysql57, postgresql, lua, openldap, geoip, curl, opendbx, unixODBC
 }:
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     boost mysql57.connector-c postgresql lua openldap sqlite protobuf geoip
-    libyamlcpp libsodium curl opendbx unixODBC botan2 openssl
+    libyamlcpp libsodium curl opendbx unixODBC openssl
   ];
 
   # nix destroy with-modules arguments, when using configureFlags
@@ -25,8 +25,7 @@ stdenv.mkDerivation rec {
       --with-sqlite3
       --with-socketdir=/var/lib/powerdns
       --with-libcrypto=${openssl.dev}
-      --enable-libsodium
-      --enable-botan
+      --with-libsodium
       --enable-tools
       --disable-dependency-tracking
       --disable-silent-rules

--- a/pkgs/servers/dns/powerdns/default.nix
+++ b/pkgs/servers/dns/powerdns/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig
+{ stdenv, fetchurl, pkgconfig, nixosTests
 , boost, libyamlcpp, libsodium, sqlite, protobuf, openssl, systemd
 , mysql57, postgresql, lua, openldap, geoip, curl, opendbx, unixODBC
 }:
@@ -37,6 +37,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
   doCheck = true;
+
+  passthru.tests = {
+    nixos = nixosTests.powerdns;
+  };
 
   meta = with stdenv.lib; {
     description = "Authoritative DNS server";

--- a/pkgs/servers/dns/powerdns/default.nix
+++ b/pkgs/servers/dns/powerdns/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig
-, boost, libyamlcpp, libsodium, sqlite, protobuf, openssl
+, boost, libyamlcpp, libsodium, sqlite, protobuf, openssl, systemd
 , mysql57, postgresql, lua, openldap, geoip, curl, opendbx, unixODBC
 }:
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     boost mysql57.connector-c postgresql lua openldap sqlite protobuf geoip
-    libyamlcpp libsodium curl opendbx unixODBC openssl
+    libyamlcpp libsodium curl opendbx unixODBC openssl systemd
   ];
 
   # nix destroy with-modules arguments, when using configureFlags
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
       --disable-silent-rules
       --enable-reproducible
       --enable-unit-tests
+      --enable-systemd
     )
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://doc.powerdns.com/authoritative/appendices/compiling.html
> The PowerDNS Authoritative Server can link with libsodium to support ed25519 (DNSSEC algorithm 15). To detect libsodium, use the --with-libsodium configure option.
>
> Changed in version 4.2.0: This option was previously --enable-libsodium

https://doc.powerdns.com/authoritative/appendices/crypto-export.html
> Optionally, PowerDNS can link in a copy of the open source Botan cryptographic library. Starting with 4.2.0, linking in Botan is no longer possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
