### PR TITLE
python3Packages.block-io: fix build

### DIFF
--- a/pkgs/development/python-modules/block-io/default.nix
+++ b/pkgs/development/python-modules/block-io/default.nix
@@ -20,12 +20,15 @@ buildPythonPackage rec {
 
   preConfigure = ''
     substituteInPlace setup.py \
-      --replace "ecdsa==0.13" "ecdsa>=0.13"
+      --replace "ecdsa==0.13" "ecdsa>=0.13" \
+      --replace "base58==1.0.3" "base58>=1.0.3"
   '';
 
   # Tests needs a BlockIO API key to run properly
   # https://github.com/BlockIo/block_io-python/blob/79006bc8974544b70a2d8e9f19c759941d32648e/test.py#L18
   doCheck = false;
+
+  pythonImportsCheck = [ "block_io" ];
 
   meta = with stdenv.lib; {
     description = "Integrate Bitcoin, Dogecoin and Litecoin in your Python applications using block.io";


### PR DESCRIPTION
Fix base58 dependency and remove Python 2 support

Fix build https://hydra.nixos.org/build/127631234

ZHF: #97479
@NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
