### PR TITLE
nextinspace: init at 1.0.2

### DIFF
--- a/pkgs/applications/science/misc/nextinspace/default.nix
+++ b/pkgs/applications/science/misc/nextinspace/default.nix
@@ -1,6 +1,6 @@
-{ lib, buildPythonPackage, fetchPypi, pythonPackages }:
+{ lib, fetchPypi, python3Packages }:
 
-buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "nextinspace";
   version = "1.0.2";
 
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "0wrvdwpxwf9aq4mq377mmdlhbgy2ngzf58frp71jdbsipkhb2kcf";
   };
 
-  pythonPath = with pythonPackages; [
+  pythonPath = with python3Packages; [
     requests
     tzlocal
     colorama

--- a/pkgs/applications/science/misc/nextinspace/default.nix
+++ b/pkgs/applications/science/misc/nextinspace/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, pythonPackages }:
+
+buildPythonPackage rec {
+  pname = "nextinspace";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wrvdwpxwf9aq4mq377mmdlhbgy2ngzf58frp71jdbsipkhb2kcf";
+  };
+
+  pythonPath = with pythonPackages; [
+    requests
+    tzlocal
+    colorama
+  ];
+
+  vendorSha256 = "0z3r8fvpy36ybgb18sr0lril1sg8z7s99xv1a6g1v3zdnj3zimav";
+
+  meta = with lib; {
+    description = "Print upcoming space-related events in your terminal";
+    homepage = "https://github.com/The-Kid-Gid/nextinspace";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ penguwin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26778,9 +26778,7 @@ in
 
   netlogo = callPackage ../applications/science/misc/netlogo { };
 
-  nextinspace = python3Packages.callPackage ../applications/science/misc/nextinspace {
-    pythonPackages = python3Packages;
-  };
+  nextinspace = python3Packages.callPackage ../applications/science/misc/nextinspace { };
 
   ns-3 = callPackage ../development/libraries/science/networking/ns-3 { python = python3; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26778,6 +26778,10 @@ in
 
   netlogo = callPackage ../applications/science/misc/netlogo { };
 
+  nextinspace = python3Packages.callPackage ../applications/science/misc/nextinspace {
+    pythonPackages = python3Packages;
+  };
+
   ns-3 = callPackage ../development/libraries/science/networking/ns-3 { python = python3; };
 
   root = callPackage ../applications/science/misc/root {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

bring the [nextinspace](https://github.com/The-Kid-Gid/nextinspace) command-line tool to nixpkgs. This is my first contribution for a project written in python therefore I'm not really sure if this is packaged 'the right way'.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
