### PR TITLE
treewide: Fix broken desktop files and mark packages as broken

### DIFF
--- a/pkgs/applications/misc/toggldesktop/default.nix
+++ b/pkgs/applications/misc/toggldesktop/default.nix
@@ -139,6 +139,7 @@ buildEnv {
   paths = [ desktopItem toggldesktop-icons toggldesktop-wrapped ];
 
   meta = with lib; {
+    broken = true; # libtoggl is broken
     description = "Client for Toggl time tracking service";
     homepage = "https://github.com/toggl/toggldesktop";
     license = licenses.bsd3;

--- a/pkgs/applications/networking/ostinato/default.nix
+++ b/pkgs/applications/networking/ostinato/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
       GenericName[it]=Generatore ed Analizzatore di pacchetti di rete
       Comment[it]=Generatore ed Analizzatore di pacchetti di rete con interfaccia amichevole
     '';
+    fileValidation = false;
   };
 
   postInstall = ''

--- a/pkgs/applications/networking/termius/default.nix
+++ b/pkgs/applications/networking/termius/default.nix
@@ -59,6 +59,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A cross-platform SSH client with cloud data sync and more";
     homepage = "https://termius.com/";
     downloadPage = "https://termius.com/linux/";

--- a/pkgs/applications/science/math/sage/sage.nix
+++ b/pkgs/applications/science/math/sage/sage.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Open Source Mathematics Software, free alternative to Magma, Maple, Mathematica, and Matlab";
     license = licenses.gpl2;
     maintainers = with maintainers; [ timokau ];

--- a/pkgs/games/frogatto/default.nix
+++ b/pkgs/games/frogatto/default.nix
@@ -34,6 +34,7 @@ in buildEnv {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = "https://frogatto.com";
     description = description;
     license = with licenses; [ cc-by-30 unfree ];

--- a/pkgs/games/tdm/default.nix
+++ b/pkgs/games/tdm/default.nix
@@ -16,6 +16,7 @@ let
     type = "Application";
     categories = "Game;";
     genericName = pname;
+    fileValidation = false;
   };
 in stdenv.mkDerivation {
   name = "${pname}-${version}";

--- a/pkgs/games/tome2/default.nix
+++ b/pkgs/games/tome2/default.nix
@@ -14,6 +14,7 @@ let
     type = "Application";
     categories = "Game;RolePlaying;";
     genericName = pname;
+    fileValidation = false;
   };
 
 in stdenv.mkDerivation {


### PR DESCRIPTION
This fixes all packages that are failed `nixpkgs-review` in #91790.
Packages that were broken prior to that PR were marked as broken.
Packages that failed because of #75729 were fixed.

Affected packages:

| Package | Broken reason | Fix | Maintainer ping |
|---------|---------------|-----|-----------------|
| frogatto | Build failure | Mark as broken | @astro |
| ~~ipmiview~~ | ~~Desktop file broken~~ | ~~Disable validation~~ Fixed in ~~#100534~~ #92053 | @vlaci |
| ostinato | Desktop file broken | Disable validation | @rick68 |
| ~~python37Packages.spyder~~ | ~~Build failure~~ | ~~Mark as broken~~ Fixed on master | @gebner |
| ~~react-native-debugger~~ | ~~Desktop file broken~~ | ~~Disable validation~~ Fixed on master | **No maintainers!** |
| sage | Python tests fail | Mark as broken | @timokau |
| sageWithDoc | Python tests fail | Mark as broken | @timokau |
| ~~softmaker-office~~ | ~~Hash mismatch in fixed output derivation~~ | ~~Mark as broken~~ Fixed on master | @danieldk |
| tdm | Desktop file broken | Disable validation | @cizra |
| termius | Download URL 403 | Mark as broken | @Br1ght0ne |
| toggldesktop | libtoggl build failure | Mark as broken | @yegortimoshenko |
| tome2 | Desktop file broken | Disable validation | @cizra |
| ~~ut2004demo~~ | ~~Download URL 404~~ | ~~Mark as broken~~ Fixed in #100424 | @abbradar |

###### Motivation for this change

Less build failures!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review 100532"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
