### PR TITLE
swiProlog: 8.1.15 -> 8.3.9

### DIFF
--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  version = "8.1.26";
+  version = "8.3.9";
   packInstall = swiplPath: pack:
     ''${swiplPath}/bin/swipl -g "pack_install(${pack}, [package_directory(\"${swiplPath}/lib/swipl/pack\"), silent(true), interactive(false)])." -t "halt."
     '';
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     owner = "SWI-Prolog";
     repo = "swipl-devel";
     rev = "V${version}";
-    sha256 = "001bd8n9sn1pwvsyd87r0vwvipidpdx0rb5f6xpqmn24sq8hcjwa";
+    sha256 = "0ixb8pc5s7q8q0njs8is1clpvik6jhhdcwnys7m9rpwdzgi10sjz";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  version = "8.1.15";
+  version = "8.1.26";
   packInstall = swiplPath: pack:
     ''${swiplPath}/bin/swipl -g "pack_install(${pack}, [package_directory(\"${swiplPath}/lib/swipl/pack\"), silent(true), interactive(false)])." -t "halt."
     '';
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     owner = "SWI-Prolog";
     repo = "swipl-devel";
     rev = "V${version}";
-    sha256 = "0czbrscx2s4079nmwvipp9cnwfny16m3fpnp823llm7wyljchgvq";
+    sha256 = "001bd8n9sn1pwvsyd87r0vwvipidpdx0rb5f6xpqmn24sq8hcjwa";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Updating to the latest version, with an intermediate commit since I need access to 8.1.26 and its nice to have a nixpkgs commit to pin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
