### PR TITLE
gofer: init at 2.30b

### DIFF
--- a/pkgs/by-name/go/gofer/modern-platforms.patch
+++ b/pkgs/by-name/go/gofer/modern-platforms.patch
@@ -1,0 +1,72 @@
+From: Ben Siraphob <bensiraphob@gmail.com>
+Date: Wed, 12 Aug 2026 11:05:38 -0700
+Subject: Support modern 64-bit Unix systems
+
+Select the POSIX terminal interface and use pointer-width cells in the
+Gofer-to-C runtime.
+
+diff --git a/prelude.h b/prelude.h
+--- a/prelude.h
++++ b/prelude.h
+@@ -28,14 +28,14 @@
+ #define ZTC      0	/* For IBM PC (>= 386) Zortech C++ v3.0 (-mx)	   */
+ #define DJGPP    0	/* For DJGPP version 1.09 (gcc2.2.2) and DOS 5.0   */
+ #define OS2      0	/* For IBM OS/2 2.0 using EMX GCC		   */
+-#define SUNOS    1      /* For Sun 3/Sun 4 running SunOs 4.x		   */
++#define SUNOS    0      /* For Sun 3/Sun 4 running SunOs 4.x		   */
+ #define MIPS	 0	/* For MIPS RC6280/Sony machine NWS-3870	UN */
+ #define NEXTSTEP 0      /* For NeXTstep 3.0 using NeXT cc		   */
+ #define NEXTGCC  0	/* For NeXTstep with gcc 2.x, doesn't work w/ NS3.2*/
+ #define MINIX68K 0	/* For Minix68k with gcc			UN */
+ #define AMIGA    0	/* For Amiga using gcc 2.2.2			UN */
+ #define HPUX     0      /* For HPUX using gcc				   */
+-#define LINUX    0      /* For Linux using gcc				UN */
++#define LINUX    1      /* For Linux using gcc				UN */
+ #define RISCOS   0	/* For Acorn DesktopC and RISCOS2 or 3		   */
+ #define ALPHA	 0	/* For DEC Alpha with OSF/1 (32 bit ints, no gofc) */
+ #define SVR4	 0	/* For SVR4 using GCC2.2			   */
+@@ -88,10 +88,10 @@
+ #define LARGE_GOFER	(UNIX   | WATCOM)
+ #define JMPBUF_ARRAY	(UNIX   | DJGPP | RISCOS | ZTC | ATARI)
+ #define DOS_IO		(TURBOC | BCC | DJGPP | ZTC | WATCOM | ATARI)
+-#define TERMIO_IO	(LINUX  | HPUX | OS2 | SVR4 | SGI4)
++#define TERMIO_IO	0
+ #define SGTTY_IO	(SUNOS  | NEXTSTEP | NEXTGCC | AMIGA | MINIX68K | \
+ 			 ALPHA  | ULTRIX | AIX | MIPS)
+-#define TERMIOS_IO      (NETBSD)
++#define TERMIOS_IO      1
+ #define BREAK_FLOATS	(TURBOC | BCC)
+ #define HAS_FLOATS	(REGULAR_GOFER | LARGE_GOFER | BREAK_FLOATS)
+ 
+diff --git a/gofc.h b/gofc.h
+--- a/gofc.h
++++ b/gofc.h
+@@ -8,13 +8,14 @@
+  * ------------------------------------------------------------------------*/
+ 
+ #include "prelude.h"
++#include <stdint.h>
+ 
+ /*- Garbage collected heap ------------------------------------------------*/
+ 
+ #define GC_MARKSCAN	0			/* for mark/scan collector */
+ #define GC_TWOSPACE	1			/* for twospace collector  */
+ 
+-typedef Int		Cell;			/* general cell value	   */
++typedef intptr_t	Cell;			/* general cell value	   */
+ typedef Cell far	*Heap;			/* storage of heap	   */
+ extern  Int		heapSize;		/* Pairs are stored in the */
+ extern  Void		garbageCollect Args((Void));
+@@ -123,10 +124,10 @@ extern	FloatPro	floatOf		Args((Cell));
+ extern	String		floatToString	Args((FloatPro));
+ extern  FloatPro	stringToFloat	Args((String));
+ 
+-#define mkString(s)	pair(STRCELL,(Int)(s))
++#define mkString(s)	pair(STRCELL,(Cell)(s))
+ #define stringOf(c)	((String)(snd(c)))
+ 
+-#define mkSuper(sc)	pair(SUPERCOMB,(Int)(sc))
++#define mkSuper(sc)	pair(SUPERCOMB,(Cell)(sc))
+ #define superOf(c)      ((Super *)(snd(c)))
+ 
+ /*- Cells>MAXTAG represent small integers, characters, dictionaries and -- */

