### PR TITLE
[20.09] python3Packages.pyhaversion: add missing semantic-version

### DIFF
--- a/pkgs/development/python-modules/pyhaversion/default.nix
+++ b/pkgs/development/python-modules/pyhaversion/default.nix
@@ -5,6 +5,7 @@
 # propagatedBuildInputs
 , aiohttp
 , async-timeout
+, semantic-version
 # buildInputs
 , pytestrunner
 # checkInputs
@@ -27,6 +28,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     aiohttp
     async-timeout
+    semantic-version
   ];
 
   buildInputs = [


### PR DESCRIPTION
(cherry picked from commit 92bf2d7c03f0d93334b229e612f9f365a7db72b2)

###### Motivation for this change

ZHF: #97479
backport of #97578

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip -b release-20.09"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - (there are none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  - :x: `meta.license` is not set
  - :thinking: a verb seems to be missing in `meta.description`:
    > A python module to the newest version number of Home Assistant

    although that [matches the upstream README](https://github.com/ludeeus/pyhaversion/blob/3.3.0/README.md#pyhaversion-), it should maybe be
    > A python module to __determine__ the newest version number of Home Assistant

    or similar?