### PR TITLE
Kicad

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -1,23 +1,51 @@
-{ lib, stdenv, fetchFromGitLab, cmake, libGLU, libGL, zlib, wxGTK
-, libX11, gettext, glew, glm, cairo, curl, openssl, boost, pkgconfig
-, doxygen, pcre, libpthreadstubs, libXdmcp, fetchpatch, lndir, callPackages
+{ lib
+, stdenv
+, fetchFromGitLab
+, cmake
+, libGLU
+, libGL
+, zlib
+, wxGTK
+, libX11
+, gettext
+, glew
+, glm
+, cairo
+, curl
+, openssl
+, boost
+, pkgconfig
+, doxygen
+, pcre
+, libpthreadstubs
+, libXdmcp
+, fetchpatch
+, lndir
+, callPackages
 
 , stable ? true
 , baseName ? "kicad"
 , versions ? { }
-, oceSupport ? false, opencascade
-, withOCCT ? true, opencascade-occt
-, ngspiceSupport ? true, libngspice
-, scriptingSupport ? true, swig, python, wxPython
-, debug ? false, valgrind
+, oceSupport ? false
+, opencascade
+, withOCCT ? true
+, opencascade-occt
+, ngspiceSupport ? true
+, libngspice
+, scriptingSupport ? true
+, swig
+, python
+, wxPython
+, debug ? false
+, valgrind
 , withI18n ? true
+, gtk3
 }:
 
 assert ngspiceSupport -> libngspice != null;
 
 with lib;
 let
-
   versionConfig = versions.${baseName};
 
   # oce on aarch64 fails a test
@@ -95,8 +123,22 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake doxygen pkgconfig lndir ];
 
   buildInputs = [
-    libGLU libGL zlib libX11 wxGTK pcre libXdmcp gettext
-    glew glm libpthreadstubs cairo curl openssl boost
+    libGLU
+    libGL
+    zlib
+    libX11
+    wxGTK
+    pcre
+    libXdmcp
+    gettext
+    glew
+    glm
+    libpthreadstubs
+    cairo
+    curl
+    openssl
+    boost
+    gtk3
   ]
   ++ optionals (scriptingSupport) [ swig python wxPython ]
   ++ optional (ngspiceSupport) libngspice

--- a/pkgs/applications/science/electronics/kicad/update.sh
+++ b/pkgs/applications/science/electronics/kicad/update.sh
@@ -58,7 +58,6 @@ file="${here}/versions.nix"
 # just in case this runs in parallel
 tmp="${here}/,versions.nix.${RANDOM}"
 
-# libraries currently on github, move to $gitlab/libraries planned
 libs=( symbols templates footprints packages3d )
 
 get_rev="git ls-remote --heads --tags"
@@ -66,9 +65,6 @@ get_rev="git ls-remote --heads --tags"
 gitlab="https://gitlab.com/kicad"
 # append commit hash or tag
 gitlab_pre="https://gitlab.com/api/v4/projects/kicad%2Fcode%2Fkicad/repository/archive.tar.gz?sha="
-
-# append "-$lib/archive/[hash or tag].tar.gz
-github="https://github.com/kicad/kicad"
 
 # not a lib, but separate and already moved to gitlab
 i18n="${gitlab}/code/kicad-i18n.git"
@@ -147,8 +143,8 @@ for version in "${all_versions[@]}"; do
 
           for lib in "${libs[@]}"; do
             echo "Checking ${lib}" >&2
-            url="${github}-${lib}.git"
-            lib_rev="$(${get_rev} "${url}" "${version}" | cut -f1)"
+            url="${gitlab}/libraries/kicad-${lib}.git"
+            lib_rev="$(${get_rev} "${url}" "${version}" | cut -f1 | head -n1)"
             has_rev="$(grep -sm 1 "\"${pname}\"" -A 19 "${file}" | grep -sm 1 "${lib_rev}" || true)"
             has_hash="$(grep -sm 1 "\"${pname}\"" -A 20 "${file}" | grep -sm 1 "${lib}.sha256")"
             if [[ -n ${has_rev} && -n ${has_hash} && -z ${clean} ]]; then
@@ -161,7 +157,7 @@ for version in "${all_versions[@]}"; do
               esac
               printf "\"%s\";\n" "${lib_rev}"
               printf "%8s%s.sha256 =\t\"%s\";\n" "" \
-              "${lib}" "$(${prefetch} "${github}-${lib}/archive/${lib_rev}.tar.gz")"
+                "${lib}" "$(${prefetch} "https://gitlab.com/api/v4/projects/kicad%2Flibraries%2Fkicad-${lib}/repository/archive.tar.gz?sha=${lib_rev}")"
               count=$((count+1))
             fi
           done
@@ -172,7 +168,7 @@ for version in "${all_versions[@]}"; do
     printf "\nReusing old %s\n" "${pname}" >&2
     grep -sm 1 "\"${pname}\"" -A 23 "${file}"
   fi
