### PR TITLE
python3Packages.google_auth: 1.20.1 -> 1.22.1

### DIFF
--- a/pkgs/development/python-modules/google-cloud-iam/default.nix
+++ b/pkgs/development/python-modules/google-cloud-iam/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder
+, google_api_core, libcst, mock, proto-plus, pytest-asyncio }:
+
+buildPythonPackage rec {
+  pname = "google-cloud-iam";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1zxsx5avs8njiyw32zvsx2yblmmiwxy771x334hbgmy0aqms4lak";
+  };
+
+  propagatedBuildInputs = [ google_api_core libcst proto-plus ];
+  checkInputs = [ mock pytestCheckHook pytest-asyncio ];
+
+  meta = with lib; {
+    description = "Google Cloud IAM API client library";
+    homepage = "https://github.com/googleapis/python-iam";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/development/python-modules/google_api_core/default.nix
+++ b/pkgs/development/python-modules/google_api_core/default.nix
@@ -1,32 +1,27 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder, isPy27
-, google_auth, protobuf, googleapis_common_protos, requests, setuptools, grpcio
-, mock
-}:
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, google_auth, protobuf
+, googleapis_common_protos, requests, grpcio, mock, pytest, pytest-asyncio, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "google-api-core";
-  version = "1.22.1";
-  disabled = isPy27; # google namespace no longer works on python2
+  version = "1.22.4";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "35cba563034d668ae90ffe1f03193a84e745b38f09592f60258358b5e5ee6238";
+    sha256 = "06pck3hwl1pks26q843hv6pxchby9viab05mxf72k7ksab17m7aa";
   };
 
-  propagatedBuildInputs = [
-    googleapis_common_protos protobuf
-    google_auth requests setuptools grpcio
-  ];
+  propagatedBuildInputs =
+    [ googleapis_common_protos protobuf google_auth requests grpcio ];
 
-  # requires nox
-  doCheck = false;
-  checkInputs = [ mock ];
+  checkInputs = [ google_auth mock protobuf pytest-asyncio pytestCheckHook ];
 
