### PR TITLE
kwin: apply @tildearrow's low latency patch

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -12,7 +12,9 @@
   kcoreaddons, kcrash, kdeclarative, kdecoration, kglobalaccel, ki18n,
   kiconthemes, kidletime, kinit, kio, knewstuff, knotifications, kpackage,
   kscreenlocker, kservice, kwayland, kwidgetsaddons, kwindowsystem, kxmlgui,
-  plasma-framework, libcap, libdrm, mesa
+  plasma-framework, libcap, libdrm, mesa,
+  
+  lowLatencyPatch ? true, fetchpatch ? null
 }:
 
 # TODO (ttuegel): investigate qmlplugindump failure
@@ -37,7 +39,13 @@ mkDerivation {
   patches = [
     ./0001-follow-symlinks.patch
     ./0002-xwayland.patch
-  ];
+  ]++ lib.optional lowLatencyPatch (fetchpatch {
+    # WARNING: we can't depend the url on the version 
+    # so we must update this url+hash on plasma version update as described in
+    # "https://github.com/tildearrow/kwin-lowlatency#patch-format (branch depending on the Plasma version)
+    url = "https://tildearrow.zapto.org/storage/kwin-lowlatency/kwin-lowlatency-5.18.5-3.patch";
+    hash = "sha256-YsCgQxWduEpzUVMme0D4QQAEdSRs1+tiLEiZQVNgE00=";
+  });
   CXXFLAGS = [
     ''-DNIXPKGS_XWAYLAND=\"${lib.getBin xwayland}/bin/Xwayland\"''
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adapting my previous work in https://github.com/NixOS/nixpkgs/pull/89234 to Plasma 5.18
Fixes https://github.com/NixOS/nixpkgs/issues/85541
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
