### PR TITLE
[20.09] pythonPackages.pymc3: fix build, init pythonPackages.fastprogress at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/fastprogress/default.nix
+++ b/pkgs/development/python-modules/fastprogress/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, numpy
+, pytest
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "fastprogress";
+  version = "1.0.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1zhv37q6jkqd1pfhlkd4yzrc3dg83vyksgzf32mjlhd5sb0qmql9";
+  };
+
+  propagatedBuildInputs = [ numpy ];
+
+  # no real tests
+  doCheck = false;
+  pythonImportsCheck = [ "fastprogress" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/fastai/fastprogress";
+    description = "Simple and flexible progress bar for Jupyter Notebook and console";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ris ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1972,6 +1972,8 @@ in {
 
   fastpbkdf2 = callPackage ../development/python-modules/fastpbkdf2 { };
 
+  fastprogress = callPackage ../development/python-modules/fastprogress { };
+
   fastrlock = callPackage ../development/python-modules/fastrlock { };
 
   fasttext = callPackage ../development/python-modules/fasttext { };


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

This is a modified & combined backport of #99587 and #100867.

Because 20.09 is missing #97597 and #93560 (and I think including them at this stage might be a bit risky), importing/using `theano` from within a nix build environment (i.e. with `NIX_ENFORCE_PURITY=1`) will only succeed if the tmpdir used is actually literally `/tmp`, which you can't really do from a sandboxed build. So this uses `libredirect` to convince the compiler wrapper we are actually working with `/tmp`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
