### PR TITLE
[20.09] python{2,3}Package.pytest-bdd: upgrade and fix test

### DIFF
--- a/pkgs/development/python-modules/pytest-bdd/default.nix
+++ b/pkgs/development/python-modules/pytest-bdd/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "pytest-bdd";
-  version = "3.2.1";
+  version = "4.0.1";
 
   # tests are not included in pypi tarball
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = pname;
     rev = version;
-    sha256 = "02y28l5h1m9grj54p681qvv7nrhd7ly9jkqdchyw4p0lnmcmnsrd";
+    sha256 = "1yqzz44as4pxffmg4hk9lijvnvlc2chg1maq1fbj5i4k4jpagvjz";
   };
 
   propagatedBuildInputs = [ glob2 Mako parse parse-type py pytest six ];
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   # Tests require extra dependencies
   checkInputs = [ execnet mock pytest ];
   checkPhase = ''
-    pytest
+    PATH=$PATH:$out/bin pytest
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
backport https://github.com/NixOS/nixpkgs/pull/100522

ZHF: #97479
cc @NixOS/nixos-release-managers

fix https://hydra.nixos.org/build/127939944

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