-  pythonImportsCheck = [
-    "google.auth"
-    "google.protobuf"
-    "google.api"
-  ];
+  # prevent google directory from shadowing google imports
+  preCheck = ''
+    rm -r google
+  '';
+
+  pythonImportsCheck = [ "google.auth" "google.protobuf" "google.api" ];
 
   meta = with lib; {
     description = "Core Library for Google Client Libraries";
@@ -35,7 +30,8 @@ buildPythonPackage rec {
       helpers used by all Google API clients.
     '';
     homepage = "https://github.com/googleapis/python-api-core";
-    changelog = "https://github.com/googleapis/python-api-core/blob/v${version}/CHANGELOG.md";
+    changelog =
+      "https://github.com/googleapis/python-api-core/blob/v${version}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/google_auth/default.nix
+++ b/pkgs/development/python-modules/google_auth/default.nix
@@ -1,28 +1,18 @@
-{ stdenv, buildPythonPackage, fetchpatch, fetchPypi
-, cachetools
-, flask
-, freezegun
-, mock
-, oauth2client
-, pyasn1-modules
-, pytest
-, pytest-localserver
-, requests
-, responses
-, rsa
-, setuptools
-, six
-, urllib3
-}:
+{ stdenv, buildPythonPackage, fetchpatch, fetchPypi, pythonOlder
+, pytestCheckHook, cachetools, flask, freezegun, mock, oauth2client
+, pyasn1-modules, pytest, pytest-localserver, requests, responses, rsa
+, setuptools, six, urllib3 }:
 
 buildPythonPackage rec {
   pname = "google-auth";
-  version = "1.20.1";
+  version = "1.22.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2f34dd810090d0d4c9d5787c4ad7b4413d1fbfb941e13682c7a2298d3b6cdcc8";
+    sha256 = "1fs448jcx2cbpk0nq3picndfryjsakmd9allggvh7mrqjiw723ww";
   };
+
+  disabled = pythonOlder "3.5";
 
   propagatedBuildInputs = [ six pyasn1-modules cachetools rsa setuptools ];
 
@@ -31,16 +21,12 @@ buildPythonPackage rec {
     freezegun
     mock
     oauth2client
-    pytest
+    pytestCheckHook
     pytest-localserver
     requests
     responses
     urllib3
   ];
-
-  checkPhase = ''
-    py.test
-  '';
 
   meta = with stdenv.lib; {
     description = "Google Auth Python Library";
@@ -49,7 +35,8 @@ buildPythonPackage rec {
       authentication mechanisms to access Google APIs.
     '';
     homepage = "https://github.com/googleapis/google-auth-library-python";
-    changelog = "https://github.com/googleapis/google-auth-library-python/blob/v${version}/CHANGELOG.md";
+    changelog =
+      "https://github.com/googleapis/google-auth-library-python/blob/v${version}/CHANGELOG.md";
     # Documentation: https://googleapis.dev/python/google-auth/latest/index.html
     license = licenses.asl20;
     maintainers = with maintainers; [ ];

--- a/pkgs/development/python-modules/google_cloud_automl/default.nix
+++ b/pkgs/development/python-modules/google_cloud_automl/default.nix
@@ -1,34 +1,38 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, enum34
-, google_api_core
-, google_cloud_storage
-, pandas
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, pytestCheckHook, libcst
+, google_api_core, google_cloud_storage, google_cloud_testutils, pandas
+, proto-plus, pytest-asyncio, mock }:
 
 buildPythonPackage rec {
   pname = "google-cloud-automl";
-  version = "1.0.1";
+  version = "2.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f08abe78d37fb94a3748aa43e66dae2bad52f991cc7740501a341bc6f6387fd5";
+    sha256 = "16hr1i2771z4yh19xg6kk037h9cv5j64q5bxb9nmkvj12hdwbwgv";
   };
 
-  checkInputs = [ pandas pytest mock google_cloud_storage ];
-  propagatedBuildInputs = [ enum34 google_api_core ];
+  disabled = pythonOlder "3.6";
+
+  checkInputs = [
+    google_cloud_storage
+    google_cloud_testutils
+    mock
+    pandas
+    pytest-asyncio
+    pytestCheckHook
+  ];
+  propagatedBuildInputs = [ google_api_core libcst proto-plus ];
 
   # ignore tests which need credentials
-  checkPhase = ''
-    pytest tests/unit -k 'not upload and not prediction_client_client_info'
+  disabledTests = [ "test_prediction_client_client_info" ];
+  preCheck = ''
+    rm -r google
+    rm tests/system/gapic/v1beta1/test_system_tables_client_v1.py
   '';
 
   meta = with stdenv.lib; {
     description = "Cloud AutoML API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-automl";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_bigquery/default.nix
+++ b/pkgs/development/python-modules/google_cloud_bigquery/default.nix
@@ -1,42 +1,46 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, freezegun
-, google_resumable_media
-, google_api_core
-, google_cloud_core
-, pandas
-, pyarrow
-, pytest
-, mock
-, ipython
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder, freezegun
+, google_api_core, google_cloud_core, google_cloud_testutils
+, google_resumable_media, grpcio, ipython, mock, pandas, proto-plus, pyarrow }:
 
 buildPythonPackage rec {
   pname = "google-cloud-bigquery";
-  version = "1.26.1";
+  version = "2.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "51c29b95d460486d9e0210f63e8193691cd08480b69775270e84dd3db87c1bf2";
+    sha256 = "0x5g6n151rcdgq4s80f71zpsl7bsvyyrs07l58psdpyd3kwf4sbk";
   };
 
-  checkInputs = [ pytest mock ipython freezegun ];
-  propagatedBuildInputs = [ google_resumable_media google_api_core google_cloud_core pandas pyarrow ];
+  disabled = pythonOlder "3.6";
 
-  # prevent local directory from shadowing google imports
-  # call_api_applying_custom_retry_on_timeout requires credentials
+  checkInputs =
+    [ freezegun google_cloud_testutils ipython mock pytestCheckHook ];
+  propagatedBuildInputs = [
+    google_resumable_media
+    google_api_core
+    google_cloud_core
+    pandas
+    proto-plus
+    pyarrow
+  ];
+
+  # prevent google directory from shadowing google imports
   # test_magics requires modifying sys.path
-  checkPhase = ''
+  preCheck = ''
     rm -r google
-    pytest tests/unit \
-      -k 'not call_api_applying_custom_retry_on_timeout' \
-      --ignore=tests/unit/test_magics.py
+    rm tests/unit/test_magics.py
   '';
+
+  # call_api_applying_custom_retry_on_timeout requires credentials
+  # to_dataframe_timestamp_out_of_pyarrow_bounds has inconsistent results
+  disabledTests = [
+    "call_api_applying_custom_retry_on_timeout"
+    "to_dataframe_timestamp_out_of_pyarrow_bounds"
+  ];
 
   meta = with stdenv.lib; {
     description = "Google BigQuery API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://pypi.org/project/google-cloud-bigquery";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_container/default.nix
+++ b/pkgs/development/python-modules/google_cloud_container/default.nix
@@ -1,23 +1,20 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, google_api_core
-, grpc_google_iam_v1
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, google_api_core
+, grpc_google_iam_v1, libcst, mock, proto-plus, pytest, pytest-asyncio }:
 
 buildPythonPackage rec {
   pname = "google-cloud-container";
-  version = "2.0.1";
+  version = "2.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6f714e3d427e2b36d1365fc400f4d379972529fb40f798d9c0e06c7c3418fc89";
+    sha256 = "07rcq4c49zfaacyn5df62bs7qjf5hpmdm9mpb6nx510lylq0507x";
   };
 
-  checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ google_api_core grpc_google_iam_v1 ];
+  disabled = pythonOlder "3.6";
+
+  checkInputs = [ mock pytest pytest-asyncio ];
+  propagatedBuildInputs =
+    [ google_api_core grpc_google_iam_v1 libcst proto-plus ];
 
   checkPhase = ''
     pytest tests/unit
@@ -25,7 +22,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Google Container Engine API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-container";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_core/default.nix
+++ b/pkgs/development/python-modules/google_cloud_core/default.nix
@@ -1,26 +1,30 @@
-{ stdenv, buildPythonPackage, fetchPypi, python
-, google_api_core, grpcio, pytest, mock, setuptools }:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, pytestCheckHook, python
+, google_api_core, grpcio, mock }:
 
 buildPythonPackage rec {
   pname = "google-cloud-core";
-  version = "1.4.1";
+  version = "1.4.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "613e56f164b6bee487dd34f606083a0130f66f42f7b10f99730afdf1630df507";
+    sha256 = "103bgv9d6fw01vbbdx0qxa5gqdzxqmiwlpdvibmqxkhb3c6bgbr1";
   };
 
-  propagatedBuildInputs = [ google_api_core grpcio setuptools ];
-  checkInputs = [ pytest mock ];
+  disabled = pythonOlder "3.5";
 
-  checkPhase = ''
-    cd tests
-    ${python.interpreter} -m unittest discover
+  propagatedBuildInputs = [ google_api_core grpcio ];
+  checkInputs = [ google_api_core mock pytestCheckHook ];
+
+  pythonImportsCheck = [ "google.cloud" ];
+
+  # prevent google directory from shadowing google imports
+  preCheck = ''
+    rm -r google
   '';
 
   meta = with stdenv.lib; {
     description = "API Client library for Google Cloud: Core Helpers";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-cloud-core";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/google_cloud_error_reporting/default.nix
+++ b/pkgs/development/python-modules/google_cloud_error_reporting/default.nix
@@ -1,31 +1,31 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, google_cloud_logging
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder
+, google_cloud_logging, google_cloud_testutils, libcst, mock, proto-plus
+, pytest-asyncio }:
 
 buildPythonPackage rec {
   pname = "google-cloud-error-reporting";
-  version = "0.34.0";
+  version = "1.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "34edd11601b17c87a89c2e1cefdc27d975e1e9243a88ba3c0c48bfe6a05c404f";
+    sha256 = "1y5vkkg1cmzshj5j68zk1876857z8a7sjm0wqhf4rzgqgkr2kcdd";
   };
 
-  checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ google_cloud_logging ];
+  disabled = pythonOlder "3.6";
 
