### PR TITLE
bup: use python3

### DIFF
--- a/pkgs/tools/backup/bup/default.nix
+++ b/pkgs/tools/backup/bup/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, makeWrapper
-, perl, pandoc, python2Packages, git
+, perl, pandoc, python3Packages, git
 , par2cmdline ? null, par2Support ? true
 }:
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     git
-    (python2Packages.python.withPackages
+    (python3Packages.python.withPackages
       (p: with p; [ setuptools tornado ]
         ++ stdenv.lib.optionals (!stdenv.isDarwin) [ pyxattr pylibacl fuse ]))
   ];


### PR DESCRIPTION
###### Motivation for this change
The neverending quest for the deprecation of python 2

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via `make long-check`: everything passes except two tests about `man` (probably unrelated)
- [x] Tested compilation of all pkgs that depend on this change (`bup`)
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @muflax