### PR TITLE
python3Packages.scikit-fuzzy: init at unstable-2020-10-03

### DIFF
--- a/pkgs/development/python-modules/scikit-fuzzy/default.nix
+++ b/pkgs/development/python-modules/scikit-fuzzy/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchFromGitHub
+, matplotlib
+, networkx
+, nose
+, numpy
+, scipy
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "scikit-fuzzy";
+  version = "unstable-2020-10-03";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "eecf303b701e3efacdc9b9066207ef605d4facaa";
+    sha256 = "18dl0017iqwc7446hqgabhibgjwdakhmycpis6zpvvkkv4ip5062";
+  };
+
+  propagatedBuildInputs = [ networkx numpy scipy ];
+  checkInputs = [ matplotlib nose pytestCheckHook ];
+
+  meta = with lib; {
+    homepage = "https://github.com/scikit-fuzzy/scikit-fuzzy";
+    description = "Fuzzy logic toolkit for scientific Python";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6341,6 +6341,8 @@ in {
 
   scikit-fmm = callPackage ../development/python-modules/scikit-fmm { };
 
+  scikit-fuzzy = callPackage ../development/python-modules/scikit-fuzzy { };
+
   scikitimage = callPackage ../development/python-modules/scikit-image { };
 
   scikitlearn = let args = { inherit (pkgs) gfortran glibcLocales; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
