### PR TITLE
google-play-music-desktop-player: copy icons

### DIFF
--- a/pkgs/applications/audio/google-play-music-desktop-player/default.nix
+++ b/pkgs/applications/audio/google-play-music-desktop-player/default.nix
@@ -1,6 +1,6 @@
 { stdenv, alsaLib, atk, at-spi2-atk, cairo, cups, dbus, dpkg, expat, fontconfig, freetype
-, fetchurl, GConf, gdk-pixbuf, glib, gtk2, gtk3, libpulseaudio, makeWrapper, nspr
-, nss, pango, udev, xorg
+, fetchurl, GConf, gdk-pixbuf, glib, gtk2, gtk3, imagemagick, libpulseaudio, makeWrapper
+, nspr, nss, pango, udev, xorg
 }:
 
 let
@@ -54,6 +54,7 @@ stdenv.mkDerivation {
 
   dontBuild = true;
   buildInputs = [ dpkg makeWrapper ];
+  nativeBuildInputs = [ imagemagick ];
 
   unpackPhase = ''
     dpkg -x $src .

--- a/pkgs/applications/audio/google-play-music-desktop-player/default.nix
+++ b/pkgs/applications/audio/google-play-music-desktop-player/default.nix
@@ -72,6 +72,16 @@ stdenv.mkDerivation {
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath deps}"
   '';
 
+  postInstall = ''
+    # create desktop icons
+    for size in 16 32 48 64 72 96 128 192 512 1024; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      convert -resize "$size"x"$size" \
+        $out/share/pixmaps/google-play-music-desktop-player.png \
+        $out/share/icons/hicolor/"$size"x"$size"/apps/google-play-music-desktop-player.png
+    done
+  '';
+
   meta = {
     homepage = "https://www.googleplaymusicdesktopplayer.com/";
     description = "A beautiful cross platform Desktop Player for Google Play Music";


### PR DESCRIPTION
Icons need to be copied over to correct directories in order for share's .desktop to function.

###### Motivation for this change

Issue: https://github.com/NixOS/nixpkgs/issues/98139
Unable to get Google play music to launch from KDE without a terminal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ]  NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
