### PR TITLE
python3Packages.cassandra-driver: fix build by packaging new dependencies

### DIFF
--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -1,47 +1,85 @@
-{ lib, buildPythonPackage, fetchPypi, python, pythonOlder
+{ stdenv, lib, buildPythonPackage, fetchFromGitHub, python, pythonOlder
 , cython
 , eventlet
 , futures
+, iana-etc
+, geomet
 , libev
 , mock
 , nose
-, pytest
+, pytestCheckHook
 , pytz
 , pyyaml
 , scales
 , six
 , sure
+, gremlinpython
+, gevent
+, twisted
+, libredirect
 }:
 
 buildPythonPackage rec {
   pname = "cassandra-driver";
   version = "3.24.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "83ec8d9a5827ee44bb1c0601a63696a8a9086beaf0151c8255556299246081bd";
+  # pypi tarball doesn't include tests
+  src = fetchFromGitHub {
+    owner = "datastax";
+    repo = "python-driver";
+    rev = version;
+    sha256 = "1rr69hly5q810xpn8rkzxwzlq55wxxp7kwki9vfri3gh674d2wip";
   };
 
   nativeBuildInputs = [ cython ];
   buildInputs = [ libev ];
-  propagatedBuildInputs = [ six ]
+  propagatedBuildInputs = [ six geomet ]
     ++ lib.optionals (pythonOlder "3.4") [ futures ];
 
-  checkInputs = [ eventlet mock nose pytest pytz pyyaml sure ];
-
-  # ignore test files which try to do socket.getprotocolname('tcp')
-  # as it fails in sandbox mode due to lack of a /etc/protocols file
-  checkPhase = ''
-    pytest tests/unit \
-      --ignore=tests/unit/io/test_libevreactor.py \
-      --ignore=tests/unit/io/test_eventletreactor.py \
-      --ignore=tests/unit/io/test_asyncorereactor.py
+  # Make /etc/protocols accessible to allow socket.getprotobyname('tcp') in sandbox,
+  # also /etc/resolv.conf is referenced by some tests
+  preCheck = (stdenv.lib.optionalString stdenv.isLinux ''
+    echo "nameserver 127.0.0.1" > resolv.conf
+    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/resolv.conf=$(realpath resolv.conf)
+    export LD_PRELOAD=${libredirect}/lib/libredirect.so
+  '') + ''
+    # increase tolerance for time-based test
+    substituteInPlace tests/unit/io/utils.py --replace 'delta=.15' 'delta=.3'
   '';
+  postCheck = ''
+    unset NIX_REDIRECTS LD_PRELOAD
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+    eventlet
+    mock
+    nose
+    pytz
+    pyyaml
+    sure
+    scales
+    gremlinpython
+    gevent
+    twisted
+  ];
+
+  pytestFlagsArray = [
+    "tests/unit"
+    # requires puresasl
+    "--ignore=tests/unit/advanced/test_auth.py"
+  ];
+  disabledTests = [
+    # doesn't seem to be intended to be run directly
+    "_PoolTests"
+    # attempts to make connection to localhost
+    "test_connection_initialization"
+  ];
 
   meta = with lib; {
     description = "A Python client driver for Apache Cassandra";
     homepage = "http://datastax.github.io/python-driver";
     license = licenses.asl20;
-    broken = true; # geomet doesn't exist
+    maintainers = with maintainers; [ turion ris ];
   };
 }

--- a/pkgs/development/python-modules/geomet/default.nix
+++ b/pkgs/development/python-modules/geomet/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, click
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "geomet";
+  version = "0.2.1";
+
+  # pypi tarball doesn't include tests
+  src = fetchFromGitHub {
+    owner = "geomet";
+    repo = "geomet";
+    rev = version;
+    sha256 = "0fdi26glsmrsyqk86rnsfcqw79svn2b0ikdv89pq98ihrpwhn85y";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "python-3.8-support.patch";
+      url = "https://github.com/geomet/geomet/commit/dc4cb4a856d3ad814b57b4b7487d86d9e0f0fad4.patch";
+      sha256 = "1f1cdfqyp3z01jdjvax77219l3gc75glywqrisqpd2k0m0g7fwh3";
+    })
+  ];
+
+  propagatedBuildInputs = [ click six ];
+
+  meta = with lib; {
+    homepage = "https://github.com/geomet/geomet";
+    license = licenses.asl20;
+    description = "Convert GeoJSON to WKT/WKB (Well-Known Text/Binary), and vice versa.";
+    maintainers = with maintainers; [ turion ris ];
+  };
+}