--- a/pkgs/by-name/go/gofer/package.nix
+++ b/pkgs/by-name/go/gofer/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation {
+  pname = "gofer";
+  version = "2.30b";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://web.cecs.pdx.edu/~mpj/goferarc/gofer230b.tar.gz";
+    hash = "sha256-f7l+Qez5Up2C4eB+WrKMDXXuiROgCftoU2eTDtl9z9E=";
+  };
+
+  sourceRoot = "src";
+
+  patches = [ ./modern-platforms.patch ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace cmachine.c \
+      --replace-fail /usr/local/lib/Gofer/gofc.h ${placeholder "out"}/lib/gofer/gofc.h
+  '';
+
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-implicit-int -Wno-implicit-function-declaration -Wno-error=format-security";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 gofer gofc -t "$out/libexec/gofer"
+    install -Dm644 runtime.o gofc.h prelude.h -t "$out/lib/gofer"
+    install -Dm644 ../*.prelude -t "$out/lib/gofer"
+
+    makeWrapper "$out/libexec/gofer/gofer" "$out/bin/gofer" \
+      --set-default GOFER "$out/lib/gofer/standard.prelude"
+
+    makeWrapper "$out/libexec/gofer/gofc" "$out/bin/gofc" \
+      --set-default GOFER "$out/lib/gofer/standard.prelude"
+
+    install -Dm755 ../scripts/goferc "$out/bin/goferc"
+    substituteInPlace "$out/bin/goferc" \
+      --replace-fail /home/staff/ian/gofer/lib/standard.prelude \
+        ${placeholder "out"}/lib/gofer/standard.prelude \
+      --replace-fail /usr/local/lib/Gofer/gofc \
+        ${placeholder "out"}/libexec/gofer/gofc \
+      --replace-fail gcc ${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc \
+      --replace-fail /usr/local/lib/Gofer/runtime.o \
+        ${placeholder "out"}/lib/gofer/runtime.o \
+      --replace-fail strip ':'
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    testDir=$(mktemp -d)
+    cd "$testDir"
+    printf '1 + 2\n:quit\n' | "$out/bin/gofer" | grep -F '? 3'
+    printf 'main = print (1 + 2)\n' > test.gs
+    "$out/bin/gofc" test.gs
+    test -s test.c
+    "$out/bin/goferc" test.gs
+    test "$(./test)" = "3"
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Compiler and interpreter for the Gofer functional programming language";
+    homepage = "https://web.cecs.pdx.edu/~mpj/goferarc/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ siraben ];
+    mainProgram = "gofer";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Packages Gofer 2.30b, the final archived release of Mark P. Jones's functional programming environment.

We package 2.30b instead of 2.30a because it updates Gofer from 1.02 to 1.03 and fixes generated-C stack handling, array primitive declarations, and array runtime behavior.

We also do:
- configures the historical source for modern Unix systems;
- installs the standard prelude and Gofer→C runtime in the Nix store;
- wraps `gofer`, `gofc`, and `goferc` with the required paths; and
- includes install checks for interpreter evaluation and Gofer→C generation.

`gofer`, `gofc`, and `goferc` work on aarch64-darwin and x86_64-linux. The package patches Gofer→C runtime cells to use pointer-width storage on modern 64-bit systems.

Upstream archive: http://web.cecs.pdx.edu/~mpj/goferarc/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests` or package check phases.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test