### PR TITLE
Added out-of-date package reports to github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/out_of_date_package_report.md
+++ b/.github/ISSUE_TEMPLATE/out_of_date_package_report.md
@@ -2,7 +2,7 @@
 name: Out-of-date package reports
 about: For packages that are out-of-date
 title: ''
-labels: '0.kind: out-of-date package'
+labels: '9.needs: package (update)'
 assignees: ''
 
 ---
@@ -22,18 +22,18 @@ The "new_version" is the the current version of the package
 <!--
 Type the name of your package and try to find an open pull request for the package
 If you find an open pull request, you can review it!
-You will probably have the new version of the package while helping the community!
+There's a high chance that you'll have the new version right away while helping the community!
 -->
 - [ ] Checked the [nixpkgs pull requests](https://github.com/NixOS/nixpkgs/pulls)
 
 ###### Project name
-`nix search` name: 
+`nix search` name:
 <!--
 The current version can be found easily with the same process than above for checking the master branch
 If an open PR is present for the package, take this version as the current one and link to the PR
 -->
-current version: 
-desired version: 
+current version:
+desired version:
 
 ###### Notify maintainers
 <!--
@@ -41,7 +41,7 @@ Search your package here: https://search.nixos.org/packages?channel=unstable
 If no maintainer is listed for your package, tag the person that last updated the package
 -->
 
-maintainers: 
+maintainers:
 
 ###### Note for maintainers
 

--- a/.github/ISSUE_TEMPLATE/out_of_date_package_report.md
+++ b/.github/ISSUE_TEMPLATE/out_of_date_package_report.md
@@ -7,8 +7,42 @@ assignees: ''
 
 ---
 
-**Project name**
-_give the name of the project_
 
-**Notify maintainers**
+###### Checklist
 
+<!-- Note that these are hard requirements -->
+
+<!--
+You can use the "Go to file" functionality on github to find the package
+Then you can go to the history for this package
+Find the latest "package_name: old_version -> new_version" commit
+The "new_version" is the the current version of the package
+-->
+- [ ] Checked the [nixpkgs master branch](https://github.com/NixOS/nixpkgs)
+<!--
+Type the name of your package and try to find an open pull request for the package
+If you find an open pull request, you can review it!
+You will probably have the new version of the package while helping the community!
+-->
+- [ ] Checked the [nixpkgs pull requests](https://github.com/NixOS/nixpkgs/pulls)
+
+###### Project name
+`nix search` name: 
+<!--
+The current version can be found easily with the same process than above for checking the master branch
+If an open PR is present for the package, take this version as the current one and link to the PR
+-->
+current version: 
+desired version: 
+
+###### Notify maintainers
+<!--
+Search your package here: https://search.nixos.org/packages?channel=unstable
+If no maintainer is listed for your package, tag the person that last updated the package
+-->
+
+maintainers: 
+
+###### Note for maintainers
+
+Please tag this issue in your PR.

--- a/.github/ISSUE_TEMPLATE/out_of_date_package_report.md
+++ b/.github/ISSUE_TEMPLATE/out_of_date_package_report.md
@@ -1,0 +1,14 @@
+---
+name: Out-of-date package reports
+about: For packages that are out-of-date
+title: ''
+labels: '0.kind: out-of-date package'
+assignees: ''
+
+---
+
+**Project name**
+_give the name of the project_
+
+**Notify maintainers**
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
There are a lot of outdated packages on nix, and no easy way to report them.
This added template will also help categorizing issues related to out of date packages for maintainers to take care of.
Furthermore, for new contributors, updating an out-of-date package is way easier than creating a new package.
Adding a pinned issue on updating out-of-date packages could also be a very good idea. something like [ZERO hydra failures 20.09](https://github.com/NixOS/nixpkgs/issues/97479) which provides as well video tutorials on how to do the job.
This could be a very good first issue for everyone that wants to contribute to Nix.

###### Things done
**This is not a package**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
