### PR TITLE
nixos/containers: allow containers with long names to create private networks

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -72,6 +72,7 @@ in
   containers-imperative = handleTest ./containers-imperative.nix {};
   containers-ip = handleTest ./containers-ip.nix {};
   containers-macvlans = handleTest ./containers-macvlans.nix {};
+  containers-names = handleTest ./containers-names.nix {};
   containers-physical_interfaces = handleTest ./containers-physical_interfaces.nix {};
   containers-portforward = handleTest ./containers-portforward.nix {};
   containers-reloadable = handleTest ./containers-reloadable.nix {};

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -1,5 +1,3 @@
-# Test for NixOS' container support.
-
 let
   hostIp = "192.168.0.1";
   containerIp = "192.168.0.100/24";
@@ -7,10 +5,10 @@ let
   containerIp6 = "fc00::2/7";
 in
 
-import ./make-test-python.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "containers-bridge";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ aristid aszlig eelco kampfschlaefer ];
+  meta = {
+    maintainers = with lib.maintainers; [ aristid aszlig eelco kampfschlaefer ];
   };
 
   machine =

--- a/nixos/tests/containers-custom-pkgs.nix
+++ b/nixos/tests/containers-custom-pkgs.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ pkgs, lib, ...} : let
+import ./make-test-python.nix ({ pkgs, lib, ... }: let
 
   customPkgs = pkgs.appendOverlays [ (self: super: {
     hello = super.hello.overrideAttrs (old: {
@@ -8,8 +8,8 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : let
 
 in {
   name = "containers-custom-pkgs";
-  meta = with lib.maintainers; {
-    maintainers = [ adisbladis earvstedt ];
+  meta = {
+    maintainers = with lib.maintainers; [ adisbladis earvstedt ];
   };
 
   machine = { config, ... }: {

--- a/nixos/tests/containers-ephemeral.nix
+++ b/nixos/tests/containers-ephemeral.nix
@@ -1,7 +1,8 @@
-# Test for NixOS' container support.
-
-import ./make-test-python.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "containers-ephemeral";
+  meta = {
+    maintainers = with lib.maintainers; [ patryk27 ];
+  };
 
   machine = { pkgs, ... }: {
     virtualisation.memorySize = 768;

--- a/nixos/tests/containers-extra_veth.nix
+++ b/nixos/tests/containers-extra_veth.nix
@@ -1,9 +1,7 @@
-# Test for NixOS' container support.
-
-import ./make-test-python.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "containers-extra_veth";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ kampfschlaefer ];
+  meta = {
+    maintainers = with lib.maintainers; [ kampfschlaefer ];
   };
 
   machine =

--- a/nixos/tests/containers-hosts.nix
+++ b/nixos/tests/containers-hosts.nix
@@ -1,9 +1,7 @@
-# Test for NixOS' container support.
-
-import ./make-test-python.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "containers-hosts";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ montag451 ];
+  meta = {
+    maintainers = with lib.maintainers; [ montag451 ];
   };
 
   machine =

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -1,9 +1,7 @@
-# Test for NixOS' container support.
-
-import ./make-test-python.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "containers-imperative";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ aristid aszlig eelco kampfschlaefer ];
+  meta = {
+    maintainers = with lib.maintainers; [ aristid aszlig eelco kampfschlaefer ];
   };
 
   machine =

--- a/nixos/tests/containers-ip.nix
+++ b/nixos/tests/containers-ip.nix
@@ -1,5 +1,3 @@
-# Test for NixOS' container support.
-
 let
   webserverFor = hostAddress: localAddress: {
     inherit hostAddress localAddress;
@@ -13,10 +11,10 @@ let
     };
   };
 
-in import ./make-test-python.nix ({ pkgs, ...} : {
+in import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "containers-ipv4-ipv6";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ aristid aszlig eelco kampfschlaefer ];
+  meta = {
+    maintainers = with lib.maintainers; [ aristid aszlig eelco kampfschlaefer ];
   };
 
   machine =

--- a/nixos/tests/containers-macvlans.nix
+++ b/nixos/tests/containers-macvlans.nix
@@ -1,15 +1,13 @@
-# Test for NixOS' container support.
-
 let
   # containers IP on VLAN 1
   containerIp1 = "192.168.1.253";
   containerIp2 = "192.168.1.254";
 in
 
-import ./make-test-python.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "containers-macvlans";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ montag451 ];
+  meta = {
+    maintainers = with lib.maintainers; [ montag451 ];
   };
 
   nodes = {

--- a/nixos/tests/containers-names.nix
+++ b/nixos/tests/containers-names.nix
@@ -1,0 +1,37 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "containers-names";
+  meta = {
+    maintainers = with lib.maintainers; [ patryk27 ];
+  };
+
+  machine = { ... }: {
+    # We're using the newest kernel, so that we can test containers with long names.
+    # Please see https://github.com/NixOS/nixpkgs/issues/38509 for details.
+    boot.kernelPackages = pkgs.linuxPackages_latest;
+
+    containers = let
+      container = subnet: {
+        autoStart = true;
+        privateNetwork = true;
+        hostAddress = "192.168.${subnet}.1";
+        localAddress = "192.168.${subnet}.2";
+        config = { };
+      };
+
+     in {
+      first = container "1";
+      second = container "2";
+      really-long-name = container "3";
+      really-long-long-name-2 = container "4";
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("default.target")
+
+    machine.succeed("ip link show | grep ve-first")
+    machine.succeed("ip link show | grep ve-second")
+    machine.succeed("ip link show | grep ve-really-lFYWO")
+    machine.succeed("ip link show | grep ve-really-l3QgY")
+  '';
+})

--- a/nixos/tests/containers-physical_interfaces.nix
+++ b/nixos/tests/containers-physical_interfaces.nix
@@ -1,8 +1,7 @@
-
-import ./make-test-python.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "containers-physical_interfaces";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ kampfschlaefer ];
+  meta = {
+    maintainers = with lib.maintainers; [ kampfschlaefer ];
   };
 
   nodes = {

--- a/nixos/tests/containers-portforward.nix
+++ b/nixos/tests/containers-portforward.nix
@@ -1,5 +1,3 @@
-# Test for NixOS' container support.
-
 let
   hostIp = "192.168.0.1";
   hostPort = 10080;
@@ -7,10 +5,10 @@ let
   containerPort = 80;
 in
 
-import ./make-test-python.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "containers-portforward";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ aristid aszlig eelco kampfschlaefer ianwookim ];
+  meta = {
+    maintainers = with lib.maintainers; [ aristid aszlig eelco kampfschlaefer ianwookim ];
   };
 
   machine =

--- a/nixos/tests/containers-reloadable.nix
+++ b/nixos/tests/containers-reloadable.nix
@@ -1,7 +1,6 @@
-import ./make-test-python.nix ({ pkgs, lib, ...} :
+import ./make-test-python.nix ({ pkgs, lib, ... }:
 let
   client_base = {
-
     containers.test1 = {
       autoStart = true;
       config = {
@@ -16,8 +15,8 @@ let
   };
 in {
   name = "containers-reloadable";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ danbst ];
+  meta = {
+    maintainers = with lib.maintainers; [ danbst ];
   };
 
   nodes = {

--- a/nixos/tests/containers-restart_networking.nix
+++ b/nixos/tests/containers-restart_networking.nix
@@ -1,5 +1,3 @@
-# Test for NixOS' container support.
-
 let
   client_base = {
     networking.firewall.enable = false;
@@ -16,11 +14,11 @@ let
       };
     };
   };
-in import ./make-test-python.nix ({ pkgs, ...} :
+in import ./make-test-python.nix ({ pkgs, lib, ... }:
 {
   name = "containers-restart_networking";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ kampfschlaefer ];
+  meta = {
+    maintainers = with lib.maintainers; [ kampfschlaefer ];
   };
 
   nodes = {

--- a/nixos/tests/containers-tmpfs.nix
+++ b/nixos/tests/containers-tmpfs.nix
@@ -1,9 +1,7 @@
-# Test for NixOS' container support.
-
-import ./make-test-python.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "containers-tmpfs";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ ];
+  meta = {
+    maintainers = with lib.maintainers; [ patryk27 ];
   };
 
   machine =


### PR DESCRIPTION
###### Motivation for this change

Launching a container with a private network requires creating a
dedicated networking interface for it; name of that interface is derived
from the container name itself - e.g. a container named `foo` gets
attached to an interface named `ve-foo`.

An interface name can span up to IFNAMSIZ characters, which means that a
container name must contain at most IFNAMSIZ - 3 - 1 = 11 characters;
it's a limit that we validate using a build-time assertion.

This limit has been upgraded with Linux 5.8, as it allows for an
interface to contain a so-called altname, which can be much longer,
while remaining treated as a first-class citizen.

Since altnames have been supported natively by systemd for a while now,
due diligence on our side ends with dropping the name-assertion on newer
kernels.

This merge request closes #38509.

systemd/systemd#14467
systemd/systemd#17220
https://lwn.net/Articles/794289/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
