### PR TITLE
brotli: 1.0.7 -> 1.0.9

### DIFF
--- a/pkgs/tools/compression/brotli/default.nix
+++ b/pkgs/tools/compression/brotli/default.nix
@@ -32,11 +32,11 @@ stdenv.mkDerivation rec {
 
   # This breaks on Darwin because our cmake hook tries to make a build folder
   # and the wonderful bazel BUILD file is already there (yay case-insensitivity?)
-  prePatch = "rm BUILD"
-    # Upstream fixed this reference to runtime-path after the release
-    # and with this references g++ complains about invalid option -R
-    + ''
+  prePatch = ''
+      rm BUILD
 
+      # Upstream fixed this reference to runtime-path after the release
+      # and with this references g++ complains about invalid option -R
       sed -i 's/ -R''${libdir}//' scripts/libbrotli*.pc.in
       cat scripts/libbrotli*.pc.in
     '';

--- a/pkgs/tools/compression/brotli/default.nix
+++ b/pkgs/tools/compression/brotli/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "brotli";
-  version = "1.0.7";
+  version = "1.0.9";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "brotli";
     rev = "v" + version;
-    sha256 = "1811b55wdfg4kbsjcgh1kc938g118jpvif97ilgrmbls25dfpvvw";
+    sha256 = "z6Dhrabav1MDQ4rAcXaDv0aN+qOoh9cvoXZqEWBB13c=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -32,7 +32,14 @@ stdenv.mkDerivation rec {
 
   # This breaks on Darwin because our cmake hook tries to make a build folder
   # and the wonderful bazel BUILD file is already there (yay case-insensitivity?)
-  prePatch = "rm BUILD";
+  prePatch = "rm BUILD"
+    # Upstream fixed this reference to runtime-path after the release
+    # and with this references g++ complains about invalid option -R
+    + ''
+
+      sed -i 's/ -R''${libdir}//' scripts/libbrotli*.pc.in
+      cat scripts/libbrotli*.pc.in
+    '';
 
   # Don't bother with "man" output for now,
   # it currently only makes the manpages hard to use.


### PR DESCRIPTION
(cherry picked from commit 9d5a3f2e33ee28b2e32b3bdc41930d8725c2edee)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream upgrade containing fix for a CVE:

 * https://nvd.nist.gov/vuln/detail/CVE-2020-8927

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
