### PR TITLE
hdf4: 4.2.14 -> 4.2.15, fix build

### DIFF
--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -9,30 +9,17 @@
 
 stdenv.mkDerivation rec {
   pname = "hdf";
-  version = "4.2.14";
+  version = "4.2.15";
   src = fetchurl {
     url = "https://support.hdfgroup.org/ftp/HDF/releases/HDF${version}/src/hdf-${version}.tar.bz2";
-    sha256 = "0n29klrrbwan9307np0d9hr128dlpc4nnlf57a140080ll3jmp8l";
+    sha256 = "04nbgfxyj5jg4d6sr28162cxbfwqgv0sa7vz1ayzvm8wbbpkbq5x";
   };
 
-  patches = let
-    # The Debian patch revision to fetch from; this may differ from our package
-    # version, but older patches should still apply.
-    patchRev = "4.2.13-4";
-    getPatch = name: sha256: fetchpatch {
-      inherit sha256;
-      url = "https://salsa.debian.org/debian-gis-team/hdf4/raw/debian/${patchRev}/debian/patches/${name}";
-    };
-
-  in [
-    (getPatch "64bit"                     "1xqk9zpch4m6ipa0f3x2cm8rwaz4p0ppp1vqglvz18j6q91p8b5y")
-    (getPatch "hdfi.h"                    "01fr9csylnvk9jd9jn9y23bvxy192s07p32pr76mm3gwhgs9h7r4")
-    (getPatch "hdf-4.2.10-aarch64.patch"  "1hl0xw5pd9xhpq49xpwgg7c4z6vv5p19x6qayixw0myvgwj1r4zn")
-    (getPatch "reproducible-builds.patch" "02j639w26xkxpxx3pdhbi18ywz8w3qmjpqjb83n47gq29y4g13hc")
+  nativeBuildInputs = [
+    cmake
   ];
 
   buildInputs = [
-    cmake
     libjpeg
     szip
     zlib


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken in #100647

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
