### PR TITLE
knightos platforms

### DIFF
--- a/pkgs/development/tools/knightos/kcc/default.nix
+++ b/pkgs/development/tools/knightos/kcc/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     description = "KnightOS C compiler";
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ siraben ];
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/tools/knightos/kimg/default.nix
+++ b/pkgs/development/tools/knightos/kimg/default.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation rec {
     description = "Converts image formats supported by ImageMagick to the KnightOS image format";
     license     = licenses.mit;
     maintainers = with maintainers; [ siraben ];
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/tools/knightos/kpack/default.nix
+++ b/pkgs/development/tools/knightos/kpack/default.nix
@@ -23,5 +23,6 @@ stdenv.mkDerivation rec {
     description = "A tool to create or extract KnightOS packages";
     license     = licenses.lgpl2Only;
     maintainers = with maintainers; [ siraben ];
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/tools/knightos/patchrom/default.nix
+++ b/pkgs/development/tools/knightos/patchrom/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation rec {
     description = "Patches jumptables into TI calculator ROM files and generates an include file";
     license     = licenses.mit;
     maintainers = with maintainers; [ siraben ];
+    platforms   = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
@danieldk's suggestion to add `meta.platforms` (not already enforced by ofborg?)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
