### PR TITLE
burpsuite: 2020.1 -> 2020.9.2

### DIFF
--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, runtimeShell }:
+{ stdenv, fetchurl, jre, writeShellScript, chromium, unzip }:
 
 let
   version = "2020.9.2";
@@ -7,8 +7,10 @@ let
     url = "https://portswigger.net/Burp/Releases/Download?productId=100&version=${version}&type=Jar";
     sha256 = "d4a3abd973ae79fb1c21926dd1323d6d74763fa59bbc70d0105eccf7f41811ee";
   };
-  launcher = ''
-    #!${runtimeShell}
+  launcher = writeShellScript "burpsuite-launcher" ''
+    eval "$(${unzip}/bin/unzip -p ${jar} chromium.properties)"
+    mkdir -p "$HOME/.BurpSuite/burpbrowser/$linux64"
+    ln -sf "${chromium}/bin/chromium" "$HOME/.BurpSuite/burpbrowser/$linux64/chrome"
     exec ${jre}/bin/java -jar ${jar} "$@"
   '';
 in stdenv.mkDerivation {
@@ -16,8 +18,7 @@ in stdenv.mkDerivation {
   inherit version;
   buildCommand = ''
     mkdir -p $out/bin
-    echo "${launcher}" > $out/bin/burpsuite
-    chmod +x $out/bin/burpsuite
+    cp "${launcher}" $out/bin/burpsuite
   '';
 
   preferLocalBuild = true;

--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, jre, runtimeShell }:
 
 let
-  version = "2020.1";
+  version = "2020.9.2";
   jar = fetchurl {
     name = "burpsuite.jar";
     url = "https://portswigger.net/Burp/Releases/Download?productId=100&version=${version}&type=Jar";
-    sha256 = "12awfy0f8fyqjc0kza1gkmdx1g8bniw1xqaps2dhjimi6s0lq5jx";
+    sha256 = "d4a3abd973ae79fb1c21926dd1323d6d74763fa59bbc70d0105eccf7f41811ee";
   };
   launcher = ''
     #!${runtimeShell}


### PR DESCRIPTION
###### Motivation for this change
Update Burpsuite to the latest release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
