### PR TITLE
Treesitter lua

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -11,9 +11,9 @@ let
   # 1) change all these hashes
   # 2) nix-build -A tree-sitter.updater.update-all-grammars
   # 3) run the ./result script that is output by that (it updates ./grammars)
-  version = "0.16.9";
-  sha256 = "sha256-e5Ft+jEpExLgBBFmiswW0VFrsKume4gmUiOiF4ODhhQ=";
-  cargoSha256 = "sha256-XbPLQEvf4JX517ddpx18eweiPrztS5E/X2pejkqmlCU=";
+  version = "0.17.1";
+  sha256 = "sha256-k61actAEyao/Ea8aw9PCm252U+1I0d43MAYC68/lui4=";
+  cargoSha256 = "sha256-Jp/Fl20ZZfaIdWinOOujNVH5JjJNtyUYHfyTrmeeoRg=";
 
   src = fetchFromGitHub {
     owner = "tree-sitter";

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -8,6 +8,7 @@
   javascript = (builtins.fromJSON (builtins.readFile ./tree-sitter-javascript.json));
   jsdoc = (builtins.fromJSON (builtins.readFile ./tree-sitter-jsdoc.json));
   json = (builtins.fromJSON (builtins.readFile ./tree-sitter-json.json));
+  lua = (builtins.fromJSON (builtins.readFile ./tree-sitter-lua.json));
   php = (builtins.fromJSON (builtins.readFile ./tree-sitter-php.json));
   python = (builtins.fromJSON (builtins.readFile ./tree-sitter-python.json));
   ruby = (builtins.fromJSON (builtins.readFile ./tree-sitter-ruby.json));

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/nvim-treesitter/tree-sitter-lua",
+  "rev": "278b0ea1f1f3d86afc86faaca0cbbf6c01182a54",
+  "date": "2020-09-08T18:29:23+02:00",
+  "path": "/nix/store/xkaqsw030bf6zd6pivrzrg3d50j1ka1k-tree-sitter-lua",
+  "sha256": "0i8jdp0bbl02h58hfhpild4v3rvy8yk5r5l90navvfxw4ad4f6f3",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
want to use lua grammar in neovim + treesitter

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
