### PR TITLE
[20.09]  thunderbird, thunderbird-bin: 78.3.1 -> 78.3.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.3.1";
+  version = "78.3.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/af/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/af/thunderbird-78.3.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "dc14e5319ecee546f10f7decca4489718bfc94bc30f8b08e9571ef2ea6a3d6bd";
+      sha256 = "928a2aa2fefa53f088ca8122010732bf12ad660e6bd434cfa8062fd9450d6886";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/ar/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/ar/thunderbird-78.3.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "c2b3315de4d006ca44e3c5a68ed8e77024b89de2323970d4615490b86e0fdfd9";
+      sha256 = "fd7cda5dadb0233067e6ac1c19ea556fa0d4503ff04c0acaf75532bc149eabca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/ast/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/ast/thunderbird-78.3.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "0ffaca9fdce6bd88a0a850e149f1e3fc4e2cb167c637af7f9d674616038cf0a3";
+      sha256 = "cd23011acdae26cea8e37cab52e174f559e26c033e2a335bef1fb8fc74c3e6e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/be/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/be/thunderbird-78.3.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "e52c73a0e1a93d6cb51004dd041f88213658673adfc67860f9550ee39adf9250";
+      sha256 = "4c8703308ad7f26bfe28e8d602a36a379d3f0baf0c14a421c02a73a034c2aaaa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/bg/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/bg/thunderbird-78.3.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "62ceac4d1085e1fcbc2446069c6b667be8391a4be5ade4b5f78107ddd3fcc170";
+      sha256 = "eea7b06f9d4dc03b675fc8f7c86eb72a900a88925a6d824983d513539d05f9fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/br/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/br/thunderbird-78.3.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "0de6e27f09912f549e92136d46e02fa3738a3177897dd34e2858ee56b803224c";
+      sha256 = "a28f92a5237722e00913d2a7b9bb597ce94094f4609c53af2cb6542251957247";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/ca/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/ca/thunderbird-78.3.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "ace99257cea52ecf6f99d9a819cf343a23b74e56c1f0bf2a3e66600dbcded779";
+      sha256 = "b574e593656c978689e924fa2f87591395f5fb0221dd8f5cb158356bd153c5ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/cak/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/cak/thunderbird-78.3.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "f39736d27349ba66d142d61070e2c37c4c0a463a1cf89ea72fb1cabb264d38eb";
+      sha256 = "3ad3fc4ec3b45be4b3ec5e8196b558d37c6a008139aa0c8e21ee1f734ae1c8dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/cs/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/cs/thunderbird-78.3.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "a068533fc0ac55972956aa9a9520f403df9519bc291c5102618476f249c911a7";
+      sha256 = "272f9f732266f6db4b446274c02210617b9c0ae7f406e589b68a3553f0ed8a1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/cy/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/cy/thunderbird-78.3.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "bfd66cda463454684865f055339072513fc4b8774b34e96f3c799c6f555122fd";
+      sha256 = "dd4cf52fcfefa2a45a19cedf6d6d8e3c083cfc7e87fd103afb472f31e6ae7c5b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/da/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/da/thunderbird-78.3.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "885bdd4063aa9d8d8dbd352af7291208766fb864b9989b68bb2fa038d314bd8b";
+      sha256 = "bb8260f9fe22408f4811f5e7a93890ebd9a8f13ad50c511c507ffd3e00f1fc86";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/de/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/de/thunderbird-78.3.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "f1d9d91e6a4ef5e3945d958457e96cedde86a0f3b62ac5aee21eeff54c40c999";
+      sha256 = "20fabc41f2375020e00517065ad3316905bb619c727422196d49475a42f151cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/dsb/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/dsb/thunderbird-78.3.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "73628a6c666f69529b04ea8c60dc2fdffce17e9cf13ed6e3af24c8443f093b74";
+      sha256 = "1b0deceff0d884da593e4e6b63cd544ddb680300db7eca1cb33ea556e63942a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/el/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/el/thunderbird-78.3.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "ec532079ebac4e8ba6e58e97d0c7eb1d7f5e0e20c1563985cabd03101dc2c995";
+      sha256 = "02d7c36b55d3874b9b97ca70605af2bd665778f63620f70f3e8773c145fc89b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/en-CA/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/en-CA/thunderbird-78.3.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "1a1366cf35f9ab6b39300405538590e55d6a0833e406a61c9e3924a72adc2bcc";
+      sha256 = "5696ae6535e5a7a8502a86a7834da57ba63b6b2b46e17b46b50535165c1cf9e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/en-GB/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/en-GB/thunderbird-78.3.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "1f62e839e1fff1c0a833ad2ee73fc72542bc3723e0e368ac1d9f153378da8859";
+      sha256 = "6e4c70de2f11a97487e0312af883bd966e3ef937867ebe11e0fd97fab70bb0ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/en-US/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/en-US/thunderbird-78.3.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "c46a8dde6a03c9588d0101354f2a09123d940bce507ea0a693807ea825b5edd1";
+      sha256 = "09e237e75ea4b7c66f249344bd4774c69b9e271176280be3efd8b037699eaa3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/es-AR/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/es-AR/thunderbird-78.3.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "3885122a529f8cc9cc7a579696f6e74f0d42a37309f44a33a18dbc99d01a433a";
+      sha256 = "1df4ab6d9ef48a36b90e2f37ca872a772d0e445a9c4d1428a65b3484facf142c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/es-ES/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/es-ES/thunderbird-78.3.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "d61e5d9e82f52de243cecfc8ccf0ec4476e3309167a33f9c4b7f513c31808527";
+      sha256 = "eb4f2ed2a4ceeeb7146f46a5b675949337aa6251b26714d9e7bf21213e4a81c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/et/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/et/thunderbird-78.3.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "1ddc1fb310c75104c2642c145f9250fbffa834d5a9fb100c12c2e3ea31955321";
+      sha256 = "1e52313ce19c31c0e8f1015b9bdf4f16ec81235673ce1305b1754dccc9d549c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/eu/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/eu/thunderbird-78.3.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "fdb2fd4d1650edc40f193c028a8bd6ac832742a383a2537f7cf7244f8d736717";
+      sha256 = "452c7663e25c88a19232afbadf5c04b2d9bde6095259b4b6e23961d134682d63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/fa/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/fa/thunderbird-78.3.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "7ea9ed9eef1167792c2468372bd5c35a9a36401ec40d63a14a8b3d86cb6f6687";
+      sha256 = "afd84bbe0728f69ded3ea9babf15d9fcc7cd52c242c2ac37dfcac14d0a700a45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/fi/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/fi/thunderbird-78.3.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "efd073de097cb5f82a26a239fbb360b653041a48bf4c98e983b2fa9675e8c64e";
+      sha256 = "fc2042612a6d4366ae5e7d86dd254a16865ec4fea4c47d242c9d170de738fc00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/fr/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/fr/thunderbird-78.3.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "c07c981bc7fa69a10b3c78602e5cff029860b90243ccc3270f7df56505163b81";
+      sha256 = "55acb0633729a54eb594489b5e586626220abd51b36a18d57b78ea5cf44c74f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/fy-NL/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/fy-NL/thunderbird-78.3.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "433912fe6bf0b36788f55f34d28cc56dc9a9c6f19684132e4ce51def7b968097";
+      sha256 = "5789bc3439d9cad9b6a19b341ed20ef1addf0fd5e6e2b7fd811262a6b03efb42";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/ga-IE/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/ga-IE/thunderbird-78.3.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "36a890c2aef942121a0e0717118328668d51961d506eab833141cb80c826768a";
+      sha256 = "25628528647077b5d002a362588f2cc51102a9e56cb69e1adab3ce6248934d50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/gd/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/gd/thunderbird-78.3.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "146853c4725c744d636acfcae4fdb3e65e2f37bd15d5abcbe105bf7ef8854b2f";
+      sha256 = "f7a3d9ee0b0e7eb879ab213d2d607b4030a28e6f8c9fa8b9fa344dd800280873";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/gl/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/gl/thunderbird-78.3.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "32f7c157a764c58a4b2d7aa45388919553300e6c0212ac1b48f30121a04332ee";
+      sha256 = "81f43c7f99cc40d14292cf6bd2011067a626651018d1db9d8565171f8c1d3e9c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/he/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/he/thunderbird-78.3.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "49e44de01ad2f13f1c2f82d137a1eab13d5800a1f72d7eb99514ea3d8bbac1d1";
+      sha256 = "4ba5ab71163107ab78a3b2a54d3069ef055cc052e64b253d12e8bdad1fc2b807";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/hr/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/hr/thunderbird-78.3.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "de3df9903e42dbaa6d2f98da953ff141ac81728537c94505414c7df0721580ab";
+      sha256 = "3bc0688dc2e7bffff8f57bd93dc6aa5442809372bfe76866ee73b0a255940d52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/hsb/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/hsb/thunderbird-78.3.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "3a851331fb698a7f6b5e54b26bba180f9952d55c29a0f8387e2637c0d8a83c79";
+      sha256 = "d72f79876011e5b9b51aa5a6f13fcf94953aa2e88c78b622882ea7e488aebf2a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/hu/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/hu/thunderbird-78.3.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "bbfeee0ce02dfc34012c994d914c69fe6a7d5b4ff0e36bc9e9ec453edc756725";
+      sha256 = "758a16aa0d6e8531c29f32735958984af64861aba71b7bf4b1abd0f9317cd9e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/hy-AM/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/hy-AM/thunderbird-78.3.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "b43ca227a53d8587da34219b02c1bd58f8ed23d63e425cd4911c5e1caa3a5254";
+      sha256 = "3c322f520d8e3aecfe0380235034322e3cd5b507bcec1b637ea5257dccc5675c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/id/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/id/thunderbird-78.3.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "87ed1fb328b592418c515ac16dc8c45349c2dba4c69f8552f3e1f2aa9753bfca";
+      sha256 = "7e77937597d5a1edc597ef8e0531d7f221f7d94d8197a39949bb343a42e2787f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/is/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/is/thunderbird-78.3.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "acfdf1a9dba0372966c82aa3629b5488111b8592b26aec3aa5162c6527ec29a6";
+      sha256 = "762cee2b1bf56c06d85b89d41b2e0dfe171ab69603d33f8b424ad1f0a38e74c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/it/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/it/thunderbird-78.3.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "04480c988c1518b7d2dc06c836f42b4bbbe243df7014a332d195a774fbafbd93";
+      sha256 = "9af51c566595d8d55109144ed47ba334610afcbbfdd732c092ae4b5627c7f773";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/ja/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/ja/thunderbird-78.3.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "a8041d9fc9c2e25367682b0c8d3343cf1a748d32616d4befc2ee3ab0cec24ee6";
+      sha256 = "01f5ddf7c493d22cd30854209ada1936f9b22f0969c1fe16dca5782773a9c670";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/ka/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/ka/thunderbird-78.3.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "d6df8809fd92b9a70a4cd95a035abbb14e0c0e8869034d3c90e50b2e531fa4d4";
+      sha256 = "57d567f1e3905ddecbfb56faf12f286d59b41e7243449d1890eed7d603b3edd1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/kab/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/kab/thunderbird-78.3.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "6170fb0321369588af4417ce8ac25bb74ec14c932a8ecc22119f3c7d15bc9336";
+      sha256 = "d8648f69c846b151014f3d4fe14ca52be266faf38dcbcc0bb1d86e2484626353";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/kk/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/kk/thunderbird-78.3.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "a3a9d5e5c1651f0d46fb6c3d74e87cbde964f2aac9484dbe0b12afabb66adfdf";
+      sha256 = "bae241982062ce0e5edadf6d413f3fc97b8d40fe20cb6690f4c637daf37235c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/ko/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/ko/thunderbird-78.3.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "729a243dd4b5ab5dfd615228875ebba18a8b99d34ade0711cb7c1d2f4534b11d";
+      sha256 = "827a13876cfbc38932cdd7530b6ce677f4a45d83cacf78afd1fd38b63a4e60f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/lt/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/lt/thunderbird-78.3.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "df653c6a2af688591a1e549fddf29f176046723601e5ef85633f69105f5ce23e";
+      sha256 = "21a8895cc45fb8e952c36b0775010ce62a61e6cb5e2d971a3bbc764c1c4d24a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/ms/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/ms/thunderbird-78.3.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "278252b8d98cc29ce713eb00f59c87b54a324a0d3e833434a9912b3e1a0cd796";
+      sha256 = "94b48b693ec3acb9151f115eab1ac737d2f8a4a230f30c032e6a79377943b4fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/nb-NO/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/nb-NO/thunderbird-78.3.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "665760b1c1035a831624c690053c5400d0ae93e28bc04a50bcc8014bc0111f5b";
+      sha256 = "7501edb879e572a82c167d27d7d27332dd4ead3b7aa023c1f629b24c3a1f5bed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/nl/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/nl/thunderbird-78.3.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "466cc2363465d0e3b6e80a9b3a27faaf010f693ed6b8b26f99610c1b4943db10";
+      sha256 = "9997c61862c1dd313e975924ae6eb6de920ae9d2314fef6190049d4de807b810";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/nn-NO/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/nn-NO/thunderbird-78.3.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "32f6aedcc9c9dad560e84c6de83452808e87b903c5cf69834f3a315ff560503c";
+      sha256 = "3d63ed34b338292396364cba16cc9bc2c8fe02f561b0230cc90f4db8757496f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/pa-IN/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/pa-IN/thunderbird-78.3.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "12073cbc4476a11c717a35f8281d9e8590f7eb35b20faf46aadeb41ffd875bfa";
+      sha256 = "3483353b87fe794035e20c38acb2ff138fdf0bc18622a392f30c35417a06098a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/pl/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/pl/thunderbird-78.3.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "3b8131571d497c6479615c48f908f324a76b297f9f0430eb18228283ab4de198";
+      sha256 = "2423e8b4598f5af27a901a9954f63815fc97bc03cd5eb54922eb8fe4c358ec7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/pt-BR/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/pt-BR/thunderbird-78.3.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "618abb8f3e7c48f33002e4c99f05769b66036331a040ff395c65fd1dc9d60dbf";
+      sha256 = "da6be790a40fdaeced699e60e880f403ec65f5789a3db60f6c02afcef4a73095";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/pt-PT/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/pt-PT/thunderbird-78.3.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "a43ea5f9181d9a7abc977ae3b0f5a20215c45d8d3e9baeae581ef15be0909489";
+      sha256 = "b2468b71039ce92df55efd702da6d94ccb94ae86003426cda059b002ba11cfd8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/rm/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/rm/thunderbird-78.3.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "69ea896f45830fe8eeb08e2244579a7454fc18fbdbafe781331bbad97ca4ccec";
+      sha256 = "2acfc84306064c9938b36cbdac93e49d680ff56bb15235335751db85c328d6e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/ro/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/ro/thunderbird-78.3.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "751137453712a435060346649a3f16a2422379ab0dab9141add053e85f0de8d8";
+      sha256 = "88092024e915640ba75f79f853800e3bfc8ddc2a8d0414189128dab95f02d532";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/ru/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/ru/thunderbird-78.3.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "26f2d8b5704ee445835bb7a0f5bcec222359ea83d7d53fe9c9870e664fe3a70f";
+      sha256 = "8b591cba711f89bb8c31919974328e189b02db7afea7a605601b8f245b6ad1e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/si/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/si/thunderbird-78.3.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "1f450ffc77cf5309e8b01646c90324b14cc465b5b7d04566f3ff6cc56506d202";
+      sha256 = "9cde54c8c6e1dedab2a1c39283a76c2a06842917a6f5649eb38de81efe4d3d2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/sk/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/sk/thunderbird-78.3.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "f95af873292f04fe6c224e24a68ed715a8e4015a81be7b45352363f16233ee58";
+      sha256 = "c46599c8c0a6fa8d9c8e52e360864fe8fa5d434ebba227055990d75f2df7feec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/sl/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/sl/thunderbird-78.3.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "ae49c848187a5eae1d8e8bb3f3b85e9c51794a5caed2832a38c9ac38910c85b6";
+      sha256 = "5a232ec6a3968c9198e61f9ddfcd201f55c780428d8ae036161670784e414e13";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/sq/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/sq/thunderbird-78.3.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "aa10a2fa4c73cef05c2b0657daa27c80697cda70e792be56b09ab1f9a66f544d";
+      sha256 = "0fef369af4d7fcfcf306aa0246288aac58ec4e688c19e226b7e75a533dab14f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/sr/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/sr/thunderbird-78.3.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "92daea64a552175341b8223d9264a1bd5bbc5f3938f3420c8b81c7d0e9685b9c";
+      sha256 = "33343981ddb24b43edee0aa8200069e41bc40c0e1befac7d8177124070856bec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/sv-SE/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/sv-SE/thunderbird-78.3.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "d001f1c61dea17d34dc309f6a1f120c57d6fdfe9fd0b3d336b1a1493f47dc196";
+      sha256 = "ccb7a53d2e49fb53fd1affaa0f51d2ee41f33a84d3d2683c241d6391f0030786";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/th/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/th/thunderbird-78.3.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "0f640917646cb88c90aa7f85a79942f0e9dcce70e5d6d65da7e2d4cabfb73fb6";
+      sha256 = "913e379bfb662542f9ddcc1835aa668559ebfead343b4ba9302e8453ff89394f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/tr/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/tr/thunderbird-78.3.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "2150dc844df54651020d8ab4d43ba86d0624cbc06fceb12ab41eec5bafe7339e";
+      sha256 = "0c316e292faae020d17e34f99fa8454616ed72a6e22f075096a961ebebb6a838";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/uk/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/uk/thunderbird-78.3.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "1d9bdddcd7e53d47e77c4fedef5f50559c45e61778e29fc98c04cc4538dcadd7";
+      sha256 = "8d9d5da837d7600c2debdf5b565ebd0a4a95352229382debc7aeb9dac3be1f5b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/uz/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/uz/thunderbird-78.3.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "281f2cb9c35c5710c387fd17a6a55b85c29a01b3f1e32a2b377392566d821b55";
+      sha256 = "f1188953fff54663ed02d4fae4855d4aea08694485c8e3fd50bd35fda5b7cfaa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/vi/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/vi/thunderbird-78.3.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "1678dae6f876b7799f61701db64ab1aa4d6aa3c316535a04734ec7f9481d6042";
+      sha256 = "69faa905db5349c0039ad34ab8a8d17ed94a4d17be4abd38670abb8ab3dc1744";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/zh-CN/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/zh-CN/thunderbird-78.3.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "42c8fcced2d06b91f402c6a9c12b48dc1b024f1a5b2d01aa96a80df088700656";
+      sha256 = "187f8674521c338ca69586f993fad11a913935bb57e33015b4de9ff377d272e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-x86_64/zh-TW/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-x86_64/zh-TW/thunderbird-78.3.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "bbea2d5abe313825efd93e7fe8e63f5c73eeff72ab247b1990210256efee8aad";
+      sha256 = "f71f2865d99a3898b8868a333d259ec653916093a8d87b32a68542ff5b025bbe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/af/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/af/thunderbird-78.3.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "a54cfb6c0965d464ddfaa96dd214444ee51cea6c894e5efac236925d43de0be3";
+      sha256 = "354b1eaad2911860ccca8854f3284978f412452a7f190eeb0dca40f91c374a60";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/ar/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/ar/thunderbird-78.3.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "4d79eb10a38b01539b0c6d31db50f69004fbe5816c09e876cc338984aab0496b";
+      sha256 = "2a61b943aee6cd0bbb479779f4b9cb01cc82a1090881523352264cd55bb9349b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/ast/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/ast/thunderbird-78.3.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "5aa985186c01afe978961b64d702d98a59851257b1a3cd3d9873b7f67dcf1f61";
+      sha256 = "b7c01f059333466686bf4c29c5506649d379ed7402d9a90fdfc8c94169287d81";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/be/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/be/thunderbird-78.3.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "08d6da278f79b3e7c0132b8aec649b804d3a64b0d5c02223b66f83061e421c6e";
+      sha256 = "bdb0bde174dc55c41434e1184c38f55de3692350b119b112eb0231f01af38d60";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/bg/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/bg/thunderbird-78.3.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "c8749049c243474693272795cc3706e096873f743d22be171bb373746afe8a6e";
+      sha256 = "4186901879e228c8bd8f88f893e4e15275fff93e6a8477600360c6f6be0cb205";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/br/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/br/thunderbird-78.3.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "ecc9f08ef1b384d4844ea039ede864ad0f37c1cf83a75b8ee73a34b7f229e4f1";
+      sha256 = "5c7fe36626a5792aa2c58152631068bd3505486f085130d901270eaf33b42797";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/ca/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/ca/thunderbird-78.3.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "92c9e0bbd375c525ad5c28dca4f8bc68726477ed49d908bf479d32729fb44c0a";
+      sha256 = "fd19428f26fb4d2f6c616fe9ea950e6762a4867fbc28b96c5a0c22bfe89bdaa7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/cak/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/cak/thunderbird-78.3.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "33127a2b75dbdab2c33c8fb8a65e6bf053da6422449cb463c7cbf08fe7839d1e";
+      sha256 = "4968a288e8bb2d5badb5347dbcd4cbb5ef0619a213d043a892d267792410aa50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/cs/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/cs/thunderbird-78.3.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "67d137a336085ffbc414d870d57152a275b082c80d240a6b9079f6573e172df0";
+      sha256 = "8ba961d56d2227e310d5998bf099bbdbfb351b10ad7868de7e7a4d4d5bb7b324";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/cy/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/cy/thunderbird-78.3.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "18115d42cf211dc6a90881d836c9431624d54adc30a9521d6b1a1718d95a864b";
+      sha256 = "0270ab63bbc9b94d7dd5a2740a71deaf9f1d2625224ad43d74d0f8c3e4a6cc05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/da/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/da/thunderbird-78.3.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "faea4b3a26149a036d8b44aa0709c4d04e5e917d321d13d1b00cd80b629e5627";
+      sha256 = "2a3be495e24161babfe8186cf3d263705e890f036dd3121ef55bf3d700c06c25";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/de/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/de/thunderbird-78.3.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "1bb244032bfefc15c6e7e2a1e564fa51cfc80c18b6501f079ae65aa5bddc269d";
+      sha256 = "e4c831c8e858ef9b3f889c4b08ff091fad07c3850e92490de16988a5eb64730f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/dsb/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/dsb/thunderbird-78.3.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "687089560ea3561b21ba7f8cef77970f467b953671e5cfe956e0c0aa3dfa72cf";
+      sha256 = "e52993b8fb4d9e8ab064ae3d79d58bb097d24af51d9821889da133e873e1de76";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/el/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/el/thunderbird-78.3.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "5c8021489c7fdfea19446832b6676640134f805537474814f5a7e8d840a2e01c";
+      sha256 = "6cdc29bb73eca549762edf7725327ab366c5c04340b387c43e5b4381849a01e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/en-CA/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/en-CA/thunderbird-78.3.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "a2c9c7f94191e9883f29dd43d7bee51158287cb45e3330ee5649f6553428d6f1";
+      sha256 = "7b98391dc4d42dd1b531400c2f9c73f3e8beefc70b6652e13a39fd2b61af845e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/en-GB/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/en-GB/thunderbird-78.3.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "6afea217b721756cc1ebfd7b99e86a2af239855ef1fe04d6e7fe9e00e00f787c";
+      sha256 = "e257688a0f461be4fcff0f2cca52cf6f63cb143ea4ace3bf81224cf46f0b594d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/en-US/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/en-US/thunderbird-78.3.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "24ae6fe44729cad965c36c8294b00831f426a815bda43bd39fb6e4ed8248a611";
+      sha256 = "d6c97eb8621ca662d2363d0a713f694ce6927d8674e85e3c7d45ad1d5a9429e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/es-AR/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/es-AR/thunderbird-78.3.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "3fd89cac92b8ae97766b56a84d0e8a16f51966cd77a8963ab92b5706cb8fafce";
+      sha256 = "0db8cd545cd003399e462351137f30f5cbadda56bbe33d6367ea1469360ec3fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/es-ES/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/es-ES/thunderbird-78.3.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "5227c2e2624bbc0ff3ec35be01ed42579c280ccbc5b2ab195aca3a6a760bb944";
+      sha256 = "084e2846de52187b45d00b80b192ad4bfc5248a49d956e2eb2977e343a1d9d93";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/et/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/et/thunderbird-78.3.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "1991aa5a22f7a4f6435ed9a116cbbc1b87eccf957f1401b6f20af3ae67b1b3fd";
+      sha256 = "51c1a9105322783c689012dc6d5a875fd0f55611c5d79d2a6e3237ea81475d99";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/eu/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/eu/thunderbird-78.3.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "b9a6cdbd518ab307c646f38757bf8f2706ad51d4dd5f5193e719e112f343f021";
+      sha256 = "5f32ec406d4ed76b29f683e71f73fb67af098a206102043e5e624cd321d9d964";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/fa/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/fa/thunderbird-78.3.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "49805c2c97109cc22075d08503926a57910f367010a2ff8ed9c91556ad4d419b";
+      sha256 = "b5a22adacde7e0b931f8daed54f7876dd1e1bb845e59558fe11960484369b7db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/fi/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/fi/thunderbird-78.3.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "ce6e16cc46ee16ca9aad6154be7442dd8bdaee09e89a75c13639f1c1979dbb57";
+      sha256 = "de546582b1944aecdc75d62fb8da39158f3bcc9af54cd6b761db23056e9283f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/fr/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/fr/thunderbird-78.3.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "d2e4abb6fead6aeda1e8172c04ce7b809bfa8038ffaec89431791422e70b8932";
+      sha256 = "f0dc1417bf759bc29ff026a651bb7c3af6bbe4125e4f4ba683ea69d1b1255487";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/fy-NL/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/fy-NL/thunderbird-78.3.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "6286b7bdee544c51137c2bdc423eb72523b20ddde3eb4bee7b4ab575aebf30fc";
+      sha256 = "32ab772135e7d225b4523fe8a285528c62de998e83afebccd05ceaf19b421f45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/ga-IE/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/ga-IE/thunderbird-78.3.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "b145a9b44cbafce2ebc22f4454ee6d4017c531918dd690598eb421822f4b0548";
+      sha256 = "a7bc030ed725fd70d8a56c2f16c9ba3b6351d1b4774d122660a53b5e1a74bd1f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/gd/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/gd/thunderbird-78.3.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "c0835ac49602ad6de4d37e016d40f51268bf3e43ff04a2bc1a83c5f7f7b12556";
+      sha256 = "f628c45bac5b24e4520c891afdde79b5235938ddb560803b29e9aa92c68577ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/gl/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/gl/thunderbird-78.3.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "22c5cfdfb8c64d18d10e2c839166ffbdb21b54d4bcebb51bb7bcaec21a3efdbb";
+      sha256 = "621d843e20100641fed4fa2646d633ec4e78669113ff6627dcda9be07848a550";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/he/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/he/thunderbird-78.3.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "85f2170d4f4e20f91631a717bf78f28ac7ca45d47bb4fbfef3e56aeba291fbfc";
+      sha256 = "2e4916e0555d64e7a54a036612bf343e6f4307afddb4819f4b8839485a76f781";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/hr/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/hr/thunderbird-78.3.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "2aa8960e96ebbb32be8f019f30d9eca73f69aefef0989b760223569ed8e1bca6";
+      sha256 = "0f77b57b10b69eae4c3c6a3aeb11ff1cdd038bc01ab852d93d3201f4d868750c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/hsb/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/hsb/thunderbird-78.3.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "0c1f3803399da44d1c518057f191c3a544a3a3af3e2893be44e386edd43a5ae2";
+      sha256 = "c66cd470205f8a54d2427c04300fa8198c771d803b06875b907d373c49962550";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/hu/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/hu/thunderbird-78.3.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "2f357cb86c535ec8bbe657d6987b657ed1d0257d2c94620359cab42570d35983";
+      sha256 = "8b9bb5089451dbf01e497a99a74e7baf5a1a23f32ef4aebfb2cdadd5f0862b29";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/hy-AM/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/hy-AM/thunderbird-78.3.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "ab3582a00d26e83a6b01cc2daa17ab9cf9708de1e1dcf9260f827f4e3fdde100";
+      sha256 = "9d20881caa1b397d82bf55e9934c0aae7a202a3e10dfdf618e213fc5df7d657a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/id/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/id/thunderbird-78.3.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "8d5a97914ee601a47a89dd7bbe971f95a1b5bfb4a7047feb164875daa316417d";
+      sha256 = "2ec49e638f0f3cd7d18ad7e9e02827f9935161913ff84a9c99a1f98694293097";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/is/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/is/thunderbird-78.3.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "089b7c67b70763d3e0080aba6a7d8201cd656e2c85bfe60739ad57b569b9c54a";
+      sha256 = "d74bfe64c452883d71885185f4f4d896a31288822fd23e6b64b81dc0bf35413f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/it/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/it/thunderbird-78.3.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "45aa6b0c5d3c00812efd815e197dc35a538002c63639d3b9857ca49f8e3e3692";
+      sha256 = "ced883ab4b3581e935e7f984c719854e3ba56477850173474c6bdc35ae40d7c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/ja/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/ja/thunderbird-78.3.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "ea52820e216c79d015dc8715e5341ec2fdd4c7e99f772086652721488681d69b";
+      sha256 = "f4bd7f453e97f8647c95be13b9141d3a5ae9616c656da89af9805825105d0b38";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/ka/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/ka/thunderbird-78.3.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "6fc3af0c7a5b78350714d9f8f640f71c7094cc77590038cb6e817bbc40ccd74b";
+      sha256 = "d7bb492589f676319711227edcf413e0a8605b0361a107bb0bf57081f640ebce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/kab/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/kab/thunderbird-78.3.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "2b387a1fec481a3a98c0a62b3bcc06cf83c1b8504b46b89d1bec12572252db6e";
+      sha256 = "7f963664d38d0d8798bbcded7472cba761b8c0c87a83bb3829f5ca725151674f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/kk/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/kk/thunderbird-78.3.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "55f5d12ac7b5c0aee1d1d616a871f9c7ed3f5bd882acb9fd9538a3d29a0e58ee";
+      sha256 = "9c95f44d25b57fd09c45b65ce5d4dd19d9ffb3c1999fb240376b152f1427e631";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/ko/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/ko/thunderbird-78.3.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "8090cf9a8ce14dfe2dfd65b985501ab9580ca28f923377dca8a57b0529b0eb23";
+      sha256 = "f887280432dcef0606612e8abc1b7d7ff0b63776ead6d3c12c8be6d5f114c8cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/lt/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/lt/thunderbird-78.3.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "17584b8859a7356022a39b14fe2ee81f5b1d37df3ef0fc9e2caeae297bff61ce";
+      sha256 = "08e427b38c00dc46c0f6cb4ea856f4b62ad8478cfdc75b24e4cfd453b6ad4e15";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/ms/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/ms/thunderbird-78.3.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "0a0119c8f5f458003aec3d4b933d9f4f1c9d7dca30a25886ec11079906a327a4";
+      sha256 = "dae2e31ee21de7d7bf4bc5bc3f45ce1f4ca650b7f45e47b7ae8d6c09800fb35a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/nb-NO/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/nb-NO/thunderbird-78.3.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "d22e4ff9b10f278fa382a6e045790231fcdca2b0adfb5678d50963afce2c1cad";
+      sha256 = "58199dcfbebbdcc122308140c128d56c6ca464e477c76c8ec39d22c6c444b6a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/nl/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/nl/thunderbird-78.3.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "882d4eec92d78f61b3fac34277bef4d9f331bfafc7c80fcd4518862a4e96ea7e";
+      sha256 = "c62325f5e2718f9e28554a7df99c3c68376d9c8208a62345a913e176e0388510";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/nn-NO/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/nn-NO/thunderbird-78.3.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "b97c95e6e483185ae010d21ce9c977ef71209363ceba56a91ebbf26e62febda6";
+      sha256 = "f560d924bf9d267f231ff0869c0770d2216690f8944df79b417f1d53dc814bd5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/pa-IN/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/pa-IN/thunderbird-78.3.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "804f3ea53314ff6ea73d16a7b46f37e603161bdcd60272d7fbe1ce16a3588d62";
+      sha256 = "bbb256675969e68bfd0595dbe6a1c3096622f8fb818d08759e7c3d1648745b32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/pl/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/pl/thunderbird-78.3.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "faedc7b47d029583c3e1d2549b3f85ed37d933e545aeb5782b6c7db59cda71e1";
+      sha256 = "a6fbe42f3a0be3e4e3df2156d668e1ac83c2e58abdf55ddce1469a90e2cec9dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/pt-BR/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/pt-BR/thunderbird-78.3.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "4b1dfb1ff39d6200502746ffbdd1c97267c496276d6d019f27f8788be67c8dbc";
+      sha256 = "bbf82582f1c9b214e4f47bb1f4cc03a0df32d779a2d2f752bef3329540c321a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/pt-PT/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/pt-PT/thunderbird-78.3.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "ca48dea62d3934197317e737a68ed685d60fcd21274022fbf74956e7b5767b26";
+      sha256 = "3a5b00fd0a85cd5f613a8a98d8f41e8419335a9012e9f933e2adc7d2431e584a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/rm/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/rm/thunderbird-78.3.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "2c71fcd755e02377499ee364c5777c9dd02e856de1923417fd1caa22a5fbae72";
+      sha256 = "3f3ff94e6cffa497146590b7efa57e6051ff8b815fac50e3339eff1c7ec51e8b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/ro/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/ro/thunderbird-78.3.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "0c28dd6d2345432beba854984384c7ef48eb33e93860ce601f977ba95286837e";
+      sha256 = "a9968a9b3e0c1323f9d08dc7efe31d77f0f5dacceceba1f9cdb737340b4a74c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/ru/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/ru/thunderbird-78.3.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "98b29b6d65f93a265a1b77a717b49445f8a51209a1bd83a160ecb51ff4217a91";
+      sha256 = "e02d0d2b19787892b80ee987665e59129fd84d3f9c4e3cd139589cb41d25ae7a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/si/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/si/thunderbird-78.3.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "c8b63b0fe37222493b1f35fbdd9aeedd4af9bb10585ed9ec2f2dc1e2c52eba40";
+      sha256 = "bfd849787426abcdfdfc97933e4e9bb4360a96d1912d6c5f7f1ac6cd4d9370df";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/sk/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/sk/thunderbird-78.3.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "c9d7715b8330e35ebefc386d8258c6ab00a12f14400fe01ad61037cd396b2cfa";
+      sha256 = "855560f2af08f0ee27c658cbf755973b7333604c731d9442418e75fc1bf50fa2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/sl/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/sl/thunderbird-78.3.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "2403387bbaab64e925c2729076ea039206d8b4e6964e7aa825877074eb6ccf57";
+      sha256 = "6f40769e00da9228e806304edc63e5730126937dbec77bc91d92e27ff28c0c15";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/sq/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/sq/thunderbird-78.3.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "a8e83d18620b057c6981a170fafcef44f0e7800168c305abeb3ed6c5a936220c";
+      sha256 = "067738a24e3f541d8e8c4515570ea61c5f17e95bcc4f61aff29db7e43f916106";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/sr/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/sr/thunderbird-78.3.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "6cfd9ddd429240f48c8f478d785b881047e262ebe6d3460f7780f57248b22da6";
+      sha256 = "f067575a282cf0e59e87b9b6eed247d697249e181febe1713bde8555adc17cbd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/sv-SE/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/sv-SE/thunderbird-78.3.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "e8db182f239050020f91b1aab23514245c04d3aab977df6215165c401c010ce0";
+      sha256 = "c7c80cea8b8196da0bd13de4320715f14cce50a1bb9d5a529dc6c1ad48ec9535";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/th/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/th/thunderbird-78.3.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "20d5cc43be200cc6359c56a3988f76583fb6887834bed0512125296f2c25b0f9";
+      sha256 = "667fc7175767cd7383cfe29e0774d5b302cead6670edc28032aadf1404d4ffbe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/tr/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/tr/thunderbird-78.3.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "8e74feb16b9c23689fec026e88a1749bc2c78fba0cf048db0228168f93fa7d2c";
+      sha256 = "b41831259a05028054c80378f30cd3edd8b1cee012d7045b34d2a62f38ea4980";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/uk/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/uk/thunderbird-78.3.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "6bd6d8c2b346adf03f0a12a84cdcd68b7e3d7e4c1caa7ebf23f5ecd90b0c0513";
+      sha256 = "c7ec76e5052c7a0b91a37bfa889a23c43503a5da5d672af2faf529e3bb626adf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/uz/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/uz/thunderbird-78.3.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "b227ca8402b6ba1db029a4964ca4e3a28403ce5ade7bcb6cb9157665759426aa";
+      sha256 = "c6b95124196c7865cc2d4f04a32e3bccad4a6d57ec8c9b4a4477f6cef2cc8d69";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/vi/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/vi/thunderbird-78.3.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "09962111baf14ad41f6277b3f625a38458ba07fbdbf17673807f29dd347e8eac";
+      sha256 = "e20fce086298932fa45bf8627a2306e160395e9302b7c5b48092a8dbd2f78f2f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/zh-CN/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/zh-CN/thunderbird-78.3.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "b86d0b18a3d87dc3fd018672f3bb8fa8eb5105fc56d1c4161ce324c6babc8286";
+      sha256 = "b5a9e98af41d24d12ab111356c035769c71ddd3d9a79a959584d4ae11ca8f706";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.1/linux-i686/zh-TW/thunderbird-78.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.3.2/linux-i686/zh-TW/thunderbird-78.3.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "4e09553f18e9955b7072326b2e7f40bbb2e19f13f137742a0d9b29664f570d8a";
+      sha256 = "9978aa31d4ef744921e43a116cdc2deead358f7db368ee64e90d37119819a4fc";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -70,13 +70,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.3.1";
+  version = "78.3.2";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "16b05e51776ba16503bc5fba02a6d0b5050a206e264a4707544354ad76af61902fd2dcf5d97b82b432dc69362ccd18543a0acccd80e06648e6c6f470886da450";
+      "3c5b9400k3nrlabr2cvm5s3nz4ngy9qnz0j44mczh67v5xsmxi1hks8dx75s8sbbhnzmg0id4vlxfwd7i259p2xc039nkzkahmfn2wc";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

#100079 for 20.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
