### PR TITLE
pythonPackages.django-anymail: 6.1.0 -> 8.1, fixing build

### DIFF
--- a/pkgs/development/python-modules/django-anymail/default.nix
+++ b/pkgs/development/python-modules/django-anymail/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "django-anymail";
-  version = "6.1.0";
+  version = "8.1";
 
   src = fetchFromGitHub {
     owner = "anymail";
     repo = pname;
-    rev = "v6.1";
-    sha256 = "04jgz3qnsnba18rlqgxyb2g9128pk3ivflnj6695kibxg724fcpv";
+    rev = "v${version}";
+    sha256 = "1v8ayd3nh7pna9lg0pzwgwmvmzzh2g1kxsy7i6mka0hi52g1xvz5";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Bumping this package brings it back into a working state.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
