### PR TITLE
apache-kafka: replace ParNew to G1 YoungGeneration

### DIFF
--- a/nixos/modules/services/misc/apache-kafka.nix
+++ b/nixos/modules/services/misc/apache-kafka.nix
@@ -94,14 +94,12 @@ in {
         "-server"
         "-Xmx1G"
         "-Xms1G"
-        "-XX:+UseCompressedOops"
         "-XX:+UseG1GC"
-        "-XX:+UseConcMarkSweepGC"
-        "-XX:+CMSClassUnloadingEnabled"
-        "-XX:+CMSScavengeBeforeRemark"
-        "-XX:+DisableExplicitGC"
+        "-XX:+ExplicitGCInvokesConcurrent"
+        "-XX:InitiatingHeapOccupancyPercent=35"
+        "-XX:MaxGCPauseMillis=20"
+        "-XX:InitiatingHeapOccupancyPercent=35"
         "-Djava.awt.headless=true"
-        "-Djava.net.preferIPv4Stack=true"
       ];
       type = types.listOf types.str;
       example = [

--- a/nixos/modules/services/misc/apache-kafka.nix
+++ b/nixos/modules/services/misc/apache-kafka.nix
@@ -95,7 +95,7 @@ in {
         "-Xmx1G"
         "-Xms1G"
         "-XX:+UseCompressedOops"
-        "-XX:+UseParNewGC"
+        "-XX:+UseG1GC"
         "-XX:+UseConcMarkSweepGC"
         "-XX:+CMSClassUnloadingEnabled"
         "-XX:+CMSScavengeBeforeRemark"

--- a/nixos/tests/kafka.nix
+++ b/nixos/tests/kafka.nix
@@ -32,9 +32,15 @@ let
           zookeeper = "zookeeper1:2181";
           # These are the default options, but UseCompressedOops doesn't work with 32bit JVM
           jvmOptions = [
-            "-server" "-Xmx1G" "-Xms1G" "-XX:+UseParNewGC" "-XX:+UseConcMarkSweepGC" "-XX:+CMSClassUnloadingEnabled"
-            "-XX:+CMSScavengeBeforeRemark" "-XX:+DisableExplicitGC" "-Djava.awt.headless=true" "-Djava.net.preferIPv4Stack=true"
-          ] ++ optionals (! pkgs.stdenv.isi686 ) [ "-XX:+UseCompressedOops" ];
+            "-Xmx1G"
+            "-Xms1G"
+            "-XX:+UseG1GC"
+            "-XX:+ExplicitGCInvokesConcurrent"
+            "-XX:InitiatingHeapOccupancyPercent=35"
+            "-XX:MaxGCPauseMillis=20"
+            "-XX:InitiatingHeapOccupancyPercent=35"
+            "-Djava.awt.headless=true"
+          ];
         };
 
         networking.firewall.allowedTCPPorts = [ 9092 ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
1. the flag of `UseParNewGC ` has been deprecated in JDK 9 and removed in JDK 10.

you can find info from here:
- https://bugs.openjdk.java.net/browse/JDK-8151084
- https://stackoverflow.com/questions/49962437/unrecognized-vm-option-useparnewgc-error-could-not-create-the-java-virtual
2. remove CMS flags
`
Dropping support for CMS and then removing the CMS code, or at least more thoroughly segregating it, will reduce the maintenance burden of the GC code base and accelerate new development. The G1 garbage collector is intended, in the long term, to be a replacement for most uses of CMS.
`
- https://openjdk.java.net/jeps/291


the issue output will be like this:
```
Unrecognized VM option 'UseParNewGC'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```
###### Things done
- test flags
```
 more /nix/store/bq7qd8mmm63rwn1kzbw9rsfprnpa7q10-run-kafka/nix/store/y853yiia1ky7aipp73fv08xd2n6y3jyd-openjdk-14.0.2-ga/bin/java \
  -cp "/nix/store/kvq4jw9d9kzigdik4n2wrx1q9mzgapc2-apache-kafka-2.13-2.5.0/libs/*" \
  -Dlog4j.configuration=file:/nix/store/7qq35w8373pvbn9av0xk9c2rmwbas20m-log4j.properties \
  -server -Xmx1G -Xms1G -XX:+UseCompressedOops -XX:+UseG1GC -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeR
emark -XX:+DisableExplicitGC -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true \
  kafka.Kafka \
  /nix/store/ys10abnr79brsqh9ys1mxzx19jwmcd59-server.properties
```
- output
NOTICE: the ignoring warning will be sloved in second commit.
```
/nix/store/2jysm3dfsgby5sw5jgj43qjrb5v79ms9-bash-4.4-p23/bin/bash /nix/store/bq7qd8mmm63rwn1kzbw9rsfprnpa7q10-run-kafka
OpenJDK 64-Bit Server VM warning: Ignoring option UseConcMarkSweepGC; support was removed in 14.0
OpenJDK 64-Bit Server VM warning: Ignoring option CMSClassUnloadingEnabled; support was removed in 14.0
OpenJDK 64-Bit Server VM warning: Ignoring option CMSScavengeBeforeRemark; support was removed in 14.0
[2020-10-10 07:01:56,191] INFO Registered kafka:type=kafka.Log4jController MBean (kafka.utils.Log4jControllerRegistration$)
[2020-10-10 07:01:56,444] INFO Setting -D jdk.tls.rejectClientInitiatedRenegotiation=true to disable client-initiated TLS renegotiation (org.apache.zookeeper.common.X509Util)
[2020-10-10 07:01:56,491] INFO Registered signal handlers for TERM, INT, HUP (org.apache.kafka.common.utils.LoggingSignalHandler)
[2020-10-10 07:01:56,495] INFO starting (kafka.server.KafkaServer)
[2020-10-10 07:01:56,496] INFO Connecting to zookeeper on localhost:2181 (kafka.server.KafkaServer)
[2020-10-10 07:01:56,517] INFO [ZooKeeperClient Kafka server] Initializing a new session to localhost:2181. (kafka.zookeeper.ZooKeeperClient)
[2020-10-10 07:01:56,525] INFO Client environment:zookeeper.version=3.5.7-f0fdd52973d373ffd9c86b81d99842dc2c7f660e, built on 02/10/2020 11:30 GMT (org.apache.zookeeper.ZooKeeper)
[2020-10-10 07:01:56,525] INFO Client environment:host.name=gtcompile (org.apache.zookeeper.ZooKeeper)
[2020-10-10 07:01:56,525] INFO Client environment:java.version=14.0.2-internal (org.apache.zookeeper.ZooK
```
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
