### PR TITLE
FormEncode: 1.3.1 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/FormEncode/default.nix
+++ b/pkgs/development/python-modules/FormEncode/default.nix
@@ -1,24 +1,28 @@
-{ stdenv, buildPythonPackage, fetchPypi, dnspython, pycountry, nose }:
+{ stdenv, buildPythonPackage, fetchPypi, dnspython, pycountry, nose, setuptools_scm, six, isPy27 }:
 
 buildPythonPackage rec {
   pname = "FormEncode";
-  version = "1.3.1";
+  version = "2.0.0";
+
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1xm77h2mds2prlaz0z4nzkx13g61rx5c2v3vpgjq9d5ij8bzb8md";
+    sha256 = "049pm276140h30xgzwylhpii24xcln1qfdlfmbj69sqpfhlr5szj";
   };
 
-  buildInputs = [ dnspython pycountry nose ];
-
-  patchPhase = ''
-    # dnspython3 has been superseded, see its PyPI page
-    substituteInPlace setup.py --replace dnspython3 dnspython
+  postPatch = ''
+    sed -i 's/setuptools_scm_git_archive//' setup.py
+    sed -i 's/use_scm_version=.*,/version="${version}",/' setup.py
   '';
 
+  nativeBuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ dnspython pycountry nose ];
+
   preCheck = ''
-    # two tests require dns resolving
-    sed -i 's/test_cyrillic_email/noop/' formencode/tests/test_email.py
+    # requires dns resolving
     sed -i 's/test_unicode_ascii_subgroup/noop/' formencode/tests/test_email.py
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://r.ryantm.com/log/2020-10-09.log

###### Things done

No longer available for Python because pycountry is to new.

```
ERROR: Could not find a version that satisfies the requirement pycountry<19 (from versions: none)
ERROR: No matching distribution found for pycountry<19
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
