### PR TITLE
xrdc: add option to specify a log file location

### DIFF
--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -24,7 +24,7 @@ let
       --replace EnableSyslog=true EnableSyslog=false
 
     substituteInPlace $out/sesman.ini \
-      --replace LogFile=xrdp-sesman.log LogFile=/dev/null \
+      --replace LogFile=xrdp-sesman.log LogFile=${cfg.logFile} \
       --replace EnableSyslog=1 EnableSyslog=0
 
     # Ensure that clipboard works for non-ASCII characters
@@ -88,6 +88,15 @@ in
         description = ''
           The script to run when user log in, usually a window manager, e.g. "icewm", "xfce4-session"
           This is per-user overridable, if file ~/startwm.sh exists it will be used instead.
+        '';
+      };
+
+      logFile = mkOption {
+        type = types.str;
+        default = "/dev/null";
+        example = "/var/log/xrdp-sesman.log";
+        description = ''
+          location for xrdp to write its logs
         '';
       };
 


### PR DESCRIPTION
xrdc: add option to specify a log file location
adds the services.xrdc.logFile attribute to specify the location to use for the service logs
defaults to off (/dev/null) which is the current behavior

###### Motivation for this change
I'm having trouble getting xrdp working with Pantheon and not having logging for xrdp is making it very difficult to debug

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
