### PR TITLE
libplacebo: fix building with shaderc 2020.2

### DIFF
--- a/pkgs/development/libraries/libplacebo/default.nix
+++ b/pkgs/development/libraries/libplacebo/default.nix
@@ -31,10 +31,6 @@ stdenv.mkDerivation rec {
       url = "https://code.videolan.org/videolan/libplacebo/-/commit/523056828ab86c2f17ea65f432424d48b6fdd389.patch";
       sha256 = "051vhd0l3yad1fzn5zayi08kqs9an9j8p7m63kgqyfv1ksnydpcs";
     })
-    (fetchpatch {
-      url = "https://code.videolan.org/videolan/libplacebo/-/commit/82e3be1839379791b58e98eb049415b42888d5b0.patch";
-      sha256 = "0nklj9gfiwkbbj6wfm1ck33hphaxrvzb84c4h2nfj88bapnlm90l";
-    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This fixes a regression introduced by #94049.

>     builder for '/nix/store/86lrf5m4vy9r4hbwm6r95ljv6w0pwi4d-libplacebo-2.72.0.drv' failed with exit code 1; last 10 log lines:
>       build flags: -j128 -l128
>       [42/44] Compiling C++ object 'src/25a6634@@placebo@sha/glsl_glslang.cc.o's_gen.c.o'
>       FAILED: src/25a6634@@placebo@sha/glsl_glslang.cc.o
>       g++ -Isrc/25a6634@@placebo@sha -Isrc -I../src -I../src/include -I../src/include/dummy -I../subprojects/xtalloc/include -I../subprojects/bstr/include -I/nix/store/81iy20n5rhvcm18ha289anygpgq5qyjc-lcms2-2.11-dev/include -I/nix/store/riw48ysh0rhkf2fck7m1iiany4rif2mv-vulkan-headers-1.2.141.0/include -I/nix/store/psda85jw38cxzqp6fa59vrdipz67h6bk-epoxy-1.5.4-dev/include -I/usr/include/glslang -I/nix/store/my4bdsgi308bq216gkhfwnwnk35yhszn-libplacebo-2.72.0/include/glslang -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -std=c++11 -Wundef -Wshadow -Wparentheses -Wpointer-arith -fvisibility=hidden -fPIC -pthread -MD -MQ 'src/25a6634@@placebo@sha/glsl_glslang.cc.o' -MF 'src/25a6634@@placebo@sha/glsl_glslang.cc.o.d' -o 'src/25a6634@@placebo@sha/glsl_glslang.cc.o' -c ../src/glsl/glslang.cc
>       ../src/glsl/glslang.cc:229:1: error: cannot convert '<brace-enclosed initializer list>' to 'int' in initialization
>         229 | };
>             | ^

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
