### PR TITLE
nixos/borgbackup: add backup job runtimeLimit option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -168,6 +168,15 @@
    </listitem>
    <listitem>
     <para>
+     BorgBackup jobs now have a default runtime limit set to <literal>24h</literal>
+     to prevent silent failures through indefinite hanging.
+     This can be configured through the newly introduced
+     <xref linkend="opt-services.borgbackup.jobs.<name>.runtimeLimit" /> option.
+     The limit can be removed by setting it to <literal>infinity</literal>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      The setting <xref linkend="opt-services.redis.bind" /> defaults to <literal>127.0.0.1</literal> now, making Redis listen on the loopback interface only, and not all public network interfaces.
     </para>
    </listitem>

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -80,6 +80,7 @@ let
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;
+        RuntimeMaxSec = cfg.runtimeLimit;
         # Only run when no other process is using CPU or disk
         CPUSchedulingPolicy = "idle";
         IOSchedulingClass = "idle";
@@ -289,6 +290,20 @@ in {
               automatically, use <literal>[ ]</literal>.
               It will generate a systemd service borgbackup-job-NAME.
               You may trigger it manually via systemctl restart borgbackup-job-NAME.
+            '';
+          };
+
+          runtimeLimit = mkOption {
+            type = types.str;
+            default = "24h";
+            description = ''
+              Maximum time for the backup job to run.
+              The corresponding service is terminated and put into a failure
+              state if the specified time limit is exceeded.
+              Must be in the time span format described in
+              <citerefentry><refentrytitle>systemd.time</refentrytitle>
+              <manvolnum>7</manvolnum></citerefentry>.
+              Use <literal>infinity</literal> to set no runtime limit.
             '';
           };
 


### PR DESCRIPTION
###### Motivation for this change

This adds an option controlling the maximum runtime duration of backup
jobs in order to prevent silent failures through indefinite hanging.
The service is now put into an explicit failed state if this limit is
exceeded.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