-  checkPhase = ''
+  checkInputs = [ google_cloud_testutils mock pytestCheckHook pytest-asyncio ];
+  propagatedBuildInputs = [ google_cloud_logging libcst proto-plus ];
+
+  # Disable tests that require credentials
+  disabledTests = [ "test_report_error_event" "test_report_exception" ];
+  # prevent google directory from shadowing google imports
+  preCheck = ''
     rm -r google
-    pytest tests/unit
   '';
 
   meta = with stdenv.lib; {
     description = "Stackdriver Error Reporting API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-error-reporting";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_kms/default.nix
+++ b/pkgs/development/python-modules/google_cloud_kms/default.nix
@@ -1,32 +1,28 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, enum34
-, grpc_google_iam_v1
-, google_api_core
-, pytest
-, mock
+{ stdenv, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder
+, grpc_google_iam_v1, google_api_core, libcst, mock, proto-plus, pytest-asyncio
 }:
 
 buildPythonPackage rec {
   pname = "google-cloud-kms";
-  version = "2.0.1";
+  version = "2.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c590a8ab12a3f776ab35e570d21c0881f9d73c444bd509e54321a4c715233372";
+    sha256 = "0f3k2ixp1zsgydpvkj75bs2mb805389snyw30hn41c38qq5ksdga";
   };
 
-  checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ enum34 grpc_google_iam_v1 google_api_core ];
+  disabled = pythonOlder "3.6";
 
