### PR TITLE
python3Packages.pytest-trio: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/pytest-trio/default.nix
+++ b/pkgs/development/python-modules/pytest-trio/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "pytest-trio";
-  version = "0.6.0";
-  disabled = pythonOlder "3.5";
+  version = "0.7.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "python-trio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "09v2031yxm8ryhq12205ldcck76n3wwqhjjsgfmn6dxfiqb0vbw9";
+    sha256 = "0bhh2nknhp14jzsx4zzpqm4qnfaihyi65cjf6kf6qgdhc0ax6nf4";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release.

https://github.com/python-trio/pytest-trio/releases/tag/v0.7.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
