### PR TITLE
python3Packages.proto-plus: enable tests, disable for py2

### DIFF
--- a/pkgs/development/python-modules/proto-plus/default.nix
+++ b/pkgs/development/python-modules/proto-plus/default.nix
@@ -1,12 +1,16 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy3k
 , protobuf
+, google_api_core
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "proto-plus";
   version = "1.10.1";
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
@@ -14,6 +18,8 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ protobuf ];
+
+  checkInputs = [ pytestCheckHook google_api_core ];
 
   meta = with stdenv.lib; {
     description = "Beautiful, idiomatic protocol buffers in Python";


### PR DESCRIPTION
###### Motivation for this change
#100138 got merged without this enhancement.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
