### PR TITLE
devilutionx: 1.0.1 -> 1.1.0-nixpkg-static-sdl2

### DIFF
--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
     ''-DTTF_FONT_PATH="${placeholder "out"}/share/fonts/truetype/CharisSILB.ttf"''
   ];
 
+  cmakeFlags = [
+    "-DBINARY_RELEASE=ON"
+  ];
+
   nativeBuildInputs = [ pkg-config cmake ];
   buildInputs = [ libsodium SDL2 SDL2_mixer SDL2_ttf ];
 

--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, cmake, SDL2, SDL2_mixer, SDL2_ttf, libsodium, pkg-config }:
 stdenv.mkDerivation rec {
-  version = "1.0.1";
+  version = "1.1.0-nixpkg-static-sdl2";
   pname = "devilutionx";
 
   src = fetchFromGitHub {
-    owner = "diasurgical";
+    owner = "karolchmist";
     repo = "devilutionX";
     rev = version;
-    sha256 = "1jvjlch9ql5s5jx9g5y5pkc2xn62199qylsmzpqzx1jc3k2vmw5i";
+    sha256 = "11brk4b34q8083qqczbrcj6yglnwzar040b2di9g5d34lc075vb5";
   };
 
   NIX_CFLAGS_COMPILE = [


### PR DESCRIPTION
###### Motivation for this change

The build of devilutoinX was [broken](https://github.com/NixOS/nixpkgs/pull/88519) on master due to changes in SDL2 build. 

Also, a new version 1.1.0 of DevilutionX was released unexpectedly. 

This PR proposes a build based on a fork of devilutionX, until the upstream enables building with static SDL2. Hopefully it will be included NixOS 20.09 (though I'm affraid it's too late probably).
  
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
