### PR TITLE
iSCSI: add various modules and a test

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -652,6 +652,9 @@
   ./services/networking/iodine.nix
   ./services/networking/iperf3.nix
   ./services/networking/ircd-hybrid/default.nix
+  ./services/networking/iscsi/initiator.nix
+  ./services/networking/iscsi/root-initiator.nix
+  ./services/networking/iscsi/target.nix
   ./services/networking/iwd.nix
   ./services/networking/jicofo.nix
   ./services/networking/jitsi-videobridge.nix

--- a/nixos/modules/services/networking/iscsi/initiator.nix
+++ b/nixos/modules/services/networking/iscsi/initiator.nix
@@ -1,0 +1,56 @@
+{ config, lib, pkgs, ... }: with lib;
+let
+  cfg = config.services.openiscsi;
+in {
+  options.services.openiscsi = with types; {
+    enable = mkEnableOption "the openiscsi iscsi daemon";
+    enableAutoLoginOut = mkEnableOption ''
+      automatic login and logout of all automatic targets.
+      You probably do not want this.
+    '';
+    discoverPortal = mkOption {
+      type = nullOr str;
+      default = null;
+      description = "Portal to discover targets on";
+    };
+    name = mkOption {
+      type = str;
+      description = "Name of this iscsi initiator";
+      example = "iqn.2020-08.org.linux-iscsi.initiatorhost:example";
+    };
+    package = mkOption {
+      type = package;
+      description = "openiscsi package to use";
+      default = pkgs.openiscsi;
+      defaultText = "pkgs.openiscsi";
+    };
+
+    extraConfig = mkOption {
+      type = str;
+      default = "";
+      description = "Lines to append to default iscsid.conf";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."iscsi/iscsid.conf".text = ''
+      ${readFile "${cfg.package}/etc/iscsi/iscsid.conf"}
+      ${cfg.extraConfig}
+      ${optionalString cfg.enableAutoLoginOut "node.startup = automatic"}
+    '';
+    environment.etc."iscsi/initiatorname.iscsi".text = "InitiatorName=${cfg.name}";
+
+    systemd.packages = [ cfg.package ];
+
+    systemd.services."iscsid".wantedBy = [ "multi-user.target" ];
+    systemd.sockets."iscsid".wantedBy = [ "sockets.target" ];
+
+    systemd.services."iscsi" = mkIf cfg.enableAutoLoginOut {
+      wantedBy = [ "remote-fs.target" ];
+      serviceConfig.ExecStartPre = mkIf (cfg.discoverPortal != null) "${cfg.package}/bin/iscsiadm --mode discoverydb --type sendtargets --portal ${cfg.discoverPortal} --discover";
+    };
+
+    environment.systemPackages = [ cfg.package ];
+    boot.kernelModules = [ "iscsi_tcp" ]; # TODO
+  };
+}

--- a/nixos/modules/services/networking/iscsi/root-initiator.nix
+++ b/nixos/modules/services/networking/iscsi/root-initiator.nix
@@ -1,0 +1,108 @@
+{ config, lib, pkgs, ... }: with lib;
+let
+  cfg = config.boot.iscsi-initiator;
+in {
+  # Note: Theoretically you might want to connect to multiple portals and log in to multiple targets
+  # However, we assume that you're only crazy enough to boot from iSCSI but not actually crazy enough to boot from multiple iSCSI targets
+  # If you are, feel free to implement it, it shouldn't be _that_ hard.
+  options.boot.iscsi-initiator = with types; {
+    name = mkOption {
+      description = ''
+        Name of the iSCSI initiator to boot from.
+      '';
+      default = null;
+      example = "iqn.2020-08.org.linux-iscsi.initiatorhost:example";
+      type = nullOr str;
+    };
+
+    discoverPortal = mkOption {
+      description = ''
+        iSCSI portal to boot from.
+      '';
+      default = null;
+      example = "192.168.1.1:3260";
+      type = nullOr str;
+    };
+
+    target = mkOption {
+      description = ''
+        Name of the iSCSI target to boot from.
+      '';
+      default = null;
+      example = "iqn.2020-08.org.linux-iscsi.targethost:example";
+      type = nullOr str;
+    };
+
+    loginAll = mkOption {
+      description = ''
+        Do not log into a specific target on the portal, but to all that we discover.
+        This overrides setting target.
+      '';
+      type = bool;
+      default = false;
+    };
+  };
+
+  config = mkIf (cfg.name != null) {
+    boot.initrd = {
+      network.enable = true;
+
+      kernelModules = [ "iscsi_tcp" ];
+
+      extraUtilsCommands = ''
+        copy_bin_and_libs ${pkgs.openiscsi}/bin/iscsid
+        copy_bin_and_libs ${pkgs.openiscsi}/bin/iscsiadm
+        ${optionalString (!config.boot.initrd.network.ssh.enable) "cp -pv ${pkgs.glibc.out}/lib/libnss_files.so.* $out/lib"}
+
+        mkdir -p $out/etc
+        cp ${config.environment.etc.hosts.source} $out/etc/hosts
+        cp ${pkgs.openiscsi}/etc/iscsi/iscsid.conf $out/etc/iscsid.conf
+      '';
+
+      extraUtilsCommandsTest = ''
+        $out/bin/iscsiadm --version
+      '';
+
+      preLVMCommands = ''
+        ${optionalString (!config.boot.initrd.network.ssh.enable) ''
+          # stolen from initrd-ssh.nix
+          echo 'root:x:0:0:root:/root:/bin/ash' > /etc/passwd
+          echo 'passwd: files' > /etc/nsswitch.conf
+        ''}
+
+        # oc
+        cp -f $extraUtils/etc/hosts /etc/hosts
+
+        mkdir -p /etc/iscsi /run/lock/iscsi
+        echo "InitiatorName=${cfg.name}" > /etc/iscsi/initiatorname.iscsi
+        cp -f $extraUtils/etc/iscsid.conf /etc/iscsi/iscsid.conf
+        ${optionalString cfg.loginAll ''echo "node.startup = automatic" >> /etc/iscsi/iscsid.conf''}
+        iscsid -f -n -d 9 &
+        iscsiadm --mode discoverydb --type sendtargets --portal ${cfg.discoverPortal} --discover -d 9
+        ${if cfg.loginAll then ''
+          iscsiadm --mode node -L all
+        '' else ''
+          iscsiadm --mode node --targetname ${cfg.target} --login
+        ''}
+        pkill -9 iscsid
+      '';
+
+      postMountCommands = ''
+        ln -sfn /nix/var/nix/profiles/system/init /mnt-root/init
+        stage2Init=/init
+      '';
+    };
+
+    services.openiscsi = {
+      enable = true;
+      inherit (cfg) name;
+    };
+
+    assertions = [
+      {
+        assertion = cfg.loginAll -> cfg.target == null;
+        message = "iSCSI target name is set while login on all portals is enabled.";
+      }
+    ];
+  };
+}

--- a/nixos/modules/services/networking/iscsi/target.nix
+++ b/nixos/modules/services/networking/iscsi/target.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.target;
+in
+{
+  ###### interface
+  options = {
+    services.target = with types; {
+      enable = mkOption {
+        type = bool;
+        default = false;
+        description = ''
+          Whether to enable the kernel's LIO iscsi target
+        '';
+      };
+
+      config = mkOption {
+        type = attrs;
+        default = {};
+        description = ''
+          Content of /etc/target/saveconfig.json
+          This file is normally read and written by targetcli
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    environment.etc."target/saveconfig.json" = {
+      text = builtins.toJSON cfg.config;
+      mode = "0600";
+    };
+
+    environment.systemPackages = with pkgs; [ targetcli ];
+
+    boot.kernelModules = [ "configfs" "target_core_mod" "iscsi_target_mod" ];
+
+    systemd.services.iscsi-target = {
+      enable = true;
+      after = [ "network.target" "local-fs.target" ];
+      requires = [ "sys-kernel-config.mount" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.python3.pkgs.rtslib}/bin/targetctl restore";
+        ExecStop = "${pkgs.python3.pkgs.rtslib}/bin/targetctl clear";
+        RemainAfterExit = "yes";
+      };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d /etc/target 0700 root root - -"
+    ];
+  };
+}

--- a/nixos/tests/iscsi.nix
+++ b/nixos/tests/iscsi.nix
@@ -1,0 +1,149 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+let
+  initiatorName = "iqn.2020-08.org.linux-iscsi.initiatorhost:example";
+  targetName = "iqn.2003-01.org.linux-iscsi.target.x8664:sn.acf8fd9c23af";
+
+  initiatorRootConfig = { config, pkgs, modulesPath, lib, ... }: {
+    imports = [
+      ../modules/testing/test-instrumentation.nix
+      ../modules/virtualisation/qemu-vm.nix
+    ];
+
+    boot.loader.grub.enable = false;
+    boot.kernelParams = lib.mkOverride 5 ([
+      "boot.shell_on_fail"
+      "console=tty1"
+    ] ++ lib.optional (config.networking ? "primaryIPAddress") "ip=${config.networking.primaryIPAddress}:::255.255.255.0::ens9:none");
+    # extremely useful for debugging
+    # virtualisation.qemu.consoles = lib.mkForce [ "tty1" ];
+    # defaults to true, puts some code in the initrd that tries to mount an overlayfs on /nix/store
+    virtualisation.writableStore = false;
+
+    fileSystems = lib.mkOverride 5 {
+      "/" = {
+        fsType = "xfs";
+        device = "/dev/sda";
+      };
+    };
+
+    services.openiscsi = {
+      enable = true;
+      name = initiatorName;
+    };
+
+    boot.iscsi-initiator = {
+      discoverPortal = "target";
+      name = initiatorName;
+      target = targetName;
+    };
+  };
+
+  initiatorRootSystem = (pkgs.nixos initiatorRootConfig).config.system.build.toplevel;
+in {
+  name = "iscsi";
+  skipLint = true;
+
+  nodes = {
+    target = { config, pkgs, lib, ... }: {
+      services.target = {
+        enable = true;
+        config = {
+          fabric_modules = [ ];
+          storage_objects = [{
+            dev = "/dev/vdb";
+            name = "test";
+            plugin = "block";
+            write_back = true;
+            wwn = "92b17c3f-6b40-4168-b082-ceeb7b495522";
+          }];
+          targets = [{
+            fabric = "iscsi";
+            tpgs = [{
+              enable = true;
+              attributes = {
+                authentication = 0;
+                generate_node_acls = 1;
+              };
+              luns = [{
+                alias = "94dfe06967";
+                alua_tg_pt_gp_name = "default_tg_pt_gp";
+                index = 0;
+                storage_object = "/backstores/block/test";
+              }];
+              node_acls = [{
+                mapped_luns = [{
+                  alias = "d42f5bdf8a";
+                  index = 0;
+                  tpg_lun = 0;
+                  write_protect = false;
+                }];
+                node_wwn = initiatorName;
+              }];
+              portals = [{
+                ip_address = "0.0.0.0";
+                iser = false;
+                offload = false;
+                port = 3260;
+              }];
+              tag = 1;
+            }];
+            wwn = targetName;
+          }];
+        };
+      };
+
+      networking.firewall.allowedTCPPorts = [ 3260 ];
+      networking.firewall.allowedUDPPorts = [ 3260 ];
+
+      virtualisation.memorySize = 2048;
+      virtualisation.emptyDiskImages = [ 2048 ];
+
+      system.extraDependencies = [ initiatorRootSystem ];
+
+      nix.binaryCaches = lib.mkForce [ ];
+      nix.extraOptions = ''
+        hashed-mirrors =
+        connect-timeout = 1
+      '';
+    };
+
+    initiatorAuto = { config, pkgs, ... }: {
+      services.openiscsi = {
+        enable = true;
+        enableAutoLoginOut = true;
+        discoverPortal = "target";
+        name = initiatorName;
+      };
+
+      environment.systemPackages = with pkgs; [
+        xfsprogs
+      ];
+    };
+
+    initiatorRootTargetName = initiatorRootConfig;
+  };
+
+  testScript = ''
+    target.start()
+    initiatorAuto.start()
+    target.wait_for_unit("iscsi-target.service")
+
+    initiatorAuto.wait_for_unit("iscsid.service")
+    initiatorAuto.wait_for_unit("iscsi.service")
+    initiatorAuto.get_unit_info("iscsi")
+
+    initiatorAuto.succeed("mkfs.xfs /dev/sda")
+    initiatorAuto.shutdown()
+    target.stop_job("iscsi-target")
+    target.succeed("mkdir /mnt; mount /dev/vdb /mnt")
+
+    target.succeed('nixos-install --no-bootloader --no-root-passwd --system ${initiatorRootSystem}')
+    target.succeed("umount /mnt; rmdir /mnt")
+    target.start_job("iscsi-target")
+
+    initiatorRootTargetName.start()
+    initiatorRootTargetName.wait_for_unit("multi-user.target")
+    initiatorRootTargetName.wait_for_unit("iscsid")
+    initiatorRootTargetName.succeed("touch test")
+  '';
+})

--- a/pkgs/os-specific/linux/open-iscsi/default.nix
+++ b/pkgs/os-specific/linux/open-iscsi/default.nix
@@ -25,8 +25,16 @@ stdenv.mkDerivation rec {
     sed -i 's|/usr|/|' Makefile
   '';
 
+  installFlags = [
+    "install"
+    "install_systemd"
+  ];
+
   postInstall = ''
     cp usr/iscsistart $out/sbin/
+    for f in $out/lib/systemd/system/*; do
+      substituteInPlace $f --replace /sbin $out/bin
+    done
     $out/sbin/iscsistart -v
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This builds on top of #97793, to provide some iSCSI stuff.

Not sure if and how useful this would be to anyone, tbh.

cc @zaninime 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
