### PR TITLE
fx: init at 20.0.2

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -77,6 +77,7 @@
 , {"fast-cli": "1.x"}
 , "fkill-cli"
 , "forever"
+, "fx"
 , "get-graphql-schema"
 , "git-run"
 , "git-ssb"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -3307,6 +3307,15 @@ let
         sha512 = "RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==";
       };
     };
+    "@medv/blessed-2.0.1" = {
+      name = "_at_medv_slash_blessed";
+      packageName = "@medv/blessed";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@medv/blessed/-/blessed-2.0.1.tgz";
+        sha512 = "/NdX1Ql8hKNM0vHFJnEr/bcw6BG0ULHD3HhInpniZw5ixpl+n/QIRfMEEmLCn7acedbM1zGdZvU5ZMbn9kcF5Q==";
+      };
+    };
     "@microsoft/load-themed-styles-1.10.114" = {
       name = "_at_microsoft_slash_load-themed-styles";
       packageName = "@microsoft/load-themed-styles";
@@ -73521,6 +73530,40 @@ in
     meta = {
       description = "A simple CLI tool for ensuring that a given node script runs continuously (i.e. forever)";
       homepage = "https://github.com/foreverjs/forever#readme";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
+  fx = nodeEnv.buildNodePackage {
+    name = "fx";
+    packageName = "fx";
+    version = "20.0.2";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/fx/-/fx-20.0.2.tgz";
+      sha512 = "BgZNylpsDf5V0c4DwjWnre2dld9YbEbdNUnXzOC2WJv4R/AnJG8cu7mBERhkqxue3S3hgmJr3lqoqeKb2PedGQ==";
+    };
+    dependencies = [
+      sources."@medv/blessed-2.0.1"
+      sources."ansi-regex-5.0.0"
+      sources."ansi-styles-4.3.0"
+      sources."chalk-4.1.0"
+      sources."color-convert-2.0.1"
+      sources."color-name-1.1.4"
+      sources."emoji-regex-8.0.0"
+      sources."has-flag-4.0.0"
+      sources."indent-string-4.0.0"
+      sources."is-fullwidth-code-point-3.0.0"
+      sources."lossless-json-1.0.4"
+      sources."string-width-4.2.0"
+      sources."strip-ansi-6.0.0"
+      sources."supports-color-7.2.0"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Command-line JSON viewer";
+      homepage = https://fx.wtf/;
       license = "MIT";
     };
     production = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1999,6 +1999,8 @@ in
 
   futhark = haskell.lib.justStaticExecutables haskellPackages.futhark;
 
+  inherit (nodePackages) fx;
+
   tllist = callPackage ../development/libraries/tllist { };
 
   fcft = callPackage ../development/libraries/fcft { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Obsoletes #96189.

This also adds fx at the top level, since it's an application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
