### PR TITLE
open-policy-agent: 0.23.2 -> 0.24.0

### DIFF
--- a/pkgs/development/tools/open-policy-agent/default.nix
+++ b/pkgs/development/tools/open-policy-agent/default.nix
@@ -12,6 +12,8 @@ buildGoPackage rec {
     sha256 = "18hpanfrzg6xnq1g0yws6g0lw4y191pnrqphccv13j6kqk3k10ps";
   };
 
+  subPackages = [ "." ];
+
   buildFlagsArray = ''
     -ldflags=
       -X ${goPackagePath}/version.Version=${version}

--- a/pkgs/development/tools/open-policy-agent/default.nix
+++ b/pkgs/development/tools/open-policy-agent/default.nix
@@ -2,14 +2,14 @@
 
 buildGoPackage rec {
   pname = "open-policy-agent";
-  version = "0.23.2";
+  version = "0.24.0";
 
   goPackagePath = "github.com/open-policy-agent/opa";
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "opa";
     rev = "v${version}";
-    sha256 = "18hpanfrzg6xnq1g0yws6g0lw4y191pnrqphccv13j6kqk3k10ps";
+    sha256 = "0fv2rq8a01hapcpgfqp71v113iyyzs5w1sam14h9clyr1vqrbcf2";
   };
 
   subPackages = [ "." ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Only build and install `opa`
Previously it was building the following:

* `generate-man`
* `genopacapabilities`
* `genopawasm`
* `opa`
* `wasm-rego-testgen`

Bump version to `0.24.0`

###### Things done

set `subPackages` to `[ "." ]`

bump version and sha

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
