### PR TITLE
ocamlPackages.pgocaml: 4.0 → 4.2.2

### DIFF
--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocsigen-toolkit, pgocaml_ppx, macaque, safepass, yojson
+{ stdenv, fetchFromGitHub, ocaml, findlib, ocsigen-toolkit, pgocaml_ppx, safepass, yojson
 , cohttp-lwt-unix
 , resource-pooling
 }:
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   createFindlibDestdir = true;
-  
+
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "ocsigen-start";

--- a/pkgs/development/ocaml-modules/pgocaml/default.nix
+++ b/pkgs/development/ocaml-modules/pgocaml/default.nix
@@ -1,22 +1,21 @@
 { lib, fetchFromGitHub, buildDunePackage
-, calendar, csv, hex, re
+, calendar, csv, hex, ppx_deriving, ppx_sexp_conv, re, rresult, sexplib
 }:
 
 buildDunePackage rec {
   pname = "pgocaml";
-  version = "4.0";
+  version = "4.2.2";
   src = fetchFromGitHub {
     owner = "darioteixeira";
     repo = "pgocaml";
-    rev = "v${version}";
-    sha256 = "1s8c5prr7jb9k76bz990m836czm6k8rv5bvp6s2zg9ra0w19w90j";
+    rev = version;
+    sha256 = "1rdypc83nap9j2ml9r6n1pzgf79gk1yffwyi6fmcrl7zmy01cg0n";
   };
 
-  minimumOCamlVersion = "4.05";
+  minimumOCamlVersion = "4.07";
+  useDune2 = true;
 
-  preConfigure = "patchShebangs src/genconfig.sh";
-
-  propagatedBuildInputs = [ calendar csv hex re ];
+  propagatedBuildInputs = [ calendar csv hex ppx_deriving ppx_sexp_conv re rresult sexplib ];
 
   meta = with lib; {
     description = "An interface to PostgreSQL databases for OCaml applications";

--- a/pkgs/development/ocaml-modules/pgocaml/ppx.nix
+++ b/pkgs/development/ocaml-modules/pgocaml/ppx.nix
@@ -1,8 +1,8 @@
-{ buildDunePackage, pgocaml, ppx_tools, ppx_tools_versioned, rresult }:
+{ buildDunePackage, pgocaml, ppx_optcomp, ppx_tools, ppx_tools_versioned, rresult }:
 
 buildDunePackage {
   pname = "pgocaml_ppx";
-  inherit (pgocaml) src version meta;
+  inherit (pgocaml) src version useDune2 meta;
 
-  propagatedBuildInputs = [ pgocaml ppx_tools ppx_tools_versioned rresult ];
+  propagatedBuildInputs = [ pgocaml ppx_optcomp ppx_tools ppx_tools_versioned rresult ];
 }


### PR DESCRIPTION
###### Motivation for this change

Use dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
