### PR TITLE
pam_mount: update to add support for LUKS2

### DIFF
--- a/pkgs/os-specific/linux/pam_mount/default.nix
+++ b/pkgs/os-specific/linux/pam_mount/default.nix
@@ -1,11 +1,12 @@
-{ stdenv, fetchurl, autoconf, automake, pkgconfig, libtool, pam, libHX, libxml2, pcre, perl, openssl, cryptsetup, utillinux }:
+{ stdenv, fetchgit, autoconf, automake, pkgconfig, libtool, pam, libHX, libxml2, pcre, perl, openssl, cryptsetup, utillinux }:
 
 stdenv.mkDerivation rec {
-  name = "pam_mount-2.16";
+  name = "pam_mount-2.16-g40b6f2f";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/pam-mount/pam_mount/2.16/${name}.tar.xz";
-    sha256 = "1rvi4irb7ylsbhvx1cr6islm2xxw1a4b19q6z4a9864ndkm0f0mf";
+  src = fetchgit {
+    url    = "git://git.code.sf.net/p/pam-mount/pam-mount";
+    rev    = "40b6f2f920922ff8bbfb45d1d5dfd5a554c16f62";
+    sha256 = "01f6fdy3abld4465yqkshn1p7ja8ydglzzc48iqjw4q46hgz6rv1";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Support for LUKS2 exists in the pam_mount git repo[1] but has not been
released yet. Ubuntu has been backporting a slightly different fix for a
while now[2]. This changes pam_mount to use git instead of the last
release.

[1] https://sourceforge.net/p/pam-mount/pam-mount/ci/d4434c05e7
[2] https://bugs.launchpad.net/ubuntu/+source/libpam-mount/+bug/1804408

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
