### PR TITLE
mons: 20200107 -> 20200320

### DIFF
--- a/pkgs/tools/misc/mons/default.nix
+++ b/pkgs/tools/misc/mons/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   pname = "mons";
-  version = "20200107";
+  version = "20200320";
 
   src = fetchFromGitHub {
     owner = "Ventto";
     repo = pname;
-    rev = "0c9e1a1dddff23a0525ed8e4ec9af8f9dd8cad4c";
-    sha256 = "02c41mw3g1mgl91hhpz1n45iaqk9s7mdk1ixm8yv6sv17hy8rr4w";
+    rev = "375bbba3aa700c8b3b33645a7fb70605c8b0ff0c";
+    sha256 = "19r5y721yrxhd9jp99s29jjvm0p87vl6xfjlcj38bljq903f21cl";
     fetchSubmodules = true;
   };
 
-  # PR: https://github.com/Ventto/mons/pull/36
-  preConfigure = ''sed -i 's/usr\///' Makefile'';
-  
   nativeBuildInputs = [ help2man ];
-  makeFlags = [ "DESTDIR=$(out)" ];
+  makeFlags = [
+    "DESTDIR=$(out)"
+    "PREFIX="
+  ];
 
   meta = with lib; {
     description = "POSIX Shell script to quickly manage 2-monitors display";


### PR DESCRIPTION
###### Motivation for this change

Make the build simpler now that PR https://github.com/Ventto/mons/pull/36 is merged upstream.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
