### PR TITLE
perlPackages.IOAsyncSSL: init at 0.22

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9956,6 +9956,22 @@ let
     };
   };
 
+  IOAsyncSSL = buildPerlModule {
+    pname = "IO-Async-SSL";
+    version = "0.22";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/IO-Async-SSL-0.22.tar.gz";
+      sha256 = "0c7363a7f1a08805bd1b2cf2b1a42a950ca71914c2aedbdd985970e011331a21";
+    };
+    buildInputs = [ TestIdentity ];
+    propagatedBuildInputs = [ Future IOAsync IOSocketSSL ];
+    meta = {
+      description = "Use SSL/TLS with IO::Async";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.zakame ];
+    };
+  };
+
   IOCapture = buildPerlPackage {
     pname = "IO-Capture";
     version = "0.05";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This pure-Perl addon for [IO::Async](https://search.nixos.org/packages?show=perl532Packages.IOAsync&query=IOAsync&from=0&size=30&sort=relevance&channel=unstable#disabled) extends it to allow creating TLS/SSL servers or clients via [IO::Socket::SSL](https://search.nixos.org/packages?show=perl532Packages.IOSocketSSL&query=IOSocketSSL&from=0&size=30&sort=relevance&channel=unstable#disabled).

This is a somewhat required module for other IO::Async-based code that connect/serve TLS/SSL resources, such as those in the [Net::Async namespace](https://metacpan.org/search?size=20&q=Net%3A%3AAsync).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
