### PR TITLE
tree-wide: rename nixos-rebuild to nixos-config

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@ if ! builtins ? nixVersion || builtins.compareVersions requiredVersion builtins.
 
     This version of Nixpkgs requires Nix >= ${requiredVersion}, please upgrade:
 
-    - If you are running NixOS, `nixos-rebuild' can be used to upgrade your system.
+    - If you are running NixOS, `nixos-config' can be used to upgrade your system.
 
     - Alternatively, with Nix > 2.0 `nix upgrade-nix' can be used to imperatively
       upgrade Nix. You may use `nix-env --version' to check which version you have.

--- a/doc/contributing/submitting-changes.xml
+++ b/doc/contributing/submitting-changes.xml
@@ -155,7 +155,7 @@ Additional information.
         <itemizedlist>
          <listitem>
           <para>
-           You can add new module to your NixOS configuration file (usually it's <command>/etc/nixos/configuration.nix</command>). And do <command>sudo nixos-rebuild test -I nixpkgs=&lt;path to your local nixpkgs folder&gt; --fast</command>.
+           You can add new module to your NixOS configuration file (usually it's <command>/etc/nixos/configuration.nix</command>). And do <command>sudo nixos-config test -I nixpkgs=&lt;path to your local nixpkgs folder&gt; --fast</command>.
           </para>
          </listitem>
         </itemizedlist>

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -657,7 +657,7 @@ rec {
   mkOptionDefault = mkOverride 1500; # priority of option defaults
   mkDefault = mkOverride 1000; # used in config sections of non-user modules to set a default
   mkForce = mkOverride 50;
-  mkVMOverride = mkOverride 10; # used by ‘nixos-rebuild build-vm’
+  mkVMOverride = mkOverride 10; # used by ‘nixos-config build-vm’
 
   mkStrict = builtins.trace "`mkStrict' is obsolete; use `mkOverride 0' instead." (mkOverride 0);
 

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -9,13 +9,13 @@ let
     modules = [ configuration ];
   };
 
-  # This is for `nixos-rebuild build-vm'.
+  # This is for `nixos-config build-vm'.
   vmConfig = (import ./lib/eval-config.nix {
     inherit system;
     modules = [ configuration ./modules/virtualisation/qemu-vm.nix ];
   }).config;
 
-  # This is for `nixos-rebuild build-vm-with-bootloader'.
+  # This is for `nixos-config build-vm-with-bootloader'.
   vmWithBootLoaderConfig = (import ./lib/eval-config.nix {
     inherit system;
     modules =

--- a/nixos/doc/manual/administration/cleaning-store.xml
+++ b/nixos/doc/manual/administration/cleaning-store.xml
@@ -56,7 +56,7 @@
   <para>
    If your <filename>/boot</filename> partition runs out of space, after
    clearing old profiles you must rebuild your system with
-   <literal>nixos-rebuild</literal> to update the <filename>/boot</filename>
+   <literal>nixos-config</literal> to update the <filename>/boot</filename>
    partition and clear space.
   </para>
  </section>

--- a/nixos/doc/manual/administration/containers.xml
+++ b/nixos/doc/manual/administration/containers.xml
@@ -24,7 +24,7 @@
   <command>nixos-container</command>, and declaratively, by specifying them in
   your <filename>configuration.nix</filename>. The declarative approach implies
   that containers get upgraded along with your host system when you run
-  <command>nixos-rebuild</command>, which is often not what you want. By
+  <command>nixos-config</command>, which is often not what you want. By
   contrast, in the imperative approach, containers are configured and updated
   independently from the host system.
  </para>

--- a/nixos/doc/manual/administration/declarative-containers.xml
+++ b/nixos/doc/manual/administration/declarative-containers.xml
@@ -19,7 +19,7 @@ containers.database =
       };
   };
 </programlisting>
-  If you run <literal>nixos-rebuild switch</literal>, the container will be
+  If you run <literal>nixos-config switch</literal>, the container will be
   built. If the container was already running, it will be updated in place,
   without rebooting. The container can be configured to start automatically by
   setting <literal>containers.database.autoStart = true</literal> in its
@@ -46,7 +46,7 @@ containers.database = {
 
  <para>
   To disable the container, just remove it from
-  <filename>configuration.nix</filename> and run <literal>nixos-rebuild
+  <filename>configuration.nix</filename> and run <literal>nixos-config
   switch</literal>. Note that this will not delete the root directory of the
   container in <literal>/var/lib/containers</literal>. Containers can be
   destroyed using the imperative method: <literal>nixos-container destroy

--- a/nixos/doc/manual/administration/imperative-containers.xml
+++ b/nixos/doc/manual/administration/imperative-containers.xml
@@ -105,7 +105,7 @@ Linux foo 3.4.82 #1-NixOS SMP Thu Mar 20 14:44:05 UTC 2014 x86_64 GNU/Linux
 
  <para>
   Alternatively, you can change the configuration from within the container
-  itself by running <command>nixos-rebuild switch</command> inside the
+  itself by running <command>nixos-config switch</command> inside the
   container. Note that the container by default does not have a copy of the
   NixOS channel, so you should run <command>nix-channel --update</command>
   first.

--- a/nixos/doc/manual/administration/network-problems.xml
+++ b/nixos/doc/manual/administration/network-problems.xml
@@ -8,7 +8,7 @@
  <para>
   Nix uses a so-called <emphasis>binary cache</emphasis> to optimise building a
   package from source into downloading it as a pre-built binary. That is,
-  whenever a command like <command>nixos-rebuild</command> needs a path in the
+  whenever a command like <command>nixos-config</command> needs a path in the
   Nix store, Nix will try to download that path from the Internet rather than
   build it from source. The default binary cache is
   <uri>https://cache.nixos.org/</uri>. If this cache is unreachable, Nix
@@ -16,12 +16,12 @@
   disable the use of the binary cache by adding <option>--option
   use-binary-caches false</option>, e.g.
 <screen>
-<prompt># </prompt>nixos-rebuild switch --option use-binary-caches false
+<prompt># </prompt>nixos-config switch --option use-binary-caches false
 </screen>
   If you have an alternative binary cache at your disposal, you can use it
   instead:
 <screen>
-<prompt># </prompt>nixos-rebuild switch --option binary-caches <replaceable>http://my-cache.example.org/</replaceable>
+<prompt># </prompt>nixos-config switch --option binary-caches <replaceable>http://my-cache.example.org/</replaceable>
 </screen>
  </para>
 </section>

--- a/nixos/doc/manual/administration/rollback.xml
+++ b/nixos/doc/manual/administration/rollback.xml
@@ -6,7 +6,7 @@
  <title>Rolling Back Configuration Changes</title>
 
  <para>
-  After running <command>nixos-rebuild</command> to switch to a new
+  After running <command>nixos-config</command> to switch to a new
   configuration, you may find that the new configuration doesn’t work very
   well. In that case, there are several ways to return to a previous
   configuration.
@@ -26,7 +26,7 @@
  <para>
   Second, you can switch to the previous configuration in a running system:
 <screen>
-<prompt># </prompt>nixos-rebuild switch --rollback</screen>
+<prompt># </prompt>nixos-config switch --rollback</screen>
   This is equivalent to running:
 <screen>
 <prompt># </prompt>/nix/var/nix/profiles/system-<replaceable>N</replaceable>-link/bin/switch-to-configuration switch</screen>

--- a/nixos/doc/manual/administration/store-corruption.xml
+++ b/nixos/doc/manual/administration/store-corruption.xml
@@ -18,7 +18,7 @@
   If the corruption is in a path in the closure of the NixOS system
   configuration, you can fix it by doing
 <screen>
-<prompt># </prompt>nixos-rebuild switch --repair
+<prompt># </prompt>nixos-config switch --repair
 </screen>
   This will cause Nix to check every path in the closure, and if its
   cryptographic hash differs from the hash recorded in Nix’s database, the

--- a/nixos/doc/manual/configuration/ad-hoc-packages.xml
+++ b/nixos/doc/manual/configuration/ad-hoc-packages.xml
@@ -30,7 +30,7 @@
   and then running <literal>nix-env -i</literal> again. Other packages in the
   profile are <emphasis>not</emphasis> affected; this is the crucial difference
   with the declarative style of package management, where running
-  <command>nixos-rebuild switch</command> causes all packages to be updated to
+  <command>nixos-config switch</command> causes all packages to be updated to
   their current versions in the NixOS channel. You can however upgrade all
   packages for which there is a newer version by doing:
 <screen>

--- a/nixos/doc/manual/configuration/adding-custom-packages.xml
+++ b/nixos/doc/manual/configuration/adding-custom-packages.xml
@@ -22,10 +22,10 @@ xlink:href="https://nixos.org/nixpkgs/manual">Nixpkgs
 <programlisting>
 <xref linkend="opt-environment.systemPackages"/> = [ pkgs.my-package ];
 </programlisting>
-  and you run <command>nixos-rebuild</command>, specifying your own Nixpkgs
+  and you run <command>nixos-config</command>, specifying your own Nixpkgs
   tree:
 <screen>
-<prompt># </prompt>nixos-rebuild switch -I nixpkgs=/path/to/my/nixpkgs</screen>
+<prompt># </prompt>nixos-config switch -I nixpkgs=/path/to/my/nixpkgs</screen>
  </para>
 
  <para>

--- a/nixos/doc/manual/configuration/config-file.xml
+++ b/nixos/doc/manual/configuration/config-file.xml
@@ -67,7 +67,7 @@
   NixOS checks your option definitions for correctness. For instance, if you
   try to define an option that doesn’t exist (that is, doesn’t have a
   corresponding <emphasis>option declaration</emphasis>),
-  <command>nixos-rebuild</command> will give an error like:
+  <command>nixos-config</command> will give an error like:
 <screen>
 The option `services.httpd.enable' defined in `/etc/nixos/configuration.nix' does not exist.
 </screen>

--- a/nixos/doc/manual/configuration/configuration.xml
+++ b/nixos/doc/manual/configuration/configuration.xml
@@ -10,7 +10,7 @@
    through the configuration file
    <filename>/etc/nixos/configuration.nix</filename>. As described in
    <xref linkend="sec-changing-config" />, changes to this file only take
-   effect after you run <command>nixos-rebuild</command>.
+   effect after you run <command>nixos-config</command>.
   </para>
  </partintro>
  <xi:include href="config-syntax.xml" />

--- a/nixos/doc/manual/configuration/declarative-packages.xml
+++ b/nixos/doc/manual/configuration/declarative-packages.xml
@@ -16,7 +16,7 @@
 </programlisting>
   The effect of this specification is that the Thunderbird package from Nixpkgs
   will be built or downloaded as part of the system when you run
-  <command>nixos-rebuild switch</command>.
+  <command>nixos-config switch</command>.
  </para>
 
  <note>
@@ -45,7 +45,7 @@ nixos.firefox   firefox-23.0   Mozilla Firefox - the browser, reloaded
  <para>
   To “uninstall” a package, simply remove it from
   <xref linkend="opt-environment.systemPackages"/> and run
-  <command>nixos-rebuild switch</command>.
+  <command>nixos-config switch</command>.
  </para>
 
  <xi:include href="customizing-packages.xml" />

--- a/nixos/doc/manual/configuration/modularity.xml
+++ b/nixos/doc/manual/configuration/modularity.xml
@@ -58,7 +58,7 @@
  <para>
   For other types of options, a merge may not be possible. For instance, if two
   modules define <xref linkend="opt-services.httpd.adminAddr"/>,
-  <command>nixos-rebuild</command> will give an error:
+  <command>nixos-config</command> will give an error:
 <screen>
 The unique option `services.httpd.adminAddr' is defined multiple times, in `/etc/nixos/httpd.nix' and `/etc/nixos/configuration.nix'.
 </screen>

--- a/nixos/doc/manual/configuration/package-mgmt.xml
+++ b/nixos/doc/manual/configuration/package-mgmt.xml
@@ -12,7 +12,7 @@
     <para>
      <emphasis>Declarative</emphasis>, where you declare what packages you want
      in your <filename>configuration.nix</filename>. Every time you run
-     <command>nixos-rebuild</command>, NixOS will ensure that you get a
+     <command>nixos-config</command>, NixOS will ensure that you get a
      consistent set of binaries corresponding to your specification.
     </para>
    </listitem>

--- a/nixos/doc/manual/configuration/user-mgmt.xml
+++ b/nixos/doc/manual/configuration/user-mgmt.xml
@@ -26,13 +26,13 @@
   key. Users created in this way do not have a password by default, so they
   cannot log in via mechanisms that require a password. However, you can use
   the <command>passwd</command> program to set a password, which is retained
-  across invocations of <command>nixos-rebuild</command>.
+  across invocations of <command>nixos-config</command>.
  </para>
  <para>
   If you set <xref linkend="opt-users.mutableUsers"/> to false, then the
   contents of <literal>/etc/passwd</literal> and <literal>/etc/group</literal>
   will be congruent to your NixOS configuration. For instance, if you remove a
-  user from <xref linkend="opt-users.users"/> and run nixos-rebuild, the user
+  user from <xref linkend="opt-users.users"/> and run nixos-config, the user
   account will cease to exist. Also, imperative commands for managing users and
   groups, such as useradd, are no longer available. Passwords may still be
   assigned by setting the user's

--- a/nixos/doc/manual/development/building-parts.xml
+++ b/nixos/doc/manual/development/building-parts.xml
@@ -22,7 +22,7 @@
      <para>
       The top-level option that builds the entire NixOS system. Everything else
       in your configuration is indirectly pulled in by this option. This is
-      what <command>nixos-rebuild</command> builds and what
+      what <command>nixos-config</command> builds and what
       <filename>/run/current-system</filename> points to afterwards.
      </para>
      <para>
@@ -75,7 +75,7 @@
    </varlistentry>
    <varlistentry>
     <term>
-     <varname>system.build.nixos-rebuild</varname>
+     <varname>system.build.nixos-config</varname>
     </term>
     <term>
      <varname>system.build.nixos-install</varname>

--- a/nixos/doc/manual/development/sources.xml
+++ b/nixos/doc/manual/development/sources.xml
@@ -5,7 +5,7 @@
         xml:id="sec-getting-sources">
  <title>Getting the Sources</title>
  <para>
-  By default, NixOS’s <command>nixos-rebuild</command> command uses the NixOS
+  By default, NixOS’s <command>nixos-config</command> command uses the NixOS
   and Nixpkgs sources provided by the <literal>nixos</literal> channel (kept in
   <filename>/nix/var/nix/profiles/per-user/root/channels/nixos</filename>). To
   modify NixOS, however, you should check out the latest sources from Git. This
@@ -54,10 +54,10 @@
  </para>
  <para>
   If you want to rebuild your system using your (modified) sources, you need to
-  tell <command>nixos-rebuild</command> about them using the
+  tell <command>nixos-config</command> about them using the
   <option>-I</option> flag:
 <screen>
-<prompt># </prompt>nixos-rebuild switch -I nixpkgs=<replaceable>/my/sources</replaceable>/nixpkgs
+<prompt># </prompt>nixos-config switch -I nixpkgs=<replaceable>/my/sources</replaceable>/nixpkgs
 </screen>
  </para>
  <para>

--- a/nixos/doc/manual/installation/changing-config.xml
+++ b/nixos/doc/manual/installation/changing-config.xml
@@ -9,7 +9,7 @@
   <link linkend="ch-configuration">changed something</link> in that file, you
   should do
 <screen>
-<prompt># </prompt>nixos-rebuild switch
+<prompt># </prompt>nixos-config switch
 </screen>
   to build the new configuration, make it the default configuration for
   booting, and try to realise the configuration in the running system (e.g., by
@@ -17,7 +17,7 @@
   <warning>
    <para>
     This command doesn't start/stop <link linkend="opt-systemd.user.services">user
-    services</link> automatically. <command>nixos-rebuild</command> only runs a
+    services</link> automatically. <command>nixos-config</command> only runs a
     <literal>daemon-reload</literal> for each user with running user services.
    </para>
   </warning>
@@ -31,7 +31,7 @@
  <para>
   You can also do
 <screen>
-<prompt># </prompt>nixos-rebuild test
+<prompt># </prompt>nixos-config test
 </screen>
   to build the configuration and switch the running system to it, but without
   making it the boot default. So if (say) the configuration locks up your
@@ -40,7 +40,7 @@
  <para>
   There is also
 <screen>
-<prompt># </prompt>nixos-rebuild boot
+<prompt># </prompt>nixos-config boot
 </screen>
   to build the configuration and make it the boot default, but not switch to it
   now (so it will only take effect after the next reboot).
@@ -49,7 +49,7 @@
   You can make your configuration show up in a different submenu of the GRUB 2
   boot screen by giving it a different <emphasis>profile name</emphasis>, e.g.
 <screen>
-<prompt># </prompt>nixos-rebuild switch -p test
+<prompt># </prompt>nixos-config switch -p test
 </screen>
   which causes the new configuration (and previous ones created using
   <literal>-p test</literal>) to show up in the GRUB submenu “NixOS - Profile
@@ -59,7 +59,7 @@
  <para>
   Finally, you can do
 <screen>
-<prompt>$ </prompt>nixos-rebuild build
+<prompt>$ </prompt>nixos-config build
 </screen>
   to build the configuration but nothing more. This is useful to see whether
   everything compiles cleanly.
@@ -70,7 +70,7 @@
   <emphasis>virtual machine</emphasis> that contains the desired configuration.
   Just do
 <screen>
-<prompt>$ </prompt>nixos-rebuild build-vm
+<prompt>$ </prompt>nixos-config build-vm
 <prompt>$ </prompt>./result/bin/run-*-vm
 </screen>
   The VM does not have any data from your host system, so your existing user

--- a/nixos/doc/manual/installation/upgrading.xml
+++ b/nixos/doc/manual/installation/upgrading.xml
@@ -92,10 +92,10 @@ nixos https://nixos.org/channels/nixos-unstable
   You can then upgrade NixOS to the latest version in your chosen channel by
   running
 <screen>
-<prompt># </prompt>nixos-rebuild switch --upgrade
+<prompt># </prompt>nixos-config switch --upgrade
 </screen>
   which is equivalent to the more verbose <literal>nix-channel --update nixos;
-  nixos-rebuild switch</literal>.
+  nixos-config switch</literal>.
  </para>
  <note>
   <para>
@@ -124,7 +124,7 @@ nixos https://nixos.org/channels/nixos-unstable
 </programlisting>
    This enables a periodically executed systemd service named
    <literal>nixos-upgrade.service</literal>. If the <literal>allowReboot</literal>
-   option is <literal>false</literal>, it runs <command>nixos-rebuild switch
+   option is <literal>false</literal>, it runs <command>nixos-config switch
    --upgrade</command> to upgrade NixOS to the latest version in the current
    channel. (To see when the service runs, see <command>systemctl list-timers</command>.)
    If <literal>allowReboot</literal> is <literal>true</literal>, then the

--- a/nixos/doc/manual/man-configuration.xml
+++ b/nixos/doc/manual/man-configuration.xml
@@ -16,7 +16,7 @@
   <para>
    The file <filename>/etc/nixos/configuration.nix</filename> contains the
    declarative specification of your NixOS system configuration. The command
-   <command>nixos-rebuild</command> takes this file and realises the system
+   <command>nixos-config</command> takes this file and realises the system
    configuration specified therein.
   </para>
  </refsection>

--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -2,20 +2,20 @@
           xmlns:xlink="http://www.w3.org/1999/xlink"
           xmlns:xi="http://www.w3.org/2001/XInclude">
  <refmeta>
-  <refentrytitle><command>nixos-rebuild</command>
+  <refentrytitle><command>nixos-config</command>
   </refentrytitle><manvolnum>8</manvolnum>
   <refmiscinfo class="source">NixOS</refmiscinfo>
 <!-- <refmiscinfo class="version"><xi:include href="version.txt" parse="text"/></refmiscinfo> -->
  </refmeta>
 
  <refnamediv>
-  <refname><command>nixos-rebuild</command></refname>
+  <refname><command>nixos-config</command></refname>
   <refpurpose>reconfigure a NixOS machine</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
   <cmdsynopsis>
-   <command>nixos-rebuild</command><group choice='req'>
+   <command>nixos-config</command><group choice='req'>
    <arg choice='plain'>
     <option>switch</option>
    </arg>
@@ -154,7 +154,7 @@
    <filename>/etc/nixos/configuration.nix</filename> or
    <filename>/etc/nixos/flake.nix</filename>. Thus, every time you
    modify the configuration or any other NixOS module, you must run
-   <command>nixos-rebuild</command> to make the changes take
+   <command>nixos-config</command> to make the changes take
    effect. It builds the new system in
    <filename>/nix/store</filename>, runs its activation script, and
    stop and (re)starts any system services if needed. Please note that
@@ -177,7 +177,7 @@
        That is, the configuration is added to the GRUB boot menu as the default
        menu entry, so that subsequent reboots will boot the system into the new
        configuration. Previous configurations activated with
-       <command>nixos-rebuild switch</command> or <command>nixos-rebuild
+       <command>nixos-config switch</command> or <command>nixos-config
        boot</command> remain available in the GRUB menu.
       </para>
      </listitem>
@@ -190,7 +190,7 @@
      <listitem>
       <para>
        Build the new configuration and make it the boot default (as with
-       <command>nixos-rebuild switch</command>), but do not activate it. That
+       <command>nixos-config switch</command>), but do not activate it. That
        is, the system continues to run the previous configuration until the
        next reboot.
       </para>
@@ -206,8 +206,8 @@
        Build and activate the new configuration, but do not add it to the GRUB
        boot menu. Thus, if you reboot the system (or if it crashes), you will
        automatically revert to the default configuration (i.e. the
-       configuration resulting from the last call to <command>nixos-rebuild
-       switch</command> or <command>nixos-rebuild boot</command>).
+       configuration resulting from the last call to <command>nixos-config
+       switch</command> or <command>nixos-config boot</command>).
       </para>
      </listitem>
     </varlistentry>
@@ -226,7 +226,7 @@
 <prompt>$ </prompt>nix-build /path/to/nixpkgs/nixos -A system
 </screen>
        Note that you do not need to be <literal>root</literal> to run
-       <command>nixos-rebuild build</command>.
+       <command>nixos-config build</command>.
       </para>
      </listitem>
     </varlistentry>
@@ -251,7 +251,7 @@
       <para>
        Build the new configuration, but instead of activating it, show what
        changes would be performed by the activation (i.e. by
-       <command>nixos-rebuild test</command>). For instance, this command will
+       <command>nixos-config test</command>). For instance, this command will
        print which systemd units would be restarted. The list of changes is not
        guaranteed to be complete.
       </para>
@@ -282,7 +282,7 @@
        at the script that starts the VM. Thus, to test a NixOS configuration in
        a virtual machine, you should do the following:
 <screen>
-<prompt>$ </prompt>nixos-rebuild build-vm
+<prompt>$ </prompt>nixos-config build-vm
 <prompt>$ </prompt>./result/bin/run-*-vm
 </screen>
       </para>
@@ -298,7 +298,7 @@
        The VM mounts the Nix store of the host through the 9P file system. The
        host Nix store is read-only, so Nix commands that modify the Nix store
        will not work in the VM. This includes commands such as
-       <command>nixos-rebuild</command>; to change the VM’s configuration,
+       <command>nixos-config</command>; to change the VM’s configuration,
        you must halt the VM and re-run the commands above.
       </para>
 
@@ -324,7 +324,7 @@
        into the kernel and initial ramdisk of the system. This allows you to
        test whether the boot loader works correctly. However, it does not
        guarantee that your NixOS configuration will boot successfully on the
-       host hardware (i.e., after running <command>nixos-rebuild
+       host hardware (i.e., after running <command>nixos-config
        switch</command>), because the hardware and boot loader configuration in
        the VM are different. The boot loader is installed on an automatically
        generated virtual disk containing a <filename>/boot</filename>
@@ -358,7 +358,7 @@
       <para>
         In addition to the <literal>nixos</literal> channel, the root
         user's channels which have a file named
-        <literal>.update-on-nixos-rebuild</literal> in their base
+        <literal>.update-on-nixos-config</literal> in their base
         directory will also be updated.
       </para>
       <para>
@@ -386,7 +386,7 @@
     </term>
     <listitem>
      <para>
-      Normally, <command>nixos-rebuild</command> first builds the
+      Normally, <command>nixos-config</command> first builds the
       <varname>nixUnstable</varname> attribute in Nixpkgs, and uses the
       resulting instance of the Nix package manager to build the new system
       configuration. This is necessary if the NixOS modules use features not
@@ -404,7 +404,7 @@
      <para>
       Equivalent to <option>--no-build-nix</option>
       <option>--show-trace</option>. This option is useful if you call
-      <command>nixos-rebuild</command> frequently (e.g. if you’re hacking on
+      <command>nixos-config</command> frequently (e.g. if you’re hacking on
       a NixOS module).
      </para>
     </listitem>
@@ -432,7 +432,7 @@
     <listitem>
      <para>
       Allow ad-hoc remote builders for building the new system. This requires
-      the user executing <command>nixos-rebuild</command> (usually root) to be
+      the user executing <command>nixos-config</command> (usually root) to be
       configured as a trusted user in the Nix daemon. This can be achieved by
       using the <literal>nix.trustedUsers</literal> NixOS option. Examples
       values for that option are described in the <literal>Remote builds
@@ -468,7 +468,7 @@
       <filename>test.nix</filename> without affecting the default system
       profile, you would do:
 <screen>
-<prompt>$ </prompt>nixos-rebuild switch -p test -I nixos-config=./test.nix
+<prompt>$ </prompt>nixos-config switch -p test -I nixos-config=./test.nix
 </screen>
       The new configuration will appear in the GRUB 2 submenu “NixOS -
       Profile 'test'”.
@@ -538,7 +538,7 @@
     </term>
     <listitem>
      <para>
-      When set, nixos-rebuild prefixes remote commands that run on
+      When set, nixos-config prefixes remote commands that run on
       the <option>--build-host</option> and <option>--target-host</option>
       systems with <command>sudo</command>. Setting this option allows
       deploying as a non-root user.
@@ -566,7 +566,7 @@
   </variablelist>
 
   <para>
-   In addition, <command>nixos-rebuild</command> accepts various Nix-related
+   In addition, <command>nixos-config</command> accepts various Nix-related
    flags, including <option>--max-jobs</option> / <option>-j</option>,
    <option>--show-trace</option>, <option>--keep-failed</option>,
    <option>--keep-going</option>, <option>--impure</option>, and <option>--verbose</option> /
@@ -615,7 +615,7 @@
     </term>
     <listitem>
      <para>
-      If this file exists, then <command>nixos-rebuild</command> will
+      If this file exists, then <command>nixos-config</command> will
       use it as if the <option>--flake</option> option was given. This
       file may be a symlink to a <filename>flake.nix</filename> in an
       actual flake; thus <filename>/etc/nixos</filename> need not be a

--- a/nixos/doc/manual/man-pages.xml
+++ b/nixos/doc/manual/man-pages.xml
@@ -15,6 +15,6 @@
  <xi:include href="man-nixos-install.xml" />
  <xi:include href="man-nixos-enter.xml" />
  <xi:include href="man-nixos-option.xml" />
- <xi:include href="man-nixos-rebuild.xml" />
+ <xi:include href="man-nixos-config.xml" />
  <xi:include href="man-nixos-version.xml" />
 </reference>

--- a/nixos/doc/manual/release-notes/rl-1404.xml
+++ b/nixos/doc/manual/release-notes/rl-1404.xml
@@ -62,7 +62,7 @@
   xlink:href="https://www.usenix.org/legacy/event/lisa02/tech/full_papers/traugott/traugott_html/">congruent</link>
      to your NixOS configuration. For instance, if you remove a user from
      <option>users.extraUsers</option> and run
-     <command>nixos-rebuild</command>, the user account will cease to exist.
+     <command>nixos-config</command>, the user account will cease to exist.
      Also, imperative commands for managing users and groups, such as
      <command>useradd</command>, are no longer available. If
      <option>users.mutableUsers</option> is <literal>true</literal> (the

--- a/nixos/doc/manual/release-notes/rl-1412.xml
+++ b/nixos/doc/manual/release-notes/rl-1412.xml
@@ -40,7 +40,7 @@
     <para>
      If <option>users.mutableUsers</option> is enabled (the default), changes
      made to the declaration of a user or group will be correctly realised when
-     running <command>nixos-rebuild</command>. For instance, removing a user
+     running <command>nixos-config</command>. For instance, removing a user
      specification from <filename>configuration.nix</filename> will cause the
      actual user account to be deleted. If <option>users.mutableUsers</option>
      is disabled, it is no longer necessary to specify UIDs or GIDs; if

--- a/nixos/doc/manual/release-notes/rl-1509.xml
+++ b/nixos/doc/manual/release-notes/rl-1509.xml
@@ -51,7 +51,7 @@
 system.autoUpgrade.enable = true;
 </programlisting>
     This will cause the system to periodically check for updates in your
-    current channel and run <command>nixos-rebuild</command>.
+    current channel and run <command>nixos-config</command>.
    </para>
   </listitem>
   <listitem>
@@ -627,7 +627,7 @@ nix-env -f &quot;&lt;nixpkgs&gt;&quot; -iA haskellPackages.pandoc
      In case of an infinite loop, use the <command>--show-trace</command>
      command line argument and read the line just above the error message.
 <screen>
-<prompt>$ </prompt>nixos-rebuild build --show-trace
+<prompt>$ </prompt>nixos-config build --show-trace
 …
 while evaluating the module argument `pkgs' in "/etc/nixos/my-module.nix":
 infinite recursion encountered

--- a/nixos/doc/manual/release-notes/rl-1609.xml
+++ b/nixos/doc/manual/release-notes/rl-1609.xml
@@ -210,7 +210,7 @@
     Special filesystems, like <literal>/proc</literal>, <literal>/run</literal>
     and others, now have the same mount options as recommended by systemd and
     are unified across different places in NixOS. Mount options are updated
-    during <command>nixos-rebuild switch</command> if possible. One benefit
+    during <command>nixos-config switch</command> if possible. One benefit
     from this is improved security — most such filesystems are now mounted
     with <literal>noexec</literal>, <literal>nodev</literal> and/or
     <literal>nosuid</literal> options.

--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -505,7 +505,7 @@
       <listitem>
        <para>
         After changing the interface names, rebuild your system with
-        <literal>nixos-rebuild boot</literal> to activate the new configuration
+        <literal>nixos-config boot</literal> to activate the new configuration
         after a reboot. If you switch to the new configuration right away you
         might lose network connectivity! If using <literal>nixops</literal>,
         deploy with <literal>nixops deploy --force-reboot</literal>.

--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -897,7 +897,7 @@ inherit (pkgs.nixos {
    </listitem>
    <listitem>
     <para>
-     The config activation script of <literal>nixos-rebuild</literal> now
+     The config activation script of <literal>nixos-config</literal> now
      <link xlink:href="https://www.freedesktop.org/software/systemd/man/systemctl.html#Manager%20Lifecycle%20Commands">reloads</link>
      all user units for each authenticated user.
     </para>

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -166,7 +166,7 @@
       <para>
        For users of NixOS 17.09, you will first need to upgrade Nix by setting
        <literal>nix.package = pkgs.nixStable2;</literal> and run
-       <command>nixos-rebuild switch</command> as the <literal>root</literal>
+       <command>nixos-config switch</command> as the <literal>root</literal>
        user.
       </para>
      </listitem>
@@ -644,9 +644,9 @@
      ZRAM algorithm can be changed now.
     </para>
     <para>
-     Changes to ZRAM algorithm are applied during <literal>nixos-rebuild
+     Changes to ZRAM algorithm are applied during <literal>nixos-config
      switch</literal>, so make sure you have enough swap space on disk to
-     survive ZRAM device rebuild. Alternatively, use <literal>nixos-rebuild
+     survive ZRAM device rebuild. Alternatively, use <literal>nixos-config
      boot; reboot</literal>.
     </para>
    </listitem>
@@ -760,7 +760,7 @@
    </listitem>
    <listitem>
     <para>
-     A new subcommand <command>nixos-rebuild edit</command> was added.
+     A new subcommand <command>nixos-config edit</command> was added.
     </para>
    </listitem>
   </itemizedlist>

--- a/nixos/modules/i18n/input-method/default.xml
+++ b/nixos/modules/i18n/input-method/default.xml
@@ -114,7 +114,7 @@ ibus.engines = with pkgs.ibus-engines; [ table table-others ];
 
   <para>
    To use any input method, the package must be added in the configuration, as
-   shown above, and also (after running <literal>nixos-rebuild</literal>) the
+   shown above, and also (after running <literal>nixos-config</literal>) the
    input method must be added from IBus' preference dialog.
   </para>
 

--- a/nixos/modules/installer/cd-dvd/channel.nix
+++ b/nixos/modules/installer/cd-dvd/channel.nix
@@ -10,7 +10,7 @@ let
 
   # We need a copy of the Nix expressions for Nixpkgs and NixOS on the
   # CD.  These are installed into the "nixos" channel of the root
-  # user, as expected by nixos-rebuild/nixos-install. FIXME: merge
+  # user, as expected by nixos-config/nixos-install. FIXME: merge
   # with make-channel.nix.
   channelSources = pkgs.runCommand "nixos-${config.system.nixos.version}"
     { preferLocalBuild = true; }

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -701,7 +701,7 @@ in
         # CD in the Nix database in the tmpfs.
         ${config.nix.package.out}/bin/nix-store --load-db < /nix/store/nix-path-registration
 
-        # nixos-rebuild also requires a "system" profile and an
+        # nixos-config also requires a "system" profile and an
         # /etc/NIXOS tag.
         touch /etc/NIXOS
         ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system

--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -232,7 +232,7 @@ in
         # Register the contents of the initial Nix store
         ${config.nix.package.out}/bin/nix-store --load-db < /nix-path-registration
 
-        # nixos-rebuild also requires a "system" profile and an /etc/NIXOS tag.
+        # nixos-config also requires a "system" profile and an /etc/NIXOS tag.
         touch /etc/NIXOS
         ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
 

--- a/nixos/modules/installer/cd-dvd/system-tarball-sheevaplug.nix
+++ b/nixos/modules/installer/cd-dvd/system-tarball-sheevaplug.nix
@@ -18,7 +18,7 @@ let
       { config, pkgs, ... }:
 
       {
-        # Add your own options below and run "nixos-rebuild switch".
+        # Add your own options below and run "nixos-config switch".
         # E.g.,
         #   services.openssh.enable = true;
       }

--- a/nixos/modules/installer/cd-dvd/system-tarball.nix
+++ b/nixos/modules/installer/cd-dvd/system-tarball.nix
@@ -82,7 +82,7 @@ in
           rm /nix-path-registration
         fi
 
-        # nixos-rebuild also requires a "system" profile and an
+        # nixos-config also requires a "system" profile and an
         # /etc/NIXOS tag.
         touch /etc/NIXOS
         ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -101,7 +101,7 @@ with lib;
         # in the Nix database in the tmpfs.
         ${config.nix.package}/bin/nix-store --load-db < /nix/store/nix-path-registration
 
-        # nixos-rebuild also requires a "system" profile and an
+        # nixos-config also requires a "system" profile and an
         # /etc/NIXOS tag.
         touch /etc/NIXOS
         ${config.nix.package}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system

--- a/nixos/modules/installer/tools/nixos-config.sh
+++ b/nixos/modules/installer/tools/nixos-config.sh
@@ -8,7 +8,7 @@ set -o pipefail
 export PATH=@path@:$PATH
 
 showSyntax() {
-    exec man nixos-rebuild
+    exec man nixos-config
     exit 1
 }
 
@@ -220,7 +220,7 @@ if [ -z "$action" ]; then showSyntax; fi
 # Only run shell scripts from the Nixpkgs tree if the action is
 # "switch", "boot", or "test". With other actions (such as "build"),
 # the user may reasonably expect that no code from the Nixpkgs tree is
-# executed, so it's safe to run nixos-rebuild against a potentially
+# executed, so it's safe to run nixos-config against a potentially
 # untrusted tree.
 canRun=
 if [ "$action" = switch -o "$action" = boot -o "$action" = test ]; then
@@ -232,7 +232,7 @@ fi
 # run ‘nix-channel --update nixos’.
 if [[ -n $upgrade && -z $_NIXOS_REBUILD_REEXEC && -z $flake ]]; then
     # If --upgrade-all is passed, or there are other channels that
-    # contain a file called ".update-on-nixos-rebuild", update them as
+    # contain a file called ".update-on-nixos-config", update them as
     # well. Also upgrade the nixos channel.
 
     for channelpath in /nix/var/nix/profiles/per-user/root/channels/*; do
@@ -240,7 +240,7 @@ if [[ -n $upgrade && -z $_NIXOS_REBUILD_REEXEC && -z $flake ]]; then
 
         if [[ "$channel_name" == "nixos" ]]; then
             nix-channel --update "$channel_name"
-        elif [ -e "$channelpath/.update-on-nixos-rebuild" ]; then
+        elif [ -e "$channelpath/.update-on-nixos-config" ]; then
             nix-channel --update "$channel_name"
         elif [[ -n $upgrade_all ]] ; then
             nix-channel --update "$channel_name"
@@ -265,12 +265,12 @@ if [[ -z $flake && -e /etc/nixos/flake.nix ]]; then
     flake="$(dirname "$(readlink -f /etc/nixos/flake.nix)")"
 fi
 
-# Re-execute nixos-rebuild from the Nixpkgs tree.
-# FIXME: get nixos-rebuild from $flake.
+# Re-execute nixos-config from the Nixpkgs tree.
+# FIXME: get nixos-config from $flake.
 if [[ -z $_NIXOS_REBUILD_REEXEC && -n $canRun && -z $fast && -z $flake ]]; then
-    if p=$(nix-build --no-out-link --expr 'with import <nixpkgs/nixos> {}; config.system.build.nixos-rebuild' "${extraBuildFlags[@]}"); then
+    if p=$(nix-build --no-out-link --expr 'with import <nixpkgs/nixos> {}; config.system.build.nixos-config' "${extraBuildFlags[@]}"); then
         export _NIXOS_REBUILD_REEXEC=1
-        exec $p/bin/nixos-rebuild "${origArgs[@]}"
+        exec $p/bin/nixos-config "${origArgs[@]}"
         exit 1
     fi
 fi
@@ -313,7 +313,7 @@ if [ "$action" = edit ]; then
 fi
 
 
-tmpDir=$(mktemp -t -d nixos-rebuild.XXXXXX)
+tmpDir=$(mktemp -t -d nixos-config.XXXXXX)
 SSHOPTS="$NIX_SSHOPTS -o ControlMaster=auto -o ControlPath=$tmpDir/ssh-%n -o ControlPersist=60"
 
 cleanup() {

--- a/nixos/modules/misc/label.nix
+++ b/nixos/modules/misc/label.nix
@@ -35,7 +35,7 @@ in
         branch=`(cd nixpkgs ; git branch 2>/dev/null | sed -n '/^\* / { s|^\* ||; p; }')`
         revision=`(cd nixpkgs ; git rev-parse HEAD)`
         export NIXOS_LABEL_VERSION="$today.$branch-''${revision:0:7}"
-        nixos-rebuild switch</screen>
+        nixos-config switch</screen>
       '';
     };
 

--- a/nixos/modules/profiles/clone-config.nix
+++ b/nixos/modules/profiles/clone-config.nix
@@ -96,7 +96,7 @@ in
 
         ${optionalString config.installer.cloneConfig ''
           # Provide a configuration for the CD/DVD itself, to allow users
-          # to run nixos-rebuild to change the configuration of the
+          # to run nixos-config to change the configuration of the
           # running system on the CD/DVD.
           if ! [ -e /etc/nixos/configuration.nix ]; then
             cp ${configClone} /etc/nixos/configuration.nix

--- a/nixos/modules/profiles/docker-container.nix
+++ b/nixos/modules/profiles/docker-container.nix
@@ -50,7 +50,7 @@ in {
         rm /nix-path-registration
       fi
 
-      # nixos-rebuild also requires a "system" profile
+      # nixos-config also requires a "system" profile
       ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
     '';
 

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -10,7 +10,7 @@ with lib;
       ../installer/scan/detected.nix
       ../installer/scan/not-detected.nix
 
-      # Allow "nixos-rebuild" to work properly by providing
+      # Allow "nixos-config" to work properly by providing
       # /etc/nixos/configuration.nix.
       ./clone-config.nix
 

--- a/nixos/modules/services/backup/borgbackup.xml
+++ b/nixos/modules/services/backup/borgbackup.xml
@@ -119,7 +119,7 @@ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID78zmOyA+5uPG4Ot0hfAy+sLDPU1L4AiIoRYEIVbbQ/
   </para>
   <para>The following few commands (run as root) let you test your backup.
       <programlisting>
-> nixos-rebuild switch
+> nixos-config switch
 ...restarting the following units: polkit.service
 > systemctl restart borgbackup-job-backupToLocalServer
 > sleep 10

--- a/nixos/modules/services/databases/foundationdb.xml
+++ b/nixos/modules/services/databases/foundationdb.xml
@@ -44,7 +44,7 @@ services.foundationdb.package = pkgs.foundationdb52; # FoundationDB 5.2.x
   </para>
 
   <para>
-   After running <command>nixos-rebuild</command>, you can verify whether
+   After running <command>nixos-config</command>, you can verify whether
    FoundationDB is running by executing <command>fdbcli</command> (which is
    added to <option>environment.systemPackages</option>):
 <screen>

--- a/nixos/modules/services/databases/postgresql.xml
+++ b/nixos/modules/services/databases/postgresql.xml
@@ -30,7 +30,7 @@
   </para>
 
 <!--
-<para>After running <command>nixos-rebuild</command>, you can verify
+<para>After running <command>nixos-config</command>, you can verify
 whether PostgreSQL works by running <command>psql</command>:
 
 <screen>

--- a/nixos/modules/services/editors/emacs.xml
+++ b/nixos/modules/services/editors/emacs.xml
@@ -281,7 +281,7 @@ nix-env -f "<nixpkgs>" -qaP -A emacsPackages.orgPackages
    </para>
 
    <para>
-    In this case, the next <command>nixos-rebuild switch</command> will take
+    In this case, the next <command>nixos-config switch</command> will take
     care of adding your <command>emacs</command> to the <varname>PATH</varname>
     environment variable (see <xref linkend="sec-changing-config" />).
    </para>
@@ -396,7 +396,7 @@ in [...]
    <para>
     To start the daemon, execute the following:
 <screen>
-<prompt>$ </prompt>nixos-rebuild switch  # to activate the new configuration.nix
+<prompt>$ </prompt>nixos-config switch  # to activate the new configuration.nix
 <prompt>$ </prompt>systemctl --user daemon-reload        # to force systemd reload
 <prompt>$ </prompt>systemctl --user start emacs.service  # to start the Emacs daemon
 </screen>
@@ -520,7 +520,7 @@ emacsclient --create-frame --tty  # opens a new frame on the current terminal
 
    <para>
     You can use <function>woman</function> to get completion of all available
-    man pages. For example, type <literal>M-x woman &lt;RET&gt; nixos-rebuild
+    man pages. For example, type <literal>M-x woman &lt;RET&gt; nixos-config
     &lt;RET&gt;.</literal>
    </para>
   </section>

--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -149,7 +149,7 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
         description = "xrdp session manager";
-        restartIfChanged = false; # do not restart on "nixos-rebuild switch". like "display-manager", it can have many interactive programs as children
+        restartIfChanged = false; # do not restart on "nixos-config switch". like "display-manager", it can have many interactive programs as children
         serviceConfig = {
           ExecStart = "${cfg.package}/bin/xrdp-sesman --nodaemon --config ${confDir}/sesman.ini";
           ExecStop  = "${pkgs.coreutils}/bin/kill -INT $MAINPID";

--- a/nixos/modules/services/security/vault.nix
+++ b/nixos/modules/services/security/vault.nix
@@ -129,7 +129,7 @@ in
       after = [ "network.target" ]
            ++ optional (config.services.consul.enable && cfg.storageBackend == "consul") "consul.service";
 
-      restartIfChanged = false; # do not restart on "nixos-rebuild switch". It would seal the storage and disrupt the clients.
+      restartIfChanged = false; # do not restart on "nixos-config switch". It would seal the storage and disrupt the clients.
 
       serviceConfig = {
         User = "vault";

--- a/nixos/modules/services/system/cloud-init.nix
+++ b/nixos/modules/services/system/cloud-init.nix
@@ -27,7 +27,7 @@ in
 
           This configuration is not completely compatible with the
           NixOS way of doing configuration, as configuration done by
-          cloud-init might be overriden by a subsequent nixos-rebuild
+          cloud-init might be overriden by a subsequent nixos-config
           call. However, some parts of cloud-init fall outside of
           NixOS's responsibility, like filesystem resizing and ssh
           public key provisioning, and cloud-init is useful for that

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -58,7 +58,7 @@ in
         system configuration is activated.  Examples are updating
         /etc, creating accounts, and so on.  Since these are executed
         every time you boot the system or run
-        <command>nixos-rebuild</command>, it's important that they are
+        <command>nixos-config</command>, it's important that they are
         idempotent and fast.
       '';
 
@@ -121,7 +121,7 @@ in
         service when a NixOS system configuration is activated. Examples are
         rebuilding the .desktop file cache for showing applications in the menu.
         Since these are executed every time you run
-        <command>nixos-rebuild</command>, it's important that they are
+        <command>nixos-config</command>, it's important that they are
         idempotent and fast.
       '';
 

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
@@ -115,7 +115,7 @@ addEntry() {
 tmpFile="$target/extlinux/extlinux.conf.tmp.$$"
 
 cat > $tmpFile <<EOF
-# Generated file, all changes will be lost on nixos-rebuild!
+# Generated file, all changes will be lost on nixos-config!
 
 # Change this to e.g. nixos-42 to temporarily boot to an older configuration.
 DEFAULT nixos-default

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1140,7 +1140,7 @@ in
     systemd.services.systemd-remount-fs.restartIfChanged = false;
     systemd.services.systemd-update-utmp.restartIfChanged = false;
     systemd.services.systemd-user-sessions.restartIfChanged = false; # Restart kills all active sessions.
-    systemd.services.systemd-udev-settle.restartIfChanged = false; # Causes long delays in nixos-rebuild
+    systemd.services.systemd-udev-settle.restartIfChanged = false; # Causes long delays in nixos-config
     # Restarting systemd-logind breaks X11
     # - upstream commit: https://cgit.freedesktop.org/xorg/xserver/commit/?id=dc48bd653c7e101
     # - systemd announcement: https://github.com/systemd/systemd/blob/22043e4317ecd2bc7834b48a6d364de76bb26d91/NEWS#L103-L112

--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -16,7 +16,7 @@ in {
         description = ''
           Whether to periodically upgrade NixOS to the latest
           version. If enabled, a systemd timer will run
-          <literal>nixos-rebuild switch --upgrade</literal> once a
+          <literal>nixos-config switch --upgrade</literal> once a
           day.
         '';
       };
@@ -54,7 +54,7 @@ in {
           "http://my-cache.example.org/"
         ];
         description = ''
-          Any additional flags passed to <command>nixos-rebuild</command>.
+          Any additional flags passed to <command>nixos-config</command>.
 
           If you are using flakes and use a local repo you can add
           <command>[ "--update-input" "nixpkgs" "--commit-lock-file" ]</command>
@@ -143,19 +143,19 @@ in {
       ];
 
       script = let
-        nixos-rebuild =
-          "${config.system.build.nixos-rebuild}/bin/nixos-rebuild";
+        nixos-config =
+          "${config.system.build.nixos-config}/bin/nixos-config";
       in if cfg.allowReboot then ''
-        ${nixos-rebuild} boot ${toString cfg.flags}
+        ${nixos-config} boot ${toString cfg.flags}
         booted="$(readlink /run/booted-system/{initrd,kernel,kernel-modules})"
         built="$(readlink /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules})"
         if [ "$booted" = "$built" ]; then
-          ${nixos-rebuild} switch ${toString cfg.flags}
+          ${nixos-config} switch ${toString cfg.flags}
         else
           /run/current-system/sw/bin/shutdown -r +1
         fi
       '' else ''
-        ${nixos-rebuild} switch ${toString cfg.flags}
+        ${nixos-config} switch ${toString cfg.flags}
       '';
 
       startAt = cfg.dates;

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -304,7 +304,7 @@ let
               '')}" > /run/${n}.interfaces
 
               ${optionalString config.virtualisation.libvirtd.enable ''
-                  # Enslave dynamically added interfaces which may be lost on nixos-rebuild
+                  # Enslave dynamically added interfaces which may be lost on nixos-config
                   #
                   # if `libvirtd.service` is not running, do not use `virsh` which would try activate it via 'libvirtd.socket' and thus start it out-of-order.
                   # `libvirtd.service` will set up bridge interfaces when it will start normally.

--- a/nixos/modules/virtualisation/amazon-init.nix
+++ b/nixos/modules/virtualisation/amazon-init.nix
@@ -7,7 +7,7 @@ let
     echo "attempting to fetch configuration from EC2 user data..."
 
     export HOME=/root
-    export PATH=${pkgs.lib.makeBinPath [ config.nix.package pkgs.systemd pkgs.gnugrep pkgs.git pkgs.gnutar pkgs.gzip pkgs.gnused config.system.build.nixos-rebuild]}:$PATH
+    export PATH=${pkgs.lib.makeBinPath [ config.nix.package pkgs.systemd pkgs.gnugrep pkgs.git pkgs.gnutar pkgs.gzip pkgs.gnused config.system.build.nixos-config]}:$PATH
     export NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels
 
     userData=/etc/ec2-metadata/user-data
@@ -38,7 +38,7 @@ let
       exit
     fi
 
-    nixos-rebuild switch
+    nixos-config switch
   '';
 in {
   systemd.services.amazon-init = {

--- a/nixos/modules/virtualisation/azure-config-user.nix
+++ b/nixos/modules/virtualisation/azure-config-user.nix
@@ -2,7 +2,7 @@
 
 {
   # To build the configuration or use nix-env, you need to run
-  # either nixos-rebuild --upgrade or nix-channel --update
+  # either nixos-config --upgrade or nix-channel --update
   # to fetch the nixos channel.
 
   # This configures everything but bootstrap services,

--- a/nixos/modules/virtualisation/brightbox-image.nix
+++ b/nixos/modules/virtualisation/brightbox-image.nix
@@ -64,12 +64,12 @@ in
           printRegistration=1 perl ${pkgs.pathsFromGraph} /tmp/xchg/closure | \
               chroot /mnt ${config.nix.package.out}/bin/nix-store --load-db --option build-users-group ""
 
-          # Create the system profile to allow nixos-rebuild to work.
+          # Create the system profile to allow nixos-config to work.
           chroot /mnt ${config.nix.package.out}/bin/nix-env \
               -p /nix/var/nix/profiles/system --set ${config.system.build.toplevel} \
               --option build-users-group ""
 
-          # `nixos-rebuild' requires an /etc/NIXOS.
+          # `nixos-config' requires an /etc/NIXOS.
           mkdir -p /mnt/etc
           touch /mnt/etc/NIXOS
 

--- a/nixos/modules/virtualisation/digital-ocean-init.nix
+++ b/nixos/modules/virtualisation/digital-ocean-init.nix
@@ -46,7 +46,7 @@ in {
         RemainAfterExit = true;
       };
       restartIfChanged = false;
-      path = [ pkgs.jq pkgs.gnused pkgs.gnugrep pkgs.systemd config.nix.package config.system.build.nixos-rebuild ];
+      path = [ pkgs.jq pkgs.gnused pkgs.gnugrep pkgs.systemd config.nix.package config.system.build.nixos-config ];
       environment = {
         HOME = "/root";
         NIX_PATH = concatStringsSep ":" [
@@ -84,7 +84,7 @@ in {
             exit
           fi
 
-          nixos-rebuild switch
+          nixos-config switch
         else
           echo "no user data is available"
         fi

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -245,7 +245,7 @@ let
           mkdir -p /dev/block
           ln -s /dev/vda2 /dev/block/254:2
 
-          # Set up system profile (normally done by nixos-rebuild / nix-env --set)
+          # Set up system profile (normally done by nixos-config / nix-env --set)
           mkdir -p /nix/var/nix/profiles
           ln -s ${config.system.build.toplevel} /nix/var/nix/profiles/system-1-link
           ln -s /nix/var/nix/profiles/system-1-link /nix/var/nix/profiles/system

--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -80,7 +80,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
             old_etag, new_etag
         )
 
-    with subtest("config is reloaded on nixos-rebuild switch"):
+    with subtest("config is reloaded on nixos-config switch"):
         webserver.succeed(
             "${justReloadSystem}/bin/switch-to-configuration test >&2"
         )

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -24,10 +24,10 @@ let
           ln -s vda1 /dev/xvda1
         '';
 
-        # Needed by nixos-rebuild due to the lack of network
+        # Needed by nixos-config due to the lack of network
         # access. Determined by trial and error.
         system.extraDependencies = with pkgs; ( [
-          # Needed for a nixos-rebuild.
+          # Needed for a nixos-config.
           busybox
           cloud-utils
           desktop-file-utils

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -20,7 +20,7 @@ let
             <nixpkgs/nixos/modules/testing/test-instrumentation.nix>
           ];
 
-        # To ensure that we can rebuild the grub configuration on the nixos-rebuild
+        # To ensure that we can rebuild the grub configuration on the nixos-config
         system.extraDependencies = with pkgs; [ stdenvNoCC ];
 
         ${optionalString (bootLoader == "grub") ''
@@ -181,8 +181,8 @@ let
               "/etc/nixos/configuration.nix",
           )
 
-      with subtest("Check whether nixos-rebuild works"):
-          machine.succeed("nixos-rebuild switch >&2")
+      with subtest("Check whether nixos-config works"):
+          machine.succeed("nixos-config switch >&2")
 
       with subtest("Test nixos-option"):
           kernel_modules = machine.succeed("nixos-option boot.initrd.kernelModules")
@@ -208,11 +208,11 @@ let
           }",
           "/etc/nixos/configuration.nix",
       )
-      machine.succeed("nixos-rebuild boot >&2")
+      machine.succeed("nixos-config boot >&2")
       machine.shutdown()
 
       # And just to be sure, check that the machine still boots after
-      # "nixos-rebuild switch".
+      # "nixos-config switch".
       machine = create_machine_named("boot-after-rebuild-switch")
       ${preBootCommands}
       machine.wait_for_unit("network.target")

--- a/nixos/tests/misc.nix
+++ b/nixos/tests/misc.nix
@@ -70,8 +70,8 @@ import ./make-test-python.nix ({ pkgs, ...} : rec {
       with subtest("nixos-version"):
           machine.succeed("[ `nixos-version | wc -w` = 2 ]")
 
-      with subtest("nixos-rebuild"):
-          assert "NixOS module" in machine.succeed("nixos-rebuild --help")
+      with subtest("nixos-config"):
+          assert "NixOS module" in machine.succeed("nixos-config --help")
 
       with subtest("Sanity check for uid/gid assignment"):
           assert "4" == machine.succeed("id -u messagebus").strip()

--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -99,7 +99,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         new_etag = check_etag()
         assert old_etag != new_etag
 
-    with subtest("config is reloaded on nixos-rebuild switch"):
+    with subtest("config is reloaded on nixos-config switch"):
         webserver.succeed(
             "${justReloadSystem}/bin/switch-to-configuration test >&2"
         )
@@ -114,7 +114,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         webserver.wait_for_unit("nginx")
         webserver.succeed("journalctl -u nginx | grep -q -i stopped")
 
-    with subtest("nixos-rebuild --switch should fail when there are configuration errors"):
+    with subtest("nixos-config --switch should fail when there are configuration errors"):
         webserver.fail(
             "${reloadWithErrorsSystem}/bin/switch-to-configuration test >&2"
         )

--- a/nixos/tests/openstack-image.nix
+++ b/nixos/tests/openstack-image.nix
@@ -16,7 +16,7 @@ let
       ../modules/testing/test-instrumentation.nix
       ../modules/profiles/qemu-guest.nix
       {
-        # Needed by nixos-rebuild due to lack of network access.
+        # Needed by nixos-config due to lack of network access.
         system.extraDependencies = with pkgs; [
           stdenv
         ];

--- a/nixos/tests/os-prober.nix
+++ b/nixos/tests/os-prober.nix
@@ -70,7 +70,7 @@ in {
                   ../modules/profiles/base.nix ];
       virtualisation.memorySize = 1300;
       # The test cannot access the network, so any packages
-      # nixos-rebuild needs must be included in the VM.
+      # nixos-config needs must be included in the VM.
       system.extraDependencies = with pkgs;
         [ sudo
           libxml2.bin
@@ -116,7 +116,7 @@ in {
         "${configFile}",
         "/etc/nixos/configuration.nix",
     )
-    machine.succeed("nixos-rebuild boot >&2")
+    machine.succeed("nixos-config boot >&2")
 
     machine.succeed("egrep 'menuentry.*debian' /boot/grub/grub.cfg")
   '';

--- a/pkgs/build-support/release/default.nix
+++ b/pkgs/build-support/release/default.nix
@@ -95,7 +95,7 @@ rec {
       phases = [ "unpackPhase" "patchPhase" "installPhase" ];
 
       patchPhase = stdenv.lib.optionalString isNixOS ''
-        touch .update-on-nixos-rebuild
+        touch .update-on-nixos-config
       '';
 
       installPhase = ''

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -248,7 +248,7 @@ in buildFHSUserEnv rec {
         cat <<EOF > /dev/stderr
     **
     WARNING: Steam is not set up. Add the following options to /etc/nixos/configuration.nix
-    and then run \`sudo nixos-rebuild switch\`:
+    and then run \`sudo nixos-config switch\`:
     {
       hardware.opengl.driSupport32Bit = true;
       hardware.pulseaudio.support32Bit = true;

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -90,7 +90,7 @@ let
   };
   remediate_whitelist = allow_attr: attrs:
     ''
-      a) For `nixos-rebuild` you can set
+      a) For `nixos-config` you can set
         { nixpkgs.config.allow${allow_attr} = true; }
       in configuration.nix to override this.
 
@@ -113,7 +113,7 @@ let
 
              $ export NIXPKGS_ALLOW_INSECURE=1
 
-        b) for `nixos-rebuild` you can add ‘${getName attrs}’ to
+        b) for `nixos-config` you can add ‘${getName attrs}’ to
            `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
            like so:
 


### PR DESCRIPTION
###### Motivation for this change

After all these years, `nixos-rebuild` is still weird to type.
`nixos-config` is much more intuitive.

Compare `nixos-rebuild build` vs `nixos-config build`. Or `nixos-rebuild
switch` with `nixos-config switch`. A fresh mind is able to make out
what the latter will do.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
