### PR TITLE
ytop: Add "ytop" to ytop's error message

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -666,7 +666,7 @@ mapAliases ({
   xpraGtk3 = xpra; # added 2018-09-13
   xv = xxv; # added 2020-02-22
   youtubeDL = youtube-dl;  # added 2014-10-26
-  ytop = throw "Abandoned by upstream. Consider switching to bottom instead";
+  ytop = throw "ytop has been abandoned by upstream. Consider switching to bottom instead";
   zdfmediathk = mediathekview; # added 2019-01-19
   gnome_user_docs = gnome-user-docs; # added 2019-11-20
   # spidermonkey is not ABI upwards-ompatible, so only allow this for nix-shell


### PR DESCRIPTION
Right now, running `nixos-rebuild` gives an obscure error:

```
$ nixos-rebuild switch
building Nix...
building the system configuration...
error: Abandoned by upstream. Consider switching to bottom instead
(use '--show-trace' to show detailed location information)
```

(And `--show-trace` adds no useful information.)

The error message doesn't indicate that `ytop` is what's causing the problem.
By adding `ytop` to the error message, configurations that still reference `ytop` will be easier to debug and fix.