### PR TITLE
pcsx2: multiple improvements

### DIFF
--- a/pkgs/misc/emulators/pcsx2/default.nix
+++ b/pkgs/misc/emulators/pcsx2/default.nix
@@ -1,6 +1,6 @@
-{ alsaLib, cmake, fetchFromGitHub, gettext, glib, gtk3, harfbuzz, libaio
-, libpcap, libpng, libxml2, makeWrapper, perl, pkgconfig, portaudio, SDL2
-, soundtouch, stdenv, udev, wrapGAppsHook, wxGTK, zlib
+{ alsaLib, cmake, fetchFromGitHub, gcc-unwrapped, gettext, glib, gtk3, harfbuzz
+, libaio, libpcap, libpng, libxml2, makeWrapper, perl, pkgconfig, portaudio
+, SDL2, soundtouch, stdenv, udev, wrapGAppsHook, wxGTK, zlib
 }:
 
 stdenv.mkDerivation {
@@ -25,11 +25,19 @@ stdenv.mkDerivation {
     "-DPACKAGE_MODE=TRUE"
     "-DPLUGIN_DIR=${placeholder "out"}/lib/pcsx2"
     "-DREBUILD_SHADER=TRUE"
+    "-DUSE_LTO=TRUE"
     "-DwxWidgets_CONFIG_EXECUTABLE=${wxGTK}/bin/wx-config"
     "-DwxWidgets_INCLUDE_DIRS=${wxGTK}/include"
     "-DwxWidgets_LIBRARIES=${wxGTK}/lib"
     "-DXDG_STD=TRUE"
   ];
+
+  postPatch = ''
+    substituteInPlace cmake/BuildParameters.cmake \
+      --replace /usr/bin/gcc-ar ${gcc-unwrapped}/bin/gcc-ar \
+      --replace /usr/bin/gcc-nm ${gcc-unwrapped}/bin/gcc-nm \
+      --replace /usr/bin/gcc-ranlib ${gcc-unwrapped}/bin/gcc-ranlib
+  '';
 
   postFixup = ''
     wrapProgram $out/bin/PCSX2 \

--- a/pkgs/misc/emulators/pcsx2/default.nix
+++ b/pkgs/misc/emulators/pcsx2/default.nix
@@ -1,20 +1,18 @@
-{ alsaLib, cmake, fetchFromGitHub, glib, gettext, gtk2, harfbuzz, lib, libaio
-, libpng, libpcap, libxml2, makeWrapper, perl, pkgconfig, portaudio
-, SDL2, soundtouch, stdenv, udev, wxGTK, zlib
+{ alsaLib, cmake, fetchFromGitHub, gettext, glib, gtk3, harfbuzz, libaio
+, libpcap, libpng, libxml2, makeWrapper, perl, pkgconfig, portaudio, SDL2
+, soundtouch, stdenv, udev, wrapGAppsHook, wxGTK, zlib
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "pcsx2";
-  version = "1.6.0";
+  version = "unstable-2020-10-10";
 
   src = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2";
-    rev = "v${version}";
-    sha256 = "0528kh3275285lvfsykycdhc35c1z8pmccl2s7dfi3va2cp4x8wa";
+    rev = "7e2ccd64e8e6049b6059141e8767037463421c33";
+    sha256 = "0c7m74ch68p4y9xlld34a9r38kb2py6wlkg4vranc6dicxvi1b3r";
   };
-
-  postPatch = "sed '1i#include \"x86intrin.h\"' -i common/src/x86emitter/cpudetect.cpp";
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
@@ -23,17 +21,14 @@ stdenv.mkDerivation rec {
     "-DDOC_DIR=${placeholder "out"}/share/doc/pcsx2"
     "-DGAMEINDEX_DIR=${placeholder "out"}/share/pcsx2"
     "-DGLSL_SHADER_DIR=${placeholder "out"}/share/pcsx2"
-    "-DwxWidgets_LIBRARIES=${wxGTK}/lib"
-    "-DwxWidgets_INCLUDE_DIRS=${wxGTK}/include"
-    "-DwxWidgets_CONFIG_EXECUTABLE=${wxGTK}/bin/wx-config"
+    "-DGTK3_API=TRUE"
     "-DPACKAGE_MODE=TRUE"
     "-DPLUGIN_DIR=${placeholder "out"}/lib/pcsx2"
     "-DREBUILD_SHADER=TRUE"
+    "-DwxWidgets_CONFIG_EXECUTABLE=${wxGTK}/bin/wx-config"
+    "-DwxWidgets_INCLUDE_DIRS=${wxGTK}/include"
+    "-DwxWidgets_LIBRARIES=${wxGTK}/lib"
     "-DXDG_STD=TRUE"
-    "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include"
-    "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include"
-    "-DGTK2_INCLUDE_DIRS=${gtk2.dev}/include/gtk-2.0"
-    "-DGTK3_API=FALSE"
   ];
 
   postFixup = ''
@@ -41,13 +36,13 @@ stdenv.mkDerivation rec {
       --set __GL_THREADED_OPTIMIZATIONS 1
   '';
 
-  nativeBuildInputs = [ cmake makeWrapper perl pkgconfig ];
+  nativeBuildInputs = [ cmake makeWrapper perl pkgconfig wrapGAppsHook ];
 
   buildInputs = [
     alsaLib
-    glib
     gettext
-    gtk2
+    glib
+    gtk3
     harfbuzz
     libaio
     libpcap
@@ -71,13 +66,13 @@ stdenv.mkDerivation rec {
       PC, with many additional features and benefits.
     '';
     homepage = "https://pcsx2.net";
-    maintainers = with maintainers; [ hrdinka ];
+    maintainers = with maintainers; [ hrdinka samuelgrf ];
 
     # PCSX2's source code is released under LGPLv3+. It However ships
     # additional data files and code that are licensed differently.
     # This might be solved in future, for now we should stick with
     # license.free
     license = licenses.free;
-    platforms = platforms.i686;
+    platforms = platforms.x86;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22682,8 +22682,8 @@ in
     ffmpeg = ffmpeg_2;
   };
 
-  pcsx2 = pkgsi686Linux.callPackage ../misc/emulators/pcsx2 {
-    wxGTK = pkgsi686Linux.wxGTK30;
+  pcsx2 = callPackage ../misc/emulators/pcsx2 {
+    wxGTK = wxGTK30-gtk3;
   };
 
   pekwm = callPackage ../applications/window-managers/pekwm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Build pcsx2 with `gtk3`, this is already done on both [Arch](https://github.com/archlinux/svntogit-community/blob/9a92a0c12e437cbfa4ad6626c3d27fb248658590/trunk/PKGBUILD#L72) and [Gentoo](https://gitweb.gentoo.org/repo/gentoo.git/tree/games-emulation/pcsx2/pcsx2-1.6.0.ebuild#n82).
I updated the pcsx2 version to master, because it would otherwise crash with `trace trap (core dumped)` when opening menus.

I also enabled x86_64 builds, since it is supported on master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
