### PR TITLE
pythonPackages.flake8-future-import: fix build

### DIFF
--- a/pkgs/development/python-modules/flake8-future-import/default.nix
+++ b/pkgs/development/python-modules/flake8-future-import/default.nix
@@ -1,4 +1,4 @@
-{ lib, isPy27, fetchFromGitHub, buildPythonPackage, pythonOlder, fetchpatch, flake8, importlib-metadata, six }:
+{ lib, isPy27, isPy38, fetchFromGitHub, buildPythonPackage, pythonOlder, fetchpatch, flake8, importlib-metadata, six }:
 
 buildPythonPackage rec {
   pname = "flake8-future-import";
@@ -20,7 +20,8 @@ buildPythonPackage rec {
   # Upstream disables this test case naturally on python 3, but it also fails
   # inside NixPkgs for python 2. Since it's going to be deleted, we just skip it
   # on py2 as well.
-  patches = lib.optionals isPy27 [ ./skip-test.patch ];
+  patches = lib.optionals isPy38 [ ./fix-annotations-version.patch ]
+    ++ lib.optionals isPy27 [ ./skip-test.patch ];
 
   meta = with lib; {
     description = "A flake8 extension to check for the imported __future__ modules to make it easier to have a consistent code base";

--- a/pkgs/development/python-modules/flake8-future-import/fix-annotations-version.patch
+++ b/pkgs/development/python-modules/flake8-future-import/fix-annotations-version.patch
@@ -1,0 +1,13 @@
+diff --git a/flake8_future_import.py b/flake8_future_import.py
+index 92c3fda..27a1a66 100755
+--- a/flake8_future_import.py
++++ b/flake8_future_import.py
+@@ -76,7 +76,7 @@ UNICODE_LITERALS = Feature(4, 'unicode_literals', (2, 6, 0), (3, 0, 0))
+ GENERATOR_STOP = Feature(5, 'generator_stop', (3, 5, 0), (3, 7, 0))
+ NESTED_SCOPES = Feature(6, 'nested_scopes', (2, 1, 0), (2, 2, 0))
+ GENERATORS = Feature(7, 'generators', (2, 2, 0), (2, 3, 0))
+-ANNOTATIONS = Feature(8, 'annotations', (3, 7, 0), (4, 0, 0))
++ANNOTATIONS = Feature(8, 'annotations', (3, 7, 0), (3, 10, 0))
+ 
+ 
+ # Order important as it defines the error code


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Breaks esphome which subsequently requires platformio, which in turn requires esphome.

Was broken after python3.8 upgraded to 3.8.6 due to this change:

> bpo-41314: Changed the release when from future import annotations becomes the default from 4.0 to 3.10 (following a change in PEP 563).

Reported upstream in https://github.com/xZise/flake8-future-import/issues/24.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
