### PR TITLE
Erlang: fix cross compilation

### DIFF
--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -6,6 +6,7 @@
 , libGL ? null, libGLU ? null, wxGTK ? null, wxmac ? null, xorg ? null # wxSupport
 , parallelBuild ? false
 , withSystemd ? stdenv.isLinux, systemd # systemd support in epmd
+, buildPackages
 }:
 
 { baseName ? "erlang"
@@ -43,6 +44,8 @@ let
   inherit (stdenv.lib) optional optionals optionalAttrs optionalString;
   wxPackages2 = if stdenv.isDarwin then [ wxmac ] else wxPackages;
 
+  isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+
 in stdenv.mkDerivation ({
   name = "${baseName}-${version}"
     + optionalString javacSupport "-javac"
@@ -50,7 +53,15 @@ in stdenv.mkDerivation ({
 
   inherit src version;
 
-  nativeBuildInputs = [ autoconf makeWrapper perl gnum4 libxslt libxml2 ];
+  nativeBuildInputs = [
+    buildPackages.autoreconfHook
+    buildPackages.makeWrapper
+    buildPackages.perl
+    buildPackages.gnum4
+    buildPackages.libxslt
+    buildPackages.libxml2
+  ]
+    ++ optional isCross buildPackages.erlang;
 
   buildInputs = [ ncurses openssl ]
     ++ optionals wxSupport wxPackages2
@@ -85,7 +96,7 @@ in stdenv.mkDerivation ({
     ++ optional enableThreads "--enable-threads"
     ++ optional enableSmpSupport "--enable-smp-support"
     ++ optional enableKernelPoll "--enable-kernel-poll"
-    ++ optional enableHipe "--enable-hipe"
+    ++ optional (enableHipe && !isCross) "--enable-hipe"
     ++ optional javacSupport "--with-javac"
     ++ optional odbcSupport "--with-odbc=${unixODBC}"
     ++ optional wxSupport "--enable-wx"


### PR DESCRIPTION
##### Motivation for this change

Erlang does not cross compile right now through Nix. This is trying to address this, in particular with the recent rise of AWS Graviton2 instances. https://github.com/NixOS/nixpkgs/pull/58042 was doing a lot already, but staled. This is going from there and continuing. I kept the old commit and the new one for now, there is probably still some work to be done

###### Things done

I tried to shrink the dependency on `buildPackages` but it seems that it get spliced the Host perl instead of the Build perl into the built of the host package. Same for libxslt. I don't know why, if someone have an idea i would love to hear about it.

The dependency on `buildPackages.erlang_nox` is also problematic. It is due to the fact that erlang need to bootstrap in cross compilation. But it needs to use the _same version_, which i found no good way to do here. So i use the default `erlang_nox` and pray that it works. That is potentially problematic. The other solution would be to bootstrap manually by building a limited bootstrapping OTP. The erlang build system offer that option, but i did not find a way to do that nicely without having to rebuild that bootstrapping lib each time. The other solution would be to build an intermediate derivation _exclusively_ in the case of cross compilation. If this is something NixPkgs would be ok with, i could do that.

I am also not a fan of injecting `"erl_xcomp_sysroot=${stdenv.cc.libc}"` but it is needed by erlang build system or it decides it cannot find SSL for the host target. If there is a better option i would like that.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
