### PR TITLE
shmig: fix `migrate` command when postgres is enabled

### DIFF
--- a/pkgs/development/tools/database/shmig/default.nix
+++ b/pkgs/development/tools/database/shmig/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , withMySQL ? true, withPSQL ? false, withSQLite ? false
-, mysql, postgresql, sqlite, gawk
+, mysql, postgresql, sqlite, gawk, gnugrep, findutils, gnused
 , lib
 }:
 
@@ -24,7 +24,10 @@ stdenv.mkDerivation rec {
       --replace "\`which mysql\`" "${lib.optionalString withMySQL "${mysql.client}/bin/mysql"}" \
       --replace "\`which psql\`" "${lib.optionalString withPSQL "${postgresql}/bin/psql"}" \
       --replace "\`which sqlite3\`" "${lib.optionalString withSQLite "${sqlite}/bin/sqlite3"}" \
-      --replace "awk" "${gawk}/bin/awk"
+      --replace "awk" "${gawk}/bin/awk" \
+      --replace "grep" "${gnugrep}/bin/grep" \
+      --replace "find" "${findutils}/bin/find" \
+      --replace "sed" "${gnused}/bin/sed"
   '';
 
   preBuild = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
