### PR TITLE
ppsspp: 1.9.4 -> 1.10.3

### DIFF
--- a/pkgs/misc/emulators/ppsspp/default.nix
+++ b/pkgs/misc/emulators/ppsspp/default.nix
@@ -16,21 +16,19 @@
 
 mkDerivation rec {
   pname = "ppsspp";
-  version = "1.9.4";
+  version = "1.10.3";
 
   src = fetchFromGitHub {
     owner = "hrydgard";
-    repo = "ppsspp";
+    repo = pname;
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "0ivi0dcfxwa4nz19amki80qacnjhqr42f0ihyby1scxafl3nq55c";
+    sha256 = "sha256-W41Poq5S+opkasIGYo13SQZWQF1HjfFnH7u9DW5HNA0=";
   };
 
   postPatch = ''
-    substituteInPlace git-version.cmake \
-      --replace unknown ${src.rev}
-    substituteInPlace UI/NativeApp.cpp \
-      --replace /usr/share $out/share
+    substituteInPlace git-version.cmake --replace unknown ${src.rev}
+    substituteInPlace UI/NativeApp.cpp --replace /usr/share $out/share
   '';
 
   nativeBuildInputs = [ cmake pkgconfig python3 ];
@@ -52,6 +50,7 @@ mkDerivation rec {
     "-DUSE_SYSTEM_LIBZIP=ON"
     "-DUSE_SYSTEM_SNAPPY=ON"
     "-DUSING_QT_UI=ON"
+    "-DHEADLESS=OFF"
   ];
 
   installPhase = ''
@@ -61,9 +60,11 @@ mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A PSP emulator for Android, Windows, Mac and Linux, written in C++";
+    description = "A HLE Playstation Portable emulator, written in C++";
     homepage = "https://www.ppsspp.org/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.linux;
   };
 }
+# TODO: add SDL headless port


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
