### PR TITLE
zegrapher: init at 3.1.1

### DIFF
--- a/pkgs/applications/science/math/zegrapher/default.nix
+++ b/pkgs/applications/science/math/zegrapher/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, fetchFromGitHub
+, qmake
+, wrapQtAppsHook
+, boost }:
+
+stdenv.mkDerivation rec {
+  pname = "zegrapher";
+  version = "3.1.1";
+
+  src = fetchFromGitHub {
+    owner = "AdelKS";
+    repo = "ZeGrapher";
+    rev = "v${version}";
+    sha256 = "sha256-OSQXm0gDI1zM2MBM4iiY43dthJcAZJkprklolsNMEvk=";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+  buildInputs = [
+    boost
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://zegrapher.com/";
+    description = "An open source math plotter";
+    longDescription = ''
+      An open source, free and easy to use math plotter. It can plot functions,
+      sequences, parametric equations and data on the plane.
+    '';
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26330,6 +26330,8 @@ in
     cmake = cmakeCurses;
   });
 
+  zegrapher = libsForQt5.callPackage ../applications/science/math/zegrapher { };
+
   ### SCIENCE/MEDICINE
 
   aliza = callPackage ../applications/science/medicine/aliza { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

ZeGrapher is a graph plotter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
