### PR TITLE
devpi-server: fix tests

### DIFF
--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -1,18 +1,22 @@
-{ stdenv, python3Packages, nginx }:
+{ stdenv, fetchFromGitHub, python3Packages, nginx }:
 
 python3Packages.buildPythonApplication rec {
   pname = "devpi-server";
-  version = "5.5.0";
+  version = "6.0.0.dev0";
 
-  src = python3Packages.fetchPypi {
-    inherit pname version;
-    sha256 = "0lily4a0k13bygx07x2f2q4nkwny0fj34hpac9i6mc70ysdn1hhi";
+  src = fetchFromGitHub {
+    owner = "devpi";
+    repo = "devpi";
+    rev = "68ee291ef29a93f6d921d4927aec8d13919b4a4c";
+    sha256 = "1ivd5dy9f2gq07w8n2gywa0n0d9wv8644l53ni9fz7i69jf8q2fm";
   };
+  sourceRoot = "source/server";
 
   propagatedBuildInputs = with python3Packages; [
     py
     appdirs
     devpi-common
+    defusedxml
     execnet
     itsdangerous
     repoze_lru


### PR DESCRIPTION
Tests relied on a function that has no order guarantee. A fix was merged
to devpi master [1]. We point the package to this commit which should fix
the failing tests on hydra.

[1] https://github.com/devpi/devpi/pull/821

ZHF: #97479
cc @NixOS/nixos-release-managers

Fix build https://hydra.nixos.org/build/127650244/nixlog/2

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
