### PR TITLE
pythonPackages.sqlparse: 0.3.1 -> 0.4.1

### DIFF
--- a/pkgs/development/python-modules/sqlparse/default.nix
+++ b/pkgs/development/python-modules/sqlparse/default.nix
@@ -1,28 +1,31 @@
-{ stdenv
+{ lib
 , buildPythonPackage
 , fetchPypi
-, pytest
+, installShellFiles
+, pytestCheckHook
 , isPy3k
 }:
 
 buildPythonPackage rec {
   pname = "sqlparse";
-  version = "0.3.1";
+  version = "0.4.1";
+
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548";
+    sha256 = "0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8";
   };
 
-  checkInputs = [ pytest ];
-  checkPhase = ''
-    py.test
+  nativeBuildInputs = [ installShellFiles ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  postInstall = ''
+    installManPage docs/sqlformat.1
   '';
 
-  # Package supports 3.x, but tests are clearly 2.x only.
-  doCheck = !isPy3k;
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Non-validating SQL parser for Python";
     longDescription = ''
       Provides support for parsing, splitting and formatting SQL statements.
@@ -30,5 +33,4 @@ buildPythonPackage rec {
     homepage = "https://github.com/andialbrecht/sqlparse";
     license = licenses.bsd3;
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
