### PR TITLE
[20.09] pythonPackages.poetry: 1.0.10 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -13,21 +13,15 @@
 
 buildPythonPackage rec {
   pname = "poetry-core";
-  version = "1.0.0a9";
+  version = "1.0.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "python-poetry";
     repo = pname;
     rev = version;
-    sha256 = "1ln47x1bc1yvhdfwfnkqx4d2j7988a59v8vmcriw14whfgzfki75";
+    sha256 = "02pqkwzbg43xz2zsw8q7m0sfkj8wbw07in83gy0bk0znhljhp0vw";
   };
-
-  # avoid mass-rebuild of python packages
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "^1.7.0" "^1.6.0"
-  '';
 
   nativeBuildInputs = [
     intreehooks
@@ -50,7 +44,7 @@ buildPythonPackage rec {
   ];
 
   # requires git history to work correctly
-  disabledTests = [ "default_with_excluded_data" ];
+  disabledTests = [ "default_with_excluded_data" "default_src_with_excluded_data" ];
 
   pythonImportsCheck = [ "poetry.core" ];
 

--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "poetry";
-  version = "1.1.0";
+  version = "1.1.1";
   format = "pyproject";
   disabled = isPy27;
 
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     owner = "python-poetry";
     repo = pname;
     rev = version;
-    sha256 = "0kl23dkq9n112z1pqjg6f1wv3qk77ij6q5glg15lwrj7yrl9k65c";
+    sha256 = "1j3ij8qsd709p7ww5r4759f2xnk2s7g40kzm9vx99l98zw890g05";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -7,14 +7,11 @@
 , httpretty
 , importlib-metadata
 , intreehooks
-, jsonschema
 , keyring
 , lockfile
 , pexpect
 , pkginfo
-, pygments
-, pyparsing
-, pyrsistent
+, poetry-core
 , pytestCheckHook
 , pytestcov
 , pytest-mock
@@ -22,11 +19,12 @@
 , requests-toolbelt
 , shellingham
 , tomlkit
+, virtualenv
 }:
 
 buildPythonPackage rec {
   pname = "poetry";
-  version = "1.0.10";
+  version = "1.1.0";
   format = "pyproject";
   disabled = isPy27;
 
@@ -34,19 +32,13 @@ buildPythonPackage rec {
     owner = "python-poetry";
     repo = pname;
     rev = version;
-    sha256 = "00qfzjjs6clh93gfl1px3ma9km8qxl3f4z819nmyl58zc8ni3zyv";
+    sha256 = "0kl23dkq9n112z1pqjg6f1wv3qk77ij6q5glg15lwrj7yrl9k65c";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-     --replace "pyrsistent = \"^0.14.2\"" "pyrsistent = \"^0.16.0\"" \
-     --replace "requests-toolbelt = \"^0.8.0\"" "requests-toolbelt = \"^0.9.1\"" \
-     --replace 'importlib-metadata = {version = "~1.1.3", python = "<3.8"}' \
-       'importlib-metadata = {version = ">=1.3,<2", python = "<3.8"}' \
-     --replace "tomlkit = \"^0.5.11\"" "tomlkit = \"<2\"" \
-     --replace "cleo = \"^0.7.6\"" "cleo = \"^0.8.0\"" \
-     --replace "version = \"^20.0.1\", python = \"^3.5\"" "version = \"^21.0.0\", python = \"^3.5\"" \
-     --replace "clikit = \"^0.4.2\"" "clikit = \"^0.6.2\""
+     --replace 'importlib-metadata = {version = "^1.6.0", python = "<3.8"}' \
+       'importlib-metadata = {version = ">=1.6,<2", python = "<3.8"}'
   '';
 
   nativeBuildInputs = [ intreehooks ];
@@ -57,17 +49,16 @@ buildPythonPackage rec {
     cleo
     clikit
     html5lib
-    jsonschema
     keyring
     lockfile
     pexpect
     pkginfo
-    pyparsing
-    pyrsistent
+    poetry-core
     requests
     requests-toolbelt
     shellingham
     tomlkit
+    virtualenv
   ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   postInstall = ''
@@ -79,7 +70,7 @@ buildPythonPackage rec {
     "$out/bin/poetry" completions fish > "$out/share/fish/vendor_completions.d/poetry.fish"
   '';
 
-  checkInputs = [ pytestCheckHook httpretty pytest-mock pygments pytestcov ];
+  checkInputs = [ pytestCheckHook httpretty pytest-mock pytestcov ];
   preCheck = "export HOME=$TMPDIR";
   disabledTests = [
     # touches network
@@ -88,10 +79,13 @@ buildPythonPackage rec {
     "load"
     "vcs"
     "prereleases_if_they_are_compatible"
+    "test_executor"
     # requires git history to work correctly
     "default_with_excluded_data"
     # toml ordering has changed
     "lock"
+    # fs permission errors
+    "test_builder_should_execute_build_scripts"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Combined backport of #99507 and #99684. While this doesn't fix anything in itself, it will allow me to backport #100168 

I thought this would be a backport too far, but the rebuild actually succeeded apart from `apache-airflow` and `toggl-cli`, both already broken on this branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
