### PR TITLE
[20.09] pythonPackages.cma: 2.7.0 -> 3.0.3

### DIFF
--- a/pkgs/development/python-modules/cma/default.nix
+++ b/pkgs/development/python-modules/cma/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "cma";
-  version = "2.7.0";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "CMA-ES";
     repo = "pycma";
     rev = "r${version}";
-    sha256 = "0c26969pcqj047axksfffd9pj77n16k4r9h6pyid9q3ah5zk0xg3";
+    sha256 = "00vv7imdkv0bqcs4b8dg9nggxcl2fkcnhdd46n22bcmnwy8rjxv6";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

Backport of #87293.

Reverse dependency `optuna` is already broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
