### PR TITLE
agdarsec: init at 0.4.1

### DIFF
--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -49,6 +49,7 @@ let
     , meta
     , buildInputs ? []
     , everythingFile ? "./Everything.agda"
+    , includePaths ? []
     , libraryName ? pname
     , libraryFile ? "${libraryName}.agda-lib"
     , buildPhase ? null
@@ -57,6 +58,7 @@ let
     , ...
     }: let
       agdaWithArgs = withPackages (builtins.filter (p: p ? isAgdaDerivation) buildInputs);
+      includePathArgs = concatMapStrings (path: "-i" + path + " ") (includePaths ++ [(dirOf everythingFile)]);
     in
       {
         inherit libraryName libraryFile;
@@ -67,7 +69,7 @@ let
 
         buildPhase = if buildPhase != null then buildPhase else ''
           runHook preBuild
-          agda -i ${dirOf everythingFile} ${everythingFile}
+          agda ${includePathArgs} ${everythingFile}
           runHook postBuild
         '';
 

--- a/pkgs/development/libraries/agda/agdarsec/default.nix
+++ b/pkgs/development/libraries/agda/agdarsec/default.nix
@@ -1,0 +1,28 @@
+{ lib, mkDerivation, fetchFromGitHub
+, standard-library }:
+
+mkDerivation rec {
+  pname = "agdarsec";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "gallais";
+    repo = "agdarsec";
+    rev = "v${version}";
+    sha256 = "02fqkycvicw6m2xsz8p01aq8n3gj2d2gyx8sgj15l46f8434fy0x";
+  };
+
+  everythingFile = "./index.agda";
+
+  includePaths = [ "src" "examples" ];
+
+  buildInputs = [ standard-library ];
+
+  meta = with lib; {
+    homepage = "https://gallais.github.io/agdarsec/";
+    description = "Total Parser Combinators in Agda";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ turion ];
+  };
+}

--- a/pkgs/top-level/agda-packages.nix
+++ b/pkgs/top-level/agda-packages.nix
@@ -31,5 +31,7 @@ let
       ../development/libraries/agda/functional-linear-algebra { };
 
     generic = callPackage ../development/libraries/agda/generic { };
+
+    agdarsec = callPackage ../development/libraries/agda/agdarsec { };
   };
 in mkAgdaPackages Agda


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add the https://github.com/gallais/agdarsec/ library to nixpkgs
u
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@alexarice 