### PR TITLE
imv: enable LIBNSGIF and LIBJPEG backends

### DIFF
--- a/pkgs/applications/graphics/imv/default.nix
+++ b/pkgs/applications/graphics/imv/default.nix
@@ -1,8 +1,23 @@
-{ stdenv, fetchFromGitHub
-, freeimage, fontconfig, pkgconfig
-, asciidoc, docbook_xsl, libxslt, cmocka
-, librsvg, pango, libxkbcommon, wayland
-, libGLU, icu
+{ asciidoc
+, cmocka
+, docbook_xsl
+, fetchFromGitHub
+, fontconfig
+, freeimage
+, icu
+, libGLU
+, libheif
+, libjpeg_turbo
+, libpng
+, librsvg
+, libtiff
+, libxkbcommon
+, libxslt
+, netsurf
+, pango
+, pkgconfig
+, stdenv
+, wayland
 }:
 
 stdenv.mkDerivation rec {
@@ -10,36 +25,30 @@ stdenv.mkDerivation rec {
   version = "4.1.0";
 
   src = fetchFromGitHub {
-    owner  = "eXeC64";
-    repo   = "imv";
-    rev    = "v${version}";
+    owner = "eXeC64";
+    repo = "imv";
+    rev = "v${version}";
     sha256 = "0gk8g178i961nn3bls75a8qpv6wvfvav6hd9lxca1skaikd33zdx";
   };
 
-  preBuild = ''
-    # Version is 4.0.1, but Makefile was not updated
-    sed -i 's/echo v4\.0\.0/echo v4.0.1/' Makefile
-  '';
-
-  nativeBuildInputs = [
-    asciidoc
-    cmocka
-    docbook_xsl
-    libxslt
-  ];
+  nativeBuildInputs = [ asciidoc cmocka docbook_xsl libxslt ];
 
   buildInputs = [
     freeimage
+    icu
     libGLU
+    libjpeg_turbo
     librsvg
     libxkbcommon
+    netsurf.libnsgif
     pango
     pkgconfig
     wayland
-    icu
   ];
 
   installFlags = [ "PREFIX=$(out)" "CONFIGPREFIX=$(out)/etc" ];
+
+  makeFlags = [ "BACKEND_LIBJPEG=yes" "BACKEND_LIBNSGIF=yes" ];
 
   postFixup = ''
     # The `bin/imv` script assumes imv-wayland or imv-x11 in PATH,
@@ -53,9 +62,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A command line image viewer for tiling window managers";
-    homepage    = "https://github.com/eXeC64/imv";
-    license     = licenses.gpl2;
+    homepage = "https://github.com/eXeC64/imv";
+    license = licenses.gpl2;
     maintainers = with maintainers; [ rnhmjoj markus1189 ];
-    platforms   = platforms.all;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Enables two backends that have been disabled previously, `libnsgif` and `libjpeg-turbo`.  Especially the latter yields MUCH better performance when viewing large jpeg files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
