### PR TITLE
Revert "linuxPackages.nvidia_x11.persistenced: fix build"

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -235,7 +235,7 @@ in
     hardware.opengl.extraPackages32 = optional offloadCfg.enable nvidia_libs32;
 
     environment.systemPackages = [ nvidia_x11.bin nvidia_x11.settings ]
-      ++ optional nvidiaPersistencedEnabled [ nvidia_x11.persistenced ];
+      ++ optionals nvidiaPersistencedEnabled [ nvidia_x11.persistenced ];
 
     systemd.packages = optional cfg.powerManagement.enable nvidia_x11.out;
 

--- a/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
@@ -1,6 +1,6 @@
 nvidia_x11: sha256:
 
-{ stdenv, fetchFromGitHub, m4, pkg-config, libtirpc }:
+{ stdenv, fetchFromGitHub, m4 }:
 
 stdenv.mkDerivation rec {
   pname = "nvidia-persistenced";
@@ -13,9 +13,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  nativeBuildInputs = [ m4 pkg-config ];
-
-  buildInputs = [ libtirpc ];
+  nativeBuildInputs = [ m4 ];
 
   installFlags = [ "PREFIX=$(out)" ];
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#100991

Although it fixed the build, the program just crashes at runtime now.

Probably better to just update from upstream and hope that they have fixed the issue