### PR TITLE
[20.09] python3Packages.google_cloud_asset: fix build, 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/google-cloud-access-context-manager/default.nix
+++ b/pkgs/development/python-modules/google-cloud-access-context-manager/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, google_api_core }:
+
+buildPythonPackage rec {
+  pname = "google-cloud-access-context-manager";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qy7wv1xn7g3x5z0vvv0pwmxhin4hw2m9fs9iklnghy00vg37v0b";
+  };
+
+  disabled = pythonOlder "3.5";
+
+  propagatedBuildInputs = [ google_api_core ];
+
+  # No tests in repo
+  doCheck = false;
+
+  pythonImportsCheck = [ "google.identity.accesscontextmanager" ];
+
+  meta = with lib; {
+    description = "Protobufs for Google Access Context Manager.";
+    homepage = "https://github.com/googleapis/python-access-context-manager";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/development/python-modules/google-cloud-org-policy/default.nix
+++ b/pkgs/development/python-modules/google-cloud-org-policy/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, google_api_core }:
+
+buildPythonPackage rec {
+  pname = "google-cloud-org-policy";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ncgcnbvmgqph54yh2pjx2hh82gnkhsrw5yirp4wlf7jclh6j9xh";
+  };
+
+  disabled = pythonOlder "3.5";
+
+  propagatedBuildInputs = [ google_api_core ];
+
+  # No tests in repo
+  doCheck = false;
+
+  pythonImportsCheck = [ "google.cloud.orgpolicy" ];
+
+  meta = with lib; {
+    description = "Protobufs for Google Cloud Organization Policy.";
+    homepage = "https://github.com/googleapis/python-org-policy";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_asset/default.nix
+++ b/pkgs/development/python-modules/google_cloud_asset/default.nix
@@ -1,32 +1,37 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, enum34
-, grpc_google_iam_v1
-, google_api_core
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, grpc_google_iam_v1
+, google_api_core, google-cloud-access-context-manager, google-cloud-org-policy
+, libcst, proto-plus, pytest, pytest-asyncio, pytestCheckHook, mock }:
 
 buildPythonPackage rec {
   pname = "google-cloud-asset";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "fd4c0f7f61a8a1c5907cd6cc27a028b16236bf3d982ff412df0d2c981cef5ae5";
+    sha256 = "14r77bcxy7bmqhmz2hzcf3km2y4vivf5sfzgqjwlyynaydhn4f6j";
   };
 
-  checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ enum34 grpc_google_iam_v1 google_api_core ];
+  disabled = pythonOlder "3.6";
 
-  checkPhase = ''
-    pytest tests/unit
+  checkInputs = [ mock pytest-asyncio pytestCheckHook ];
+  disabledTests = [ "asset_service_transport_auth_adc" ];
+  propagatedBuildInputs = [
+    grpc_google_iam_v1
+    google_api_core
+    google-cloud-access-context-manager
+    google-cloud-org-policy
+    libcst
+    proto-plus
+  ];
+
+  # Remove tests intended to be run in VPC
+  preCheck = ''
+    rm -rf tests/system
   '';
 
   meta = with stdenv.lib; {
-    description = "Cloud Asset API API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    description = "Python Client for Google Cloud Asset API";
+    homepage = "https://github.com/googleapis/python-asset";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2428,6 +2428,8 @@ in {
 
   google_cloud_monitoring = callPackage ../development/python-modules/google_cloud_monitoring { };
 
+  google-cloud-org-policy = callPackage ../development/python-modules/google-cloud-org-policy { };
+
   google_cloud_pubsub = callPackage ../development/python-modules/google_cloud_pubsub { };
 
   google_cloud_redis = callPackage ../development/python-modules/google_cloud_redis { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2390,6 +2390,8 @@ in {
 
   google-auth-oauthlib = callPackage ../development/python-modules/google-auth-oauthlib { };
 
+  google-cloud-access-context-manager = callPackage ../development/python-modules/google-cloud-access-context-manager { };
+
   google_cloud_asset = callPackage ../development/python-modules/google_cloud_asset { };
 
   google_cloud_automl = callPackage ../development/python-modules/google_cloud_automl { };


### PR DESCRIPTION
###### Motivation for this change

Backport of: #100009

ZHF: #97479
https://hydra.nixos.org/build/127625743

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).