### PR TITLE
python3Packages.datasette: minimize test time

### DIFF
--- a/pkgs/development/python-modules/datasette/default.nix
+++ b/pkgs/development/python-modules/datasette/default.nix
@@ -73,19 +73,26 @@ buildPythonPackage rec {
       --replace "PyYAML~=5.3" "PyYAML"
   '';
 
-  # test_html is very slow
-  # test_black fails on darwin
-  dontUseSetuptoolsCheck = true;
+  # takes 30-180 mins to run entire test suite, not worth the cpu resources, slows down reviews
+  # with pytest-xdist, it still takes around 10mins with 32 cores
+  # just run the messages tests, as this should give some indictation of correctness
   pytestFlagsArray = [
-    "--ignore=tests/test_html.py"
-    "--ignore=tests/test_docs.py"
-    "--ignore=tests/test_black.py"
+    "tests/test_messages.py"
   ];
   disabledTests = [
     "facet"
     "_invalid_database" # checks error message when connecting to invalid database
   ];
-  pythonImportsCheck = [ "datasette" ];
+
+  pythonImportsCheck = [
+    "datasette"
+    "datasette.cli"
+    "datasette.app"
+    "datasette.database"
+    "datasette.renderer"
+    "datasette.tracer"
+    "datasette.plugins"
+  ];
 
   meta = with lib; {
     description = "An instant JSON API for your SQLite databases";


### PR DESCRIPTION
###### Motivation for this change
tests shouldn't take 60+ mins.

backport #100862 

(cherry picked from commit 67f67075c0e7d4958144fa01164ff4eb89a3d83f)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
