### PR TITLE
[20.03] podman: Add patch for CVE-2020-14370

### DIFF
--- a/pkgs/applications/virtualization/podman/CVE-2020-14370.patch
+++ b/pkgs/applications/virtualization/podman/CVE-2020-14370.patch
@@ -1,0 +1,26 @@
+diff --git a/cmd/podman/shared/create.go b/cmd/podman/shared/create.go
+index 010c80373..562cc047b 100644
+--- a/cmd/podman/shared/create.go
++++ b/cmd/podman/shared/create.go
+@@ -826,15 +826,17 @@ func CreateContainerFromCreateConfig(r *libpod.Runtime, createConfig *cc.CreateC
+ 	return ctr, nil
+ }
+ 
+-var defaultEnvVariables = map[string]string{
+-	"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+-	"TERM": "xterm",
++func defaultEnvVariables() map[string]string {
++  return map[string]string {
++	  "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
++	  "TERM": "xterm",
++  }
+ }
+ 
+ // EnvVariablesFromData gets sets the default environment variables
+ // for containers, and reads the variables from the image data, if present.
+ func EnvVariablesFromData(data *inspect.ImageData) map[string]string {
+-	env := defaultEnvVariables
++	env := defaultEnvVariables()
+ 	if data != nil {
+ 		for _, e := range data.Config.Env {
+ 			split := strings.SplitN(e, "=", 2)

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -14,6 +14,10 @@ buildGoPackage rec {
     sha256 = "1rbapks11xg0vgl9m322mijirx0wm6c4yav8aw2y41wsr7qd7db4";
   };
 
+  patches = [
+    ./CVE-2020-14370.patch
+  ];
+
   goPackagePath = "github.com/containers/libpod";
 
   outputs = [ "bin" "out" "man" ];


### PR DESCRIPTION
###### Motivation for this change

See #99829

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
