### PR TITLE
marker: init at 2020.04.04

### DIFF
--- a/pkgs/applications/editors/marker/default.nix
+++ b/pkgs/applications/editors/marker/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook
+, gtk3
+, gtksourceview
+, gtkspell3
+, webkitgtk
+, pandoc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "marker";
+  version = "2020.04.04";
+
+  src = fetchFromGitHub {
+    owner = "fabiocolacio";
+    repo = "Marker";
+    rev = "${version}";
+    fetchSubmodules = true;
+    sha256 = "1iy7izyprf050bix8am1krqivgyxnhx3jm775v8f80cgbqxy7m5r";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    gtksourceview
+    gtkspell3
+    webkitgtk
+    pandoc
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://fabiocolacio.github.io/Marker/";
+    description = "Markdown editor for the Linux desktop";
+    maintainers = with maintainers; [ trepetti ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    changelog = "https://github.com/fabiocolacio/Marker/releases/tag/${version}";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21187,6 +21187,8 @@ in
 
   lwm = callPackage ../applications/window-managers/lwm { };
 
+  marker = callPackage ../applications/editors/marker { };
+
   musikcube = callPackage ../applications/audio/musikcube {};
 
   pinboard-notes-backup = haskell.lib.overrideCabal


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add Marker, a GTK3-based markdown editor for Linux desktops.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
