### PR TITLE
virt-manager: 2.2.1 -> 3.1.0

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -2,7 +2,7 @@
 , wrapGAppsHook, gtk-vnc, vte, avahi, dconf
 , gobject-introspection, libvirt-glib, system-libvirt
 , gsettings-desktop-schemas, glib, libosinfo, gnome3
-, gtksourceview4
+, gtksourceview4, docutils
 , spiceSupport ? true, spice-gtk ? null
 , cpio, e2fsprogs, findutils, gzip
 }:
@@ -11,16 +11,17 @@ with stdenv.lib;
 
 python3Packages.buildPythonApplication rec {
   pname = "virt-manager";
-  version = "2.2.1";
+  version = "3.1.0";
 
   src = fetchurl {
     url = "http://virt-manager.org/download/sources/virt-manager/${pname}-${version}.tar.gz";
-    sha256 = "06ws0agxlip6p6n3n43knsnjyd91gqhh2dadgc33wl9lx1k8vn6g";
+    sha256 = "0al34lxlywqnj98hdm72a38zk8ns91wkqgrc3h1mhv1kikd8pjfc";
   };
 
   nativeBuildInputs = [
     intltool file
     gobject-introspection # for setup hook populating GI_TYPELIB_PATH
+    docutils
   ];
 
   buildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
[Changelog: (3.1.0, 3.0.0)](https://github.com/virt-manager/virt-manager/blob/master/NEWS.md)

###### Package changes
- Add `docutils`, because `virt-manager` now uses rst2man to generate man pages. I wasn't sure if the `nativeBuildInputs` is the correct place for `docutils`, but as far as I have tested, that's the only place where the build doesn't fail.

###### Notes
- `virt-manager` is now using `pytest`, so it might be easier to integrate tests. I haven't tried that though.
- I wasn't sure about the formatting of the file, so it might be incorrect.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
