### PR TITLE
trigger: 0.6.6 -> 0.6.6.1

### DIFF
--- a/pkgs/games/trigger/default.nix
+++ b/pkgs/games/trigger/default.nix
@@ -1,20 +1,23 @@
-{ fetchurl, stdenv, runtimeShell
-, SDL2, freealut, SDL2_image, openal, physfs, zlib, libGLU, libGL, glew }:
+{ fetchurl, stdenv, runtimeShell, SDL2, freealut, SDL2_image, openal, physfs
+, zlib, libGLU, libGL, glew, tinyxml-2 }:
 
 stdenv.mkDerivation rec {
-  name = "trigger-rally-0.6.6";
+  name = "trigger-rally-0.6.6.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/trigger-rally/${name}.tar.gz";
-    sha256 = "08qa2f2s8zyn42ff6jb1gsi64d916020ixkzvl16kbb88rabqra8";
+    sha256 = "016bc2hczqscfmngacim870hjcsmwl8r3aq8x03vpf22s49nw23z";
   };
 
-  buildInputs = [ SDL2 freealut SDL2_image openal physfs zlib libGLU libGL glew ];
+  buildInputs =
+    [ SDL2 freealut SDL2_image openal physfs zlib libGLU libGL glew tinyxml-2 ];
 
   preConfigure = ''
     sed s,/usr/local,$out, -i bin/*defs
 
     cd src
+
+    sed s,lSDL2main,lSDL2, -i GNUmakefile
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${SDL2.dev}/include/SDL2"
     export makeFlags="$makeFlags prefix=$out"
   '';
@@ -31,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Rally";
+    description = "A fast-paced single-player racing game";
     homepage = "http://trigger-rally.sourceforge.net/";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [viric];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
- Trigger doesn't build currently
- Trigger is outdated

###### Things done
- Updated trigger 0.6.6.1
- added tinyxml-2 as dependency
- fix linker flag for trigger
- improved description

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
