### PR TITLE
soil: fix dead url, enable on darwin

### DIFF
--- a/pkgs/development/libraries/soil/default.nix
+++ b/pkgs/development/libraries/soil/default.nix
@@ -1,28 +1,45 @@
-{ stdenv, fetchurl, unzip, mesa, libX11, libGL }:
+{ stdenv, lib
+, Carbon
+, fetchzip
+, libGL
+, libX11
+}:
 
 stdenv.mkDerivation {
   name = "soil";
 
-  src = fetchurl {
-    url    = "http://www.lonesock.net/files/soil.zip";
-    sha256 = "00gpwp9dldzhsdhksjvmbhsd2ialraqbv6v6dpikdmpncj6mnc52";
+  src = fetchzip {
+    url = "https://web.archive.org/web/20200104042737id_/http://www.lonesock.net/files/soil.zip";
+    sha256 = "1c05nwbnfdgwaz8ywn7kg2xrcvrcbpdyhcfkkiiwk69zvil0pbgd";
   };
 
-  buildInputs = [ unzip mesa libGL libX11 ];
+  buildInputs = if stdenv.hostPlatform.isDarwin then [
+    Carbon
+  ] else [
+    libGL
+    libX11
+  ];
 
-  sourceRoot = "Simple OpenGL Image Library/projects/makefile";
-  preBuild   = "mkdir obj";
-  preInstall = "mkdir -p $out/lib $out/include";
-  makeFlags  = [ "LOCAL=$(out)" ];
+  buildPhase = ''
+    cd src
+    $CC $NIX_CFLAGS_COMPILE -c *.c
+    $AR rcs libSOIL.a *.o
+  '';
+  installPhase = ''
+    mkdir -p $out/lib $out/include/SOIL
+    cp libSOIL.a $out/lib/
+    cp SOIL.h $out/include/SOIL/
+  '';
 
-  meta = {
-    description     = "Simple OpenGL Image Library";
+  meta = with lib; {
+    description = "Simple OpenGL Image Library";
     longDescription = ''
       SOIL is a tiny C library used primarily for uploading textures
       into OpenGL.
     '';
-    homepage  = "https://www.lonesock.net/soil.html";
-    license   = stdenv.lib.licenses.publicDomain;
-    platforms = stdenv.lib.platforms.linux;
+    homepage = "https://www.lonesock.net/soil.html";
+    license = licenses.publicDomain;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ r-burns ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15704,7 +15704,9 @@ in
 
   sofia_sip = callPackage ../development/libraries/sofia-sip { };
 
-  soil = callPackage ../development/libraries/soil { };
+  soil = callPackage ../development/libraries/soil {
+    inherit (darwin.apple_sdk.frameworks) Carbon;
+  };
 
   sonic = callPackage ../development/libraries/sonic { };
 


### PR DESCRIPTION
Added myself as a maintainer as this appears to be orphaned.

~~The new github source appears to be the most popular mirror, and has a number of bugfixes along with a more sophisticated cmake build system which works on macos with no modifications.~~

The only dependee is already marked as broken, but I've successfully used this in another package I'm hacking on.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
