### PR TITLE
update-python-libraries: enable top-level github attrs

### DIFF
--- a/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
+++ b/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
@@ -193,9 +193,12 @@ def _get_latest_version_github(package, extension, current_version, target):
         matches = re.findall(r"^([^0-9]*)", string)
         return next(iter(matches), "")
 
+    # when invoked as an updateScript, UPDATE_NIX_ATTR_PATH will be set
+    # this allows us to work with packages which live outside of python-modules
+    attr_path = os.environ.get("UPDATE_NIX_ATTR_PATH", f"python3Packages.{package}")
     try:
         homepage = subprocess.check_output(
-            ["nix", "eval", "-f", f"{NIXPGKS_ROOT}/default.nix", "--raw", f"python3Packages.{package}.src.meta.homepage"])\
+            ["nix", "eval", "-f", f"{NIXPGKS_ROOT}/default.nix", "--raw", f"{attr_path}.src.meta.homepage"])\
             .decode('utf-8')
     except Exception as e:
         raise ValueError(f"Unable to determine homepage: {e}")


### PR DESCRIPTION
###### Motivation for this change
allow for the python update script read the attr path when determining the homepage for a given package. This should allow for packages which live outside of `python-modules` to be updated as well.

The old 
```
  $ ./update-python-libraries ../../pkgs/development/python-modules/**/default.nix
```
workflow should still be valid

before:
```
[12:11:22] jon@nixos ~/projects/nixpkgs (master)
$ nix-shell maintainers/scripts/update.nix --argstr package pdd
these derivations will be built:
  /nix/store/90rjy3d79651ib866izghivqc2aik413-update-python-libraries.drv
  /nix/store/cxs6jwz7n9jdh57pz77rxkp4sbx71f4d-packages.json.drv
building '/nix/store/90rjy3d79651ib866izghivqc2aik413-update-python-libraries.drv'...
patching script interpreter paths in /nix/store/dnwlyxz8nmqb5sxq4v4mzrfx9ypcp2d3-update-python-libraries
/nix/store/dnwlyxz8nmqb5sxq4v4mzrfx9ypcp2d3-update-python-libraries: interpreter directive changed from "/usr/bin/env python3" to "/nix/store/9kw0xpxizyrjlcrxmh2knzrq3rzv08fn-python3-3.8.6-env/bin/python3"
building '/nix/store/cxs6jwz7n9jdh57pz77rxkp4sbx71f4d-packages.json.drv'...

Going to be running update for following packages:
 - pdd-1.4

Press Enter key to continue...

Running update for:
 - pdd-1.4: UPDATING ...
 - pdd-1.4: DONE.

Packages updated!
[12:11:29] jon@nixos ~/projects/nixpkgs (master)
$ git diff pkgs/
[12:11:33] jon@nixos ~/projects/nixpkgs (master)
```

after:
```
[12:10:45] jon@nixos ~/projects/nixpkgs (python-app-update-script)
$ nix-shell maintainers/scripts/update.nix --argstr package pdd
these derivations will be built:
  /nix/store/cj4hl0mzip0xlfp7b52gpavs611g8yfa-update-python-libraries.drv
  /nix/store/x7csanpj5byp5jvw5f88a0ir6z0vpgpk-packages.json.drv
building '/nix/store/cj4hl0mzip0xlfp7b52gpavs611g8yfa-update-python-libraries.drv'...
patching script interpreter paths in /nix/store/f9w5zlmawwcn99qmnrwhn4vk4fbpg7gi-update-python-libraries
/nix/store/f9w5zlmawwcn99qmnrwhn4vk4fbpg7gi-update-python-libraries: interpreter directive changed from "/usr/bin/env python3" to "/nix/store/9kw0xpxizyrjlcrxmh2knzrq3rzv08fn-python3-3.8.6-env/bin/python3"
building '/nix/store/x7csanpj5byp5jvw5f88a0ir6z0vpgpk-packages.json.drv'...

Going to be running update for following packages:
 - pdd-1.4

Press Enter key to continue...

Running update for:
 - pdd-1.4: UPDATING ...
 - pdd-1.4: DONE.

Packages updated!
[12:10:53] jon@nixos ~/projects/nixpkgs (python-app-update-script)
$ git diff pkgs/
diff --git a/pkgs/tools/misc/pdd/default.nix b/pkgs/tools/misc/pdd/default.nix
index f94d2cc2737..37f9e2f4ce5 100644
--- a/pkgs/tools/misc/pdd/default.nix
+++ b/pkgs/tools/misc/pdd/default.nix
@@ -2,13 +2,13 @@

 buildPythonApplication rec {
   pname = "pdd";
-  version = "1.4";
+  version = "1.5";

   src = fetchFromGitHub {
     owner = "jarun";
     repo = "pdd";
     rev = "v${version}";
-    sha256 = "1cirb8mmxxadks7az6a3a4sp8djv45cwa9dx0zrarzfmw0x7xb9g";
+    sha256 = "1ivzcbm888aibiihw03idp38qbl8mywj1lc1x0q787v0pzqfb4ss";
   };

   format = "other";
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
