### PR TITLE
[20.09] python{2,3}Packages.galario: 1.2.1 -> 1.2.2

### DIFF
--- a/pkgs/development/libraries/galario/default.nix
+++ b/pkgs/development/libraries/galario/default.nix
@@ -18,20 +18,20 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "galario";
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "mtazzari";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1akz7md7ly16a89zr880c265habakqdg9sj8iil90klqa0i21w6g";
+    sha256 = "0dw88ga50x3jwyfgcarn4azlhiarggvdg262hilm7rbrvlpyvha0";
   };
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ fftw fftwFloat ]
-    ++ stdenv.lib.optional enablePython pythonPackages.python
-    ++ stdenv.lib.optional stdenv.isDarwin llvmPackages.openmp
+  ++ stdenv.lib.optional enablePython pythonPackages.python
+  ++ stdenv.lib.optional stdenv.isDarwin llvmPackages.openmp
   ;
 
   propagatedBuildInputs = stdenv.lib.optional enablePython [
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     pythonPackages.pytest
   ];
 
-  checkInputs = stdenv.lib.optional enablePython pythonPackages.scipy;
+  checkInputs = stdenv.lib.optional enablePython [ pythonPackages.scipy pythonPackages.pytestcov ];
 
   preConfigure = ''
     mkdir -p build/external/src


### PR DESCRIPTION
Upgrading fixes the tests

(cherry picked from commit cbd37d0128e2647893705708a514d03cbe1873ff)

Backport https://github.com/NixOS/nixpkgs/pull/100767
ZHF: #97479
cc @NixOS/nixos-release-managers
fix https://hydra.nixos.org/build/127623662

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
