### PR TITLE
pythonPackages.umap-learn: 0.3.10 -> 0.4.5

### DIFF
--- a/pkgs/development/python-modules/umap-learn/default.nix
+++ b/pkgs/development/python-modules/umap-learn/default.nix
@@ -6,21 +6,23 @@
 , scikitlearn
 , scipy
 , numba
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "umap-learn";
-  version = "0.3.10";
+  version = "0.4.5";
 
   src = fetchFromGitHub {
     owner = "lmcinnes";
     repo = "umap";
     rev = version;
-    sha256 = "0nck5va5km7qkbrhn15dsn0p2mms9kc641lcypy7l8haqgm44h8x";
+    sha256 = "080by8h4rxr5ijx8vp8kn952chiqz029j26c04k4js4g9s7201bq";
   };
 
   checkInputs = [
     nose
+    pytestCheckHook
   ];
 
   propagatedBuildInputs = [
@@ -30,15 +32,15 @@ buildPythonPackage rec {
     numba
   ];
 
-  postConfigure = ''
-   substituteInPlace umap/tests/test_umap.py \
-     --replace "def test_umap_transform_on_iris()" "@SkipTest
-def test_umap_transform_on_iris()"
-  '';
+  disabledTests = [
+    # Plot functionality requires additional packages.
+    # These test also fail with 'RuntimeError: cannot cache function' error.
+    "test_umap_plot_testability"
+    "test_plot_runs_at_all"
 
-  checkPhase = ''
-    nosetests -s umap
-  '';
+    # Flaky test. Fails with AssertionError sometimes.
+    "test_sparse_hellinger"
+  ];
 
   meta = with lib; {
     description = "Uniform Manifold Approximation and Projection";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Updating umap-learn package and fixing build. Unfortunately, I had to disable three tests since they were failing.

ZHF: #97479
@NixOS/nixos-release-managers

Fixing this build: https://hydra.nixos.org/build/127633974

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
