### PR TITLE
harfbuzz: 2.7.1 -> 2.7.2

### DIFF
--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  version = "2.7.1";
+  version = "2.7.2";
   inherit (stdenv.lib) optional optionals optionalString;
   mesonFeatureFlag = opt: b:
     "-D${opt}=${if b then "enabled" else "disabled"}";
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     owner  = "harfbuzz";
     repo   = "harfbuzz";
     rev    = version;
-    sha256 = "172jmwp666xbs6yy1pc2495gnkz8xw11b8zkz3j19jxlvvp4mxcs";
+    sha256 = "0vfyxr3lvzp80j1347nrwpr1ndv265p15rj2q8rj31lb26nyz4dm";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
https://github.com/harfbuzz/harfbuzz/releases/tag/2.7.2

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).