### PR TITLE
python3Packages.google_cloud_spanner: 1.17.1 -> 1.19.1

### DIFF
--- a/pkgs/development/python-modules/google_cloud_spanner/default.nix
+++ b/pkgs/development/python-modules/google_cloud_spanner/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , grpc_google_iam_v1
 , grpcio-gcp
 , google_api_core
@@ -11,12 +12,14 @@
 
 buildPythonPackage rec {
   pname = "google-cloud-spanner";
-  version = "1.17.1";
+  version = "1.19.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3240a04eaa6496e9d8bf4929f4ff04de1652621fd49555eb83b743c48ed9ca04";
+    sha256 = "0b9ifh9i4hkcs19b4l6v8j8v93yd8p3j19qrrjvvf5a44bc7bhsh";
   };
+
+  disabled = pythonOlder "3.5";
 
   checkInputs = [ pytest mock ];
   propagatedBuildInputs = [ grpcio-gcp grpc_google_iam_v1 google_api_core google_cloud_core ];
@@ -29,7 +32,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Cloud Spanner API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://pypi.org/project/google-cloud-spanner";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };


### PR DESCRIPTION
###### Motivation for this change

Fixes the build and upgrades the package. Will backport to 20.09 for ZHF.

https://hydra.nixos.org/build/127652854

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).