### PR TITLE
pasystray: ayatana appindicators instead of libappindicator

### DIFF
--- a/pkgs/tools/audio/pasystray/default.nix
+++ b/pkgs/tools/audio/pasystray/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, wrapGAppsHook
-, gnome3, avahi, gtk3, libappindicator-gtk3, libnotify, libpulseaudio
+{ stdenv, fetchpatch, fetchFromGitHub, pkgconfig, autoreconfHook, wrapGAppsHook
+, gnome3, avahi, gtk3, libayatana-appindicator-gtk3, libnotify, libpulseaudio
 , xlibsWrapper, gsettings-desktop-schemas
 }:
 
@@ -17,12 +17,18 @@ stdenv.mkDerivation rec {
   patches = [
     # https://github.com/christophgysin/pasystray/issues/90#issuecomment-306190701
     ./fix-wayland.patch
+
+    # https://github.com/christophgysin/pasystray/issues/98
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/p/pasystray/0.7.1-1/debian/patches/0001-Build-against-ayatana-appindicator.patch";
+      sha256 = "0hijphrf52n2zfwdnrmxlp3a7iwznnkb79awvpzplz0ia2lqywpw";
+    })
   ];
 
   nativeBuildInputs = [ pkgconfig autoreconfHook wrapGAppsHook ];
   buildInputs = [
     gnome3.adwaita-icon-theme
-    avahi gtk3 libappindicator-gtk3 libnotify libpulseaudio xlibsWrapper
+    avahi gtk3 libayatana-appindicator-gtk3 libnotify libpulseaudio xlibsWrapper
     gsettings-desktop-schemas
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Applies the debian patch to build against libayatana-appindicator-gtk3
instead of libappindicator-gtk3 (deprecated)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).