### PR TITLE
hime: fix enable hime, remove hime-all package

### DIFF
--- a/nixos/modules/i18n/input-method/default.xml
+++ b/nixos/modules/i18n/input-method/default.xml
@@ -252,8 +252,8 @@ i18n.inputMethod = {
   <para>
    Hime is an extremely easy-to-use input method framework. It is lightweight,
    stable, powerful and supports many commonly used input methods, including
-   Cangjie, Zhuyin, Dayi, Rank, Shrimp, Greek, Japanese Anthy, Korean Pinyin,
-   Latin Alphabet, Rancang hunting birds, cool music, etc...
+   Cangjie, Zhuyin, Dayi, Rank, Shrimp, Greek, Korean Pinyin, Latin Alphabet,
+   etc...
   </para>
 
   <para>

--- a/nixos/modules/i18n/input-method/hime.nix
+++ b/nixos/modules/i18n/input-method/hime.nix
@@ -1,23 +1,9 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 with lib;
 {
-  options = {
-    i18n.inputMethod.hime = {
-      enableChewing = mkOption {
-        type    =  with types; nullOr bool;
-        default = null;
-        description = "enable chewing input method";
-      };
-      enableAnthy = mkOption {
-        type    =  with types; nullOr bool;
-        default = null;
-        description = "enable anthy input method";
-      };
-    };
-  };
-
   config = mkIf (config.i18n.inputMethod.enabled == "hime") {
+    i18n.inputMethod.package = pkgs.hime;
     environment.variables = {
       GTK_IM_MODULE = "hime";
       QT_IM_MODULE  = "hime";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -79,6 +79,7 @@
   ./hardware/xpadneo.nix
   ./i18n/input-method/default.nix
   ./i18n/input-method/fcitx.nix
+  ./i18n/input-method/hime.nix
   ./i18n/input-method/ibus.nix
   ./i18n/input-method/nabi.nix
   ./i18n/input-method/uim.nix

--- a/pkgs/tools/inputmethods/hime/default.nix
+++ b/pkgs/tools/inputmethods/hime/default.nix
@@ -1,8 +1,9 @@
 {
 stdenv, fetchFromGitHub, pkgconfig, which, gtk2, gtk3, qt4, qt5, libXtst, lib,
-enableChewing ? true, libchewing,
-enableAnthy ? true, anthy,
 }:
+
+# chewing and anthy do not work well
+# so we do not enable these input method at this moment
 
 stdenv.mkDerivation {
   name = "hime";
@@ -16,25 +17,18 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ which pkgconfig ];
-  buildInputs = [ libXtst gtk2 gtk3 qt4 qt5.qtbase ]
-    ++ lib.optional enableChewing libchewing
-    ++ lib.optional enableAnthy anthy;
+  buildInputs = [ libXtst gtk2 gtk3 qt4 qt5.qtbase ];
 
-  patchPhase = ''
-    patchShebangs configure
-  '';
-
-  # The configure script already auto-detect libchewing and anthy,
-  # so we do not need additional flags for libchewing or anthy
+  preConfigure = "patchShebangs configure";
   configureFlags = [ "--disable-lib64" "--disable-qt5-immodule" ];
 
 
   meta = with stdenv.lib; {
-    homepage      = "http://hime-ime.github.io/";
-    downloadPage  = "https://github.com/hime-ime/hime/downloads";
-    description   = "A useful input method engine for Asia region";
-    license       = licenses.gpl2Plus;
-    platforms     = platforms.linux;
-    maintainers   = with maintainers; [ yanganto ];
+    homepage = "http://hime-ime.github.io/";
+    downloadPage = "https://github.com/hime-ime/hime/downloads";
+    description = "A useful input method engine for Asia region";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ yanganto ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1104,6 +1104,8 @@ in
 
   google-amber = callPackage ../tools/graphics/amber { };
 
+  hime = callPackage ../tools/inputmethods/hime {};
+
   hpe-ltfs = callPackage ../tools/backup/hpe-ltfs { };
 
   http2tcp = callPackage ../tools/networking/http2tcp { };
@@ -5594,13 +5596,6 @@ in
   mytetra = libsForQt5.callPackage ../applications/office/mytetra { };
 
   nabi = callPackage ../tools/inputmethods/nabi { };
-
-  hime = callPackage ../tools/inputmethods/hime {};
-
-  hime-all = callPackage ../tools/inputmethods/hime {
-    enableChewing = true;
-    enableAnthy = true;
-  };
 
   nahid-fonts = callPackage ../data/fonts/nahid-fonts { };
 


### PR DESCRIPTION
###### Motivation for this change
- fix inputMethod.enable hime
- rm hime-all package, because chewing, anthy modules does not work well

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
