### PR TITLE
agda-packages: add functional-linear-algebra library at v0.1

### DIFF
--- a/pkgs/development/libraries/agda/functional-linear-algebra/default.nix
+++ b/pkgs/development/libraries/agda/functional-linear-algebra/default.nix
@@ -1,0 +1,26 @@
+{ fetchFromGitHub, lib, stdenv, mkDerivation, standard-library }:
+
+mkDerivation rec {
+  version = "0.1";
+  pname = "functional-linear-algebra";
+
+  buildInputs = [ standard-library ];
+
+  src = fetchFromGitHub {
+    repo = "functional-linear-algebra";
+    owner = "ryanorendorff";
+    rev = "v${version}";
+    sha256 = "09ri3jmgp9jjwi1mzv4c3w6rvcmyx6spa2qxpwlcn0f4bmfva6wm";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ryanorendorff/functional-linear-algebra";
+    description = ''
+      Formalizing linear algebra in Agda by representing matrices as functions
+      from one vector space to another.
+    '';
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ryanorendorff ];
+  };
+}

--- a/pkgs/top-level/agda-packages.nix
+++ b/pkgs/top-level/agda-packages.nix
@@ -25,6 +25,9 @@ let
 
     cubical = callPackage ../development/libraries/agda/cubical { };
 
+    functional-linear-algebra = callPackage
+      ../development/libraries/agda/functional-linear-algebra { };
+
     generic = callPackage ../development/libraries/agda/generic { };
   };
 in mkAgdaPackages Agda


### PR DESCRIPTION
Adds the functional-linear-algebra library to the agda package set.

Tested using the following command from the root of the nixpkgs repo:

```
nix-build -E "with import ./. {}; pkgs.agda.withPackages (p: with p; [ functional-linear-algebra ])"
```

Addresses issue https://github.com/ryanorendorff/functional-linear-algebra/issues/16 from the `fla` repository. 

@turion Ready for your review!

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
