### PR TITLE
nixos/matomo: point path.geoip2 outside of the nix store.

### DIFF
--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -164,6 +164,7 @@ in {
             # Copy config folder
             chmod g+s "${dataDir}"
             cp -r "${cfg.package}/share/config" "${dataDir}/"
+            mkdir -p "${dataDir}/misc"
             chmod -R u+rwX,g+rwX,o-rwx "${dataDir}"
 
             # check whether user setup has already been done

--- a/pkgs/servers/web-apps/matomo/change-path-geoip2.patch
+++ b/pkgs/servers/web-apps/matomo/change-path-geoip2.patch
@@ -1,0 +1,10 @@
+--- a/plugins/GeoIp2/config/config.php
++++ b/plugins/GeoIp2/config/config.php
+@@ -1,5 +1,5 @@
+ <?php
+ 
+ return [
+-    'path.geoip2' => DI\string('{path.root}/misc/'),
++    'path.geoip2' => PIWIK_USER_PATH . '/misc/',
+ ];
+\ Pas de fin de ligne à la fin du fichier

--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -32,14 +32,19 @@ let
 
         nativeBuildInputs = [ makeWrapper ];
 
-        # make-localhost-default-database-server.patch:
-        #   This changes the default value of the database server field
-        #   from 127.0.0.1 to localhost.
-        #   unix socket authentication only works with localhost,
-        #   but password-based SQL authentication works with both.
-        # TODO: is upstream interested in this?
-        # -> discussion at https://github.com/matomo-org/matomo/issues/12646
-        patches = [ ./make-localhost-default-database-host.patch ];
+        patches = [
+          # This changes the default value of the database server field
+          # from 127.0.0.1 to localhost.
+          # unix socket authentication only works with localhost,
+          # but password-based SQL authentication works with both.
+          # TODO: is upstream interested in this?
+          # -> discussion at https://github.com/matomo-org/matomo/issues/12646
+          ./make-localhost-default-database-host.patch
+
+          # This changes the default config for path.geoip2 so that it doesn't point
+          # to the nix store.
+          ./change-path-geoip2.patch
+        ];
 
         # this bootstrap.php adds support for getting PIWIK_USER_PATH
         # from an environment variable. Point it to a mutable location
@@ -73,6 +78,7 @@ let
           "misc/composer/build-xhprof.sh"
           "misc/composer/clean-xhprof.sh"
           "misc/cron/archive.sh"
+          "plugins/GeoIp2/config/config.php"
           "plugins/Installation/FormDatabaseSetup.php"
           "vendor/leafo/lessphp/package.sh"
           "vendor/pear/archive_tar/sync-php4"


### PR DESCRIPTION
path.geoip2 pointed to the nix store which is read only. Matomo fails to
download geoip database. See #64759.

###### Motivation for this change

By default matomo config path.geoip2 points to the nix store. One can setup geolocalisation from the UI, but the download would fail because the nix store is read-only. See #64759.
This PR changes the path to point to the matomo state directory, allowing one to enable the matomo service and then configure the geolocalisation from the matomo UI without pain.

Note that there are already some efforts to build a geoip database (e.g. #73767), but matomo can also handle it for simpler set-ups.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