-  checkPhase = ''
-    pytest tests/unit
-  '';
+  checkInputs = [ mock pytestCheckHook pytest-asyncio ];
+  propagatedBuildInputs =
+    [ grpc_google_iam_v1 google_api_core libcst proto-plus ];
+
+  # Disable tests that need credentials
+  disabledTests = [ "test_list_global_key_rings" ];
 
   meta = with stdenv.lib; {
     description = "Cloud Key Management Service (KMS) API API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-kms";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_logging/default.nix
+++ b/pkgs/development/python-modules/google_cloud_logging/default.nix
@@ -1,14 +1,6 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, google_api_core
-, google_cloud_core
-, pytest
-, mock
-, webapp2
-, django
-, flask
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder, django
+, flask, google_api_core, google_cloud_core, google_cloud_testutils, mock
+, webapp2 }:
 
 buildPythonPackage rec {
   pname = "google-cloud-logging";
@@ -19,17 +11,27 @@ buildPythonPackage rec {
     sha256 = "cb0d4af9d684eb8a416f14c39d9fa6314be3adf41db2dd8ee8e30db9e8853d90";
   };
 
-  checkInputs = [ pytest mock webapp2 django flask ];
+  disabled = pythonOlder "3.5";
+
+  checkInputs =
+    [ django flask google_cloud_testutils mock pytestCheckHook webapp2 ];
   propagatedBuildInputs = [ google_api_core google_cloud_core ];
 
-  checkPhase = ''
+  # api_url test broken, fix not yet released
+  # https://github.com/googleapis/python-logging/pull/66
+  disabledTests =
+    [ "test_build_api_url_w_custom_endpoint" "test_write_log_entries" ];
+
+  # prevent google directory from shadowing google imports
+  # remove system integration tests
+  preCheck = ''
     rm -r google
-    pytest tests/unit
+    rm tests/system/test_system.py
   '';
 
   meta = with stdenv.lib; {
     description = "Stackdriver Logging API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-logging";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_pubsub/default.nix
+++ b/pkgs/development/python-modules/google_cloud_pubsub/default.nix
@@ -1,36 +1,34 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, enum34
-, grpc_google_iam_v1
-, google_api_core
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, pytestCheckHook
+, google_api_core, google_cloud_testutils, grpc_google_iam_v1, libcst, mock
+, proto-plus, pytest-asyncio }:
 
 buildPythonPackage rec {
   pname = "google-cloud-pubsub";
-  version = "1.7.0";
+  version = "2.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c8d098ebd208d00c8f3bb55eefecd8553e7391d59700426a97d35125f0dcb248";
+    sha256 = "0358g5q4igq1pgy8dznbbkc6y7zf36y4m81hhh8hvzzhaa37vc22";
   };
 
-  checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ enum34 grpc_google_iam_v1 google_api_core ];
+  disabled = pythonOlder "3.6";
 
