### PR TITLE
ocamlPackages.mirage-{kv,fs}: init at 3.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-fs/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-fs/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchurl, buildDunePackage
+, cstruct, fmt, lwt, mirage-device, mirage-kv
+}:
+
+buildDunePackage rec {
+  pname = "mirage-fs";
+  version = "3.0.1";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-fs/releases/download/v${version}/mirage-fs-v${version}.tbz";
+    sha256 = "0px18bgk528vr7iw78r0j3z4sdcz684sfcj47ibbly2adbvd64yk";
+  };
+
+  propagatedBuildInputs = [ cstruct fmt lwt mirage-device mirage-kv ];
+
+  meta = {
+    description = "MirageOS signatures for filesystem devices";
+    homepage = "https://github.com/mirage/mirage-fs";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage-kv/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-kv/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchurl, buildDunePackage
+, fmt, mirage-device
+, alcotest
+}:
+
+buildDunePackage rec {
+  pname = "mirage-kv";
+  version = "3.0.1";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-kv/releases/download/v${version}/mirage-kv-v${version}.tbz";
+    sha256 = "1n736sjvdd8rkbc2b5jm9sn0w6hvhjycma5328r0l03v24vk5cki";
+  };
+
+  propagatedBuildInputs = [ fmt mirage-device ];
+
+  doCheck = true;
+  checkInputs = [ alcotest ];
+
+  meta = {
+    description = "MirageOS signatures for key/value devices";
+    homepage = "https://github.com/mirage/mirage-kv";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -559,6 +559,8 @@ let
 
     mirage-flow-unix = callPackage ../development/ocaml-modules/mirage-flow/unix.nix { };
 
+    mirage-kv = callPackage ../development/ocaml-modules/mirage-kv { };
+
     mirage-protocols = callPackage ../development/ocaml-modules/mirage-protocols { };
 
     mirage-random = callPackage ../development/ocaml-modules/mirage-random { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -559,6 +559,8 @@ let
 
     mirage-flow-unix = callPackage ../development/ocaml-modules/mirage-flow/unix.nix { };
 
+    mirage-fs = callPackage ../development/ocaml-modules/mirage-fs { };
+
     mirage-kv = callPackage ../development/ocaml-modules/mirage-kv { };
 
     mirage-protocols = callPackage ../development/ocaml-modules/mirage-protocols { };


### PR DESCRIPTION
###### Motivation for this change

#23955 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
