### PR TITLE
ultralist: rename from todolist, update

### DIFF
--- a/pkgs/applications/misc/ultralist/default.nix
+++ b/pkgs/applications/misc/ultralist/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "ultralist";
-  version = "v0.8.1";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "ultralist";
     repo = "ultralist";
     rev = version;
-    sha256 = "0dazfymby5xm4482p9cyj23djmkz5q7g79cqm2d85mczvz7vks8p";
+    sha256 = "09kgf83jn5k35lyrnyzbsy0l1livzmy292qmlbx5dkdpaq5wxnmp";
   };
 
   vendorSha256 = null;

--- a/pkgs/applications/misc/ultralist/default.nix
+++ b/pkgs/applications/misc/ultralist/default.nix
@@ -1,21 +1,21 @@
-{ lib, stdenv, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
-  pname = "todolist";
+buildGoModule rec {
+  pname = "ultralist";
   version = "v0.8.1";
 
-  goPackagePath = "github.com/gammons/todolist";
-
   src = fetchFromGitHub {
-    owner = "gammons";
-    repo = "todolist";
+    owner = "ultralist";
+    repo = "ultralist";
     rev = version;
     sha256 = "0dazfymby5xm4482p9cyj23djmkz5q7g79cqm2d85mczvz7vks8p";
   };
 
+  vendorSha256 = null;
+
   meta = with lib; {
     description = "Simple GTD-style todo list for the command line";
-    homepage = "http://todolist.site";
+    homepage = "https://ultralist.io";
     license = licenses.mit;
     maintainers = with maintainers; [ uvnikita ];
   };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -794,6 +794,8 @@ mapAliases ({
 
   gcc-snapshot = throw "gcc-snapshot: Marked as broken for >2 years, additionally this 'snapshot' pointed to a fairly old one from gcc7.";
 
+  todolist = throw "todolist is now ultralist."; # added 2020-12-27
+
   /* Cleanup before 21.03 */
   riot-desktop = throw "riot-desktop is now element-desktop!";
   riot-web = throw "riot-web is now element-web";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12456,8 +12456,6 @@ in
 
   todoist-electron = callPackage ../applications/misc/todoist-electron { };
 
-  todolist = callPackage ../applications/misc/todolist { };
-
   travis = callPackage ../development/tools/misc/travis { };
 
   tree-sitter = callPackage ../development/tools/parsing/tree-sitter {
@@ -20574,6 +20572,8 @@ in
 
 
   ultimate-oldschool-pc-font-pack = callPackage ../data/fonts/ultimate-oldschool-pc-font-pack { };
+
+  ultralist = callPackage ../applications/misc/ultralist { };
 
   undefined-medium = callPackage ../data/fonts/undefined-medium { };
 


### PR DESCRIPTION
###### Motivation for this change
todolist package was renamed to ultralist.
Here is announcement: ultralist/ultralist#136.

Also updated package to the latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
