### PR TITLE
sndio: use multiple outputs

### DIFF
--- a/pkgs/misc/sndio/default.nix
+++ b/pkgs/misc/sndio/default.nix
@@ -7,6 +7,18 @@ stdenv.mkDerivation rec {
   buildInputs = stdenv.lib.optionals stdenv.isLinux [ alsaLib ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ fixDarwinDylibNames ];
 
+  # out is required but empty, see issue #16182
+  outputs = [ "bin" "dev" "devman" "lib" "man" "out" ];
+
+  setOutputFlags = false;
+
+  configureFlags =
+    [ "--bindir=${placeholder "bin"}/bin"
+      "--includedir=${placeholder "dev"}/include"
+      "--libdir=${placeholder "lib"}/lib"
+      "--mandir=${placeholder "man"}/share/man"
+    ];
+
   src = fetchurl {
     url = "http://www.sndio.org/sndio-${version}.tar.gz";
     sha256 = "0ljmac0lnjn61admgbcwjfcr5fwccrsblx9rj9bys8wlhz8f796x";
@@ -16,7 +28,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.sndio.org";
     description = "Small audio and MIDI framework part of the OpenBSD project";
     license = licenses.isc;
-    maintainers = with maintainers; [ chiiruno ];
+    maintainers = with maintainers; [ chiiruno sna ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Use multiple outputs, reduce runtime closure size, etc..

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I built `mpv` as well.