### PR TITLE
gnomeExtensions.dash-to-dock: 2020-04-20 -> 69

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/dash-to-dock/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/dash-to-dock/default.nix
@@ -5,15 +5,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-dash-to-dock-unstable";
-  version = "2020-04-20";
+  pname = "gnome-shell-dash-to-dock";
+  version = "69";
 
   src = fetchFromGitHub {
     owner = "micheleg";
     repo = "dash-to-dock";
-    # rev = "extensions.gnome.org-v" + version;
-    rev = "1788f31b049b622f78d0e65c56bef76169022ca9";
-    sha256 = "1s8ychvs5l4mbjp8chc5nk62s4887q6vd3dj6spk4gimni2nayrk";
+    rev = "extensions.gnome.org-v" + version;
+    hash = "sha256-YuLtC7E8dK57JSuFdbDQe5Ml+KQfl9qSdrHdVhFaNiE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
This version supports both 3.36 and 3.38.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
The current version is a little buggy. Will backport after testing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
