### PR TITLE
cagebreak: 1.4.2 -> 1.4.3

### DIFF
--- a/pkgs/applications/window-managers/cagebreak/default.nix
+++ b/pkgs/applications/window-managers/cagebreak/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cagebreak";
-  version = "1.4.2";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "project-repo";
     repo = "cagebreak";
     rev = version;
-    hash = "sha256-+Ww1rsUR7qe/BixLPR8GiRc3C6QmpLzWpT2wym8b4/M=";
+    hash = "sha256-iMoj++yjGK4hn3C675QntBYcsoBx0lEjjCM8fdvRJYo=";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config wayland scdoc makeWrapper ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

**Fixes**
- **Issue 17**
  Cagebreak up to and including version 1.4.2 might have a use-after-free on destroying unmapped views. view->workspace was set on view creation. If the output containing this view was subsequently destroyed, the workspace was freed, leading to a use-after-free when the view was destroyed.
- **Issue 18**
  Cagebreak up to and including release 1.4.2 does not handle the position of xwayland views adequately.
- **Issue 19**
  Cagebreak up to and including release 1.4.2 does not handle unmanaged views adequately.
- **Issue 20**
  Cagebreak up to and including release 1.4.2 does not handle damaging adequately, when scanning out views.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
