### PR TITLE
treewide: don't use spidermonkey attr

### DIFF
--- a/pkgs/servers/http/couchdb/2.0.0.nix
+++ b/pkgs/servers/http/couchdb/2.0.0.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, erlang, icu, openssl, spidermonkey
+{ stdenv, fetchurl, erlang, icu, openssl, spidermonkey_68
 , coreutils, bash, makeWrapper, python3 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ erlang icu openssl spidermonkey (python3.withPackages(ps: with ps; [ requests ]))];
+  buildInputs = [ erlang icu openssl spidermonkey_68 (python3.withPackages(ps: with ps; [ requests ]))];
 
   patches = [ ./jsapi.patch ];
   postPatch = ''

--- a/pkgs/servers/http/couchdb/2.0.0.nix
+++ b/pkgs/servers/http/couchdb/2.0.0.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, erlang, icu, openssl, spidermonkey_68
+{ stdenv, fetchurl, erlang, icu, openssl, spidermonkey_1_8_5
 , coreutils, bash, makeWrapper, python3 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ erlang icu openssl spidermonkey_68 (python3.withPackages(ps: with ps; [ requests ]))];
+  buildInputs = [ erlang icu openssl spidermonkey_1_8_5 (python3.withPackages(ps: with ps; [ requests ]))];
 
   patches = [ ./jsapi.patch ];
   postPatch = ''

--- a/pkgs/servers/http/couchdb/3.nix
+++ b/pkgs/servers/http/couchdb/3.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, erlang, icu, openssl, spidermonkey
+{ stdenv, fetchurl, erlang, icu, openssl, spidermonkey_68
 , coreutils, bash, makeWrapper, python3 }:
 
 stdenv.mkDerivation rec {
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
     sha256 = "1vgqj3zsrkdqgnwzji3mqkapnfd6kq466f5xnya0fvzzl6bcfrs8";
   };
 
-  buildInputs = [ erlang icu openssl spidermonkey (python3.withPackages(ps: with ps; [ requests ]))];
+  buildInputs = [ erlang icu openssl spidermonkey_68 (python3.withPackages(ps: with ps; [ requests ]))];
   postPatch = ''
-    substituteInPlace src/couch/rebar.config.script --replace '/usr/include/mozjs-68' "${spidermonkey.dev}/include/mozjs-68"
+    substituteInPlace src/couch/rebar.config.script --replace '/usr/include/mozjs-68' "${spidermonkey_68.dev}/include/mozjs-68"
     patchShebangs bin/rebar
   '';
 

--- a/pkgs/servers/http/couchdb/default.nix
+++ b/pkgs/servers/http/couchdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, erlang, icu, openssl, spidermonkey_68, curl, help2man
+{ stdenv, fetchurl, erlang, icu, openssl, spidermonkey_1_8_5, curl, help2man
 , sphinx, which, file, pkgconfig, getopt }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ help2man which file pkgconfig sphinx ];
-  buildInputs = [ erlang icu openssl spidermonkey_68 curl ];
+  buildInputs = [ erlang icu openssl spidermonkey_1_8_5 curl ];
 
   postInstall = ''
     substituteInPlace $out/bin/couchdb --replace getopt "${getopt}/bin/getopt"

--- a/pkgs/servers/http/couchdb/default.nix
+++ b/pkgs/servers/http/couchdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, erlang, icu, openssl, spidermonkey, curl, help2man
+{ stdenv, fetchurl, erlang, icu, openssl, spidermonkey_68, curl, help2man
 , sphinx, which, file, pkgconfig, getopt }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ help2man which file pkgconfig sphinx ];
-  buildInputs = [ erlang icu openssl spidermonkey curl ];
+  buildInputs = [ erlang icu openssl spidermonkey_68 curl ];
 
   postInstall = ''
     substituteInPlace $out/bin/couchdb --replace getopt "${getopt}/bin/getopt"

--- a/pkgs/servers/mediatomb/default.nix
+++ b/pkgs/servers/mediatomb/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit
-, sqlite, expat, mp4v2, flac, spidermonkey, taglib, libexif, curl, ffmpeg_3, file
+, sqlite, expat, mp4v2, flac, spidermonkey_68, taglib, libexif, curl, ffmpeg_3, file
 , pkgconfig, autoreconfHook }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1mimslr4q6mky865y6561rr64cbn4gf0qc2dhgb31hxp4rc1kmzd";
   };
 
-  buildInputs = [ sqlite expat spidermonkey taglib libexif curl ffmpeg_3 file mp4v2 flac
+  buildInputs = [ sqlite expat spidermonkey_68 taglib libexif curl ffmpeg_3 file mp4v2 flac
                   pkgconfig autoreconfHook ];
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/mediatomb/default.nix
+++ b/pkgs/servers/mediatomb/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit
-, sqlite, expat, mp4v2, flac, spidermonkey_68, taglib, libexif, curl, ffmpeg_3, file
+, sqlite, expat, mp4v2, flac, spidermonkey, taglib, libexif, curl, ffmpeg_3, file
 , pkgconfig, autoreconfHook }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1mimslr4q6mky865y6561rr64cbn4gf0qc2dhgb31hxp4rc1kmzd";
   };
 
-  buildInputs = [ sqlite expat spidermonkey_68 taglib libexif curl ffmpeg_3 file mp4v2 flac
+  buildInputs = [ sqlite expat spidermonkey taglib libexif curl ffmpeg_3 file mp4v2 flac
                   pkgconfig autoreconfHook ];
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16418,18 +16418,15 @@ in
   };
 
   couchdb = callPackage ../servers/http/couchdb {
-    spidermonkey = spidermonkey_1_8_5;
     sphinx = python27Packages.sphinx;
     erlang = erlangR19;
   };
 
   couchdb2 = callPackage ../servers/http/couchdb/2.0.0.nix {
-    spidermonkey = spidermonkey_1_8_5;
     erlang = erlangR21;
   };
 
   couchdb3 = callPackage ../servers/http/couchdb/3.nix {
-    spidermonkey = spidermonkey_68;
     erlang = erlangR22;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
