### PR TITLE
rpcs3: 0.0.8-9300-341fdf7eb -> 0.0.12-10811-a86a3d2fe

### DIFF
--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -7,8 +7,8 @@
 }:
 
 let
-  majorVersion = "0.0.8";
-  gitVersion = "9300-341fdf7eb"; # echo $(git rev-list HEAD --count)-$(git rev-parse --short HEAD)
+  majorVersion = "0.0.12";
+  gitVersion = "10811-a86a3d2fe"; # echo $(git rev-list HEAD --count)-$(git rev-parse --short HEAD)
 in
 mkDerivation {
   pname = "rpcs3";
@@ -17,12 +17,13 @@ mkDerivation {
   src = fetchgit {
     url = "https://github.com/RPCS3/rpcs3";
     rev = "v${majorVersion}";
-    sha256 = "1qx97zkkjl6bmv5rhfyjqynbz0v8h40b2wxqnl59g287wj0yk3y1";
+    sha256 = "182rkmbnnlcfzam4bwas7lwv10vqiqvvaw3299a3hariacd7rq8x";
   };
 
   preConfigure = ''
     cat > ./rpcs3/git-version.h <<EOF
     #define RPCS3_GIT_VERSION "${gitVersion}"
+    #define RPCS3_GIT_FULL_BRANCH "RPCS3/rpcs3/master"
     #define RPCS3_GIT_BRANCH "HEAD"
     #define RPCS3_GIT_VERSION_NO_UPDATE 1
     EOF

--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -49,7 +49,7 @@ mkDerivation {
   meta = with lib; {
     description = "PS3 emulator/debugger";
     homepage = "https://rpcs3.net/";
-    maintainers = with maintainers; [ abbradar nocent ];
+    maintainers = with maintainers; [ abbradar neonfuz nocent ];
     license = licenses.gpl2;
     platforms = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
###### Motivation for this change

Version bump

I defined RPCS3_GIT_FULL_BRANCH="RPCS3/rpcs3/master" because rpcs3 now warns that you're using an unofficial build if the string isn't set to this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
