### PR TITLE
[20.09] pythonPackages.pytest-cram: 0.2.0 -> 0.2.2

### DIFF
--- a/pkgs/development/python-modules/pytest-cram/default.nix
+++ b/pkgs/development/python-modules/pytest-cram/default.nix
@@ -1,7 +1,7 @@
-{lib, buildPythonPackage, fetchPypi, pytest, cram, bash}:
+{ lib, buildPythonPackage, fetchPypi, pytest, cram, bash }:
 
 buildPythonPackage rec {
-  version = "0.2.0";
+  version = "0.2.2";
   pname = "pytest-cram";
 
   checkInputs = [ pytest ];
@@ -9,8 +9,8 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "006p5dr3q794sbwwmxmdls3nwq0fvnyrxxmc03pgq8n74chl71qn";
-    extension = "zip";
+    sha256 = "0405ymmrsv6ii2qhq35nxfjkb402sdb6d13xnk53jql3ybgmiqq0";
+    extension = "tar.gz";
   };
 
   postPatch = ''


### PR DESCRIPTION
Backport https://github.com/NixOS/nixpkgs/pull/100529

Fix build https://hydra.nixos.org/build/127627259

ZHF: #97479
@NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
