### PR TITLE
x265: fix build on aarch64

### DIFF
--- a/pkgs/development/libraries/x265/0001-dynamicHDR10-update-CMakeLists.txt-for-aarch64-suppo.patch
+++ b/pkgs/development/libraries/x265/0001-dynamicHDR10-update-CMakeLists.txt-for-aarch64-suppo.patch
@@ -1,0 +1,48 @@
+From 4ba35c72ff39fa1f379e7c69e8c4fd0662961df9 Mon Sep 17 00:00:00 2001
+From: Andrew Childs <lorne@cons.org.nz>
+Date: Sat, 17 Oct 2020 13:26:01 +0900
+Subject: [PATCH] dynamicHDR10: update CMakeLists.txt for aarch64 support
+
+Directly copied from the main CMakeLists.txt, which was updated in
+ec7396adaa6afd2c8aab1918cfe4bb6e384740c3
+---
+ source/dynamicHDR10/CMakeLists.txt | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/source/dynamicHDR10/CMakeLists.txt b/source/dynamicHDR10/CMakeLists.txt
+index 22fb79d44..853378d27 100644
+--- a/source/dynamicHDR10/CMakeLists.txt
++++ b/source/dynamicHDR10/CMakeLists.txt
+@@ -43,14 +43,24 @@ if(GCC)
+         endif()
+     endif()
+     if(ARM AND CROSS_COMPILE_ARM)
+-        set(ARM_ARGS -march=armv6 -mfloat-abi=soft -mfpu=vfp -marm -fPIC)
++        if(ARM64)
++            set(ARM_ARGS -fPIC)
++        else()
++            set(ARM_ARGS -march=armv6 -mfloat-abi=soft -mfpu=vfp -marm -fPIC)
++        endif()
++        message(STATUS "cross compile arm")
+     elseif(ARM)
+-        find_package(Neon)
+-        if(CPU_HAS_NEON)
+-            set(ARM_ARGS -mcpu=native -mfloat-abi=hard -mfpu=neon -marm -fPIC)
++        if(ARM64)
++            set(ARM_ARGS -fPIC)
+             add_definitions(-DHAVE_NEON)
+         else()
+-            set(ARM_ARGS -mcpu=native -mfloat-abi=hard -mfpu=vfp -marm)
++            find_package(Neon)
++            if(CPU_HAS_NEON)
++                set(ARM_ARGS -mcpu=native -mfloat-abi=hard -mfpu=neon -marm -fPIC)
++                add_definitions(-DHAVE_NEON)
++            else()
++                set(ARM_ARGS -mcpu=native -mfloat-abi=hard -mfpu=vfp -marm)
++            endif()
+         endif()
+     endif()
+     add_definitions(${ARM_ARGS})
+-- 
+2.28.0
+


### PR DESCRIPTION
###### Motivation for this change

Fixing aarch64 build of x265 after #98091.

I'll send the patch upstream when I figure out how to do so.

As for the high bit rate support, the [header file for aarch64 assembly](https://bitbucket.org/multicoreware/x265_git/src/a82c6c7a7d5f5ef836c82941788a37c6a443e0fe/source/common/aarch64/ipfilter8.h) doesn't include the the prefixed versions (`x265_10bit`, `x265_12bit`) from which I conclude it is not supported. Since it seems like it has to be explicitly implemented I made this a whitelist of just `isx86_64`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (`aarch64-linux` only)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
