### PR TITLE
python3Packages.pytest-flask: remove support for python 2.7

### DIFF
--- a/pkgs/development/python-modules/pytest-flask/default.nix
+++ b/pkgs/development/python-modules/pytest-flask/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest, flask, werkzeug, setuptools_scm }:
+{ stdenv, buildPythonPackage, fetchPypi, pytest, flask, werkzeug, setuptools_scm, isPy27 }:
 
 buildPythonPackage rec {
   pname = "pytest-flask";
   version = "1.0.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
@@ -11,11 +12,8 @@ buildPythonPackage rec {
 
   doCheck = false;
 
-  buildInputs = [
-     pytest
-  ];
-
   propagatedBuildInputs = [
+    pytest
     flask
     werkzeug
   ];


### PR DESCRIPTION
As stated in its changelog [1], python 2.7 is no longer supported.

[1] https://github.com/pytest-dev/pytest-flask/blob/master/docs/changelog.rst

ZHF: #97479
@NixOS/nixos-release-managers

Fixes https://hydra.nixos.org/build/127652828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
