### PR TITLE
lib3mf: 1.8.1 → 2.0.0

### DIFF
--- a/pkgs/development/libraries/lib3mf/default.nix
+++ b/pkgs/development/libraries/lib3mf/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lib3mf";
-  version = "1.8.1";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "3MFConsortium";
     repo = pname;
     rev = "v${version}";
-    sha256 = "11wpk6n9ga2p57h1dcrp37w77mii0r7r6mlrgmykf7rvii1rzgqd";
+    sha256 = "0w4d9zvl95g1x3r5nyd6cr27g6fwhhwaivh8a5r1xs5l6if21x19";
   };
 
   nativeBuildInputs = [ cmake ninja ];
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
   buildInputs = if stdenv.isDarwin then [ libossp_uuid ] else [ libuuid ];
 
   postPatch = ''
-    rmdir UnitTests/googletest
-    ln -s ${gtest.src} UnitTests/googletest
+    rmdir Tests/googletest
+    ln -s ${gtest.src} Tests/googletest
 
     # fix libdir=''${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
     sed -i 's,=''${\(exec_\)\?prefix}/,=,' lib3MF.pc.in


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Failed in https://r.ryantm.com/log/2020-10-17.log

Result of nixpkgs-review 1[1]

<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>lib3mf</li>
    <li>openscad</li>
  </ul>
</details>

[1]: https://github.com/Mic92/nixpkgs-review

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
