### PR TITLE
lib: Add listFilesRecursive function to filesystem

### DIFF
--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -42,4 +42,16 @@
               type = (builtins.readDir parent).${base} or null;
           in file == /. || type == "directory";
     in go (if isDir then file else parent);
+
+
+  # listFilesRecursive: Path -> [ Path ]
+  #
+  # Given a directory, return a flattened list of all files within it recursively.
+  listFilesRecursive = dir: lib.flatten (lib.mapAttrsToList (name: type:
+    if type == "directory" then
+      lib.filesystem.listFilesRecursive (dir + "/${name}")
+    else
+      dir + "/${name}"
+  ) (builtins.readDir dir));
+
 }


### PR DESCRIPTION
###### Motivation for this change

_Add a friendly function to easily return a flattened list of files within a directory._

This is useful if you want to easily iterate or concatStringsSep the list of
files all found within a directory. (i.e. when constructing Java's CLASSPATH)

```bash
❯ tree /nix/store/g87va52nkc8jzbmi1aqdcf2f109r4dvn-maven-repository | head
/nix/store/g87va52nkc8jzbmi1aqdcf2f109r4dvn-maven-repository
├── antlr
│   └── antlr
│       └── 2.7.2
│           ├── antlr-2.7.2.jar -> /nix/store/d027c8f2cnmj5yrynpbq2s6wmc9cb559-antlr-2.7.2.jar
│           └── antlr-2.7.2.pom -> /nix/store/mv42fc5gizl8h5g5vpywz1nfiynmzgp2-antlr-2.7.2.pom
├── avalon-framework
│   └── avalon-framework
│       └── 4.1.3
│           ├── avalon-framework-4.1.3.jar -> /nix/store/iv5fp3955w3nq28ff9xfz86wvxbiw6n9-avalon-framework-4.1.3.jar


❯ nix-repl> listFilesRecursive /nix/store/g87va52nkc8jzbmi1aqdcf2f109r4dvn-maven-repository
[ /nix/store/g87va52nkc8jzbmi1aqdcf2f109r4dvn-maven-repository/antlr/antlr/2.7.2/antlr-2.7.2.jar /nix/store/g87va52nkc8jzbmi1aqdcf2f109r4dvn-maven-repository/antlr/antlr/2.7.2/antlr-2.7.2.pom /nix/store/g87va52nkc8jzbmi1aqdcf2f109r4dvn-maven-repository/avalon-framework/avalon-framework/4.1.3/avalon-framework-4.1.3.jar /nix/store/g87va52nkc8jzbmi1aqdcf2f109r4dvn-maven-repository/avalon-framework/avalon-framework/4.1.3/avalon-framework-4.1.3.pom /nix/store/g87va52nkc8jzbmi1aqdcf2f109r4dvn-maven-repository/backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.jar ..
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
