### PR TITLE
python3Packages.wled: init at 0.4.4

### DIFF
--- a/pkgs/development/python-modules/wled/default.nix
+++ b/pkgs/development/python-modules/wled/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, aiohttp
+, backoff
+, packaging
+, yarl
+, aresponses
+, pytest-asyncio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "wled";
+  version = "0.4.4";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "frenck";
+    repo = "python-wled";
+    rev = "v${version}";
+    sha256 = "1adh23v4c9kia3ddqdq0brksd5rhgh4ff7l5hil8klx4dmkrjfz3";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    backoff
+    packaging
+    yarl
+  ];
+
+  checkInputs = [
+    aresponses
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportCheck = [ "wled" ];
+
+  meta = with lib; {
+    description = "Asynchronous Python client for WLED";
+    homepage = "https://github.com/frenck/python-wled";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -922,7 +922,7 @@
     "wink" = ps: with ps; [ aiohttp-cors ]; # missing inputs: pubnubsub-handler python-wink
     "wirelesstag" = ps: with ps; [ ]; # missing inputs: wirelesstagpy
     "withings" = ps: with ps; [ aiohttp-cors ]; # missing inputs: withings-api
-    "wled" = ps: with ps; [ ]; # missing inputs: wled
+    "wled" = ps: with ps; [ wled ];
     "wolflink" = ps: with ps; [ ]; # missing inputs: wolf_smartset
     "workday" = ps: with ps; [ holidays ];
     "worldclock" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7548,6 +7548,8 @@ in {
 
   willow = callPackage ../development/python-modules/willow { };
 
+  wled = callPackage ../development/python-modules/wled { };
+
   word2vec = callPackage ../development/python-modules/word2vec { };
 
   wordcloud = callPackage ../development/python-modules/wordcloud { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Integrate WLED devices into home-assistant.

https://www.home-assistant.io/integrations/wled/
https://github.com/Aircoookie/WLED

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


```
[1 built, 1 copied (0.0 MiB), 0.0 MiB DL]
2 packages built:
python37Packages.wled python38Packages.wled
```

