### PR TITLE
[Draft] Make python310Packages usable

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.10/fix-no-dot-version.patch
+++ b/pkgs/development/interpreters/python/cpython/3.10/fix-no-dot-version.patch
@@ -1,0 +1,346 @@
+From fd5a12de8e4b19dc2c3d38252c88e1afa85900f7 Mon Sep 17 00:00:00 2001
+From: mattip <matti.picus@gmail.com>
+Date: Sat, 23 May 2020 23:50:48 +0300
+Subject: [PATCH 01/13] Make py_version_nodot 3_10 not 310
+
+---
+ Lib/sysconfig.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
+index bf04ac541e6b0..ad622e3b6958a 100644
+--- a/Lib/sysconfig.py
++++ b/Lib/sysconfig.py
+@@ -86,7 +86,7 @@
+ 
+ _PY_VERSION = sys.version.split()[0]
+ _PY_VERSION_SHORT = '%d.%d' % sys.version_info[:2]
+-_PY_VERSION_SHORT_NO_DOT = '%d%d' % sys.version_info[:2]
++_PY_VERSION_SHORT_NO_DOT = '%d_%d' % sys.version_info[:2]
+ _PREFIX = os.path.normpath(sys.prefix)
+ _BASE_PREFIX = os.path.normpath(sys.base_prefix)
+ _EXEC_PREFIX = os.path.normpath(sys.exec_prefix)
+
+From 76a596c6f657d55513f4d5369090d225a58d9c1d Mon Sep 17 00:00:00 2001
+From: mattip <matti.picus@gmail.com>
+Date: Sun, 24 May 2020 01:37:18 +0300
+Subject: [PATCH 02/13] fix another place
+
+---
+ Lib/distutils/command/install.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Lib/distutils/command/install.py b/Lib/distutils/command/install.py
+index aaa300efa96e6..0ab66d99e4820 100644
+--- a/Lib/distutils/command/install.py
++++ b/Lib/distutils/command/install.py
+@@ -292,7 +292,7 @@ def finalize_options(self):
+                             'dist_fullname': self.distribution.get_fullname(),
+                             'py_version': py_version,
+                             'py_version_short': '%d.%d' % sys.version_info[:2],
+-                            'py_version_nodot': '%d%d' % sys.version_info[:2],
++                            'py_version_nodot': '%d_%d' % sys.version_info[:2],
+                             'sys_prefix': prefix,
+                             'prefix': prefix,
+                             'sys_exec_prefix': exec_prefix,
+
+From 5eb6a84e507fd08c82e071612e911469b8e7cb4d Mon Sep 17 00:00:00 2001
+From: mattip <matti.picus@gmail.com>
+Date: Mon, 25 May 2020 12:38:51 +0300
+Subject: [PATCH 03/13] fix more places that do not use py_version_nodot
+
+---
+ configure    | 4 ++--
+ configure.ac | 4 ++--
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/configure b/configure
+index 1124412dce475..3b7036cb32f68 100755
+--- a/configure
++++ b/configure
+@@ -15295,7 +15295,7 @@ $as_echo_n "checking ABIFLAGS... " >&6; }
+ $as_echo "$ABIFLAGS" >&6; }
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking SOABI" >&5
+ $as_echo_n "checking SOABI... " >&6; }
+-SOABI='cpython-'`echo $VERSION | tr -d .`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
++SOABI='cpython-'`echo $VERSION | tr "." "_"`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $SOABI" >&5
+ $as_echo "$SOABI" >&6; }
+ 
+@@ -15303,7 +15303,7 @@ $as_echo "$SOABI" >&6; }
+ if test "$Py_DEBUG" = 'true' -a "$with_trace_refs" != "yes"; then
+   # Similar to SOABI but remove "d" flag from ABIFLAGS
+ 
+-  ALT_SOABI='cpython-'`echo $VERSION | tr -d .``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
++  ALT_SOABI='cpython-'`echo $VERSION | tr -d "." "_"``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+ 
+ cat >>confdefs.h <<_ACEOF
+ #define ALT_SOABI "${ALT_SOABI}"
+diff --git a/configure.ac b/configure.ac
+index 84d1f00983f89..9fdc2f69ee82b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -4737,14 +4737,14 @@ AC_SUBST(SOABI)
+ AC_MSG_CHECKING(ABIFLAGS)
+ AC_MSG_RESULT($ABIFLAGS)
+ AC_MSG_CHECKING(SOABI)
+-SOABI='cpython-'`echo $VERSION | tr -d .`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
++SOABI='cpython-'`echo $VERSION | tr -d "." "_"`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+ AC_MSG_RESULT($SOABI)
+ 
+ # Release and debug (Py_DEBUG) ABI are compatible, but not Py_TRACE_REFS ABI
+ if test "$Py_DEBUG" = 'true' -a "$with_trace_refs" != "yes"; then
+   # Similar to SOABI but remove "d" flag from ABIFLAGS
+   AC_SUBST(ALT_SOABI)
+-  ALT_SOABI='cpython-'`echo $VERSION | tr -d .``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
++  ALT_SOABI='cpython-'`echo $VERSION | tr -d "." "_"``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+   AC_DEFINE_UNQUOTED(ALT_SOABI, "${ALT_SOABI}",
+             [Alternative SOABI used in debug build to load C extensions built in release mode])
+ fi
+
+From 9759ea9a75f22347e69202d0842867eea0634d5d Mon Sep 17 00:00:00 2001
+From: "blurb-it[bot]" <43283697+blurb-it[bot]@users.noreply.github.com>
+Date: Mon, 25 May 2020 09:46:32 +0000
+Subject: [PATCH 04/13] =?UTF-8?q?=F0=9F=93=9C=F0=9F=A4=96=20Added=20by=20b?=
+ =?UTF-8?q?lurb=5Fit.?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+---
+ Misc/NEWS.d/next/Build/2020-05-25-09-46-32.bpo-40747.ef15ix.rst | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 Misc/NEWS.d/next/Build/2020-05-25-09-46-32.bpo-40747.ef15ix.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2020-05-25-09-46-32.bpo-40747.ef15ix.rst b/Misc/NEWS.d/next/Build/2020-05-25-09-46-32.bpo-40747.ef15ix.rst
+new file mode 100644
+index 0000000000000..3d8e0b058de25
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2020-05-25-09-46-32.bpo-40747.ef15ix.rst
+@@ -0,0 +1 @@
++The PEP 425 python tag, taken from ``py_version_nodot``, adds a ``_`` so ``cp310`` is now ``cp3_10``.
+\ No newline at end of file
+
+From b9fe6c246d770feba0ec087ac0f819303a2d96e0 Mon Sep 17 00:00:00 2001
+From: mattip <matti.picus@gmail.com>
+Date: Mon, 25 May 2020 12:54:37 +0300
+Subject: [PATCH 05/13] test SOABI and py_version_nodot agree on the python
+ version
+
+---
+ Lib/test/test_sysconfig.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/Lib/test/test_sysconfig.py b/Lib/test/test_sysconfig.py
+index 44e44bf5ea995..c3bad2cbb4762 100644
+--- a/Lib/test/test_sysconfig.py
++++ b/Lib/test/test_sysconfig.py
+@@ -386,6 +386,12 @@ def test_osx_ext_suffix(self):
+         suffix = sysconfig.get_config_var('EXT_SUFFIX')
+         self.assertTrue(suffix.endswith('-darwin.so'), suffix)
+ 
++    def test_SOABI_consistency(self):
++        SOABI = sysconfig.get_config_var('SOABI')
++        pynodot = sysconfig.get_config_var('py_version_nodot')
++        if SOABI is not None:
++            self.assertTrue(SOABI.split('-')[1] == pynodot)
++
+ class MakefileTests(unittest.TestCase):
+ 
+     @unittest.skipIf(sys.platform.startswith('win'),
+
+From 7149e08db2e84fde0cf80a20f57ec89eb597ba82 Mon Sep 17 00:00:00 2001
+From: mattip <matti.picus@gmail.com>
+Date: Mon, 25 May 2020 13:28:53 +0300
+Subject: [PATCH 06/13] change test
+
+---
+ Lib/test/test_sysconfig.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Lib/test/test_sysconfig.py b/Lib/test/test_sysconfig.py
+index c3bad2cbb4762..cd53173ab053e 100644
+--- a/Lib/test/test_sysconfig.py
++++ b/Lib/test/test_sysconfig.py
+@@ -390,7 +390,7 @@ def test_SOABI_consistency(self):
+         SOABI = sysconfig.get_config_var('SOABI')
+         pynodot = sysconfig.get_config_var('py_version_nodot')
+         if SOABI is not None:
+-            self.assertTrue(SOABI.split('-')[1] == pynodot)
++            self.assertEqual(SOABI.split('-')[1], pynodot)
+ 
+ class MakefileTests(unittest.TestCase):
+ 
+
+From 4f9b8693b7b81e45297f29ee319f6244299a4bc6 Mon Sep 17 00:00:00 2001
+From: mattip <matti.picus@gmail.com>
+Date: Mon, 25 May 2020 14:36:37 +0300
+Subject: [PATCH 07/13] change test, SOABI has a 'd' after the python version
+
+---
+ Lib/test/test_sysconfig.py | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/Lib/test/test_sysconfig.py b/Lib/test/test_sysconfig.py
+index cd53173ab053e..8e08cdd803c85 100644
+--- a/Lib/test/test_sysconfig.py
++++ b/Lib/test/test_sysconfig.py
+@@ -387,10 +387,11 @@ def test_osx_ext_suffix(self):
+         self.assertTrue(suffix.endswith('-darwin.so'), suffix)
+ 
+     def test_SOABI_consistency(self):
+-        SOABI = sysconfig.get_config_var('SOABI')
++        soabi = sysconfig.get_config_var('SOABI')
+         pynodot = sysconfig.get_config_var('py_version_nodot')
+-        if SOABI is not None:
+-            self.assertEqual(SOABI.split('-')[1], pynodot)
++        if soabi is not None:
++            soabi_pyver = soabi.split('-')[1]
++            self.assertTrue(soabi_pyver.startswith(pynodot))
+ 
+ class MakefileTests(unittest.TestCase):
+ 
+
+From 48ec1e91283829c9b062f172516fe04dcd4cc5e4 Mon Sep 17 00:00:00 2001
+From: mattip <matti.picus@gmail.com>
+Date: Thu, 28 May 2020 08:39:18 +0300
+Subject: [PATCH 08/13] remove '-d' from tr
+
+---
+ configure    | 4 ++--
+ configure.ac | 5 +++--
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/configure b/configure
+index 3b7036cb32f68..fcd30aef73ad8 100755
+--- a/configure
++++ b/configure
+@@ -15295,7 +15295,7 @@ $as_echo_n "checking ABIFLAGS... " >&6; }
+ $as_echo "$ABIFLAGS" >&6; }
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking SOABI" >&5
+ $as_echo_n "checking SOABI... " >&6; }
+-SOABI='cpython-'`echo $VERSION | tr "." "_"`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
++SOABI='cpython-'`echo $VERSION | tr . _`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $SOABI" >&5
+ $as_echo "$SOABI" >&6; }
+ 
+@@ -15303,7 +15303,7 @@ $as_echo "$SOABI" >&6; }
+ if test "$Py_DEBUG" = 'true' -a "$with_trace_refs" != "yes"; then
+   # Similar to SOABI but remove "d" flag from ABIFLAGS
+ 
+-  ALT_SOABI='cpython-'`echo $VERSION | tr -d "." "_"``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
++  ALT_SOABI='cpython-'`echo $VERSION | tr . _``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+ 
+ cat >>confdefs.h <<_ACEOF
+ #define ALT_SOABI "${ALT_SOABI}"
+diff --git a/configure.ac b/configure.ac
+index 9fdc2f69ee82b..8704a5c448849 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -4737,16 +4737,17 @@ AC_SUBST(SOABI)
+ AC_MSG_CHECKING(ABIFLAGS)
+ AC_MSG_RESULT($ABIFLAGS)
+ AC_MSG_CHECKING(SOABI)
+-SOABI='cpython-'`echo $VERSION | tr -d "." "_"`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
++SOABI='cpython-'`echo $VERSION | tr . _`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+ AC_MSG_RESULT($SOABI)
+ 
+ # Release and debug (Py_DEBUG) ABI are compatible, but not Py_TRACE_REFS ABI
+ if test "$Py_DEBUG" = 'true' -a "$with_trace_refs" != "yes"; then
+   # Similar to SOABI but remove "d" flag from ABIFLAGS
+   AC_SUBST(ALT_SOABI)
+-  ALT_SOABI='cpython-'`echo $VERSION | tr -d "." "_"``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
++  ALT_SOABI='cpython-'`echo $VERSION | tr . _``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+   AC_DEFINE_UNQUOTED(ALT_SOABI, "${ALT_SOABI}",
+             [Alternative SOABI used in debug build to load C extensions built in release mode])
++  AC_MSG_RESULT($ALT_SOABI)
+ fi
+ 
+ AC_SUBST(EXT_SUFFIX)
+
+From 5e3760bd784d619812d31d0232d046758c0e3606 Mon Sep 17 00:00:00 2001
+From: mattip <matti.picus@gmail.com>
+Date: Wed, 9 Sep 2020 00:44:45 +0300
+Subject: [PATCH 10/13] dig into windows dll names and install schemes
+
+---
+ Lib/sysconfig.py           |  2 +-
+ PC/pyconfig.h              |  4 ++--
+ 5 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
+index 8452f8fc9351e..dc9b9a5c8269d 100644
+--- a/Lib/sysconfig.py
++++ b/Lib/sysconfig.py
+@@ -545,7 +545,7 @@ def get_config_vars(*args):
+             # sys.abiflags may not be defined on all platforms.
+             _CONFIG_VARS['abiflags'] = ''
+         try:
+-            _CONFIG_VARS['py_version_nodot_plat'] = sys.winver.replace('.', '')
++            _CONFIG_VARS['py_version_nodot_plat'] = sys.winver.replace('.', '_')
+         except AttributeError:
+             _CONFIG_VARS['py_version_nodot_plat'] = ''
+ 
+diff --git a/PC/pyconfig.h b/PC/pyconfig.h
+index b29f63c35bccb..aa1464425b599 100644
+--- a/PC/pyconfig.h
++++ b/PC/pyconfig.h
+@@ -269,11 +269,11 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
+                         file in their Makefile (other compilers are
+                         generally taken care of by distutils.) */
+ #                       if defined(_DEBUG)
+-#                               pragma comment(lib,"python310_d.lib")
++#                               pragma comment(lib,"python3_10_d.lib")
+ #                       elif defined(Py_LIMITED_API)
+ #                               pragma comment(lib,"python3.lib")
+ #                       else
+-#                               pragma comment(lib,"python310.lib")
++#                               pragma comment(lib,"python3_10.lib")
+ #                       endif /* _DEBUG */
+ #               endif /* _MSC_VER */
+ #       endif /* Py_BUILD_CORE */
+
+From b549f0919b6c5c5bf33a56e864ee8b1a1aa0a450 Mon Sep 17 00:00:00 2001
+From: mattip <matti.picus@gmail.com>
+Date: Tue, 13 Oct 2020 09:35:05 +0300
+Subject: [PATCH 13/13] changes from review
+
+---
+ Doc/whatsnew/3.10.rst                       |  2 ++
+ PC/layout/support/constants.py              |  8 ++++----
+ 11 files changed, 36 insertions(+), 28 deletions(-)
+
+diff --git a/Doc/whatsnew/3.10.rst b/Doc/whatsnew/3.10.rst
+index f6f276a8bfa49..e0f4fb69d5a21 100644
+--- a/Doc/whatsnew/3.10.rst
++++ b/Doc/whatsnew/3.10.rst
+@@ -93,6 +93,8 @@ Other Language Changes
+   :meth:`~object.__index__` method).
+   (Contributed by Serhiy Storchaka in :issue:`37999`.)
+ 
++* The ``nodot`` version number has been changed to ``3_10`` for clarity
++  (:issue:`40747`)
+ 
+ New Modules
+ ===========
+diff --git a/PC/layout/support/constants.py b/PC/layout/support/constants.py
+index 6cf0fe1d34c4a..1341d281d7e13 100644
+--- a/PC/layout/support/constants.py
++++ b/PC/layout/support/constants.py
+@@ -32,11 +32,11 @@ def _get_suffix(field4):
+ VER_FIELD3 = VER_MICRO << 8 | VER_FIELD4
+ VER_DOT = "{}.{}".format(VER_MAJOR, VER_MINOR)
+ 
+-PYTHON_DLL_NAME = "python{}{}.dll".format(VER_MAJOR, VER_MINOR)
++PYTHON_DLL_NAME = "python{}_{}.dll".format(VER_MAJOR, VER_MINOR)
+ PYTHON_STABLE_DLL_NAME = "python{}.dll".format(VER_MAJOR)
+-PYTHON_ZIP_NAME = "python{}{}.zip".format(VER_MAJOR, VER_MINOR)
+-PYTHON_PTH_NAME = "python{}{}._pth".format(VER_MAJOR, VER_MINOR)
++PYTHON_ZIP_NAME = "python{}_{}.zip".format(VER_MAJOR, VER_MINOR)
++PYTHON_PTH_NAME = "python{}_{}._pth".format(VER_MAJOR, VER_MINOR)
+ 
+-PYTHON_CHM_NAME = "python{}{}{}{}.chm".format(
++PYTHON_CHM_NAME = "python{}_{}{}{}.chm".format(
+     VER_MAJOR, VER_MINOR, VER_MICRO, VER_SUFFIX
+ )
+

--- a/pkgs/development/interpreters/python/cpython/3.10/no-ldconfig.patch
+++ b/pkgs/development/interpreters/python/cpython/3.10/no-ldconfig.patch
@@ -1,0 +1,100 @@
+From 597e73f2a4b2f0b508127931b36d5540d6941823 Mon Sep 17 00:00:00 2001
+From: Frederik Rietdijk <fridh@fridh.nl>
+Date: Mon, 28 Aug 2017 09:24:06 +0200
+Subject: [PATCH] Don't use ldconfig
+
+---
+ Lib/ctypes/util.py | 70 ++----------------------------------------------------
+ 1 file changed, 2 insertions(+), 68 deletions(-)
+
+diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
+index 5e8b31a854..7b45ce6c15 100644
+--- a/Lib/ctypes/util.py
++++ b/Lib/ctypes/util.py
+@@ -94,46 +94,7 @@ elif os.name == "posix":
+     import re, tempfile
+ 
+     def _findLib_gcc(name):
+-        # Run GCC's linker with the -t (aka --trace) option and examine the
+-        # library name it prints out. The GCC command will fail because we
+-        # haven't supplied a proper program with main(), but that does not
+-        # matter.
+-        expr = os.fsencode(r'[^\(\)\s]*lib%s\.[^\(\)\s]*' % re.escape(name))
+-
+-        c_compiler = shutil.which('gcc')
+-        if not c_compiler:
+-            c_compiler = shutil.which('cc')
+-        if not c_compiler:
+-            # No C compiler available, give up
+-            return None
+-
+-        temp = tempfile.NamedTemporaryFile()
+-        try:
+-            args = [c_compiler, '-Wl,-t', '-o', temp.name, '-l' + name]
+-
+-            env = dict(os.environ)
+-            env['LC_ALL'] = 'C'
+-            env['LANG'] = 'C'
+-            try:
+-                proc = subprocess.Popen(args,
+-                                        stdout=subprocess.PIPE,
+-                                        stderr=subprocess.STDOUT,
+-                                        env=env)
+-            except OSError:  # E.g. bad executable
+-                return None
+-            with proc:
+-                trace = proc.stdout.read()
+-        finally:
+-            try:
+-                temp.close()
+-            except FileNotFoundError:
+-                # Raised if the file was already removed, which is the normal
+-                # behaviour of GCC if linking fails
+-                pass
+-        res = re.search(expr, trace)
+-        if not res:
+-            return None
+-        return os.fsdecode(res.group(0))
++        return None
+ 
+ 
+     if sys.platform == "sunos5":
+@@ -255,34 +216,7 @@ elif os.name == "posix":
+     else:
+ 
+         def _findSoname_ldconfig(name):
+-            import struct
+-            if struct.calcsize('l') == 4:
+-                machine = os.uname().machine + '-32'
+-            else:
+-                machine = os.uname().machine + '-64'
+-            mach_map = {
+-                'x86_64-64': 'libc6,x86-64',
+-                'ppc64-64': 'libc6,64bit',
+-                'sparc64-64': 'libc6,64bit',
+-                's390x-64': 'libc6,64bit',
+-                'ia64-64': 'libc6,IA-64',
+-                }
+-            abi_type = mach_map.get(machine, 'libc6')
+-
+-            # XXX assuming GLIBC's ldconfig (with option -p)
+-            regex = r'\s+(lib%s\.[^\s]+)\s+\(%s'
+-            regex = os.fsencode(regex % (re.escape(name), abi_type))
+-            try:
+-                with subprocess.Popen(['/sbin/ldconfig', '-p'],
+-                                      stdin=subprocess.DEVNULL,
+-                                      stderr=subprocess.DEVNULL,
+-                                      stdout=subprocess.PIPE,
+-                                      env={'LC_ALL': 'C', 'LANG': 'C'}) as p:
+-                    res = re.search(regex, p.stdout.read())
+-                    if res:
+-                        return os.fsdecode(res.group(1))
+-            except OSError:
+-                pass
++            return None
+ 
+         def _findLib_ld(name):
+             # See issue #9998 for why this is needed
+-- 
+2.15.0
+

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -150,6 +150,11 @@ in with passthru; stdenv.mkDerivation {
           sha256 = "1h18lnpx539h5lfxyk379dxwr8m2raigcjixkf133l4xy3f4bzi2";
         }
     )
