### PR TITLE
fastd: 19 -> 21

### DIFF
--- a/pkgs/tools/networking/fastd/default.nix
+++ b/pkgs/tools/networking/fastd/default.nix
@@ -1,28 +1,19 @@
-{ stdenv, fetchFromGitHub, cmake, bison, pkgconfig
+{ stdenv, fetchFromGitHub, bison, meson, ninja, pkgconfig
 , libuecc, libsodium, libcap, json_c, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "fastd";
-  version = "19";
+  version = "21";
 
   src = fetchFromGitHub {
     owner  = "Neoraider";
     repo = "fastd";
     rev = "v${version}";
-    sha256 = "1h3whjvy2n2cyvbkbg4y1z9vlrn790spzbdhj4glwp93xcykhz5i";
+    sha256 = "1p4k50dk8byrghbr0fwmgwps8df6rlkgcd603r14i71m5g27z5gw";
   };
 
-  postPatch = ''
-    substituteInPlace src/crypto/cipher/CMakeLists.txt \
-      --replace 'add_subdirectory(aes128_ctr)' ""
-  '';
-
-  nativeBuildInputs = [ pkgconfig bison cmake ];
+  nativeBuildInputs = [ pkgconfig bison meson ninja ];
   buildInputs = [ libuecc libsodium libcap json_c openssl ];
-
-  cmakeFlags = [
-    "-DENABLE_OPENSSL=true"
-  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream releases.

https://fastd.readthedocs.io/en/stable/releases/v20.html
https://fastd.readthedocs.io/en/stable/releases/v21.html

```
Faster than expected, there is a new release of fastd, fixing a critial
Denial of Service (fastd crash) vulnerability. All users of fastd v20 must
update.

In fastd v19 and older, the same vulnerablity exists, but exploiting it
will cause a memory leak rather than an instant crash. Users that can't or
do not want to update to v21 yet should apply the patch that is attached to
this mail.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
