### PR TITLE
chromium: fix build on i686

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -244,7 +244,7 @@ let
 
     gnFlags = mkGnFlags ({
       use_lld = false;
-      use_gold = true;
+      use_gold = stdenv.buildPlatform.is64bit;  # ld.gold outs-of-memory on i686
       gold_path = "${stdenv.cc}/bin";
       is_debug = false;
 


### PR DESCRIPTION
ld.gold outs of memory on i686.

I am not sure why ld.gold is needed at all, probably `use_gold = false;` would be a better option.
I kept it `true` on 64-bit platforms only to avoid rebuild