### PR TITLE
[20.09] python3Packages.dask: limit processes on tests

### DIFF
--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -32,8 +32,6 @@ buildPythonPackage rec {
     pytest_xdist # takes >10mins to run single-threaded
   ];
 
-  pytestFlagsArray = [ "-n $NIX_BUILD_CORES" ];
-
   dontUseSetuptoolsCheck = true;
 
   propagatedBuildInputs = [
@@ -55,6 +53,13 @@ buildPythonPackage rec {
       --replace "version=versioneer.get_version()," "version='${version}'," \
       --replace "cmdclass=versioneer.get_cmdclass()," ""
   '';
+
+  # dask test suite with consistently fail when using high core counts
+  preCheck = ''
+    NIX_BUILD_CORES=$((NIX_BUILD_CORES > 8 ? 8 : NIX_BUILD_CORES))
+  '';
+
+  pytestFlagsArray = [ "-n $NIX_BUILD_CORES" ];
 
   disabledTests = [
     "test_argwhere_str"


### PR DESCRIPTION
###### Motivation for this change
missed a commit in #100167

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
