### PR TITLE
astroid: fix python plugin usage

### DIFF
--- a/pkgs/applications/networking/mailreaders/astroid/default.nix
+++ b/pkgs/applications/networking/mailreaders/astroid/default.nix
@@ -1,12 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkgconfig, gnome3, gmime3, webkitgtk
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, gnome3, gmime3, webkitgtk, ronn
 , libsass, notmuch, boost, wrapGAppsHook, glib-networking, protobuf, vim_configurable
-, gtkmm3, libpeas, gsettings-desktop-schemas
-, python3, python3Packages
-, vim ? vim_configurable.override {
-                    features = "normal";
-                    gui = "auto";
-                  }
-, ronn
+, gtkmm3, libpeas, gsettings-desktop-schemas, gobject-introspection, python3
+
+# vim to be used, should support the GUI mode.
+, vim ? vim_configurable.override { features = "normal"; gui = "auto"; }
+
+# additional python3 packages to be available within plugins
+, extraPythonPackages ? []
 }:
 
 stdenv.mkDerivation rec {
@@ -20,22 +20,30 @@ stdenv.mkDerivation rec {
     sha256 = "11cxbva9ni98gii59xmbxh4c6idcg3mg0pgdsp1c3j0yg7ix0lj3";
   };
 
-  nativeBuildInputs = [ cmake ronn pkgconfig wrapGAppsHook ];
+  nativeBuildInputs = [
+    cmake ronn pkg-config wrapGAppsHook gobject-introspection
+    python3 python3.pkgs.wrapPython
+  ];
 
   buildInputs = [
     gtkmm3 gmime3 webkitgtk libsass libpeas
-    python3 python3Packages.pygobject3
+    python3
     notmuch boost gsettings-desktop-schemas gnome3.adwaita-icon-theme
     glib-networking protobuf
-   ] ++ (if vim == null then [] else [ vim ]);
+    vim
+  ];
 
   postPatch = ''
     sed -i "s~gvim ~${vim}/bin/vim -g ~g" src/config.cc
     sed -i "s~ -geom 10x10~~g" src/config.cc
   '';
 
-  postInstall = ''
-    wrapProgram "$out/bin/astroid" --set CHARSET=en_us.UTF-8
+  pythonPath = with python3.pkgs; requiredPythonModules [ pygobject3 ] ++ extraPythonPackages;
+  preFixup = ''
+    buildPythonPath "$out $pythonPath"
+    gappsWrapperArgs+=(
+      --prefix PYTHONPATH : "$program_PYTHONPATH"
+    )
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Astroid's python-based plugin system was not usable before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
