### PR TITLE
tangram: init at 1.3.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/tangram/default.nix
+++ b/pkgs/applications/networking/instant-messengers/tangram/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, lib, fetchFromGitHub, appstream-glib, desktop-file-utils, gdk-pixbuf
+, gettext, gjs, glib, gobject-introspection, gsettings-desktop-schemas, gtk3
+, hicolor-icon-theme, meson, ninja, pkgconfig, python3, webkitgtk, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tangram";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "sonnyp";
+    repo = "Tangram";
+    rev = "v${version}";
+    sha256 = "0bhs9s6c2k06i3cx01h2102lgl7g6vxm3k63jkkhh2bwdpc9kvn3";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ gdk-pixbuf gjs glib gsettings-desktop-schemas gtk3 webkitgtk ];
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    gettext
+    gobject-introspection
+    hicolor-icon-theme
+    meson
+    ninja
+    pkgconfig
+    python3
+    wrapGAppsHook
+  ];
+
+  dontWrapGApps = true;
+
+  # Fixes https://github.com/NixOS/nixpkgs/issues/31168
+  postPatch = ''
+    chmod +x build-aux/meson/postinstall.py
+    patchShebangs build-aux/meson/postinstall.py
+  '';
+
+  postFixup = ''
+    for file in $out/bin/re.sonny.Tangram; do
+      sed -e $"2iimports.package._findEffectiveEntryPointName = () => \'$(basename $file)\' " \
+         -i $file
+      wrapGApp "$file"
+     done
+  '';
+
+  meta = with lib; {
+    description = "Run web apps on your desktop";
+    homepage = "https://github.com/sonnyp/Tangram";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7824,6 +7824,8 @@ in
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
+  tangram = callPackage ../applications/networking/instant-messengers/tangram { };
+
   t1utils = callPackage ../tools/misc/t1utils { };
 
   talkfilters = callPackage ../misc/talkfilters {};


### PR DESCRIPTION
###### Motivation for this change

Add package. Unfortunately while it builds it doesn't run.

```
❯ result/bin/.re.sonny.Tangram-wrapped 

(gjs:13038): GLib-GObject-WARNING **: 19:03:21.993: cannot register existing type 'GDBusConnection'

(gjs:13038): GLib-GObject-WARNING **: 19:03:21.993: cannot register existing type 'GInitable'

(gjs:13038): GLib-GObject-CRITICAL **: 19:03:21.993: g_type_interface_add_prerequisite: assertion 'G_TYPE_IS_INTERFACE (interface_type)' failed

(gjs:13038): GLib-CRITICAL **: 19:03:21.993: g_once_init_leave: assertion 'result != 0' failed

(gjs:13038): GLib-GObject-CRITICAL **: 19:03:21.993: g_type_add_interface_static: assertion 'G_TYPE_IS_INSTANTIATABLE (instance_type)' failed

(gjs:13038): GLib-GObject-WARNING **: 19:03:21.993: cannot register existing type 'GAsyncInitable'

(gjs:13038): GLib-GObject-CRITICAL **: 19:03:21.993: g_type_interface_add_prerequisite: assertion 'G_TYPE_IS_INTERFACE (interface_type)' failed

(gjs:13038): GLib-CRITICAL **: 19:03:21.993: g_once_init_leave: assertion 'result != 0' failed

(gjs:13038): GLib-GObject-CRITICAL **: 19:03:21.993: g_type_add_interface_static: assertion 'G_TYPE_IS_INSTANTIATABLE (instance_type)' failed

(gjs:13038): GLib-CRITICAL **: 19:03:21.993: g_once_init_leave: assertion 'result != 0' failed

(gjs:13038): Gjs-WARNING **: 19:03:21.993: JS ERROR: Error: Unsupported type (null), deriving from fundamental (null)
_init@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:473:5
@resource:///org/gnome/gjs/modules/script/package.js:32:13
@result/bin/.re.sonny.Tangram-wrapped:2:1


(gjs:13038): Gjs-CRITICAL **: 19:03:21.993: Script result/bin/.re.sonny.Tangram-wrapped threw an exception
```

@jtojnar in searching around for similar areas I've seen your name, any ideas?

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).