### PR TITLE
gitAndTools.git-trim: 0.3.2 -> 0.4.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-trim/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-trim/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "git-trim";
-  version = "0.3.2";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "foriequal0";
     repo = pname;
     rev = "v${version}";
-    sha256 = "079kavm3n776wvmy25jq1g4qdvmhh3d3x1vdpb1f6pw5rkky8lyw";
+    sha256 = "0w6qrr53wal4p4jvz35f9mpqwz1vfcymj17sz418n9p9lw45f24n";
   };
 
-  cargoSha256 = "1ii5l7z9avg0gzlaav2gnfbr8wkbp008i5rz6k6bs2sfqnpnn5k6";
+  cargoSha256 = "1mlvkvgcln59bi249z87v8i0ixq1a7walkzsjml6d219rmy5550h";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/foriequal0/git-trim/releases/tag/v0.4.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
