### PR TITLE
k3s: 1.18.8+k3s1 -> 1.19.2-k3s1

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -42,9 +42,9 @@ with lib;
 # Those pieces of software we entirely ignore upstream's handling of, and just
 # make sure they're in the path if desired.
 let
-  k3sVersion = "1.18.8+k3s1";     # k3s git tag
+  k3sVersion = "1.19.2+k3s1";     # k3s git tag
   traefikChartVersion = "1.81.0"; # taken from ./scripts/download at the above k3s tag
-  k3sRootVersion = "0.4.1";       # taken from ./scripts/download at the above k3s tag
+  k3sRootVersion = "0.6.0-rc3";   # taken from ./scripts/download at the above k3s tag
   k3sCNIVersion = "0.8.6-k3s1";   # taken from ./scripts/version.sh at the above k3s tag
   # bundled into the k3s binary
   traefikChart = fetchurl {
@@ -63,7 +63,7 @@ let
   k3sRoot = fetchzip {
     # Note: marked as apache 2.0 license
     url = "https://github.com/rancher/k3s-root/releases/download/v${k3sRootVersion}/k3s-root-amd64.tar";
-    sha256 = "0ppj8y9g410hn6mjkfgfsi2j9yv7rcpic21znpmbrkx8b2070hf0";
+    sha256 = "0xj3dcqawpzyzmz545iwh151krzbs9csnzg3zfl74lkv2kxgidk6";
     stripRoot = false;
   };
   k3sPlugins = buildGoPackage rec {
@@ -94,7 +94,7 @@ let
     url = "https://github.com/rancher/k3s";
     rev = "v${k3sVersion}";
     leaveDotGit = true; # ./scripts/version.sh depends on git
-    sha256 = "17qsvbj1lvgxqdkxayyqnjwsjs3cx06nfv2hqvixjszn4vf30qlg";
+    sha256 = "1hbnarchs9w52w061bvfjvssdh7ycnxa04camjwkcx8vr0k804h4";
   };
   # Stage 1 of the k3s build:
   # Let's talk about how k3s is structured.

--- a/pkgs/applications/networking/cluster/k3s/patches/0002-Add-nixpkgs-patches.patch
+++ b/pkgs/applications/networking/cluster/k3s/patches/0002-Add-nixpkgs-patches.patch
@@ -56,10 +56,10 @@ index 4ca6333c4a..df15f7db1d 100755
  echo Building containerd-shim
  rm -f ./vendor/github.com/containerd/containerd/bin/containerd-shim
 diff --git a/scripts/package-cli b/scripts/package-cli
-index f33d8c66dd..da34397a28 100755
+index d1aad638d9..90479b6fa1 100755
 --- a/scripts/package-cli
 +++ b/scripts/package-cli
-@@ -49,16 +49,18 @@ fi
+@@ -49,15 +49,18 @@ fi
  
  CMD_NAME=dist/artifacts/k3s${BIN_SUFFIX}
  
@@ -71,17 +71,14 @@ index f33d8c66dd..da34397a28 100755
      -w -s
  "
 -STATIC="-extldflags '-static'"
+-CGO_ENABLED=0 "${GO}" build -ldflags "$LDFLAGS $STATIC" -o ${CMD_NAME} ./cmd/k3s/main.go
 +# STATIC="-extldflags '-static'"
 +# nixpkgs: we can depend on dynamic linking because we have a good package manager
- if [ "$DQLITE" = "true" ]; then
-     DQLITE_TAGS="dqlite"
- fi
--CGO_ENABLED=0 "${GO}" build -tags "$DQLITE_TAGS" -ldflags "$LDFLAGS $STATIC" -o ${CMD_NAME} ./cmd/k3s/main.go
-+"${GO}" build -tags "$DQLITE_TAGS" -ldflags "$LDFLAGS" -o ${CMD_NAME} ./cmd/k3s/main.go
++"${GO}" build -ldflags "$LDFLAGS" -o ${CMD_NAME} ./cmd/k3s/main.go
+ 
+ stat ${CMD_NAME}
  
 -./scripts/build-upload ${CMD_NAME} ${COMMIT}
 +# nixpkgs: skip uploading
 +# ./scripts/build-upload ${CMD_NAME} ${COMMIT}
--- 
-2.25.4
-
++


### PR DESCRIPTION

###### Motivation for this change

Update version.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Maintainer: @euank 