### PR TITLE
biber: add patch for upstream bug 329

### DIFF
--- a/pkgs/tools/typesetting/biber/default.nix
+++ b/pkgs/tools/typesetting/biber/default.nix
@@ -10,6 +10,14 @@ perlPackages.buildPerlModule {
 
   src = "${biberSource}/source/bibtex/biber/biblatex-biber.tar.gz";
 
+  patches = [
+    # Fix for https://github.com/plk/biber/issues/329
+    (fetchpatch {
+      url = "https://github.com/plk/biber/commit/fa312ce402fe581ba7cc0890c83a1d47c2610e26.diff";
+      sha256 = "1j87mdwvx368z9b5x6b72s753hwvrldf2pb42p6hflq5hzkicy50";
+    })
+  ];
+
   buildInputs = with perlPackages; [
     autovivification BusinessISBN BusinessISMN BusinessISSN ConfigAutoConf
     DataCompare DataDump DateSimple EncodeEUCJPASCII EncodeHanExtra EncodeJIS2K


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes issue reported by @gebner in https://github.com/NixOS/nixpkgs/pull/100121#issuecomment-707640929

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
