### PR TITLE
haskellPackages.hindent: unbreak by fetching more recent source

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1323,10 +1323,6 @@ self: super: {
   trial = doJailbreak super.trial;
 
   # 2020-06-24: Tests are broken in hackage distribution.
-  # See: https://github.com/kowainik/stan/issues/316
-  stan = dontCheck super.stan;
-
-  # 2020-06-24: Tests are broken in hackage distribution.
   # See: https://github.com/robstewart57/rdf4h/issues/39
   rdf4h = dontCheck super.rdf4h;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -630,6 +630,9 @@ self: super: {
 
   # Make elisp files available at a location where people expect it.
   hindent = (overrideCabal super.hindent (drv: {
+    # 2020-10-19: needs MonadFail fix, see https://github.com/mihaimaruseac/hindent/issues/570
+    patches = [ ./patches/hindent-monadfail.patch ];
+
     # We cannot easily byte-compile these files, unfortunately, because they
     # depend on a new version of haskell-mode that we don't have yet.
     postInstall = ''
@@ -637,7 +640,6 @@ self: super: {
       mkdir -p $data/share/emacs
       ln -s $lispdir $data/share/emacs/site-lisp
     '';
-    doCheck = false; # https://github.com/chrisdone/hindent/issues/299
   }));
 
   # https://github.com/bos/configurator/issues/22

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1481,6 +1481,9 @@ self: super: {
   # stack-2.5.1 needs a more current version of pantry to compile
   pantry = self.pantry_0_5_1_3;
 
+  # Too tight version bounds, see https://github.com/haskell-hvr/microaeson/pull/4
+  microaeson = doJailbreak super.microaeson;
+
   # haskell-language-server needs a more current version of pantry to compile
 } // (let
   inherit (self) hls-ghcide hls-brittany;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -43,4 +43,44 @@ self: super: {
   unix = null;
   xhtml = null;
 
+  # Take the 3.4.x release candidate.
+  cabal-install = assert super.cabal-install.version == "3.2.0.0";
+                  overrideCabal super.cabal-install (drv: {
+    postUnpack = "sourceRoot+=/cabal-install; echo source root reset to $sourceRoot";
+    version = "cabal-install-3.4.0.0-rc4";
+    editedCabalFile = null;
+    src = pkgs.fetchgit {
+      url = "git://github.com/haskell/cabal.git";
+      rev = "cabal-install-3.4.0.0-rc4";
+      sha256 = "049hllk1d8jid9yg70hmcsdgb0n7hm24p39vavllaahfb0qfimrk";
+    };
+  });
+
+  # Jailbreaks!
+  dec = doJailbreak super.dec;
+  ed25519 = doJailbreak super.ed25519;
+  integer-logarithms = overrideCabal (doJailbreak super.integer-logarithms) (drv: { postPatch = "sed -i -e 's,integer-gmp <1.1,integer-gmp < 2,' integer-logarithms.cabal"; });
+  parallel = doJailbreak super.parallel;
+  primitive = doJailbreak super.primitive_0_7_1_0;
+  regex-posix = doJailbreak super.regex-posix;
+  singleton-bool = doJailbreak super.singleton-bool;
+  tar = doJailbreak super.tar;
+  th-abstraction = self.th-abstraction_0_4_0_0;
+  zlib = doJailbreak super.zlib;
+  splitmix = doJailbreak super.splitmix;
+
+  # Apply patches from head.hackage.
+  language-haskell-extract = appendPatch (doJailbreak super.language-haskell-extract) (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/master/patches/language-haskell-extract-0.2.4.patch";
+    sha256 = "0rgzrq0513nlc1vw7nw4km4bcwn4ivxcgi33jly4a7n3c1r32v1f";
+  });
+  regex-base = appendPatch (doJailbreak super.regex-base) (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/master/patches/regex-base-0.94.0.0.patch";
+    sha256 = "0k5fglbl7nnhn8400c4cpnflxcbj9p3xi5prl9jfmszr31jwdy5d";
+  });
+  syb = appendPatch (dontCheck super.syb) (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/master/patches/syb-0.7.1.patch";
+    sha256 = "1407r8xv6bfnmpbw7glfh4smi76a2fc9pkq300c3d9f575708zqr";
+  });
+
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -7729,7 +7729,6 @@ broken-packages:
   - Michelangelo
   - miconix-test
   - micro-recursion-schemes
-  - microaeson
   - microbase
   - microformats2-parser
   - microformats2-types

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -10001,7 +10001,6 @@ broken-packages:
   - stackage-types
   - stackage-upload
   - stackage2nix
-  - stan
   - standalone-derive-topdown
   - standalone-haddock
   - starling

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -730,6 +730,7 @@ self: super: builtins.intersectAttrs super {
 
   # break infinite recursion with base-orphans
   primitive = dontCheck super.primitive;
+  primitive_0_7_1_0 = dontCheck super.primitive_0_7_1_0;
 
   cut-the-crap =
     let path = pkgs.stdenv.lib.makeBinPath [ pkgs.ffmpeg_3 pkgs.youtube-dl ];

--- a/pkgs/development/haskell-modules/patches/hindent-monadfail.patch
+++ b/pkgs/development/haskell-modules/patches/hindent-monadfail.patch
@@ -1,0 +1,223 @@
+diff --git a/src/HIndent/Pretty.hs b/src/HIndent/Pretty.hs
+index 46d8254..1e18473 100644
+--- a/src/HIndent/Pretty.hs
++++ b/src/HIndent/Pretty.hs
+@@ -979,17 +979,20 @@ instance Pretty Alt where
+ instance Pretty Asst where
+   prettyInternal x =
+     case x of
+-      ClassA _ name types -> spaced (pretty name : map pretty types)
+-      i@InfixA {} -> pretty' i
+       IParam _ name ty -> do
+         pretty name
+         write " :: "
+         pretty ty
++      ParenA _ asst -> parens (pretty asst)
++#if MIN_VERSION_haskell_src_exts(1,21,0)
++      TypeA _ ty -> pretty ty
++#else
++      ClassA _ name types -> spaced (pretty name : map pretty types)
++      i@InfixA {} -> pretty' i
+       EqualP _ a b -> do
+         pretty a
+         write " ~ "
+         pretty b
+-      ParenA _ asst -> parens (pretty asst)
+       AppA _ name tys ->
+         spaced (pretty name : map pretty tys)
+       WildCardA _ name ->
+@@ -998,6 +1001,7 @@ instance Pretty Asst where
+           Just n -> do
+             write "_"
+             pretty n
++#endif
+ 
+ instance Pretty BangType where
+   prettyInternal x =
+diff --git a/src/HIndent/Types.hs b/src/HIndent/Types.hs
+index 78d1ceb..0bfaf68 100644
+--- a/src/HIndent/Types.hs
++++ b/src/HIndent/Types.hs
+@@ -71,7 +71,11 @@ data Config = Config
+     }
+ 
+ -- | Parse an extension.
++#if __GLASGOW_HASKELL__ >= 808
++readExtension :: (Monad m, MonadFail m) => String -> m Extension
++#else
+ readExtension :: Monad m => String -> m Extension
++#endif
+ readExtension x =
+   case classifyExtension x -- Foo
+        of
+diff --git a/src/HIndent/Types.hs b/src/HIndent/Types.hs
+index 0bfaf68..18e35a9 100644
+--- a/src/HIndent/Types.hs
++++ b/src/HIndent/Types.hs
+@@ -1,3 +1,4 @@
++{-# OPTIONS_GHC -cpp #-}
+ {-# LANGUAGE RankNTypes #-}
+ {-# LANGUAGE OverloadedStrings #-}
+ {-# LANGUAGE GADTs #-}
+diff --git a/src/HIndent/CodeBlock.hs b/src/HIndent/CodeBlock.hs
+index b936352..2e0c164 100644
+--- a/src/HIndent/CodeBlock.hs
++++ b/src/HIndent/CodeBlock.hs
+@@ -7,7 +7,6 @@ module HIndent.CodeBlock
+ 
+ import Data.ByteString (ByteString)
+ import qualified Data.ByteString.Char8 as S8
+-import Data.Monoid
+ 
+ -- | A block of code.
+ data CodeBlock
+diff --git a/src/HIndent/CodeBlock.hs b/src/HIndent/CodeBlock.hs
+index 2e0c164..b936352 100644
+--- a/src/HIndent/CodeBlock.hs
++++ b/src/HIndent/CodeBlock.hs
+@@ -7,6 +7,7 @@ module HIndent.CodeBlock
+ 
+ import Data.ByteString (ByteString)
+ import qualified Data.ByteString.Char8 as S8
++import Data.Monoid
+ 
+ -- | A block of code.
+ data CodeBlock
+diff --git a/src/main/Test.hs b/src/main/Test.hs
+index 5a8484e..feaaab3 100644
+--- a/src/main/Test.hs
++++ b/src/main/Test.hs
+@@ -35,6 +35,12 @@ reformat cfg code =
+   either (("-- " <>) . L8.pack) L.toLazyByteString $
+   HIndent.reformat cfg (Just HIndent.defaultExtensions) Nothing code
+ 
++#if __GLASGOW_HASKELL__ >= 808
++-- Orphan instance for Spec
++-- TODO(mihaimaruseac): Rewrite to reduce preprocessing stuff
++deriving instance MonadFail Spec
++#endif
++
+ -- | Convert the Markdone document to Spec benchmarks.
+ toSpec :: [Markdone] -> Spec
+ toSpec = go
+diff --git a/src/main/Test.hs b/src/main/Test.hs
+index feaaab3..51935af 100644
+--- a/src/main/Test.hs
++++ b/src/main/Test.hs
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE OverloadedStrings #-}
+ 
+ -- | Test the pretty printer.
+diff --git a/src/main/Test.hs b/src/main/Test.hs
+index 51935af..661c682 100644
+--- a/src/main/Test.hs
++++ b/src/main/Test.hs
+@@ -1,5 +1,6 @@
+ {-# LANGUAGE CPP #-}
+ {-# LANGUAGE OverloadedStrings #-}
++{-# LANGUAGE StandaloneDeriving #-}
+ 
+ -- | Test the pretty printer.
+ module Main where
+diff --git a/src/main/Test.hs b/src/main/Test.hs
+index 661c682..935cc1f 100644
+--- a/src/main/Test.hs
++++ b/src/main/Test.hs
+@@ -44,7 +44,7 @@ deriving instance MonadFail Spec
+ #endif
+ 
+ -- | Convert the Markdone document to Spec benchmarks.
+-toSpec :: [Markdone] -> Spec
++toSpec :: [Markdone] -> SpecM
+ toSpec = go
+   where
+     cfg = HIndent.Types.defaultConfig {configTrailingNewline = False}
+diff --git a/src/main/Test.hs b/src/main/Test.hs
+index 935cc1f..1cf6c52 100644
+--- a/src/main/Test.hs
++++ b/src/main/Test.hs
+@@ -40,11 +40,11 @@ reformat cfg code =
+ #if __GLASGOW_HASKELL__ >= 808
+ -- Orphan instance for Spec
+ -- TODO(mihaimaruseac): Rewrite to reduce preprocessing stuff
+-deriving instance MonadFail Spec
++deriving instance MonadFail SpecM
+ #endif
+ 
+ -- | Convert the Markdone document to Spec benchmarks.
+-toSpec :: [Markdone] -> SpecM
++toSpec :: [Markdone] -> Spec
+ toSpec = go
+   where
+     cfg = HIndent.Types.defaultConfig {configTrailingNewline = False}
+diff --git a/src/main/Test.hs b/src/main/Test.hs
+index 1cf6c52..2318d58 100644
+--- a/src/main/Test.hs
++++ b/src/main/Test.hs
+@@ -21,6 +21,7 @@ import           HIndent.CodeBlock
+ import           HIndent.Types
+ import           Markdone
+ import           Test.Hspec
++import           Test.Hspec.Core.Spec.Monad (SpecM)
+ 
+ -- | Main benchmarks.
+ main :: IO ()
+diff --git a/src/main/Test.hs b/src/main/Test.hs
+index 2318d58..4311ad9 100644
+--- a/src/main/Test.hs
++++ b/src/main/Test.hs
+@@ -21,7 +21,7 @@ import           HIndent.CodeBlock
+ import           HIndent.Types
+ import           Markdone
+ import           Test.Hspec
+-import           Test.Hspec.Core.Spec.Monad (SpecM)
++import           Test.Hspec.Core (SpecM)
+ 
+ -- | Main benchmarks.
+ main :: IO ()
+diff --git a/src/main/Test.hs b/src/main/Test.hs
+index 4311ad9..51660c9 100644
+--- a/src/main/Test.hs
++++ b/src/main/Test.hs
+@@ -21,7 +21,6 @@ import           HIndent.CodeBlock
+ import           HIndent.Types
+ import           Markdone
+ import           Test.Hspec
+-import           Test.Hspec.Core (SpecM)
+ 
+ -- | Main benchmarks.
+ main :: IO ()
+@@ -38,12 +37,6 @@ reformat cfg code =
+   either (("-- " <>) . L8.pack) L.toLazyByteString $
+   HIndent.reformat cfg (Just HIndent.defaultExtensions) Nothing code
+ 
+-#if __GLASGOW_HASKELL__ >= 808
+--- Orphan instance for Spec
+--- TODO(mihaimaruseac): Rewrite to reduce preprocessing stuff
+-deriving instance MonadFail SpecM
+-#endif
+-
+ -- | Convert the Markdone document to Spec benchmarks.
+ toSpec :: [Markdone] -> Spec
+ toSpec = go
+@@ -70,7 +63,7 @@ toSpec = go
+                 shouldBeReadable (reformat cfg code) (L.fromStrict codeExpect)
+               go next'
+             _ ->
+-              fail
++              error
+                 "'haskell given' block must be followed by a 'haskell expect' block"
+         "haskell pending" -> do
+           it (UTF8.toString desc) pending
+diff --git a/src/main/Test.hs b/src/main/Test.hs
+index 51660c9..750fdbf 100644
+--- a/src/main/Test.hs
++++ b/src/main/Test.hs
+@@ -1,6 +1,4 @@
+-{-# LANGUAGE CPP #-}
+ {-# LANGUAGE OverloadedStrings #-}
+-{-# LANGUAGE StandaloneDeriving #-}
+ 
+ -- | Test the pretty printer.
+ module Main where


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Hindent fails to build due to a missing `MonadFail` instance, which is already present at HEAD, but not yet released.

There is an open issue for a release here: https://github.com/mihaimaruseac/hindent/issues/570

Meanwhile, we can fix `hindent` by fetching a more recent version.

Also, enable the tests, because they pass.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
