### PR TITLE
onnxconverter-common: init at 1.7.0

### DIFF
--- a/pkgs/development/python-modules/onnxconverter-common/default.nix
+++ b/pkgs/development/python-modules/onnxconverter-common/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/microsoft/onnxconverter-common/";
-    description = "functions and utilities for converting from variousAI frameworks to ONNX";
+    description = "Functions and utilities for converting from variousAI frameworks to ONNX";
     license = licenses.mit;
     maintainers = with maintainers; [ imalsogreg ];
   };

--- a/pkgs/development/python-modules/onnxconverter-common/default.nix
+++ b/pkgs/development/python-modules/onnxconverter-common/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi, protobuf, numpy, requests, onnx }:
+
+buildPythonPackage rec {
+  pname = "onnxconverter_common";
+  version = "1.7.0";
+
+  propagatedBuildInputs = [ protobuf numpy requests onnx ];
+  format = "wheel";
+  src = fetchPypi {
+    inherit pname version;
+    format = "wheel";
+    sha256 = "1mgfxvcii4h6d7z2zbr5979aajhdblayfpaakm0vv9ka313i0dvd";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/microsoft/onnxconverter-common/";
+    description = "functions and utilities for converting from variousAI frameworks to ONNX";
+    license = licenses.mit;
+    maintainers = with maintainers; [ imalsogreg ];
+  };
+}

--- a/pkgs/development/python-modules/onnxconverter-common/default.nix
+++ b/pkgs/development/python-modules/onnxconverter-common/default.nix
@@ -3,14 +3,15 @@
 buildPythonPackage rec {
   pname = "onnxconverter_common";
   version = "1.7.0";
-
-  propagatedBuildInputs = [ protobuf numpy requests onnx ];
   format = "wheel";
+  
   src = fetchPypi {
     inherit pname version;
     format = "wheel";
     sha256 = "1mgfxvcii4h6d7z2zbr5979aajhdblayfpaakm0vv9ka313i0dvd";
   };
+    
+  propagatedBuildInputs = [ protobuf numpy requests onnx ];
 
   meta = with lib; {
     homepage = "https://github.com/microsoft/onnxconverter-common/";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4163,6 +4163,8 @@ in {
 
   onnx = callPackage ../development/python-modules/onnx { };
 
+  onnxconverter-common = callPackage ../development/python-modules/onnxconverter-common { };
+
   openant = callPackage ../development/python-modules/openant { };
 
   openapi-spec-validator = callPackage ../development/python-modules/openapi-spec-validator { };


### PR DESCRIPTION
###### Motivation for this change

Add `onnxconverter-common`, part of the python deep learning ecosystem.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` (there are no downstream dependencies for this package yet)
- [x] Tested execution of all binary files (usually in `./result/bin/`) (there are no binaries)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
