### PR TITLE
wsl-open: init at 2.1.1

### DIFF
--- a/pkgs/tools/misc/wsl-open/default.nix
+++ b/pkgs/tools/misc/wsl-open/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, installShellFiles }:
+
+stdenv.mkDerivation rec {
+  pname = "wsl-open";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "4U6U57";
+    repo = "wsl-open";
+    rev = "v${version}";
+    sha256 = "1mwak846zh47p3pp4q5f54cw8d9qk61zn43q81j2pkcm35mv9lzg";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  installPhase = ''
+    install -m0755 -D wsl-open.sh $out/bin/wsl-open
+    installManPage wsl-open.1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Open files with xdg-open from Windows Subsystem for Linux (WSL) in Windows applications";
+    homepage = "https://gitlab.com/4U6U57/wsl-open";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3596,6 +3596,8 @@ in
 
   wshowkeys = callPackage ../tools/wayland/wshowkeys { };
 
+  wsl-open = callPackage ../tools/misc/wsl-open { };
+
   xkcdpass = with pythonPackages; toPythonApplication xkcdpass;
 
   xob = callPackage ../tools/X11/xob { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Sometimes I need to use WSL and this is handy with an alias.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
