### PR TITLE
nixos/xserver: use modern video drivers

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -150,30 +150,10 @@
 <xref linkend="opt-services.xserver.videoDrivers"/> = [ "nvidiaLegacy390" ];
 <xref linkend="opt-services.xserver.videoDrivers"/> = [ "nvidiaLegacy340" ];
 <xref linkend="opt-services.xserver.videoDrivers"/> = [ "nvidiaLegacy304" ];
-<xref linkend="opt-services.xserver.videoDrivers"/> = [ "nvidiaLegacy173" ];
 </programlisting>
    You may need to reboot after enabling this driver to prevent a clash with
    other kernel modules.
   </para>
- </simplesect>
- <simplesect xml:id="sec-x11--graphics-cards-amd">
-  <title>Proprietary AMD drivers</title>
-  <para>
-   AMD provides a proprietary driver for its graphics cards that has better 3D
-   performance than the X.org drivers. It is not enabled by default because
-   it’s not free software. You can enable it as follows:
-<programlisting>
-<xref linkend="opt-services.xserver.videoDrivers"/> = [ "ati_unfree" ];
-</programlisting>
-   You will need to reboot after enabling this driver to prevent a clash with
-   other kernel modules.
-  </para>
-  <note>
-  <para>
-   For recent AMD GPUs you most likely want to keep either the defaults
-   or <literal>"amdgpu"</literal> (both free).
-  </para>
-  </note>
  </simplesect>
  <simplesect xml:id="sec-x11-touchpads">
   <title>Touchpads</title>

--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -335,6 +335,11 @@ http://some.json-exporter.host:7979/probe?target=https://example.com/some/json/e
        official documentation</link> of the json_exporter.
      </para>
    </listitem>
+   <listitem>
+     <para>
+       <xref linkend="opt-services.xserver.videoDrivers" /> no longer uses the <literal>cirrus</literal> and <literal>vesa</literal> device dependent X drivers by default.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -251,11 +251,10 @@ in
 
       videoDrivers = mkOption {
         type = types.listOf types.str;
-        # !!! We'd like "nv" here, but it segfaults the X server.
-        default = [ "radeon" "cirrus" "vesa" "modesetting" ];
+        default = [ "amdgpu" "radeon" "nouveau" "modesetting" "fbdev" ];
         example = [
-          "ati_unfree" "amdgpu" "amdgpu-pro"
-          "nv" "nvidia" "nvidiaLegacy390" "nvidiaLegacy340" "nvidiaLegacy304"
+          "nvidia" "nvidiaLegacy390" "nvidiaLegacy340" "nvidiaLegacy304"
+          "amdgpu-pro"
         ];
         # TODO(@oxij): think how to easily add the rest, like those nvidia things
         relatedPackages = concatLists


### PR DESCRIPTION
###### Motivation for this change
cirrus is obsolete: https://www.vintage3d.org/cirrus.php
nv is obsolete: https://www.phoronix.com/scan.php?page=article&item=nvidia_kills_nv&num=1
vesa is obsolete: https://www.phoronix.com/scan.php?page=news_item&px=Nzc3Nw
ati and ati_unfree are superseded by amdgpu and amdgpu-pro: https://wiki.gentoo.org/wiki/ATI_FAQ#Is_my_AMD.2FATI_board_supported.3F
nouveau and fbdev added for better fallback support.

###### Things done
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).