### PR TITLE
python3Packages.pyelftools: disable tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/pyelftools/default.nix
+++ b/pkgs/development/python-modules/pyelftools/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     sha256 = "sha256-O7l1kj0k8bOSOtZJVzS674oVnM+X3oP00Ybs0qjb64Q=";
   };
 
-  doCheck = stdenv.is64bit;
+  doCheck = stdenv.is64bit && !stdenv.isDarwin;
 
   checkPhase = ''
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" test/external_tools/readelf


### PR DESCRIPTION
af27072 broke the build on Darwin (see #99202)

There does not seem to be any way to sanely enable tests on Darwin.

Tests initially fail because of missing 'greadelf'
expected by test/run_readelf_tests.py.

This is fixed by:

- adding 'binutils-unwrapped' to checkInputs
- hardlinking 'readelf' to 'greadelf' in a temp bin dir
- exporting temp bin dir to PATH

This leads to further test failures because of 'readelf' version mismatch
causing output inconsistencies.

See test/run_readelf_tests.py:31 for further details.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

build on Darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] ~Ensured that relevant documentation is up to date~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
