### PR TITLE
wayst: init at 2020-10-12

### DIFF
--- a/pkgs/applications/misc/wayst/default.nix
+++ b/pkgs/applications/misc/wayst/default.nix
@@ -1,0 +1,91 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkgconfig
+, freetype
+, fontconfig
+, libGL
+, libX11
+, libXrandr
+, libxcb
+, libxkbcommon
+, utf8proc
+, wayland
+
+, libnotify
+, xdg_utils
+, makeDesktopItem
+}:
+
+let
+  desktopItem = makeDesktopItem {
+    desktopName = "Wayst";
+    name = "wayst";
+    exec = "wayst";
+    icon = "wayst";
+    terminal = "false";
+    categories = "System;TerminalEmulator";
+    comment = "A simple terminal emulator";
+    extraEntries = ''
+      GenericName=Terminal
+      Keywords=wayst;terminal;
+    '';
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "wayst";
+  version = "unstable-2020-10-12";
+
+  src = fetchFromGitHub {
+    owner = "91861";
+    repo = pname;
+    rev = "b8c7ca00a785a748026ed1ba08bf3d19916ced18";
+    hash = "sha256-wHAU1yxukxApzhLLLctZ/AYqF7t21HQc5omPBZyxra0=";
+  };
+
+  makeFlags = [ "INSTALL_DIR=\${out}/bin" ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [
+    fontconfig
+    libX11
+    freetype
+    libGL
+    libxcb
+    libxkbcommon
+    libXrandr
+    utf8proc
+    wayland
+  ];
+
+  # This patch forces the Makefile to use utf8proc
+  # The makefile relies on ldconfig to find the utf8proc libraries
+  # which is not possible on nixpkgs
+  patches = [ ./utf8proc.patch ];
+
+  postPatch = ''
+    substituteInPlace src/settings.c \
+      --replace xdg-open ${xdg_utils}/bin/xdg-open
+    substituteInPlace src/main.c \
+      --replace notify-send ${libnotify}/bin/notify-send
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/applications
+    ln -s ${desktopItem}/share/applications/* $out/share/applications
+    install -D icons/wayst.svg $out/share/icons/hicolor/scalable/apps/wayst.svg
+  '';
+
+  meta = with lib; {
+    description = "A simple terminal emulator";
+    homepage = "https://github.com/91861/wayst";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ berbiche ];
+  };
+}

--- a/pkgs/applications/misc/wayst/utf8proc.patch
+++ b/pkgs/applications/misc/wayst/utf8proc.patch
@@ -1,0 +1,24 @@
+commit caa5a6bed31937f2d1b322da204e11eae57a720f
+Author: Nicolas Berbiche <nicolas@normie.dev>
+Date:   Tue Oct 20 18:14:44 2020 -0400
+
+    PATCH: use nixpkgs utf8proc
+    
+    This patch forces the Makefile to use utf8proc from `buildInputs`.
+    The Makefile relies on ldconfig to find the utf8proc libraries,
+    which is not possible with nixpkgs.
+
+diff --git a/Makefile b/Makefile
+index caccdf7..90b11ea 100644
+--- a/Makefile
++++ b/Makefile
+@@ -29,7 +29,7 @@ else
+ 	LDFLAGS = -O2 -flto
+ endif
+ 
+-ifeq ($(shell ldconfig -p | grep libutf8proc.so > /dev/null || echo fail),fail)
++ifeq (false,fail)
+ $(info libutf8proc not found. Support for language-specific combining characters and unicode normalization will be disabled.)
+ 	CFLAGS += -DNOUTF8PROC
+ else
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3427,6 +3427,8 @@ in
 
   wayland-utils = callPackage ../tools/wayland/wayland-utils { };
 
+  wayst = callPackage ../applications/misc/wayst { };
+
   wev = callPackage ../tools/misc/wev { };
 
   wl-clipboard = callPackage ../tools/misc/wl-clipboard { };
@@ -28319,4 +28321,5 @@ in
   cagebreak = callPackage ../applications/window-managers/cagebreak/default.nix {};
 
   psftools = callPackage ../os-specific/linux/psftools {};
+
 }


### PR DESCRIPTION
###### Motivation for this change

Package [wayst](https://github.com/91861/wayst), a simple terminal emulator that supports both Wayland and X11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
