### PR TITLE
[20.09] pythonPackages.wxPython: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/wxPython/3.0.nix
+++ b/pkgs/development/python-modules/wxPython/3.0.nix
@@ -37,10 +37,25 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ pkgconfig ]
     ++ (lib.optionals (!stdenv.isDarwin) [ wxGTK libX11 ])
-    ++ (lib.optionals stdenv.isDarwin [ wxmac darwin.apple_sdk.frameworks.Cocoa ]);
+    ++ (lib.optionals stdenv.isDarwin [ wxmac ]);
 
   buildInputs = [ ]
     ++ (lib.optionals (!stdenv.isDarwin) [  (wxGTK.gtk) ])
+    ++ (lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+      ApplicationServices
+      AudioToolbox
+      CFNetwork
+      Carbon
+      Cocoa
+      CoreGraphics
+      CoreServices
+      CoreText
+      DiskArbitration
+      IOKit
+      ImageIO
+      OpenGL
+      Security
+    ]))
     ++ (lib.optional openglSupport pyopengl);
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of #99586

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
