### PR TITLE
pythonPackages.yq: Fix tests

### DIFF
--- a/pkgs/development/python-modules/yq/default.nix
+++ b/pkgs/development/python-modules/yq/default.nix
@@ -10,7 +10,6 @@
 , flake8
 , jq
 , pytest
-, unixtools
 , toml
 }:
 
@@ -23,6 +22,10 @@ buildPythonPackage rec {
     sha256 = "1q4rky0a6n4izmq7slb91a54g8swry1xrbfqxwc8lkd3hhvlxxkl";
   };
 
+  postPatch = ''
+    substituteInPlace test/test.py --replace "expect_exit_codes={0} if sys.stdin.isatty() else {2}" "expect_exit_codes={0}"
+  '';
+
   propagatedBuildInputs = [
     pyyaml
     xmltodict
@@ -32,7 +35,6 @@ buildPythonPackage rec {
   doCheck = true;
 
   checkInputs = [
-   unixtools.script
    pytest
    coverage
    flake8
@@ -40,8 +42,7 @@ buildPythonPackage rec {
    toml
   ];
 
-  # tests fails if stdin is not a tty
-  checkPhase = "echo | script -c 'pytest ./test/test.py'";
+  checkPhase = "pytest ./test/test.py";
 
   pythonImportsCheck = [ "yq" ];
 


### PR DESCRIPTION
Revert commit 40a58cc65bec0ed5b784178239e55f7c7ac969f5 introduced in https://github.com/NixOS/nixpkgs/pull/98282.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The reverted commit introduced two problems, as far as I can tell:

1. The test `test/test.py::TestYq::test_yq_arg_handling` fails on NixOS using latest nixpkgs master
2. The BSD [script(1)](https://www.freebsd.org/cgi/man.cgi?script(1)) doesn't have the `-c` option causing this to fail on macOS

Maybe this isn't the perfect way to address the issue but by reverting this commit, macOS and NixOS build the package just fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
