### PR TITLE
doc: add the removal of Python 3.5 to the 20.09 release notes (#95765)

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -66,6 +66,12 @@
    </listitem>
    <listitem>
     <para>
+     Python 3.5 has reached its upstream EOL at the end of September 2020: it
+     has been removed from the list of available packages.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      Two new options, <link linkend="opt-services.openssh.authorizedKeysCommand">authorizedKeysCommand</link>
      and <link linkend="opt-services.openssh.authorizedKeysCommandUser">authorizedKeysCommandUser</link>, have
      been added to the <literal>openssh</literal> module. If you have <literal>AuthorizedKeysCommand</literal>


### PR DESCRIPTION
###### Motivation for this change
Update release note for 20.09 with the removal of Python 3.5, as part of #95765.