### PR TITLE
[20.09] libsForQt5X.qtquickcontrols: disable

### DIFF
--- a/pkgs/applications/audio/kid3/default.nix
+++ b/pkgs/applications/audio/kid3/default.nix
@@ -2,7 +2,7 @@
 , pkgconfig, cmake, python, ffmpeg_3, phonon, automoc4
 , chromaprint, docbook_xml_dtd_45, docbook_xsl, libxslt
 , id3lib, taglib, mp4v2, flac, libogg, libvorbis
-, zlib, readline , qtbase, qttools, qtmultimedia, qtquickcontrols
+, zlib, readline , qtbase, qttools, qtmultimedia, qtquickcontrols2
 , wrapQtAppsHook
 }:
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   [ pkgconfig cmake python ffmpeg_3 phonon automoc4
     chromaprint docbook_xml_dtd_45 docbook_xsl libxslt
     id3lib taglib mp4v2 flac libogg libvorbis zlib readline
-    qtbase qttools qtmultimedia qtquickcontrols ];
+    qtbase qttools qtmultimedia qtquickcontrols2 ];
 
   cmakeFlags = [ "-DWITH_APPS=Qt;CLI" ];
   NIX_LDFLAGS = "-lm -lpthread";

--- a/pkgs/applications/kde/konquest.nix
+++ b/pkgs/applications/kde/konquest.nix
@@ -4,13 +4,13 @@
 , kdoctools
 , kdelibs4support
 , libkdegames
-, qtquickcontrols
+, qtquickcontrols2
 }:
 
 mkDerivation {
   name = "konquest";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
-  buildInputs = [ kdelibs4support libkdegames qtquickcontrols ];
+  buildInputs = [ kdelibs4support libkdegames qtquickcontrols2 ];
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ lheckemann ];

--- a/pkgs/applications/misc/cool-retro-term/default.nix
+++ b/pkgs/applications/misc/cool-retro-term/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, mkDerivation, qtbase, qtquick1, qmltermwidget
-, qtquickcontrols, qtgraphicaleffects, qmake }:
+{ stdenv, fetchFromGitHub, mkDerivation, qtbase, qmltermwidget
+, qtquickcontrols2, qtgraphicaleffects, qmake }:
 
 mkDerivation rec {
   version = "1.1.1";
@@ -16,7 +16,7 @@ mkDerivation rec {
     sed -i -e '/qmltermwidget/d' cool-retro-term.pro
   '';
 
-  buildInputs = [ qtbase qtquick1 qmltermwidget qtquickcontrols qtgraphicaleffects ];
+  buildInputs = [ qtbase qmltermwidget qtquickcontrols2 qtgraphicaleffects ];
   nativeBuildInputs = [ qmake ];
 
   installFlags = [ "INSTALL_ROOT=$(out)" ];

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub
 # Dynamic libraries
 , dbus, glib, libGL, libX11, libXfixes, libuuid, libxcb, qtbase, qtdeclarative
-, qtgraphicaleffects, qtimageformats, qtlocation, qtquickcontrols
+, qtgraphicaleffects, qtimageformats, qtlocation
 , qtquickcontrols2, qtscript, qtsvg , qttools, qtwayland, qtwebchannel
 , qtwebengine
 # Runtime
@@ -41,7 +41,7 @@ in mkDerivation {
 
   buildInputs = [
     dbus glib libGL libX11 libXfixes libuuid libxcb faac qtbase
-    qtdeclarative qtgraphicaleffects qtlocation qtquickcontrols qtquickcontrols2
+    qtdeclarative qtgraphicaleffects qtlocation qtquickcontrols2
     qtscript qtwebchannel qtwebengine qtimageformats qtsvg qttools qtwayland
   ];
 

--- a/pkgs/development/libraries/pyotherside/default.nix
+++ b/pkgs/development/libraries/pyotherside/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, python3, qmake, qtbase, qtquickcontrols, qtsvg, ncurses }:
+, python3, qmake, qtbase, qtquickcontrols2, qtsvg, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "pyotherside";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ qmake ];
   buildInputs = [
-    python3 qtbase qtquickcontrols qtsvg ncurses
+    python3 qtbase qtquickcontrols2 qtsvg ncurses
   ];
 
   patches = [ ./qml-path.patch ];

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -162,7 +162,7 @@ let
       };
       qtnetworkauth = callPackage ../modules/qtnetworkauth.nix {};
       qtquick1 = null;
-      qtquickcontrols = callPackage ../modules/qtquickcontrols.nix {};
+      qtquickcontrols = null;
       qtquickcontrols2 = callPackage ../modules/qtquickcontrols2.nix {};
       qtscript = callPackage ../modules/qtscript.nix {};
       qtsensors = callPackage ../modules/qtsensors.nix {};

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -132,7 +132,7 @@ let
       };
       qtnetworkauth = callPackage ../modules/qtnetworkauth.nix {};
       qtquick1 = null;
-      qtquickcontrols = callPackage ../modules/qtquickcontrols.nix {};
+      qtquickcontrols = null;
       qtquickcontrols2 = callPackage ../modules/qtquickcontrols2.nix {};
       qtscript = callPackage ../modules/qtscript.nix {};
       qtsensors = callPackage ../modules/qtsensors.nix {};

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -126,7 +126,7 @@ let
       };
       qtnetworkauth = callPackage ../modules/qtnetworkauth.nix {};
       qtquick1 = null;
