### PR TITLE
pg_featureserv: init at 1.1.1

### DIFF
--- a/pkgs/servers/pg_featureserv/default.nix
+++ b/pkgs/servers/pg_featureserv/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "pg_featureserv";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "CrunchyData";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0vfrwncx41yn9n2hqb32av3xgd13fqplrs1qzg5mv25i4qppd88l";
+  };
+
+  vendorSha256 = "1jqrkx850ghmpnfjhqky93r8fq7q63m5ivs0lzljzbvn7ya75f2r";
+
+  meta = with lib; {
+    description = "Lightweight RESTful Geospatial Feature Server for PostGIS in Go";
+    homepage = "https://github.com/CrunchyData/pg_featureserv";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16987,6 +16987,8 @@ in
 
   tomcat-native = callPackage ../servers/http/tomcat/tomcat-native.nix { };
 
+  pg_featureserv = callPackage ../servers/pg_featureserv { };
+
   pg_tileserv = callPackage ../servers/pg_tileserv { };
 
   pies = callPackage ../servers/pies { };


### PR DESCRIPTION
###### Motivation for this change
[pg_featureserv](https://github.com/CrunchyData/pg_featureserv) - lightweight RESTful Geospatial Feature Server for PostGIS in Go.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
