### PR TITLE
xorg.xf86inputlibinput: 0.28.2 -> 0.30.0

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1717,11 +1717,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xf86inputlibinput = callPackage ({ stdenv, pkgconfig, fetchurl, xorgproto, libinput, xorgserver }: stdenv.mkDerivation {
-    name = "xf86-input-libinput-0.28.2";
+    name = "xf86-input-libinput-0.30.0";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/driver/xf86-input-libinput-0.28.2.tar.bz2";
-      sha256 = "0818vr0yhk9j1y1wcbxzcd458vrvp06rrhi8k43bhqkb5jb4dcxq";
+      url = "mirror://xorg/individual/driver/xf86-input-libinput-0.30.0.tar.bz2";
+      sha256 = "1h4np66p87jf0c85ig524w8f5rbhl5gx8fww1qg0c55f87yzkizr";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -83,7 +83,7 @@ mirror://xorg/individual/doc/xorg-sgml-doctools-1.11.tar.bz2
 mirror://xorg/individual/driver/xf86-input-evdev-2.10.6.tar.bz2
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.3.tar.bz2
 mirror://xorg/individual/driver/xf86-input-keyboard-1.9.0.tar.bz2
-mirror://xorg/individual/driver/xf86-input-libinput-0.28.2.tar.bz2
+mirror://xorg/individual/driver/xf86-input-libinput-0.30.0.tar.bz2
 mirror://xorg/individual/driver/xf86-input-mouse-1.9.3.tar.bz2
 mirror://xorg/individual/driver/xf86-input-synaptics-1.9.1.tar.bz2
 mirror://xorg/individual/driver/xf86-input-vmmouse-13.1.0.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2019-August/003017.html
https://lists.x.org/archives/xorg-announce/2020-May/003045.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).