### PR TITLE
Add basic phpmyadmin implementation

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5861,6 +5861,16 @@
     githubId = 754512;
     name = "Mogria";
   };
+  mohe2015 = {
+    name = "Moritz Hedtke";
+    email = "Moritz.Hedtke@t-online.de";
+    github = "mohe2015";
+    githubId = 13287984;
+    keys = [{
+      longkeyid = "rsa4096/0x6794D45A488C2EDE";
+      fingerprint = "1248 D3E1 1D11 4A85 75C9  8934 6794 D45A 488C 2EDE";
+    }];
+  };
   monsieurp = {
     email = "monsieurp@gentoo.org";
     github = "monsieurp";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -873,6 +873,7 @@
   ./services/web-apps/nextcloud.nix
   ./services/web-apps/nexus.nix
   ./services/web-apps/pgpkeyserver-lite.nix
+  ./services/web-apps/phpmyadmin.nix
   ./services/web-apps/matomo.nix
   ./services/web-apps/moinmoin.nix
   ./services/web-apps/restya-board.nix

--- a/nixos/modules/services/web-apps/phpmyadmin.nix
+++ b/nixos/modules/services/web-apps/phpmyadmin.nix
@@ -1,0 +1,170 @@
+{ config, lib, pkgs, ... }:
+
+# heavily inspired by nixos/modules/services/web-apps/wordpress.nix
+
+let
+  inherit (lib) mkDefault mkEnableOption mkForce mkIf mkMerge mkOption types;
+  inherit (lib) any attrValues concatMapStringsSep flatten literalExample;
+  inherit (lib) mapAttrs mapAttrs' mapAttrsToList nameValuePair optional optionalAttrs optionalString;
+
+  eachInstance = config.services.phpmyadmin;
+  user = "phpmyadmin";
+  group = config.services.httpd.group;
+  stateDir = hostName: "/var/lib/phpmyadmin/${hostName}";
+
+  phpmyadminConfig = hostName: cfg: pkgs.writeText "config.inc-${hostName}.php" ''
+    <?php
+      require_once('${stateDir hostName}/blowfish_secret.php');
+
+      $cfg['TempDir'] = '/tmp';
+
+      ${cfg.extraConfig}
+    ?>
+  '';
+
+  secretsScript = hostStateDir: ''
+    if ! test -e "${hostStateDir}/blowfish_secret.php"; then
+      umask 0177
+      echo "<?php" >> "${hostStateDir}/blowfish_secret.php"
+      echo "\$cfg['blowfish_secret'] = '`tr -dc a-zA-Z0-9 </dev/urandom | head -c 64`';" >> "${hostStateDir}/blowfish_secret.php"
+      echo "?>" >> "${hostStateDir}/blowfish_secret.php"
+      chmod 440 "${hostStateDir}/blowfish_secret.php"
+    fi
+  '';
+
+  instanceOpts = { lib, name, ... }:
+    {
+      options = {
+        package = mkOption {
+          default = pkgs.phpmyadmin;
+          type = types.package;
+          description = "
+            phpmyadmin package to use.
+          ";
+        };
+
+        virtualHost = mkOption {
+          type = types.submodule (import ../web-servers/apache-httpd/vhost-options.nix);
+          example = literalExample ''
+            {
+              hostName = "www.example.org";
+              adminAddr = "webmaster@example.org";
+              forceSSL = true;
+              enableACME = true;
+            }
+          '';
+          description = ''
+            Apache configuration can be done by adapting <option>services.httpd.virtualHosts</option>.
+          '';
+        };
+
+        poolConfig = mkOption {
+          type = with types; attrsOf (oneOf [ str int bool ]);
+          default = {
+            "pm" = "dynamic";
+            "pm.max_children" = 5;
+            "pm.start_servers" = 1;
+            "pm.min_spare_servers" = 1;
+            "pm.max_spare_servers" = 2;
+            "pm.max_requests" = 500;
+          };
+          description = ''
+            Options for the phpmyadmin PHP pool. See the documentation on <literal>php-fpm.conf</literal>
+            for details on configuration directives.
+          '';
+        };
+
+        extraConfig = mkOption {
+          type = types.lines;
+          default = "";
+          description = ''
+            Any additional text to be appended to the config.inc.php
+            configuration file. This is a PHP script. For configuration
+            settings, see <link xlink:href='https://docs.phpmyadmin.net/en/latest/config.html'/>.
+          '';
+        };
+
+        extraHttpdConfig = mkOption {
+          type = types.lines;
+          default = "";
+          example = literalExample ''
+            AuthType Basic
+            AuthName "Restricted Content"
+            AuthUserFile /etc/nixos/.htpasswd
+            Require valid-user
+          '';
+          description = "Any additional text to be appended to the httpd directory config.";
+        };
+      };
+
+      config.virtualHost.hostName = mkDefault name;
+    };
+in
+{
+  # interface
+  options = {
+    services.phpmyadmin = mkOption {
+      type = types.attrsOf (types.submodule instanceOpts);
+      default = {};
+      description = "Specification of one or more phpmyadmin instances to serve via Apache. You still need to create a mysql user with a password to access the database using the web-interface.";
+    };
+  };
+
+  # implementation
+  config = mkIf (eachInstance != {}) {
+
+    services.phpfpm.pools = mapAttrs' (hostName: cfg: (
+      nameValuePair "phpmyadmin-${hostName}" {
+        inherit user group;
+        phpEnv.PHPMYADMIN_CONFIG = "${phpmyadminConfig hostName cfg}";
+        settings = {
+          "listen.owner" = config.services.httpd.user;
+          "listen.group" = config.services.httpd.group;
+        } // cfg.poolConfig;
+      }
+    )) eachInstance;
+
+    services.httpd = {
+      enable = true;
+      extraModules = [ "proxy_fcgi" ];
+      virtualHosts = mapAttrs (hostName: cfg: mkMerge [ cfg.virtualHost {
+        documentRoot = mkForce "${cfg.package}";
+        extraConfig = ''
+            <Directory "${cfg.package}">
+              <FilesMatch "\.php$">
+                <If "-f %{REQUEST_FILENAME}">
+                  SetHandler "proxy:unix:${config.services.phpfpm.pools."phpmyadmin-${hostName}".socket}|fcgi://localhost/"
+                </If>
+              </FilesMatch>
+              DirectoryIndex index.php
+              ${cfg.extraHttpdConfig}
+            </Directory>
+        '';
+      } ]) eachInstance;
+    };
+
+    systemd.tmpfiles.rules = flatten (mapAttrsToList (hostName: cfg: [
+      "d '${stateDir hostName}' 0750 ${user} ${group} - -"
+    ]) eachInstance);
+
+    systemd.services = mkMerge [
+      (mapAttrs' (hostName: cfg: (
+        nameValuePair "phpmyadmin-init-${hostName}" {
+          wantedBy = [ "multi-user.target" ];
+          before = [ "phpfpm-phpmyadmin-${hostName}.service" ];
+          script = secretsScript (stateDir hostName);
+
+          serviceConfig = {
+            Type = "oneshot";
+            User = user;
+            Group = group;
+          };
+      })) eachInstance)
+    ];
+
+    users.users.${user} = {
+      group = group;
+      isSystemUser = true;
+    };
+  };
+}

