### PR TITLE
virtscreen: fix qt error

### DIFF
--- a/pkgs/tools/admin/virtscreen/default.nix
+++ b/pkgs/tools/admin/virtscreen/default.nix
@@ -1,4 +1,13 @@
-{ stdenv, fetchFromGitHub, python3Packages, x11vnc, xrandr, libGL }:
+{
+  stdenv,
+  fetchFromGitHub,
+  python3Packages,
+  x11vnc,
+  xrandr,
+  libGL,
+  wrapQtAppsHook,
+  full
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "virtscreen";
@@ -18,10 +27,17 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [
     netifaces
-    pyqt5
     quamash
     x11vnc
     xrandr
+    full
+  ];
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
+  dontWrapQtApps = true;
+
+  makeWrapperArgs = [
+    "\${qtWrapperArgs[@]}"
   ];
 
   postPatch = let

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23948,7 +23948,7 @@ in
 
   virtinst = callPackage ../applications/virtualization/virtinst {};
 
-  virtscreen = callPackage ../tools/admin/virtscreen {};
+  virtscreen = libsForQt514.callPackage ../tools/admin/virtscreen {};
 
   virtual-ans = callPackage ../applications/audio/virtual-ans {};
 


### PR DESCRIPTION
should fix https://github.com/NixOS/nixpkgs/issues/84511
well this at least fixes the qt errors during startup, sadly now it throws this error when trying to start the interface:
```
QSystemTrayIcon::setVisible: No Icon set
file:///nix/store/k1srawz1rd0sk9582r4j3j7a92sjf3gd-virtscreen-0.3.1/lib/python3.8/site-packages/virtscreen/assets/AppWindow.qml:59:13: Type Label unavailable
file:///nix/store/hxrpj8j78819sxg3n1zrv91pai0lc8kk-qtquickcontrols2-5.14.2-bin/lib/qt-5.14.2/qml/QtQuick/Controls.2/Material/qmldir: plugin cannot be loaded for module ".nix.store.hxrpj8j78819sxg3n1zrv91pai0lc8kk-qtquickcontrols2-5.14.2-bin.lib.qt-5.14.2.qml.QtQuick.Controls.Material": Module namespace 'QtQuick.Controls.Material' does not match import URI '.nix.store.hxrpj8j78819sxg3n1zrv91pai0lc8kk-qtquickcontrols2-5.14.2-bin.lib.qt-5.14.2.qml.QtQuick.Controls.Material'
qml: Loader Status Changed. 3
```