### PR TITLE
nix-output-monitor: Init at 0.1.0.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -782,6 +782,11 @@ self: super: builtins.intersectAttrs super {
     testToolDepends = [ pkgs.git pkgs.mercurial ];
   });
 
+  nix-output-monitor = overrideCabal super.nix-output-monitor {
+    # Can't ran the golden-tests with nix, because they call nix
+    testTarget = "unit-tests";
+  };
+
   haskell-language-server = overrideCabal super.haskell-language-server (drv: {
     postInstall = let
       inherit (pkgs.lib) concatStringsSep take splitString;

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -25,6 +25,8 @@ self: super: {
   hls-ghcide = self.callPackage ../tools/haskell/haskell-language-server/hls-ghcide.nix { };
   hls-brittany = self.callPackage ../tools/haskell/haskell-language-server/hls-brittany.nix { };
 
+  nix-output-monitor = self.callPackage ../../tools/nix/nix-output-monitor { };
+
   # cabal2nix --revision <rev> https://github.com/hasura/ci-info-hs.git
   ci-info = self.callPackage ../misc/haskell/hasura/ci-info {};
   # cabal2nix --revision <rev> https://github.com/hasura/pg-client-hs.git

--- a/pkgs/tools/nix/nix-output-monitor/default.nix
+++ b/pkgs/tools/nix/nix-output-monitor/default.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, ansi-terminal, async, attoparsec, base, containers
+, directory, HUnit, mtl, nix-derivation, process, relude, stdenv
+, stm, text, time, unix, fetchFromGitHub
+}:
+mkDerivation {
+  pname = "nix-output-monitor";
+  version = "0.1.0.0";
+  src = fetchFromGitHub {
+    owner = "maralorn";
+    repo = "nix-output-monitor";
+    sha256 = "1k9fni02y7xb97mkif1k7s0y1xv06hnqbkds35k4gg8mnf5z911i";
+    rev = "a0e0b09";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    ansi-terminal async attoparsec base containers directory mtl
+    nix-derivation relude stm text time unix
+  ];
+  executableHaskellDepends = [
+    ansi-terminal async attoparsec base containers directory mtl
+    nix-derivation relude stm text time unix
+  ];
+  testHaskellDepends = [
+    ansi-terminal async attoparsec base containers directory HUnit mtl
+    nix-derivation process relude stm text time unix
+  ];
+  homepage = "https://github.com/maralorn/nix-output-monitor";
+  description = "Parses output of nix-build to show additional information";
+  license = stdenv.lib.licenses.agpl3Plus;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2286,6 +2286,8 @@ in
 
   nix-direnv = callPackage ../tools/misc/nix-direnv { };
 
+  nix-output-monitor = haskell.lib.justStaticExecutables (haskellPackages.nix-output-monitor);
+
   nix-template = callPackage ../tools/package-management/nix-template { };
 
   nixpkgs-pytools = with python3.pkgs; toPythonApplication nixpkgs-pytools;


### PR DESCRIPTION
By popular demand (see maralorn/nix-output-monitor#2)

/cc @turion @peti 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