--- a/pkgs/servers/web-apps/phpmyadmin/default.nix
+++ b/pkgs/servers/web-apps/phpmyadmin/default.nix
@@ -1,0 +1,38 @@
+{ pkgs, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "phpmyadmin";
+  version = "5.0.4";
+
+  src = fetchurl {
+    url = "https://files.phpmyadmin.net/phpMyAdmin/${version}/phpMyAdmin-${version}-all-languages.tar.gz";
+    sha256 = "+7mTt0p8Kc4vzba2viKwtsWL/43zKSq0L2KAhxRQwxY=";
+  };
+
+  phpConfig = pkgs.writeText "config.php" ''
+  <?php
+    return require(getenv('PHPMYADMIN_CONFIG'));
+  ?>
+  '';
+
+  phases = [
+    "unpackPhase"
+    "installPhase"
+  ];
+
+  installPhase =
+  ''
+    mkdir -p $out
+    cp -r * $out/
+
+    cp ${phpConfig} $out/config.inc.php
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A web interface for MySQL and MariaDB";
+    license = licenses.gpl2Only;
+    homepage = "https://www.phpmyadmin.net/";
+    maintainers = with maintainers; [mohe2015];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27562,6 +27562,8 @@ in
 
   pgfplots = callPackage ../tools/typesetting/tex/pgfplots { };
 
+  phpmyadmin = callPackage ../servers/web-apps/phpmyadmin { };
+
   physlock = callPackage ../misc/screensavers/physlock { };
 
   pjsip = callPackage ../applications/networking/pjsip {


### PR DESCRIPTION
###### Motivation for this change
phpmyadmin is useful to quickly do database changes or backups / recoveries.

###### Things done
Added phpmyadmin package.
Added phpmyadmin module.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
