### PR TITLE
python3Packages.python-markdown-math: remove support for python 2.7

### DIFF
--- a/pkgs/development/python-modules/python-markdown-math/default.nix
+++ b/pkgs/development/python-modules/python-markdown-math/default.nix
@@ -2,11 +2,13 @@
 , buildPythonPackage
 , fetchPypi
 , markdown
+, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "python-markdown-math";
   version = "0.7";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
As stated in its changelog [1], python 2.7 is no longer supported.

[1] https://github.com/mitya57/python-markdown-math/blob/master/changelog#L4

ZHF: #97479
@NixOS/nixos-release-managers
Fixes https://hydra.nixos.org/build/127635267

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
