### PR TITLE
nixos/kresd: Listen on IPv4 wildcard, too

### DIFF
--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -15,7 +15,7 @@ let
       (throw "services.kresd.*: incorrect address specification '${addr}'")
       [ al_v4 al_v6 al_portOnly ];
     port = last al;
-    addrSpec = if al_portOnly == null then "'${head al}'" else "{'::', '127.0.0.1'}";
+    addrSpec = if al_portOnly == null then "'${head al}'" else "{'::', '0.0.0.0'}";
     in # freebind is set for compatibility with earlier kresd services;
        # it could be configurable, for example.
       ''


### PR DESCRIPTION
If only a port is specified in listen{Plain,TLS,DoH} option, kresd will now listen on IPv4 and IPv6 wildcard.

###### Motivation for this change

As specified here (https://github.com/CZ-NIC/knot-resolver/blob/d5fc45b3ac2aec9aba82c9b4868dc52a4ccbf026/daemon/io.c#L137) kresd 5.x will listen to IPv6 only, if a IPv6 address is specified in the `net.listen` directive.

Listening on IPv6 wildcard and IPv4 localhost looks like a mistake to me.
In addition, the current behavior tries to mimic the syntax of systemd.socket(5) `ListenStream` directive.
While the default for a port-only configuration depends on `/proc/sys/net/ipv6/bindv6only`, assuming this to be false seem fair to me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
