### PR TITLE
geeqie: 1.4.0 -> 1.5.1

### DIFF
--- a/pkgs/applications/graphics/geeqie/default.nix
+++ b/pkgs/applications/graphics/geeqie/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "geeqie";
-  version = "1.4";
+  version = "1.5.1";
 
   src = fetchurl {
     url = "http://geeqie.org/${pname}-${version}.tar.xz";
-    sha256 = "0ciygvcxb78pqg59r6p061mkbpvkgv2rv3r79j3kgv3kalb3ln2w";
+    sha256 = "02m1vqaasin249xx792cdj11xyag8lnanwzxd108y7y34g9xam28";
   };
 
   patches = [
@@ -19,12 +19,6 @@ stdenv.mkDerivation rec {
       url = "https://src.fedoraproject.org/rpms/geeqie/raw/132fb04a1a5e74ddb333d2474f7edb9a39dc8d27/f/geeqie-1.4-goodbye-changelog.patch";
       sha256 = "00a35dds44kjjdqsbbfk0x9y82jspvsbpm2makcm1ivzlhjjgszn";
     })
-    # Fixes build with exiv2 0.27.1
-    (fetchpatch {
-      name = "geeqie-exiv2-0.27.patch";
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/geeqie-exiv2-0.27.patch?h=packages/geeqie&id=dee28a8b3e9039b9cd6927b5a93ef2a07cd8271d";
-      sha256 = "05skpbyp8pcq92psgijyccc8liwfy2cpwprw6m186pf454yb5y9p";
-    })
   ];
 
   preConfigure = "./autogen.sh";
@@ -32,6 +26,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig autoconf automake gettext intltool
     wrapGAppsHook
   ];
+
   buildInputs = [
     gtk3 lcms2 exiv2 libchamplain clutter-gtk ffmpegthumbnailer fbida
   ];
@@ -63,7 +58,7 @@ stdenv.mkDerivation rec {
 
     homepage = "http://geeqie.sourceforge.net";
 
-    maintainers = with maintainers; [ jfrankenau pSub ];
+    maintainers = with maintainers; [ jfrankenau pSub markus1189 ];
     platforms = platforms.gnu ++ platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update `geeqie` to v1.5.1 (http://www.geeqie.org/)

The patch for `exiv2` seems to be superfluous with `0.27.3`, so I removed the patch

Also, add myself to list of maintainers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).