### PR TITLE
llvmPackages_10: cross-compilation support

### DIFF
--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -34,7 +34,6 @@ let
     llvm = callPackage ./llvm.nix { };
 
     clang-unwrapped = callPackage ./clang {
-      inherit (tools) lld;
       inherit clang-tools-extra_src;
     };
 

--- a/pkgs/development/compilers/llvm/10/lld.nix
+++ b/pkgs/development/compilers/llvm/10/lld.nix
@@ -1,4 +1,5 @@
 { stdenv
+, buildPackages
 , fetch
 , cmake
 , libxml2
@@ -14,6 +15,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm libxml2 ];
+
+  cmakeFlags = stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "-DLLVM_TABLEGEN_EXE=${buildPackages.llvm_10}/bin/llvm-tblgen"
+    "-DLLVM_CONFIG_PATH=${llvm}/bin/llvm-config-native"
+  ];
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/compilers/llvm/10/llvm.nix
+++ b/pkgs/development/compilers/llvm/10/llvm.nix
@@ -124,7 +124,7 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_TABLEGEN=${buildPackages.llvm_10}/bin/llvm-tblgen"
     (
       let
-        nativeCC = pkgsBuildBuild.stdenv.cc;
+        nativeCC = pkgsBuildBuild.targetPackages.stdenv.cc;
         nativeBintools = nativeCC.bintools.bintools;
         nativeToolchainFlags = [
           "-DCMAKE_C_COMPILER=${nativeCC}/bin/${nativeCC.targetPrefix}cc"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9808,7 +9808,7 @@ in
   llvmPackages_10 = callPackage ../development/compilers/llvm/10 {
     inherit (stdenvAdapters) overrideCC;
     buildLlvmTools = buildPackages.llvmPackages_10.tools;
-    targetLlvmLibraries = targetPackages.llvmPackages_10.libraries;
+    targetLlvmLibraries = targetPackages.llvmPackages_10.libraries or llvmPackages_10.libraries;
   };
 
   llvmPackages_11 = callPackage ../development/compilers/llvm/11 ({


### PR DESCRIPTION
##### Motivation for this change

Cross compilation of clang 10. Ultimately to make bootstrap tools for platforms that use clang in their stdenv.

Tested building on `x86_64-linux` with

```
nix-build \
  --keep-going \
  --argstr crossSystem aarch64-linux \
  -A llvmPackages_10.llvm \
  -A llvmPackages_10.lld \
  -A llvmPackages_10.compiler-rt \
  -A llvmPackages_10.libcxx \
  -A llvmPackages_10.libcxxabi \
  -A llvmPackages_10.clang-unwrapped \
  -A pkgsCross.wasi32.hello
```

Note that presently I can't test the following due to a build cycle in gcc:
```
cycle detected in the references of '/nix/store/dkc8jicyd1pibg3hfgasbnvl6schw9da-gcc-debug-9.3.0-aarch64-unknown-linux-gnu-lib' from '/nix/store/nv8nb53m5ypywdgjh6b38pxi0klncgls-gcc-debug-9.3.0-aarch64-unknown-linux-gnu'
```

```sh
nix-build \
  --argstr crossSystem aarch64-linux \
  -A llvmPackages_10.clang \
  -A llvmPackages_10.libcxxClang
```

Note that while it's possible to build a wrapper, the wrapper uses the build platform's shell so I was unable to test it.

Some interesting points:
 - `clang-tblgen` doesn't seem to have an install rule within clang, which suggests it's never meant to be installed. To export it without altering the interface I added a `tablegen` output.
 - `llvm-config` is installed by llvm to work a bit like `pkg-config` and help locate components of llvm. Installing the native version to a different output didn't work, since it assumes it's installed alongside llvm. I made up the name `llvm-config-native` to avoid a conflict, but I'm hoping there's a nicer way to do this. The two versions here are:
    -  the installed version, which runs on the host platform, installed by cmake as `llvm-config`. This tool is probably never used when building with nixpkgs.
    - the "NATIVE" version, which runs on the build platform, installed in `postInstall` as `llvm-config-native`. This is required for the `lld` and `clang` builds.
 - I don't see why `lld` would be required to build clang so I removed it. The build didn't fail, but I don't have a strong argument as for why it should or should not be included.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
