### PR TITLE
coq: also install ocaml and findlib

### DIFF
--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -109,7 +109,7 @@ self = stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ]
   ++ stdenv.lib.optional (!versionAtLeast "8.6") gnumake42
   ;
-  buildInputs = [ ncurses ocamlPackages.ocaml ocamlPackages.findlib ]
+  buildInputs = [ ncurses ]
   ++ stdenv.lib.optional (!versionAtLeast "8.10") ocamlPackages.camlp5
   ++ stdenv.lib.optional (!versionAtLeast "8.12") ocamlPackages.num
   ++ stdenv.lib.optionals buildIde
@@ -117,7 +117,10 @@ self = stdenv.mkDerivation {
      then [ ocamlPackages.lablgtk3-sourceview3 glib gnome3.defaultIconTheme wrapGAppsHook ]
      else [ ocamlPackages.lablgtk ]);
 
-  propagatedBuildInputs = stdenv.lib.optional (versionAtLeast "8.12") ocamlPackages.num;
+  propagatedBuildInputs = [ ocamlPackages.ocaml ocamlPackages.findlib ]
+    ++ stdenv.lib.optional (versionAtLeast "8.12") ocamlPackages.num;
+
+  propagatedUserEnvPkgs = [ ocamlPackages.ocaml ocamlPackages.findlib ];
 
   postPatch = ''
     UNAME=$(type -tp uname)


### PR DESCRIPTION
###### Motivation for this change

Fix #34657.

`native_compute` does not work without OCaml and findlib being installed in the user environment.
By installing more packages, this may create installation conflicts, but I argued (in #34657) that these conflicts are fine because if a user has an incompatible OCaml version in scope, they may face even more surprising issues when trying to use `native_compute` or to build a plugin.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
