### PR TITLE
pythonPackages.pyatv: 0.7.2 -> 0.7.4

### DIFF
--- a/pkgs/development/python-modules/pyatv/default.nix
+++ b/pkgs/development/python-modules/pyatv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage
 , aiohttp
 , aiozeroconf
 , asynctest
@@ -11,15 +11,20 @@
 , pytest-asyncio
 , pytestrunner
 , srptools
+, zeroconf
+, fetchFromGitHub
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pyatv";
-  version = "0.7.2";
+  version = "v0.7.4";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "83d86fac517d33a1e3063a547ee2a520fde74c74a1b95cb5a6f20afccfd59843";
+  src = fetchFromGitHub {
+    owner = "postlund";
+    repo = pname;
+    rev = version;
+    sha256 = "17gsamn4aibsx4w50r9dwr5kr9anc7dd0f0dvmdl717rkgh13zyi";
   };
 
   nativeBuildInputs = [ pytestrunner];
@@ -31,6 +36,8 @@ buildPythonPackage rec {
     protobuf
     cryptography
     netifaces
+    zeroconf
+    pytestCheckHook
   ];
 
   checkInputs = [
@@ -39,11 +46,6 @@ buildPythonPackage rec {
     pytest-aiohttp
     pytest-asyncio
   ];
-
-  # just run vanilla pytest to avoid inclusion of coverage reports and xdist
-  checkPhase = ''
-    pytest
-  '';
 
   meta = with stdenv.lib; {
     description = "A python client library for the Apple TV";


### PR DESCRIPTION
Also fixes build by switching to github since base_versions.txt is missing
in pypi.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Updating pyatv to 0.7.4 and fixing this build: https://hydra.nixos.org/build/127633443.

ZHF: #97479
@NixOS/nixos-release-managers

Fixing this build: https://hydra.nixos.org/build/127633974
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
