### PR TITLE
rtsp-simple-server: init at 0.10.0

### DIFF
--- a/pkgs/servers/rtsp-simple-server/default.nix
+++ b/pkgs/servers/rtsp-simple-server/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, fetchFromGitHub
+, buildGoModule
+}:
+
+buildGoModule rec {
+  pname = "rtsp-simple-server";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "aler9";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "rnUmPyT9jAqm7Vf2TokgRGPTn7rTBUvrpJU21IopFsM=";
+  };
+
+  vendorSha256 = "jAWDz/TclfCKQR/Gh99zSiGAsraciNU+yzFe5DGTeQI=";
+
+  # Tests need docker
+  doCheck = false;
+
+  buildFlagsArray = [
+    "-ldflags=-X main.Version=${version}"
+  ];
+
+  meta = with stdenv.lib; {
+    description =
+      "Ready-to-use RTSP server and RTSP proxy that allows to read and publish video and audio streams"
+    ;
+    inherit (src.meta) homepage;
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18527,6 +18527,8 @@ in
 
   roccat-tools = callPackage ../os-specific/linux/roccat-tools { };
 
+  rtsp-simple-server = callPackage ../servers/rtsp-simple-server { };
+
   rtkit = callPackage ../os-specific/linux/rtkit { };
 
   rt5677-firmware = callPackage ../os-specific/linux/firmware/rt5677 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
