### PR TITLE
linux: 5.8.15 -> 5.8.16

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-5.8.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.8.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "5.8.15";
+  version = "5.8.16";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "0hfnq4n902pws8sjxd1lsdxxa0v45g988imp73xnqfqv2d71r0bj";
+    sha256 = "1icxa0pgqhji924ryz37mpjjf4zlkrm8bidanjyn2mzbar7migzx";
   };
 } // (args.argsOverride or {}))


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Potentially security critical PR in the context of BleedingTooth. [5.8.16](https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.8.16) releases a lot of bluetooth updates.

###### Things done 
Ran nix-build nixos/tests/kernel-latest.nix with kernelPackages set to linuxPackages_5_8.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)): 
```
$ cd nixos/tests
$ sed -e s/linuxPackages_latest/linuxPackages_5_8/ kernel-latest.nix > foo.nix 
$ nix-build foo.nix
```
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
