### PR TITLE
gfan: fix build failures with cddlib v0.94l

### DIFF
--- a/pkgs/applications/science/math/gfan/default.nix
+++ b/pkgs/applications/science/math/gfan/default.nix
@@ -8,11 +8,15 @@ stdenv.mkDerivation rec {
     sha256 = "02pihqb1lb76a0xbfwjzs1cd6ay3ldfxsm8dvsbl6qs3vkjxax56";
   };
 
-  patchPhase = stdenv.lib.optionalString stdenv.cc.isClang ''
+  patches = [
+    ./gfan-0.6.2-cddlib-prefix.patch
+  ];
+
+  postPatch = stdenv.lib.optionalString stdenv.cc.isClang ''
     substituteInPlace Makefile --replace "-fno-guess-branch-probability" ""
   '';
 
-  buildFlags = [ "CC=cc" "CXX=c++" "cddnoprefix=1" ];
+  buildFlags = [ "CC=cc" "CXX=c++" ];
   installFlags = [ ''PREFIX=$(out)'' ];
   buildInputs = [ gmp mpir cddlib ];
 

--- a/pkgs/applications/science/math/gfan/gfan-0.6.2-cddlib-prefix.patch
+++ b/pkgs/applications/science/math/gfan/gfan-0.6.2-cddlib-prefix.patch
@@ -1,0 +1,55 @@
+diff -ru gfan0.6.2.orig/src/app_librarytest.cpp gfan0.6.2/src/app_librarytest.cpp
+--- gfan0.6.2.orig/src/app_librarytest.cpp	2020-10-19 08:41:27.981863500 +0900
++++ gfan0.6.2/src/app_librarytest.cpp	2020-10-19 08:42:44.551863500 +0900
+@@ -12,8 +12,8 @@
+ #include "setoper.h"
+ #include "cdd.h"
+ #else
+-#include "cdd/setoper.h"
+-#include "cdd/cdd.h"
++#include "cddlib/setoper.h"
++#include "cddlib/cdd.h"
+ #endif
+ #include <iostream>
+ #include <fstream>
+diff -ru gfan0.6.2.orig/src/gfanlib_zcone.cpp gfan0.6.2/src/gfanlib_zcone.cpp
+--- gfan0.6.2.orig/src/gfanlib_zcone.cpp	2020-10-19 08:41:27.981863500 +0900
++++ gfan0.6.2/src/gfanlib_zcone.cpp	2020-10-19 08:42:44.571863500 +0900
+@@ -16,8 +16,8 @@
+ #include "setoper.h"
+ #include "cdd.h"
+ #else
+-#include "cdd/setoper.h"
+-#include "cdd/cdd.h"
++#include "cddlib/setoper.h"
++#include "cddlib/cdd.h"
+ #endif
+ //}
+ 
+@@ -52,8 +52,8 @@
+ 				  "dd_free_global_constants()\n"
+ 				  "in your deinitialisation code (only available for cddlib version>=094d).\n"
+ 				  "This requires the header includes:\n"
+-				  "#include \"cdd/setoper.h\"\n"
+-				  "#include \"cdd/cdd.h\"\n"
++				  "#include \"cddlib/setoper.h\"\n"
++				  "#include \"cddlib/cdd.h\"\n"
+ 				  "\n"
+ 				  "Alternatively, you may call gfan:initializeCddlibIfRequired() and deinitializeCddlibIfRequired()\n"
+ 				  "if gfanlib is the only code using cddlib. If at some point cddlib is no longer required by gfanlib\n"
+diff -ru gfan0.6.2.orig/src/lp_cdd.cpp gfan0.6.2/src/lp_cdd.cpp
+--- gfan0.6.2.orig/src/lp_cdd.cpp	2020-10-19 08:41:27.991863500 +0900
++++ gfan0.6.2/src/lp_cdd.cpp	2020-10-19 08:42:44.571863500 +0900
+@@ -5,9 +5,9 @@
+ #include "cdd.h"
+ #include "cdd_f.h"
+ #else
+-#include "cdd/setoper.h"
+-#include "cdd/cdd.h"
+-#include "cdd/cdd_f.h"
++#include "cddlib/setoper.h"
++#include "cddlib/cdd.h"
++#include "cddlib/cdd_f.h"
+ #endif
+ //}
+ #include "termorder.h"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This change fixes https://github.com/NixOS/nixpkgs/issues/100622.

 Some of the tests in `sage-tests` fail on my machine, though it is still an improvement toward making Sage latest and working.
> 2 packages failed to build:
> sage sageWithDoc
>
> 1 package built:
> gfan

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
