### PR TITLE
kdeApplications.print-manager: add qtquickcontrols2

### DIFF
--- a/pkgs/applications/kde/print-manager.nix
+++ b/pkgs/applications/kde/print-manager.nix
@@ -4,7 +4,7 @@
   cups, ki18n,
   kconfig, kconfigwidgets, kdbusaddons, kiconthemes, kcmutils, kio,
   knotifications, kwidgetsaddons, kwindowsystem, kitemviews, plasma-framework,
-  qtdeclarative
+  qtdeclarative, qtquickcontrols2
 }:
 
 mkDerivation {
@@ -18,9 +18,7 @@ mkDerivation {
   propagatedBuildInputs = [
     kconfig kconfigwidgets kdbusaddons kiconthemes kcmutils knotifications
     kwidgetsaddons kitemviews kio kwindowsystem plasma-framework qtdeclarative
+    qtquickcontrols2
   ];
   outputs = [ "out" "dev" ];
-  # Fix build with cups deprecations etc.
-  # See: https://github.com/NixOS/nixpkgs/issues/73334
-  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations -Wno-error=format-security";
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/98536

###### Things done
I enabled printing in QEMU NixOS VM. `systemsettings` printing all opened, but I didn't see the plasmoid anywhere.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
