### PR TITLE
heaptrack: build with zstd support

### DIFF
--- a/pkgs/development/tools/profiling/heaptrack/default.nix
+++ b/pkgs/development/tools/profiling/heaptrack/default.nix
@@ -1,6 +1,6 @@
 {
   lib, mkDerivation, fetchFromGitHub, cmake, extra-cmake-modules,
-  zlib, boost, libunwind, elfutils, sparsehash,
+  zlib, boost, libunwind, elfutils, sparsehash, zstd,
   qtbase, kio, kitemmodels, threadweaver, kconfigwidgets, kcoreaddons, kdiagram
 }:
 
@@ -17,7 +17,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];
   buildInputs = [
-    zlib boost libunwind elfutils sparsehash
+    zlib boost libunwind elfutils sparsehash zstd
     qtbase kio kitemmodels threadweaver kconfigwidgets kcoreaddons kdiagram
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
[Heaptrack](https://github.com/KDE/heaptrack) has supported `zstd` since around https://github.com/KDE/heaptrack/commit/4edc10044f2743e067b0387d04518b94afd602e1.
The AppImage has been built with support for `zstd` since around https://github.com/KDE/heaptrack/commit/dd6a4e83ca6b0a7016e60df0ce4201c429ff266b.

Supporting `zstd` allows for e.g. opening `heaptrack.$APP.$PID.zst` files.

I am happy to make this an option that is initially disabled if it's not something we want to enable by default.

###### Things done
- Add `zstd` to `buildInputs`

###### Results
After building with `zstd` in `buildInputs`, I am able to open `heaptrack.*.zst` files and navigate them with the `heaptrack`.

The increase in closure size seems negligible:
```
nix path-info -Ss
/nix/store/1xai6fj16i9iwishi5a0vxxwh9mc90xx-heaptrack-1.2.0         1819808      1490725304
/nix/store/2n9a4s18ai89g6f5c69dcj0fr44x4whc-heaptrack-1.2.0         1916016      1491624872

nix path-info -Ssh
/nix/store/1xai6fj16i9iwishi5a0vxxwh9mc90xx-heaptrack-1.2.0        1.7M    1.4G
/nix/store/2n9a4s18ai89g6f5c69dcj0fr44x4whc-heaptrack-1.2.0        1.8M    1.4G
```