### PR TITLE
waifu2x-converter-cpp: 5.2.4 -> 5.3.3, add OpenCL support

### DIFF
--- a/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
+++ b/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
@@ -1,16 +1,16 @@
-{ cmake, fetchFromGitHub, opencv3, stdenv, opencl-headers
+{ cmake, fetchFromGitHub, opencv3, stdenv, ocl-icd, opencl-headers
 , cudaSupport ? false, cudatoolkit ? null
 }:
 
 stdenv.mkDerivation rec {
   pname = "waifu2x-converter-cpp";
-  version = "5.2.4";
+  version = "5.3.3";
 
   src = fetchFromGitHub {
     owner = "DeadSix27";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0r7xcjqbyaa20gsgmjj7645640g3nb2bn1pc1nlfplwlzjxmz213";
+    sha256 = "04r0xyjknvcwk70ilj1p3qwlcz3i6sqgcp0qbc9qwxnsgrrgz09w";
   };
 
   patchPhase = ''
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    opencv3 opencl-headers
+    opencv3 opencl-headers ocl-icd
   ] ++ stdenv.lib.optional cudaSupport cudatoolkit;
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
+++ b/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
@@ -1,4 +1,4 @@
-{ cmake, fetchFromGitHub, opencv3, stdenv, ocl-icd, opencl-headers
+{ cmake, fetchFromGitHub, makeWrapper, opencv3, stdenv, ocl-icd, opencl-headers
 , cudaSupport ? false, cudatoolkit ? null
 }:
 
@@ -19,10 +19,14 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    opencv3 opencl-headers ocl-icd
+    ocl-icd opencv3 opencl-headers
   ] ++ stdenv.lib.optional cudaSupport cudatoolkit;
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake makeWrapper ];
+
+  preFixup = ''
+    wrapProgram $out/bin/waifu2x-converter-cpp --prefix LD_LIBRARY_PATH : "${ocl-icd}/lib"
+  '';
 
   meta = {
     description = "Improved fork of Waifu2X C++ using OpenCL and OpenCV";


### PR DESCRIPTION
###### Motivation for this change

Currently, waifu2x-converter-cpp only supports GPGPU with nvidia cards (via CUDA). This PR adds support for Intel and AMD GPUs by adding ocl-icd to the library path. This PR also updates waifu2x-converter-cpp to version 5.3.3 (which requires ocl-icd at build time), because version 5.2.4 tries to place the OpenCL device binary into the nix store at runtime (and fails since it is read only).

I tested it on an i5-4300U’s integrated GPU (via beignet) and on an AMD RX480 (via rocm).

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
