### PR TITLE
gnomeExtensions.recents: init at 2019-11-29

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/recents/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/recents/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, gnome3 }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-recents";
+  version = "2019-11-29";
+
+  src = fetchFromGitHub {
+    repo = "gnome-shell-extension-Recents";
+    owner = "leonardo-bartoli";
+    rev = "c9b9355ba20f45a3449dcca514957665ad9ae442";
+    sha256 = "0dlw67vllxamxgijciw021x7vls23jgriiyhyv38j4x99w6ba3xb";
+  };
+
+  uuid = "Recents@leonardo.bartoli.gmail.com";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -r ./ $out/share/gnome-shell/extensions/${uuid}
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Adds an indicator to gnome shell panel to quickly navigate recent open files";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ dawidsowa ];
+    homepage = "https://github.com/leonardo-bartoli/gnome-shell-extension-Recents";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25732,6 +25732,7 @@ in
     no-title-bar = callPackage ../desktops/gnome-3/extensions/no-title-bar { };
     paperwm = callPackage ../desktops/gnome-3/extensions/paperwm { };
     pidgin-im-integration = callPackage ../desktops/gnome-3/extensions/pidgin-im-integration { };
+    recents = callPackage ../desktops/gnome-3/extensions/recents { };
     remove-dropdown-arrows = callPackage ../desktops/gnome-3/extensions/remove-dropdown-arrows { };
     sound-output-device-chooser = callPackage ../desktops/gnome-3/extensions/sound-output-device-chooser { };
     system-monitor = callPackage ../desktops/gnome-3/extensions/system-monitor { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add [Recents](https://github.com/leonardo-bartoli/gnome-shell-extension-Recents) gnome extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
