### PR TITLE
goreleaser: init at 0.145.0

### DIFF
--- a/pkgs/tools/misc/goreleaser/default.nix
+++ b/pkgs/tools/misc/goreleaser/default.nix
@@ -2,23 +2,32 @@
 
 buildGoModule rec {
   pname = "goreleaser";
-  version = "0.132.0";
+  version = "0.145.0";
 
   src = fetchFromGitHub {
     owner = "goreleaser";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1iwxlvwsmasp8gq1yh84hl9rys0hgm9fwpmsqh2mx9ln4prm7sgq";
+    sha256 = "1w2mbyywr3zsn068cshkx502x0zrxrbrgaw23x4spfri0nk6v4fd";
   };
 
-  modSha256 = "0a4qr8xsi4szggvzapw2ljvvvqjbyi15i4mi8myfhknlpxf65kcl";
+  vendorSha256 = "0drk58bhcvx75cd6s0xnyh6swph1vlvpzp2nngr7agvjdcrbady6";
 
-  buildFlagsArray = [ "-ldflags=-s -w -X main.version=${version}" ];
+  buildFlagsArray = [
+    "-ldflags="
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+    "-X main.builtBy=nixpkgs"
+  ];
+
+  # tests expect the source files to be a build repo
+  doCheck = false;
 
   meta = with lib; {
     description = "Deliver Go binaries as fast and easily as possible";
     homepage = "https://goreleaser.com";
-    maintainers = [ maintainers.c0deaddict ];
+    maintainers = with maintainers; [ c0deaddict sarcasticadmin ];
     license = licenses.mit;
   };
 }

--- a/pkgs/tools/misc/goreleaser/default.nix
+++ b/pkgs/tools/misc/goreleaser/default.nix
@@ -27,7 +27,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "Deliver Go binaries as fast and easily as possible";
     homepage = "https://goreleaser.com";
-    maintainers = with maintainers; [ c0deaddict sarcasticadmin ];
+    maintainers = with maintainers; [ c0deaddict endocrimes sarcasticadmin ];
     license = licenses.mit;
   };
 }

--- a/pkgs/tools/misc/goreleaser/default.nix
+++ b/pkgs/tools/misc/goreleaser/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "goreleaser";
+  version = "0.132.0";
+
+  src = fetchFromGitHub {
+    owner = "goreleaser";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1iwxlvwsmasp8gq1yh84hl9rys0hgm9fwpmsqh2mx9ln4prm7sgq";
+  };
+
+  modSha256 = "0a4qr8xsi4szggvzapw2ljvvvqjbyi15i4mi8myfhknlpxf65kcl";
+
+  buildFlagsArray = [ "-ldflags=-s -w -X main.version=${version}" ];
+
+  meta = with lib; {
+    description = "Deliver Go binaries as fast and easily as possible";
+    homepage = "https://goreleaser.com";
+    maintainers = [ maintainers.c0deaddict ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4143,6 +4143,8 @@ in
 
   gopro = callPackage ../tools/video/gopro { };
 
+  goreleaser = callPackage ../tools/misc/goreleaser { };
+
   goreplay = callPackage ../tools/networking/goreplay { };
 
   gource = callPackage ../applications/version-management/gource { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Currently leveraging `goreleaser` for releasing go tools.

Pigging backing initial work from https://github.com/NixOS/nixpkgs/pull/82986 but it looks like its outdated. @c0deaddict FYI

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
