### PR TITLE
kicad: add srcs parameter to allow configuring kicad versions

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -71,6 +71,17 @@
       for consistency with other X11 resources.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      A number of options have been renamed in the kicad interface. <literal>oceSupport</literal>
+      has been renamed to <literal>withOCE</literal>, <literal>withOCCT</literal> has been renamed
+      to <literal>withOCC</literal>, <literal>ngspiceSupport</literal> has been renamed to
+      <literal>withNgspice</literal>, and <literal>scriptingSupport</literal> has been renamed to
+      <literal>withScripting</literal>. Additionally, <literal>kicad/base.nix</literal> no longer
+      provides default argument values since these are provided by
+      <literal>kicad/default.nix</literal>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -1,5 +1,4 @@
-{ lib
-, stdenv
+{ stdenv
 , fetchFromGitLab
 , cmake
 , libGLU
@@ -44,7 +43,6 @@
 
 assert ngspiceSupport -> libngspice != null;
 
-with lib;
 let
   versionConfig = versions.${baseName};
 
@@ -54,6 +52,7 @@ let
 
   libraries = callPackages ./libraries.nix versionConfig.libVersion;
 
+  inherit (stdenv.lib) optional optionals;
 in
 stdenv.mkDerivation rec {
 
@@ -166,7 +165,7 @@ stdenv.mkDerivation rec {
       the libraries are passed via an env var in the wrapper, default.nix
     '';
     homepage = "https://www.kicad-pcb.org/";
-    license = licenses.agpl3;
-    platforms = platforms.all;
+    license = stdenv.lib.licenses.agpl3;
+    platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -20,11 +20,13 @@
 , libXdmcp
 , fetchpatch
 , lndir
-, callPackages
+, callPackage
 
 , stable
 , baseName
-, versions
+, kicadSrc
+, kicadVersion
+, i18n
 , withOCE
 , opencascade
 , withOCC
@@ -45,28 +47,13 @@ assert stdenv.lib.asserts.assertMsg (!(withOCE && stdenv.isAarch64)) "OCE fails 
 assert stdenv.lib.asserts.assertMsg (!(withOCC && withOCE))
   "Only one of OCC and OCE may be enabled";
 let
-  versionConfig = versions.${baseName};
-
-  libraries = callPackages ./libraries.nix versionConfig.libVersion;
-
   inherit (stdenv.lib) optional optionals;
-  versionConfig = versions.${baseName};
-  libraries = callPackages ./libraries.nix versionConfig.libVersion;
 in
 stdenv.mkDerivation rec {
-
-  i18n = libraries.i18n;
-
   pname = "kicad-base";
-  version = "${builtins.substring 0 10 versions.${baseName}.kicadVersion.src.rev}";
+  version = kicadVersion;
 
-  src = fetchFromGitLab (
-    {
-      group = "kicad";
-      owner = "code";
-      repo = "kicad";
-    } // versionConfig.kicadVersion.src
-  );
+  src = kicadSrc;
 
   # quick fix for #72248
   # should be removed if a a more permanent fix is published

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -81,8 +81,8 @@ stdenv.mkDerivation rec {
     ++ optionals (scriptingSupport)
     [ python.pkgs.wrapPython ];
 
-  # wrapGAppsHook added the equivalent to ${base}/share
-  # though i noticed no difference without it
+  # We are emulating wrapGAppsHook, along with other variables to the
+  # wrapper
   makeWrapperArgs = with passthru.libraries; [
     "--prefix XDG_DATA_DIRS : ${base}/share"
     "--prefix XDG_DATA_DIRS : ${hicolor-icon-theme}/share"

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -1,5 +1,5 @@
-{ lib
-, stdenv
+{ stdenv
+, fetchFromGitLab
 , gnome3
 , wxGTK30
 , wxGTK31
@@ -29,8 +29,6 @@
 }:
 
 assert ngspiceSupport -> libngspice != null;
-
-with lib;
 let
   baseName = if (stable) then "kicad" else "kicad-unstable";
 
@@ -55,6 +53,7 @@ let
   python = python3;
   wxPython = python.pkgs.wxPython_4_0;
 
+  inherit (stdenv.lib) concatStringsSep flatten optionalString optionals;
 in
 stdenv.mkDerivation rec {
 
@@ -109,7 +108,7 @@ stdenv.mkDerivation rec {
   # why does $makeWrapperArgs have to be added explicitly?
   # $out and $program_PYTHONPATH don't exist when makeWrapperArgs gets set?
   # kicad-ogltest's source seems to indicate that crashing is expected behaviour...
-  installPhase = with lib;
+  installPhase =
     let
       tools = [ "kicad" "pcbnew" "eeschema" "gerbview" "pcb_calculator" "pl_editor" "bitmap2component" ];
       utils = [ "dxf2idf" "idf2vrml" "idfcyl" "idfrect" "kicad2step" "kicad-ogltest" ];
@@ -148,7 +147,7 @@ stdenv.mkDerivation rec {
       KiCad is an open source software suite for Electronic Design Automation.
       The Programs handle Schematic Capture, and PCB Layout with Gerber output.
     '';
-    license = licenses.agpl3;
+    license = stdenv.lib.licenses.agpl3;
     # berce seems inactive...
     maintainers = with stdenv.lib.maintainers; [ evils kiwi berce ];
     # kicad is cross platform

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -1,16 +1,29 @@
-{ lib, stdenv, gnome3, wxGTK30, wxGTK31
+{ lib
+, stdenv
+, gnome3
+, wxGTK30
+, wxGTK31
 , makeWrapper
-, gsettings-desktop-schemas, hicolor-icon-theme
-, callPackage, callPackages
-, librsvg, cups
+, gsettings-desktop-schemas
+, hicolor-icon-theme
+, callPackage
+, callPackages
+, librsvg
+, cups
 
 , pname ? "kicad"
 , stable ? true
-, oceSupport ? false, opencascade
-, withOCCT ? true, opencascade-occt
-, ngspiceSupport ? true, libngspice
-, scriptingSupport ? true, swig, python3
-, debug ? false, valgrind
+, oceSupport ? false
+, opencascade
+, withOCCT ? true
+, opencascade-occt
+, ngspiceSupport ? true
+, libngspice
+, scriptingSupport ? true
+, swig
+, python3
+, debug ? false
+, valgrind
 , with3d ? true
 , withI18n ? true
 }:
@@ -19,18 +32,25 @@ assert ngspiceSupport -> libngspice != null;
 
 with lib;
 let
-
   baseName = if (stable) then "kicad" else "kicad-unstable";
 
-  versions =  import ./versions.nix;
+  versions = import ./versions.nix;
   versionConfig = versions.${baseName};
 
-  wxGTK = if (stable)
+  wxGTK =
+    if (stable)
     # wxGTK3x may default to withGtk2 = false, see #73145
-    then wxGTK30.override { withGtk2 = false; }
+    then
+      wxGTK30.override
+        {
+          withGtk2 = false;
+        }
     # wxGTK31 currently introduces an issue with opening the python interpreter in pcbnew
     # but brings high DPI support?
-    else wxGTK31.override { withGtk2 = false; };
+    else
+      wxGTK31.override {
+        withGtk2 = false;
+      };
 
   python = python3;
   wxPython = python.pkgs.wxPython_4_0;
@@ -59,7 +79,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ]
     ++ optionals (scriptingSupport)
-      [ python.pkgs.wrapPython ];
+    [ python.pkgs.wrapPython ];
 
   # wrapGAppsHook added the equivalent to ${base}/share
   # though i noticed no difference without it
@@ -94,17 +114,19 @@ stdenv.mkDerivation rec {
       tools = [ "kicad" "pcbnew" "eeschema" "gerbview" "pcb_calculator" "pl_editor" "bitmap2component" ];
       utils = [ "dxf2idf" "idf2vrml" "idfcyl" "idfrect" "kicad2step" "kicad-ogltest" ];
     in
-    ( concatStringsSep "\n"
-      ( flatten [
-        ( optionalString (scriptingSupport) "buildPythonPath \"${base} $pythonPath\" \n" )
+    (concatStringsSep "\n"
+      (flatten [
+        (optionalString (scriptingSupport) "buildPythonPath \"${base} $pythonPath\" \n")
 
         # wrap each of the directly usable tools
-        ( map ( tool: "makeWrapper ${base}/bin/${tool} $out/bin/${tool} $makeWrapperArgs"
-          + optionalString (scriptingSupport) " --set PYTHONPATH \"$program_PYTHONPATH\""
-            ) tools )
+        (map
+          (tool: "makeWrapper ${base}/bin/${tool} $out/bin/${tool} $makeWrapperArgs"
+            + optionalString (scriptingSupport) " --set PYTHONPATH \"$program_PYTHONPATH\""
+          )
+          tools)
 
         # link in the CLI utils
-        ( map ( util: "ln -s ${base}/bin/${util} $out/bin/${util}" ) utils )
+        (map (util: "ln -s ${base}/bin/${util} $out/bin/${util}") utils)
       ])
     )
   ;
@@ -118,9 +140,9 @@ stdenv.mkDerivation rec {
 
   meta = rec {
     description = (if (stable)
-      then "Open Source Electronics Design Automation suite"
-      else "Open Source EDA suite, development build")
-      + (if (!with3d) then ", without 3D models" else "");
+    then "Open Source Electronics Design Automation suite"
+    else "Open Source EDA suite, development build")
+    + (if (!with3d) then ", without 3D models" else "");
     homepage = "https://www.kicad-pcb.org/";
     longDescription = ''
       KiCad is an open source software suite for Electronic Design Automation.

--- a/pkgs/applications/science/electronics/kicad/i18n.nix
+++ b/pkgs/applications/science/electronics/kicad/i18n.nix
@@ -1,0 +1,18 @@
+{ stdenv
+, cmake
+, gettext
+, src
+, version
+}:
+
+stdenv.mkDerivation {
+  inherit src version;
+
+  pname = "kicad-i18n";
+
+  nativeBuildInputs = [ cmake gettext ];
+  meta = with stdenv.lib; {
+    license = licenses.gpl2; # https://github.com/KiCad/kicad-i18n/issues/3
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/science/electronics/kicad/libraries.nix
+++ b/pkgs/applications/science/electronics/kicad/libraries.nix
@@ -1,6 +1,11 @@
-{ lib, stdenv, cmake, gettext
-, fetchFromGitHub, fetchFromGitLab
-, version, libSources
+{ lib
+, stdenv
+, cmake
+, gettext
+, fetchFromGitHub
+, fetchFromGitLab
+, version
+, libSources
 }:
 
 # callPackage libraries {
@@ -33,7 +38,7 @@ let
         platforms = stdenv.lib.platforms.all;
         # the 3d models are a ~1 GiB download and occupy ~5 GiB in store.
         # this would exceed the hydra output limit
-        hydraPlatforms = if (name == "packages3d" ) then [ ] else platforms;
+        hydraPlatforms = if (name == "packages3d") then [ ] else platforms;
       };
     };
 in

--- a/pkgs/applications/science/electronics/kicad/libraries.nix
+++ b/pkgs/applications/science/electronics/kicad/libraries.nix
@@ -1,5 +1,4 @@
-{ lib
-, stdenv
+{ stdenv
 , cmake
 , gettext
 , fetchFromGitHub
@@ -15,7 +14,6 @@
 #     sha256 = "...";
 #   };
 # };
-with lib;
 let
   mkLib = name:
     stdenv.mkDerivation {
@@ -34,7 +32,7 @@ let
       nativeBuildInputs = [ cmake ];
 
       meta = rec {
-        license = licenses.cc-by-sa-40;
+        license = stdenv.lib.licenses.cc-by-sa-40;
         platforms = stdenv.lib.platforms.all;
         # the 3d models are a ~1 GiB download and occupy ~5 GiB in store.
         # this would exceed the hydra output limit
@@ -69,7 +67,7 @@ in
       );
       nativeBuildInputs = [ cmake gettext ];
       meta = {
-        license = licenses.gpl2; # https://github.com/KiCad/kicad-i18n/issues/3
+        license = stdenv.lib.licenses.gpl2; # https://github.com/KiCad/kicad-i18n/issues/3
         platforms = stdenv.lib.platforms.all;
       };
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Allows overriding kicad versions which are otherwise inaccessible.

###### Things done
Added srcs parameter that can be used to customize kicad or kicad-unstable versions, including libraries. For instance, you could do something like:
```nix
final: prev:

{
  kicad-unstable = (prev.kicad-unstable.override {
    srcs = {
      "kicad-unstable" = {
        kicadVersion = {
          version = "2020-10-08";
          src = {
            rev = "fd22fe8e374ce71d57e9f683ba996651aa69fa4e";
            sha256 = "sha256-F8qugru/jU3DgZSpQXQhRGNFSk0ybFRkpyWb7HAGBdc=";
          };
        };
        libVersion = {
          version = "2020-08-22";
          libSources = {
            i18n.rev = "cbbb1efd940094bf0c3168280698b2b059a8c509";
            i18n.sha256 = "1q4jakn6m8smnr2mg7jgb520nrb6fag9mdvlcpx3smp3qbxka818";
            symbols.rev = "9ca6a5348cdeb88e699582d4ed051ff7303b44d3";
            symbols.sha256 = "13w6pb34rhz96rnar25z7kiscy6q1fm8l39hq1bpb8g9yn86ssz4";
            templates.rev = "ae16953b81055855bcede4a33305413599d86a15";
            templates.sha256 = "1pkv90p3liy3bj4nklxsvpzh9m56p0k5ldr22armvgqfaqaadx9v";
            footprints.rev = "f94c2d5d619d16033f69a555b449f59604d97865";
            footprints.sha256 = "1g71sk77jvqaf9xvgq6dkyvd9pij2lb4n0bn0dqnwddhwam935db";
            packages3d.rev = "f699b0e3c13fe75618086913e39279c85da14cc7";
            packages3d.sha256 = "0m5rb5axa946v729z35ga84in76y4zpk32qzi0hwqx957zy72hs9";
          };
        };
      };
    };
}
```

I've also reformatted the existing code. Let me know if the reformatting is too invasive and I'll revert.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
