### PR TITLE
cairo: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -35,6 +35,9 @@ in stdenv.mkDerivation rec {
       url    = "https://gitlab.freedesktop.org/cairo/cairo/commit/6edf572ebb27b00d3c371ba5ae267e39d27d5b6d.patch";
       sha256 = "112hgrrsmcwxh1r52brhi5lksq4pvrz4xhkzcf2iqp55jl2pb7n1";
     })
+  ] ++ optionals stdenv.hostPlatform.isDarwin [
+    # Workaround https://gitlab.freedesktop.org/cairo/cairo/-/issues/121
+    ./skip-configure-stderr-check.patch
   ];
 
   outputs = [ "out" "dev" "devdoc" ];

--- a/pkgs/development/libraries/cairo/skip-configure-stderr-check.patch
+++ b/pkgs/development/libraries/cairo/skip-configure-stderr-check.patch
@@ -1,0 +1,89 @@
+https://bugs.freedesktop.org/show_bug.cgi?id=30910#c6
+
+Comment 6 Jeremy Huddleston Sequoia 2014-07-15 04:12:40 UTC
+
+Yes, it is still an issue.  We just disable the buggy '"x$cairo_cc_stderr" != "x"' logic, but that's not really a portable solution for you:
+
+diff -Naurp cairo-1.12.2.orig/configure cairo-1.12.2/configure
+--- cairo-1.12.2.orig/configure	2012-04-29 11:49:59.000000000 -0700
++++ cairo-1.12.2/configure	2012-05-03 11:23:49.000000000 -0700
+@@ -18044,7 +18044,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+ 
+-	if test "x$cairo_cc_stderr" != "x"; then
++	if false; then
+ 		cairo_cc_flag=no
+ 	fi
+ 
+@@ -18091,7 +18091,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+ 
+-	if test "x$cairo_cc_stderr" != "x"; then
++	if false; then
+ 		cairo_cc_flag=no
+ 	fi
+ 
+@@ -18161,7 +18161,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+ 
+-	if test "x$cairo_cc_stderr" != "x"; then
++	if false; then
+ 		cairo_cc_flag=no
+ 	fi
+ 
+@@ -18217,7 +18217,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+ 
+-	if test "x$cairo_cc_stderr" != "x"; then
++	if false; then
+ 		cairo_cc_flag=no
+ 	fi
+ 
+@@ -19663,7 +19663,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+ 
+-	if test "x$cairo_cc_stderr" != "x"; then
++	if false; then
+ 		cairo_cc_flag=no
+ 	fi
+ 
+@@ -19710,7 +19710,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+ 
+-	if test "x$cairo_cc_stderr" != "x"; then
++	if false; then
+ 		cairo_cc_flag=no
+ 	fi
+ 
+@@ -32692,7 +32692,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+ 
+-	if test "x$cairo_cc_stderr" != "x"; then
++	if false; then
+ 		cairo_cc_flag=no
+ 	fi
+ 
+@@ -32811,7 +32811,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+ 
+-	if test "x$cairo_cc_stderr" != "x"; then
++	if false ; then
+ 		cairo_cc_flag=no
+ 	fi
+ 
+@@ -32892,7 +32892,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+ 
+-	if test "x$cairo_cc_stderr" != "x"; then
++	if false; then
+ 		cairo_cc_flag=no
+ 	fi


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
