### PR TITLE
[20.09] pythonPackages.xarray, pythonPackages.arviz: bump/fix build

### DIFF
--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -22,13 +22,13 @@
 
 buildPythonPackage rec {
   pname = "arviz";
-  version = "0.7.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "arviz-devs";
     repo = "arviz";
-    rev = version;
-    sha256 = "03hj7bkkj6kfqdk6ri2mp53wk4k7xpafxk01vgs6k9zg3rlnq7ny";
+    rev = "v${version}";
+    sha256 = "1cnj972knkvi084cfcpc12lv0wxm8xm9clfd55r3hvv42g1ms5d9";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/xarray/default.nix
+++ b/pkgs/development/python-modules/xarray/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "xarray";
-  version = "0.16.0";
+  version = "0.16.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1js3xr3fl9bwid8hl3w2pnigqzjd2rvkncald5x1x5fg7wjy8pb6";
+    sha256 = "5e1af056ff834bf62ca57da917159328fab21b1f8c25284f92083016bb2d92a5";
   };
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

This is a combined backport of #93412 and #99500. #93412 simply needed to satisfy the bumped `arviz`'s dependencies.

Only reverse dependency build failures for me are already failing on `release-20.09`. (The test suite for `datashader` has never completed on my machine)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
