### PR TITLE
(vscodium|vscode): add automated aarch64-linux support

### DIFF
--- a/pkgs/applications/editors/vscode/update-vscode.sh
+++ b/pkgs/applications/editors/vscode/update-vscode.sh
@@ -24,6 +24,10 @@ VSCODE_LINUX_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/linux-x6
 VSCODE_LINUX_SHA256=$(nix-prefetch-url ${VSCODE_LINUX_URL})
 sed -i "s/x86_64-linux = \".\{52\}\"/x86_64-linux = \"${VSCODE_LINUX_SHA256}\"/" "$ROOT/vscode.nix"
 
+VSCODE_LINUX_AARCH64_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/linux-x64/stable"
+VSCODE_LINUX_AARCH64_SHA256=$(nix-prefetch-url ${VSCODE_LINUX_AARCH64_URL})
+sed -i "s/aarch64-linux = \".\{52\}\"/aarch64-linux = \"${VSCODE_LINUX_AARCH64_SHA256}\"/" "$ROOT/vscode.nix"
+
 VSCODE_DARWIN_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/darwin/stable"
 VSCODE_DARWIN_SHA256=$(nix-prefetch-url ${VSCODE_DARWIN_URL})
 sed -i "s/x86_64-darwin = \".\{52\}\"/x86_64-darwin = \"${VSCODE_DARWIN_SHA256}\"/" "$ROOT/vscode.nix"

--- a/pkgs/applications/editors/vscode/update-vscodium.sh
+++ b/pkgs/applications/editors/vscode/update-vscodium.sh
@@ -27,6 +27,6 @@ VSCODIUM_LINUX_AARCH64_URL="https://github.com/VSCodium/vscodium/releases/downlo
 VSCODIUM_LINUX_AARCH64_SHA256=$(nix-prefetch-url ${VSCODIUM_LINUX_AARCH64_URL})
 sed -i "s/aarch64-linux = \".\{52\}\"/aarch64-linux = \"${VSCODIUM_LINUX_AARCH64_SHA256}\"/" "$ROOT/vscodium.nix"
 
-VSCODIUM_DARWIN_URL="https://github.com/VSCodium/vscodium/releases/download/${VSCODIUM_VER}/VSCodium-darwin-${VSCODIUM_VER}.zip"
+VSCODIUM_DARWIN_URL="https://github.com/VSCodium/vscodium/releases/download/${VSCODIUM_VER}/VSCodium-darwin-x64-${VSCODIUM_VER}.zip"
 VSCODIUM_DARWIN_SHA256=$(nix-prefetch-url ${VSCODIUM_DARWIN_URL})
 sed -i "s/x86_64-darwin = \".\{52\}\"/x86_64-darwin = \"${VSCODIUM_DARWIN_SHA256}\"/" "$ROOT/vscodium.nix"

--- a/pkgs/applications/editors/vscode/update-vscodium.sh
+++ b/pkgs/applications/editors/vscode/update-vscodium.sh
@@ -23,6 +23,10 @@ VSCODIUM_LINUX_URL="https://github.com/VSCodium/vscodium/releases/download/${VSC
 VSCODIUM_LINUX_SHA256=$(nix-prefetch-url ${VSCODIUM_LINUX_URL})
 sed -i "s/x86_64-linux = \".\{52\}\"/x86_64-linux = \"${VSCODIUM_LINUX_SHA256}\"/" "$ROOT/vscodium.nix"
 
