### PR TITLE
cargo-edit: fix Darwin build

### DIFF
--- a/pkgs/tools/package-management/cargo-edit/default.nix
+++ b/pkgs/tools/package-management/cargo-edit/default.nix
@@ -1,6 +1,14 @@
-{ stdenv, lib, darwin
-, rustPlatform, fetchFromGitHub
-, openssl, pkg-config, libiconv }:
+{ stdenv
+, lib
+, darwin
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, xcbuild
+, openssl
+, libiconv
+, zlib
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-edit";
@@ -15,8 +23,18 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1h1sy54p7zxijydnhzvkxli90d72biv1inni17licb0vb9dihmnf";
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.Security ];
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.isDarwin [
+    # The cc crate runs xcbuild. This dependency can be removed once
+    # the following PR is merged from staging into master:
+    #
+    # https://github.com/NixOS/nixpkgs/pull/97000
+    xcbuild
+  ];
+
+  buildInputs = [ openssl zlib ] ++ lib.optionals stdenv.isDarwin [
+    libiconv
+    darwin.apple_sdk.frameworks.Security
+  ];
 
   doCheck = false; # integration tests depend on changing cargo config
 

--- a/pkgs/tools/package-management/cargo-edit/default.nix
+++ b/pkgs/tools/package-management/cargo-edit/default.nix
@@ -1,12 +1,12 @@
 { stdenv
 , lib
-, darwin
 , rustPlatform
 , fetchFromGitHub
 , pkg-config
 , xcbuild
 , openssl
 , libiconv
+, Security
 , zlib
 }:
 
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ openssl zlib ] ++ lib.optionals stdenv.isDarwin [
     libiconv
-    darwin.apple_sdk.frameworks.Security
+    Security
   ];
 
   doCheck = false; # integration tests depend on changing cargo config

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9702,7 +9702,9 @@ in
   };
   cargo-deps = callPackage ../tools/package-management/cargo-deps { };
   cargo-download = callPackage ../tools/package-management/cargo-download { };
-  cargo-edit = callPackage ../tools/package-management/cargo-edit { };
+  cargo-edit = callPackage ../tools/package-management/cargo-edit {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
   cargo-kcov = callPackage ../tools/package-management/cargo-kcov { };
   cargo-graph = callPackage ../tools/package-management/cargo-graph { };
   cargo-license = callPackage ../tools/package-management/cargo-license { };


### PR DESCRIPTION
##### Motivation for this change

Latest version was not building on darwin

###### Things done

Originally my intent was only to change things on darwin platform.
It appears though that libz was missing as a dependency.
Also in a lot of recent rust builds, cc crate attempts to run xcbuild.
I also run nixfmt, so some format has changed a little bit.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
