### PR TITLE
rust-analyzer: 2020-10-05 -> 2020-10-12

### DIFF
--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -2,10 +2,10 @@
 
 {
   rust-analyzer-unwrapped = callPackage ./generic.nix rec {
-    rev = "2020-10-05";
+    rev = "2020-10-12";
     version = "unstable-${rev}";
-    sha256 = "1vj5xwqif2ipzlb8ngpq3ymgqvv65d0700ihq7hx81k0i2m2awa6";
-    cargoSha256 = "14n7nk64qq27a7ygqm0bly2bby3bmsav6nvsap3bkbkppyr5gyrg";
+    sha256 = "194xax87pwdh3p8zx46igvqwznlpnl4jp8lj987616gyldfgall0";
+    cargoSha256 = "1rvf3a2fpqpf4q52pi676qzq7h0xfqlcbp15sc5vqc8nbbs7c7vw";
   };
 
   rust-analyzer = callPackage ./wrapper.nix {} {

--- a/pkgs/development/tools/rust/rust-analyzer/generic.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/generic.nix
@@ -16,15 +16,16 @@ rustPlatform.buildRustPackage {
     inherit rev sha256;
   };
 
-  # FIXME: Temporary fix for our rust 1.45.0 since rust-analyzer requires 1.46.0
+  # FIXME: Temporary fixes for our rust 1.45.0
   cargoPatches = [
-    ./downgrade-smol_str.patch
+    ./downgrade-smol_str.patch # Requires rustc 1.46.0
   ];
 
   patches = [
-    # FIXME: Temporary fix for our rust 1.45.0 since rust-analyzer requires 1.46.0
-    ./no-loop-in-const-fn.patch
-    ./no-option-zip.patch
+    ./no-track_env_var.patch              # Requires rustc 1.47.0
+    ./no-match-unsizing-in-const-fn.patch # Requires rustc 1.46.0
+    ./no-loop-in-const-fn.patch           # Requires rustc 1.46.0
+    ./no-option-zip.patch                 # Requires rustc 1.46.0
   ];
 
   buildAndTestSubdir = "crates/rust-analyzer";

--- a/pkgs/development/tools/rust/rust-analyzer/no-match-unsizing-in-const-fn.patch
+++ b/pkgs/development/tools/rust/rust-analyzer/no-match-unsizing-in-const-fn.patch
@@ -1,0 +1,30 @@
+diff --git a/crates/assists/src/handlers/convert_integer_literal.rs b/crates/assists/src/handlers/convert_integer_literal.rs
+index ea35e833a..4df80a3c0 100644
+--- a/crates/assists/src/handlers/convert_integer_literal.rs
++++ b/crates/assists/src/handlers/convert_integer_literal.rs
+@@ -105,7 +105,7 @@ impl IntegerLiteralBase {
+         }
+     }
+
+-    const fn base(&self) -> u32 {
++    fn base(&self) -> u32 {
+         match self {
+             Self::Binary => 2,
+             Self::Octal => 8,
+@@ -114,14 +114,14 @@ impl IntegerLiteralBase {
+         }
+     }
+
+-    const fn prefix_len(&self) -> usize {
++    fn prefix_len(&self) -> usize {
+         match self {
+             Self::Decimal => 0,
+             _ => 2,
+         }
+     }
+
+-    const fn bases() -> &'static [IntegerLiteralBase] {
++    fn bases() -> &'static [IntegerLiteralBase] {
+         &[
+             IntegerLiteralBase::Binary,
+             IntegerLiteralBase::Octal,

--- a/pkgs/development/tools/rust/rust-analyzer/no-track_env_var.patch
+++ b/pkgs/development/tools/rust/rust-analyzer/no-track_env_var.patch
@@ -1,0 +1,120 @@
+This patch revert 3d169bd3f4cdc2dc3dd09eadbbc17c19214d69f3 (Add track_env_var to the proc macro server).
+
+diff --git a/crates/proc_macro_srv/src/proc_macro/bridge/client.rs b/crates/proc_macro_srv/src/proc_macro/bridge/client.rs
+index 55d6330cc..cb4b3bdb0 100644
+--- a/crates/proc_macro_srv/src/proc_macro/bridge/client.rs
++++ b/crates/proc_macro_srv/src/proc_macro/bridge/client.rs
+@@ -160,7 +160,6 @@ macro_rules! define_handles {
+ }
+ define_handles! {
+     'owned:
+-    FreeFunctions,
+     TokenStream,
+     TokenStreamBuilder,
+     TokenStreamIter,
+diff --git a/crates/proc_macro_srv/src/proc_macro/bridge/mod.rs b/crates/proc_macro_srv/src/proc_macro/bridge/mod.rs
+index b97886eb9..aeb05aad4 100644
+--- a/crates/proc_macro_srv/src/proc_macro/bridge/mod.rs
++++ b/crates/proc_macro_srv/src/proc_macro/bridge/mod.rs
+@@ -57,10 +57,6 @@ use std::thread;
+ macro_rules! with_api {
+     ($S:ident, $self:ident, $m:ident) => {
+         $m! {
+-            FreeFunctions {
+-                fn drop($self: $S::FreeFunctions);
+-                fn track_env_var(var: &str, value: Option<&str>);
+-            },
+             TokenStream {
+                 fn drop($self: $S::TokenStream);
+                 fn clone($self: &$S::TokenStream) -> $S::TokenStream;
+diff --git a/crates/proc_macro_srv/src/proc_macro/bridge/server.rs b/crates/proc_macro_srv/src/proc_macro/bridge/server.rs
+index 3acb239af..45d41ac02 100644
+--- a/crates/proc_macro_srv/src/proc_macro/bridge/server.rs
++++ b/crates/proc_macro_srv/src/proc_macro/bridge/server.rs
+@@ -11,8 +11,6 @@ use super::client::HandleStore;
+ /// Declare an associated item of one of the traits below, optionally
+ /// adjusting it (i.e., adding bounds to types and default bodies to methods).
+ macro_rules! associated_item {
+-    (type FreeFunctions) =>
+-        (type FreeFunctions: 'static;);
+     (type TokenStream) =>
+         (type TokenStream: 'static + Clone;);
+     (type TokenStreamBuilder) =>
+diff --git a/crates/proc_macro_srv/src/proc_macro/mod.rs b/crates/proc_macro_srv/src/proc_macro/mod.rs
+index fc6e7344f..ee0dc9722 100644
+--- a/crates/proc_macro_srv/src/proc_macro/mod.rs
++++ b/crates/proc_macro_srv/src/proc_macro/mod.rs
+@@ -924,25 +924,3 @@ impl fmt::Debug for Literal {
+         self.0.fmt(f)
+     }
+ }
+-
+-pub mod tracked_env {
+-    use std::env::{self, VarError};
+-    use std::ffi::OsStr;
+-
+-    /// Retrieve an environment variable and add it to build dependency info.
+-    /// Build system executing the compiler will know that the variable was accessed during
+-    /// compilation, and will be able to rerun the build when the value of that variable changes.
+-    /// Besides the dependency tracking this function should be equivalent to `env::var` from the
+-    /// standard library, except that the argument must be UTF-8.
+-    pub fn var<K: AsRef<OsStr> + AsRef<str>>(key: K) -> Result<String, VarError> {
+-        use std::ops::Deref;
+-
+-        let key: &str = key.as_ref();
+-        let value = env::var(key);
+-        super::bridge::client::FreeFunctions::track_env_var(
+-            key,
+-            value.as_ref().map(|t| t.deref()).ok(),
+-        );
+-        value
+-    }
+-}
+diff --git a/crates/proc_macro_srv/src/rustc_server.rs b/crates/proc_macro_srv/src/rustc_server.rs
+index c5fe3591e..7d1695c86 100644
+--- a/crates/proc_macro_srv/src/rustc_server.rs
++++ b/crates/proc_macro_srv/src/rustc_server.rs
+@@ -242,8 +242,6 @@ impl TokenStreamBuilder {
+     }
+ }
+
+-pub struct FreeFunctions;
+-
+ #[derive(Clone)]
+ pub struct TokenStreamIter {
+     trees: IntoIter<TokenTree>,
+@@ -256,7 +254,6 @@ pub struct Rustc {
+ }
+
+ impl server::Types for Rustc {
+-    type FreeFunctions = FreeFunctions;
+     type TokenStream = TokenStream;
+     type TokenStreamBuilder = TokenStreamBuilder;
+     type TokenStreamIter = TokenStreamIter;
+@@ -270,13 +267,6 @@ impl server::Types for Rustc {
+     type MultiSpan = Vec<Span>;
+ }
+
+-impl server::FreeFunctions for Rustc {
+-    fn track_env_var(&mut self, _var: &str, _value: Option<&str>) {
+-        // FIXME: track env var accesses
+-        // https://github.com/rust-lang/rust/pull/71858
+-    }
+-}
+-
+ impl server::TokenStream for Rustc {
+     fn new(&mut self) -> Self::TokenStream {
+         Self::TokenStream::new()
+diff --git a/xtask/src/install.rs b/xtask/src/install.rs
+index fcc4f05e4..d829790d7 100644
+--- a/xtask/src/install.rs
++++ b/xtask/src/install.rs
+@@ -7,7 +7,7 @@ use anyhow::{bail, format_err, Context, Result};
+ use crate::not_bash::{pushd, run};
+
+ // Latest stable, feel free to send a PR if this lags behind.
+-const REQUIRED_RUST_VERSION: u32 = 47;
++const REQUIRED_RUST_VERSION: u32 = 46;
+
+ pub struct InstallCmd {
+     pub client: Option<ClientOpt>,


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bump version.

Note that only attribute `rust-analyzer` is tested. The vscode extension `vscode-extensions.matklad.rust-analyzer` is currently failed to build on master, which is fixed in another PR #100358 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
