### PR TITLE
puddletag: fix wrapping

### DIFF
--- a/pkgs/applications/audio/puddletag/default.nix
+++ b/pkgs/applications/audio/puddletag/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3Packages, chromaprint }:
+{ stdenv, fetchFromGitHub, python3Packages, wrapQtAppsHook, chromaprint }:
 
 python3Packages.buildPythonApplication rec {
   pname = "puddletag";
@@ -13,6 +13,8 @@ python3Packages.buildPythonApplication rec {
 
   sourceRoot = "source/source";
 
+  nativeBuildInputs = [ wrapQtAppsHook ];
+
   propagatedBuildInputs = [ chromaprint ] ++ (with python3Packages; [
     configobj
     mutagen
@@ -20,9 +22,13 @@ python3Packages.buildPythonApplication rec {
     pyqt5
   ]);
 
-  doCheck = false;   # there are no tests
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
 
-  dontStrip = true;  # we are not generating any binaries
+  doCheck = false; # there are no tests
+
+  dontStrip = true; # we are not generating any binaries
 
   meta = with stdenv.lib; {
     description = "An audio tag editor similar to the Windows program, Mp3tag";
@@ -30,6 +36,5 @@ python3Packages.buildPythonApplication rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.linux;
-    broken = true; # Needs Qt wrapping
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20728,7 +20728,7 @@ in
 
   gradio = callPackage ../applications/audio/gradio { };
 
-  puddletag = callPackage ../applications/audio/puddletag { };
+  puddletag = libsForQt5.callPackage ../applications/audio/puddletag { };
 
   w_scan = callPackage ../applications/video/w_scan { };
 


### PR DESCRIPTION
###### Motivation for this change

Fixes QT wrapping.

Further to #99956.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).