### PR TITLE
pymetno: 0.5.1 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/pymetno/default.nix
+++ b/pkgs/development/python-modules/pymetno/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "PyMetno";
-  version = "0.5.1";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "Danielhiversen";
     rev = version;
-    sha256 = "1ihq1lzgzcxbg916izakx9jp0kp1vdrcdwcwwwsws838wc08ax6m";
+    sha256 = "1jngf0mbn5hn166pqh1ga5snwwvv7n5kv1k9kaksrfibixkvpw6h";
   };
 
   propagatedBuildInputs = [ aiohttp async-timeout pytz xmltodict ];


### PR DESCRIPTION
- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