-done 
+done
 printf "}\n"
 } > "${tmp}"
 

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,49 +3,49 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"5.1.6";
+      version = "5.1.6";
       src = {
-        rev =			"c6e7f7de7df655fd59b57823499efc443009de6b";
-        sha256 =		"1pa3z0h0679jmgxlzc833h6q85b5paxdp69kf2h93vkaryj58622";
+        rev = "c6e7f7de7df655fd59b57823499efc443009de6b";
+        sha256 = "1pa3z0h0679jmgxlzc833h6q85b5paxdp69kf2h93vkaryj58622";
       };
     };
     libVersion = {
-      version =			"5.1.6";
+      version = "5.1.6";
       libSources = {
-        i18n.rev =		"5ad171ce5c8d90f4740517c2adecb310d8be51bd";
-        i18n.sha256 =		"0qryi8xjm23ka363zfl7bbga0v5c31fr3d4nyxp3m168vkv9zhha";
-        symbols.rev =		"5150eaa2a7d15cfc6bb1459c527c4ebaa66d7708";
-        symbols.sha256 =	"12w3rdy085drlikkpb27n9ni7cyg9l0pqy7hnr86cxjcw3l5wcx6";
-        templates.rev =		"9213d439f757e6049b7e54f3ea08272a0d0f44a9";
-        templates.sha256 =	"1hppcsrkn4dk6ggby6ckh0q65qxkywrbyxa4lwpaf7pxjyv498xg";
-        footprints.rev =	"a61b4e49762fb355f654e65a1c7db1aaf7bb2332";
-        footprints.sha256 =	"1kmf91a5mmvj9izrv40mkaw1w36yjgn8daczd9rq2wlmd0rdp1zx";
-        packages3d.rev =	"150ff1caf0b01dc04c84f4f966f4f88fedfa8f8c";
-        packages3d.sha256 =	"0b9jglf77fy0n0r8xs4yqkv6zvipyfvp0z5dnqlzp32csy5aqpi1";
+        i18n.rev = "5ad171ce5c8d90f4740517c2adecb310d8be51bd";
+        i18n.sha256 = "0qryi8xjm23ka363zfl7bbga0v5c31fr3d4nyxp3m168vkv9zhha";
+        symbols.rev = "5150eaa2a7d15cfc6bb1459c527c4ebaa66d7708";
+        symbols.sha256 = "12w3rdy085drlikkpb27n9ni7cyg9l0pqy7hnr86cxjcw3l5wcx6";
+        templates.rev = "9213d439f757e6049b7e54f3ea08272a0d0f44a9";
+        templates.sha256 = "1hppcsrkn4dk6ggby6ckh0q65qxkywrbyxa4lwpaf7pxjyv498xg";
+        footprints.rev = "a61b4e49762fb355f654e65a1c7db1aaf7bb2332";
+        footprints.sha256 = "1kmf91a5mmvj9izrv40mkaw1w36yjgn8daczd9rq2wlmd0rdp1zx";
+        packages3d.rev = "150ff1caf0b01dc04c84f4f966f4f88fedfa8f8c";
+        packages3d.sha256 = "0b9jglf77fy0n0r8xs4yqkv6zvipyfvp0z5dnqlzp32csy5aqpi1";
       };
     };
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2020-08-22";
+      version =			"2020-10-09";
       src = {
-        rev =			"a2341f0f335b0abb9fc8cb86d19cbe6f9b38fade";
-        sha256 =		"0167yb39f800xarq3khn7sbdkgcx9j2ayhy8c7lhhks6kh7459g0";
+        rev =			"560428a70f0196fb4ade620042c5ddefc1685ebe";
+        sha256 =		"0rzn83bpl06v1d49lcvwfg93nirn684bqqq536zxhmjm0ayx29ka";
       };
     };
     libVersion = {
-      version =			"2020-08-22";
+      version =			"2020-10-09";
       libSources = {
-        i18n.rev =		"cbbb1efd940094bf0c3168280698b2b059a8c509";
-        i18n.sha256 =		"1q4jakn6m8smnr2mg7jgb520nrb6fag9mdvlcpx3smp3qbxka818";
-        symbols.rev =		"9ca6a5348cdeb88e699582d4ed051ff7303b44d3";
-        symbols.sha256 =	"13w6pb34rhz96rnar25z7kiscy6q1fm8l39hq1bpb8g9yn86ssz4";
-        templates.rev =		"ae16953b81055855bcede4a33305413599d86a15";
-        templates.sha256 =	"1pkv90p3liy3bj4nklxsvpzh9m56p0k5ldr22armvgqfaqaadx9v";
-        footprints.rev =	"f94c2d5d619d16033f69a555b449f59604d97865";
-        footprints.sha256 =	"1g71sk77jvqaf9xvgq6dkyvd9pij2lb4n0bn0dqnwddhwam935db";
-        packages3d.rev =	"f699b0e3c13fe75618086913e39279c85da14cc7";
-        packages3d.sha256 =	"0m5rb5axa946v729z35ga84in76y4zpk32qzi0hwqx957zy72hs9";
+        i18n.rev =		"d24af2da8cab4ce1081c401909a4a880514e5549";
+        i18n.sha256 =		"0r0sv52k84sw4jxf10lrmzwmn58d2fv5h57fdrspnmvnh10q63xf";
+        symbols.rev =		"9c50f4333bafc5a1abf7786436db5ffb6a66758d";
+        symbols.sha256 =	"06ic59svz0256isy93863i5ay4k8wshvp1kspnqrc776wmq03l3k";
+        templates.rev =		"41eae4ccd3ac02fdb969e3aa272c07ab51dcf5af";
+        templates.sha256 =	"0xxfkpsgbnafmpaxpz1747zn7fhqp0kfl32rzjrx4vzxyp25q805";
+        footprints.rev =	"50015af7e603cc499199c7e1c6daa7c85dd732ae";
+        footprints.sha256 =	"16bic67klbj7sgj7cab8ha2fg3ypp9ap82gxkn6ijvpl7dka8bhb";
+        packages3d.rev =	"df0dc0074491bb665b2c3ce569cbd4aa16118ad6";
+        packages3d.sha256 =	"027jlcp9fpryldjkcxhb1b5bpwqna9kl6r0lnkd86x238kj3rd8v";
       };
     };
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Modifies the kicad update script to use gitlab and updates kicad-unstable.

###### Things done
kicad-unstable now requires gtk3 as a build input to compile. I've also reformatted the files to have one parameter per line and one build input per line.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
