### PR TITLE
grub2: fix grub-kbdcomp

### DIFF
--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -1,10 +1,12 @@
 { lib, stdenv, fetchgit, flex, bison, python3, autoconf, automake, gnulib, libtool
 , gettext, ncurses, libusb-compat-0_1, freetype, qemu, lvm2, unifont, pkg-config
 , fuse # only needed for grub-mount
+, runtimeShell
 , zfs ? null
 , efiSupport ? false
 , zfsSupport ? false
 , xenSupport ? false
+, kbdcompSupport ? false, ckbcomp
 }:
 
 with lib;
@@ -52,6 +54,13 @@ stdenv.mkDerivation rec {
   patches = [
     ./fix-bash-completion.patch
   ];
+
+  postPatch = if kbdcompSupport then ''
+    sed -i util/grub-kbdcomp.in -e 's@\bckbcomp\b@${ckbcomp}/bin/ckbcomp@'
+  '' else ''
+    echo '#! ${runtimeShell}' > util/grub-kbdcomp.in
+    echo 'echo "Compile grub2 with { kbdcompSupport = true; } to enable support for this command."' >> util/grub-kbdcomp.in
+  '';
 
   nativeBuildInputs = [ bison flex python3 pkg-config autoconf automake ];
   buildInputs = [ ncurses libusb-compat-0_1 freetype gettext lvm2 fuse libtool ]


### PR DESCRIPTION
The `grub-kbdcomp` command was calling `ckbcomp` directly without patching to provide its path in the nix store. As a result the command was crashing because `ckbcomp` was not found.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This change adds the option `kbdcompSupport` and fixes `grub-kbdcomp`:
* when `kbdcompSupport = true` the command works correctly
* when `kbdcompSupport = false` (default value) the command is replaced with an explanation message (is this a good thing?)

This will also help with #41247 since a possible solution for this issue uses `grub-kbdcomp`.

The motivation for adding an option is to avoid bringing `ckbcomp` and its dependencies (some part of x11 as `xkeyboardconfig`) when we only want to use grub.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
