### PR TITLE
Add --rev to update-source-version, add a generic unstable updater

### DIFF
--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -10,7 +10,7 @@ die() {
 
 usage() {
     echo "Usage: $scriptName <attr> <version> [<new-source-hash>] [<new-source-url>]"
-    echo "                              [--version-key=<version-key>] [--system=<system>] [--file=<file-to-update>]"
+    echo "                              [--version-key=<version-key>] [--system=<system>] [--file=<file-to-update>] [--rev=<revision>]"
     echo "                              [--ignore-same-hash] [--print-changes]"
 }
 
@@ -29,6 +29,9 @@ for arg in "$@"; do
             if [[ ! -f "$nixFile" ]]; then
                 die "Could not find provided file $nixFile"
             fi
+        ;;
+        --rev=*)
+            newRevision="${arg#*=}"
         ;;
         --ignore-same-hash)
             ignoreSameHash="true"
@@ -111,6 +114,13 @@ if [[ "$oldVersion" = "$newVersion" ]]; then
     exit 0
 fi
 
+if [[ -n "$newRevision" ]]; then
+    oldRevision=$(nix-instantiate $systemArg --eval -E "with import ./. {}; $attr.src.rev" | tr -d '"')
+    if [[ -z "$oldRevision" ]]; then
+        die "Couldn't evaluate source revision from '$attr.src'!"
+    fi
+fi
+
 # Escape regex metacharacter that are allowed in store path names
 oldVersionEscaped=$(echo "$oldVersion" | sed -re 's|[.+]|\\&|g')
 oldUrlEscaped=$(echo "$oldUrl" | sed -re 's|[${}.+]|\\&|g')
@@ -172,6 +182,15 @@ fi
 sed -i "$nixFile" -re "s|\"$oldHashEscaped\"|\"$tempHash\"|"
 if cmp -s "$nixFile" "$nixFile.bak"; then
     die "Failed to replace source hash of '$attr' to a temporary hash!"
+fi
+
+# Replace new revision, if given
+if [[ -n "$newRevision" ]]; then
+    sed -i "$nixFile" -re "s|\"$oldRevision\"|\"$newRevision\"|"
+
+    if cmp -s "$nixFile" "$nixFile.bak"; then
+        die "Failed to replace source revision '$oldRevision' to '$newRevision' in '$attr'!"
+    fi
 fi
 
 # If new hash not given on the command line, recalculate it ourselves.

--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, writeShellScript
+, coreutils
+, git
+, nix
+, common-updater-scripts
+}:
+
+# This is an updater for unstable packages that should always use the latest
+# commit.
+{ url ? null # The git url, if empty it will be set to src.url
+}:
+
+let
+  updateScript = writeShellScript "unstable-update-script.sh" ''
+    set -ex
+
+    url="$1"
+
+    # By default we set url to src.url
+    if [[ -z "$url" ]]; then
+        url="$(${nix}/bin/nix-instantiate $systemArg --eval -E \
+                   "with import ./. {}; $UPDATE_NIX_ATTR_PATH.src.url" \
+            | tr -d '"')"
+    fi
+
+    # Get info about HEAD from a shallow git clone
+    tmpdir="$(${coreutils}/bin/mktemp -d)"
+    ${git}/bin/git clone --bare --depth=1 "$url" "$tmpdir"
+    pushd "$tmpdir"
+    commit_date="$(${git}/bin/git show -s --pretty='format:%cs')"
+    commit_sha="$(${git}/bin/git show -s --pretty='format:%H')"
+    popd
+    ${coreutils}/bin/rm -rf "$tmpdir"
+
+    # update the nix expression
+    ${common-updater-scripts}/bin/update-source-version \
+        "$UPDATE_NIX_ATTR_PATH" \
+        "unstable-$commit_date" \
+        --rev="$commit_sha"
+  '';
+
+in [ updateScript url ]
+

--- a/pkgs/development/compilers/qbe/default.nix
+++ b/pkgs/development/compilers/qbe/default.nix
@@ -1,6 +1,9 @@
-{ stdenv, fetchgit }:
+{ stdenv
+, fetchgit
+, unstableGitUpdater
+}:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "qbe";
   version = "unstable-2019-07-11";
 
@@ -11,6 +14,9 @@ stdenv.mkDerivation {
   };
 
   makeFlags = [ "PREFIX=$(out)" ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
   meta = with stdenv.lib; {
     homepage = "https://c9x.me/compile/";
     description = "A small compiler backend written in C";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -94,6 +94,8 @@ in
 
   genericUpdater = callPackage ../common-updater/generic-updater.nix { };
 
+  unstableGitUpdater = callPackage ../common-updater/unstable-updater.nix { };
+
   nix-update-script = callPackage ../common-updater/nix-update.nix { };
 
   ### Push NixOS tests inside the fixed point


### PR DESCRIPTION
###### Motivation for this change

Unstable packages are tedious to keep up to date. You have to manually check the repository for new commits, update the version to HEAD's commit date, and update the revision to HEAD's sha.

This patch adds a `--rev` parameter to `update-source-version` (necessary since in unstable packages version and rev are independent), and a generic unstable updater to handle the case described above.

Finally, in the last commit, the updater is applied to a package, `qbe`, that benefits from it, and on which you can test the updater.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
