### PR TITLE
prometheus-xmpp-alerts: 0.4.2 -> 0.5.1; apply RFC 42

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/xmpp-alerts.nix
+++ b/nixos/modules/services/monitoring/prometheus/xmpp-alerts.nix
@@ -4,21 +4,29 @@ with lib;
 
 let
   cfg = config.services.prometheus.xmpp-alerts;
-
-  configFile = pkgs.writeText "prometheus-xmpp-alerts.yml" (builtins.toJSON cfg.configuration);
-
+  settingsFormat = pkgs.formats.yaml {};
+  configFile = settingsFormat.generate "prometheus-xmpp-alerts.yml" cfg.settings;
 in
-
 {
-  options.services.prometheus.xmpp-alerts = {
+  imports = [
+    (mkRenamedOptionModule
+      [ "services" "prometheus" "xmpp-alerts" "configuration" ]
+      [ "services" "prometheus" "xmpp-alerts" "settings" ])
+  ];
 
+  options.services.prometheus.xmpp-alerts = {
     enable = mkEnableOption "XMPP Web hook service for Alertmanager";
 
-    configuration = mkOption {
-      type = types.attrs;
-      description = "Configuration as attribute set which will be converted to YAML";
-    };
+    settings = mkOption {
+      type = settingsFormat.type;
+      default = {};
 
+      description = ''
+        Configuration for prometheus xmpp-alerts, see
+        <link xlink:href="https://github.com/jelmer/prometheus-xmpp-alerts/blob/master/xmpp-alerts.yml.example"/>
+        for supported values.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {

--- a/pkgs/servers/monitoring/prometheus/xmpp-alerts.nix
+++ b/pkgs/servers/monitoring/prometheus/xmpp-alerts.nix
@@ -1,17 +1,36 @@
-{ lib, fetchFromGitHub, pythonPackages }:
+{ lib
+, fetchFromGitHub
+, python3Packages
+, prometheus-alertmanager
+}:
 
-pythonPackages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "prometheus-xmpp-alerts";
-  version = "0.4.2";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "jelmer";
     repo = pname;
-    rev = version;
-    sha256 = "17aq6v4ahnga82r350kx1y8i7zgikpzmwzaacj7a339kh8hxkh63";
+    rev = "v${version}";
+    sha256 = "0qmmmlcanbrhyyxi32gy3gibgvj7jdjwpa8cf5ci9czvbyxg4rld";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ slixmpp prometheus_client pyyaml ];
+  propagatedBuildInputs = [
+    prometheus-alertmanager
+  ] ++ (with python3Packages; [
+    aiohttp
+    slixmpp
+    prometheus_client
+    pyyaml
+  ]);
+
+  checkInputs = with python3Packages; [
+    pytz
+  ];
+
+  checkPhase = ''
+    ${python3Packages.python.interpreter} -m unittest discover
+  '';
 
   meta = {
     description = "XMPP Web hook for Prometheus";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19193,9 +19193,7 @@ in
   prometheus-wireguard-exporter = callPackage ../servers/monitoring/prometheus/wireguard-exporter.nix {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
-  prometheus-xmpp-alerts = callPackage ../servers/monitoring/prometheus/xmpp-alerts.nix {
-    pythonPackages = python3Packages;
-  };
+  prometheus-xmpp-alerts = callPackage ../servers/monitoring/prometheus/xmpp-alerts.nix { };
 
   prometheus-cpp = callPackage ../development/libraries/prometheus-cpp { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix 500s that come back when the alertmanager sends alerts

```
prometheus-xmpp-alerts[30888]: ERROR    Error handling request
prometheus-xmpp-alerts[30888]: Traceback (most recent call last):
prometheus-xmpp-alerts[30888]:   File "/nix/store/nlvjjvb9471dbpdj8fhdih0ak90cq9d9-python3.8-aiohttp-3.6.2/lib/python3.8/site-packages/aiohttp/web_protocol.py", line 418, in start
prometheus-xmpp-alerts[30888]:     resp = await task
prometheus-xmpp-alerts[30888]:   File "/nix/store/nlvjjvb9471dbpdj8fhdih0ak90cq9d9-python3.8-aiohttp-3.6.2/lib/python3.8/site-packages/aiohttp/web_app.py", line 458, in _handle
prometheus-xmpp-alerts[30888]:     resp = await handler(request)
prometheus-xmpp-alerts[30888]:   File "/nix/store/n2axls35979gx2aqdfnl0yafnrffl100-prometheus-xmpp-alerts-0.4.2/bin/.prometheus-xmpp-alerts-wrapped", line 141, in serve_alert
prometheus-xmpp-alerts[30888]:     text = '\n--\n'.join(create_message_full(alert))
prometheus-xmpp-alerts[30888]:   File "/nix/store/n2axls35979gx2aqdfnl0yafnrffl100-prometheus-xmpp-alerts-0.4.2/lib/python3.8/site-packages/prometheus_xmpp/__init__.py", line 57, in create_message_full
prometheus-xmpp-alerts[30888]:     alert['annotations']['summary'],
prometheus-xmpp-alerts[30888]: KeyError: 'summary'
prometheus-xmpp-alerts[30888]: INFO     ::1 [11/Oct/2020:20:18:38 +0000] "POST /alert HTTP/1.1" 500 244 "-" "Alertmanager/0.21.0"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
