### PR TITLE
sayonara: 1.5.1-stable5 -> 1.6.0-beta6

### DIFF
--- a/pkgs/applications/audio/sayonara/default.nix
+++ b/pkgs/applications/audio/sayonara/default.nix
@@ -1,12 +1,12 @@
 { mkDerivation
 , cmake
-, fetchgit
+, fetchFromGitLab
 , gst_all_1
 , lib
 , libpulseaudio
 , ninja
 , pcre
-, pkgconfig
+, pkg-config
 , qtbase
 , qttools
 , taglib
@@ -15,34 +15,16 @@
 
 mkDerivation rec {
   pname = "sayonara-player";
-  version = "1.5.1-stable5";
+  version = "1.6.0-beta6";
 
-  src = fetchgit {
-    url = "https://git.sayonara-player.com/sayonara.git";
+  src = fetchFromGitLab {
+    owner = "luciocarreras";
+    repo = "sayonara-player";
     rev = version;
-    sha256 = "13l7r3gaszrkyf4z8rdijfzxvcnilax4ki2mcm30wqk8d4g4qdzj";
+    sha256 = "sha256-SbJS0DQvbW++CNXbuDHQxFlLRb1kTtDdIdHOqu0YxeQ=";
   };
 
-  # all this can go with version 1.5.2
-  postPatch = ''
-    # if we don't delete this, sayonara will look here instead of the provided taglib
-    rm -r src/3rdParty/taglib
-
-    for f in \
-      src/DBus/DBusNotifications.cpp \
-      src/Gui/Resources/Icons/CMakeLists.txt \
-      src/Utils/Utils.cpp \
-      test/Util/FileHelperTest.cpp \
-      ; do
-
-      substituteInPlace $f --replace /usr $out
-    done
-
-    substituteInPlace src/Components/Shutdown/Shutdown.cpp \
-      --replace /usr/bin/systemctl systemctl
-  '';
-
-  nativeBuildInputs = [ cmake ninja pkgconfig qttools ];
+  nativeBuildInputs = [ cmake ninja pkg-config qttools ];
 
   buildInputs = [
     libpulseaudio


### PR DESCRIPTION
###### Motivation for this change

I'm aware that we don't normally upgrade from stable to betas but in
this case:

1. the out-of-the-box experience is much better as the skeleton DB
   copied over on first run now has the proper permissions
2. we can drop all our iffy patching

And let's face it - it's a music player. If it breaks somebody's special
use-case, there's about a million alternatives.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).