### PR TITLE
libayatana-appindicator: 0.5.4 -> 0.5.5, generate typelibs for gobject-introspection

### DIFF
--- a/pkgs/development/libraries/ayatana-ido/default.nix
+++ b/pkgs/development/libraries/ayatana-ido/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, pkgconfig, autoreconfHook
+, pkg-config, autoreconfHook
 , gtk3, gobject-introspection, gtk-doc, vala
 }:
 
@@ -14,16 +14,16 @@ stdenv.mkDerivation rec {
     sha256 = "1jmdvvgrgicpnpnygc24qcisqb9y026541gb6lw6fwapvc9aj73p";
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook gtk-doc vala ];
+  nativeBuildInputs = [ pkg-config autoreconfHook gtk-doc vala gobject-introspection ];
 
-  buildInputs = [ gtk3 gobject-introspection ];
+  buildInputs = [ gtk3 ];
 
   meta = with stdenv.lib; {
     description = "Ayatana Display Indicator Objects";
     homepage = "https://github.com/AyatanaIndicators/ayatana-ido";
     changelog = "https://github.com/AyatanaIndicators/ayatana-ido/blob/${version}/ChangeLog";
-    license = [ licenses.gpl3 licenses.lgpl21 ];
+    license = [ licenses.lgpl3Plus licenses.lgpl21Plus ];
     maintainers = [ maintainers.nickhu ];
-    platforms = platforms.x86_64;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libayatana-appindicator/default.nix
+++ b/pkgs/development/libraries/libayatana-appindicator/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, lib
-, pkgconfig, autoreconfHook , gtk-doc
+, pkg-config, autoreconfHook , gtk-doc
+, gobject-introspection
 , gtkVersion ? "3"
 , gtk2, libayatana-indicator-gtk2, libdbusmenu-gtk2
 , gtk3, libayatana-indicator-gtk3, libdbusmenu-gtk3
@@ -8,24 +9,24 @@
 
 stdenv.mkDerivation rec {
   pname = "libayatana-appindicator-gtk${gtkVersion}";
-  version = "0.5.4";
+  version = "0.5.5";
 
   src = fetchFromGitHub {
     owner = "AyatanaIndicators";
     repo = "libayatana-appindicator";
     rev = version;
-    sha256 = "0bqjqb7gabdk7mifk8azi630qw39z978f973fx2ylgdgr4a66j1v";
+    sha256 = "1sba0w455rdkadkhxrx4fr63m0d9blsbb1q1hcshxw1k1z2nh1gk";
   };
 
-  patchPhase = ''
+  prePatch = ''
     substituteInPlace configure.ac \
       --replace "codegendir pygtk-2.0" "codegendir pygobject-2.0"
   '';
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook gtk-doc ];
+  nativeBuildInputs = [ pkg-config autoreconfHook gtk-doc gobject-introspection python2 python2Packages.pygtk dbus-glib ];
 
-  buildInputs = [ dbus-glib python2 python2Packages.pygtk ]
-    ++ lib.lists.optional (gtkVersion == "2") libayatana-indicator-gtk2
+  buildInputs =
+    lib.lists.optional (gtkVersion == "2") libayatana-indicator-gtk2
     ++ lib.lists.optional (gtkVersion == "3") libayatana-indicator-gtk3;
 
   propagatedBuildInputs =
@@ -42,8 +43,8 @@ stdenv.mkDerivation rec {
     description = "Ayatana Application Indicators Shared Library";
     homepage = "https://github.com/AyatanaIndicators/libayatana-appindicator";
     changelog = "https://github.com/AyatanaIndicators/libayatana-appindicator/blob/${version}/ChangeLog";
-    license = [ licenses.gpl3 licenses.lgpl21 ];
+    license = [ licenses.lgpl3Plus licenses.lgpl21Plus ];
     maintainers = [ maintainers.nickhu ];
-    platforms = platforms.x86_64;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libayatana-indicator/default.nix
+++ b/pkgs/development/libraries/libayatana-indicator/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, lib
-, pkgconfig, autoreconfHook
+, pkg-config, autoreconfHook
 , gtkVersion ? "3"
 , gtk2
 , gtk3
@@ -8,16 +8,16 @@
 
 stdenv.mkDerivation rec {
   pname = "libayatana-indicator-gtk${gtkVersion}";
-  version = "0.6.3";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "AyatanaIndicators";
     repo = "libayatana-indicator";
     rev = version;
-    sha256 = "1q9wmaw6pckwyrv0s7wkqzm1yrk031pbz4xbr8cwn75ixqyfcb28";
+    sha256 = "1wlqm3pj12vgz587a72widbg0vcmm1klsd2lh3mpzfy20m3vjxhj";
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
 
   buildInputs = [ ayatana-ido ]
     ++ lib.lists.optionals (gtkVersion == "2") [ gtk2 ]
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
     description = "Ayatana Indicators Shared Library";
     homepage = "https://github.com/AyatanaIndicators/libayatana-indicator";
     changelog = "https://github.com/AyatanaIndicators/libayatana-indicator/blob/${version}/ChangeLog";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = [ maintainers.nickhu ];
-    platforms = platforms.x86_64;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This change makes it so that lines like

```python
from gi.repository import AyatanaAppIndicator3
```

in Python code works, by making sure the typelib is generated (see
https://github.com/AyatanaIndicators/libayatana-appindicator/blob/master/configure.ac#L80).

I also bumped the versions, and fixed some metadata that was incorrect.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).