-  # tests don't clean up file descriptors correctly
-  doCheck = false;
-  checkPhase = ''
-    pytest tests/unit
+  checkInputs = [ google_cloud_testutils mock pytestCheckHook pytest-asyncio ];
+  propagatedBuildInputs =
+    [ grpc_google_iam_v1 google_api_core libcst proto-plus ];
+
+  # prevent google directory from shadowing google imports
+  # Tests in pubsub_v1 attempt to contact pubsub.googleapis.com
+  preCheck = ''
+    rm -r google
+    rm -r tests/unit/pubsub_v1
   '';
 
   pythonImportsCheck = [ "google.cloud.pubsub" ];
 
   meta = with stdenv.lib; {
     description = "Google Cloud Pub/Sub API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://pypi.org/project/google-cloud-pubsub";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_resource_manager/default.nix
+++ b/pkgs/development/python-modules/google_cloud_resource_manager/default.nix
@@ -1,11 +1,5 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, google_cloud_core
-, google_api_core
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder
+, google_cloud_core, google_api_core, mock, pytest }:
 
 buildPythonPackage rec {
   pname = "google-cloud-resource-manager";
@@ -16,17 +10,24 @@ buildPythonPackage rec {
     sha256 = "de7eba5235df61deee2291a2fe70b904154df613a334109488afdea7a4c0011f";
   };
 
-  checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ google_cloud_core google_api_core ];
+  disabled = pythonOlder "3.5";
 
-  checkPhase = ''
+  checkInputs = [ mock pytestCheckHook ];
+  propagatedBuildInputs = [ google_api_core google_cloud_core ];
+
+  # api_url test broken, fix not yet released
+  # https://github.com/googleapis/python-resource-manager/pull/31
+  disabledTests =
+    [ "api_url_no_extra_query_param" "api_url_w_custom_endpoint" ];
+
+  # prevent google directory from shadowing google imports
+  preCheck = ''
     rm -r google
-    pytest tests/unit
   '';
 
   meta = with stdenv.lib; {
     description = "Google Cloud Resource Manager API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-resource-manager";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_runtimeconfig/default.nix
+++ b/pkgs/development/python-modules/google_cloud_runtimeconfig/default.nix
@@ -1,11 +1,5 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, google_api_core
-, google_cloud_core
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder
+, google_api_core, google_cloud_core, mock }:
 
 buildPythonPackage rec {
   pname = "google-cloud-runtimeconfig";
@@ -16,18 +10,24 @@ buildPythonPackage rec {
     sha256 = "3d125c01817d5bef2b644095b044d22b03b9d8d4591088cadd8e97851f7a150a";
   };
 
-  checkInputs = [ pytest mock ];
+  disabled = pythonOlder "3.5";
+
+  checkInputs = [ mock pytestCheckHook ];
   propagatedBuildInputs = [ google_api_core google_cloud_core ];
 
-  # ignore tests which require credentials or network
-  checkPhase = ''
+  # api_url test broken, fix not yet released
+  # https://github.com/googleapis/python-resource-manager/pull/31
+  # Client tests require credentials
+  disabledTests = [ "build_api_url_w_custom_endpoint" "client_options" ];
+
+  # prevent google directory from shadowing google imports
+  preCheck = ''
     rm -r google
-    pytest tests/unit -k 'not client and not extra_headers'
   '';
 
   meta = with stdenv.lib; {
     description = "Google Cloud RuntimeConfig API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://pypi.org/project/google-cloud-runtimeconfig";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_spanner/default.nix
+++ b/pkgs/development/python-modules/google_cloud_spanner/default.nix
@@ -1,35 +1,32 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, grpc_google_iam_v1
-, grpcio-gcp
-, google_api_core
-, google_cloud_core
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder
+, grpc_google_iam_v1, grpcio-gcp, google_api_core, google_cloud_core
+, google_cloud_testutils, mock, pytest }:
 
 buildPythonPackage rec {
   pname = "google-cloud-spanner";
-  version = "1.17.1";
+  version = "1.19.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3240a04eaa6496e9d8bf4929f4ff04de1652621fd49555eb83b743c48ed9ca04";
+    sha256 = "0b9ifh9i4hkcs19b4l6v8j8v93yd8p3j19qrrjvvf5a44bc7bhsh";
   };
 
-  checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ grpcio-gcp grpc_google_iam_v1 google_api_core google_cloud_core ];
+  disabled = pythonOlder "3.5";
 
