### PR TITLE
openorienteering-mapper: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , mkDerivation
 , fetchFromGitHub
+, substituteAll
 , gdal
 , cmake
 , ninja
@@ -18,7 +19,7 @@
 
 mkDerivation rec {
   pname = "OpenOrienteering-Mapper";
-  version = "0.9.3";
+  version = "0.9.4";
 
   buildInputs = [
     gdal
@@ -37,18 +38,14 @@ mkDerivation rec {
     owner = "OpenOrienteering";
     repo = "mapper";
     rev = "v${version}";
-    sha256 = "05bliglpc8170px6k9lfrp9ylpnb2zf47gnjns9b2bif8dv8zq0l";
+    sha256 = "13k9dirqm74lknhr8w121zr1hjd9gm1y73cj4rrj98rx44dzmk7b";
   };
 
-  patches = [
+  patches = (substituteAll {
     # See https://github.com/NixOS/nixpkgs/issues/86054
-    ./fix-qttranslations-path.diff
-  ];
-
-  postPatch = ''
-    substituteInPlace src/util/translation_util.cpp \
-      --subst-var-by qttranslations ${qttranslations}
-  '';
+    src = ./fix-qttranslations-path.diff;
+    inherit qttranslations;
+  });
 
   cmakeFlags = [
     # Building the manual and bundling licenses fails

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22595,7 +22595,7 @@ in
 
   openjump = callPackage ../applications/misc/openjump { };
 
-  openorienteering-mapper = libsForQt514.callPackage ../applications/gis/openorienteering-mapper { };
+  openorienteering-mapper = libsForQt5.callPackage ../applications/gis/openorienteering-mapper { };
 
   openscad = libsForQt5.callPackage ../applications/graphics/openscad {};
 


### PR DESCRIPTION
###### Motivation for this change
* [0.9.4 changelog](https://github.com/OpenOrienteering/mapper/releases/tag/v0.9.4)
* Fix on darwin (#97479)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
