### PR TITLE
pythonPackages.pysam: add libdeflate and enable tests

### DIFF
--- a/pkgs/development/python-modules/pysam/default.nix
+++ b/pkgs/development/python-modules/pysam/default.nix
@@ -6,6 +6,7 @@
 , curl
 , cython
 , htslib
+, libdeflate
 , lzma
 , pytest
 , samtools
@@ -27,22 +28,72 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ samtools ];
-  buildInputs = [ bzip2 curl cython lzma zlib ];
+  buildInputs = [
+    bzip2
+    curl
+    cython
+    libdeflate
+    lzma
+    zlib
+  ];
 
-  checkInputs = [ pytest bcftools htslib ];
-  checkPhase = "py.test";
+  # Use nixpkgs' htslib instead of the bundled one
+  # See https://pysam.readthedocs.io/en/latest/installation.html#external
+  # NOTE that htslib should be version compatible with pysam
+  preBuild = ''
+    export HTSLIB_MODE=shared
+    export HTSLIB_LIBRARY_DIR=${htslib}/lib
+    export HTSLIB_INCLUDE_DIR=${htslib}/include
+  '';
 
-  # tests require samtools<=1.9
-  doCheck = false;
-  preCheck = ''
+  checkInputs = [
+    pytest
+    bcftools
+    htslib
+  ];
+
+  # See https://github.com/NixOS/nixpkgs/pull/100823 for why we aren't using
+  # disabledTests and pytestFlagsArray through pytestCheckHook
+  checkPhase = ''
+    # Needed to avoid /homeless-shelter error
     export HOME=$(mktemp -d)
+
+    # To avoid API incompatibilities, these should ideally show the same version
+    echo "> samtools --version"
+    samtools --version
+    echo "> htsfile --version"
+    htsfile --version
+    echo "> bcftools --version"
+    bcftools --version
+
+    # Create auxiliary test data
     make -C tests/pysam_data
     make -C tests/cbcf_data
+
+    # Delete pysam folder in current directory to avoid importing it during testing
+    rm -rf pysam
+
+    # Deselect tests that are known to fail due to upstream issues
+    # See https://github.com/pysam-developers/pysam/issues/961
+    py.test \
+      --deselect tests/AlignmentFileHeader_test.py::TestHeaderBAM::test_dictionary_access_works \
+      --deselect tests/AlignmentFileHeader_test.py::TestHeaderBAM::test_header_content_is_as_expected \
+      --deselect tests/AlignmentFileHeader_test.py::TestHeaderCRAM::test_dictionary_access_works \
+      --deselect tests/AlignmentFileHeader_test.py::TestHeaderCRAM::test_header_content_is_as_expected \
+      --deselect tests/AlignmentFile_test.py::TestIO::testBAM2SAM \
+      --deselect tests/AlignmentFile_test.py::TestIO::testSAM2BAM \
+      --deselect tests/AlignmentFile_test.py::TestIO::testWriteUncompressedBAMFile \
+      --deselect tests/AlignmentFile_test.py::TestDeNovoConstruction::testBAMWholeFile \
+      --deselect tests/AlignmentFile_test.py::TestEmptyHeader::testEmptyHeader \
+      --deselect tests/AlignmentFile_test.py::TestHeaderWithProgramOptions::testHeader \
+      --deselect tests/StreamFiledescriptors_test.py::StreamTest::test_text_processing \
+      tests/
   '';
 
   pythonImportsCheck = [
     "pysam"
     "pysam.bcftools"
+    "pysam.libchtslib"
     "pysam.libcutils"
     "pysam.libcvcf"
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Tests are currently not enabled and upstream is not always in sync with the latest samtools/htslib versions leading to some incompatibilities.
Tests that are known to fail have been reported upstream and disabled/deselected here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
