### PR TITLE
agave: 22 -> 30

### DIFF
--- a/pkgs/data/fonts/agave/default.nix
+++ b/pkgs/data/fonts/agave/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "agave";
-  version = "22";
+  version = "30";
 in fetchurl {
   name = "${pname}-${version}";
   url = "https://github.com/agarick/agave/releases/download/v${version}/Agave-Regular.ttf";
@@ -13,7 +13,7 @@ in fetchurl {
     install -D $downloadedFile $out/share/fonts/truetype/Agave-Regular.ttf
   '';
 
-  sha256 = "1jb8f0xcv5z0l5nyx733b6zclswi82vrh2nwyyhbqzgqrl4y1h6s";
+  sha256 = "1f2f1fycwi8xbf8x03yfq78nv11b2msl4ll9flw8rkg023h9vwg7";
 
   meta = with lib; {
     description = "truetype monospaced typeface designed for X environments";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/agarick/agave/releases/tag/v30
(see also notes for other releases, not linked here)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).