### PR TITLE
flake.nix: allow inclusion of `nixpkgs` as `path:/.../`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
               modules ++ [
                 {
                   system.nixos.versionSuffix =
-                    ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified)}.${self.shortRev or "dirty"}";
+                    ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
                   system.nixos.revision = final.mkIf (self ? rev) self.rev;
 
                   system.build = {


### PR DESCRIPTION
When adding `nixpkgs` as flake-input using the `path`-fetcher, you
currently get the following error since neither `lastModifiedDate` nor
`lastModified` are stored in `flake.lock` for paths:

```
error: --- EvalError --------------------------------------------------------------------------- nix-build
at: (48:71) in file: /nix/store/147clg8svaxyj7pl80ra9kmmm72mdg94-source/flake.nix

    47|                   system.nixos.versionSuffix =
    48|                     ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified)}.${self.shortRev or "dirty"}";
      |                                                                       ^
    49|                   system.nixos.revision = final.mkIf (self ? rev) self.rev;

attribute 'lastModified' missing
```

This patch adds the fallback-value `"19700101"` to `versionSuffix` if none
of `lastModified{,Date}` are set in the lockfile.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
