### PR TITLE
rufo (Ruby formatter): init at 0.12.0

### DIFF
--- a/pkgs/development/tools/rufo/Gemfile
+++ b/pkgs/development/tools/rufo/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'rufo'

--- a/pkgs/development/tools/rufo/Gemfile.lock
+++ b/pkgs/development/tools/rufo/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rufo (0.12.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rufo
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/development/tools/rufo/default.nix
+++ b/pkgs/development/tools/rufo/default.nix
@@ -1,0 +1,16 @@
+{ bundlerApp, bundlerUpdateScript, lib }:
+
+bundlerApp {
+  pname = "rufo";
+  gemdir = ./.;
+  exes = [ "rufo" ];
+
+  passthru.updateScript = bundlerUpdateScript "rufo";
+
+  meta = with lib; {
+    description = "Ruby formatter";
+    homepage = "https://github.com/ruby-formatter/rufo";
+    license = licenses.mit;
+    maintainers = with maintainers; [ andersk ];
+  };
+}

--- a/pkgs/development/tools/rufo/gemset.nix
+++ b/pkgs/development/tools/rufo/gemset.nix
@@ -1,0 +1,12 @@
+{
+  rufo = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nwasskcm0nrf7f52019x4fvxa5zckj4fcvf4cdl0qflrcwb1l9f";
+      type = "gem";
+    };
+    version = "0.12.0";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11568,6 +11568,8 @@ in
   rr = callPackage ../development/tools/analysis/rr { };
   rr-unstable = callPackage ../development/tools/analysis/rr/unstable.nix { }; # This is a temporary attribute, please see the corresponding file for details.
 
+  rufo = callPackage ../development/tools/rufo { };
+
   samurai = callPackage ../development/tools/build-managers/samurai { };
 
   saleae-logic = callPackage ../development/tools/misc/saleae-logic { };


### PR DESCRIPTION
##### Motivation for this change

Package [Rufo](https://github.com/ruby-formatter/rufo), the Ruby formatter.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
