### PR TITLE
[20.09] kdeFrameworks.plasma-framework: aligned with QtQuick 2.12

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/plasma-framework.nix
+++ b/pkgs/development/libraries/kde-frameworks/plasma-framework.nix
@@ -18,4 +18,10 @@ mkDerivation {
     qtquickcontrols2
   ];
   propagatedBuildInputs = [ kpackage kservice qtbase ];
+  # align QtQuick usage with qt5.12, otherwise it will be unable to find certain components
+  # see https://github.com/NixOS/nixpkgs/issues/98536
+  postPatch = ''
+    substituteInPlace src/declarativeimports/plasmaextracomponents/qml/ExpandableListItem.qml \
+      --replace "import QtQuick 2.14" "import QtQuick 2.12"
+  '';
 }


### PR DESCRIPTION
###### Motivation for this change
A less invasive remedy for #98536

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
