### PR TITLE
xtuner: init at 1.0

### DIFF
--- a/pkgs/applications/audio/xtuner/default.nix
+++ b/pkgs/applications/audio/xtuner/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, fetchFromGitHub
+, pkg-config
+, cairo
+, libX11
+, libjack2
+, liblo
+, libsigcxx
+, zita-resampler
+, fftwFloat
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xtuner";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "brummer10";
+    repo = "XTuner";
+    rev = "v${version}";
+    sha256 = "1i5chfnf3hcivwzni9z6cn9pb68qmwsx8bf4z7d29a5vig8kbhrv";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ cairo libX11 libjack2 liblo libsigcxx zita-resampler fftwFloat ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/brummer10/XTuner";
+    description = "Tuner for Jack Audio Connection Kit";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ magnetophon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24581,6 +24581,8 @@ in
 
   xtruss = callPackage ../tools/X11/xtruss { };
 
+  xtuner = callPackage ../applications/audio/xtuner { };
+
   xmacro = callPackage ../tools/X11/xmacro { };
 
   xmenu = callPackage ../applications/misc/xmenu { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
