### PR TITLE
ocamlPackages.opium_kernel: 0.17.1 → 0.18.0

### DIFF
--- a/pkgs/development/ocaml-modules/opium_kernel/default.nix
+++ b/pkgs/development/ocaml-modules/opium_kernel/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildDunePackage
-, fetchFromGitHub
+, fetchurl
 
 , ppx_fields_conv
 , ppx_sexp_conv
@@ -8,35 +8,36 @@
 , cohttp-lwt
 , ezjsonm
 , hmap
+, sexplib
 }:
 
 buildDunePackage rec {
-	pname = "opium_kernel";
-  version = "0.17.1";
+  pname = "opium_kernel";
+  version = "0.18.0";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.04.1";
-  
-	src = fetchFromGitHub {
-		owner = "rgrinberg";
-		repo = "opium";
-		rev = "v${version}";
-		sha256 = "03xzh0ik6k3c0yn1w1avph667vdagwclzimwwrlf9qdxnzxvcnp3";
-	};
+
+  src = fetchurl {
+    url = "https://github.com/rgrinberg/opium/releases/download/${version}/opium-${version}.tbz";
+    sha256 = "0a2y9gw55psqhqli3a5ps9mfdab8r46fnbj882r2sp366sfcy37q";
+  };
 
   doCheck = true;
 
-	buildInputs = [
+  buildInputs = [
     ppx_sexp_conv ppx_fields_conv
   ];
 
-	propagatedBuildInputs = [
-    hmap cohttp-lwt ezjsonm
+  propagatedBuildInputs = [
+    hmap cohttp-lwt ezjsonm sexplib
   ];
 
   meta = {
-		description = "Sinatra like web toolkit for OCaml based on cohttp & lwt";
+    description = "Sinatra like web toolkit for OCaml based on cohttp & lwt";
     homepage = "https://github.com/rgrinberg/opium";
-		license = lib.licenses.mit;
-		maintainers = [ lib.maintainers.pmahoney ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.pmahoney ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Improvements: https://github.com/rgrinberg/opium/releases/tag/0.18.0

The derivation used a mix of tabs & spaces: this PR changes it to space only.

cc maintainer @pmahoney 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
