### PR TITLE
gtk+: refactor name

### DIFF
--- a/pkgs/development/libraries/gtk/2.x.nix
+++ b/pkgs/development/libraries/gtk/2.x.nix
@@ -12,9 +12,15 @@ assert cupsSupport -> cups != null;
 
 with stdenv.lib;
 
-stdenv.mkDerivation rec {
+let
   pname = "gtk+";
-  version = "2.24.32";
+  version = "2.24.32"; # remove passthru on next update
+in
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  
+  # passthru to prevent rebuild but allow pname and version
+  passthru = { inherit pname version; };
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk+/2.24/${pname}-${version}.tar.xz";

--- a/pkgs/development/libraries/gtk/2.x.nix
+++ b/pkgs/development/libraries/gtk/2.x.nix
@@ -18,7 +18,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  
+
   # passthru to prevent rebuild but allow pname and version
   passthru = { inherit pname version; };
 

--- a/pkgs/development/libraries/gtk/2.x.nix
+++ b/pkgs/development/libraries/gtk/2.x.nix
@@ -13,10 +13,11 @@ assert cupsSupport -> cups != null;
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "gtk+-2.24.32";
+  pname = "gtk+";
+  version = "2.24.32";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gtk+/2.24/${name}.tar.xz";
+    url = "mirror://gnome/sources/gtk+/2.24/${pname}-${version}.tar.xz";
     sha256 = "b6c8a93ddda5eabe3bfee1eb39636c9a03d2a56c7b62828b359bf197943c582e";
   };
 


### PR DESCRIPTION
Use newer pname + version instead of name, I will be using this
when packaging lxde.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