+  ] ++ optionals isPy310 [
+    # Fix for `py_version_nodot` returning 310 instead of 3_10
+    # This is significant because the python-tag for wheels is determined
+    # through this value, and will produce an incompatible wheel.
+    ./3.10/fix-no-dot-version.patch
   ] ++ [
     # LDSHARED now uses $CC instead of gcc. Fixes cross-compilation of extension modules.
     ./3.8/0001-On-all-posix-systems-not-just-Darwin-set-LDSHARED-if.patch

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -28,6 +28,7 @@ with pkgs;
         isPy37 = pythonVersion == "3.7";
         isPy38 = pythonVersion == "3.8";
         isPy39 = pythonVersion == "3.9";
+        isPy310 = pythonVersion == "3.10";
         isPy2 = lib.strings.substring 0 1 pythonVersion == "2";
         isPy3 = lib.strings.substring 0 1 pythonVersion == "3";
         isPy3k = isPy3;
@@ -111,6 +112,19 @@ in {
       suffix = "";
     };
     sha256 = "0m18z05nlmqm1zjw9s0ifgrn1jvjn3jwjg0bpswhjmw5k4yfcwww";
+    inherit (darwin) configd;
+    inherit passthruFun;
+  };
+
+  python310 = callPackage ./cpython {
+    self = python310;
+    sourceVersion = {
+      major = "3";
+      minor = "10";
+      patch = "0";
+      suffix = "a1";
+    };
+    sha256 = "0q59a99w1yad808mx4w6l0j7bk7dbd2kakngbk0w1h9z4dhr8wyv";
     inherit (darwin) configd;
     inherit passthruFun;
   };

