### PR TITLE
chromium: build on all cores

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -319,15 +319,8 @@ let
     NIX_CFLAGS_COMPILE = "-Wno-unknown-warning-option";
 
     buildPhase = let
-      # Build paralelism: on Hydra the build was frequently running into memory
-      # exhaustion, and even other users might be running into similar issues.
-      # -j is halved to avoid memory problems, and -l is slightly increased
-      # so that the build gets slight preference before others
-      # (it will often be on "critical path" and at risk of timing out)
       buildCommand = target: ''
-        ninja -C "${buildPath}"  \
-          -j$(( ($NIX_BUILD_CORES+1) / 2 )) -l$(( $NIX_BUILD_CORES+1 )) \
-          "${target}"
+        ninja -C "${buildPath}" "${target}"
         (
           source chrome/installer/linux/common/installer.include
           PACKAGE=$packageName

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -320,7 +320,7 @@ let
 
     buildPhase = let
       buildCommand = target: ''
-        ninja -C "${buildPath}" "${target}"
+        ninja -C "${buildPath}" -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES "${target}"
         (
           source chrome/installer/linux/common/installer.include
           PACKAGE=$packageName

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
@@ -353,7 +353,7 @@ let
 
     buildPhase = let
       buildCommand = target: ''
-        ninja -C "${buildPath}" "${target}"
+        ninja -C "${buildPath}" -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES "${target}"
         (
           source chrome/installer/linux/common/installer.include
           PACKAGE=$packageName

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
@@ -352,15 +352,8 @@ let
     NIX_CFLAGS_COMPILE = "-Wno-unknown-warning-option";
 
     buildPhase = let
-      # Build paralelism: on Hydra the build was frequently running into memory
-      # exhaustion, and even other users might be running into similar issues.
-      # -j is halved to avoid memory problems, and -l is slightly increased
-      # so that the build gets slight preference before others
-      # (it will often be on "critical path" and at risk of timing out)
       buildCommand = target: ''
-        ninja -C "${buildPath}"  \
-          -j$(( ($NIX_BUILD_CORES+1) / 2 )) -l$(( $NIX_BUILD_CORES+1 )) \
-          "${target}"
+        ninja -C "${buildPath}" "${target}"
         (
           source chrome/installer/linux/common/installer.include
           PACKAGE=$packageName


### PR DESCRIPTION
`chromium` is built on half of `$NIX_BUILD_CORES` due to an old Hydra out of memory issue.

Nowadays, when hardware typically has more memory and cores, this increases build time twofold causing build timeouts.

Also, the most memory consuming task is `ld.gold` linker which works on single-core anyway and @TredwellGit is going to get rid of it (https://github.com/NixOS/nixpkgs/pull/100512#issuecomment-709356964).

Fixes #100486
Related #78347 #100512
cc @vcunat @thefloweringash @TredwellGit 