### PR TITLE
[20.09] elastix: 5.0.0 -> 5.0.1; unbreak OS X build

### DIFF
--- a/pkgs/development/libraries/science/biology/elastix/default.nix
+++ b/pkgs/development/libraries/science/biology/elastix/default.nix
@@ -1,32 +1,26 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, itk, python3 }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, itk, python3, Cocoa }:
 
 stdenv.mkDerivation rec {
   pname    = "elastix";
-  version = "5.0.0";
+  version = "5.0.1";
 
   src = fetchFromGitHub {
     owner  = "SuperElastix";
     repo   = pname;
     rev    = version;
-    sha256 = "1zrl7rz4lwsx88b2shnl985f3a97lmp4ksbd437h9y0hfjq8l0lj";
+    sha256 = "1mx8kkak2d3ibfrxrh8jkmh2zkdlgl9h578wiw3617zcwaa97bxw";
   };
 
   patches = [
     (fetchpatch {
-      name = "itk-5.1-compat.patch";
-      url = "https://github.com/SuperElastix/elastix/commit/402e9a26f22f805b8f2db00c00e59f75fa1783ad.patch";
-      sha256 = "1il6gc1lgy78i0w6gkkppr61nh6g0yjspbfk19hcz20778m5jhz9";
-    })
-    (fetchpatch {
-      name = "fix-osx-build.patch";
-      url = "https://github.com/SuperElastix/elastix/commit/52e1dc3928046f9fbb85d4b2ecd0d5175fa9695d.patch";
-      sha256 = "1hf7kgx1jv497pf0x5wj79sy1wncxcvhrkix9w086lcr8zwxvn9q";
+      name = "install-executables.patch";  # https://github.com/SuperElastix/elastix/issues/305
+      url = "https://github.com/SuperElastix/elastix/commit/8e26cdc0d66f6030c7be085fdc424d84d4fc7546.patch";
+      sha256 = "12y9wbpi9jlarnw6fk4iby97jxvx5g4daq9zqblbcmn51r134bj5";
     })
   ];
 
-
   nativeBuildInputs = [ cmake python3 ];
-  buildInputs = [ itk ];
+  buildInputs = [ itk ] ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa ];
 
   doCheck = !stdenv.isDarwin;  # usual dynamic linker issues
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12181,7 +12181,9 @@ in
 
   egl-wayland = callPackage ../development/libraries/egl-wayland {};
 
-  elastix = callPackage ../development/libraries/science/biology/elastix { };
+  elastix = callPackage ../development/libraries/science/biology/elastix {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   enchant1 = callPackage ../development/libraries/enchant/1.x.nix { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backport of #100766 for ZHF (#97479).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
