### PR TITLE
[20.09] python3Packages.dask: limit processes on tests, fix downstream

### DIFF
--- a/pkgs/development/python-modules/clifford/default.nix
+++ b/pkgs/development/python-modules/clifford/default.nix
@@ -1,14 +1,15 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, numpy
-, scipy
-, sparse
-, numba
+, isPy27
 , future
 , h5py
-, nose
-, isPy27
+, ipython
+, numba
+, numpy
+, pytestCheckHook
+, scipy
+, sparse
 }:
 
 buildPythonPackage rec {
@@ -22,26 +23,34 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    future
+    h5py
+    numba
     numpy
     scipy
     sparse
-    numba
-    future
-    h5py
   ];
 
   checkInputs = [
-    nose
+    pytestCheckHook
+    ipython
   ];
 
-  preConfigure = ''
+  postPatch = ''
     substituteInPlace setup.py \
       --replace "'numba==0.43'" "'numba'"
   '';
 
-  checkPhase = ''
-    nosetests
+  # avoid collecting local files
+  preCheck = ''
+    cd clifford/test
   '';
+
+  pytestFlagsArray = [
+    "-m \"not veryslow\""
+    "--ignore=test_algebra_initialisation.py" # fails without JIT
+    "--ignore=test_cga.py"
+  ];
 
   meta = with lib; {
     description = "Numerical Geometric Algebra Module";

--- a/pkgs/development/python-modules/datashader/default.nix
+++ b/pkgs/development/python-modules/datashader/default.nix
@@ -74,8 +74,9 @@ buildPythonPackage rec {
       --replace "'numba >=0.37.0,<0.49'" "'numba'"
   '';
 
+  # dask doesn't do well with large core counts
   checkPhase = ''
-    pytest -n $NIX_BUILD_CORES datashader
+    pytest -n $NIX_BUILD_CORES datashader -k 'not dask.array'
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchPypi, isPy27, python, buildPythonPackage
 , numpy, hdf5, cython, six, pkgconfig, unittest2, fetchpatch
-, mpi4py ? null, openssh }:
+, mpi4py ? null, openssh, pytest }:
 
 assert hdf5.mpiSupport -> mpi4py != null && hdf5.mpi == mpi4py.mpi;
 
@@ -10,19 +10,14 @@ let
   mpi = hdf5.mpi;
   mpiSupport = hdf5.mpiSupport;
 in buildPythonPackage rec {
-  version = "2.9.0";
+  version = "2.10.0";
   pname = "h5py";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9d41ca62daf36d6b6515ab8765e4c8c4388ee18e2a665701fef2b41563821002";
+    sha256 = "84412798925dc870ffd7107f045d7659e60f5d46d1c70c700375248bf6bf512d";
   };
-
-  patches = [ ( fetchpatch {
-    # Skip a test that probes an already fixed bug in HDF5 (upstream patch)
-    url = "https://github.com/h5py/h5py/commit/141eafa531c6c09a06efe6a694251a1eea84908d.patch";
-    sha256 = "0lmdn0gznr7gadx7qkxybl945fvwk6r0cc4lg3ylpf8ril1975h8";
-  })];
 
   configure_flags = "--hdf5=${hdf5}" + optionalString mpiSupport " --mpi";
 
@@ -36,7 +31,7 @@ in buildPythonPackage rec {
 
   preBuild = if mpiSupport then "export CC=${mpi}/bin/mpicc" else "";
 
-  checkInputs = optional isPy27 unittest2 ++ [ openssh ];
+  checkInputs = optional isPy27 unittest2 ++ [ pytest openssh ];
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ hdf5 cython ]
     ++ optional mpiSupport mpi;

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -6,19 +6,19 @@
 , holoviews
 , hvplot
 , jinja2
-, msgpack-numpy
 , msgpack
+, msgpack-numpy
 , numpy
 , pandas
 , panel
 , pyarrow
+, pytestCheckHook
+, pythonOlder
 , python-snappy
 , requests
 , ruamel_yaml
 , six
 , tornado
-, pytest
-, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -32,7 +32,6 @@ buildPythonPackage rec {
     sha256 = "0c284abeb74927a7366dcab6cefc010c4d050365b8af61c37326a2473a490a4e";
   };
 
