### PR TITLE
python{2,3}Package.zope_filerepresentation: fix test

### DIFF
--- a/pkgs/development/python-modules/zope_filerepresentation/default.nix
+++ b/pkgs/development/python-modules/zope_filerepresentation/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , zope_schema
+, zope_interface
 }:
 
 buildPythonPackage rec {
@@ -10,10 +11,14 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3fbca4730c871d8e37b9730763c42b69ba44117cf6d0848014495bb301cae2d6";
+    sha256 = "1mp2r80v6ns92j089l7ngh8l9fk95g2661vkp4vqw7c71irs9g1z";
   };
 
-  propagatedBuildInputs = [ zope_schema ];
+  propagatedBuildInputs = [ zope_interface zope_schema ];
+
+  checkPhase = ''
+    cd src/zope/filerepresentation && python -m unittest
+  '';
 
   meta = with stdenv.lib; {
     homepage = "https://zopefilerepresentation.readthedocs.io/";


### PR DESCRIPTION
Fix test

ZHF: #97479
@NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
