### PR TITLE
mesa: Attempt to upgrade the drivers with a minimal rebuild impact

### DIFF
--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -150,8 +150,8 @@ in
     environment.sessionVariables.LD_LIBRARY_PATH = mkIf cfg.setLdLibraryPath
       ([ "/run/opengl-driver/lib" ] ++ optional cfg.driSupport32Bit "/run/opengl-driver-32/lib");
 
-    hardware.opengl.package = mkDefault pkgs.mesa.drivers;
-    hardware.opengl.package32 = mkDefault pkgs.pkgsi686Linux.mesa.drivers;
+    hardware.opengl.package = mkDefault pkgs.mesa_drivers;
+    hardware.opengl.package32 = mkDefault pkgs.pkgsi686Linux.mesa_drivers;
 
     boot.extraModulePackages = optional (elem "virtualbox" videoDrivers) kernelPackages.virtualboxGuestAdditions;
   };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -318,7 +318,6 @@ mapAliases ({
   # gcsecurity bussiness is done: https://www.theregister.co.uk/2018/02/08/bruce_perens_grsecurity_anti_slapp/
   # floating point textures patents are expired,
   # so package reduced to alias
-  mesa_drivers = mesa.drivers;
   mesos = throw "mesos has been removed from nixpkgs, as it's unmaintained"; # added 2020-08-15
   midoriWrapper = midori; # added 2015-01
   mist = throw "mist has been removed as the upstream project has been abandoned, see https://github.com/ethereum/mist#mist-browser-deprecated"; # added 2020-08-15

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14677,6 +14677,15 @@ in
     inherit (darwin.apple_sdk.libs) Xplugin;
   };
 
+  # mesa_drivers is only for hardware.opengl.package!:
+  mesa_drivers = (mesa.overrideAttrs (oldAttrs: rec {
+    version = "20.2.2";
+    src = fetchurl {
+      url = "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz";
+      sha256 = "0qdqi767vshclnfg9drlsmp2pa17hi7y0172s064jwfgj08fp4qz";
+    };
+  })).drivers;
+
   mesa_glu =  callPackage ../development/libraries/mesa-glu {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

See #44831, though this is a more extreme approach.

Not sure yet if this is a stupid idea or a good way to quickly apply Mesa updates. This mainly makes sense under the assumption that minor/patch releases only update the drivers (`mesa.drivers`) anyway. The plan would be to freeze `mesa` at `X.Y.1` (first stable release of a series) and update `mesa_drivers` to `X.Y.1+N` without going through staging first. Or another idea would be to simultaneously update `mesa` via `staging` and `mesa_drivers` via `master`.

Personally I'm already using that approach to test Mesa updates and it seemed to be fine so far (though I only did very minimal testing). However with `lsof` I can always see a few references to the previous Mesa version, though mainly(/only?) for `libgbm` IIRC (e.g. `/nix/store/***-mesa-X.Y.Z/lib/libgbm.so.1.0.0`). For that reasons it might make sense to simultaneously update `mesa` via `staging` or implement the approach from #44831.

Note: The update to `20.1.10` doesn't make sense since `20.2.1` is already in staging, it only serves as an example.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
