### PR TITLE
miranda: init at 2.066

### DIFF
--- a/pkgs/development/compilers/miranda/default.nix
+++ b/pkgs/development/compilers/miranda/default.nix
@@ -1,0 +1,73 @@
+{ stdenv, lib, fetchzip, fetchpatch, gcc }:
+
+stdenv.mkDerivation rec {
+  pname = "miranda";
+  version = "2.066";
+
+  # The build generates object files (`.x`) from module files (`.m`).
+  # To be able to invalidate object file, it contains the `mtime`
+  # of the corresponding module file at the time of the build.
+  # When a file is installed to Nix store its `mtime` is set to `1`,
+  # so the `mtime` field in the object file would no longer match
+  # and Miranda would try to regenerate it at the runtime,
+  # even though it is up to date.
+  # Using `fetchzip` will make all the source files have `mtime=1`
+  # from the start so this mismatch cannot occur.
+  src = fetchzip {
+    url = "https://www.cs.kent.ac.uk/people/staff/dat/miranda/src/mira-${builtins.replaceStrings [ "." ] [ "" ] version}-src.tgz";
+    sha256 = "KE/FTL9YW9l7VBAgkFZlqgSM1Bt/BXT6GkkONtyKJjQ=";
+  };
+
+  patches = [
+    # Allow passing `PREFIX` to makeFlags.
+    # Sent upstream on 2020-10-10.
+    (fetchpatch {
+      name = "fix-makefile-variables.patch";
+      url = "https://github.com/jtojnar/miranda/commit/be62d2150725a4c314aa7e3e1e75a165c90be65d.patch";
+      sha256 = "0r8nnr7iyzp1a3w3n6y1xi0ralqhm1ifp75yhyj3h1g229vk51a6";
+    })
+
+    # Create the installation directories.
+    # Sent upstream on 2020-10-10.
+    (fetchpatch {
+      name = "add-mkdirs-makefile.patch";
+      url = "https://github.com/jtojnar/miranda/commit/048754606625975d5358e946549c41ae7b5d3428.patch";
+      sha256 = "1n8xv679i7s789km2dxxrs2pphyyi7vr7rhafqvmkcdmhmxk9h2a";
+    })
+
+    # Use correct installation path for finding the library.
+    # Sent upstream on 2020-10-10.
+    (fetchpatch {
+      name = "c-path-fixes.patch";
+      url = "https://github.com/jtojnar/miranda/commit/aea0a118a802a0da6029b781f7cfd388224263cf.patch";
+      sha256 = "1z3giv8fzc35a23ga9ahz9d1fbvya67kavnb8h4rv2icbzr5j5gd";
+    })
+
+    # Make build reproducible.
+    # Sent upstream on 2020-10-10.
+    (fetchpatch {
+      name = "deterministic-build.patch";
+      url = "https://github.com/jtojnar/miranda/commit/daf8abb8f30ec1cca21698e3fc355578b9f7c571.patch";
+      sha256 = "TC/YrHrMzdlwicJ3oJ/TjwhkufmV3ypemgyqhMmVut4=";
+    })
+  ];
+
+  makeFlags = [
+    "CC=cc"
+    "CFLAGS=-O2"
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    patchShebangs quotehostinfo
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Compiler for Miranda -- a pure, non-strict, polymorphic, higher order functional programming language";
+    homepage = "https://www.cs.kent.ac.uk/people/staff/dat/miranda/";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9470,6 +9470,8 @@ in
    enableX11 = true;
   };
 
+  miranda = callPackage ../development/compilers/miranda {};
+
   mkcl = callPackage ../development/compilers/mkcl {};
 
   mlkit = callPackage ../development/compilers/mlkit {};


### PR DESCRIPTION
###### Motivation for this change
Add `miranda`. It's not building ATM, hope to get more eyes on it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
