### PR TITLE
lcms2: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/lcms2/default.nix
+++ b/pkgs/development/libraries/lcms2/default.nix
@@ -12,6 +12,9 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ libtiff libjpeg zlib ];
 
+  # See https://trac.macports.org/ticket/60656
+  LDFLAGS = if stdenv.hostPlatform.isDarwin then "-Wl,-w" else null;
+
   meta = with stdenv.lib; {
     description = "Color management engine";
     homepage = "http://www.littlecms.com/";


### PR DESCRIPTION
This is the same workaround used by macports, see https://github.com/macports/macports-ports/commit/879d4b1e4ca86d268f5082449ab8cbe7d8237d4e

###### Motivation for this change

ZHF 20.09 https://github.com/NixOS/nixpkgs/issues/97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
