### PR TITLE
pg_tileserv: init at 1.0.3

### DIFF
--- a/pkgs/servers/pg_tileserv/default.nix
+++ b/pkgs/servers/pg_tileserv/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "pg_tileserv";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "CrunchyData";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "19ycpir662dv6jg3fnlj3208cjhy0lxww3wc3h19x96556yklnfg";
+  };
+
+  vendorSha256 = "1wpzj6par25z7cyyz6p41cxdll4nzb0jjdl1pffgawiy9z7j17vb";
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A very thin PostGIS-only tile server in Go";
+    homepage = "https://github.com/CrunchyData/pg_tileserv";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16825,6 +16825,8 @@ in
 
   tomcat-native = callPackage ../servers/http/tomcat/tomcat-native.nix { };
 
+  pg_tileserv = callPackage ../servers/pg_tileserv { };
+
   pies = callPackage ../servers/pies { };
 
   rpcbind = callPackage ../servers/rpcbind { };


### PR DESCRIPTION
###### Motivation for this change
[pg_tileserv](https://github.com/CrunchyData/pg_tileserv) - a very thin PostGIS-only tile server in Go. Takes in HTTP tile requests, executes SQL, returns MVT tiles.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