-  checkInputs = [ pyarrow pytest ];
   propagatedBuildInputs = [
     appdirs
     dask
@@ -51,6 +50,8 @@ buildPythonPackage rec {
     tornado
   ];
 
+  checkInputs = [ pyarrow pytestCheckHook ];
+
   postPatch = ''
     # Is in setup_requires but not used in setup.py...
     substituteInPlace setup.py --replace "'pytest-runner'" ""
@@ -58,8 +59,18 @@ buildPythonPackage rec {
 
   # test_discover requires driver_with_entrypoints-0.1.dist-info, which is not included in tarball
   # test_filtered_compressed_cache requires calvert_uk_filter.tar.gz, which is not included in tarball
-  checkPhase = ''
-    PATH=$out/bin:$PATH HOME=$(mktemp -d) pytest -k "not test_discover and not test_filtered_compressed_cache"
+  preCheck = ''
+    HOME=$TMPDIR
+    PATH=$out/bin:$PATH
+  '';
+
+  # disable tests which touch network
+  disabledTests = ''
+    "test_discover"
+    "test_filtered_compressed_cache"
+    "test_get_dir"
+    "test_remote_cat"
+    "http"
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mask-rcnn/default.nix
+++ b/pkgs/development/python-modules/mask-rcnn/default.nix
@@ -12,7 +12,7 @@
 , pillow
 , scikitimage
 , scipy
-, tensorflow
+, tensorflow_2
 }:
 
 buildPythonPackage rec {
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pillow
     scikitimage
     scipy
-    tensorflow
+    tensorflow_2 # Keras only supports tensorflow 2 now
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/tensorflow-estimator/2/default.nix
+++ b/pkgs/development/python-modules/tensorflow-estimator/2/default.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "tensorflow-estimator";
-  version = "2.2.0";
+  version = "2.3.0";
   format = "wheel";
 
   src = fetchPypi {
     pname = "tensorflow_estimator";
     inherit version format;
-    sha256 = "1hkx4k6927xn4qpwiba6wa56n0qqm7s23bymm377j9bz2bfsr7fh";
+    sha256 = "11n4sl9wfr00fv1i837b7a36ink86ggmlsgj7i06kcfc011h6pmp";
   };
 
   propagatedBuildInputs = [ mock numpy absl-py ];

--- a/pkgs/development/python-modules/tensorflow/2/default.nix
+++ b/pkgs/development/python-modules/tensorflow/2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, bazel_0_29, buildBazelPackage, lib, fetchFromGitHub, fetchpatch, symlinkJoin
+{ stdenv, pkgs, bazel_3, buildBazelPackage, lib, fetchFromGitHub, fetchpatch, symlinkJoin
 , addOpenGLRunpath
 # Python deps
 , buildPythonPackage, isPy3k, isPy27, pythonOlder, pythonAtLeast, python
@@ -6,7 +6,7 @@
 , numpy, tensorflow-tensorboard_2, backports_weakref, mock, enum34, absl-py
 , future, setuptools, wheel, keras-preprocessing, keras-applications, google-pasta
 , functools32
-, opt-einsum
+, opt-einsum, astunparse, h5py
 , termcolor, grpcio, six, wrapt, protobuf, tensorflow-estimator_2
 # Common deps
 , git, swig, which, binutils, glibcLocales, cython
@@ -17,7 +17,7 @@
 # that in nix as well. It would make some things easier and less confusing, but
 # it would also make the default tensorflow package unfree. See
 # https://groups.google.com/a/tensorflow.org/forum/#!topic/developers/iRCt5m4qUz0
-, cudaSupport ? false, nvidia_x11 ? null, cudatoolkit ? null, cudnn ? null, nccl ? null
+, cudaSupport ? false, cudatoolkit ? null, cudnn ? null, nccl ? null
 , mklSupport ? false, mkl ? null
 # XLA without CUDA is broken
 , xlaSupport ? cudaSupport
@@ -30,8 +30,7 @@
 , Foundation, Security
 }:
 
-assert cudaSupport -> nvidia_x11 != null
-                   && cudatoolkit != null
+assert cudaSupport -> cudatoolkit != null
                    && cudnn != null;
 
 # unsupported combination
@@ -72,7 +71,7 @@ let
 
   tfFeature = x: if x then "1" else "0";
 
-  version = "2.1.0";
+  version = "2.3.0";
   variant = if cudaSupport then "-gpu" else "";
   pname = "tensorflow${variant}";
 
@@ -97,40 +96,32 @@ let
 
   bazel-build = buildBazelPackage {
     name = "${pname}-${version}";
-    bazel = bazel_0_29;
+    bazel = bazel_3;
 
     src = fetchFromGitHub {
       owner = "tensorflow";
       repo = "tensorflow";
       rev = "v${version}";
-      sha256 = "1g79xi8yl4sjia8ysk9b7xfzrz83zy28v5dlb2wzmcf0k5pmz60p";
+      sha256 = "1dd5fgyiazyfy7y2iv4v42qnap51fr6dzwb26inrsj7aaas06j71";
     };
 
     patches = [
-      # Work around https://github.com/tensorflow/tensorflow/issues/24752
-      ../no-saved-proto.patch
       # Fixes for NixOS jsoncpp
       ../system-jsoncpp.patch
 
-      (fetchpatch {
-        name = "backport-pr-18950.patch";
-        url = "https://github.com/tensorflow/tensorflow/commit/73640aaec2ab0234d9fff138e3c9833695570c0a.patch";
-        sha256 = "1n9ypbrx36fc1kc9cz5b3p9qhg15xxhq4nz6ap3hwqba535nakfz";
-      })
-
-      (fetchpatch {
-        # Don't try to fetch things that don't exist
-        name = "prune-missing-deps.patch";
-        url = "https://github.com/tensorflow/tensorflow/commit/b39b1ed24b4814db27d2f748dc85c10730ae851d.patch";
-        sha256 = "1skysz53nancvw1slij6s7flar2kv3gngnsq60ff4lap88kx5s6c";
-        excludes = [ "tensorflow/cc/saved_model/BUILD" ];
-      })
-
       ./lift-gast-restriction.patch
 
-      # cuda 10.2 does not have "-bin2c-path" option anymore
-      # https://github.com/tensorflow/tensorflow/issues/34429
-      ../cuda-10.2-no-bin2c-path.patch
+      # see https://github.com/tensorflow/tensorflow/issues/40688
+      (fetchpatch {
+        url = "https://github.com/tensorflow/tensorflow/commit/75ea0b31477d6ba9e990e296bbbd8ca4e7eebadf.patch";
+        sha256 = "1xp1icacig0xm0nmb05sbrf4nw4xbln9fhc308birrv8286zx7wv";
+      })
+
+      # see https://github.com/tensorflow/tensorflow/issues/40884
+      (fetchpatch {
+        url = "https://github.com/tensorflow/tensorflow/pull/41867/commits/65341f73d110bf173325768947343e1bb8f699fc.patch";
+        sha256 = "18ykkycaag1pcarz53bz6ydxjlah92j4178qn58gcayx1fy7hvh3";
+      })
     ];
 
     # On update, it can be useful to steal the changes from gentoo
@@ -147,7 +138,7 @@ let
       git
 
       # libs taken from system through the TF_SYS_LIBS mechanism
-      # grpc
+      grpc
       sqlite
       openssl
       jsoncpp
@@ -165,7 +156,6 @@ let
     ] ++ lib.optionals cudaSupport [
       cudatoolkit
       cudnn
-      nvidia_x11
     ] ++ lib.optionals mklSupport [
       mkl
     ] ++ lib.optionals stdenv.isDarwin [
@@ -182,24 +172,26 @@ let
     TF_SYSTEM_LIBS = lib.concatStringsSep "," [
       "absl_py"
       "astor_archive"
+      "astunparse_archive"
       "boringssl"
       # Not packaged in nixpkgs
       # "com_github_googleapis_googleapis"
       # "com_github_googlecloudplatform_google_cloud_cpp"
+      "com_github_grpc_grpc"
       "com_google_protobuf"
       "com_googlesource_code_re2"
       "curl"
       "cython"
       "double_conversion"
+      "enum34_archive"
       "flatbuffers"
+      "functools32_archive"
       "gast_archive"
-      # Lots of errors, requires an older version
-      # "grpc"
+      "gif"
       "hwloc"
       "icu"
-      "jpeg"
       "jsoncpp_git"
-      "keras_applications_archive"
+      "libjpeg_turbo"
       "lmdb"
       "nasm"
       # "nsync" # not packaged in nixpkgs
@@ -207,12 +199,14 @@ let
       "org_sqlite"
       "pasta"
       "pcre"
+      "png"
+      "pybind11"
       "six_archive"
       "snappy"
       "swig"
       "termcolor_archive"
       "wrapt"
-      "zlib_archive"
+      "zlib"
     ];
 
     INCLUDEDIR = "${includes_joined}/include";
@@ -235,13 +229,16 @@ let
     TF_CUDA_COMPUTE_CAPABILITIES = lib.concatStringsSep "," cudaCapabilities;
 
     postPatch = ''
-      # https://github.com/tensorflow/tensorflow/issues/20919
-      sed -i '/androidndk/d' tensorflow/lite/kernels/internal/BUILD
-
       # Tensorboard pulls in a bunch of dependencies, some of which may
       # include security vulnerabilities. So we make it optional.
       # https://github.com/tensorflow/tensorflow/issues/20280#issuecomment-400230560
       sed -i '/tensorboard >=/d' tensorflow/tools/pip_package/setup.py
+
+      # numpy 1.19 added in https://github.com/tensorflow/tensorflow/commit/75ea0b31477d6ba9e990e296bbbd8ca4e7eebadf.patch
+      sed -i 's/numpy >= 1.16.0, < 1.19.0/numpy >= 1.16.0/' tensorflow/tools/pip_package/setup.py
+
+      # bazel 3.3 should work just as well as bazel 3.1
+      rm -f .bazelversion
     '';
 
     preConfigure = let
@@ -272,15 +269,8 @@ let
       runHook postConfigure
     '';
 
-    # FIXME: Tensorflow uses dlopen() for CUDA libraries.
-    NIX_LDFLAGS = lib.optionalString cudaSupport "-lcudart -lcublas -lcufft -lcurand -lcusolver -lcusparse -lcudnn";
-
     hardeningDisable = [ "format" ];
 
-    bazelFlags = [
-      # temporary fixes to make the build work with bazel 0.27
-      "--incompatible_no_support_tools_in_action_inputs=false"
-    ];
     bazelBuildFlags = [
       "--config=opt" # optimize using the flags set in the configure phase
     ]
@@ -288,15 +278,17 @@ let
 
     bazelTarget = "//tensorflow/tools/pip_package:build_pip_package //tensorflow/tools/lib_package:libtensorflow";
 
+    removeRulesCC = false;
+
     fetchAttrs = {
       # So that checksums don't depend on these.
       TF_SYSTEM_LIBS = null;
 
       # cudaSupport causes fetch of ncclArchive, resulting in different hashes
       sha256 = if cudaSupport then
-        "1kqk1gx5g63kb2zdj392x6mnpbrmgqghrdv597aipn7s23xzj8pd"
+        "0pf8128chkm6fxnhd4956n6gvijlj00mjmvry33gq3xx3bayhs9g"
       else
-        "1plpcm2ydpajsrxdvmmpfy7l0gfdir78hap72w4k7ddm6d3rm2fv";
+        "0mkgss2nyk21zlj8hp24cs3dmpdnxk8qi6qq4hyc18lp82p09xwa";
     };
 
     buildAttrs = {
@@ -347,7 +339,7 @@ let
 
 in buildPythonPackage {
   inherit version pname;
-  disabled = isPy27 || (pythonAtLeast "3.8");
+  disabled = isPy27;
 
   src = bazel-build.python;
 
@@ -377,6 +369,8 @@ in buildPythonPackage {
     wrapt
     grpcio
     opt-einsum
+    astunparse
+    h5py
   ] ++ lib.optionals (!isPy3k) [
     mock
     future
@@ -392,6 +386,8 @@ in buildPythonPackage {
   postFixup = lib.optionalString cudaSupport ''
     find $out -type f \( -name '*.so' -or -name '*.so.*' \) | while read lib; do
       addOpenGLRunpath "$lib"
+
+      patchelf --set-rpath "${cudatoolkit}/lib:${cudatoolkit.lib}/lib:${cudnn}/lib:${nccl}/lib:$(patchelf --print-rpath "$lib")" "$lib"
     done
   '';
 

--- a/pkgs/development/python-modules/tensorflow/2/default.nix
+++ b/pkgs/development/python-modules/tensorflow/2/default.nix
@@ -46,6 +46,7 @@ let
     paths = [
       cudatoolkit.lib
       cudatoolkit.out
+    ] ++ lib.optionals (lib.versionOlder cudatoolkit.version "11") [
       # for some reason some of the required libs are in the targets/x86_64-linux
       # directory; not sure why but this works around it
       "${cudatoolkit}/targets/${stdenv.system}"

--- a/pkgs/development/python-modules/tensorflow/2/lift-gast-restriction.patch
+++ b/pkgs/development/python-modules/tensorflow/2/lift-gast-restriction.patch
@@ -2,10 +2,10 @@ diff --git a/tensorflow/tools/pip_package/setup.py b/tensorflow/tools/pip_packag
 index 992f2eae22..d9386f9b13 100644
 --- a/tensorflow/tools/pip_package/setup.py
 +++ b/tensorflow/tools/pip_package/setup.py
-@@ -54,5 +54,5 @@ REQUIRED_PACKAGES = [
-     'enum34 >= 1.1.6;python_version<"3.4"',
--    'gast == 0.2.2',
-+    'gast >= 0.2.2',
-     'google_pasta >= 0.1.6',
-     'keras_applications >= 1.0.8',
-     'keras_preprocessing >= 1.0.5',
+@@ -56,5 +56,5 @@ REQUIRED_PACKAGES = [
+     'astunparse == 1.6.3',
+-    'gast == 0.3.3',
++    'gast >= 0.3.3',
+     'google_pasta >= 0.1.8',
+     'h5py >= 2.10.0, < 2.11.0',
+     'keras_preprocessing >= 1.1.1, < 1.2',

--- a/pkgs/development/python-modules/tensorly/default.nix
+++ b/pkgs/development/python-modules/tensorly/default.nix
@@ -22,7 +22,9 @@ buildPythonPackage rec {
     sha256 = "1ml91yaxwx4msisxbm92yf22qfrscvk58f3z2r1jhi96pw2k4i7x";
   };
 
-  propagatedBuildInputs = [ numpy scipy sparse ];
+  propagatedBuildInputs = [ numpy scipy sparse ]
+    ++ lib.optionals (!doCheck) [ nose ]; # upstream added nose to install_requires
+
   checkInputs = [ pytest nose pytorch ];
   # also has a cupy backend, but the tests are currently broken
   # (e.g. attempts to access cupy.qr instead of cupy.linalg.qr)
@@ -30,11 +32,15 @@ buildPythonPackage rec {
   # as well as tensorflow and mxnet backends, but the tests don't
   # seem to exercise these backend by default
 
+  # uses >= 140GB of ram to test
+  doCheck = false;
   checkPhase = ''
     runHook preCheck
     nosetests -e "test_cupy"
     runHook postCheck
   '';
+
+  pythonImportsCheck = [ "tensorly" ];
 
   meta = with lib; {
     description = "Tensor learning in Python";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6881,7 +6881,6 @@ in {
 
   tensorflow-build_2 = callPackage ../development/python-modules/tensorflow/2 {
     cudaSupport = pkgs.config.cudaSupport or false;
-    inherit (pkgs.linuxPackages) nvidia_x11;
     cudatoolkit = pkgs.cudatoolkit_10;
     cudnn = pkgs.cudnn_cudatoolkit_10;
     nccl = pkgs.nccl_cudatoolkit_10;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6881,9 +6881,9 @@ in {
 
   tensorflow-build_2 = callPackage ../development/python-modules/tensorflow/2 {
     cudaSupport = pkgs.config.cudaSupport or false;
-    cudatoolkit = pkgs.cudatoolkit_10;
-    cudnn = pkgs.cudnn_cudatoolkit_10;
-    nccl = pkgs.nccl_cudatoolkit_10;
+    cudatoolkit = pkgs.cudatoolkit_11;
+    cudnn = pkgs.cudnn_cudatoolkit_11;
+    nccl = pkgs.nccl_cudatoolkit_11;
     openssl = pkgs.openssl_1_1;
     inherit (pkgs.darwin.apple_sdk.frameworks) Foundation Security;
   };


### PR DESCRIPTION
###### Motivation for this change
backport #99575

includes some build fixes, but also makes some package much faster to review (specifically tensorly)

also backported #95824 to fix tensorflow_2 build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
