### PR TITLE
llvmPackages_11.compiler-rt: enable support for i486 i586 i686

### DIFF
--- a/pkgs/development/compilers/llvm/11/compiler-rt-X86-support-extension.patch
+++ b/pkgs/development/compilers/llvm/11/compiler-rt-X86-support-extension.patch
@@ -1,0 +1,23 @@
+diff --git a/lib/builtins/CMakeLists.txt b/lib/builtins/CMakeLists.txt
+index 3a66dd9c3fb..7efc85d9f9f 100644
+--- a/lib/builtins/CMakeLists.txt
++++ b/lib/builtins/CMakeLists.txt
+@@ -301,6 +301,10 @@ if (NOT MSVC)
+     i386/umoddi3.S
+   )
+ 
++  set(i486_SOURCES ${i386_SOURCES})
++  set(i586_SOURCES ${i386_SOURCES})
++  set(i686_SOURCES ${i386_SOURCES})
++
+   if (WIN32)
+     set(i386_SOURCES
+       ${i386_SOURCES}
+@@ -608,6 +612,7 @@ else ()
+   endif()
+ 
+   foreach (arch ${BUILTIN_SUPPORTED_ARCH})
++      message("arch: ${arch}")
+     if (CAN_TARGET_${arch})
+       # For ARM archs, exclude any VFP builtins if VFP is not supported
+       if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")

--- a/pkgs/development/compilers/llvm/11/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/11/compiler-rt.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
+    ./compiler-rt-X86-support-extension.patch # Add support for i486 i586 i686 by reusing i386 config
   ]# ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
     ++ stdenv.lib.optional stdenv.hostPlatform.isAarch32 ./compiler-rt-armv7l.patch;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
compiler-rt (and as a result clang) can't be build for i686 (as noticed here: #99984).
The patch adds the required variables and should result in the same behavior as in the nixpkgs-llvm10. It essentially forces to use i386 buildins when using i486, i586 or i686, which are not supported.


Fixes  #100392
###### Things done

- tested build for i686 and x86_64 locally.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
