### PR TITLE
zsh plugins: use omz-compatible paths

### DIFF
--- a/pkgs/by-name/zs/zsh-autosuggestions/package.nix
+++ b/pkgs/by-name/zs/zsh-autosuggestions/package.nix
@@ -20,8 +20,12 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   installPhase = ''
+    install -D zsh-autosuggestions.plugin.zsh \
+      $out/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.plugin.zsh
     install -D zsh-autosuggestions.zsh \
-      $out/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+      $out/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh
+    ln -s $out/share/zsh/plugins/zsh-autosuggestions \
+      $out/share/zsh-autosuggestions
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/zs/zsh-bd/package.nix
+++ b/pkgs/by-name/zs/zsh-bd/package.nix
@@ -19,10 +19,16 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p $out/share/zsh-bd
-    cp {.,$out/share/zsh-bd}/bd.zsh
-    cd $out/share/zsh-bd
-    ln -s bd{,.plugin}.zsh
+    runHook preInstall
+
+    install -D bd.zsh \
+      $out/share/plugins/zsh-bd/bd.zsh
+    ln -s $out/share/plugins/zsh-bd/bd.zsh \
+      $out/share/plugins/zsh-bd/bd.plugin.zsh
+    ln -s $out/share/plugins/zsh-bd \
+      $out/share/zsh-bd
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/zs/zsh-fast-syntax-highlighting/package.nix
+++ b/pkgs/by-name/zs/zsh-fast-syntax-highlighting/package.nix
@@ -20,7 +20,7 @@ stdenvNoCC.mkDerivation rec {
   dontBuild = true;
 
   installPhase = ''
-    plugindir="$out/share/zsh/site-functions"
+    plugindir="$out/share/zsh/plugins/fast-syntax-highlighting"
 
     mkdir -p "$plugindir"
     cp -r -- {,_,-,.}fast-* *chroma themes "$plugindir"/

--- a/pkgs/by-name/zs/zsh-history-substring-search/package.nix
+++ b/pkgs/by-name/zs/zsh-history-substring-search/package.nix
@@ -17,8 +17,12 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   installPhase = ''
+    install -D zsh-history-substring-search.plugin.zsh \
+      "$out/share/zsh/plugins/zsh-history-substring-search/zsh-history-substring-search.plugin.zsh"
     install -D zsh-history-substring-search.zsh \
-      "$out/share/zsh-history-substring-search/zsh-history-substring-search.zsh"
+      "$out/share/zsh/plugins/zsh-history-substring-search/zsh-history-substring-search.zsh"
+    ln -s $out/share/zsh/plugins/zsh-history-substring-search \
+      $out/share/zsh-history-substring-search
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/zs/zsh-nix-shell/package.nix
+++ b/pkgs/by-name/zs/zsh-nix-shell/package.nix
@@ -22,8 +22,9 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   buildInputs = [ bash ];
   installPhase = ''
-    install -D nix-shell.plugin.zsh --target-directory=$out/share/zsh-nix-shell
-    install -D scripts/* --target-directory=$out/share/zsh-nix-shell/scripts
+    install -D nix-shell.plugin.zsh --target-directory=$out/share/zsh/plugins/zsh-nix-shell
+    install -D scripts/* --target-directory=$out/share/zsh/plugins/zsh-nix-shell/scripts
+    ln -s $out/share/zsh/plugins/zsh-nix-shell $out/share/zsh-nix-shell
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/zs/zsh-powerlevel10k/package.nix
+++ b/pkgs/by-name/zs/zsh-powerlevel10k/package.nix
@@ -32,11 +32,12 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    install -D powerlevel10k.zsh-theme --target-directory=$out/share/zsh-powerlevel10k
-    install -D powerlevel9k.zsh-theme --target-directory=$out/share/zsh-powerlevel10k
-    install -D config/* --target-directory=$out/share/zsh-powerlevel10k/config
-    install -D internal/* --target-directory=$out/share/zsh-powerlevel10k/internal
-    cp -R gitstatus $out/share/zsh-powerlevel10k/gitstatus
+    install -D powerlevel10k.zsh-theme --target-directory=$out/share/zsh/themes/powerlevel10k
+    install -D powerlevel9k.zsh-theme --target-directory=$out/share/zsh/themes/powerlevel10k
+    install -D config/* --target-directory=$out/share/zsh/themes/powerlevel10k/config
+    install -D internal/* --target-directory=$out/share/zsh/themes/powerlevel10k/internal
+    cp -R gitstatus $out/share/zsh/themes/powerlevel10k/gitstatus
+    ln -s $out/share/zsh/themes/powerlevel10k $out/share/zsh-powerlevel10k
 
     runHook postInstall
   '';

--- a/pkgs/by-name/zs/zsh-powerlevel9k/package.nix
+++ b/pkgs/by-name/zs/zsh-powerlevel9k/package.nix
@@ -16,8 +16,9 @@ stdenv.mkDerivation {
 
   strictDeps = true;
   installPhase = ''
-    install -D powerlevel9k.zsh-theme --target-directory=$out/share/zsh-powerlevel9k
-    install -D functions/* --target-directory=$out/share/zsh-powerlevel9k/functions
+    install -D powerlevel9k.zsh-theme --target-directory=$out/share/zsh/themes/powerlevel9k
+    install -D functions/* --target-directory=$out/share/zsh/themes/powerlevel9k/functions
+    ln -s $out/share/zsh/themes/powerlevel9k $out/share/zsh-powerlevel9k
   '';
 
   meta = {


### PR DESCRIPTION
Note: This is my first pull request, I apologize in advance for
anything bad or non-standard I may have done. Point me in the right
direction and I'll try to correct it.

###### Motivation for this change

This allows for easier configuration of zsh through NixOS configuration.

The `programs.zsh.ohMyZsh.customPkgs` option expects that arguments
passed to it will have a zsh plugin/theme/completion in a path like
`$out/share/zsh/{plugins,themes,completions}`, and copies whatever is
inside those to `$ZSH_CUSTOM`.

However, some packages actually unpacked to `$out/share`, without the
proper folder structure, so they never got copied to `$ZSH_CUSTOM` and
caused "not found" errors on zsh startup.

This fixes that, and maintains compatibility with other packages
that might still expect a flatted structure. This is done though a
symlink.

Previously, one could only (at least, it was the only thing that worked
for me) add things like autosuggestions and syntax highlighting though
options like `programs.zsh.autosuggestions.enable` and 
`programs.zsh.syntaxHighlighting.enable`. Those are still supported,
but now adding the appropriate package to
`programs.zsh.ohMyZsh.customPkgs` and listing its name in 
`programs.zsh.ohMyZsh.plugins` works too. 

###### Things done

Some packages which unpacked to an improper location where refactored
and symlinked to their old path. I checked all zsh packages, the
unchanged ones seemed to already be working though some are untested. I
can try and test them if requested. 

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).