### PR TITLE
rep: init at 0.2.1

### DIFF
--- a/pkgs/development/tools/rep/default.nix
+++ b/pkgs/development/tools/rep/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, asciidoc-full }:
+
+stdenv.mkDerivation rec {
+  pname = "rep";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "eraserhd";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1p0dbaj7f4irzzw1m44x3b3j3jjij9i4rs83wkrpiamlq61077di";
+  };
+
+  nativeBuildInputs = [
+    asciidoc-full
+  ];
+
+  postPatch = ''
+    substituteInPlace rc/rep.kak --replace '$(rep' '$('"$out/bin/rep"
+  '';
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Single-shot nREPL client";
+    homepage = "https://github.com/eraserhd/rep";
+    license = licenses.epl10;
+    platforms = platforms.all;
+    maintainers = [ maintainers.eraserhd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6609,6 +6609,8 @@ in
 
   redsocks = callPackage ../tools/networking/redsocks { };
 
+  rep = callPackage ../development/tools/rep { };
+
   reredirect = callPackage ../tools/misc/reredirect { };
 
   retext = libsForQt5.callPackage ../applications/editors/retext { };


### PR DESCRIPTION
###### Motivation for this change

New package

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).