### PR TITLE
monero: 0.17.0.1 -> 0.17.1.0

### DIFF
--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -27,13 +27,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.17.0.1";
+  version = "0.17.1.0";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "1i9a3ampppyzsl4sllbqlr3w43sjpb3fdfxhb1j4n49p8g0jzmf3";
+    sha256 = "07r78ipv4g3i6z822kq380vi3qwlb958rccsy6lyybkhj9y0rx84";
   };
 
   nativeBuildInputs = [
@@ -64,9 +64,6 @@ stdenv.mkDerivation rec {
     # set monero-gui version
     substituteInPlace src/version.js.in \
        --replace '@VERSION_TAG_GUI@' '${version}'
-
-    # remove this line on the next release
-    rm cmake/Version.cmake
 
     # use monerod from the monero package
     substituteInPlace src/daemon/DaemonManager.cpp \

--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -75,10 +75,11 @@ stdenv.mkDerivation rec {
                 'add_subdirectory(monero EXCLUDE_FROM_ALL)'
   '';
 
-  cmakeFlags = [
-    "-DCMAKE_INSTALL_PREFIX=$out/bin"
-    "-DARCH=${arch}"
-  ];
+  preConfigure = ''
+    # because $out needs to be expanded
+    cmakeFlagsArray+=("-DCMAKE_INSTALL_PREFIX=$out/bin")
+    cmakeFlagsArray+=("-DARCH=${arch}")
+  '';
 
   desktopItem = makeDesktopItem {
     name = "monero-wallet-gui";

--- a/pkgs/applications/blockchains/monero/default.nix
+++ b/pkgs/applications/blockchains/monero/default.nix
@@ -17,25 +17,18 @@ assert trezorSupport -> all (x: x!=null) [ libusb1 protobuf python3 ];
 
 stdenv.mkDerivation rec {
   pname = "monero";
-  version = "0.17.0.1";
+  version = "0.17.1.0";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    sha256 = "1v0phvg5ralli4dr09a60nq032xqlci5d6v4zfq8304vgrn1ffgp";
+    sha256 = "1cngniv7sndy8r0fcfgk737640k53q3kwd36g891p5igcb985qdw";
     fetchSubmodules = true;
   };
 
   patches = [
     ./use-system-libraries.patch
-
-    # This fixes a bug in the monero-gui build system,
-    # remove it once the PR has been merged
-    (fetchpatch {
-      url = "https://github.com/monero-project/monero/pull/6867.patch";
-      sha256 = "0nxa6861df1fadrm9bmhqf2g6mljgr4jndsbxqp7g501hv9z51j3";
-    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Version bump with several bug fixes

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).