### PR TITLE
plata-theme: 0.9.8 -> 0.9.9

### DIFF
--- a/pkgs/data/themes/plata/default.nix
+++ b/pkgs/data/themes/plata/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitLab, autoreconfHook, pkg-config, parallel
-, sassc, inkscape, libxml2, glib, gtk2, gtk-engine-murrine
+, sassc, inkscape, libxml2, glib, gtk_engines, gtk-engine-murrine
 , cinnamonSupport ? true
 , gnomeFlashbackSupport ? true
 , gnomeShellSupport ? true
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation rec {
   pname = "plata-theme";
-  version = "0.9.8";
+  version = "0.9.9";
 
   src = fetchFromGitLab {
     owner = "tista500";
     repo = "plata-theme";
     rev = version;
-    sha256 = "1sqmydvx36f6r4snw22s2q4dvcyg30jd7kg7dibpzqn3njfkkfag";
+    sha256 = "1iwvlv9qcrjyfbzab00vjqafmp3vdybz1hi02r6lwbgvwyfyrifk";
   };
 
   nativeBuildInputs = [
@@ -35,14 +35,14 @@ stdenv.mkDerivation rec {
     sassc
     inkscape
     libxml2
-    glib.dev
+    glib
   ]
   ++ lib.optionals mateSupport [ gtk3 marco ]
   ++ lib.optional telegramSupport zip;
 
-  # GTK2 engines must be on the system path at runtime to be loaded.
+  buildInputs = [ gtk_engines ];
+
   propagatedUserEnvPkgs = [
-    gtk2
     gtk-engine-murrine
   ];
 

--- a/pkgs/data/themes/plata/default.nix
+++ b/pkgs/data/themes/plata/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitLab, autoreconfHook, pkg-config, parallel
-, sassc, inkscape, libxml2, glib, gdk-pixbuf, librsvg, gtk-engine-murrine
+, sassc, inkscape, libxml2, glib, gtk2, gtk-engine-murrine
 , cinnamonSupport ? true
 , gnomeFlashbackSupport ? true
 , gnomeShellSupport ? true
@@ -28,8 +28,6 @@ stdenv.mkDerivation rec {
     sha256 = "1sqmydvx36f6r4snw22s2q4dvcyg30jd7kg7dibpzqn3njfkkfag";
   };
 
-  preferLocalBuild = true;
-
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
@@ -42,12 +40,11 @@ stdenv.mkDerivation rec {
   ++ lib.optionals mateSupport [ gtk3 marco ]
   ++ lib.optional telegramSupport zip;
 
-  buildInputs = [
-    gdk-pixbuf
-    librsvg
+  # GTK2 engines must be on the system path at runtime to be loaded.
+  propagatedUserEnvPkgs = [
+    gtk2
+    gtk-engine-murrine
   ];
-
-  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
   postPatch = "patchShebangs .";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Drop unneeded `buildInputs` as this derivation produces static files with no binary dependencies.
- Add gtk2 and gtk-engine-murrine to `propagatedUserEnvPkgs` for GTK2 support at runtime.
- Bump package version to `0.9.9`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
