### PR TITLE
noaa-apt: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/applications/radio/noaa-apt/default.nix
+++ b/pkgs/applications/radio/noaa-apt/default.nix
@@ -13,13 +13,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "noaa-apt";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "martinber";
     repo = "noaa-apt";
     rev = "v${version}";
-    sha256 = "0fqki4a9c54rixdz5bpswvn433f9saw6yazgw4av3xdd7g2fdvvj";
+    sha256 = "0fmbg6lw7lmm402hzddpzgi7y9mc6kic14x8rif7fampk20mv3ms";
   };
 
   nativeBuildInputs = [
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
     pango
   ];
 
-  cargoSha256 = "1pzcq31inazmc9cz31fspzqkp0lpkjid8ai3g17sin1pfzby5jlh";
+  cargoSha256 = "0w4rbbz8lsh31xkgibzndiic47690nfcjrn1411dskf7ali6djy8";
 
   preBuild = ''
     # Used by macro pointing to resource location at compile time.

--- a/pkgs/applications/radio/noaa-apt/default.nix
+++ b/pkgs/applications/radio/noaa-apt/default.nix
@@ -59,6 +59,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "http://noaa-apt.mbernardi.com.ar/";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ trepetti ];
+    platforms = platforms.all;
     changelog = "https://github.com/martinber/noaa-apt/releases/tag/v${version}";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Version bump and making `platforms.all` explicit to make sure hydra builds binary versions: https://github.com/NixOS/nixpkgs/pull/99995#discussion_r503282420

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
