### PR TITLE
python3Packages.rich: init at 8.0.0

### DIFF
--- a/pkgs/development/python-modules/rich/default.nix
+++ b/pkgs/development/python-modules/rich/default.nix
@@ -1,18 +1,25 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, typing-extensions, pygments, recommonmark, colorama }:
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pytest, pytestcov, typing-extensions, pygments, recommonmark, colorama }:
 
 buildPythonPackage rec {
   pname = "rich";
   version = "8.0.0";
-  disabled = isPy27;
+  disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "15yz7rcn5cjv233xcvka9vd573pwafl31s6z9ni54r8y4k926l0v";
+  src = fetchFromGitHub {
+    owner = "willmcgugan";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0hv27b22x7dbx1i7nzsd8y8fymmvdak2hcx9242jwk4c1a7jr151";
   };
+
+  postPatch = ''
+   sed -i 's/setuptools.setup(name="rich")/setuptools.setup(name="rich", packages=setuptools.find_packages())/g' setup.py
+  '';
 
   propagatedBuildInputs = [ typing-extensions pygments recommonmark colorama ];
 
-  doCheck = false;
+  checkInputs = [ pytest pytestcov ];
+  checkPhase = "make test";
   pythonImportsCheck = [ "rich" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/rich/default.nix
+++ b/pkgs/development/python-modules/rich/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, typing-extensions, pygments, recommonmark, colorama }:
+
+buildPythonPackage rec {
+  pname = "rich";
+  version = "8.0.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15yz7rcn5cjv233xcvka9vd573pwafl31s6z9ni54r8y4k926l0v";
+  };
+
+  propagatedBuildInputs = [ typing-extensions pygments recommonmark colorama ];
+
+  doCheck = false;
+  pythonImportsCheck = [ "rich" ];
+
+  meta = with lib; {
+    description = "Library for rich text and beautiful formatting in the terminal";
+    homepage = "https://github.com/willmcgugan/rich";
+    license = licenses.mit;
+    maintainers = [ maintainers.sengaya ];
+  };
+}

--- a/pkgs/development/python-modules/rich/default.nix
+++ b/pkgs/development/python-modules/rich/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pytest, pytestcov, typing-extensions, pygments, recommonmark, colorama }:
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pytest, typing-extensions, pygments, recommonmark, colorama }:
 
 buildPythonPackage rec {
   pname = "rich";
@@ -13,13 +13,13 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-   sed -i 's/setuptools.setup(name="rich")/setuptools.setup(name="rich", packages=setuptools.find_packages())/g' setup.py
+    sed -i 's/setuptools.setup(name="rich")/setuptools.setup(name="rich", packages=setuptools.find_packages())/g' setup.py
   '';
 
   propagatedBuildInputs = [ typing-extensions pygments recommonmark colorama ];
 
-  checkInputs = [ pytest pytestcov ];
-  checkPhase = "make test";
+  checkInputs = [ pytest ];
+  checkPhase = "pytest";
   pythonImportsCheck = [ "rich" ];
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6180,6 +6180,8 @@ in {
 
   rhpl = disabledIf isPy3k (callPackage ../development/python-modules/rhpl { });
 
+  rich = callPackage ../development/python-modules/rich { };
+
   rig = callPackage ../development/python-modules/rig { };
 
   ripser = callPackage ../development/python-modules/ripser { };


### PR DESCRIPTION
###### Motivation for this change

Dependency for latest version of ansible-lint

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I could run the unit tests when using `fetchFromGitHub` instead of `fetchPypi` but then `pythonImportsCheck` failed. I sticked to `fetchPypi` for now and disabled the unit tests.