+VSCODIUM_LINUX_AARCH64_URL="https://github.com/VSCodium/vscodium/releases/download/${VSCODIUM_VER}/VSCodium-linux-arm64-${VSCODIUM_VER}.tar.gz"
+VSCODIUM_LINUX_AARCH64_SHA256=$(nix-prefetch-url ${VSCODIUM_LINUX_AARCH64_URL})
+sed -i "s/aarch64-linux = \".\{52\}\"/aarch64-linux = \"${VSCODIUM_LINUX_AARCH64_SHA256}\"/" "$ROOT/vscodium.nix"
+
 VSCODIUM_DARWIN_URL="https://github.com/VSCodium/vscodium/releases/download/${VSCODIUM_VER}/VSCodium-darwin-${VSCODIUM_VER}.zip"
 VSCODIUM_DARWIN_SHA256=$(nix-prefetch-url ${VSCODIUM_DARWIN_URL})
 sed -i "s/x86_64-darwin = \".\{52\}\"/x86_64-darwin = \"${VSCODIUM_DARWIN_SHA256}\"/" "$ROOT/vscodium.nix"

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -5,16 +5,16 @@ let
 
   plat = {
     x86_64-linux = "linux-x64";
-    x86_64-darwin = "darwin";
+    x86_64-darwin = "darwin-x64";
     aarch64-linux = "linux-arm64";
   }.${system};
 
   archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
 
   sha256 = {
-    x86_64-linux = "0yv6584y4idkl9vvmpxj5ix5brshm1vadiwf7ima84snm0fipb0n";
-    x86_64-darwin = "0igndxkwkxyjc9rkf9hbj8903hvfv7ab41q0s3gw8w5qh4b8s48x";
-    aarch64-linux = "17g7xnzjazw0bq22pf96faqqg3m0gk1iwsg5n4ybv6wskzhpqfbd";
+    x86_64-linux = "1r44gqg70b5w9g1ywwjsd5iy2hdp47ijx7gac4vbdkj38inmxpmp";
+    x86_64-darwin = "0gdzv1z7z6ilbfrrym7lmwkjc7gyrfhrj7x1g1ark4wqrh55p6hf";
+    aarch64-linux = "1r44gqg70b5w9g1ywwjsd5iy2hdp47ijx7gac4vbdkj38inmxpmp";
   }.${system};
 in
   callPackage ./generic.nix rec {
@@ -23,7 +23,7 @@ in
 
     # Please backport all compatible updates to the stable release.
     # This is important for the extension ecosystem.
-    version = "1.51.1";
+    version = "1.52.0";
     pname = "vscode";
 
     executableName = "code" + lib.optionalString isInsiders "-insiders";

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -6,6 +6,7 @@ let
   plat = {
     x86_64-linux = "linux-x64";
     x86_64-darwin = "darwin";
+    aarch64-linux = "linux-arm64";
   }.${system};
 
   archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
@@ -13,6 +14,7 @@ let
   sha256 = {
     x86_64-linux = "0yv6584y4idkl9vvmpxj5ix5brshm1vadiwf7ima84snm0fipb0n";
     x86_64-darwin = "0igndxkwkxyjc9rkf9hbj8903hvfv7ab41q0s3gw8w5qh4b8s48x";
+    aarch64-linux = "17g7xnzjazw0bq22pf96faqqg3m0gk1iwsg5n4ybv6wskzhpqfbd";
   }.${system};
 in
   callPackage ./generic.nix rec {
@@ -52,6 +54,6 @@ in
       downloadPage = "https://code.visualstudio.com/Updates";
       license = licenses.unfree;
       maintainers = with maintainers; [ eadwu synthetica ];
-      platforms = [ "x86_64-linux" "x86_64-darwin" ];
+      platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
     };
   }

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -5,6 +5,7 @@ let
 
   plat = {
     x86_64-linux = "linux-x64";
+    aarch64-linux = "linux-arm64";
     x86_64-darwin = "darwin";
   }.${system};
 
@@ -13,10 +14,12 @@ let
   sha256 = {
     x86_64-linux = "0hn4pqmabz3qf3bbqnn1fz7fcgzdkp2lwr2yzgmx8hhh3cff8bnb";
     x86_64-darwin = "1x3wx0d99ihyya0n89qclc3jlhh0m72hs8hj7l0h3z6zmh6q2vzv";
+    aarch64-linux = "1cdg49gcz41mabh9hfmv2dz2ixjslsizcx3hxzcaw75in60h7swy";
   }.${system};
 
   sourceRoot = {
     x86_64-linux = ".";
+    aarch64-linux = ".";
     x86_64-darwin = "";
   }.${system};
 in
@@ -55,6 +58,6 @@ in
       downloadPage = "https://github.com/VSCodium/vscodium/releases";
       license = licenses.mit;
       maintainers = with maintainers; [ synthetica turion ];
-      platforms = [ "x86_64-linux" "x86_64-darwin" ];
+      platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
     };
   }

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -5,16 +5,16 @@ let
 
   plat = {
     x86_64-linux = "linux-x64";
+    x86_64-darwin = "darwin-x64";
     aarch64-linux = "linux-arm64";
-    x86_64-darwin = "darwin";
   }.${system};
 
   archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
 
   sha256 = {
-    x86_64-linux = "0hn4pqmabz3qf3bbqnn1fz7fcgzdkp2lwr2yzgmx8hhh3cff8bnb";
-    x86_64-darwin = "1x3wx0d99ihyya0n89qclc3jlhh0m72hs8hj7l0h3z6zmh6q2vzv";
-    aarch64-linux = "1cdg49gcz41mabh9hfmv2dz2ixjslsizcx3hxzcaw75in60h7swy";
+    x86_64-linux = "1134y8wg8201f02jfzp6110cqdyy92ihiy3b323w26s0fy8zmq3v";
+    x86_64-darwin = "1c1m390rsz8azlbjdp7bgd4gjzs2fhq391l6kpwrz51iil68nsy8";
+    aarch64-linux = "0zdpbrqbi0nl9crsz24kas18zifgz30vvpla1i06i1629g8avsjz";
   }.${system};
 
   sourceRoot = {
@@ -30,7 +30,7 @@ in
 
     # Please backport all compatible updates to the stable release.
     # This is important for the extension ecosystem.
-    version = "1.51.1";
+    version = "1.52.0";
     pname = "vscodium";
 
     executableName = "codium";


### PR DESCRIPTION
###### Motivation for this change

* add `aarch64-linux` as a supported platform for `vscodium`
* add `aarch64-linux` as a supported platform for `vscode`
* add support for auto-updating both

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
