### PR TITLE
pythonPackages.hydrus: init at 413

### DIFF
--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -1,0 +1,112 @@
+{ stdenv
+, fetchFromGitHub
+, lzma
+, qt5
+, wrapQtAppsHook
+, miniupnpc_2
+, swftools
+, pythonPackages
+}:
+
+pythonPackages.buildPythonPackage {
+  pname = "hydrus";
+  version = "413";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "hydrusnetwork";
+    repo = "hydrus";
+    rev = "9fbed11bef499e01a6799b298bea7d0967d30430";
+    sha256 = "1dl7qpzmlxl376lzm0chmwvf4nl55wz6fwcsw0ikb33rm8r33gq4";
+  };
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+  ];
+
+  propagatedBuildInputs = with pythonPackages; [
+    beautifulsoup4
+    html5lib
+    lxml
+    numpy
+    opencv4
+    pillow
+    psutil
+    pyopenssl
+    pyyaml
+    requests
+    send2trash
+    service-identity
+    twisted
+    lz4
+    lzma
+    pysocks
+    matplotlib
+    qtpy
+    pyside2
+  ];
+
+  checkInputs = with pythonPackages; [ nose httmock ];
+
+  # most tests are failing, presumably because we are not using test.py
+  checkPhase = ''
+    nosetests $src/hydrus/test  \
+    -e TestClientAPI \
+    -e TestClientConstants \
+    -e TestClientDaemons \
+    -e TestClientData \
+    -e TestClientDB \
+    -e TestClientDBDuplicates \
+    -e TestClientDBTags \
+    -e TestClientImageHandling \
+    -e TestClientImportOptions \
+    -e TestClientListBoxes \
+    -e TestClientMigration \
+    -e TestClientNetworking \
+    -e TestClientTags \
+    -e TestClientThreading \
+    -e TestDialogs \
+    -e TestFunctions \
+    -e TestHydrusNATPunch \
+    -e TestHydrusSerialisable \
+    -e TestHydrusServer \
+    -e TestHydrusSessions \
+    -e TestServer \
+  '';
+
+  extraOutputsToLink = [ "doc" ];
+
+  postPatch = ''
+    sed 's;os\.path\.join(\sHC\.BIN_DIR,.*;"${miniupnpc_2}/bin/upnpc";' \
+      -i ./hydrus/core/HydrusNATPunch.py
+
+    sed 's;os\.path\.join(\sHC\.BIN_DIR,.*;"${swftools}/bin/swfrender";' \
+      -i ./hydrus/core/HydrusFlashHandling.py
+  '';
+
+  #doCheck = true;
+
+  installPhase = ''
+    # Move the hydrus module and related directories
+    mkdir -p $out/${pythonPackages.python.sitePackages}
+    mv {hydrus,static} $out/${pythonPackages.python.sitePackages}
+    mv help $out/doc/
+
+    # install the hydrus binaries
+    mkdir -p $out/bin
+    install -m0755 server.py $out/bin/hydrus-server
+    install -m0755 client.py $out/bin/hydrus-client
+  '';
+
+  dontWrapQtApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Danbooru-like image tagging and searching system for the desktop";
+    license = licenses.wtfpl;
+    homepage = "https://hydrusnetwork.github.io/hydrus/";
+    maintainers = [ maintainers.evanjs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20953,6 +20953,11 @@ in
 
   goffice = callPackage ../development/libraries/goffice { };
 
+  hydrus = python3Packages.callPackage ../applications/graphics/hydrus {
+    inherit miniupnpc_2 swftools;
+    inherit (qt5) wrapQtAppsHook;
+  };
+
   jetbrains = (recurseIntoAttrs (callPackages ../applications/editors/jetbrains {
     jdk = jetbrains.jdk;
   }) // {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
[Hydrus](https://github.com/hydrusnetwork/hydrus): "A personal booru-style media tagger that can import files and tags from your hard drive and popular websites. Content can be shared with other users via user-run servers."

#### Closes #96572
___
Related: <span><code><a href="https://github.com/Bionus/imgbrd-grabber">imgbrd-grabber</a></code></span> via #67632.

Basic navigation, settings changes, etc., can be tested by following the instructions [here](https://hydrusnetwork.github.io/hydrus/help/server.html).
I am able to run both the client and server, create an initial superuser account, and verify the connection via `services` -> `review services` -> `remote`
___

###### Things done
- Add `hydrus` to `pythonPackages`
- Add `hydrus` to `all-packages`
- Patch binaries (e.g. `swfrender`, etc. -- normally found in [bin](https://github.com/hydrusnetwork/hydrus/tree/4320d0ce95599d79f5c3475ea1c6329472bedc87/bin)) to use binaries sourced from `nixpkgs`
___
cc @deliciouslytyped @rendeko