### PR TITLE
doc: update unstable version naming conventions

### DIFF
--- a/doc/contributing/coding-conventions.xml
+++ b/doc/contributing/coding-conventions.xml
@@ -229,7 +229,7 @@ args.stdenv.mkDerivation (args // {
     </listitem>
     <listitem>
      <para>
-      If a package is not a release but a commit from a repository, then the version part of the name <emphasis>must</emphasis> be the date of that (fetched) commit. The date <emphasis>must</emphasis> be in <literal>"YYYY-MM-DD"</literal> format. Also append <literal>"unstable"</literal> to the name - e.g., <literal>"pkgname-unstable-2014-09-23"</literal>.
+      If a package is not a release but a commit from a repository, then the version part of the name <emphasis>must</emphasis> be the commit date of that (fetched) commit in <literal>"YYYY-MM-DD"</literal> format, followed by <literal>"-unstable"</literal>. For example, <literal>"pkgname-2014-09-23-unstable"</literal>.
      </para>
     </listitem>
     <listitem>


### PR DESCRIPTION
The previous explanation did not make it clear where the word
"unstable" should go when name is split into pname and version.

By putting it at the end, we can get builtins.parseDrvName to parse
things nicely:

> builtins.parseDrvName "pname-2020-10-17-unstable"

{ name = "pname"; version = "2020-10-17-unstable"; }

It is not good to put it in the pname, because then the pname will not
match with the attrpath.

Manual rendered:
![image](https://user-images.githubusercontent.com/4804/96340483-ad3e4e80-104d-11eb-8a55-b43482084c93.png)


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
