### PR TITLE
pythonPackages.pysychonaut: init at 0.6.0

### DIFF
--- a/pkgs/development/python-modules/pysychonaut/default.nix
+++ b/pkgs/development/python-modules/pysychonaut/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchPypi, requests, requests-cache, beautifulsoup4 }:
+
+buildPythonPackage rec {
+  pname = "PySychonaut";
+  version = "0.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wgk445gmi0x7xmd8qvnyxy1ka0n72fr6nrhzdm29q6687dqyi7h";
+  };
+
+  preConfigure = ''
+    substituteInPlace setup.py --replace "bs4" "beautifulsoup4"
+  '';
+
+  propagatedBuildInputs = [ requests requests-cache beautifulsoup4 ];
+
+  # No tests available
+  doCheck = false;
+  pythonImportsCheck = [ "pysychonaut" ];
+
+  meta = with lib; {
+    description = "Unofficial python api for Erowid, PsychonautWiki and AskTheCaterpillar";
+    homepage = "https://github.com/OpenJarbas/PySychonaut";
+    maintainers = [ maintainers.ivar ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5472,6 +5472,8 @@ in {
 
   pysvn = callPackage ../development/python-modules/pysvn { };
 
+  pysychonaut = callPackage ../development/python-modules/pysychonaut { };
+
   pytabix = callPackage ../development/python-modules/pytabix { };
 
   pytado = callPackage ../development/python-modules/pytado { };


### PR DESCRIPTION
##### Motivation for this change

Fairly simple package addition. 

Result of `nixpkgs-review pr 101063` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>python27Packages.pysychonaut</li>
    <li>python37Packages.pysychonaut</li>
    <li>python38Packages.pysychonaut</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
