### PR TITLE
openssh: fix static build

### DIFF
--- a/pkgs/os-specific/linux/keyutils/default.nix
+++ b/pkgs/os-specific/linux/keyutils/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     ./conf-symlink.patch
   ];
 
+  makeFlags = stdenv.lib.optionals stdenv.hostPlatform.isStatic "NO_SOLIB=1";
+
   BUILDDATE = "1970-01-01";
   outputs = [ "out" "lib" "dev" ];
 

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -63,7 +63,9 @@ stdenv.mkDerivation rec {
       substituteInPlace Makefile.in --replace '$(INSTALL) -m 4711' '$(INSTALL) -m 0711'
     '';
 
-  nativeBuildInputs = [ pkgconfig ] ++ optional (hpnSupport || withGssapiPatches) autoreconfHook;
+  nativeBuildInputs = [ pkgconfig ]
+    ++ optional (hpnSupport || withGssapiPatches) autoreconfHook
+    ++ optional withKerberos kerberos.dev;
   buildInputs = [ zlib openssl libedit pam ]
     ++ optional withFIDO libfido2
     ++ optional withKerberos kerberos;
@@ -72,6 +74,22 @@ stdenv.mkDerivation rec {
     # Setting LD causes `configure' and `make' to disagree about which linker
     # to use: `configure' wants `gcc', but `make' wants `ld'.
     unset LD
+  ''
+  # Upstream build system does not support static build, so we fall back
+  # on fragile patching of configure script.
+  #
+  # libedit is found by pkgconfig, but without --static flag, required
+  # to get also transitive dependencies for static linkage, hence sed
+  # expression.
+  #
+  # Kerberos can be found either by krb5-config or by fall-back shell
+  # code in openssh's configure.ac. Neither of them support static
+  # build, but patching code for krb5-config is simpler, so to get it
+  # into PATH, kerberos.dev is added into buildInputs.
+  + optionalString stdenv.hostPlatform.isStatic ''
+    sed -i "s,PKGCONFIG --libs,PKGCONFIG --libs --static,g" configure
+    sed -i 's#KRB5CONF --libs`#KRB5CONF --libs` -lkrb5support -lkeyutils#g' configure
+    sed -i 's#KRB5CONF --libs gssapi`#KRB5CONF --libs gssapi` -lkrb5support -lkeyutils#g' configure
   '';
 
   # I set --disable-strip because later we strip anyway. And it fails to strip


### PR DESCRIPTION
This pull requests fixes static build of openssh and its dependency,
keyutils:

````
$ nix-build -A pkgsStatic.openssh
````

It seems that this is symptom of more general problem: if library "foo"
depends on library "bar", then to link dynamically program that uses
library "foo" it is enough to pass "-lfoo" to compiler, but it is
necessary to pass "-lfoo -lbar" (in that order) to compiler to link it
statically.

Maybe proper fix would be to add -l{bar} into NIX_LDFLAGS for every
{bar} in build closure when static build is requested
(stdenv.hostPlatform.isStatic)?

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).