### PR TITLE
JuliaMono font

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8677,6 +8677,12 @@
     githubId = 9853194;
     name = "Philipp Bartsch";
   };
+  toastal = {
+    email = "toastal+nix@protonmail.com";
+    github = "toastal";
+    githubId = 561087;
+    name = "toastal";
+  };
   tobim = {
     email = "nix@tobim.fastmail.fm";
     github = "tobim";

--- a/pkgs/data/fonts/juliamono/default.nix
+++ b/pkgs/data/fonts/juliamono/default.nix
@@ -1,0 +1,36 @@
+{ lib, fetchzip }:
+
+let
+  version = "0.019";
+
+in fetchzip rec {
+  name = "juliamono-${version}";
+
+  url = "https://github.com/cormullion/juliamono/releases/download/v${version}/JuliaMono.tar.gz";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/truetype
+    tar -xzvf $downloadedFile
+    install -m444 -Dt $out/share/fonts/truetype *.ttf
+  '';
+  sha256 = "1s21vjdyfbwki73sxw1bdiqs8y2s6xkra4hsgl3lz6r921z0rgh6";
+
+  meta = with lib; {
+    homepage = "https://juliamono.netlify.app/";
+    description = "monospaced font for scientific and technical computing";
+    longDescription = ''
+      JuliaMono is a monospaced typeface designed for programming in the Julia Programming Language and in other text editing environments that require a wide range of specialist and technical Unicode characters. It was intended as an experiment to be presented at the 2020 JuliaCon conference in Lisbon, Portugal (which of course didn’t happen).
+
+      JuliaMono is:
+
+      - free
+      - distributed with a liberal licence
+      - suitable for scientific and technical programming as well as for general purpose hacking
+      - easy to use, simple, friendly, and approachable
+    '';
+    license = licenses.ofl;
+    maintainers = with maintainers; [ toastal ];
+    platforms = platforms.all;
+  };
+}
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

JuliaMono is a monospace font that optimized for unicode and Julia but is just as useful in FP languages like Haskell, PureScript, and Agda as well as Dhall.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Additionally, I've subscribed to the release of the font via GitHub as well as via RSS.

Fixes #100328
