### PR TITLE
numix-solarized-gtk-theme: 20180913 -> 20200910

### DIFF
--- a/pkgs/data/themes/numix-solarized/default.nix
+++ b/pkgs/data/themes/numix-solarized/default.nix
@@ -1,33 +1,29 @@
-{ stdenv, fetchFromGitHub, python3, sass, glib, gdk-pixbuf, libxml2,
-  inkscape, optipng, gtk-engine-murrine
-}:
+{ stdenv, fetchFromGitHub, python3, sassc, glib, gdk-pixbuf, inkscape, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
-  version = "20180913";
+  version = "20200910";
   pname = "numix-solarized-gtk-theme";
 
   src = fetchFromGitHub {
     owner = "Ferdi265";
     repo = "numix-solarized-gtk-theme";
     rev = version;
-    sha256 = "1kda0lyqi3cxh163fbj8yyi6jj6pf0y980k4s0cmyi3hkh4cqyd5";
+    sha256 = "05h1563sy6sfz76jadxsf730mav6bbjsk9xnadv49r16b8n8p9a9";
   };
 
-  nativeBuildInputs = [ python3 sass glib gdk-pixbuf libxml2 inkscape optipng ];
+  nativeBuildInputs = [ python3 sassc glib gdk-pixbuf inkscape ];
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
   postPatch = ''
     patchShebangs .
     substituteInPlace Makefile --replace '$(DESTDIR)'/usr $out
-    substituteInPlace scripts/render-assets.sh \
-      --replace /usr/bin/inkscape ${inkscape}/bin/inkscape \
-      --replace /usr/bin/optipng ${optipng}/bin/optipng
   '';
 
   buildPhase = "true";
 
   installPhase = ''
+    HOME="$NIX_BUILD_ROOT"  # shut up inkscape's warnings
     for theme in *.colors; do
       make THEME="''${theme/.colors/}" install
     done


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [20200910](https://github.com/Ferdi265/numix-solarized-gtk-theme/releases/tag/20200910)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
