### PR TITLE
sozu: 0.11.46 -> 0.11.50; fix Darwin build

### DIFF
--- a/pkgs/servers/sozu/default.nix
+++ b/pkgs/servers/sozu/default.nix
@@ -1,22 +1,26 @@
-{ stdenv, rustPlatform, fetchFromGitHub }:
+{ stdenv, rustPlatform, fetchFromGitHub, darwin }:
 
 rustPlatform.buildRustPackage rec {
-    pname = "sozu";
-    version = "0.11.46";
+  pname = "sozu";
+  version = "0.11.50";
 
-    src = fetchFromGitHub {
-        owner = "sozu-proxy";
-        repo = pname;
-        rev = version;
-        sha256 = "0anng5qvdx9plxs9qqr5wmjjz0gx5113jq28xwbxaaklvd4ni7cm";
-    };
+  src = fetchFromGitHub {
+    owner = "sozu-proxy";
+    repo = pname;
+    rev = version;
+    sha256 = "1srg2b8vwc4vp07kg4fizqj1rbm9hvf6hj1mjdh6yvb9cpbw3jz7";
+  };
 
-    cargoSha256 = "19c2s9h4jk9pff72wdqw384mvrf40d8x4sx7qysnpb4hayq2ijh3";
+  cargoSha256 = "5WOigCiQZQ5DaTd15vV8pUh8Xl3UIe9yLG1ptUtY+iA=";
 
-    meta = with stdenv.lib; {
-        description = "Open Source HTTP Reverse Proxy built in Rust for Immutable Infrastructures";
-        homepage = "https://sozu.io";
-        license = licenses.agpl3;
-        maintainers = with maintainers; [ filalex77 ];
-    };
+  buildInputs =
+    stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
+
+  meta = with stdenv.lib; {
+    description =
+      "Open Source HTTP Reverse Proxy built in Rust for Immutable Infrastructures";
+    homepage = "https://www.sozu.io";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ filalex77 ];
+  };
 }


### PR DESCRIPTION

###### Motivation for this change

build was broken on darwin

###### Things done

- I ran nixfmt, so formatting has changed a bit
- As opposed to the last similar PR, I didn't alias Security from apple_sdk, so this PR should pass the build
- upgraded sozu from 0.11.46 -> 0.11.50

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
