### PR TITLE
xorg.xcbproto: 1.13 -> 1.14.1 and xorg.libxcb: 1.13.1 -> 1.14

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1158,11 +1158,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   libxcb = callPackage ({ stdenv, pkgconfig, fetchurl, libxslt, libpthreadstubs, libXau, xcbproto, libXdmcp, python }: stdenv.mkDerivation {
-    name = "libxcb-1.13.1";
+    name = "libxcb-1.14";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "https://xcb.freedesktop.org/dist/libxcb-1.13.1.tar.bz2";
-      sha256 = "1i27lvrcsygims1pddpl5c4qqs6z715lm12ax0n3vx0igapvg7x8";
+      url = "mirror://xorg/individual/lib/libxcb-1.14.tar.xz";
+      sha256 = "0d2chjgyn5lr9sfhacfvqgnj9l9faz11vn322a06jd6lk3dxcpm5";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig python ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1431,11 +1431,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xcbproto = callPackage ({ stdenv, pkgconfig, fetchurl, python }: stdenv.mkDerivation {
-    name = "xcb-proto-1.13";
+    name = "xcb-proto-1.14.1";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "https://xcb.freedesktop.org/dist/xcb-proto-1.13.tar.bz2";
-      sha256 = "1qdxw9syhbvswiqj5dvj278lrmfhs81apzmvx6205s4vcqg7563v";
+      url = "mirror://xorg/individual/proto/xcb-proto-1.14.1.tar.xz";
+      sha256 = "1hzwazgyywd9mz4mjj1yv8ski27qqx7ypmyr27m39hrajyddsjph";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig python ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,6 +1,5 @@
 https://invisible-mirror.net/archives/luit/luit-20190106.tgz
 https://xcb.freedesktop.org/dist/libpthread-stubs-0.4.tar.bz2
-https://xcb.freedesktop.org/dist/libxcb-1.13.1.tar.bz2
 https://xcb.freedesktop.org/dist/xcb-util-0.4.0.tar.bz2
 https://xcb.freedesktop.org/dist/xcb-util-cursor-0.1.3.tar.bz2
 https://xcb.freedesktop.org/dist/xcb-util-errors-1.0.tar.bz2
@@ -180,6 +179,7 @@ mirror://xorg/individual/lib/libX11-1.6.8.tar.bz2
 mirror://xorg/individual/lib/libXau-1.0.9.tar.bz2
 mirror://xorg/individual/lib/libXaw-1.0.13.tar.bz2
 mirror://xorg/individual/lib/libXaw3d-1.6.3.tar.bz2
+mirror://xorg/individual/lib/libxcb-1.14.tar.xz
 mirror://xorg/individual/lib/libXcomposite-0.4.5.tar.bz2
 mirror://xorg/individual/lib/libXcursor-1.2.0.tar.bz2
 mirror://xorg/individual/lib/libXdamage-1.1.5.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,7 +1,6 @@
 https://invisible-mirror.net/archives/luit/luit-20190106.tgz
 https://xcb.freedesktop.org/dist/libpthread-stubs-0.4.tar.bz2
 https://xcb.freedesktop.org/dist/libxcb-1.13.1.tar.bz2
-https://xcb.freedesktop.org/dist/xcb-proto-1.13.tar.bz2
 https://xcb.freedesktop.org/dist/xcb-util-0.4.0.tar.bz2
 https://xcb.freedesktop.org/dist/xcb-util-cursor-0.1.3.tar.bz2
 https://xcb.freedesktop.org/dist/xcb-util-errors-1.0.tar.bz2
@@ -211,6 +210,7 @@ mirror://xorg/individual/lib/libXxf86dga-1.1.5.tar.bz2
 mirror://xorg/individual/lib/libXxf86misc-1.0.4.tar.bz2
 mirror://xorg/individual/lib/libXxf86vm-1.1.4.tar.bz2
 mirror://xorg/individual/lib/xtrans-1.4.0.tar.bz2
+mirror://xorg/individual/proto/xcb-proto-1.14.1.tar.xz
 mirror://xorg/individual/proto/xorgproto-2019.1.tar.bz2
 mirror://xorg/individual/util/gccmakedep-1.0.3.tar.bz2
 mirror://xorg/individual/util/imake-1.0.8.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2020-February/003038.html
https://lists.x.org/archives/xorg-announce/2020-October/003061.html

https://lists.x.org/archives/xorg-announce/2020-February/003039.html
###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).