### PR TITLE
sonobuoy: 0.16.1 -> 0.19.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9780,4 +9780,10 @@
     github = "hloeffler";
     githubId = 6627191;
   };
+  wilsonehusin = {
+    name = "Wilson E. Husin";
+    email = "wilsonehusin@gmail.com";
+    github = "wilsonehusin";
+    githubId = 14004487;
+  };
 }

--- a/pkgs/applications/networking/cluster/sonobuoy/default.nix
+++ b/pkgs/applications/networking/cluster/sonobuoy/default.nix
@@ -1,13 +1,13 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 # SHA of ${version} for the tool's help output
-let rev = "c9c2a461cd3397909fe6e45ff71836347ef89fd8";
+let rev = "e03f9ee353717ccc5f58c902633553e34b2fe46a";
 in
-buildGoPackage rec {
+buildGoModule rec {
   pname = "sonobuoy";
-  version = "0.16.1";
+  version = "0.19.0";
 
-  goPackagePath = "github.com/heptio/sonobuoy";
+  goPackagePath = "github.com/vmware-tanzu/sonobuoy";
 
   buildFlagsArray =
     let t = goPackagePath;
@@ -19,11 +19,15 @@ buildGoPackage rec {
     '';
 
   src = fetchFromGitHub {
-    sha256 = "14qc5a7jbr403wjpk6pgpb94i72yx647sg9srz07q6drq650kyfv";
+    sha256 = "1gw58a30akidk15wk8kk7f8lsyqr1q180j6fzr4462ahwxdbjgkr";
     rev = "v${version}";
     repo = "sonobuoy";
     owner = "vmware-tanzu";
   };
+
+  vendorSha256 = "1kxzd4czv8992y7y47la5jjrbhk76sxcj3v5sx0k4xplgki7np6i";
+
+  subPackages = [ "." ];
 
   meta = with lib; {
     description = ''
@@ -38,6 +42,6 @@ buildGoPackage rec {
 
     homepage = "https://sonobuoy.io";
     license = licenses.asl20;
-    maintainers = with maintainers; [ carlosdagos saschagrunert ];
+    maintainers = with maintainers; [ carlosdagos saschagrunert wilsonehusin ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
- Updating Sonobuoy to the latest version
    - Sonobuoy adopted Go modules and therefore this needs to be built with `buildGoModule`
    - Updated repository path as well, referring `vmware-tanzu` instead of `heptio` ([context captured here](https://github.com/NixOS/nixpkgs/pull/70904#issuecomment-557298005))
- Adding myself to maintainer for this package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notice to other maintainers
cc: @carlosdagos @saschagrunert 

This is my first time contributing to `nixpkgs`. Happy to assist more to ease this update, though if it's anything of the above I'd like to have some references 😃 