### PR TITLE
dotnetCorePackages.sdk_5_0: 5.0.100-rc.1.20452.10 -> 5.0.100-rc.2.204…

### DIFF
--- a/pkgs/development/compilers/dotnet/default.nix
+++ b/pkgs/development/compilers/dotnet/default.nix
@@ -106,11 +106,11 @@ rec {
   # v5.0.0
 
   sdk_5_0 = buildNetCoreSdk {
-    version = "5.0.100-rc.1.20452.10";
+    version = "5.0.100-rc.2.20479.15";
     sha512 = {
-      x86_64-linux = "d7e709dacc4bb188c2380060d24bfb5b791240dc33af8499fb4a31e1885a9377dad1d1ebc76847432ea67d5e4ac832a31679dc293e09fa6dade28f5fbbe4db9b";
-      aarch64-linux = "2d04890c71e845d1eb08f5dfbbb9c93024d7a52fb1cc3fd50bd51bc6bd44e455c5c82abc8f04eef23bd012984ae5f86143c600ceb49c4c733935d95d5b68785f";
-      x86_64-darwin = "06bb40273071f3dd1e84ebf58abc7798795d5f1ac298f24bf7109d1597fd52ff31bcbf2b81f86d91d37ae293678d07f8da0469d7cbd318d19a8d718b6629dcac";
+      x86_64-linux = "1if75vg949zk5h7i800iq6wwjca12pvafr12gl81bq469n2wbbwryavz182kl7mshccq43g85vhs43bqwhx1vk7amljff65vqy081g7";
+      aarch64-linux = "2zhvxgwr692qgdpqy0ql85p5wzzw3w4jmi19dljbn4jd5rf3qyvy3k2nnvvzb2il5pnj16rlpmklyijmacxz477826dxi18qfr4kaqs";
+      x86_64-darwin = "0fpd32b6byk1rfhyrrvnfsyg16z7n0kfy7xjbf2yjzpqa2fdw19yhyk9g935xm2dcg0w9ssfw4m0rl52qfgyyjirp9a9iqggbahv9h5";
     };
   };
 }


### PR DESCRIPTION
…79.15

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
