### PR TITLE
bit: init at 0.5.11

### DIFF
--- a/pkgs/applications/version-management/bit/default.nix
+++ b/pkgs/applications/version-management/bit/default.nix
@@ -1,0 +1,24 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "bit";
+  version = "0.5.11";
+
+  src = fetchFromGitHub {
+    owner = "chriswalz";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1rdi6wsr5w64gvqkdysxrxfjxi3xbwigy3sk8wsx9zp4fql9xnw1";
+  };
+
+  subPackages = [ "." ];
+
+  vendorSha256 = "16c1mcvz3z17pixp904hazivx2n7y592nlx3ndnyajk7ljmnwfzy";
+
+  meta = with lib; {
+    description = "Bit is a modern Git CLI";
+    homepage = "https://github.com/chriswalz/bit";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rople380 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19872,6 +19872,8 @@ in
     glew = glew110;
   };
 
+  bit = callPackage ../applications/version-management/bit { };
+
   bitkeeper = callPackage ../applications/version-management/bitkeeper {
     gperf = gperf_3_0;
   };


### PR DESCRIPTION
###### Motivation for this change

bit: init at 0.5.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
  - [ ] NixOS
  - [ ] macOS
  - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).