### PR TITLE
terraform-full: fix evaluation

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -8,24 +8,18 @@ let
   list = lib.importJSON ./providers.json;
 
   toDrv = name: data:
-    let
-      fallbackProviderSourceAddress = "nixpkgs/${data.owner}/${name}";
-      providerSourceAddress = data.provider-source-address or fallbackProviderSourceAddress;
-    in
-    buildGoPackage rec {
-      inherit (data) owner repo rev version sha256;
-      name = "${repo}-${version}";
-      goPackagePath = "github.com/${owner}/${repo}";
+    buildGoPackage {
+      pname = data.repo;
+      version = data.version;
+      goPackagePath = "github.com/${data.owner}/${data.repo}";
       subPackages = [ "." ];
       src = fetchFromGitHub {
-        inherit owner repo rev sha256;
+        inherit (data) owner repo rev sha256;
       };
       # Terraform allow checking the provider versions, but this breaks
       # if the versions are not provided via file paths.
-      postBuild = "mv $NIX_BUILD_TOP/go/bin/${repo}{,_v${version}}";
-      passthru = {
-        inherit providerSourceAddress;
-      };
+      postBuild = "mv $NIX_BUILD_TOP/go/bin/${data.repo}{,_v${data.version}}";
+      passthru = data;
     };
 
   # Google is now using the vendored go modules, which works a bit differently

--- a/pkgs/applications/networking/cluster/terraform-providers/keycloak/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/keycloak/default.nix
@@ -4,7 +4,7 @@
 }:
 
 buildGoModule rec {
-  name = "terraform-provider-keycloak-${version}";
+  pname = "terraform-provider-keycloak";
   version = "1.20.0";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
Fix the nixpkgs evaluation that was broken by
cd1b59476793278191c37572c8081b856512eec4 (#99198)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).