### PR TITLE
python3Packages.google_cloud_websecurityscanner: fix build

### DIFF
--- a/pkgs/development/python-modules/google_cloud_websecurityscanner/default.nix
+++ b/pkgs/development/python-modules/google_cloud_websecurityscanner/default.nix
@@ -1,10 +1,5 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, google_api_core
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, google_api_core, libcst
+, mock, proto-plus, pytest, pytest-asyncio }:
 
 buildPythonPackage rec {
   pname = "google-cloud-websecurityscanner";
@@ -15,8 +10,10 @@ buildPythonPackage rec {
     sha256 = "1de60f880487b898b499345f46f7acf38651f5356ebca8673116003a57f25393";
   };
 
-  checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ google_api_core ];
+  disabled = pythonOlder "3.6";
+
+  checkInputs = [ mock pytest pytest-asyncio ];
+  propagatedBuildInputs = [ google_api_core libcst proto-plus ];
 
   checkPhase = ''
     pytest tests/unit
@@ -24,7 +21,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Google Cloud Web Security Scanner API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-websecurityscanner";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };


### PR DESCRIPTION
###### Motivation for this change

Fixes broken build by adding missing dependencies. Will backport to 20.09 for ZHF.

https://hydra.nixos.org/build/127651273

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).