### PR TITLE
sshd service: Default to INFO logLevel (upstream default)

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -321,7 +321,26 @@
   </section>
   <section xml:id="sec-release-21.11-notable-changes">
     <title>Other Notable Changes</title>
-    <para>
-    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          The setting
+          <link xlink:href="options.html#opt-services.openssh.logLevel"><literal>services.openssh.logLevel</literal></link>
+          <literal>&quot;VERBOSE&quot;</literal>
+          <literal>&quot;INFO&quot;</literal>. This brings NixOS in line
+          with upstream and other Linux distributions, and reduces log
+          spam on servers due to bruteforcing botnets.
+        </para>
+        <para>
+          However, if
+          <link xlink:href="options.html#opt-services.fail2ban.enable"><literal>services.fail2ban.enable</literal></link>
+          is <literal>true</literal>, the <literal>fail2ban</literal>
+          will override the verbosity to
+          <literal>&quot;VERBOSE&quot;</literal>, so that
+          <literal>fail2ban</literal> can observe the failed login
+          attempts from the SSH logs.
+        </para>
+      </listitem>
+    </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -79,3 +79,7 @@ In addition to numerous new and upgraded packages, this release has the followin
   old 2.7.7 version.
 
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
+
+- The setting [`services.openssh.logLevel`](options.html#opt-services.openssh.logLevel) `"VERBOSE"` `"INFO"`. This brings NixOS in line with upstream and other Linux distributions, and reduces log spam on servers due to bruteforcing botnets.
+
+  However, if [`services.fail2ban.enable`](options.html#opt-services.fail2ban.enable) is `true`, the `fail2ban` will override the verbosity to `"VERBOSE"`, so that `fail2ban` can observe the failed login attempts from the SSH logs.

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -351,15 +351,12 @@ in
 
       logLevel = mkOption {
         type = types.enum [ "QUIET" "FATAL" "ERROR" "INFO" "VERBOSE" "DEBUG" "DEBUG1" "DEBUG2" "DEBUG3" ];
-        default = "VERBOSE";
+        default = "INFO"; # upstream default
         description = ''
           Gives the verbosity level that is used when logging messages from sshd(8). The possible values are:
-          QUIET, FATAL, ERROR, INFO, VERBOSE, DEBUG, DEBUG1, DEBUG2, and DEBUG3. The default is VERBOSE. DEBUG and DEBUG1
+          QUIET, FATAL, ERROR, INFO, VERBOSE, DEBUG, DEBUG1, DEBUG2, and DEBUG3. The default is INFO. DEBUG and DEBUG1
           are equivalent. DEBUG2 and DEBUG3 each specify higher levels of debugging output. Logging with a DEBUG level
           violates the privacy of users and is not recommended.
-
-          LogLevel VERBOSE logs user's key fingerprint on login.
-          Needed to have a clear audit track of which key was used to log in.
         '';
       };
 

--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -45,7 +45,12 @@ in
       enable = mkOption {
         default = false;
         type = types.bool;
-        description = "Whether to enable the fail2ban service.";
+        description = ''
+          Whether to enable the fail2ban service.
+
+          See the documentation of <option>services.fail2ban.jails</option>
+          for what jails are enabled by default.
+        '';
       };
 
       package = mkOption {
@@ -221,6 +226,15 @@ in
           defined in <filename>/etc/fail2ban/action.d</filename>,
           while filters are defined in
           <filename>/etc/fail2ban/filter.d</filename>.
+
+          NixOS comes with a default <literal>sshd</literal> jail;
+          for it to work well,
+          <option>services.openssh.logLevel</option> should be set to
+          <literal>"VERBOSE"</literal> or higher so that fail2ban
+          can observe failed login attempts.
+          This module sets it to <literal>"VERBOSE"</literal> if
+          not set otherwise, so enabling fail2ban can make SSH logs
+          more verbose.
         '';
       };
 
@@ -313,6 +327,9 @@ in
       banaction_allports = ${cfg.banaction-allports}
     '';
     # Block SSH if there are too many failing connection attempts.
+    # Benefits from verbose sshd logging to observe failed login attempts,
+    # so we set that here unless the user overrode it.
+    services.openssh.logLevel = lib.mkDefault "VERBOSE";
     services.fail2ban.jails.sshd = mkDefault ''
       enabled = true
       port    = ${concatMapStringsSep "," (p: toString p) config.services.openssh.ports}


### PR DESCRIPTION
###### Motivation for this change

This brings NixOS in line with upstream and other Linux distributions, and reduces log spam on servers due to bruteforcing botnets.

The previous justification (added in #40692) for using `VERBOSE` is incorrect, because OpenSSH does use level `INFO` to log "which key was used to log in" for sccessful logins, see:

https://github.com/openssh/openssh-portable/blob/6247812c76f70b2245f3c23f5074665b3d436cae/auth.c#L323-L328

I've verified it; sshd logs with `VERBOSE` look like:

```
sshd: Connection from 192.0.2.1 port 45668 on 192.0.2.2 port 22 rdomain ""
sshd: Accepted key RSA SHA256:Cabc123abc123abc12/abc123abc123abc123abc123 found at /etc/ssh/authorized_keys.d/root:1
sshd: Postponed publickey for root from 192.0.2.1 port 45668 ssh2 [preauth]
sshd: Accepted key RSA SHA256:Cabc123abc123abc12/abc123abc123abc123abc123 found at /etc/ssh/authorized_keys.d/root:1
sshd: Accepted publickey for root from 192.0.2.1 port 45668 ssh2: RSA SHA256:Cabc123abc123abc12/abc123abc123abc123abc123
sshd: pam_unix(sshd:session): session opened for user root by (uid=0)
systemd-logind: [🡕] New session 12 of user root.
```

and with `INFO` look like:

```
sshd: Accepted publickey for root from 192.0.2.1 port 45694 ssh2: RSA SHA256:Cabc123abc123abc12/abc123abc123abc123abc123
sshd: pam_unix(sshd:session): session opened for user root by (uid=0)
systemd-logind: [🡕] New session 12 of user root.
```

As shown, the fingerprint for the successful login is still printed with `INFO`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @bjornfor @volth @Izorkin from #40692.

CC recent `sshd` committers @aanderse @Infinisil @jeaye 

CC @eelco @lovek323 @fpletz as `fail2ban` maintainers, and @c0bw3b @Baughn as recent `fail2ban` service committers.