### PR TITLE
relibc: fix for nix 3.0

### DIFF
--- a/pkgs/development/libraries/relibc/default.nix
+++ b/pkgs/development/libraries/relibc/default.nix
@@ -7,10 +7,10 @@ let
   ];
   bootstrapCrossRust = stdenvNoCC.mkDerivation {
     name = "binary-redox-rust";
-    
+
     src = fetchTarball {
-      name = "redox-rust-toolchain-bin.tar.gz";
-      url = "https://www.dropbox.com/s/33r92en0t47l1ei/redox-rust-toolchain-bin.tar.gz?dl=1";
+      name = "redox-rust-toolchain.tar.gz";
+      url = "https://www.dropbox.com/s/qt7as0j7cwnin8z/redox-rust-toolchain.tar.gz?dl=1";
       sha256 = "1g17qp2q6b88p04yclkw6amm374pqlakrmw9kd86vw8z4g70jkxm";
     };
 

--- a/pkgs/development/libraries/relibc/default.nix
+++ b/pkgs/development/libraries/relibc/default.nix
@@ -8,7 +8,7 @@ let
   bootstrapCrossRust = stdenvNoCC.mkDerivation {
     name = "binary-redox-rust";
 
-    src = fetchTarball {
+    src = buildPackages.fetchzip {
       name = "redox-rust-toolchain.tar.gz";
       url = "https://www.dropbox.com/s/qt7as0j7cwnin8z/redox-rust-toolchain.tar.gz?dl=1";
       sha256 = "1g17qp2q6b88p04yclkw6amm374pqlakrmw9kd86vw8z4g70jkxm";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes error when using Nix 3.0:
```
[nix-shell:~/redoxpkgs]$ nix-build . -A redox-vm
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------- nix-build
tarball 'https://www.dropbox.com/s/33r92en0t47l1ei/redox-rust-toolchain-bin.tar.gz?dl=1' contains an unexpected number of top-level files
(use '--show-trace' to show detailed location information)
```

Ping for @jD91mZM2 who spotted this.

P.S. I love the new Nix error reporting features!

###### Things done

The toolchain tarball now extracts to one folder with all of the original folders inside of that. Note that the sha256 sum has not changed.

Once this and #95542 are merged, official nixpkgs plus overlay will be enough to build an entire Redox OS image that boots with Nixpkgs packages pre-installed into the $PATH.

Next step after that is hosting this bootstrapping binary toolchain somewhere more official.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
