### PR TITLE
pythonPackages.google_cloud_dataproc: Fix package by adding missing dependencies

### DIFF
--- a/pkgs/development/python-modules/google_cloud_dataproc/default.nix
+++ b/pkgs/development/python-modules/google_cloud_dataproc/default.nix
@@ -4,6 +4,8 @@
 , google_api_core
 , pytest
 , mock
+, libcst
+, proto-plus
 }:
 
 buildPythonPackage rec {
@@ -16,7 +18,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ google_api_core ];
+  propagatedBuildInputs = [ google_api_core libcst proto-plus ];
 
   checkPhase = ''
     pytest tests/unit

--- a/pkgs/development/python-modules/libcst/default.nix
+++ b/pkgs/development/python-modules/libcst/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, typing-inspect
+, pyyaml
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "libcst";
+  version = "0.3.12";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1zgwxdbhz2ljl0yzbrn1f4f464rjphx0j6r4qq0csax3m4wp50x1";
+  };
+
+  # The library uses type annotation syntax.
+  disabled = !isPy3k;
+
+  propagatedBuildInputs = [ typing-inspect pyyaml ];
+
+  # Test fails with ValueError: No data_provider tests were created for
+  # test_type_availability! Please double check your data.
+  # The tests appear to be doing some dynamic introspection, not sure what is
+  # going on there.
+  doCheck = false;
+  pythonImportsCheck = [ "libcst" ];
+
+  meta = with stdenv.lib; {
+    description = "A concrete syntax tree parser and serializer library for Python that preserves many aspects of Python's abstract syntax tree";
+    homepage = "https://libcst.readthedocs.io/en/latest/";
+    license = with licenses; [mit asl20 psfl];
+    maintainers = [ maintainers.ruuda ];
+  };
+}

--- a/pkgs/development/python-modules/proto-plus/default.nix
+++ b/pkgs/development/python-modules/proto-plus/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, protobuf
+}:
+
+buildPythonPackage rec {
+  pname = "proto-plus";
+  version = "1.10.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0n8ia51jg2dkab2sf0qnh39bssqhz65ybcqr78f3zzf7ja923lkr";
+  };
+
+  propagatedBuildInputs = [ protobuf ];
+
+  meta = with stdenv.lib; {
+    description = "Beautiful, idiomatic protocol buffers in Python";
+    homepage = "https://github.com/googleapis/proto-plus-python";
+    license = licenses.asl20;
+    maintainers = [ maintainers.ruuda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4665,6 +4665,8 @@ in {
 
   protego = callPackage ../development/python-modules/protego { };
 
+  proto-plus = callPackage ../development/python-modules/proto-plus { };
+
   protobuf = callPackage ../development/python-modules/protobuf {
     disabled = isPyPy;
     doCheck =

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3309,6 +3309,8 @@ in {
   else
     callPackage ../development/python-modules/libcloud { };
 
+  libcst = callPackage ../development/python-modules/libcst { };
+
   libevdev = callPackage ../development/python-modules/libevdev { };
 
   libfdt = toPythonModule (pkgs.dtc.override {


### PR DESCRIPTION
###### Motivation for this change

ZHF: #97479

The package was broken because two of its dependencies were missing. They were not yet packaged, so I added both.

* [`libcst`](https://github.com/Instagram/LibCST)
* [`proto-plus`](https://github.com/googleapis/proto-plus-python)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The ZHF issue says

> Please ping @NixOS/nixos-release-managers on the PR.

But it is unclear to me if that is about this PR, or about the backporting one, so I’ll ping you here.