### PR TITLE
python3Packages.pynacl: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/development/python-modules/pynacl/default.nix
+++ b/pkgs/development/python-modules/pynacl/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "pynacl";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchPypi {
     inherit version;
     pname = "PyNaCl";
-    sha256 = "0c6100edd16fefd1557da078c7a31e7b7d7a52ce39fdca2bec29d4f7b6e7600c";
+    sha256 = "01b56hxrbif3hx8l6rwz5kljrgvlbj7shmmd2rjh0hn7974a5sal";
   };
 
   checkInputs = [ pytest hypothesis_4 ];
@@ -24,19 +24,9 @@ buildPythonPackage rec {
 
   SODIUM_INSTALL = "system";
 
-  # fixed in next release 1.3.0+
-  # https://github.com/pyca/pynacl/pull/480
-  postPatch = ''
-    substituteInPlace tests/test_bindings.py \
-      --replace "average_size=128," ""
-  '';
-
   checkPhase = ''
     py.test
   '';
-
-  # https://github.com/pyca/pynacl/issues/550
-  PYTEST_ADDOPTS = "-k 'not test_wrong_types'";
 
   meta = with stdenv.lib; {
     maintainers = with maintainers; [ va1entin ];


### PR DESCRIPTION
###### Motivation for this change
ordinary bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
