### PR TITLE
ocamlPackages.google-drive-ocamlfuse: 0.7.21 → 0.7.22

### DIFF
--- a/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
+++ b/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
@@ -1,25 +1,27 @@
-{ stdenv, buildDunePackage, fetchFromGitHub
-, ocamlfuse, gapi_ocaml, ocaml_sqlite3
+{ lib, buildDunePackage, fetchFromGitHub
+, ocaml_extlib, ocamlfuse, gapi_ocaml, ocaml_sqlite3
 }:
 
 buildDunePackage rec {
   pname = "google-drive-ocamlfuse";
-  version = "0.7.21";
+  version = "0.7.22";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "astrada";
     repo = "google-drive-ocamlfuse";
     rev = "v${version}";
-    sha256 = "0by3qnjrr1mbxyl2n99zggx8dxnqlicsq2b2hhhxb2d0k8qn47sw";
+    sha256 = "027j1r2iy8vnbqs8bv893f0909yk5312ki5p3zh2pdz6s865h750";
   };
 
-  buildInputs = [ ocamlfuse gapi_ocaml ocaml_sqlite3 ];
+  buildInputs = [ ocaml_extlib ocamlfuse gapi_ocaml ocaml_sqlite3 ];
 
   meta = {
-    homepage = "http://gdfuse.forge.ocamlcore.org/";
+    inherit (src.meta) homepage;
     description = "A FUSE-based file system backed by Google Drive, written in OCaml";
-    license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ obadz ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ obadz ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Bug fix release: https://github.com/astrada/google-drive-ocamlfuse/releases/tag/v0.7.22

cc maintainer @obadz 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
