### PR TITLE
[20.09] python3Packages.perfplot: 0.5.0 -> 0.8.4, fix build by packaging new dependencies

### DIFF
--- a/pkgs/development/python-modules/dufte/default.nix
+++ b/pkgs/development/python-modules/dufte/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, pythonOlder
+, importlib-metadata
+, matplotlib
+, numpy
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "dufte";
+  version = "0.2.9";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0nkaczipbsm8c14j9svxry2wigmn5iharibb6b8g062sjaph8x17";
+  };
+  format = "pyproject";
+
+  propagatedBuildInputs = [
+    matplotlib
+    numpy
+  ] ++ stdenv.lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+    mkdir -p $HOME/.matplotlib
+    echo "backend: ps" > $HOME/.matplotlib/matplotlibrc
+  '';
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "dufte" ];
+
+  meta = with stdenv.lib; {
+    description = "Clean matplotlib plots";
+    homepage = "https://github.com/nschloe/dufte";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/development/python-modules/perfplot/default.nix
+++ b/pkgs/development/python-modules/perfplot/default.nix
@@ -1,30 +1,35 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, dufte
 , matplotlib
 , numpy
 , pipdate
 , tqdm
+, rich
 , pytest
 , isPy27
 }:
 
 buildPythonPackage rec {
   pname = "perfplot";
-  version = "0.5.0";
+  version = "0.8.4";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "nschloe";
     repo = "perfplot";
     rev = "v${version}";
-    sha256 = "16aj5ryjic1k3qn8xhpw6crczvxcs691vs5kv4pvb1zdx69g1xbv";
+    sha256 = "0avb0inx8qh8ss3j460v3z6mmn863hswa3bl19vkh475ndsjwmp0";
   };
+  format = "pyproject";
 
   propagatedBuildInputs = [
+    dufte
     matplotlib
     numpy
     pipdate
+    rich
     tqdm
   ];
 
@@ -33,7 +38,10 @@ buildPythonPackage rec {
   ];
 
   checkPhase = ''
-   HOME=$(mktemp -d) pytest test/perfplot_test.py
+    export HOME=$TMPDIR
+    mkdir -p $HOME/.matplotlib
+    echo "backend: ps" > $HOME/.matplotlib/matplotlibrc
+    pytest test/perfplot_test.py
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/rich/default.nix
+++ b/pkgs/development/python-modules/rich/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, CommonMark
+, colorama
+, dataclasses
+, ipywidgets
+, poetry
+, pygments
+, typing-extensions
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "rich";
+  version = "8.0.0";
+
+  # tests not included in pypi tarball
+  src = fetchFromGitHub {
+    owner = "willmcgugan";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0hv27b22x7dbx1i7nzsd8y8fymmvdak2hcx9242jwk4c1a7jr151";
+  };
+  format = "pyproject";
+
+  nativeBuildInputs = [ poetry ];
+  propagatedBuildInputs = [
+    CommonMark
+    colorama
+    ipywidgets
+    pygments
+    typing-extensions
+  ] ++ stdenv.lib.optional (pythonOlder "3.7") dataclasses;
+
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "rich" ];
+
+  meta = with stdenv.lib; {
+    description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal";
+    homepage = "https://github.com/willmcgugan/rich";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6111,6 +6111,8 @@ in {
 
   rhpl = disabledIf isPy3k (callPackage ../development/python-modules/rhpl { });
 
+  rich = callPackage ../development/python-modules/rich { };
+
   rig = callPackage ../development/python-modules/rig { };
 
   ripser = callPackage ../development/python-modules/ripser { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1785,6 +1785,8 @@ in {
 
   duecredit = callPackage ../development/python-modules/duecredit { };
 
+  dufte = callPackage ../development/python-modules/dufte { };
+
   dugong = callPackage ../development/python-modules/dugong { };
 
   dulwich = if isPy3k then


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of  #100168

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
