### PR TITLE
python3Packages.ansible: split into ansible and ansible-base, update to 2.10.x

### DIFF
--- a/pkgs/development/python-modules/ansible-base/default.nix
+++ b/pkgs/development/python-modules/ansible-base/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pycrypto
+, paramiko
+, jinja2
+, pyyaml
+, httplib2
+, six
+, netaddr
+, dnspython
+, jmespath
+, dopy
+, ncclient
+, windowsSupport ? false
+, pywinrm
+, mock
+, pytestCheckHook
+, pytz
+}:
+
+buildPythonPackage rec {
+  pname = "ansible-base";
+  version = "2.10.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ar2ks18hvf97fqi2hmv96xxmydf99i0hhkk46nnna1vw44f37y7";
+  };
+
+  prePatch = ''
+    # ansible-connection is wrapped, so make sure it's not passed
+    # through the python interpreter.
+    sed -i "s/\[python, /[/" lib/ansible/executor/task_executor.py
+  '';
+
+  postInstall = ''
+    for m in docs/man/man1/*; do
+      install -vD $m -t $out/share/man/man1
+    done
+  '';
+
+  propagatedBuildInputs = [
+    pycrypto paramiko jinja2 pyyaml httplib2
+    six netaddr dnspython jmespath dopy ncclient
+  ] ++ lib.optional windowsSupport pywinrm;
+
+  # requires ansible-test & docker
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "http://www.ansible.com";
+    description = "Radically simple IT automation";
+    license = [ licenses.gpl3 ] ;
+    maintainers = with maintainers; [ joamaki costrouc hexa ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -1,57 +1,26 @@
 { lib
-, fetchFromGitHub
 , buildPythonPackage
-, pycrypto
-, paramiko
-, jinja2
-, pyyaml
-, httplib2
-, six
-, netaddr
-, dnspython
-, jmespath
-, dopy
-, ncclient
-, windowsSupport ? false
-, pywinrm
+, fetchPypi
+, ansible-base
 }:
 
 buildPythonPackage rec {
   pname = "ansible";
-  version = "2.9.12";
+  version = "2.10.0";
 
-  src = fetchFromGitHub {
-    owner = "ansible";
-    repo = "ansible";
-    rev = "v${version}";
-    sha256 = "0c794k0cyl54807sh9in0l942ah6g6wlz5kf3qvy5lhd581zlgyb";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ink65zi7ghxy14rxwc2g7ck7flj799zx769aihf811zmiiddb9s";
   };
 
-  prePatch = ''
-    # ansible-connection is wrapped, so make sure it's not passed
-    # through the python interpreter.
-    sed -i "s/\[python, /[/" lib/ansible/executor/task_executor.py
-  '';
-
-  postInstall = ''
-    for m in docs/man/man1/*; do
-      install -vD $m -t $out/share/man/man1
-    done
-  '';
-
   propagatedBuildInputs = [
-    pycrypto paramiko jinja2 pyyaml httplib2
-    six netaddr dnspython jmespath dopy ncclient
-  ] ++ lib.optional windowsSupport pywinrm;
-
-  # dificult to test
-  doCheck = false;
+    ansible-base
+  ];
 
   meta = with lib; {
-    homepage = "http://www.ansible.com";
-    description = "Radically simple IT automation";
-    license = [ licenses.gpl3 ] ;
-    maintainers = with maintainers; [ joamaki costrouc hexa ];
-    platforms = platforms.linux ++ platforms.darwin;
+    description = "Ansible collections";
+    homepage = "https://pypi.org/project/ansible/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ hexa ];
   };
 }

--- a/pkgs/tools/admin/ansible/default.nix
+++ b/pkgs/tools/admin/ansible/default.nix
@@ -5,22 +5,19 @@ rec {
 
   # The python module stays at v2.9.x until the related package set has caught up. Therefore v2.10 gets an override
   # for now.
-  ansible_2_10 = python3Packages.toPythonApplication (python3Packages.ansible.overridePythonAttrs (old: rec {
-    pname = "ansible";
-    version = "2.10.0";
+  ansible_2_10 = python3Packages.toPythonApplication python3Packages.ansible-base;
 
-    # TODO: migrate to fetchurl, when release becomes available on releases.ansible.com
-    src = fetchFromGitHub {
-      owner = pname;
-      repo = pname;
-      rev = "v${version}";
-      sha256 = "0k9rs5ajx0chaq0xr1cj4x7fr5n8kd4y856miss6k01iv2m7yx42";
+  ansible_2_9 = python3Packages.toPythonApplication (python3Packages.ansible-base.overridePythonAttrs (old: rec {
+    pname = "ansible";
+    version = "2.9.14";
+
+    src = fetchurl {
+      url = "https://releases.ansible.com/ansible/${pname}-${version}.tar.gz";
+      sha256 = "1dbgzj5m6wx0jdjqbsz8n58jirlbjylfy94izngdvjgh10z1irzg";
     };
   }));
 
-  ansible_2_9 = python3Packages.toPythonApplication python3Packages.ansible;
-
-  ansible_2_8 = python3Packages.toPythonApplication (python3Packages.ansible.overridePythonAttrs (old: rec {
+  ansible_2_8 = python3Packages.toPythonApplication (python3Packages.ansible-base.overridePythonAttrs (old: rec {
     pname = "ansible";
     version = "2.8.14";
 

--- a/pkgs/tools/admin/ansible/default.nix
+++ b/pkgs/tools/admin/ansible/default.nix
@@ -19,11 +19,11 @@ rec {
 
   ansible_2_8 = python3Packages.toPythonApplication (python3Packages.ansible-base.overridePythonAttrs (old: rec {
     pname = "ansible";
-    version = "2.8.14";
+    version = "2.8.16";
 
     src = fetchurl {
       url = "https://releases.ansible.com/ansible/${pname}-${version}.tar.gz";
-      sha256 = "19ga0c9qs2b216qjg5k2yknz8ksjn8qskicqspg2d4b8x2nr1294";
+      sha256 = "05mfrsncysjfxg4kbv5vllf3g58kzs01xafmviwqd16lq2jd68a2";
     };
   }));
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -300,6 +300,8 @@ in {
 
   ansible = callPackage ../development/python-modules/ansible { };
 
+  ansible-base = callPackage ../development/python-modules/ansible-base { };
+
   ansible-kernel = callPackage ../development/python-modules/ansible-kernel { };
 
   ansible-lint = callPackage ../development/python-modules/ansible-lint { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This is a mess.

In v2.10 the ansible package was split into collections (`ansible`) and engine (`ansible-base`).

The `ansible` package requires `ansible-base`.
The `ansible-base` package holds the executables.

This means I cannot introduce `ansible` (the collections) as a `propagatedBuildInput` into `ansible-base` (the engine), because it would create an inifinite loop. Installing the `ansible` package, instead of `ansible-base` would prevent the executables from the `ansible-base` package from landing in the PATH. 

The ansible packagers clearly assume a global python path, where these things *just work*. Looking for good ideas on how to continue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
