### PR TITLE
linuxPackages.cpupower-gui: init at 1.0.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -333,6 +333,7 @@
   ./services/desktops/accountsservice.nix
   ./services/desktops/bamf.nix
   ./services/desktops/blueman.nix
+  ./services/desktops/cpupower-gui.nix
   ./services/desktops/dleyna-renderer.nix
   ./services/desktops/dleyna-server.nix
   ./services/desktops/pantheon/files.nix

--- a/nixos/modules/services/desktops/cpupower-gui.nix
+++ b/nixos/modules/services/desktops/cpupower-gui.nix
@@ -1,0 +1,56 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.cpupower-gui;
+in {
+  options = {
+    services.cpupower-gui = {
+      enable = mkOption {
+        type = lib.types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Enables dbus/systemd service needed by cpupower-gui.
+          These services are responsible for retrieving and modifying cpu power
+          saving settings.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.cpupower-gui ];
+    services.dbus.packages = [ pkgs.cpupower-gui ];
+    systemd.user = {
+      services.cpupower-gui-user = {
+        description = "Apply cpupower-gui config at user login";
+        wantedBy = [ "graphical-session.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.cpupower-gui}/bin/cpupower-gui config";
+        };
+      };
+    };
+    systemd.services = {
+      cpupower-gui = {
+        description = "Apply cpupower-gui config at boot";
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.cpupower-gui}/bin/cpupower-gui config";
+        };
+      };
+      cpupower-gui-helper = {
+        description = "cpupower-gui system helper";
+        aliases = [ "dbus-org.rnd2.cpupower_gui.helper.service" ];
+        serviceConfig = {
+          Type = "dbus";
+          BusName = "org.rnd2.cpupower_gui.helper";
+          ExecStart = "${pkgs.cpupower-gui}/lib/cpupower-gui/cpupower-gui-helper";
+        };
+      };
+    };
+  };
+}

--- a/pkgs/os-specific/linux/cpupower-gui/default.nix
+++ b/pkgs/os-specific/linux/cpupower-gui/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildPythonApplication
+, appstream-glib
+, dbus-python
+, desktop-file-utils
+, gettext
+, glib
+, gobject-introspection
+, gtk3
+, hicolor-icon-theme
+, libappindicator
+, libhandy
+, meson
+, ninja
+, pkg-config
+, pygobject3
+, pyxdg
+, systemd
+, wrapGAppsHook
+}:
+
+buildPythonApplication rec {
+  pname = "cpupower-gui";
+  version = "1.0.0";
+
+  # This packages doesn't have a setup.py
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "vagnum08";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "05lvpi3wgyi741sd8lgcslj8i7yi3wz7jwl7ca3y539y50hwrdas";
+  };
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils # needed for update-desktop-database
+    gettext
+    glib # needed for glib-compile-schemas
+    gobject-introspection # need for gtk namespace to be available
+    hicolor-icon-theme # needed for postinstall script
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+
+    # Python packages
+    dbus-python
+    libappindicator
+    pygobject3
+    pyxdg
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libhandy
+  ];
+
+  propagatedBuildInputs = [
+    dbus-python
+    libappindicator
+    pygobject3
+    pyxdg
+  ];
+
+  mesonFlags = [
+    "-Dsystemddir=${placeholder "out"}/lib/systemd"
+  ];
+
+  preConfigure = ''
+    patchShebangs build-aux/meson/postinstall.py
+  '';
+
+  strictDeps = false;
+  dontWrapGApps = true;
+
+  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+
+  postFixup = ''
+    wrapPythonProgramsIn $out/lib "$out $propagatedBuildInputs"
+  '';
+
+  meta = with lib; {
+    description = "Change the frequency limits of your cpu and its governor";
+    homepage = "https://github.com/vagnum08/cpupower-gui/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ unode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20582,6 +20582,10 @@ in
 
   cpufrequtils = callPackage ../os-specific/linux/cpufrequtils { };
 
+  cpupower-gui = python3Packages.callPackage ../os-specific/linux/cpupower-gui {
+    inherit (pkgs) meson;
+  };
+
   cpuset = callPackage ../os-specific/linux/cpuset {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
###### Motivation for this change

This is round 2 of #94676 now including the necessary dbus / polkit modules for use as regular user.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
