### PR TITLE
openjdk: add openjdk15

### DIFF
--- a/pkgs/development/compilers/openjdk/14.nix
+++ b/pkgs/development/compilers/openjdk/14.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, bash, pkgconfig, autoconf, cpio, file, which, unzip
 , zip, perl, cups, freetype, alsaLib, libjpeg, giflib, libpng, zlib, lcms2
 , libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama
-, libXcursor, libXrandr, fontconfig, openjdk15-bootstrap
+, libXcursor, libXrandr, fontconfig, openjdk14-bootstrap
 , setJavaClassPath
 , headless ? false
 , enableJavaFX ? openjfx.meta.available, openjfx
@@ -9,8 +9,8 @@
 }:
 
 let
-  major = "15";
-  update = "";
+  major = "14";
+  update = ".0.2";
   build = "-ga";
 
   openjdk = stdenv.mkDerivation rec {
@@ -18,15 +18,15 @@ let
     version = "${major}${update}${build}";
 
     src = fetchurl {
-      url = "https://hg.openjdk.java.net/jdk-updates/jdk${major}u/archive/jdk-${version}.tar.gz";
-      sha256 = "0dh1cx525f15h415vvnybnynnlps2w7yyws9dc7q7vygznw2v45j";
+      url = "http://hg.openjdk.java.net/jdk-updates/jdk${major}u/archive/jdk-${version}.tar.gz";
+      sha256 = "1s1pc6ihzf0awp4hbaqfxmbica0hnrg8nr7s0yd2hfn7nan8xmf3";
     };
 
     nativeBuildInputs = [ pkgconfig autoconf ];
     buildInputs = [
       cpio file which unzip zip perl zlib cups freetype alsaLib libjpeg giflib
       libpng zlib lcms2 libX11 libICE libXrender libXext libXtst libXt libXtst
-      libXi libXinerama libXcursor libXrandr fontconfig openjdk15-bootstrap
+      libXi libXinerama libXcursor libXrandr fontconfig openjdk14-bootstrap
     ] ++ lib.optionals (!headless && enableGnome2) [
       gtk3 gnome_vfs GConf glib
     ];
@@ -54,7 +54,7 @@ let
     '';
 
     configureFlags = [
-      "--with-boot-jdk=${openjdk15-bootstrap.home}"
+      "--with-boot-jdk=${openjdk14-bootstrap.home}"
       "--enable-unlimited-crypto"
       "--with-native-debug-symbols=internal"
       "--with-libjpeg=system"
@@ -138,7 +138,7 @@ let
       done
     '';
 
-    disallowedReferences = [ openjdk15-bootstrap ];
+    disallowedReferences = [ openjdk14-bootstrap ];
 
     meta = with stdenv.lib; {
       homepage = "http://openjdk.java.net/";
@@ -151,7 +151,6 @@ let
     passthru = {
       architecture = "";
       home = "${openjdk}/lib/openjdk";
-      inherit gtk3;
     };
   };
 in openjdk

--- a/pkgs/development/compilers/openjdk/openjfx/15.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/15.nix
@@ -1,0 +1,116 @@
+{ stdenv, lib, fetchFromGitHub, writeText, openjdk11_headless, gradleGen
+, pkgconfig, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsaLib
+, ffmpeg_3, python, ruby }:
+
+let
+  major = "15";
+  update = "9";
+  repover = "${major}+${update}";
+  gradle_ = (gradleGen.override {
+    java = openjdk11_headless;
+  }).gradle_5_6;
+
+  makePackage = args: stdenv.mkDerivation ({
+    version = "${major}+${update}";
+
+    src = fetchFromGitHub {
+      owner = "openjdk";
+      repo = "jfx";
+      rev = repover;
+      sha256 = "1f4pghgw9axqjswz3fh01p1h7wkg6n9vvzyk4ic7xbnqnzxgnnrj";
+    };
+
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsaLib ffmpeg_3 ];
+    nativeBuildInputs = [ gradle_ perl pkgconfig cmake gperf python ruby ];
+
+    dontUseCmakeConfigure = true;
+
+    config = writeText "gradle.properties" (''
+      CONF = Release
+      JDK_HOME = ${openjdk11_headless.home}
+    '' + args.gradleProperties or "");
+
+    #avoids errors about deprecation of GTypeDebugFlags, GTimeVal, etc.
+    NIX_CFLAGS_COMPILE = [ "-DGLIB_DISABLE_DEPRECATION_WARNINGS" ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      export GRADLE_USER_HOME=$(mktemp -d)
+      ln -s $config gradle.properties
+      export NIX_CFLAGS_COMPILE="$(pkg-config --cflags glib-2.0) $NIX_CFLAGS_COMPILE"
+      gradle --no-daemon $gradleFlags sdk
+
+      runHook postBuild
+    '';
+  } // args);
+
+  # Fake build to pre-download deps into fixed-output derivation.
+  # We run nearly full build because I see no other way to download everything that's needed.
+  # Anyone who knows a better way?
+  deps = makePackage {
+    pname = "openjfx-deps";
+
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME -type f -regex '.*/modules.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+      rm -rf $out/tmp
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    # Downloaded AWT jars differ by platform.
+    outputHash = {
+      x86_64-linux = "0hmyr5nnjgwyw3fcwqf0crqg9lny27jfirycg3xmkzbcrwqd6qkw";
+      # The build-time dependencies don't currently build for i686, so no
+      # reason to fetch this one correctly either...
+      i686-linux = "0000000000000000000000000000000000000000000000000000";
+    }.${stdenv.system} or (throw "Unsupported platform");
+  };
+
+in makePackage {
+  pname = "openjfx-modular-sdk";
+
+  gradleProperties = ''
+    COMPILE_MEDIA = true
+    COMPILE_WEBKIT = true
+  '';
+
+  preBuild = ''
+    swtJar="$(find ${deps} -name org.eclipse.swt\*.jar)"
+    substituteInPlace build.gradle \
+      --replace 'mavenCentral()' 'mavenLocal(); maven { url uri("${deps}") }' \
+      --replace 'name: SWT_FILE_NAME' "files('$swtJar')"
+  '';
+
+  installPhase = ''
+    cp -r build/modular-sdk $out
+  '';
+
+  # glib-2.62 deprecations
+  NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS";
+
+  stripDebugList = [ "." ];
+
+  postFixup = ''
+    # Remove references to bootstrap.
+    find "$out" -name \*.so | while read lib; do
+      new_refs="$(patchelf --print-rpath "$lib" | sed -E 's,:?${lib.escape ["+"] openjdk11_headless.outPath}[^:]*,,')"
+      patchelf --set-rpath "$new_refs" "$lib"
+    done
+  '';
+
+  disallowedReferences = [ openjdk11_headless ];
+
+  passthru.deps = deps;
+
+  meta = with stdenv.lib; {
+    homepage = "http://openjdk.java.net/projects/openjfx/";
+    license = licenses.gpl2;
+    description = "The next-generation Java client toolkit.";
+    maintainers = with maintainers; [ abbradar ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9420,6 +9420,8 @@ in
 
   openjfx14 = callPackage ../development/compilers/openjdk/openjfx/14.nix { };
 
+  openjfx15 = callPackage ../development/compilers/openjdk/openjfx/15.nix { };
+
   openjdk8-bootstrap =
     if adoptopenjdk-hotspot-bin-8.meta.available then
       adoptopenjdk-hotspot-bin-8
@@ -9486,15 +9488,16 @@ in
         };
       };
 
+  openjdk15-bootstrap = openjdk14;
+
   jdk11 = openjdk11;
   jdk11_headless = openjdk11_headless;
 
-  /* Latest JDK */
   openjdk14 =
     if stdenv.isDarwin then
       callPackage ../development/compilers/openjdk/darwin { }
     else
-      callPackage ../development/compilers/openjdk {
+      callPackage ../development/compilers/openjdk/14.nix {
         openjfx = openjfx14;
         inherit (gnome2) GConf gnome_vfs;
       };
@@ -9507,6 +9510,16 @@ in
 
   jdk14 = openjdk14;
   jdk14_headless = openjdk14_headless;
+
+  /* Latest JDK */
+  openjdk15 =
+    callPackage ../development/compilers/openjdk {
+      openjfx = openjfx15;
+      inherit (gnome2) GConf gnome_vfs;
+    };
+
+  jdk15 = openjdk15;
+
 
   /* default JDK */
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

To have the latest JDK version available.

Support for darwin (of for 32-bit systems) is not included in this PR, but it seems useful already.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
