### PR TITLE
vscx/ms-vsliveshare-vsliveshare: Init at 1.0.2902

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -194,6 +194,8 @@ in
     lldb = llvmPackages_latest.lldb;
   };
 
+  ms-vsliveshare.vsliveshare = callPackage ./ms-vsliveshare-vsliveshare {};
+
   vscodevim.vim = buildVscodeMarketplaceExtension {
     mktplcRef = {
       name = "vim";

--- a/pkgs/misc/vscode-extensions/ms-vsliveshare-vsliveshare/default.nix
+++ b/pkgs/misc/vscode-extensions/ms-vsliveshare-vsliveshare/default.nix
@@ -1,0 +1,138 @@
+# Baseed on previous attempts:
+#  -  <https://github.com/msteen/nixos-vsliveshare/blob/master/pkgs/vsliveshare/default.nix>
+#  -  <https://github.com/NixOS/nixpkgs/issues/41189>
+{ lib, gccStdenv, vscode-utils, autoPatchelfHook, bash, file, makeWrapper, dotnet-sdk_3
+, curl, gcc, icu, libkrb5, libsecret, libunwind, libX11, lttng-ust, openssl, utillinux, zlib
+, desktop-file-utils, xprop
+}:
+
+with lib;
+
+let
+  # https://docs.microsoft.com/en-us/visualstudio/liveshare/reference/linux#install-prerequisites-manually
+  libs = [
+    # .NET Core
+    openssl
+    libkrb5
+    zlib
+    icu
+
+    # Credential Storage
+    libsecret
+
+    # NodeJS
+    libX11
+
+    # https://github.com/flathub/com.visualstudio.code.oss/issues/11#issuecomment-392709170
+    libunwind
+    lttng-ust
+    curl
+
+    # General
+    gcc.cc.lib
+    utillinux # libuuid
+  ];
+
+in ((vscode-utils.override { stdenv = gccStdenv; }).buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "vsliveshare";
+    publisher = "ms-vsliveshare";
+    version = "1.0.2902";
+    sha256 = "0fx2vi0wxamcwqcgcx7wpg8hi7f1c2pibrmd2qy2whilpsv3gzmb";
+  };
+}).overrideAttrs(attrs: {
+  buildInputs = attrs.buildInputs ++ libs ++ [ autoPatchelfHook bash file makeWrapper ];
+
+  # Using a patch file won't work, because the file changes too often, causing the patch to fail on most updates.
+  # Rather than patching the calls to functions, we modify the functions to return what we want,
+  # which is less likely to break in the future.
+  postPatch = ''
+    sed -i \
+      -e 's/updateExecutablePermissionsAsync() {/& return;/' \
+      -e 's/isInstallCorrupt(traceSource, manifest) {/& return false;/' \
+      out/prod/extension-prod.js
+
+    declare ext_unique_id
+    ext_unique_id="$(basename "$out")"
+
+    # Fix extension attempting to write to 'modifiedInternalSettings.json'.
+    # Move this write to the tmp directory indexed by the nix store basename.
+    sed -i \
+      -E -e $'s/path\.resolve\(constants_1\.EXTENSION_ROOT_PATH, \'\.\/modifiedInternalSettings\.json\'\)/path.join\(os.tmpdir(), "'$ext_unique_id'" + "-modifiedInternalSettings.json"\)/g' \
+      out/prod/extension-prod.js
+
+    # Fix extension attempting to write to 'vsls-agent.lock'.
+    # Move this write to the tmp directory indexed by the nix store basename.
+    sed -i \
+      -E -e $'s/(Agent_1.getAgentPath\(\) \+ \'.lock\')/path.join\(os.tmpdir(), "'$ext_unique_id'" + "-vsls-agent.lock"\)/g' \
+      out/prod/extension-prod.js
+
+    # TODO: Under 'node_modules/@vsliveshare/vscode-launcher-linux' need to hardcode path to 'desktop-file-install'
+    # 'update-desktop-database' and 'xprop'. Might want to wrap the script instead.
+  '';
+
+  # Support for the `postInstall` hook was added only in nixos-20.03,
+  # so for backwards compatibility reasons lets not use it yet.
+  installPhase = attrs.installPhase + ''
+    # Support both the new and old directory structure of vscode extensions.
+    if [[ -d $out/ms-vsliveshare.vsliveshare ]]; then
+      cd $out/ms-vsliveshare.vsliveshare
+    elif [[ -d $out/share/vscode/extensions/ms-vsliveshare.vsliveshare ]]; then
+      cd $out/share/vscode/extensions/ms-vsliveshare.vsliveshare
+    else
+      echo "Could not find extension directory 'ms-vsliveshare.vsliveshare'." >&2
+      exit 1
+    fi
+
+    bash -s <<ENDSUBSHELL
+    shopt -s extglob
+
+    # A workaround to prevent the journal filling up due to diagnostic logging.
+    # See: https://github.com/MicrosoftDocs/live-share/issues/1272
+    # See: https://unix.stackexchange.com/questions/481799/how-to-prevent-a-process-from-writing-to-the-systemd-journal
+    gcc -fPIC -shared -ldl -o dotnet_modules/noop-syslog.so ${./noop-syslog.c}
+
+    # Normally the copying of the right executables is done externally at a later time,
+    # but we want it done at installation time.
+    cp dotnet_modules/exes/linux-x64/* dotnet_modules
+
+    # The required executables are already copied over,
+    # and the other runtimes won't be used and thus are just a waste of space.
+    rm -r dotnet_modules/exes dotnet_modules/runtimes/!(linux-x64)
+
+    # Not all executables and libraries are executable, so make sure that they are.
+    find . -type f ! -executable -exec file {} + | grep -w ELF | cut -d ':' -f1 | xargs -rd'\n' chmod +x
+
+    # Not all scripts are executed by passing them to a shell, so they need to be executable as well.
+    find . -type f -name '*.sh' ! -executable -exec chmod +x {} +
+
+    # Lock the extension downloader.
+    touch install-linux.Lock externalDeps-linux.Lock
+    ENDSUBSHELL
+  '';
+
+  rpath = makeLibraryPath libs;
+
+  postFixup = ''
+    # We cannot use `wrapProgram`, because it will generate a relative path,
+    # which will break when copying over the files.
+    mv dotnet_modules/vsls-agent{,-wrapped}
+    makeWrapper $PWD/dotnet_modules/vsls-agent{-wrapped,} \
+      --prefix LD_LIBRARY_PATH : "$rpath" \
+      --set LD_PRELOAD $PWD/dotnet_modules/noop-syslog.so \
+      --set DOTNET_ROOT ${dotnet-sdk_3}
+
+    for bn in check-reqs.sh install.sh uninstall.sh; do
+      wrapProgram "$PWD/node_modules/@vsliveshare/vscode-launcher-linux/$bn" \
+        --prefix PATH : "${makeBinPath [desktop-file-utils xprop]}"
+    done
+  '';
+
+  meta = {
+    description = "Live Share lets you achieve greater confidence at speed by streamlining collaborative editing, debugging, and more in real-time during development";
+    homepage = "https://aka.ms/vsls-docs";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ jraygauthier ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/misc/vscode-extensions/ms-vsliveshare-vsliveshare/noop-syslog.c
+++ b/pkgs/misc/vscode-extensions/ms-vsliveshare-vsliveshare/noop-syslog.c
@@ -1,0 +1,1 @@
+void syslog(int priority, const char *format, ...) { }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This vscode extension is based in some binaries that needs to be patched (elf) (won't work on nixos othewise).

https://github.com/NixOS/nixpkgs/issues/41189

Seems to be needed by quite a lot of people.

Might require some heavy level of maintenance over time.

However, as a lot of people depends on this (and this is already base on the work of others), I assume I won't be the sole maintainer of the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Tested in isolation via the following expression:

```bash
$ cd /path/to/my/nixpkgs
$ nix-build -I nixpkgs=. -E 'with import <nixpkgs> {config={allowUnfree = true;};}; vscode-with-extensions.override {vscodeExtensions = with vscode-extensions; [ms-vsliveshare.vsliveshare];}'
```

Used 2 such local instances of vscode with liveshare and validated that interaction is possible. Tested various commands (from this particular extension) from the command palette successfully. 