### PR TITLE
Implement splitString using builtins.split

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -154,6 +154,20 @@ runTests {
     expected = [ "2001" "db8" "0" "0042" "" "8a2e" "370" "" ];
   };
 
+  testSplitStringsRegex = {
+    expr = strings.splitString "\\[{}]()^$?*+|." "A\\[{}]()^$?*+|.B";
+    expected = [ "A" "B" ];
+  };
+
+  testSplitStringsDerivation = {
+    expr = take 3  (strings.splitString "/" (derivation {
+      name = "name";
+      builder = "builder";
+      system = "system";
+    }));
+    expected = ["" "nix" "store"];
+  };
+
   testSplitVersionSingle = {
     expr = versions.splitVersion "1";
     expected = [ "1" ];


### PR DESCRIPTION
###### Motivation for this change

`splitString` was slow and crashed on large strings, but it is still used over a hundred times in nixpkgs. Previously mentioned in:

- https://github.com/NixOS/nix/issues/4147
- https://github.com/NixOS/nixpkgs/pull/69345
- https://github.com/NixOS/nixpkgs/issues/68951

###### Things done

- [x] Ran `nix-instantiate --eval --strict lib/tests/misc.nix`
