### PR TITLE
linux/hardened/patches: Update

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -1,8 +1,8 @@
 {
     "4.14": {
-        "name": "linux-hardened-4.14.200.a.patch",
-        "sha256": "0z38nm0m97d8m0q34fbnlz7l0rjbf76qrvbc6kljjg7gang3cby8",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.200.a/linux-hardened-4.14.200.a.patch"
+        "name": "linux-hardened-4.14.201.a.patch",
+        "sha256": "16jkhib0fc8l96a092srqpg850wh0n49pa0yghpviz29rlids6vs",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.201.a/linux-hardened-4.14.201.a.patch"
     },
     "4.19": {
         "name": "linux-hardened-4.19.150.a.patch",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -15,8 +15,8 @@
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.71.a/linux-hardened-5.4.71.a.patch"
     },
     "5.8": {
-        "name": "linux-hardened-5.8.14.a.patch",
-        "sha256": "08w3w0w5sw7lgm6zpsy55fz1h42s2aqcznfgxi31yv9qski31lbz",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.8.14.a/linux-hardened-5.8.14.a.patch"
+        "name": "linux-hardened-5.8.15.a.patch",
+        "sha256": "0b7bfzknz2am9pfypazqzky9bcd6659sakcdx2a7p1i3bj6zxnn1",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.8.15.a/linux-hardened-5.8.15.a.patch"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -10,9 +10,9 @@
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.151.a/linux-hardened-4.19.151.a.patch"
     },
     "5.4": {
-        "name": "linux-hardened-5.4.70.a.patch",
-        "sha256": "19g7yp4dip92bh54vd8vbn7cd4p691yvb52nz76p74fdksfa71m5",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.70.a/linux-hardened-5.4.70.a.patch"
+        "name": "linux-hardened-5.4.71.a.patch",
+        "sha256": "1w4sfkx4qj9vx47z06bkf4biaiz58z2qp536g7dss26zdbx1im26",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.71.a/linux-hardened-5.4.71.a.patch"
     },
     "5.8": {
         "name": "linux-hardened-5.8.14.a.patch",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -5,9 +5,9 @@
         "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.201.a/linux-hardened-4.14.201.a.patch"
     },
     "4.19": {
-        "name": "linux-hardened-4.19.150.a.patch",
-        "sha256": "1gx09a6rm7r7ggg9ikkzj2fh22qbr2jnlfkphkq27l4fx8241lig",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.150.a/linux-hardened-4.19.150.a.patch"
+        "name": "linux-hardened-4.19.151.a.patch",
+        "sha256": "12sh1zvc72p7kkbgpm4cjppv1vlqbywsqfsva76pjx1mw0wsj7sj",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.151.a/linux-hardened-4.19.151.a.patch"
     },
     "5.4": {
         "name": "linux-hardened-5.4.70.a.patch",


### PR DESCRIPTION
##### Motivation for this change

These commits updated the kernel without updating the corresponding linux-hardened patches. The old ones no longer apply, which broke the channel-blocking tests nixos.tests.hardened and nixos.tests.latestKernel.hardened.

* bf540edc5dd4f5b0962bace7dfc145de41d0c05c linux: 5.8.14 -> 5.8.15
* 46e2758200d69f26b6fe39e91f6ad55b8a524d1c linux: 5.4.70 -> 5.4.71
* 6f4ad8b16c07c6f1be3089404b5191b8786e345f linux: 4.19.150 -> 4.19.151
* cd85afd0eb4d967dbdad3c203b9a45570cdbd1a1 linux: 4.14.200 -> 4.14.201

Update the linux-hardened patches using pkgs/os-specific/linux/kernel/update.sh.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
