### PR TITLE
jpexs: rename to jpexs-ffdec

### DIFF
--- a/pkgs/development/tools/jpexs-ffdec/default.nix
+++ b/pkgs/development/tools/jpexs-ffdec/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchzip, makeWrapper, makeDesktopItem, jdk8 }:
 
 stdenv.mkDerivation rec {
-  pname = "jpexs";
+  pname = "jpexs-ffdec";
   version = "11.3.0";
 
   src = fetchzip {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11232,7 +11232,7 @@ in
 
   jenkins-job-builder = with python3Packages; toPythonApplication jenkins-job-builder;
 
-  jpexs = callPackage ../development/tools/jpexs { };
+  jpexs-ffdec = callPackage ../development/tools/jpexs-ffdec { };
 
   julius = callPackage ../games/julius { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
`jpexs` is just the developer's name.
The `ffdec` abbreviation is used in the official repo, so `jpexs-ffdec` seems like the best package name to use in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