-  # avoid importing local package
-  checkPhase = ''
+  checkInputs = [ google_cloud_testutils mock pytestCheckHook ];
+  propagatedBuildInputs =
+    [ grpcio-gcp grpc_google_iam_v1 google_api_core google_cloud_core ];
+
+  # prevent google directory from shadowing google imports
+  # remove tests that require credentials
+  preCheck = ''
     rm -r google
-    pytest tests/unit
+    rm tests/system/test_system.py
   '';
 
   meta = with stdenv.lib; {
     description = "Cloud Spanner API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://pypi.org/project/google-cloud-spanner";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_storage/default.nix
+++ b/pkgs/development/python-modules/google_cloud_storage/default.nix
@@ -1,13 +1,7 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
-, google_resumable_media
-, google_api_core
-, google_cloud_core
-, pytest
-, mock
-, setuptools
-}:
+{ lib, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder
+, google_api_core, google_auth, google-cloud-iam, google_cloud_core
+, google_cloud_kms, google_cloud_testutils, google_resumable_media, mock
+, requests }:
 
 buildPythonPackage rec {
   pname = "google-cloud-storage";
@@ -18,27 +12,36 @@ buildPythonPackage rec {
     sha256 = "da12b7bd79bbe978a7945a44b600604fbc10ece2935d31f243e751f99135e34f";
   };
 
+  disabled = pythonOlder "3.5";
+
   propagatedBuildInputs = [
     google_api_core
+    google_auth
     google_cloud_core
     google_resumable_media
-    setuptools
+    requests
   ];
   checkInputs = [
+    google-cloud-iam
+    google_cloud_kms
+    google_cloud_testutils
     mock
-    pytest
+    pytestCheckHook
   ];
 
-  # remove directory from interferring with importing modules
-  # ignore tests which require credentials
-  checkPhase = ''
+  # disable tests which require credentials
+  disabledTests = [ "create" "get" "post" "test_build_api_url" ];
+
+  # prevent google directory from shadowing google imports
+  # remove tests which require credentials
+  preCheck = ''
     rm -r google
-    pytest tests/unit -k 'not (create or get or post)'
+    rm tests/system/test_system.py tests/unit/test_client.py
   '';
 
   meta = with lib; {
     description = "Google Cloud Storage API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-storage";
     license = licenses.asl20;
     maintainers = with maintainers; [ costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_testutils/default.nix
+++ b/pkgs/development/python-modules/google_cloud_testutils/default.nix
@@ -1,34 +1,22 @@
-{ stdenv
-, buildPythonPackage
-, fetchFromGitHub
-, six
-, google_auth
-}:
+{ stdenv, buildPythonPackage, fetchPypi, google_auth, pytest, six }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "google-cloud-testutils";
-  version = "unstable-36ffa923c7037e8b4fdcaa76272cb6267e908a9d";
+  version = "0.1.0";
 
-  # google-cloud-testutils is not "really"
-  # released as a python package
-  # but it is required for google-cloud-* tests
-  # so why not package it as a module
-  src = fetchFromGitHub {
-    owner = "googleapis";
-    repo = "google-cloud-python";
-    rev = "36ffa923c7037e8b4fdcaa76272cb6267e908a9d";
-    sha256 = "1fvcnssmpgf4lfr7l9h7cz984rbc5mfr1j1br12japcib5biwzjy";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bn1pz00lxym3vkl6l45b3nydpmfdvmylwggh2lspldrxwx39a0k";
   };
 
-  propagatedBuildInputs = [ six google_auth ];
+  propagatedBuildInputs = [ google_auth six ];
 
-  postPatch = ''
-    cd test_utils
-  '';
+  # There are no tests
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "System test utilities for google-cloud-python";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-test-utils";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_texttospeech/default.nix
+++ b/pkgs/development/python-modules/google_cloud_texttospeech/default.nix
@@ -1,10 +1,5 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, google_api_core
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder
+, google_api_core, libcst, mock, proto-plus, pytest-asyncio, }:
 
 buildPythonPackage rec {
   pname = "google-cloud-texttospeech";
@@ -15,16 +10,17 @@ buildPythonPackage rec {
     sha256 = "cbbd397e72b6189668134f3c8e8c303198188334a4e6a5f77cc90c3220772f9e";
   };
 
-  checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ google_api_core ];
+  disabled = pythonOlder "3.5";
 
-  checkPhase = ''
-    pytest tests/unit
-  '';
+  checkInputs = [ mock pytest-asyncio pytestCheckHook ];
+  propagatedBuildInputs = [ google_api_core libcst proto-plus ];
+
+  # Disable tests that require credentials
+  disabledTests = ["test_synthesize_speech" "test_list_voices"];
 
   meta = with stdenv.lib; {
     description = "Google Cloud Text-to-Speech API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-texttospeech";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_translate/default.nix
+++ b/pkgs/development/python-modules/google_cloud_translate/default.nix
@@ -1,12 +1,6 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, google_api_core
-, google_cloud_core
-, grpcio
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder
+, google_api_core, google_cloud_core, google_cloud_testutils, grpcio, libcst
+, mock, proto-plus, pytest-asyncio }:
 
 buildPythonPackage rec {
   pname = "google-cloud-translate";
@@ -17,18 +11,29 @@ buildPythonPackage rec {
     sha256 = "ecdea3e176e80f606d08c4c7fd5acea6b3dd960f4b2e9a65951aaf800350a759";
   };
 
-  # google_cloud_core[grpc] -> grpcio
-  propagatedBuildInputs = [ google_api_core google_cloud_core grpcio ];
+  disabled = pythonOlder "3.6";
 
-  checkInputs = [ pytest mock ];
-  checkPhase = ''
-    cd tests # prevent local google/__init__.py from getting loaded
-    pytest unit -k 'not extra_headers'
+  # google_cloud_core[grpc] -> grpcio
+  propagatedBuildInputs =
+    [ google_api_core google_cloud_core grpcio libcst proto-plus ];
+
+  checkInputs = [ google_cloud_testutils mock pytest-asyncio pytestCheckHook ];
+
+  # test_http.py broken, fix not yet released
+  # https://github.com/googleapis/python-translate/pull/69
+  disabledTests = [
+    "test_build_api_url_w_extra_query_params"
+    "test_build_api_url_no_extra_query_params"
+    "test_build_api_url_w_custom_endpoint"
+  ];
+
+  preCheck = ''
+    rm -r google
   '';
 
   meta = with stdenv.lib; {
     description = "Google Cloud Translation API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-translate";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/google_cloud_websecurityscanner/default.nix
+++ b/pkgs/development/python-modules/google_cloud_websecurityscanner/default.nix
@@ -1,10 +1,5 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, google_api_core
-, pytest
-, mock
-}:
+{ stdenv, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder
+, google_api_core, libcst, mock, proto-plus, pytest-asyncio }:
 
 buildPythonPackage rec {
   pname = "google-cloud-websecurityscanner";
@@ -15,16 +10,14 @@ buildPythonPackage rec {
     sha256 = "1de60f880487b898b499345f46f7acf38651f5356ebca8673116003a57f25393";
   };
 
-  checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ google_api_core ];
+  disabled = pythonOlder "3.6";
 
-  checkPhase = ''
-    pytest tests/unit
-  '';
+  checkInputs = [ mock pytest-asyncio pytestCheckHook ];
+  propagatedBuildInputs = [ google_api_core libcst proto-plus ];
 
   meta = with stdenv.lib; {
     description = "Google Cloud Web Security Scanner API client library";
-    homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
+    homepage = "https://github.com/googleapis/python-websecurityscanner";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/servers/sql/patroni/default.nix
+++ b/pkgs/servers/sql/patroni/default.nix
@@ -39,7 +39,7 @@ pythonPackages.buildPythonApplication rec {
   checkInputs = with pythonPackages; [
     flake8
     mock
-    pytest
+    pytestCheckHook
     pytestcov
     requests
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2468,6 +2468,8 @@ in {
 
   google_cloud_firestore = callPackage ../development/python-modules/google_cloud_firestore { };
 
+  google-cloud-iam = callPackage ../development/python-modules/google-cloud-iam { };
+
   google_cloud_iot = callPackage ../development/python-modules/google_cloud_iot { };
 
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };


### PR DESCRIPTION
###### Motivation for this change

Upgrades `google_auth`, fixes many Google Cloud packages. Will backport to 20.09 for ZHF.

https://hydra.nixos.org/build/127647323

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).