### PR TITLE
Cherry-pick netaddr-0.8.0 upgrade on release-20.09

### DIFF
--- a/pkgs/development/python-modules/netaddr/default.nix
+++ b/pkgs/development/python-modules/netaddr/default.nix
@@ -1,41 +1,32 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, pytest
-, fetchpatch
+, pythonOlder
 , glibcLocales
+, importlib-resources
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "netaddr";
-  version = "0.7.19";
+  version = "0.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd";
+    sha256 = "0hx2npi0wnhwlcybilgwlddw6qffx1mb7a3sj4p9s7bvl33mgk6n";
   };
 
   LC_ALL = "en_US.UTF-8";
-  checkInputs = [ glibcLocales pytest ];
 
-  checkPhase = ''
-    # fails on python3.7: https://github.com/drkjam/netaddr/issues/182
-    py.test \
-      -k 'not test_ip_splitter_remove_prefix_larger_than_input_range' \
-      netaddr/tests
-  '';
+  propagatedBuildInputs = stdenv.lib.optionals (pythonOlder "3.7") [ importlib-resources ];
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/drkjam/netaddr/commit/2ab73f10be7069c9412e853d2d0caf29bd624012.patch";
-      sha256 = "0s1cdn9v5alpviabhcjmzc0m2pnpq9dh2fnnk2x96dnry1pshg39";
-    })
-  ];
+  checkInputs = [ glibcLocales pytestCheckHook ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/drkjam/netaddr/";
+    homepage = "https://netaddr.readthedocs.io/en/latest/";
+    downloadPage = "https://github.com/netaddr/netaddr/releases";
+    changelog = "https://netaddr.readthedocs.io/en/latest/changes.html";
     description = "A network address manipulation library for Python";
     license = licenses.mit;
   };
-
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Updating to >= 0.7.20 fixes tests on macOS Catalina and newer:

```
        #   inet_pton has to be different on Mac OSX *sigh*
        assert IPAddress('010.000.000.001', flags=INET_PTON) == IPAddress('10.0.0.1')
>       assert int_to_str(0xffff) == '::0.0.255.255'
E       AssertionError: assert '::ffff' == '::0.0.255.255'
E         - ::0.0.255.255
E         + ::ffff
```

(cherry picked from commit c32441811f1b80de23c80d9acc89625235100685)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
