### PR TITLE
python3Packages.google_cloud_translate: fix build

### DIFF
--- a/pkgs/development/python-modules/google_cloud_translate/default.nix
+++ b/pkgs/development/python-modules/google_cloud_translate/default.nix
@@ -1,12 +1,5 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, google_api_core
-, google_cloud_core
-, grpcio
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, google_api_core, google_cloud_core
+, grpcio, libcst, mock, proto-plus, pythonOlder, pytest, pytest-asyncio }:
 
 buildPythonPackage rec {
   pname = "google-cloud-translate";
@@ -17,10 +10,13 @@ buildPythonPackage rec {
     sha256 = "ecdea3e176e80f606d08c4c7fd5acea6b3dd960f4b2e9a65951aaf800350a759";
   };
 
-  # google_cloud_core[grpc] -> grpcio
-  propagatedBuildInputs = [ google_api_core google_cloud_core grpcio ];
+  disabled = pythonOlder "3.6";
 
-  checkInputs = [ pytest mock ];
+  # google_cloud_core[grpc] -> grpcio
+  propagatedBuildInputs =
+    [ google_api_core google_cloud_core grpcio libcst proto-plus ];
+
+  checkInputs = [ mock pytest pytest-asyncio ];
   checkPhase = ''
     cd tests # prevent local google/__init__.py from getting loaded
     pytest unit -k 'not extra_headers'
@@ -28,7 +24,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Google Cloud Translation API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-translate";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };


### PR DESCRIPTION
###### Motivation for this change

Fixes broken build by adding missing dependencies. Will backport to 20.09 for ZHF.

https://hydra.nixos.org/build/127630084

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).