### PR TITLE
ocamlPackages.yaml: 2.0.1 → 2.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/yaml/default.nix
+++ b/pkgs/development/ocaml-modules/yaml/default.nix
@@ -1,17 +1,21 @@
 { lib, fetchurl, buildDunePackage
+, dune-configurator
 , ppx_sexp_conv
 , bos, ctypes, fmt, logs, rresult, sexplib
 }:
 
 buildDunePackage rec {
   pname = "yaml";
-  version = "2.0.1";
+  version = "2.1.0";
+
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/avsm/ocaml-yaml/releases/download/v${version}/yaml-v${version}.tbz";
-    sha256 = "1r8jj572h416g2zliwmxj2j9hkv73nxnpfb9gmbj9gixg24lskx0";
+    sha256 = "03g8vsh5jgi1cm5q78v15slgnzifp91fp7n4v1i7pa8yk0bkh585";
   };
 
+  buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ bos ctypes fmt logs ppx_sexp_conv rresult sexplib ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/avsm/ocaml-yaml/releases/tag/v2.1.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