--- a/pkgs/development/python-modules/setuptools/50.3.nix
+++ b/pkgs/development/python-modules/setuptools/50.3.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, wrapPython
+, unzip
+, callPackage
+, bootstrapped-pip
+, lib
+, pipInstallHook
+, setuptoolsBuildHook
+}:
+
+let
+  pname = "setuptools";
+  version = "50.3.0";
+
+  # Create an sdist of setuptools
+  sdist = stdenv.mkDerivation rec {
+    name = "${pname}-${version}-sdist.tar.gz";
+
+    src = fetchFromGitHub {
+      owner = "pypa";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "0vsj6l8s7wrk7ily08fbqkixrig6sd6j86jwhq31hlkmllmmar60";
+      name = "${pname}-${version}-source";
+    };
+
+    buildPhase = ''
+      ${python.pythonForBuild.interpreter} bootstrap.py
+      ${python.pythonForBuild.interpreter} setup.py sdist --formats=gztar
+    '';
+
+    installPhase = ''
+      echo "Moving sdist..."
+      mv dist/*.tar.gz $out
+    '';
+  };
+in buildPythonPackage rec {
+  inherit pname version;
+  # Because of bootstrapping we don't use the setuptoolsBuildHook that comes with format="setuptools" directly.
+  # Instead, we override it to remove setuptools to avoid a circular dependency.
+  # The same is done for pip and the pipInstallHook.
+  format = "other";
+
+  src = sdist;
+
+  nativeBuildInputs = [
+    bootstrapped-pip
+    (pipInstallHook.override{pip=null;})
+    (setuptoolsBuildHook.override{setuptools=null; wheel=null;})
+  ];
+
+  preBuild = lib.strings.optionalString (!stdenv.hostPlatform.isWindows) ''
+    export SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0
+  '';
+
+  pipInstallFlags = [ "--ignore-installed" ];
+
+  # Adds setuptools to nativeBuildInputs causing infinite recursion.
+  catchConflicts = false;
+
+  # Requires pytest, causing infinite recursion.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Utilities to facilitate the installation of Python packages";
+    homepage = "https://pypi.python.org/pypi/setuptools";
+    license = with licenses; [ psfl zpl20 ];
+    platforms = python.meta.platforms;
+    priority = 10;
+  };
+}

--- a/pkgs/development/python-modules/wheel/0.35.nix
+++ b/pkgs/development/python-modules/wheel/0.35.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, bootstrapped-pip
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "wheel";
+  version = "0.35.1";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "pypa";
+    repo = pname;
+    rev = version;
+    sha256 = "1gq405z8bfbxpia1rw7z5z6v4mfvp2c9qi39r0s958nrirmvsbxr";
+    name = "${pname}-${version}-source";
+  };
+
+  nativeBuildInputs = [
+    bootstrapped-pip
+    setuptools
+  ];
+
+  # No tests in archive
+  doCheck = false;
+  pythonImportsCheck = [ "wheel" ];
+
+  # We add this flag to ignore the copy installed by bootstrapped-pip
+  pipInstallFlags = [ "--ignore-installed" ];
+
+  meta = with lib; {
+    homepage = "https://bitbucket.org/pypa/wheel/";
+    description = "A built-package format for Python";
+    longDescription = ''
+      This library is the reference implementation of the Python wheel packaging standard,
+      as defined in PEP 427.
+
+      It has two different roles:
+
+      - A setuptools extension for building wheels that provides the bdist_wheel setuptools command
+      - A command line tool for working with wheel files
+
+      It should be noted that wheel is not intended to be used as a library,
+      and as such there is no stable, public API.
+    '';
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ siriobalmelli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10253,7 +10253,7 @@ in
     pkgs = pkgs.extend (final: _: {
     });
   };
-  inherit (pythonInterpreters) python27 python36 python37 python38 python39 python3Minimal pypy27 pypy36;
+  inherit (pythonInterpreters) python27 python36 python37 python38 python39 python310 python3Minimal pypy27 pypy36;
 
   # Python package sets.
   python27Packages = lib.hiPrioSet (recurseIntoAttrs python27.pkgs);
@@ -10261,6 +10261,7 @@ in
   python37Packages = recurseIntoAttrs python37.pkgs;
   python38Packages = recurseIntoAttrs python38.pkgs;
   python39Packages = python39.pkgs;
+  python310Packages = python310.pkgs;
   pypyPackages = pypy.pkgs;
   pypy2Packages = pypy2.pkgs;
   pypy27Packages = pypy27.pkgs;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7528,7 +7528,10 @@ in {
 
   wget = callPackage ../development/python-modules/wget { };
 
-  wheel = callPackage ../development/python-modules/wheel { };
+  wheel = if isPy310 then
+      callPackage ../development/python-modules/wheel/0.35.nix { }
+    else
+      callPackage ../development/python-modules/wheel { };
 
   whichcraft = callPackage ../development/python-modules/whichcraft { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18,7 +18,7 @@ let
   packages = ( self:
 
 let
-  inherit (python.passthru) isPy27 isPy35 isPy36 isPy37 isPy38 isPy39 isPy3k isPyPy pythonAtLeast pythonOlder;
+  inherit (python.passthru) isPy27 isPy35 isPy36 isPy37 isPy38 isPy39 isPy310 isPy3k isPyPy pythonAtLeast pythonOlder;
 
   callPackage = pkgs.newScope self;
 
@@ -139,6 +139,8 @@ in {
 
   setuptools = if isPy27 then
     callPackage ../development/python-modules/setuptools/44.0.nix { }
+  else if isPy310 then
+    callPackage ../development/python-modules/setuptools/50.3.nix { }
   else
     callPackage ../development/python-modules/setuptools { };
 


### PR DESCRIPTION
###### Motivation for this change
more "controversial" side of #100384

The python packaging toolchain doesn't support 3.10 yet, this is more opinionated changes to the package set

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
