### PR TITLE
mp3gain: Fix vulnerabilities

### DIFF
--- a/pkgs/applications/audio/mp3gain/default.nix
+++ b/pkgs/applications/audio/mp3gain/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, mpg123 }:
+{ stdenv, fetchurl, fetchpatch, unzip, mpg123 }:
 
 stdenv.mkDerivation {
   name = "mp3gain-1.6.2";
@@ -11,17 +11,25 @@ stdenv.mkDerivation {
 
   sourceRoot = ".";
 
+  patches = [
+    (fetchpatch {
+      name = "0001-fix-security-bugs.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-sound/mp3gain/files/mp3gain-1.6.2-CVE-2019-18359-plus.patch?id=36f8689f7903548f5d89827a6e7bdf70a9882cee";
+      sha256 = "10n53wm0xynlcxqlnaqfgamjzcpfz41q1jlg0bhw4kq1kzhs4yyw";
+    })
+  ];
+
   buildFlags = [ "OSTYPE=linux" ];
 
   installPhase = ''
     install -vD mp3gain "$out/bin/mp3gain"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Lossless mp3 normalizer with statistical analysis";
     homepage = "http://mp3gain.sourceforge.net/";
-    license = stdenv.lib.licenses.lgpl21;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.devhell ];
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ devhell ];
   };
 }


### PR DESCRIPTION
This patch has been fetched from SuSE[1] and addresses various security
vulnerabilities.

This commit should also close https://github.com/NixOS/nixpkgs/issues/90893

[1]:
https://build.opensuse.org/package/view_file/openSUSE:Factory/mp3gain/0001-fix-security-bugs.patch

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
