### PR TITLE
nixos/tools: add desktopConfiguration option (to seed configuration into configuration.nix)

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -625,6 +625,10 @@ EOF
 
         my $networkingDhcpConfig = generateNetworkingDhcpConfig();
 
+        (my $desktopConfiguration = <<EOF)=~s/^/  /gm;
+@desktopConfiguration@
+EOF
+
         write_file($fn, <<EOF);
 @configuration@
 EOF

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -45,7 +45,7 @@ let
     src = ./nixos-generate-config.pl;
     path = lib.optionals (lib.elem "btrfs" config.boot.supportedFilesystems) [ pkgs.btrfs-progs ];
     perl = "${pkgs.perl}/bin/perl -I${pkgs.perlPackages.FileSlurp}/${pkgs.perl.libPrefix}";
-    inherit (config.system.nixos-generate-config) configuration;
+    inherit (config.system.nixos-generate-config) configuration desktopConfiguration;
   };
 
   nixos-option =
@@ -78,24 +78,42 @@ in
 
 {
 
-  options.system.nixos-generate-config.configuration = mkOption {
-    internal = true;
-    type = types.str;
-    description = ''
-      The NixOS module that <literal>nixos-generate-config</literal>
-      saves to <literal>/etc/nixos/configuration.nix</literal>.
+  options.system.nixos-generate-config = {
+    configuration = mkOption {
+      internal = true;
+      type = types.str;
+      description = ''
+        The NixOS module that <literal>nixos-generate-config</literal>
+        saves to <literal>/etc/nixos/configuration.nix</literal>.
 
-      This is an internal option. No backward compatibility is guaranteed.
-      Use at your own risk!
+        This is an internal option. No backward compatibility is guaranteed.
+        Use at your own risk!
 
-      Note that this string gets spliced into a Perl script. The perl
-      variable <literal>$bootLoaderConfig</literal> can be used to
-      splice in the boot loader configuration.
-    '';
+        Note that this string gets spliced into a Perl script. The perl
+        variable <literal>$bootLoaderConfig</literal> can be used to
+        splice in the boot loader configuration.
+      '';
+    };
+
+    desktopConfiguration = mkOption {
+      internal = true;
+      type = types.str;
+      default = "";
+      description = ''
+        Text to preseed the desktop configuration that <literal>nixos-generate-config</literal>
+        saves to <literal>/etc/nixos/configuration.nix</literal>.
+
+        This is an internal option. No backward compatibility is guaranteed.
+        Use at your own risk!
+
+        Note that this string gets spliced into a Perl script. The perl
+        variable <literal>$bootLoaderConfig</literal> can be used to
+        splice in the boot loader configuration.
+      '';
+    };
   };
 
   config = {
-
     system.nixos-generate-config.configuration = mkDefault ''
       # Edit this configuration file to define what should be installed on
       # your system.  Help is available in the configuration.nix(5) man page
@@ -113,6 +131,9 @@ in
         # networking.hostName = "nixos"; # Define your hostname.
         # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
+        # Set your time zone.
+        # time.timeZone = "Europe/Amsterdam";
+
       $networkingDhcpConfig
         # Configure network proxy if necessary
         # networking.proxy.default = "http://user:password\@proxy:port/";
@@ -125,8 +146,26 @@ in
         #   keyMap = "us";
         # };
 
-        # Set your time zone.
-        # time.timeZone = "Europe/Amsterdam";
+      $desktopConfiguration
+        # Configure keymap in X11
+        # services.xserver.layout = "us";
+        # services.xserver.xkbOptions = "eurosign:e";
+
+        # Enable CUPS to print documents.
+        # services.printing.enable = true;
+
+        # Enable sound.
+        # sound.enable = true;
+        # hardware.pulseaudio.enable = true;
+
+        # Enable touchpad support (enabled default in most desktopManager).
+        # services.xserver.libinput.enable = true;
+
+        # Define a user account. Don't forget to set a password with ‘passwd’.
+        # users.users.jane = {
+        #   isNormalUser = true;
+        #   extraGroups = [ "wheel" ]; # Enable ‘sudo’ for the user.
+        # };
 
         # List packages installed in system profile. To search, run:
         # \$ nix search wget
@@ -153,31 +192,6 @@ in
         # networking.firewall.allowedUDPPorts = [ ... ];
         # Or disable the firewall altogether.
         # networking.firewall.enable = false;
-
-        # Enable CUPS to print documents.
-        # services.printing.enable = true;
-
-        # Enable sound.
-        # sound.enable = true;
-        # hardware.pulseaudio.enable = true;
-
-        # Enable the X11 windowing system.
-        # services.xserver.enable = true;
-        # services.xserver.layout = "us";
-        # services.xserver.xkbOptions = "eurosign:e";
-
-        # Enable touchpad support (enabled default in most desktopManager).
-        # services.xserver.libinput.enable = true;
-
-        # Enable the Plasma 5 Desktop Environment.
-        # services.xserver.displayManager.sddm.enable = true;
-        # services.xserver.desktopManager.plasma5.enable = true;
-
-        # Define a user account. Don't forget to set a password with ‘passwd’.
-        # users.users.jane = {
-        #   isNormalUser = true;
-        #   extraGroups = [ "wheel" ]; # Enable ‘sudo’ for the user.
-        # };
 
         # This value determines the NixOS release from which the default
         # settings for stateful data, like file locations and database versions

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -140,7 +140,6 @@ in
         # programs.gnupg.agent = {
         #   enable = true;
         #   enableSSHSupport = true;
-        #   pinentryFlavor = "gnome3";
         # };
 
         # List services that you want to enable:

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -132,6 +132,7 @@ in
         # \$ nix search wget
         # environment.systemPackages = with pkgs; [
         #   wget vim
+        #   firefox
         # ];
 
         # Some programs need SUID wrappers, can be configured further or are

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -165,7 +165,7 @@ in
         # services.xserver.layout = "us";
         # services.xserver.xkbOptions = "eurosign:e";
 
-        # Enable touchpad support.
+        # Enable touchpad support (enabled default in most desktopManager).
         # services.xserver.libinput.enable = true;
 
         # Enable the KDE Desktop Environment.

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -168,7 +168,7 @@ in
         # Enable touchpad support (enabled default in most desktopManager).
         # services.xserver.libinput.enable = true;
 
-        # Enable the KDE Desktop Environment.
+        # Enable the Plasma 5 Desktop Environment.
         # services.xserver.displayManager.sddm.enable = true;
         # services.xserver.desktopManager.plasma5.enable = true;
 

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -179,6 +179,14 @@ in
 
   config = mkMerge [
     (mkIf (cfg.enable || flashbackEnabled) {
+      # Seed our configuration into nixos-generate-config
+      system.nixos-generate-config.desktopConfiguration = ''
+        # Enable the GNOME 3 Desktop Environment.
+        services.xserver.enable = true;
+        services.xserver.displayManager.gdm.enable = true;
+        services.xserver.desktopManager.gnome3.enable = true;
+      '';
+
       services.gnome3.core-os-services.enable = true;
       services.gnome3.core-shell.enable = true;
       services.gnome3.core-utilities.enable = mkDefault true;

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -184,6 +184,14 @@ in
 
   config = mkMerge [
     (mkIf cfg.enable {
+      # Seed our configuration into nixos-generate-config
+      system.nixos-generate-config.desktopConfiguration = ''
+        # Enable the Plasma 5 Desktop Environment.
+        services.xserver.enable = true;
+        services.xserver.displayManager.sddm.enable = true;
+        services.xserver.desktopManager.plasma5.enable = true;
+      '';
+
       services.xserver.desktopManager.session = singleton {
         name = "plasma5";
         bgSupport = true;

--- a/nixos/tests/nixos-generate-config.nix
+++ b/nixos/tests/nixos-generate-config.nix
@@ -7,7 +7,15 @@ import ./make-test-python.nix ({ lib, ... } : {
       { config, pkgs, ... }: {
         imports = [ ./hardware-configuration.nix ];
       $bootLoaderConfig
+      $desktopConfiguration
       }
+    '';
+
+    system.nixos-generate-config.desktopConfiguration = ''
+      # DESKTOP
+      # services.xserver.enable = true;
+      # services.xserver.displayManager.gdm.enable = true;
+      # services.xserver.desktopManager.gnome3.enable = true;
     '';
   };
   testScript = ''
@@ -18,9 +26,17 @@ import ./make-test-python.nix ({ lib, ... } : {
     # Test if the configuration really is overridden
     machine.succeed("grep 'OVERRIDDEN' /etc/nixos/configuration.nix")
 
+    # Test if desktop configuration really is overridden
+    machine.succeed("grep 'DESKTOP' /etc/nixos/configuration.nix")
+
     # Test of if the Perl variable $bootLoaderConfig is spliced correctly:
     machine.succeed(
         "grep 'boot\\.loader\\.grub\\.enable = true;' /etc/nixos/configuration.nix"
+    )
+
+    # Test if the Perl variable $desktopConfiguration is spliced correctly
+    machine.succeed(
+        "grep 'services\\.xserver\\.desktopManager\\.gnome3\\.enable = true;' /etc/nixos/configuration.nix"
     )
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
In 20.09 we added a GNOME ISO. It would be really great if, for all graphical iso's, we seed a configuration that **isn't commented** and only used in those respective iso's. I believe @samueldr first suggested this on the thread about adding a GNOME ISO. My current disposition is that we should block on this, I think we will have enough time to get this feature in, and it would make having another ISO feel more meaningful. If not, I'm not sure about backporting.

I also cleaned up the `configuration.nix` a bit, @ttuegel mentioned we **should not** call plasma "KDE" so I made that change to the generated configuration.nix along with some other things.

I will say, off the bat, the only issue with this is the configuration `desktopConfiguration` isn't indented properly. Anyone knowing perl or who can spot the mistake (I'm sleepy :grin: ) please mention.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
