### PR TITLE
python3Packages.spyder_3: remove broken gui app

### DIFF
--- a/pkgs/development/python-modules/spyder/3.nix
+++ b/pkgs/development/python-modules/spyder/3.nix
@@ -21,8 +21,7 @@ buildPythonPackage rec {
     pygments qtpy pyzmq chardet pyqtwebengine
   ];
 
-  # tests fail with a segfault
-  doCheck = false;
+  patches = [ ./3_no_app.patch ];
 
   postPatch = ''
     # remove dependency on pyqtwebengine
@@ -30,6 +29,14 @@ buildPythonPackage rec {
     sed -i /pyqtwebengine/d setup.py
     substituteInPlace setup.py --replace "pyqt5<5.13" "pyqt5"
   '';
+
+  # tests fail with a segfault
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "spyder.utils.icon_manager"
+    "spyder.widgets.sourcecode.codeeditor"
+  ];
 
   meta = with stdenv.lib; {
     description = "Library providing a scientific python development environment";

--- a/pkgs/development/python-modules/spyder/3_no_app.patch
+++ b/pkgs/development/python-modules/spyder/3_no_app.patch
@@ -1,0 +1,55 @@
+diff --git a/setup.py b/setup.py
+index 37b3a0a..5a50a2f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -83,19 +83,7 @@ def get_subpackages(name):
+ 
+ def get_data_files():
+     """Return data_files in a platform dependent manner"""
+-    if sys.platform.startswith('linux'):
+-        if PY3:
+-            data_files = [('share/applications', ['scripts/spyder3.desktop']),
+-                          ('share/icons', ['img_src/spyder3.png']),
+-                          ('share/metainfo', ['scripts/spyder3.appdata.xml'])]
+-        else:
+-            data_files = [('share/applications', ['scripts/spyder.desktop']),
+-                          ('share/icons', ['img_src/spyder.png'])]
+-    elif os.name == 'nt':
+-        data_files = [('scripts', ['img_src/spyder.ico',
+-                                   'img_src/spyder_reset.ico'])]
+-    else:
+-        data_files = []
++    data_files = []
+     return data_files
+ 
+ 
+@@ -130,13 +118,8 @@ CMDCLASS = {'install_data': MyInstallData}
+ #==============================================================================
+ # Main scripts
+ #==============================================================================
+-# NOTE: the '[...]_win_post_install.py' script is installed even on non-Windows
+-# platforms due to a bug in pip installation process (see Issue 1158)
+-SCRIPTS = ['%s_win_post_install.py' % NAME]
+-if PY3 and sys.platform.startswith('linux'):
+-    SCRIPTS.append('spyder3')
+-else:
+-    SCRIPTS.append('spyder')
++# None, because this is a library in nixpkgs not an app
++SCRIPTS = []
+ 
+ 
+ #==============================================================================
+@@ -265,12 +248,7 @@ if 'setuptools' in sys.modules:
+     setup_args['install_requires'] = install_requires
+     setup_args['extras_require'] = extras_require
+ 
+-    setup_args['entry_points'] = {
+-        'gui_scripts': [
+-            '{} = spyder.app.start:main'.format(
+-                'spyder3' if PY3 else 'spyder')
+-        ]
+-    }
++    setup_args['entry_points'] = {}
+ 
+     setup_args.pop('scripts', None)
+ 


### PR DESCRIPTION
@FRidh, this continues from #100126.

##### Motivation for this change

A recent update to Qt broke the gui app. This library is only used for
cq-editor and still works fine for that purpose, so this patch just
trims the gui app stuff out of setup.py.

I've also added some pythonImportsChecks, they are the exact modules that cq-editor needs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>cq-editor</li>
    <li>python37Packages.spyder_3</li>
    <li>python38Packages.spyder_3</li>
  </ul>
</details>
