### PR TITLE
ocamlPackages.mirage-bootvar-unix: init at 0.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-bootvar-unix/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-bootvar-unix/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchurl, buildDunePackage
+, lwt, parse-argv
+}:
+
+buildDunePackage rec {
+  pname = "mirage-bootvar-unix";
+  version = "0.1.0";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-bootvar-unix/releases/download/${version}/mirage-bootvar-unix-${version}.tbz";
+    sha256 = "0r92s6y7nxg0ci330a7p0hii4if51iq0sixn20cnm5j4a2clprbf";
+  };
+
+  propagatedBuildInputs = [ lwt parse-argv ];
+
+  meta = {
+    description = "Unix implementation of MirageOS Bootvar interface";
+    homepage = "https://github.com/mirage/mirage-bootvar-unix";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/parse-argv/default.nix
+++ b/pkgs/development/ocaml-modules/parse-argv/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchurl, buildDunePackage, ocaml
+, astring
+, ounit
+}:
+
+buildDunePackage rec {
+  pname = "parse-argv";
+  version = "0.2.0";
+
+  minimumOCamlVersion = "4.03";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/parse-argv/releases/download/v${version}/parse-argv-v${version}.tbz";
+    sha256 = "06dl04fcmwpkydzni2fzwrhk0bqypd55mgxfax9v82x65xrgj5gw";
+  };
+
+  propagatedBuildInputs = [ astring ];
+
+  doCheck = lib.versionAtLeast ocaml.version "4.04";
+  checkInputs = [ ounit ];
+
+  meta = {
+    description = "Process strings into sets of command-line arguments";
+    homepage = "https://github.com/mirage/parse-argv";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -539,6 +539,8 @@ let
 
     minisat = callPackage ../development/ocaml-modules/minisat { };
 
+    mirage-bootvar-unix = callPackage ../development/ocaml-modules/mirage-bootvar-unix { };
+
     mirage-clock = callPackage ../development/ocaml-modules/mirage-clock { };
 
     mirage-clock-unix = callPackage ../development/ocaml-modules/mirage-clock/unix.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -746,6 +746,8 @@ let
 
     ounit2 = callPackage ../development/ocaml-modules/ounit2 { };
 
+    parse-argv = callPackage ../development/ocaml-modules/parse-argv { };
+
     pgsolver = callPackage ../development/ocaml-modules/pgsolver { };
 
     phylogenetics = callPackage ../development/ocaml-modules/phylogenetics { };


### PR DESCRIPTION
###### Motivation for this change

#23955 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
