### PR TITLE
ocamlPackages.ppx_sqlexpr: use ppxlib instead of the deprecated ppx_core

### DIFF
--- a/pkgs/development/ocaml-modules/sqlexpr/ppx.nix
+++ b/pkgs/development/ocaml-modules/sqlexpr/ppx.nix
@@ -1,11 +1,15 @@
 { buildDunePackage, sqlexpr, ounit
-, ppx_core, ppx_tools_versioned, re, lwt_ppx
+, ppxlib, ppx_tools_versioned, re, lwt_ppx
 }:
 
 buildDunePackage {
   pname = "ppx_sqlexpr";
   inherit (sqlexpr) version src meta;
 
-  buildInputs = [ sqlexpr ounit ppx_core ppx_tools_versioned re lwt_ppx ];
+  postPatch = ''
+    substituteInPlace src/ppx/jbuild --replace ppx_core ppxlib
+  '';
+
+  buildInputs = [ sqlexpr ounit ppxlib ppx_tools_versioned re lwt_ppx ];
   doCheck = true;
 }


### PR DESCRIPTION
###### Motivation for this change

Drop dependency on the deprecated `ppx_core`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
