### PR TITLE
hubsrht: 0.10.6 -> 0.11.5

### DIFF
--- a/pkgs/applications/version-management/sourcehut/hub.nix
+++ b/pkgs/applications/version-management/sourcehut/hub.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "hubsrht";
-  version = "0.10.6";
+  version = "0.11.5";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/hub.sr.ht";
     rev = version;
-    sha256 = "N54GOk9pxwoF1Wv0ZSe4kIAPBLl/zHrSu8OlKBkacVg=";
+    sha256 = "0cysdfy1z69jaizblbq0ywpcvcnx57rlzg42k98kd9w2mqzj5173";
   };
 
   nativeBuildInputs = srht.nativeBuildInputs;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Package bumping.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
