### PR TITLE
[20.03] firefox, firefox-bin: 81.0 -> 81.0.2, firefox-esr: 78.3.0esr -> 78.3.1esr 

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "81.0";
+  version = "81.0.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ach/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ach/firefox-81.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "7ff2b7ec6f3f55fccfb7988d7a42bc9cbe572af6edc64ac9b42ea15aaed9cd4c";
+      sha256 = "2027512d879c1606c68adc4705936273ae7416125e0da24e31fb6381884c8bc3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/af/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/af/firefox-81.0.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "c1a29b1473583d28f87c764c8ccf67f7cba874fd85e5820f968230c9ce29670b";
+      sha256 = "17afbd113ef486b0d584cdf40dfa602a0a489e6674e9e326b311f8adc0537951";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/an/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/an/firefox-81.0.2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "bddab1deeaf3c6474586beb41ad9c720ed6e84f9e999a856b17bb4e7c9d97991";
+      sha256 = "d3d6217063881911fb42aaceae4faf51c0a7d5fdad1c79c97238bb05a1498d25";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ar/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ar/firefox-81.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "3c4e339627fc94df273ba7e1e1c150188033331def09678b2e0abb54e52f2120";
+      sha256 = "d47411a35c37b4ade51e83b5e222b6b8e776fc1b7c4be025310a8fc34ce9c357";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ast/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ast/firefox-81.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "e421c32fefef657287ad52dc11f2f3166e549ef9d54065099f84e5f35c8a52af";
+      sha256 = "43ab6cc595bdb0d821c0a94c5e7d099f7be598c98dc96b1a3b5df5e7403ef7a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/az/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/az/firefox-81.0.2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "e1099ab7b028d8124446a21056e55dc4b87d1f20972dea60125347b1b099e35d";
+      sha256 = "b326bf5956c540bbfd6e03498cde99462b04a5833b56b9246fdfa48b49737056";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/be/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/be/firefox-81.0.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "a216a2cd652905d946aff1cb3a0fc8738a1e3d5746d080dd863d34be244a2a50";
+      sha256 = "6bcb3e79504c685a440768eae2b07cdd5c6bae488c272e5990229ad942eb56dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/bg/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/bg/firefox-81.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "68a8a4ec3d0c1fb8a174a7466abbfb6c806bb8a263ab852b15dfdd15c35487aa";
+      sha256 = "9182efef254942eb23ed1d5eb18babd6ea10f3c7998307e4f86847bce6141088";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/bn/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/bn/firefox-81.0.2.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "3eaae9060b690391cbc63aacdb1d833b2895c7aaf6da36c32cb117e7994d94d2";
+      sha256 = "a1619499d5d994dfc23af432a68722230a7342a06af35fa1af14ac441134a8ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/br/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/br/firefox-81.0.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "806b366419eb6edab57c8f3af9f0465d3547e3e28047983af7cb2f08ad822a8d";
+      sha256 = "ee6efdf5347fee8faaf007b13d442cd848b23d14ddfff0d089d4ac47b679aba9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/bs/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/bs/firefox-81.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "025a79c350f35f8bba1a5fdd894d0eb237d22be8ee5825e6a657f18b0c99bd87";
+      sha256 = "08f44244b8d29551af6ac20b8b3e046ea39d3f0bd69a43533e8c4779488fcb86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ca-valencia/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ca-valencia/firefox-81.0.2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "806f26efe0a6317cb5dd1b631f8b96bceeaa6e8fced624d15ac334d0d2d78dc8";
+      sha256 = "b6c44812577fc2f295732aaf33ebb68f3b588bec85fe9d54310bebb80ae821e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ca/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ca/firefox-81.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "dfa651a556e024d2d27a27d97eec87750d8f4e692345a0f4e12c7a3480ac1d20";
+      sha256 = "6ef86ef2e82bb3ff74b68239681b804fdb8f5f3e89894b9e0860973d7cc85ea8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/cak/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/cak/firefox-81.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "7225d8cf7a529d8688aa7386fe14e50e4e208d55732523d5407690f63b6ab775";
+      sha256 = "b468e0390aac3751a25cb8d2d130242a39e58c50dcdac2e8eb61e5a421d15bf2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/cs/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/cs/firefox-81.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "17d22031176a4604d498743eea242fe257c74620ac8ab88f8f197d57f8615663";
+      sha256 = "7d8a3069e54914cf46b990377a0b192969aadfd214e9fd01e0d6bad711b4ea03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/cy/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/cy/firefox-81.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "82581e54dc72e188a5d4976bed58bcb8ba4153e72854fc439d3a903a5f60e6e9";
+      sha256 = "c0b8ccb2471594187ef865cea477c364299314672dbd332f795044e988545c52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/da/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/da/firefox-81.0.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "87a600d73b3fb74ff8aaf26e1d915afa52692501ce67f13e308a7c9af63e6853";
+      sha256 = "c7620a8177276045ddaecd4ee6223ce06f8dea52f6a1f530c3e69d8d90e2a794";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/de/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/de/firefox-81.0.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "a15fdfafe598fe5e2d5c5854755e316844518eb1b4634aad6cbe99fefc3e5986";
+      sha256 = "6ef5723267a6e5668b49111756b6b3f1435f765c4a69fe84e5e5a9a91160188c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/dsb/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/dsb/firefox-81.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "abb71f8df0de953ab2c27e50c9b49a69c012fbe52a0d6eb66744b03754d494ba";
+      sha256 = "d92e94a8a8a9b91b273b1be46690b9bf1100d05dc66be4a7148bcd1561079ffe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/el/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/el/firefox-81.0.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "ed3782c6e619f9e0e59b2eb1f36e5c94a92e2f7b617b2ef87e0a2da0c4e65032";
+      sha256 = "5db2868fde7014b576f77afe3a2a003bc877ef1cb223f152f6a938e56e1d56c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/en-CA/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/en-CA/firefox-81.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "5c5ae0e8345f13c346e2b756a57f465776e8d5a1ea62dd00dc6fe5a3b7c904fc";
+      sha256 = "38d64b0a790ce2d8b64ea2b4a4968010c265fbf138ab22e78abb332204b78808";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/en-GB/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/en-GB/firefox-81.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "3ed2a11824c00fd157b9b3d02dcde95ae8347b6add687f4bbc3284601360c1a2";
+      sha256 = "a87201313bcf05887515ef8895fdf12824be3f60202e33cd033da4e68f3f88be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/en-US/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/en-US/firefox-81.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "689d75035303b47266a3819e8aa3bb9026559b819aec2f6e95faa67b86888ce0";
+      sha256 = "fbe58e217adf35f454684658321c3d49287ba9161308615e0e76e479d60ac176";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/eo/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/eo/firefox-81.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "cbebf5a97e5b2fb58c187553c8fcfd6474dae4a911c97cd8730977b8bee6c6cc";
+      sha256 = "f8dad4e491ed00e28fb2a923e0e8507e16eceb8ae111661e73ba59625d292c12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/es-AR/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/es-AR/firefox-81.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "e664214c7b2809919b672426c5d35e467eadf69fcbf43d20e00f379e5ab6f558";
+      sha256 = "e34f82a15a91d2aa1f70eb7b2792fcb4eb31fa86c320aeab906b3a80b93822df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/es-CL/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/es-CL/firefox-81.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "10b07cafb315ef4497d9b2caaac0a83c86701506adab2f0e154a7873f39b3066";
+      sha256 = "a2edffed71f6fc8c6ddb4064db344b8f0f913f4aa9ee7533eb9b3632179c24ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/es-ES/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/es-ES/firefox-81.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "aeb7d0af26b7fa4be27eb0b82da4051ab57ee1406eb20d3b5d12ec5d32d0104b";
+      sha256 = "590014aa1950faa1ce3a56ce1bd3e3ea3debbe9c7fce54ac3ae58065a90442b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/es-MX/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/es-MX/firefox-81.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "c515c089afe6e4ef46df7ace24260118ed464a62146f59cce064ca465bb7affe";
+      sha256 = "8cc10d2ac6f11c4b23a1645d4f17be6b756278e8c488c227bb112d33659115a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/et/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/et/firefox-81.0.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "930c174be085acb50b18b4ee5b20b158c9a790ca19232cc25a1e34628a7b4346";
+      sha256 = "802ee1e69296b55021fd061f626aca173adb2db01b488911ac1faf7dd54b6ccb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/eu/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/eu/firefox-81.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "2f0e39cece971b12f6f5c325277e77e5a3f053ab57cdc2a2905d9f7f3e739fe8";
+      sha256 = "90c201828df686d66a0450a44d4b85f6da2d09b56c7a51272b4e6708d6cc01c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/fa/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/fa/firefox-81.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "98029d664de21403cb54276a30d650a124e5b5250939c7e315a0435ebcc2bf26";
+      sha256 = "d4bab27a1f97cc51f43ea990e215cefc360a4af4dc47e95c109817d98d44b8f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ff/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ff/firefox-81.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "097747294c73df707c7652c239330c106c69f77868fad65d490d1b896f90e689";
+      sha256 = "64b0dedb6508f5e3d30534a0a3c626d85de2dd261a8a9dda9408dac5d127e63a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/fi/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/fi/firefox-81.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "c915afc5e73f837e1e09ac0d14510271602ef5527ebf270b399be880c183b5a5";
+      sha256 = "48052f288e1416b7e144cbe75f5a1b082410476223d8e786b82a0b97775622d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/fr/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/fr/firefox-81.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "775fee38f2033be70e4d68d985602bce3df69f9106d1c427a06b3f8233e7c30f";
+      sha256 = "0113b83bdfc3524e492f42ff8b07f3f8c9c2c195b876f5fb4f085de19e9a74eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/fy-NL/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/fy-NL/firefox-81.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "49efc463dfe6b7b7a8dc0bf351cc903160bef3e1886c8faee6f11cca3abd3e90";
+      sha256 = "eb18e773b946808e72b0608d6907b4b98abd6daafeed39d7e156f3252f53724b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ga-IE/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ga-IE/firefox-81.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "6dcf0be88e5fad96c79ccd4b6a612d721b792099d9f1bc029ff5b592c4004922";
+      sha256 = "4bf3dfc73fd8d62f2b9d56bf14695103498df2979f35b4fa6d41f98b5d447529";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/gd/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/gd/firefox-81.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "924d9190a1d5dc85abcb1f23aacffb98c0116c5cbd430ec04c5275317639772e";
+      sha256 = "c91b4c60e138fe63da554959d025b0aa593c09bdcb3e88fd55790016fd54bbf8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/gl/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/gl/firefox-81.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "256c1b81294bc262770c655e2fdb5e36684286f4eb1857d6d38b87beba2b3d3d";
+      sha256 = "540131786aa643a3e23021df03d67457793a43d8c03a3e27eb082736975b1277";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/gn/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/gn/firefox-81.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "2d9d55f4755f372e18a7d07786d64f09a4b4f76e6a80d8904e06188bc6edff41";
+      sha256 = "4d9de3289b2135a37fa2dfa456263ba5da657207ff188812c08161af0af9c13c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/gu-IN/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/gu-IN/firefox-81.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "86a64d446efcaa014fbbb05787223a025d99947ae4aa8e704661f1236c08bbcd";
+      sha256 = "57ede429790fad8bfa2898e432534b87e60add0303efe5bd903aefdf9234d1a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/he/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/he/firefox-81.0.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "64b1fcd9c454d1248eb1f2d02877f964e50dce38ffbdd93ca4c367246121eed2";
+      sha256 = "7c8bf0cf1aadb37683b8da0cfb7f7e70729837daec5276dba5a2aa0fc4ce32b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/hi-IN/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/hi-IN/firefox-81.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "5d5f52e34c735df3ec5571e03e834919001fe3417a4190515f86f1e479690ace";
+      sha256 = "9485b287fcfc2253b0caa052566f56f16b25cc2c9e425e679236c5d60c73a037";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/hr/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/hr/firefox-81.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "e6085effe2607a416e80a310ace23381fcdd752bba8e58ad7611f05885e01e11";
+      sha256 = "414b5d06a4477f35719f91e8a987298dbe01127b4deb1563ecad894d64cf312a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/hsb/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/hsb/firefox-81.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "6a35c1657d78cfa843a24bea346fd98aeae041fdeb65297693f89b012f0c3786";
+      sha256 = "9c2d4430888b79365069371792904eca41304e1ddcb933c27f7a0e65791f97b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/hu/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/hu/firefox-81.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "3717f43d3d771cbf4dee43889e0bfac3eb60dff8989c06496cbf14ace5753ca3";
+      sha256 = "1d71a42ed1b367fbfa2a055dd0c92d87851a82099f6238829425d4804a9dfd12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/hy-AM/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/hy-AM/firefox-81.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "c376e1f35c8067b41415175bcb597c331b5f5352d4262f5a38d08296a307343d";
+      sha256 = "05502981476151c5d3ee598d983e6256b9ff1cd6a6485c98f3e35916ebe5c7f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ia/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ia/firefox-81.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "99e0aafd820a965cd85fe9094b7465d700f8e62cbba86ef9746a44445e5bba2d";
+      sha256 = "7dc8287a954368e4c1e210ebc73ea1a76655112e2eb574782a8e9d64e8282656";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/id/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/id/firefox-81.0.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "ada432c2d6a04fe928416980b0f3575e2a42668c7298f68c32071ae2c4f5bb8d";
+      sha256 = "c598207fe42804f6fe91390773622478f4a1f7b5aca97024d30e4125600d28d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/is/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/is/firefox-81.0.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "df304bee0b2235222c97e49e0ad8bc0e3fe1cbe3ec0ffbf1b996902a6817d863";
+      sha256 = "19cc1e787f2d04661c93cd70631e450bf47882132aa2faeb8a976b41742351df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/it/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/it/firefox-81.0.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "8c35e143b73d3019b284a006501f93aa2550b32688d7d3285e56f92703df959d";
+      sha256 = "0aae5bedd2b9c1d3466102c9430ea9539c25488d762927b4dce567806add95c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ja/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ja/firefox-81.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "39c23321100cee799e7024ac27d547a6cd7672485f07125d02c75dcd8e38f268";
+      sha256 = "569062d4b226d31bf241ebaa54713f0b1fa6d79bf8f386f6a2484b30d6e75516";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ka/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ka/firefox-81.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "b40137c85d1783ee9a8a11fbd72e33bb9a2d3baa4bc2cc9f31a0c0bf020c2233";
+      sha256 = "86b364cdb8369746dea055f199c61a673f2e87ed64b3b93d41aa1fa5e1f31ef9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/kab/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/kab/firefox-81.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "61dab84674aef3fd91db859900de4709744816f621fecdb3df46a63f4426289b";
+      sha256 = "9d493ef56f9cb7ba6c3b92c255351eefb77744733bae0b09434bee06078802f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/kk/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/kk/firefox-81.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "a9e8e32cd7441a4b78c5c7b9ea7943c756f5b362a9e6a9028e20dfcb461bb056";
+      sha256 = "7a2b9e691cd72b6079c08e35f8b8c01f505e1a7907b92fc0aa1d282987efa0c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/km/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/km/firefox-81.0.2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "f003c7a5eab166f29c37aaaf2c5cc4669d90fff33854d43e157130f606011820";
+      sha256 = "62e7f5edbe74712387a591bb89e1e0244beb70e4e00bcc8fc661ef11c48cbdc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/kn/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/kn/firefox-81.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "f23a998f16c3a93c210b7f08337bb3e739311ada223e85ac4599819b89bf7110";
+      sha256 = "8b17779e67706e4284d8417124e2c05aad6b5f1a27db671aabcfaaddc644b141";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ko/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ko/firefox-81.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "b6748a4a86fe9864a3378e32357c0fbc542846308ae8ac8005460d40f4f869b9";
+      sha256 = "f63b5fd71b0808d21f344c67d7b7967d1b952f2530dd4c98e522ae85abbbe724";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/lij/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/lij/firefox-81.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "267633fa63849ae002ebffd892ea3f520d59bace0a7dafe1f92dcbbfcaa7cf00";
+      sha256 = "ff791a959cc134be0a1d9d3c6e275610fe21e4e83fd0d4bfc0629569aa4f235a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/lt/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/lt/firefox-81.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "a985da29e6d91efed407bc9d898e8bd8f68d42cd4673b6ea163b99d8bb9cd642";
+      sha256 = "fab08be7d08b6cb42a81743da797d7f89c6c6f7977c2140bd332c836ed83c78d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/lv/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/lv/firefox-81.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "05a05361cd3b5772c30c2a8cef03e8753311245caea3ee94e03fbb3b5b6ae9ed";
+      sha256 = "2872affb0559ff68f1755b025da984e2b1edafed0a081a2f2aaebeb42a98394e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/mk/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/mk/firefox-81.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "0433579dfaa3dff715129cc45e72d83f93b7dc3a928b65744dece0a5b5687916";
+      sha256 = "5515928977539457db6a0e619486eaec66866b3b5bdd92731e7df2671cbcf437";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/mr/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/mr/firefox-81.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "38177842df2df76fda10791eaa518d30b92f03016705eb555630fa356992416f";
+      sha256 = "67de1cae2a3238a2ba62bb0186abaa866b138274f5a6ece030c0f94a2c33110f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ms/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ms/firefox-81.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "34b724fc82f330d897b1073fd4383f5fbfaec9d312cc7991f395d37d98416da1";
+      sha256 = "33437a4835939be05d051a5403b5496abcd8dea764db4d1ade11b2451aed8524";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/my/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/my/firefox-81.0.2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "a527914488954bdf8aea31a6ab406791cc723b88c11a5a27f161aef970e00d6b";
+      sha256 = "ec709e861cf45bbacdd9a69df2b5a22b4c4653969539b5359befa4073212a504";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/nb-NO/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/nb-NO/firefox-81.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "ccfa39917b8b0c2704a011bd41b0cfe4e890b0c1bc14bbbf641b7add2bf0750b";
+      sha256 = "af41f350b8442f3618fdfb997ea40482f6a5d4b6e0c4cf59e397d37f52f3df0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ne-NP/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ne-NP/firefox-81.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "a3deb02b843fa9ff7a12590ad86195a9deb1be1eae055b493c34614fb361edf9";
+      sha256 = "49b42f070ef75a92583a2b74d8bedfd1fd3bdb721f0330504cf1d3e3a1e06ec2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/nl/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/nl/firefox-81.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "864ab1ee8d70e0968570fabc1e110bd97c86d27ce5d8106a70a31c6843e16db3";
+      sha256 = "356fde435cf8c114ef3d5bb16a5e24123d7898bb1de1539ef38d589ac9292489";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/nn-NO/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/nn-NO/firefox-81.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "46d109379dba5dd3e5c9c413e54ff2578117960ac3c85ca937b48baf08bcdb76";
+      sha256 = "c6f403be62dcd65eac4b26349ed8bf4b44e5b43b1d6cd82b15fc327a85c5b18e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/oc/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/oc/firefox-81.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "71638cc84a7eccb4a563b7640c84557bc203cbb91114e433e1400554a16b2c1d";
+      sha256 = "d6200285fcb916467b1b05e85e595dfa5e94f0f0a20d71824ecefdf12b215790";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/pa-IN/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/pa-IN/firefox-81.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "8fb76633497115f927ce2be5064f6c6bb70d552c53491ccd6558df163941ef52";
+      sha256 = "7e22a7d4815012a58de31322a532205d0d8276629a3ffa5d8d2066ef3ca2ef64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/pl/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/pl/firefox-81.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "e6d38535433cc0a0c4aa07ab9aa33bad4d019041d4a2b30ccfc5553a10579a8e";
+      sha256 = "35385afc9b365042b498bb30ff330a8ff5556f8cc3c0195f485022f9306cdc8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/pt-BR/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/pt-BR/firefox-81.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "399ef81afd3b05dbcb43553cdd36a2fd95e681296a21e7476cfa0c64c0c13ae4";
+      sha256 = "ad117ed17bee468026d03bc0311ca8298f62f94eaa7a15f1dea58d9cac16f439";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/pt-PT/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/pt-PT/firefox-81.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "d6d87228f6a46237583ad8520c6758fd53d778e1905d019978a8da5fe0819cfc";
+      sha256 = "8f609c2fe5ffda723275405a938ab8329b30ca33850246c9d2410db08af66b1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/rm/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/rm/firefox-81.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "46dd4f4ddc69d82964289463baf67c05eab92a4500ad17f691a06fa0ea72830e";
+      sha256 = "8130961cacbb7c1139b978cafd29bf1f281a94284f37afb66243a0ee65622eaf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ro/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ro/firefox-81.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "8720bf2abd57615d098360e7ddb384c0d570d4422f18d509c8b2b7759dd84550";
+      sha256 = "8c4c45960a7ba85ae70f205f91035bab549ea5074f884477d7eb30ca8af5e4ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ru/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ru/firefox-81.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "6a8db970a3be16e8a0524c2bb576e4c368d33f8bd874ae201d000d112f86282f";
+      sha256 = "1706cd12f77a650e7ea7ed6d377ca4e772ae3fb7330a81673a39731853ae0b1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/si/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/si/firefox-81.0.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "1ee0f867be47f5a7884577caf08778152d8ee08d8fd1b25440a69fe8bb0d1174";
+      sha256 = "cd400af9646bbb08e54069f9748fbec82242c4f9ae973c974bc3499be76a7074";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/sk/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/sk/firefox-81.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "97bc401f7c3c48b62fb66b3b5ea759345641874a46eb001ec1570ce53b610764";
+      sha256 = "6ecdf6b3b1ce634cd048452de8e5e6128cb3d474199dfbd5fe1f66a40825c05d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/sl/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/sl/firefox-81.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "5b5dbd25fc83048de4fdeaef13126701b01e070740345838c29b8aeba65934e6";
+      sha256 = "a77a56f8b35ac4bfaf81ed9c3846ee392b4a9198b469320e9978fb5c1243db0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/son/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/son/firefox-81.0.2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "99a2c222c6e14f511dda1f5cbbef2effd2aec7d169893024e25f2dc8f4900e39";
+      sha256 = "0c04af05d6ec3f2423fc18a2315708a64db5e39008aa8f50c487b3e54193dbe5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/sq/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/sq/firefox-81.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "7ff0ec6837ed3536f73aacc8295b5439aa0e18cdd80f2882bf2b644f5e7a1637";
+      sha256 = "479e7da75628821986e3840848a739666830fa37e692b53245bf164357a76528";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/sr/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/sr/firefox-81.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "274b86c7dbdffcd11453e8103feeaf6e98931c7224ca2336d231cf885c809f21";
+      sha256 = "5a272d8ab250abc196c244af90e566039d7a351ce1b8503a8b69a6b804526544";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/sv-SE/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/sv-SE/firefox-81.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "0fc7edddf1a3aa812664e08e94cf5967c69a5f4821616400a8144c3bdda9860b";
+      sha256 = "5c48c2eb6b737df23f16e761c2db7a344ef0898b05fc16ac73d9430a8d7b4350";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ta/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ta/firefox-81.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "20121341b05c91142bd8fb4a0a2195693e78a89691b02651f6d6c3ac9f848a4f";
+      sha256 = "d54572f034c437c1fb3ea3148488574b32bb66e6cd0f0d83fdb0565c2876569c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/te/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/te/firefox-81.0.2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "bc306272b6bd53e312dfab3f404f1f92199945be9f74e1d87d19b58e7ae2ee95";
+      sha256 = "7672b53550f83100a247bfccd4905675e6572e5fc09fc9d3caa97998cc9ea65c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/th/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/th/firefox-81.0.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "52c8825f27f78624a81271a01c3b522cf6617030046a38734611ee741215658d";
+      sha256 = "8c5cfbed931ac2777742f34563a873090d4dd14cd512641c2ae2d1acac440bef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/tl/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/tl/firefox-81.0.2.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "c87f99419608a06d79bec67f54bafec6650dbcbed7fb52bda058bfe68d0ea102";
+      sha256 = "1b1b5cc2e47bf3d5940f7ce16f732f449856a3b98ed728a655db6835ec8d1f31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/tr/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/tr/firefox-81.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "a030a15ce1424717b8fd0787f1a0d13ad8e050f0f5b4cd679d6c2686fe81e0c7";
+      sha256 = "b71b7a3d25446cba4404d8310996e23f32c6801a60e9e427eac586e3ce09cff3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/trs/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/trs/firefox-81.0.2.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "762f7e33307811f6ec18c198b4f524526a085828af2621885b276ecd8bac6dd9";
+      sha256 = "b71df436eda4dd757de7b044b333fadfdbfeb180990c45fc3ad310c2a325f851";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/uk/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/uk/firefox-81.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "a698aa0d0599b97c7e9791547573d0afdc5e1bf0e5e644069752686d50644564";
+      sha256 = "5fbea5aab96db69ebcc01040e86205bc212b7a0c8e539620001e2f95fdd4c060";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/ur/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/ur/firefox-81.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "7d1759bd2f0b746be76471ebc3c0da2fa224f4550a787e72ebe52b6356fb9370";
+      sha256 = "de3de8a70d155283f68baaceda50309312a2737acdae1c306604203a587a047e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/uz/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/uz/firefox-81.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "51c21a2cf377633a46c35b2bf9096b97f5acab1bf7f8014122c96668d14c6d95";
+      sha256 = "faf6887af27095f12e9927226cb1d82a76caac0d61a6515e96ee2e6a4cda54b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/vi/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/vi/firefox-81.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "e1f3cc7866b19e60b8c368b0633bb0603d7176a87ebc910fe4c4a7575a98be7c";
+      sha256 = "010d1032acd48a36048ab1c90c854a1f617fd58b0e039fbcb510c13f9e8f6497";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/xh/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/xh/firefox-81.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "cce6577abd88d3b34ad3e83577bbb82b6df8754679fc4cdd8a34c9ec9d59acae";
+      sha256 = "de6b89dd029b4636bb660cc0bb5f64dc6430f93e2321ea3fa8f6a309ca70b0da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/zh-CN/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/zh-CN/firefox-81.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "e042d66ae743d1889d6d8ce13ef3510644098efa0943d332656b7e361b976da3";
+      sha256 = "a9d53780dc73f7bb435ed4d32d2322401fb6038756a0a0dcea5bbb1815c74cda";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-x86_64/zh-TW/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-x86_64/zh-TW/firefox-81.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "07c6ac6268b54caefc44654bbc68d19dbe8e6e15fb768c921a8030e179ec8ef4";
+      sha256 = "d7a24a82720421a691e3bbdd69353d3159b5e6f1b78d056802a19e1bff892096";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ach/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ach/firefox-81.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "bdd0995ca7d73be587ef1a9bd0395b869ec4f7f90a93ec854a5bbd1c18060ea0";
+      sha256 = "92bcb64a683b40a136f62210c328f679b3d1a4672826121d60aada840721aa75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/af/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/af/firefox-81.0.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "f662391298377d8d7f38f90c31b90bf705e61b1c3df5e1a7ed7e6c705ac700e6";
+      sha256 = "83d5bc7fcdd6ec58c62ed59a724e30ff0b1efa52efe2284b5fc4c81f94a95b4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/an/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/an/firefox-81.0.2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "46ca1495a74861429af6cf33eb791738abcfb5fa29c23060c7b9d307fc6a1b5c";
+      sha256 = "1a1164b4cd7a14475e3542940369cd3d539d006425f8ad2695245e8a5ac76f07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ar/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ar/firefox-81.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "1b781b56560f0bad0d67f155d68da1b5b759051434c76095c8ff884837595866";
+      sha256 = "ae16a97f8372cfe86aadceeaf06a5ef89f6fec141e4490fc93201a63e139a372";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ast/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ast/firefox-81.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "eae1a5378babbeb88c6b000dc6500bfccbbe8337eeb32d7bfdc9bab67448d8ae";
+      sha256 = "ff011971da1d18eaeeca9925ad10c30c82199cde00fc34904a058285ee8ec4fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/az/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/az/firefox-81.0.2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "4ba58be6ffb171c843ac5d267e97bf8ad219b4d1058a96b18f08ac4dd83c6b0c";
+      sha256 = "c858bc1382ba22fb8874f5e409c2571389f0f582df61c228791c0e4524fc2d9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/be/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/be/firefox-81.0.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "b7cbd330b3b261e8b57134c27a291348219105cbd8cc685917ccf8e03099f2e7";
+      sha256 = "e6372d667659c032f27b5cedf4304b72cde1d56b90ca2f69cbf1871efe1b5053";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/bg/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/bg/firefox-81.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "e6354feae56c656365fc4604bf394c4038399ea3a7ee503fd38610e1525d6539";
+      sha256 = "522be0fd41e182cacf8370ce55e3d4081ebe65b5697232bd37b0e3969d59ecf9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/bn/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/bn/firefox-81.0.2.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "280d01e9dbfb09a08264e36c01b5fecef97831fc2c9d99e2f5e0ed498bbf427a";
+      sha256 = "a96512ca0ae0e850e4db268adfa89dff04b9ad4132e45d62cf2e479482c6ab74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/br/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/br/firefox-81.0.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "a223fec4d16418befd75ce455f470cdc831afcecb6fb4c36139fd2f7c2588337";
+      sha256 = "4c2c91fa2b05d6c0fa8c123121654b4a860bfa3c14cbfe0c7a72437aaecd0a02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/bs/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/bs/firefox-81.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "ed7910663750af303d197ab3919f54d2a108ed691e016696e4c9a6254fe74003";
+      sha256 = "02aa8954d864744069f99a434731b7d5b848657eb9ae3c88f7b7593896dc6a33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ca-valencia/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ca-valencia/firefox-81.0.2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "19d4244b6711d3378835fd00715d7db17052de0345dd9b33b013169920f388c7";
+      sha256 = "d29036dd836772f12b01bde9c9183455241951ecd37dbb1737a3a6a411329ec0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ca/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ca/firefox-81.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "bcfa0b1785d3aeec8e5ea25b472da288c3ebced8661a70c21db08741e9ed5c67";
+      sha256 = "e0a79f1fffcc321dc5cc25df1eef7f2ec789b50ccdaf9abe2cfae45c4bfb1c28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/cak/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/cak/firefox-81.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "cbf0745604bd3f757851cb4772eaac212d16288c7279634d470610ea280b7884";
+      sha256 = "49afbe55a259abccd5d90645d54b756033570b0db0e897b61a6bad096e173c5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/cs/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/cs/firefox-81.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "1e91a12e484a2a41d87de5e60c0b3f455f81669025ceaec0c7adbb447446c367";
+      sha256 = "c24226556fab58ed16374fde899aae586e06fa8d258c68cd29100dd4febe406a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/cy/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/cy/firefox-81.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "c48491eadec23c78f071f4bedd23ac02235ef090375dd0bcb190e0b1d94fe94a";
+      sha256 = "bbc097cbef8995f847988ca8d5280c10b8486a2622845b3df59c8bfcf6ad89fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/da/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/da/firefox-81.0.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "81a1fc46b7f92b2375edb20d3464c4d7facb493a07aa4471947f8b8b84cc3054";
+      sha256 = "90d4acb222bc315ab5912ef5b084a9b90680eeff582efea5400805b7bd09b79f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/de/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/de/firefox-81.0.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "719db056506ca0b908d121cd3e7785b1d8739610c7728723e650ca35b99ce26f";
+      sha256 = "a38be4018216205b8a6ddfdc3308803dc177bbfc70eb3564f32a379ba44174be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/dsb/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/dsb/firefox-81.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "1ef45291cecb8727951808d20df4469c1f0d731b0d3442283fa1f45f39c0e3c4";
+      sha256 = "cfd51d887a50b857040d788c15155aff6b70ec7dfb587c7f57d6373d34ad85c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/el/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/el/firefox-81.0.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "b0cbd8c13a40116779b1dca51191fcc0a8b203327b568f8467f6864e4f5db9ad";
+      sha256 = "3a612c94e13e1a3b374921faa1be57b1a61cb50dfc6437e4798615c6a4a80389";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/en-CA/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/en-CA/firefox-81.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "4e4e204fb9ed3ed167fb9e3a9af2727384d09e37f1d5262bba05e296a8cb4a16";
+      sha256 = "4804e454ca39369d6d8d067a3eb3e3351aa5cf84742c1e9b76bb895cbcc516ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/en-GB/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/en-GB/firefox-81.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "7533f99bc58783e5779b4fbbfc77b96a6c04958c0e752d71b1f57387824faa74";
+      sha256 = "273d14182a3b1e912977c002c9eaf760389f8b90bd08c538920fbf551e16d30b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/en-US/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/en-US/firefox-81.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "68bebc780f225d5694506c4cdc6a7c31c779d2f1feffa792e599f99d0b2e58cd";
+      sha256 = "d12c5d96d5883a9f0dc0ecca65b771bdee61c4994366474d61228d7005d78365";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/eo/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/eo/firefox-81.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "ab08e50d0a5e5d6d02a8daf1c6a428ce9ae19b3a343bf0838739adc9a4170bb5";
+      sha256 = "9169838db0397ec2d35d76ec7ab96bad4a6072dac5272ba13661ac2588ad6358";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/es-AR/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/es-AR/firefox-81.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "837f5cff13186af4f38c0c21410f20c57f28a3b5293ec986a449fdcb3358ddc6";
+      sha256 = "a6d14c7062bb00b1aaf6d4118c07fa46d05b8bf39de914fdeaa5a6ce97c781fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/es-CL/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/es-CL/firefox-81.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "1f73cb2ab7eb1b7cd8198113941fc71c17972227365edfd5cad73680d30a9c6a";
+      sha256 = "1927ed60ccadba49b0d7ec1a49f78b565249eb1c9ea3c89da88074fd8f16c685";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/es-ES/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/es-ES/firefox-81.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "1e95337b4607808c3c3b319343e253d575a07fbe48f7ae8d8346f92a3d9c70e0";
+      sha256 = "f69768413a153852ce77cd71ad332598a6b63ba779d7fd19f1b4a5bbf9d6d390";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/es-MX/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/es-MX/firefox-81.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "cefb685c2da73fe485ff0817901a19c609a73befbb82fec151765e889e4c2d91";
+      sha256 = "3beecb997cd5e37a7460c4a9c73ec398b14d249af43588ce00eebd9677575c3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/et/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/et/firefox-81.0.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "95dbe912beb0ee6196e3bbd169093388c22fb1ed0981a7827fee4bbdbb774316";
+      sha256 = "ace910037d8aac53cb62c0a815ca63ae99c041fa33401b32190c483fdde4285c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/eu/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/eu/firefox-81.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "44047e7f01fb086c099db0ddda6e1d6641e33e038a4e658b3a57ce331ce61523";
+      sha256 = "8dd80e914dab07934140847f0d28e6c3b2c42153843bac891a3d1fce977bcda1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/fa/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/fa/firefox-81.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "252f1e06b2faac3c3f94d1a1f9f52f566c84efffca8a3147c32ee6f109feaad2";
+      sha256 = "5ff9612d84d88e53eb130baa87e31472f8c1dfd17fb9b5456dcd559f8449c256";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ff/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ff/firefox-81.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "1bd050b8d4840a17d12f042a27295b71a4a62ebdac4153ffec843230b1cc0b25";
+      sha256 = "23cff8a74feead954a55111e7a09d43b33baea6b5c74625dd1a34986f7ecbb89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/fi/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/fi/firefox-81.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "6582223e393876a91ab0250c976b1aeac0559722b17e198e05925863e53d81d1";
+      sha256 = "02bad588cc7b4d79e763f02e8cef17704d1137d94a22f2de61c7ae2b1f74b9d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/fr/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/fr/firefox-81.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "b96dc92220680f3c87d6c7cfe79f071382f8183856967133b6fcb6783a60ae6a";
+      sha256 = "f33ee5fa5744b01ee7ea86645b3b70636cc3df1101572a5a7e19522df575ea70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/fy-NL/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/fy-NL/firefox-81.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "4a90cf75ab890ebef3517db701bcdd065e42c2fd8055121ea9b97897be299543";
+      sha256 = "5b32c0bdd3d697f2d0b01d41cb235fb92a422c96e0f2fde1eec1879971a1f7ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ga-IE/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ga-IE/firefox-81.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "56491146a39eae10e9f8fb4ef1fe303a6bead300b680571427e6a410766d0069";
+      sha256 = "bd9b2707e1f5ebcc299582e3ebf770dd5393a1c0e577bcb907d569ecde712ca6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/gd/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/gd/firefox-81.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "0d9f9ad6563e31fd0ead7ec35e594e033f7f1ad0b4c94f0a5cc01cf515fea5ab";
+      sha256 = "c1c9a076dd1a92f13a099caf13682ec2ad120b8db9ea401bf45bf59d4a2e90f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/gl/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/gl/firefox-81.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "8100b774f3bb3a1c3551b9f2c4751ee9e184b04c61489652dbdc81b1fc0b6bcd";
+      sha256 = "ecf0f9769e011b85c6b4e4d3e639a1e8fa0953eb7b9c8e86910047d23383dd6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/gn/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/gn/firefox-81.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "a0002b17f1133194c9f0a0b2b3c56c6ae0d4cd981d5325193a2c96d4b5ec78b2";
+      sha256 = "ac05412736fa6067ad7c038f1721708eae224a4e1538ec4b8132cc647a32c91e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/gu-IN/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/gu-IN/firefox-81.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "6ef49394aec077569251eed4dc7631130be41991022672f477989f5202ac4d1e";
+      sha256 = "885a2d79e09f74302a5312ef96420f35453340253e8e998ab37db1f6cef37921";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/he/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/he/firefox-81.0.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "07e11a9d1a4ef6e3c87e09227d070f75098697a89e057946bb71c1336429d9bb";
+      sha256 = "0b5fdb4085809abd26687e265a7f0296c4ac9d77d7701741ff05055cca793946";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/hi-IN/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/hi-IN/firefox-81.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "39e6c7eab9945a7b9e8d500d8e0dfd416a7a915498683a4966732d8e09183e2c";
+      sha256 = "d920fddfd6c92c190ae9625b6dc27decf6678d5083a9ffccb16eeadc918d42d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/hr/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/hr/firefox-81.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "8946ba5a92d73500cee5c379a796e18cf1b50fe0df4c1867040794850ba0df04";
+      sha256 = "382eb132cc009b6616d1bd437b552cd138b9cc9f138c316166b032becd938cc3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/hsb/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/hsb/firefox-81.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "9d87edfdb5498c16a279f0f262855c4e6f822760cf6d90281cf6c38e65c325f1";
+      sha256 = "f33a2bd9be104af88cab4445f8767bbf507166135a3ce7b7d890ff0ab08bc4bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/hu/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/hu/firefox-81.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "9f515b6b8267b97efec1046c0c2329c5871337b95d7a3b4fdee310699c63b265";
+      sha256 = "01163f584fcb6a30c736d0d7178760465444a2575ab0844613bc735828b29827";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/hy-AM/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/hy-AM/firefox-81.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "1de03462f87b629033b99bb014042d774a52404e279b625f20448809399af44d";
+      sha256 = "56c1537bbcfef3d8ad97e0b7da1e1043e19970cfab7e07a885227ec49ba59dd2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ia/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ia/firefox-81.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "fdcbf5cc522e20587cbac0b4979d77589532ba683ca811e27a7b499f37fe1841";
+      sha256 = "dd883589df0819fc306357547cae94fd34c1ef7e9339fdd5376504c20974cf36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/id/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/id/firefox-81.0.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "e3cafaff6d65ca2da4513d27949b85b2fb8a1ab154d736e980df0ba8caf898be";
+      sha256 = "ab9f57b1e501ddc8d5c4fe024cca69ce15f90b3229b9e76b75ee1cb7be8c5e90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/is/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/is/firefox-81.0.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "21fba4796f2ee43a3662c3f493879d4d656ec710e46369f6da92f757e24ee706";
+      sha256 = "bde7a8f240f19a66cd7ccb26fce683e5c24311e9bb2fc41997a21b5ee5e7657f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/it/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/it/firefox-81.0.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "c8775280055d5b8eb251253e72465149da165b7295cb4c8f400a5286a16168bb";
+      sha256 = "a87a6924935472bca4d64944e7a5fd3545051a5dc00fe7a5e0d6fb2a92c79500";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ja/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ja/firefox-81.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "8870d59360577f8247be0fa51ad33afcc7ebaa2b7d6c8cd5bc100199c5436399";
+      sha256 = "871fe1476cf80f47725fc12a9bbd83dc9d13b7b4de87760c222053ba5a19f110";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ka/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ka/firefox-81.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "394edc1246d9cb08587a67069b27dfe3fb1a92f4ff4a58d314b55128c39d2bd9";
+      sha256 = "bed625be2113058fff0584e90ea89121420e08da234a93c5b57cc652d262fab2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/kab/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/kab/firefox-81.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "e30a08d4427fe896b528beb93b08b1bdc96a38a0817739faa63cd15c2f3014b4";
+      sha256 = "0b591ee502c5cf52099891727b22a8f356663e941db796884e91f821e4d7925e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/kk/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/kk/firefox-81.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "f1b807647ea9deaf7d44e9bfb56403b9a27205c19c3b9f07ba4cfa174b6532c1";
+      sha256 = "dfbbe55d2e73cc42a83bcacaa35b83ffd2e2ff89cd26790e1b608e1980f8f7b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/km/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/km/firefox-81.0.2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "650ad04c9b0c4d461ba28fab7e591453aaf75fe5bddce3c6b8993389814be589";
+      sha256 = "f782024da8726a8869f34eb36d0a4a7401b9d9c2ec28a3c6906a9b21f4f32c3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/kn/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/kn/firefox-81.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "459ec332671ff0e51e110ebb0e8b10e67743fb4b717e5fa165b5dae80054ffe1";
+      sha256 = "59276eaab00aea65992c316d258a68a3ff7bf6091fc3ab177b7e4f606b0bb78f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ko/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ko/firefox-81.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "266849f41f7aa820ba459740becfbbbcb4a551140bf8e76b1eaafc63a6f9d2da";
+      sha256 = "b19e167a77285fcf700bf37d5299c0a9e925ec12b6e60d2810ea40acdbd025ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/lij/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/lij/firefox-81.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "b429ef6b085822fd3ea0fb14fd501a894b96a3f4af8fc34944fdc9ed1c82853b";
+      sha256 = "5db02844a49ffe997b47ed5bbccc43d2ccc9a4b4840c2df5ddd1d393995b820a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/lt/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/lt/firefox-81.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "7b3c089719e901d12c8ad9153a582d229958db035badd4b94b5b496a2ab545d1";
+      sha256 = "cd72be1796eb92d61eab18adf1825fd319c5960b503f6e7fcf67dbbe02cc8c14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/lv/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/lv/firefox-81.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "3efd9d52bc61076208cedef303396c066ec260f7aa5fcccec5b072f2935d89de";
+      sha256 = "87f8d21918c1bf73940ee4ff095a454144421cbbdc78004677bd8d0b8b72c667";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/mk/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/mk/firefox-81.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "f0b1dd701cd7e068d938ec4771fba8f4c3f04e906f575e64dca1dee640fdce22";
+      sha256 = "63a6f39666c18417b34b48109b5a618aca896f48c3538b03495f56bed3769d5d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/mr/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/mr/firefox-81.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "bd5adc1fa68f82a9d2fa54b74b74bdc170f4ead9bed5a79ec1ebf1bd12781a07";
+      sha256 = "7dd84ad66b3b35a9c492456195d438b4f2c242df11df1820fdc5ddb4ff4cd082";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ms/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ms/firefox-81.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "dd106a1944d8ac9e49df16b3c67a86010be1ee62e3a780ad9c725f2335779131";
+      sha256 = "bfbd38c3cf2c611a7f7237bdf0a5a47bec27eb1e1ca160d5068e75c00a76180e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/my/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/my/firefox-81.0.2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "86e45fb6f490ad0cd66564a36e40c6d23169d69d1875022027aed09a1cad3d50";
+      sha256 = "b91368c19dea8b6d7b363e119d80254275a1d52b9e09519a04d65098e60a5258";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/nb-NO/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/nb-NO/firefox-81.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "ef6d5320470da9619f5668e13edae553038a53f80593b5d8392b3678dd8c1d5b";
+      sha256 = "bc78d4ad99fb475d99e4cab0d6a8821c40ee830346db8ded300b69b8a1265e02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ne-NP/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ne-NP/firefox-81.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "8607d4c024fb1d71068b73fb528bfbe42ee69bb12f9703343deb6a7e340c29f2";
+      sha256 = "607ec769d3454f4a4affc32d71105e7b8d900bdb7371a975760197e188d291dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/nl/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/nl/firefox-81.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "a3ea133034cd0014f34c186d9c2fafc902bd51b5314429bb9b7c06e77447fd22";
+      sha256 = "4735ccd0cb2992d41fdd5e7280749db2027bb3d55b6aa9ebce2c1e9dc43af056";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/nn-NO/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/nn-NO/firefox-81.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "09bff657619d23af40014b2e3bc845e6901abee241dfd28f4b5ef8f90c211c30";
+      sha256 = "e95f876e30ba2e97f1567b085c47a960463c7c07bf2921f3f463f8fbd7bb05d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/oc/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/oc/firefox-81.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "6eb63b7f50acf894e33fe9ea98c11b4133b7fb521e23e2fdd6bf9788570b4c78";
+      sha256 = "730084b39df6915a98f5357973f7ceeca59761bcf29c909c6585f9199eb6191f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/pa-IN/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/pa-IN/firefox-81.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "df15da9ff35e192b587ffdaea4d47d368a054148061117bb8f4222e5da6c82a2";
+      sha256 = "7d068491ecece10331c56b5679fe5de69bdb7acce62f4d3292271202804a354d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/pl/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/pl/firefox-81.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "b12bd00b3de180f77f80e80622a8631ff37c32b45362856a64122ad54abf07d2";
+      sha256 = "ab6da3187d8f87cdb9ed42796ffb9d14c5d2710690694592c64e1eb249a995d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/pt-BR/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/pt-BR/firefox-81.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "0296501261b2c55e9acd14fff125f40f8a84fe0508004ea9fda03d2ff69f238c";
+      sha256 = "34bed98380ea05205e5a83801004f694463bd505e400c596ff9183c89070b2fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/pt-PT/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/pt-PT/firefox-81.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "6a5a8328dcd10ad2da9bd45658bd43fca9ae58cc331546305594ce5d84f35017";
+      sha256 = "d1bcf96d674d52828baf8452dc620aeeaa5c5ad04b8f26fa74da3a2dd6d778ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/rm/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/rm/firefox-81.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "41b5bd2e52f0d57475179c46c089ce36c3e1441b5751c670f6fbb6406853aab8";
+      sha256 = "25796de47983159ba7f95847b66d6f382492f8b00f0e7bc16476712daada071f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ro/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ro/firefox-81.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "40a2e53b6b7dcdbd9380d3ede3e425178b670db2205b5a5066d0c4e93a3297c3";
+      sha256 = "6a454aa97f70e4ec91755caad76fc4f21f13d66faf26190404cc2a2ef8b837a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ru/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ru/firefox-81.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "b8f7ecf4a5d8f034e57672d19254cda671f213ce04914995260f6b5f97181edc";
+      sha256 = "2e1f6b8ea95b4a98d9880bdb1f61ccad792e4fe3517dd780a52c5eed5b72adad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/si/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/si/firefox-81.0.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "19d29defd33580089317b72bc6209749727a53978d48294950feba3226839135";
+      sha256 = "c75763f6d6bca7f86be911039a9efd686d8fb011bfcccdac056e2a12243947f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/sk/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/sk/firefox-81.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "4e57b3bdba217d1550fa1ec847b825d66e2d5211d6d0f5342c50ccbab33bf464";
+      sha256 = "0968c66cde907b5e61ce70b1dc1244687069dfde28921a9043d0ccd55182aca7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/sl/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/sl/firefox-81.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "cf89ee419f552622fb9eccf8a28c15f6647afd06de27af0635ab74bfd9aa9619";
+      sha256 = "cc585166dbbf6baf0dbe2b9ceda53671738436c43d2af55a0672c37eb942add6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/son/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/son/firefox-81.0.2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "64e7605b287432c38798e029ab2b02f136d7df876a9c8b3689ca603db0a736cc";
+      sha256 = "911d5fe53e9aa4937f3a697ee1e57b53b87e1ed92a6231086653e03ffd864411";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/sq/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/sq/firefox-81.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "9b56875e2f5505f7fef3c41d4ed7fd8801df8e981f9c8f7cf665104a40e255ba";
+      sha256 = "d7ba2423fc741867add3d76c5b13768f0415f001f8f947c664610c06cd7736b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/sr/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/sr/firefox-81.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "489a2d092f626f39a8e466c269486be8ae455d233e0e26d0c94953039668a57a";
+      sha256 = "456e1cdc8d8c0a0fdf39730ff2a812f8bd7a2b61d94312494fadf1d4957bd593";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/sv-SE/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/sv-SE/firefox-81.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "9e45e9a0c79f9cb3c0c34fb2a26e608afb544716aa16843d53b3e6fd390e2685";
+      sha256 = "040f71f4cf9ca2d01c1c0dfe4a44389f41da0e2a595a827fe88e36a0013cc979";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ta/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ta/firefox-81.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "2843290d4b90b057c6caa437514df0fa61a0cb901809c93690ac8247ff5b1233";
+      sha256 = "488cf25e731096c5ee1458f11adbe0c4b3cf3a665437827f2b27d79e5ca805dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/te/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/te/firefox-81.0.2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "fc9f7e9312fd1430cbbf0d92d8f001077d0af89ccef6c7edb3eff504772ddb79";
+      sha256 = "c79f19c5c2ec4e48a257bb98d4121fd95f284f97f7af4212adbb2663964b1c53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/th/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/th/firefox-81.0.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "622105aa85a0a5874c62f62afd77ffcdb1f4b2d329c255c56c7154a4bbfcb481";
+      sha256 = "4e27f5646e4d62ad70ebfc93a9603c3527ef570307ec4a8408f03bc9f72c662a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/tl/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/tl/firefox-81.0.2.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "998b966b13dc0b1eaf9ffac1788cc354049c43834d3678b51e946f907e42bd9d";
+      sha256 = "71c81c3b5f77364367aad6e004d4d455b01e7d3bbb21cd9c3e5fd7dfdb661f36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/tr/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/tr/firefox-81.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "3dacf51f059f7b974e18d0cf4437bba48a0cf246014ed8ec38d06e2e09cb76f6";
+      sha256 = "3257a340958e658be49f4f2982e8feb8e932532a251e98b236406d370d873275";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/trs/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/trs/firefox-81.0.2.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "e9ce3a2591c8a9b7c5cccc20c2b56ff47ff22947d2393f5e7b010f1242ba1982";
+      sha256 = "914af864af7d51d31abdbec4a1112828d51ffd83ee6a39bbf9f5ec0223ae4ef9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/uk/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/uk/firefox-81.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "a8f78984d01fb54b7475e980aa5775fe7c298e1796cf603446e7cb9baa371bdc";
+      sha256 = "7cff7f0f3d6b586c19d9370e78e6e0ab50a99af62b40de7a44318f5ca929db59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/ur/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/ur/firefox-81.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "0b56702343d7495b752246a9d03e4a5571be05394cebefd1ccd2ca822180259d";
+      sha256 = "b1d17f6434fb7b44576c29e6d1b2c2b3944e27fc8b3aaecf9739c4a653ecd865";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/uz/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/uz/firefox-81.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "46a98ce354b40d64690c0aaf1c553b1d1e5ce51494291ff93ae0e54a82d897d4";
+      sha256 = "3cdd2f764c88fe4a85bd32728f4ff47eb452e14c506f38f891added89fd45a0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/vi/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/vi/firefox-81.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "fcbaf1dbab64bbc8983d444b1601721591c164bb8ff50ae09d2b7925fa41185a";
+      sha256 = "ce2a5cac99bb86adc793ac6c980432a3c1c1bd6150df856088b0cc49cd8b618c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/xh/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/xh/firefox-81.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "af8ff1f66472bbe39724ca714993246f02b0e9025b537ac7e52e65be29db4534";
+      sha256 = "a943db84bba8823112738999cb31dafd20d076de62bc44ac9e2b8f2a793ab283";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/zh-CN/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/zh-CN/firefox-81.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "147a51431333da2333e4ecb0b307d4c74b3d66a626340b6bc25ded8c22c1acf5";
+      sha256 = "23a2662b2844e45cacb038f8fcc1a2647d1b03df6d7ff346c8600c08f6772dcb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0/linux-i686/zh-TW/firefox-81.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0.2/linux-i686/zh-TW/firefox-81.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "e8d577aca0ac90285e9db278c2fc9eec1318407b830e4c231082b139320a4216";
+      sha256 = "dfb5d0725fe50346dc551c407d38574a696e8f10373de73d47252ec283d1b256";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    ffversion = "81.0";
+    ffversion = "81.0.2";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "1dnxn754vb99mccqrj3wr3pg2scjy42rvs5xc6bw022gh6n8kgipx9pbkapwfivkglynxmmbw1k11ak34zhr1g6p31m3550ad6azq19";
+      sha512 = "1szsj7rwpn7ggiavvnc38a75ip0r3p5bgr2kvy2hq7519abzmr3z49jg4alpsy1ndkfylvh28zjw9h5xys0bvs40f33ps90j60z8gla";
     };
 
     patches = [

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -35,10 +35,10 @@ rec {
 
   firefox-esr-78 = common rec {
     pname = "firefox-esr";
-    ffversion = "78.3.0esr";
+    ffversion = "78.3.1esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "3rg4rjmigir2wsvzdl5dkh74hahjv36yvd04rhq0rszw6xz9wyig64nxhkrpf416z6iy3y1qavk7x9j6j02sc2f545pd6cx8abjgqc9";
+      sha512 = "10a7xfp396n81aj17fbl1b1jr8gbn5ild2ig5cfz6r5ff3wfbjs3x0iqrlwqnjfdqq2pw19k2yrv91iwymd8jwjj4p35xsfivgn0a0n";
     };
 
     patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

#100412 for 20.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
