### PR TITLE
[20.09] python3Packages.fsspec: fix tests on linux

### DIFF
--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -29,8 +29,17 @@ buildPythonPackage rec {
     # Test assumes user name is part of $HOME
     # AssertionError: assert 'nixbld' in '/homeless-shelter/foo/bar'
     "test_strip_protocol_expanduser"
-  ] ++ lib.optionals (stdenv.isDarwin && isPy38) [
-    "test_modified" # fails on hydra, works locally
+    # flaky: works locally but fails on hydra
+    # as it uses the install dir for tests instead of a temp dir
+    # resolved in https://github.com/intake/filesystem_spec/issues/432 and
+    # can be enabled again from version 0.8.4
+    "test_pathobject"
+  ] ++ lib.optionals (stdenv.isDarwin) [
+    # works locally on APFS, fails on hydra with AssertionError comparing timestamps
+    # darwin hydra builder uses HFS+ and has only one second timestamp resolution
+    # this two tests however, assume nanosecond resolution
+    "test_modified"
+    "test_touch"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/99499
ZHF: #97479
cc: @NixOS/nixos-release-managers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
