### PR TITLE
boost173 and boost174: Init both

### DIFF
--- a/pkgs/development/libraries/boost/1.73.nix
+++ b/pkgs/development/libraries/boost/1.73.nix
@@ -1,0 +1,16 @@
+{ stdenv, callPackage, fetchurl, fetchpatch, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.73.0";
+
+  src = fetchurl {
+    #url = "mirror://sourceforge/boost/boost_1_73_0.tar.bz2";
+    urls = [
+      "mirror://sourceforge/boost/boost_1_73_0.tar.bz2"
+      "https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.bz2"
+    ];
+    # SHA256 from http://www.boost.org/users/history/version_1_73_0.html
+    sha256 = "4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402";
+  };
+})
+

--- a/pkgs/development/libraries/boost/1.74.nix
+++ b/pkgs/development/libraries/boost/1.74.nix
@@ -1,0 +1,15 @@
+{ stdenv, callPackage, fetchurl, fetchpatch, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.74.0";
+
+  src = fetchurl {
+    urls = [
+      "mirror://sourceforge/boost/boost_1_74_0.tar.bz2"
+      "https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2"
+    ];
+    # SHA256 from http://www.boost.org/users/history/version_1_74_0.html
+    sha256 = "83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1";
+  };
+})
+

--- a/pkgs/development/libraries/boost/cmake-paths-173.patch
+++ b/pkgs/development/libraries/boost/cmake-paths-173.patch
@@ -1,0 +1,22 @@
+diff --git a/tools/boost_install/boost-install.jam b/tools/boost_install/boost-install.jam
+index 4238f921e..8fc1ea269 100644
+--- a/tools/boost_install/boost-install.jam
++++ b/tools/boost_install/boost-install.jam
+@@ -649,7 +649,7 @@ rule generate-cmake-config- ( target : sources * : properties * )
+         ""
+         "# Compute the include and library directories relative to this file."
+         ""
+-        "get_filename_component(_BOOST_CMAKEDIR \"${CMAKE_CURRENT_LIST_DIR}/../\" REALPATH)"
++        "get_filename_component(_BOOST_REAL_CMAKEDIR \"${CMAKE_CURRENT_LIST_DIR}/../\" REALPATH)"
+         : true ;
+ 
+     if [ path.is-rooted $(cmakedir) ]
+@@ -668,6 +668,8 @@ rule generate-cmake-config- ( target : sources * : properties * )
+             "  unset(_BOOST_CMAKEDIR_ORIGINAL)"
+             "endif()"
+             ""
++	    "# Assume that the installer actually did know where the libs were to be installed"
++            "get_filename_component(_BOOST_CMAKEDIR \"$(cmakedir-native)\" REALPATH)"
+             : true ;
+     }
+ 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -113,7 +113,8 @@ stdenv.mkDerivation {
     if version == "1.55.0"
     then ./darwin-1.55-no-system-python.patch
     else ./darwin-no-system-python.patch)
-  ++ optional (versionAtLeast version "1.70") ./cmake-paths.patch;
+  ++ optional (and (versionAtLeast version "1.70") (!versionAtLeast version "1.73")) ./cmake-paths.patch
+  ++ optional (versionAtLeast version "1.73") ./cmake-paths-173.patch;
 
   meta = {
     homepage = "http://boost.org/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11372,7 +11372,8 @@ in
   boost170 = callPackage ../development/libraries/boost/1.70.nix { };
   boost171 = callPackage ../development/libraries/boost/1.71.nix { };
   boost172 = callPackage ../development/libraries/boost/1.72.nix { };
-  boost17x = boost172;
+  boost173 = callPackage ../development/libraries/boost/1.73.nix { };
+  boost17x = boost173;
   boost = boost16x;
 
   boost_process = callPackage ../development/libraries/boost-process { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11373,7 +11373,8 @@ in
   boost171 = callPackage ../development/libraries/boost/1.71.nix { };
   boost172 = callPackage ../development/libraries/boost/1.72.nix { };
   boost173 = callPackage ../development/libraries/boost/1.73.nix { };
-  boost17x = boost173;
+  boost174 = callPackage ../development/libraries/boost/1.74.nix { };
+  boost17x = boost174;
   boost = boost16x;
 
   boost_process = callPackage ../development/libraries/boost-process { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
There were two versions of boost not available in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
