### PR TITLE
golden-cheetah: fix build, 3.5-RC2X -> 3.5

### DIFF
--- a/pkgs/applications/misc/golden-cheetah/default.nix
+++ b/pkgs/applications/misc/golden-cheetah/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, mkDerivation
+{ stdenv, fetchFromGitHub, fetchpatch, mkDerivation
 , qtbase, qtsvg, qtserialport, qtwebengine, qtmultimedia, qttools
 , qtconnectivity, qtcharts, libusb-compat-0_1
 , yacc, flex, zlib, qmake, makeDesktopItem, makeWrapper
@@ -30,6 +30,15 @@ in mkDerivation rec {
     qtconnectivity qtcharts libusb-compat-0_1
   ];
   nativeBuildInputs = [ flex makeWrapper qmake yacc ];
+
+  patches = [
+    # allow building with bison 3.7
+    # PR at https://github.com/GoldenCheetah/GoldenCheetah/pull/3590
+    (fetchpatch {
+      url = "https://github.com/GoldenCheetah/GoldenCheetah/commit/e1f42f8b3340eb4695ad73be764332e75b7bce90.patch";
+      sha256 = "1h0y9vfji5jngqcpzxna5nnawxs77i1lrj44w8a72j0ah0sznivb";
+    })
+  ];
 
   NIX_LDFLAGS = "-lz";
 

--- a/pkgs/applications/misc/golden-cheetah/default.nix
+++ b/pkgs/applications/misc/golden-cheetah/default.nix
@@ -16,13 +16,13 @@ let
   };
 in mkDerivation rec {
   pname = "golden-cheetah";
-  version = "3.5-RC2X";
+  version = "3.5";
 
   src = fetchFromGitHub {
     owner = "GoldenCheetah";
     repo = "GoldenCheetah";
     rev = "V${version}";
-    sha256 = "1d85700gjbcw2badwz225rjdr954ai89900vp8sal04sk79wbr6g";
+    sha256 = "1lyd0b2s3s9c2ppj7l4hf3s4gfzscaaam2pbiaby714bi9nr0ka7";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
`golden-cheetah` broke during aec3c76dcabb3ceeb9975c5b6492fe68f9ceafa7 (bison bump).

This applies a fix proposed upstream at https://github.com/GoldenCheetah/GoldenCheetah/pull/3590. Upstream issue: https://github.com/GoldenCheetah/GoldenCheetah/issues/3586

This also bumps to the proper release, not the RC we're currently at.

Once merged, should be backported to 20.09 as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
