### PR TITLE
powerline-go: 1.17.0 -> 1.18.0

### DIFF
--- a/pkgs/tools/misc/powerline-go/default.nix
+++ b/pkgs/tools/misc/powerline-go/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "powerline-go";
-  version = "1.17.0";
+  version = "1.18.0";
 
   src = fetchFromGitHub {
     owner = "justjanne";
     repo = pname;
     rev = "v${version}";
-    sha256 = "135j18d53nhg6adjd2hax067c5f1py9fyprzfcr3plsxnaki2hrx";
+    sha256 = "0dni842xzc8r6wbdfax25940jvxp69zk8xklczkjmyxqawvsxnjh";
   };
 
   vendorSha256 = "0dkgp9vlb76la0j439w0rb548qg5v8648zryk3rqgfhd4qywlk11";


### PR DESCRIPTION
###### Motivation for this change
Update `powerline-go` to the latest release.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