--- a/pkgs/development/python-modules/gremlinpython/default.nix
+++ b/pkgs/development/python-modules/gremlinpython/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, lib, buildPythonPackage, fetchFromGitHub, python, pythonOlder
+, pytestCheckHook, pyhamcrest, pytestrunner, pytest
+, six, isodate, tornado, aenum, radish-bdd, mock
+}:
+
+buildPythonPackage rec {
+  pname = "gremlinpython";
+  version = "3.4.8";
+
+  # pypi tarball doesn't include tests
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "tinkerpop";
+    rev = version;
+    sha256 = "0kcyhfxz7z4f8i64gig8q1q9dhy24cprbh63vwsdiwryg74q4chl";
+  };
+  sourceRoot = "source/gremlin-python/src/main/jython";
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'tornado>=4.4.1,<6.0' 'tornado' \
+      --replace 'PyHamcrest>=1.9.0,<2.0.0' 'PyHamcrest' \
+      --replace 'radish-bdd==0.8.6' 'radish-bdd' \
+      --replace 'mock>=3.0.5,<4.0.0' 'mock' \
+      --replace 'pytest>=4.6.4,<5.0.0' 'pytest'
+  '';
+
+  nativeBuildInputs = [ pytestrunner ];  # simply to placate requirements
+  propagatedBuildInputs = [ six isodate tornado aenum ];
+
+  checkInputs = [ pytestCheckHook pyhamcrest radish-bdd mock ];
+
+  # disable custom pytest report generation
+  preCheck = ''
+    substituteInPlace setup.cfg --replace 'addopts' '#addopts'
+  '';
+
+  # many tests expect a running tinkerpop server
+  pytestFlagsArray = [
+    "--ignore=tests/driver/test_client.py"
+    "--ignore=tests/driver/test_driver_remote_connection.py"
+    "--ignore=tests/driver/test_driver_remote_connection_threaded.py"
+    "--ignore=tests/process/test_dsl.py"
+    "--ignore=tests/structure/io/test_functionalityio.py"
+    # disabledTests doesn't quite allow us to be precise enough for this
+    "-k 'not (TestFunctionalGraphSONIO and (test_timestamp or test_datetime or test_uuid))'"
+  ];
+
+  meta = with lib; {
+    description = "Gremlin-Python implements Gremlin, the graph traversal language of Apache TinkerPop, within the Python language";
+    homepage = "https://tinkerpop.apache.org/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ turion ris ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2787,6 +2787,8 @@ in {
 
   grequests = callPackage ../development/python-modules/grequests { };
 
+  gremlinpython = callPackage ../development/python-modules/gremlinpython { };
+
   grib-api = disabledIf (!isPy27) (toPythonModule (pkgs.grib-api.override {
     enablePython = true;
     pythonPackages = self;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2518,6 +2518,8 @@ in {
 
   geojson-client = callPackage ../development/python-modules/geojson-client { };
 
+  geomet = callPackage ../development/python-modules/geomet { };
+
   geopandas = callPackage ../development/python-modules/geopandas { };
 
   geopy = if isPy3k then


### PR DESCRIPTION
###### Motivation for this change
ZHF: #97479

This is heavily based on @turion 's #91662, but I ended up modifying it so much I thought I should just post it separately rather than give him a long list of things to fix. Though I've still left @turion as the maintainer of these - I hope that's ok @turion?

To get `NIX_REDIRECTS` working I had to add `libredirect.so` to `LD_PRELOAD`, and also add a dummy `/etc/resolv.conf` for some later tests. Also converted to `pytestCheckHook` and disabled some tests causing trouble for various reasons.

All of the packages had to be switched to the github source because the tests weren't included in any of the pypi tarballs.

`gremlinpython`'s tests do actually run if we override some version constraints and disable some sets of tests which want to connect to a running tinkerpop server.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
