### PR TITLE
tinycc: fix build on darwin

### DIFF
--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, lib, fetchFromRepoOrCz, perl, texinfo }:
+{ stdenv, lib
+, fetchFromRepoOrCz
+, darwin
+, perl
+, texinfo
+, which
+, xcbuild
+}:
 with lib;
 
 stdenv.mkDerivation rec {
@@ -8,11 +15,12 @@ stdenv.mkDerivation rec {
 
   src = fetchFromRepoOrCz {
     repo = "tinycc";
-    rev = upstreamVersion;
-    sha256 = "12mm1lqywz0akr2yb2axjfbw8lwv57nh395vzsk534riz03ml977";
+    rev = "78da4586a002275e7f4c29d0f545430f1fc055e7";
+    sha256 = "00piy8gvnf3g8agibrlplc4jr7sifaafvwgd2dgyxb6lrj2psw1n";
   };
 
-  nativeBuildInputs = [ perl texinfo ];
+  nativeBuildInputs = [ perl texinfo which ]
+    ++ optional stdenv.isDarwin xcbuild;
 
   hardeningDisable = [ "fortify" ];
 
@@ -21,6 +29,9 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace "texi2pod.pl" \
       --replace "/usr/bin/perl" "${perl}/bin/perl"
+  '' + optionalString stdenv.isDarwin ''
+    substituteInPlace tests/tests2/Makefile \
+      --replace 'SKIP = ' 'SKIP = 106_pthread.test '
   '';
 
   preConfigure = ''
@@ -77,7 +88,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.tinycc.org/";
     license = licenses.mit;
 
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.unix;
     maintainers = [ maintainers.joachifm ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Fix build of `tinycc` on darwin (macOS for me)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
