### PR TITLE
slade-git 3.1.2 -> 3.2.0

### DIFF
--- a/pkgs/applications/misc/slade/git.nix
+++ b/pkgs/applications/misc/slade/git.nix
@@ -1,18 +1,20 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, wxGTK, gtk2, sfml, fluidsynth, curl, freeimage, ftgl, glew, zip }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, wxGTK30-gtk3, gtk3, sfml, fluidsynth, curl, freeimage, ftgl, glew, zip, lua, fmt, mpg123, wrapGAppsHook }:
 
-stdenv.mkDerivation {
-  name = "slade-git-3.1.2.2018.01.29";
+let
+  wxGTK = wxGTK30-gtk3.override { withGtk2 = false; withWebKit = true; };
+in stdenv.mkDerivation {
+  name = "slade-git-3.2.0.2020.08.21";
 
   src = fetchFromGitHub {
     owner = "sirjuddington";
     repo = "SLADE";
-    rev = "f7409c504b40c4962f419038db934c32688ddd2e";
-    sha256 = "14icxiy0r9rlcc10skqs1ylnxm1f0f3irhzfmx4sazq0pjv5ivld";
+    rev = "b247aab888afe1127f963f5572d81a8985a55446";
+    sha256 = "1qvfs9j5hnyi9i1qdyvyfijk1dg2j5j4i1l6i84anzd191c5hpzm";
   };
 
-  cmakeFlags = ["-DNO_WEBVIEW=1"];
-  nativeBuildInputs = [ cmake pkgconfig zip ];
-  buildInputs = [ wxGTK gtk2 sfml fluidsynth curl freeimage ftgl glew ];
+  cmakeFlags = [ "-DwxWidgets_CONFIG_EXECUTABLE=${wxGTK.out}/bin/wx-config" ];
+  nativeBuildInputs = [ cmake pkgconfig zip wrapGAppsHook ];
+  buildInputs = [ wxGTK gtk3 sfml fluidsynth curl freeimage ftgl glew lua fmt mpg123 ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Brings slade-git up-to-date with the current development version; now built against gtk3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Pinging maintainer @ertes 
