### PR TITLE
xmonad: put the correct xmonad binary in PATH

### DIFF
--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -22,8 +22,9 @@ let
   } cfg.config;
 
   xmonad = if (cfg.config != null) then xmonad-config else xmonad-vanilla;
-in
-{
+in {
+  meta.maintainers = with maintainers; [ lassulus xaverdh ];
+
   options = {
     services.xserver.windowManager.xmonad = {
       enable = mkEnableOption "xmonad";

--- a/nixos/tests/xmonad.nix
+++ b/nixos/tests/xmonad.nix
@@ -14,9 +14,16 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       extraPackages = with pkgs.haskellPackages; haskellPackages: [ xmobar ];
       config = ''
         import XMonad
+        import XMonad.Operations (restart)
         import XMonad.Util.EZConfig
-        main = launch $ def `additionalKeysP` myKeys
-        myKeys = [ ("M-C-x", spawn "xterm") ]
+        import XMonad.Util.SessionStart
+
+        main = launch $ def { startupHook = startup } `additionalKeysP` myKeys
+
+        startup = isSessionStart >>= \sessInit ->
+          if sessInit then setSessionStarted else spawn "xterm"
+
+        myKeys = [ ("M-C-x", spawn "xterm"), ("M-q", restart "xmonad" True) ]
       '';
     };
   };
@@ -30,12 +37,11 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     machine.send_key("alt-ctrl-x")
     machine.wait_for_window("${user.name}.*machine")
     machine.sleep(1)
-    machine.screenshot("terminal")
-    machine.wait_until_succeeds("xmonad --restart")
+    machine.screenshot("terminal1")
+    machine.send_key("alt-q")
     machine.sleep(3)
-    machine.send_key("alt-shift-ret")
     machine.wait_for_window("${user.name}.*machine")
     machine.sleep(1)
-    machine.screenshot("terminal")
+    machine.screenshot("terminal2")
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
If `services.xserver.windowManager.xmonad.config` is used, until this pr the module would put the official `xmonad` package in `systemPackages` which is almost certainly not what you want. After this pr, if you e.g. rebuild your config and then restart `xmonad` with `xmonad --restart`, it will take the binary from `PATH` which will be the one you specified in your config.
I also took the liberty to rename some things to hopefully make their purpose more obvious.

Personally I would simply consider the old behavior a bug, but not sure if somebody relies on it for some strange reason?
 
By the way don't get confused by the diff; the relevant line [here](https://github.com/xaverdh/nixpkgs/blob/67eb45ddce9d390e1c9f7f8c709d98ad68cb0bfd/nixos/modules/services/x11/window-managers/xmonad.nix#L114) is unchanged, but `xmonad` is bound to a different value.
 
###### Things done

* Tested this with my own `xmonad` config (which uses `services.xserver.windowManager.xmonad.config`). Should be no-op if not using the `config` option.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
