### PR TITLE
treewide: De-inline uses of lib.boolToString

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -499,7 +499,7 @@ rec {
         show = v:
                if builtins.isString v then ''"${v}"''
           else if builtins.isInt v then builtins.toString v
-          else if builtins.isBool v then if v then "true" else "false"
+          else if builtins.isBool v then boolToString v
           else ''<${builtins.typeOf v}>'';
       in
       mkOptionType rec {

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -153,7 +153,7 @@ let
 
       ${concatStringsSep "\n" (mapAttrsToList (name: value: let
           includeName = if name == "rspamd_proxy" then "proxy" else name;
-          tryOverride = if value.extraConfig == "" then "true" else "false";
+          tryOverride = boolToString (value.extraConfig == "");
         in ''
         worker "${value.type}" {
           type = "${value.type}";

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -45,7 +45,7 @@ let
         trusted-substituters = ${toString cfg.trustedBinaryCaches}
         trusted-public-keys = ${toString cfg.binaryCachePublicKeys}
         auto-optimise-store = ${boolToString cfg.autoOptimiseStore}
-        require-sigs = ${if cfg.requireSignedBinaryCaches then "true" else "false"}
+        require-sigs = ${boolToString cfg.requireSignedBinaryCaches}
         trusted-users = ${toString cfg.trustedUsers}
         allowed-users = ${toString cfg.allowedUsers}
         ${optionalString (!cfg.distributedBuilds) ''

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -261,7 +261,7 @@ let
 
   toLua = x:
     if builtins.isString x then ''"${x}"''
-    else if builtins.isBool x then (if x == true then "true" else "false")
+    else if builtins.isBool x then boolToString x
     else if builtins.isInt x then toString x
     else if builtins.isList x then ''{ ${lib.concatStringsSep ", " (map (n: toLua n) x) } }''
     else throw "Invalid Lua value";

--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -282,12 +282,12 @@ in
     services.fail2ban.jails.DEFAULT = ''
       ${optionalString cfg.bantime-increment.enable ''
         # Bantime incremental
-        bantime.increment    = ${if cfg.bantime-increment.enable then "true" else "false"}
+        bantime.increment    = ${boolToString cfg.bantime-increment.enable}
         bantime.maxtime      = ${cfg.bantime-increment.maxtime}
         bantime.factor       = ${cfg.bantime-increment.factor}
         bantime.formula      = ${cfg.bantime-increment.formula}
         bantime.multipliers  = ${cfg.bantime-increment.multipliers}
-        bantime.overalljails = ${if cfg.bantime-increment.overalljails then "true" else "false"}
+        bantime.overalljails = ${boolToString cfg.bantime-increment.overalljails}
       ''}
       # Miscellaneous options
       ignoreip    = 127.0.0.1/8 ${optionalString config.networking.enableIPv6 "::1"} ${concatStringsSep " " cfg.ignoreIP}

--- a/nixos/modules/services/security/usbguard.nix
+++ b/nixos/modules/services/security/usbguard.nix
@@ -19,13 +19,13 @@ let
     PresentDevicePolicy=${cfg.presentDevicePolicy}
     PresentControllerPolicy=${cfg.presentControllerPolicy}
     InsertedDevicePolicy=${cfg.insertedDevicePolicy}
-    RestoreControllerDeviceState=${if cfg.restoreControllerDeviceState then "true" else "false"}
+    RestoreControllerDeviceState=${boolToString cfg.restoreControllerDeviceState}
     # this does not seem useful for endusers to change
     DeviceManagerBackend=uevent
     IPCAllowedUsers=${concatStringsSep " " cfg.IPCAllowedUsers}
     IPCAllowedGroups=${concatStringsSep " " cfg.IPCAllowedGroups}
     IPCAccessControlFiles=/var/lib/usbguard/IPCAccessControl.d/
-    DeviceRulesWithPort=${if cfg.deviceRulesWithPort then "true" else "false"}
+    DeviceRulesWithPort=${boolToString cfg.deviceRulesWithPort}
     # HACK: that way audit logs still land in the journal
     AuditFilePath=/dev/null
   '';

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -264,7 +264,7 @@ in
     # presented and there's a little delay.
     environment.etc."gdm/custom.conf".text = ''
       [daemon]
-      WaylandEnable=${if cfg.gdm.wayland then "true" else "false"}
+      WaylandEnable=${boolToString cfg.gdm.wayland}
       ${optionalString cfg.autoLogin.enable (
         if cfg.gdm.autoLogin.delay > 0 then ''
           TimedLoginEnable=true

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -55,10 +55,10 @@ let
     XauthPath=${pkgs.xorg.xauth}/bin/xauth
     DisplayCommand=${Xsetup}
     DisplayStopCommand=${Xstop}
-    EnableHidpi=${if cfg.enableHidpi then "true" else "false"}
+    EnableHidpi=${boolToString cfg.enableHidpi}
 
     [Wayland]
-    EnableHidpi=${if cfg.enableHidpi then "true" else "false"}
+    EnableHidpi=${boolToString cfg.enableHidpi}
     SessionDir=${dmcfg.sessionData.desktops}/share/wayland-sessions
 
     ${optionalString dmcfg.autoLogin.enable ''

--- a/pkgs/applications/misc/razergenie/default.nix
+++ b/pkgs/applications/misc/razergenie/default.nix
@@ -27,8 +27,8 @@ in stdenv.mkDerivation {
   ];
 
   mesonFlags = [
-    "-Denable_experimental=${if enableExperimental then "true" else "false"}"
-    "-Dinclude_matrix_discovery=${if includeMatrixDiscovery then "true" else "false"}"
+    "-Denable_experimental=${lib.boolToString enableExperimental}"
+    "-Dinclude_matrix_discovery=${lib.boolToString includeMatrixDiscovery}"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/video/obs-studio/wlrobs.nix
+++ b/pkgs/applications/video/obs-studio/wlrobs.nix
@@ -7,7 +7,7 @@
 # ln -s ~/.nix-profile/share/obs/obs-plugins/wlrobs/bin/64bit/libwlrobs.so ~/.config/obs-studio/plugins/wlrobs/bin/64bit
 { stdenv, fetchhg, wayland, obs-studio
 , meson, ninja, pkgconfig, libX11
-, dmabufSupport ? false, libdrm ? null, libGL ? null}:
+, dmabufSupport ? false, libdrm ? null, libGL ? null, lib}:
 
 assert dmabufSupport -> libdrm != null && libGL != null;
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
   '';
 
   mesonFlags = [
-    "-Duse_dmabuf=${if dmabufSupport then "true" else "false"}"
+    "-Duse_dmabuf=${lib.boolToString dmabufSupport}"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -47,7 +47,7 @@ let
 
   removeExpr = refs: ''remove-references-to ${lib.concatMapStrings (ref: " -t ${ref}") refs}'';
 
-  deleteFlag = if deleteVendor then "true" else "false";
+  deleteFlag = lib.boolToString deleteVendor;
 
   vendCommand = if runVend then "${vend}/bin/vend" else "false";
 

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -21,6 +21,7 @@
 , doCheck ? false
 , makeWrapper
 , fetchpatch
+, lib
 }:
 
 stdenv.mkDerivation rec {
@@ -74,7 +75,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Ddocs=true"
     "-Dx11=false" # use gdk-pixbuf-xlib
-    "-Dgir=${if gobject-introspection != null then "true" else "false"}"
+    "-Dgir=${lib.boolToString (gobject-introspection != null)}"
     "-Dgio_sniffing=false"
   ];
 

--- a/pkgs/development/libraries/geoclue/default.nix
+++ b/pkgs/development/libraries/geoclue/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dsystemd-system-unit-dir=${placeholder "out"}/etc/systemd/system"
-    "-Ddemo-agent=${if withDemoAgent then "true" else "false"}"
+    "-Ddemo-agent=${boolToString withDemoAgent}"
     "--sysconfdir=/etc"
     "-Dsysconfdir_install=${placeholder "out"}/etc"
     "-Ddbus-srv-user=geoclue"

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     # Avoid the need for gobject introspection binaries in PATH in cross-compiling case.
     # Instead we just copy them over from the native output.
-    "-Dgtk_doc=${if stdenv.hostPlatform == stdenv.buildPlatform then "true" else "false"}"
+    "-Dgtk_doc=${boolToString (stdenv.hostPlatform == stdenv.buildPlatform)}"
     "-Dnls=enabled"
     "-Ddevbindir=${placeholder ''dev''}/bin"
   ];

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, glib, libxml2, meson, ninja, pkgconfig, gnome3
 , gnomeSupport ? true, sqlite, glib-networking, gobject-introspection, vala
-, libpsl, python3, brotli }:
+, libpsl, python3, brotli, lib }:
 
 stdenv.mkDerivation rec {
   pname = "libsoup";
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     "-Dtls_check=false" # glib-networking is a runtime dependency, not a compile-time dependency
     "-Dgssapi=disabled"
     "-Dvapi=enabled"
-    "-Dgnome=${if gnomeSupport then "true" else "false"}"
+    "-Dgnome=${lib.boolToString gnomeSupport}"
     "-Dntlm=disabled"
   ];
 

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -129,7 +129,7 @@ stdenv.mkDerivation {
     "-Domx-libs-path=${placeholder "drivers"}/lib/bellagio"
     "-Dva-libs-path=${placeholder "drivers"}/lib/dri"
     "-Dd3d-drivers-path=${placeholder "drivers"}/lib/d3d"
-    "-Dgallium-nine=${if enableGalliumNine then "true" else "false"}" # Direct3D in Wine
+    "-Dgallium-nine=${boolToString enableGalliumNine}" # Direct3D in Wine
     "-Dosmesa=${if enableOSMesa then "gallium" else "none"}" # used by wine
   ] ++ optionals stdenv.isLinux [
     "-Dglvnd=true"
@@ -229,7 +229,7 @@ stdenv.mkDerivation {
     inherit (libglvnd) driverLink;
   };
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "An open source 3D graphics library";
     longDescription = ''
       The Mesa project began as an open-source implementation of the OpenGL

--- a/pkgs/development/libraries/v8/default.nix
+++ b/pkgs/development/libraries/v8/default.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
 
   gnFlags = [
     "use_custom_libcxx=false"
-    "is_clang=${if stdenv.cc.isClang then "true" else "false"}"
+    "is_clang=${lib.boolToString stdenv.cc.isClang}"
     "use_sysroot=false"
     # "use_system_icu=true"
     "is_component_build=false"

--- a/pkgs/development/ocaml-modules/uchar/default.nix
+++ b/pkgs/development/ocaml-modules/uchar/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opaline, withShared ? true }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opaline, withShared ? true, lib }:
 
 stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-uchar-0.0.2";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ ocaml ocamlbuild findlib ];
   buildInputs = [ findlib ocaml ocamlbuild ];
-  buildPhase = "ocaml pkg/build.ml native=true native-dynlink=${if withShared then "true" else "false"}";
+  buildPhase = "ocaml pkg/build.ml native=true native-dynlink=${lib.boolToString withShared}";
   installPhase = "${opaline}/bin/opaline -libdir $OCAMLFIND_DESTDIR";
   configurePlatforms = [];
 

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Denable_docs=true"
-    "-Denable_kmods=${if mod then "true" else "false"}"
+    "-Denable_kmods=${lib.boolToString mod}"
   ]
   ++ lib.optional (!shared) "-Ddefault_library=static"
   ++ lib.optional stdenv.isx86_64 "-Dmachine=nehalem"

--- a/pkgs/tools/networking/network-manager/libnma/default.nix
+++ b/pkgs/tools/networking/network-manager/libnma/default.nix
@@ -19,6 +19,7 @@
 , gcr
 , glib
 , substituteAll
+, lib
 }:
 
 stdenv.mkDerivation rec {
@@ -61,7 +62,7 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dgcr=${if withGnome then "true" else "false"}"
+    "-Dgcr=${lib.boolToString withGnome}"
   ];
 
   postPatch = ''


### PR DESCRIPTION
This commit should not change eval results

`nixpkgs-review rev HEAD` said `Nothing to be built.`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