-      qtquickcontrols = callPackage ../modules/qtquickcontrols.nix {};
+      qtquickcontrols = null;
       qtquickcontrols2 = callPackage ../modules/qtquickcontrols2.nix {};
       qtscript = callPackage ../modules/qtscript.nix {};
       qtsensors = callPackage ../modules/qtsensors.nix {};

--- a/pkgs/development/libraries/qt-5/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwayland.nix
@@ -1,8 +1,8 @@
-{ qtModule, qtbase, wayland, pkgconfig }:
+{ qtModule, qtbase, qtquickcontrols2, wayland, pkgconfig }:
 
 qtModule {
   name = "qtwayland";
-  qtInputs = [ qtbase ];
+  qtInputs = [ qtbase qtquickcontrols2 ];
   buildInputs = [ wayland ];
   nativeBuildInputs = [ pkgconfig ];
   outputs = [ "out" "dev" "bin" ];

--- a/pkgs/development/libraries/qt-5/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwayland.nix
@@ -1,8 +1,8 @@
-{ qtModule, qtbase, qtquickcontrols, wayland, pkgconfig }:
+{ qtModule, qtbase, wayland, pkgconfig }:
 
 qtModule {
   name = "qtwayland";
-  qtInputs = [ qtbase qtquickcontrols ];
+  qtInputs = [ qtbase ];
   buildInputs = [ wayland ];
   nativeBuildInputs = [ pkgconfig ];
   outputs = [ "out" "dev" "bin" ];

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -1,5 +1,5 @@
 { qtModule, qtCompatVersion,
-  qtdeclarative, qtquickcontrols, qtlocation, qtwebchannel
+  qtdeclarative, qtquickcontrols2, qtlocation, qtwebchannel
 
 , bison, coreutils, flex, git, gperf, ninja, pkgconfig, python2, which
 
@@ -22,7 +22,7 @@ with stdenv.lib;
 
 qtModule {
   name = "qtwebengine";
-  qtInputs = [ qtdeclarative qtquickcontrols qtlocation qtwebchannel ];
+  qtInputs = [ qtdeclarative qtquickcontrols2 qtlocation qtwebchannel ];
   nativeBuildInputs = [
     bison coreutils flex git gperf ninja pkgconfig python2 which gn
   ] ++ optional stdenv.isDarwin xcbuild;

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -1,6 +1,6 @@
 { mkDerivation, lib, fetchurl, fetchgit, fetchpatch
-, qtbase, qtquickcontrols, qtscript, qtdeclarative, qmake, llvmPackages_8
-, withDocumentation ? false, withClangPlugins ? true 
+, qtbase, qtquickcontrols2, qtscript, qtdeclarative, qmake, llvmPackages_8
+, withDocumentation ? false, withClangPlugins ? true
 }:
 
 with lib;
@@ -28,9 +28,9 @@ mkDerivation rec {
     sha256 = "0ibn7bapw7m26nmxl26dns1hnpawfdqk1i1mgg0gjssja8famszg";
   };
 
-  buildInputs = [ qtbase qtscript qtquickcontrols qtdeclarative ] ++ 
-    optionals withClangPlugins [ llvmPackages_8.libclang 
-                                 clang_qt_vendor 
+  buildInputs = [ qtbase qtscript qtquickcontrols2 qtdeclarative ] ++
+    optionals withClangPlugins [ llvmPackages_8.libclang
+                                 clang_qt_vendor
                                  llvmPackages_8.llvm ];
 
   nativeBuildInputs = [ qmake ];
@@ -38,7 +38,7 @@ mkDerivation rec {
   # 0001-Fix-clang-libcpp-regexp.patch is for fixing regexp that is used to
   # find clang libc++ library include paths. By default it's not covering paths
   # like libc++-version, which is default name for libc++ folder in nixos.
-  # ./0002-Dont-remove-clang-header-paths.patch is for forcing qtcreator to not 
+  # ./0002-Dont-remove-clang-header-paths.patch is for forcing qtcreator to not
   # remove system clang include paths.
   patches = [ ./0001-Fix-clang-libcpp-regexp.patch
               ./0002-Dont-remove-clang-header-paths.patch ];
@@ -53,7 +53,7 @@ mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace src/plugins/plugins.pro \
-      --replace '$$[QT_INSTALL_QML]/QtQuick/Controls' '${qtquickcontrols}/${qtbase.qtQmlPrefix}/QtQuick/Controls' 
+      --replace '$$[QT_INSTALL_QML]/QtQuick/Controls' '${qtquickcontrols2}/${qtbase.qtQmlPrefix}/QtQuick/Controls'
     '' + optionalString withClangPlugins ''
     # Fix paths for llvm/clang includes directories.
     substituteInPlace src/shared/clang/clang_defines.pri \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21371,7 +21371,7 @@ in
           klettres klines
           kmag kmines kmix kmplot
           knavalbattle knetwalk knights
-          kollision kolourpaint kompare konsole
+          kollision kolourpaint kompare konsole konquest
           krdc kreversi krfb
           kshisen ksquares ksystemlog
           kteatime ktimer ktouch kturtle


### PR DESCRIPTION
###### Motivation for this change
Caused import conflicts with the non-deprecated qtquickcontrols2

closes #98536
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
