### PR TITLE
meson: Patch out default boost search paths

### DIFF
--- a/pkgs/development/tools/build-managers/meson/boost-Do-not-add-system-paths-on-nix.patch
+++ b/pkgs/development/tools/build-managers/meson/boost-Do-not-add-system-paths-on-nix.patch
@@ -1,0 +1,40 @@
+From 536108b10271f2f42d41c7d9ddb4ce2ea1851f4f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Niklas=20Hamb=C3=BCchen?= <mail@nh2.me>
+Date: Sat, 17 Oct 2020 19:27:08 +0200
+Subject: [PATCH] boost: Do not add system paths on nix
+
+---
+ mesonbuild/dependencies/boost.py | 17 +----------------
+ 1 file changed, 1 insertion(+), 16 deletions(-)
+
+diff --git a/mesonbuild/dependencies/boost.py b/mesonbuild/dependencies/boost.py
+index 907c0c275..ecaf11b18 100644
+--- a/mesonbuild/dependencies/boost.py
++++ b/mesonbuild/dependencies/boost.py
+@@ -643,22 +643,7 @@ class BoostDependency(ExternalDependency):
+             roots += [x for x in candidates if x.name.lower().startswith('boost') and x.is_dir()]
+         else:
+             tmp = []  # type: T.List[Path]
+-
+-            # Homebrew
+-            brew_boost = Path('/usr/local/Cellar/boost')
+-            if brew_boost.is_dir():
+-                tmp += [x for x in brew_boost.iterdir()]
+-
+-            # Add some default system paths
+-            tmp += [Path('/opt/local')]
+-            tmp += [Path('/usr/local/opt/boost')]
+-            tmp += [Path('/usr/local')]
+-            tmp += [Path('/usr')]
+-
+-            # Cleanup paths
+-            tmp = [x for x in tmp if x.is_dir()]
+-            tmp = [x.resolve() for x in tmp]
+-            roots += tmp
++            # Do not add any non-explicit paths on nix
+ 
+         return roots
+ 
+-- 
+2.25.4
+

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -52,6 +52,11 @@ python3.pkgs.buildPythonApplication rec {
     # cut-in-half-by-\0 store path references.
     # Let’s just clear the whole rpath and hope for the best.
     ./clear-old-rpath.patch
+
+    # Patch out default boost search paths to avoid impure builds on
+    # unsandboxed non-NixOS builds, see:
+    # https://github.com/NixOS/nixpkgs/issues/86131#issuecomment-711051774
+    ./boost-Do-not-add-system-paths-on-nix.patch
   ];
 
   setupHook = ./setup-hook.sh;


### PR DESCRIPTION
###### Motivation for this change

Avoids impure builds on unsandboxed non-NixOS builds, see:
https://github.com/NixOS/nixpkgs/issues/86131#issuecomment-711051774

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
