### PR TITLE
tdesktop: 2.3.0 -> 2.4.3 and enable webrtc

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchurl, fetchsvn
+{ mkDerivation, lib, fetchurl, callPackage
 , pkgconfig, cmake, ninja, python3, wrapGAppsHook, wrapQtAppsHook
 , qtbase, qtimageformats, gtk3, libsForQt5, enchant2, lz4, xxHash
 , dee, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
@@ -17,14 +17,17 @@ with lib;
 # - https://git.alpinelinux.org/aports/tree/testing/telegram-desktop/APKBUILD
 # - https://github.com/void-linux/void-packages/blob/master/srcpkgs/telegram-desktop/template
 
-mkDerivation rec {
+let
+  tg_owt = callPackage ./tg_owt.nix {};
+
+in mkDerivation rec {
   pname = "telegram-desktop";
-  version = "2.3.0";
+  version = "2.4.3";
 
   # Telegram-Desktop with submodules
   src = fetchurl {
     url = "https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz";
-    sha256 = "0yga4p36jrc5m3d8q2y2g0505c2v540w5hgcscapl4xj9hyb21dw";
+    sha256 = "15a8pnz4wf3464n8dvfzr9ck0vmhlx16ya1y889y3crjagm4ipjn";
   };
 
   postPatch = ''
@@ -44,6 +47,7 @@ mkDerivation rec {
     qtbase qtimageformats gtk3 libsForQt5.libdbusmenu enchant2 lz4 xxHash
     dee ffmpeg openalSoft minizip libopus alsaLib libpulseaudio range-v3
     tl-expected hunspell
+    tg_owt tg_owt.src # Source is used for include directories.
     # TODO: Shouldn't be required:
     pcre xorg.libpthreadstubs xorg.libXdmcp utillinux libselinux libsepol epoxy at-spi2-core libXtst
   ];
@@ -60,7 +64,6 @@ mkDerivation rec {
     "-DDESKTOP_APP_USE_PACKAGED_GSL=OFF"
     "-DTDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME=ON"
     "-DTDESKTOP_USE_PACKAGED_TGVOIP=OFF"
-    "-DDESKTOP_APP_DISABLE_WEBRTC_INTEGRATION=ON"
     #"-DDESKTOP_APP_SPECIAL_TARGET=\"\"" # TODO: Error when set to "": Bad special target '""'
     "-DTDESKTOP_LAUNCHER_BASENAME=telegramdesktop" # Note: This is the default
   ];
@@ -82,6 +85,10 @@ mkDerivation rec {
   # TODO: Package mapbox-variant
 
   postFixup = ''
+    # Nuke refs to tg_owt.src
+    sed "s|$NIX_STORE/[a-z0-9]\{32\}-source|$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-source|g" \
+      --in-place $out/bin/telegram-desktop
+
     # This is necessary to run Telegram in a pure environment.
     # We also use gappsWrapperArgs from wrapGAppsHook.
     wrapProgram $out/bin/telegram-desktop \

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -47,7 +47,7 @@ in mkDerivation rec {
     qtbase qtimageformats gtk3 libsForQt5.libdbusmenu enchant2 lz4 xxHash
     dee ffmpeg openalSoft minizip libopus alsaLib libpulseaudio range-v3
     tl-expected hunspell
-    tg_owt tg_owt.src # Source is used for include directories.
+    tg_owt
     # TODO: Shouldn't be required:
     pcre xorg.libpthreadstubs xorg.libXdmcp utillinux libselinux libsepol epoxy at-spi2-core libXtst
   ];
@@ -85,8 +85,8 @@ in mkDerivation rec {
   # TODO: Package mapbox-variant
 
   postFixup = ''
-    # Nuke refs to tg_owt.src
-    sed "s|$NIX_STORE/[a-z0-9]\{32\}-source|$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-source|g" \
+    # Nuke refs to `tg_owt` which is introduced by `__FILE__` in headers.
+    sed -E "s|($NIX_STORE/)[a-z0-9]{32}(-${tg_owt.name})|\1eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\2|g" \
       --in-place $out/bin/telegram-desktop
 
     # This is necessary to run Telegram in a pure environment.

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt-install.patch
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt-install.patch
@@ -1,22 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6fbc0da..414c302 100644
+index 6fbc0da..6cbff3c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -25,7 +25,7 @@ project(tg_owt
- )
- set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT tg_owt)
-
--get_filename_component(webrtc_loc "src" REALPATH)
-+set(webrtc_loc @@source@@/src)
- set(third_party_loc ${webrtc_loc}/third_party)
-
- include(cmake/arch.cmake)
-@@ -1856,3 +1856,36 @@ configure_file(
+@@ -1856,3 +1856,41 @@ configure_file(
      "${CMAKE_CURRENT_BINARY_DIR}/tg_owtConfig.cmake"
      COPYONLY
  )
-+
-+include(GNUInstallDirs)
 +
 +install(
 +TARGETS
@@ -40,11 +29,131 @@ index 6fbc0da..414c302 100644
 +)
 +
 +install(
++    DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/src/
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++    FILES_MATCHING PATTERN "*.h"
++)
++
++install(
 +    EXPORT tg_owtTargets
 +    NAMESPACE tg_owt::
 +    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tg_owt
 +)
++
 +install(
 +    FILES ${CMAKE_CURRENT_BINARY_DIR}/tg_owtConfig.cmake
 +    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tg_owt
 +)
+diff --git a/cmake/libabsl.cmake b/cmake/libabsl.cmake
+index 2fb3b8c..4a4f85b 100644
+--- a/cmake/libabsl.cmake
++++ b/cmake/libabsl.cmake
+@@ -123,5 +123,6 @@ PRIVATE
+
+ target_include_directories(libabsl
+ PUBLIC
+-    ${libabsl_loc}
++    $<BUILD_INTERFACE:${libabsl_loc}>
++    $<INSTALL_INTERFACE:include/third_party/abseil-cpp>
+ )
+diff --git a/cmake/libpffft.cmake b/cmake/libpffft.cmake
+index a6ceb3e..435d3a3 100644
+--- a/cmake/libpffft.cmake
++++ b/cmake/libpffft.cmake
+@@ -24,5 +24,6 @@ endif()
+
+ target_include_directories(libpffft
+ PUBLIC
+-    ${libpffft_loc}
++    $<BUILD_INTERFACE:${libpffft_loc}>
++    $<INSTALL_INTERFACE:include/third_party/pffft/src>
+ )
+diff --git a/cmake/libsrtp.cmake b/cmake/libsrtp.cmake
+index 57c54b5..26b3466 100644
+--- a/cmake/libsrtp.cmake
++++ b/cmake/libsrtp.cmake
+@@ -30,6 +30,8 @@ PRIVATE
+
+ target_include_directories(libsrtp
+ PUBLIC
+-    ${libsrtp_loc}/include
+-    ${libsrtp_loc}/crypto/include
++    $<BUILD_INTERFACE:${libsrtp_loc}/include>
++    $<BUILD_INTERFACE:${libsrtp_loc}/crypto/include>
++    $<INSTALL_INTERFACE:include/third_party/libsrtp/include>
++    $<INSTALL_INTERFACE:include/third_party/libsrtp/crypto/include>
+ )
+diff --git a/cmake/libusrsctp.cmake b/cmake/libusrsctp.cmake
+index caa0529..38d2ef6 100644
+--- a/cmake/libusrsctp.cmake
++++ b/cmake/libusrsctp.cmake
+@@ -67,6 +67,8 @@ endif()
+
+ target_include_directories(libusrsctp
+ PUBLIC
+-    ${third_party_loc}/usrsctp/usrsctplib
+-    ${libusrsctp_loc}
++    $<BUILD_INTERFACE:${third_party_loc}/usrsctp/usrsctplib>
++    $<BUILD_INTERFACE:${libusrsctp_loc}>
++    $<INSTALL_INTERFACE:include/third_party/usrsctp/usrsctplib/usrsctplib>
++    $<INSTALL_INTERFACE:include/third_party/usrsctp/usrsctplib>
+ )
+diff --git a/cmake/libvpx.cmake b/cmake/libvpx.cmake
+index e192e7e..78cf25b 100644
+--- a/cmake/libvpx.cmake
++++ b/cmake/libvpx.cmake
+@@ -68,6 +68,11 @@ else()
+     set(ASM_SUFFIX ".asm.S")
+ endif()
+
++foreach(dir ${include_directories})
++    string(REPLACE ${libvpx_loc} include/third_party/libvpx install_include_dir ${dir})
++    list(APPEND install_include_directories ${install_include_dir})
++endforeach()
++
+ function(add_sublibrary postfix)
+     add_library(libvpx_${postfix} OBJECT)
+     init_feature_target(libvpx_${postfix} ${postfix})
+@@ -75,6 +80,8 @@ function(add_sublibrary postfix)
+     target_include_directories(libvpx_${postfix}
+     PRIVATE
+         ${include_directories}
++        "$<BUILD_INTERFACE:${include_directories}>"
++        "$<INSTALL_INTERFACE:${install_include_directories}>"
+     )
+     set(sources_list ${ARGV})
+     list(REMOVE_AT sources_list 0)
+@@ -725,5 +732,6 @@ endif()
+
+ target_include_directories(libvpx
+ PUBLIC
+-    ${include_directories}
++    "$<BUILD_INTERFACE:${include_directories}>"
++    "$<INSTALL_INTERFACE:${install_include_directories}>"
+ )
+diff --git a/cmake/libwebrtcbuild.cmake b/cmake/libwebrtcbuild.cmake
+index c3520b8..9b4b543 100644
+--- a/cmake/libwebrtcbuild.cmake
++++ b/cmake/libwebrtcbuild.cmake
+@@ -44,5 +44,6 @@ endif()
+
+ target_include_directories(libwebrtcbuild
+ INTERFACE
+-    ${webrtc_loc}
++    $<BUILD_INTERFACE:${webrtc_loc}>
++    $<INSTALL_INTERFACE:include>
+ )
+diff --git a/cmake/libyuv.cmake b/cmake/libyuv.cmake
+index ebfc6f0..18e70ef 100644
+--- a/cmake/libyuv.cmake
++++ b/cmake/libyuv.cmake
+@@ -126,7 +126,8 @@ endif()
+
+ target_include_directories(libyuv
+ PUBLIC
+-    ${libyuv_loc}/include
++    $<BUILD_INTERFACE:${libyuv_loc}/include>
++    $<INSTALL_INTERFACE:include/third_party/libyuv/include>
+ )
+
+ target_compile_definitions(libyuv

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt-install.patch
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt-install.patch
@@ -1,0 +1,50 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6fbc0da..414c302 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,7 +25,7 @@ project(tg_owt
+ )
+ set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT tg_owt)
+
+-get_filename_component(webrtc_loc "src" REALPATH)
++set(webrtc_loc @@source@@/src)
+ set(third_party_loc ${webrtc_loc}/third_party)
+
+ include(cmake/arch.cmake)
+@@ -1856,3 +1856,36 @@ configure_file(
+     "${CMAKE_CURRENT_BINARY_DIR}/tg_owtConfig.cmake"
+     COPYONLY
+ )
++
++include(GNUInstallDirs)
++
++install(
++TARGETS
++    tg_owt
++    libabsl
++    libopenh264
++    libpffft
++    librnnoise
++    libsrtp
++    libusrsctp
++    libvpx
++    ${vpx_export}
++    libwebrtcbuild
++    libyuv
++    ${platform_export}
++EXPORT tg_owtTargets
++RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++)
++
++install(
++    EXPORT tg_owtTargets
++    NAMESPACE tg_owt::
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tg_owt
++)
++install(
++    FILES ${CMAKE_CURRENT_BINARY_DIR}/tg_owtConfig.cmake
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tg_owt
++)

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt.nix
@@ -18,18 +18,9 @@ in stdenv.mkDerivation {
 
   patches = [ ./tg_owt-install.patch ];
 
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace "@@source@@" "$src"
-  '';
+  nativeBuildInputs = [ pkg-config cmake ninja yasm ];
 
-  nativeBuildInputs = [ cmake ninja yasm ];
-
-  buildInputs = [ pkg-config libjpeg openssl libopus ffmpeg alsaLib libpulseaudio ];
-
-  postInstall = ''
-    ln -s $src/src $out/include
-  '';
+  buildInputs = [ libjpeg openssl libopus ffmpeg alsaLib libpulseaudio ];
 
   meta.license = lib.licenses.bsd3;
 }

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitHub, cmake, ninja, yasm
+, pkg-config, libjpeg, openssl, libopus, ffmpeg, alsaLib, libpulseaudio
+}:
+
+let
+  rev = "c73a4718cbff7048373a63db32068482e5fd11ef";
+  sha256 = "0nr20mvvmmg8ii8f2rljd7iv2szplcfjn40rpy6llkmf705mwr1k";
+
+in stdenv.mkDerivation {
+  pname = "tg_owt";
+  version = "git-${rev}";
+
+  src = fetchFromGitHub {
+    owner = "desktop-app";
+    repo = "tg_owt";
+    inherit rev sha256;
+  };
+
+  patches = [ ./tg_owt-install.patch ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "@@source@@" "$src"
+  '';
+
+  nativeBuildInputs = [ cmake ninja yasm ];
+
+  buildInputs = [ pkg-config libjpeg openssl libopus ffmpeg alsaLib libpulseaudio ];
+
+  postInstall = ''
+    ln -s $src/src $out/include
+  '';
+
+  meta.license = lib.licenses.bsd3;
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bump version.

According to https://github.com/telegramdesktop/tdesktop/issues/8483#issuecomment-702803741, webrtc is now a require dependency, and a special fork [tg_owt](https://github.com/desktop-app/tg_owt) is used.
So this PR also packaged `tg_owt` and enabled webrtc.

Fix #98994. Video calls work for me ~~but there's no sound~~. Audio also works.
 @mkg20001 for more test.

There's another attempt #100062 to package (official?) `libwebrtc`. It is how Arch package tdesktop but seems to be quite complicated, and it also need to patch tdesktop.
Well, I think the `tg_owt` fork may be more suitable here like we already use bundled `rlottie` and `libtgvoip`, but we can also change it later when `libwebrtc` is in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - 637.5M -> 653.5M
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @primeos @abbradar 