### PR TITLE
cli11: fix license and platforms

### DIFF
--- a/pkgs/development/tools/misc/cli11/default.nix
+++ b/pkgs/development/tools/misc/cli11/default.nix
@@ -35,9 +35,9 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "CLI11 is a command line parser for C++11";
     homepage = "https://github.com/CLIUtils/CLI11";
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.unix;
     maintainers = with maintainers; [ nand0p ];
-    license = licenses.unfreeRedistributable;
+    license = licenses.bsd3;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

This builds and tests ok for me on `aarch64-linux` and `x86_64-darwin`, so I'm optimistically setting platforms to `platforms.unix`.

The [license section](https://github.com/CLIUtils/CLI11/blob/438eabe5f8d91a3f12ce6c53afd1236b990798ae/README.md#license) in the readme says:
> As of version 1.0, this library is available under a 3-Clause BSD license. See the LICENSE file for details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
