### PR TITLE
imgbrd-grabber: init at 7.3.2

### DIFF
--- a/pkgs/applications/graphics/imgbrd-grabber/default.nix
+++ b/pkgs/applications/graphics/imgbrd-grabber/default.nix
@@ -1,50 +1,87 @@
 { stdenv
 , cmake
-, fetchzip
-, openssl
-, autoPatchelfHook
-, makeWrapper
-, qtmultimedia
+, fetchFromGitHub
 , wrapQtAppsHook
+, qtmultimedia
+, qttools
+, qtscript
+, qtdeclarative
+, qtbase
+, autogen
+, automake
+, makeWrapper
+, catch2
+, nodejs
+, libpulseaudio
+, openssl
+, rsync
+, typescript
 }:
 stdenv.mkDerivation rec {
   name = "imgbrd-grabber";
+
   version = "7.3.2";
+  src = fetchFromGitHub {
+    owner = "Bionus";
+    repo = "imgbrd-grabber";
+    rev = "v${version}";
+    sha256 = "053rwvcr88fcba0447a6r115cgnqsm9rl066z8d5jacqnhdij58k";
+    fetchSubmodules = true;
+  };
 
   buildInputs = [
-    stdenv.cc.cc.lib
     openssl
-    qtmultimedia
+    makeWrapper
+    libpulseaudio
+    typescript
   ];
 
   nativeBuildInputs = [
-    autoPatchelfHook
-    makeWrapper
+    qtmultimedia
+    qtbase
+    qtdeclarative
+    qttools
+    nodejs
+    cmake
     wrapQtAppsHook
   ];
 
-  installPhase = ''
-    mkdir -p $out/share/grabber
-    cp -R * $out/share/grabber
+  extraOutputsToLink = [ "doc" ];
 
-    mkdir -p $out/bin
-    ln -s $out/share/grabber/Grabber /$out/bin/grabber
+  postPatch = ''
+    # the package.sh script provides some install helpers
+    # using this might make it easier to maintain/less likely for the
+    # install phase to fail across version bumps
+    patchShebangs ./scripts/package.sh
 
-    mkdir -p $out/share/applications
-    mv $out/share/grabber/Grabber.desktop $out/share/applications/
+    # ensure the script uses the rsync package from nixpkgs
+    substituteInPlace ../scripts/package.sh --replace "rsync" "${rsync}/bin/rsync"
 
+
+    # the npm build step only runs typescript
+    # run this step directly so it doesn't try and fail to download the unnecessary node_modules, etc.
+    substituteInPlace ./sites/CMakeLists.txt --replace "npm install" "npm run build"
+
+    # remove the vendored catch2
+    rm -rf tests/src/vendor/catch
+
+    # link the catch2 sources from nixpkgs
+    ln -sf ${catch2.src} tests/src/vendor/catch
   '';
 
-  src = fetchzip {
-    url = "https://github.com/Bionus/imgbrd-grabber/releases/download/v${version}/Grabber_v${version}.tar.gz";
-    sha256 = "05isnqhvcp8ycaj8hx6wn0c3la729mb36dzpmlpxfb1p5dj8p49k";
-  };
+  postInstall = ''
+    # move the binaries to the share/Grabber folder so 
+    # some relative links can be resolved (e.g. settings.ini)
+    mv $out/bin/* $out/share/Grabber/
+    
+    cd ../..
+    # run the package.sh with $out/share/Grabber as the $APP_DIR 
+    sh ./scripts/package.sh $out/share/Grabber
 
-  meta = with stdenv.lib; {
-    homepage = "https://github.com/Bionus/imgbrd-grabber";
-    description = "Very customizable imageboard/booru downloader with powerful filenaming features.";
-    license = licenses.asl20;
-    platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ evanjs ];
-  };
+    # add symlinks for the binaries to $out/bin
+    ln -s $out/share/Grabber/Grabber $out/bin/Grabber
+    ln -s $out/share/Grabber/Grabber-cli $out/bin/Grabber-cli
+  '';
+
+  sourceRoot = "source/src";
 }

--- a/pkgs/applications/graphics/imgbrd-grabber/default.nix
+++ b/pkgs/applications/graphics/imgbrd-grabber/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
     mv $out/bin/* $out/share/Grabber/
 
     cd ../..
-    # run the package.sh with $out/share/Grabber as the $APP_DIR 
+    # run the package.sh with $out/share/Grabber as the $APP_DIR
     sh ./scripts/package.sh $out/share/Grabber
 
     # add symlinks for the binaries to $out/bin

--- a/pkgs/applications/graphics/imgbrd-grabber/default.nix
+++ b/pkgs/applications/graphics/imgbrd-grabber/default.nix
@@ -70,10 +70,10 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    # move the binaries to the share/Grabber folder so 
+    # move the binaries to the share/Grabber folder so
     # some relative links can be resolved (e.g. settings.ini)
     mv $out/bin/* $out/share/Grabber/
-    
+
     cd ../..
     # run the package.sh with $out/share/Grabber as the $APP_DIR 
     sh ./scripts/package.sh $out/share/Grabber

--- a/pkgs/applications/graphics/imgbrd-grabber/default.nix
+++ b/pkgs/applications/graphics/imgbrd-grabber/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, cmake
+, fetchzip
+, openssl
+, autoPatchelfHook
+, makeWrapper
+, qtmultimedia
+, wrapQtAppsHook
+}:
+stdenv.mkDerivation rec {
+  name = "imgbrd-grabber";
+  version = "7.3.2";
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    openssl
+    qtmultimedia
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+    wrapQtAppsHook
+  ];
+
+  installPhase = ''
+    mkdir -p $out/share/grabber
+    cp -R * $out/share/grabber
+
+    mkdir -p $out/bin
+    ln -s $out/share/grabber/Grabber /$out/bin/grabber
+
+    mkdir -p $out/share/applications
+    mv $out/share/grabber/Grabber.desktop $out/share/applications/
+
+  '';
+
+  src = fetchzip {
+    url = "https://github.com/Bionus/imgbrd-grabber/releases/download/v${version}/Grabber_v${version}.tar.gz";
+    sha256 = "05isnqhvcp8ycaj8hx6wn0c3la729mb36dzpmlpxfb1p5dj8p49k";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Bionus/imgbrd-grabber";
+    description = "Very customizable imageboard/booru downloader with powerful filenaming features.";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ evanjs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21429,7 +21429,7 @@ in
 
   img2pdf = with python3Packages; toPythonApplication img2pdf;
 
-  imgbrd-grabber = qt5.callPackage ../applications/graphics/imgbrd-grabber/default.nix { 
+  imgbrd-grabber = qt5.callPackage ../applications/graphics/imgbrd-grabber/default.nix {
     typescript = nodePackages.typescript;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21429,6 +21429,8 @@ in
 
   img2pdf = with python3Packages; toPythonApplication img2pdf;
 
+  imgbrd-grabber = qt5.callPackage ../applications/graphics/imgbrd-grabber { };
+
   imgcat = callPackage ../applications/graphics/imgcat { };
 
   imgp = python3Packages.callPackage ../applications/graphics/imgp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21429,7 +21429,9 @@ in
 
   img2pdf = with python3Packages; toPythonApplication img2pdf;
 
-  imgbrd-grabber = qt5.callPackage ../applications/graphics/imgbrd-grabber { };
+  imgbrd-grabber = qt5.callPackage ../applications/graphics/imgbrd-grabber/default.nix { 
+    typescript = nodePackages.typescript;
+  };
 
   imgcat = callPackage ../applications/graphics/imgcat { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
[imgbrd-grabber](https://github.com/Bionus/imgbrd-grabber): "Very customizable imageboard/booru downloader with powerful filenaming features."
#### Closes #67632
Can be sourced by [Hydrus](https://github.com/hydrusnetwork/hydrus) once #101034 is merged.  

###### Things Done
I only considered the Linux application but I doubt it would be much work to get things working on macOS.

###### Notes
~I initially tried to build from source, but the build uses `npm install` for [sites module](https://github.com/Bionus/imgbrd-grabber/tree/d21116ba83096d37cbe7d3b7d620dd7e10d73cfc/src/sites).~
~Additionally, the <span><code><a href="https://github.com/Bionus/imgbrd-grabber/blob/d21116ba83096d37cbe7d3b7d620dd7e10d73cfc/src/sites/package.json">package.json</a></code></span> does not contain a `version` (required for [node2nix](https://github.com/svanderburg/node2nix)), so I settled on packaging the binary application for now.~
#### Update:
I have pushed an expression that builds the application from source.

___

#### Bugs
With `7.3.2`, `Grabber-cli` crashes when used.
This is solved by https://github.com/Bionus/imgbrd-grabber/commit/3814631c0c332970330475450d64fc3de70c7e81.
This has not yet been merged, and the patch does not apply cleanly on top of `7.3.2`.
For more information, see the [issue](https://github.com/Bionus/imgbrd-grabber/issues/2094).

___
cc @klorophatu @toyo-chi @hyarsan @deliciouslytyped 
