### PR TITLE
onefetch: 2.4.0 -> 2.5.0

### DIFF
--- a/pkgs/tools/misc/onefetch/default.nix
+++ b/pkgs/tools/misc/onefetch/default.nix
@@ -3,16 +3,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "onefetch";
-  version = "2.4.0";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "o2sh";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-3bERQ480SuvrjyqlBd9wnE4iIJAbN8HODUj0X+Uxrvs=";
+    sha256 = "sha256-F1NbzcMoct0mjWKY2itz4cBqVToY7HpoaRzk3l683fY=";
   };
 
-  cargoSha256 = "sha256-Bq2ytwbdhYeXIUM4tYSfUamhckraH5w34sAQ96ayJxI=";
+  cargoSha256 = "sha256-eBY+34VEPEAv5bqerxR3i7cJrVb1GtvmWyrM7uuef2E=";
 
   buildInputs = with stdenv;
     lib.optionals isDarwin [ CoreFoundation libiconv libresolv Security ];


### PR DESCRIPTION
###### Motivation for this change
update to 2.5.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
