### PR TITLE
zfs-replicate: 1.1.14 -> 1.2.0

### DIFF
--- a/pkgs/tools/backup/zfs-replicate/default.nix
+++ b/pkgs/tools/backup/zfs-replicate/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonApplication rec {
   pname = "zfs-replicate";
-  version = "1.1.14";
+  version = "1.2.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0iqyk6q112ylcqrhrgvgbgqqvaikhwk0sb5kc7kg2wwqdc9rfwys";
+    sha256 = "1f1vjn4xw6xl11z60vsjwkv1msb2g22hvha6lha2vqd6f139vjxj";
   };
 
   checkInputs = [


### PR DESCRIPTION
This fixes the build failures when switching to NixOS 20.09 and needs to
be merged into that branch as well.  Let me know if that's another pull
request I need to submit.

I've verified this functions with: `nix-build . -A pkgs.zfs-replicate`
and I no longer get the errors I was getting when switching to 20.09
without this version change.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
