### PR TITLE
python3Packages.cocotb: fix tests, 1.3.1 -> 1.3.2

### DIFF
--- a/pkgs/development/python-modules/cocotb/default.nix
+++ b/pkgs/development/python-modules/cocotb/default.nix
@@ -33,6 +33,12 @@ buildPythonPackage rec {
   checkInputs = [ swig verilog ];
 
   checkPhase = ''
+    # test expected failures actually pass because of a fix in our icarus version
+    # https://github.com/cocotb/cocotb/issues/1952
+    substituteInPlace tests/test_cases/test_discovery/test_discovery.py \
+      --replace 'def access_single_bit' $'def foo(x): pass\ndef foo' \
+      --replace 'def access_single_bit_assignment' $'def foo(x): pass\ndef foo'
+
     export PATH=$out/bin:$PATH
     make test
   '';

--- a/pkgs/development/python-modules/cocotb/default.nix
+++ b/pkgs/development/python-modules/cocotb/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "cocotb";
-  version = "1.3.1";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "118wp5sjsl99hj8pqw5n3v2lry9r949p2hv4l92p086q1n0axxk3";
+    sha256 = "0akkxcj11543c0jn4zdw4a668lk0xg7pghs8mch3xjk8nn8wfblc";
   };
 
   propagatedBuildInputs = [
@@ -26,7 +26,7 @@ buildPythonPackage rec {
       substituteInPlace $f --replace 'shell which' 'shell command -v'
     done
 
-    # This can probably be removed in the next update after 1.3.1
+    # This can perhaps be removed in the next update after 1.3.2?
     substituteInPlace cocotb/share/makefiles/Makefile.inc --replace "-Werror" ""
   '';
 


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

A bump to our icarus verilog (just "`verilog`" for some reason) broke an expected-failure test because of a fix contained in it. Disable those tests (using an ugly hack). Reported @ https://github.com/cocotb/cocotb/issues/2121.

While we're at it, bump to 1.3.2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
