### PR TITLE
julia-mono: 0.018 -> 0.022

### DIFF
--- a/pkgs/data/fonts/julia-mono/default.nix
+++ b/pkgs/data/fonts/julia-mono/default.nix
@@ -1,14 +1,14 @@
 { lib, fetchzip }:
 
 let
-  version = "0.018";
+  version = "0.022";
 in fetchzip {
   name = "JuliaMono-${version}";
   url = "https://github.com/cormullion/juliamono/releases/download/v${version}/JuliaMono.zip";
-  sha256 = "0ss79a9gymbhih5pgjkg1mipmk0qsvqqwlkqcdm9fz87d7kfhby3";
+  sha256 = "1v4a9qbvjlszamvqrj0g65z1nhahfmf1fzkgjwzkmsrdqn909dic";
 
   postFetch = ''
-    mkdir -p $out/share/fonts
+    mkdir -p $out/share/fonts/truetype
     unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
   '';
 


### PR DESCRIPTION
#### Motivation for this change

Rebase of https://github.com/NixOS/nixpkgs/pull/100386.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
