### PR TITLE
Aws sam cli bounds

### DIFF
--- a/pkgs/development/python-modules/aws-lambda-builders/default.nix
+++ b/pkgs/development/python-modules/aws-lambda-builders/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "aws-lambda-builders";
-  version = "0.9.0";
+  version = "1.1.0";
 
   # No tests available in PyPI tarball
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-lambda-builders";
     rev = "v${version}";
-    sha256 = "0cgb0hwf4xg5dmm32wwlxqy7a77jw6gpnj7v8rq5948hsy2sfrcp";
+    sha256 = "1r4939m5k1nj6l9bv972z4fkmkl0z5f5r29bq7588yk113kkqr0c";
   };
 
   # Package is not compatible with Python 3.5

--- a/pkgs/development/python-modules/aws-sam-translator/default.nix
+++ b/pkgs/development/python-modules/aws-sam-translator/default.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "aws-sam-translator";
-  version = "1.26.0";
+  version = "1.27.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1a3fd8e48a745967e8457b9cefdc3ad0f139ac4a25af4db9c13a9e1c19ea6910";
+    sha256 = "0m24cdiry8p74s5ysyriy6wks4ic8782sf21q4yvlwfn9hpi4n1j";
   };
 
   # Tests are not included in the PyPI package

--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -7,14 +7,6 @@
 let
   py = python.override {
     packageOverrides = self: super: {
-      aws-sam-translator = super.aws-sam-translator.overridePythonAttrs (oldAttrs: rec {
-        version = "1.25.0";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "08756yl5lpqgrpr80f2b6bdcgygr37l6q1yygklcg9hz4yfpccav";
-        };
-      });
-
       flask = super.flask.overridePythonAttrs (oldAttrs: rec {
         version = "1.0.2";
         src = oldAttrs.src.override {
@@ -39,11 +31,11 @@ with py.pkgs;
 
 buildPythonApplication rec {
   pname = "aws-sam-cli";
-  version = "1.0.0rc1";
+  version = "1.6.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "011b334gdvd9lhqia8c952q3cmzj99vik680180nbp0qh2xw6zpf";
+    sha256 = "0scnymhhiiqrs2j0jaypxgq2wg1qf1w8f55qfay0b3nf51y6mh8y";
   };
 
   # Tests are not included in the PyPI package
@@ -75,12 +67,13 @@ buildPythonApplication rec {
   # fix over-restrictive version bounds
   postPatch = ''
     substituteInPlace requirements/base.txt \
-      --replace "boto3~=1.13.0, >=1.13.0" "boto3~=1.14.3" \
-      --replace "serverlessrepo==0.1.9" "serverlessrepo~=0.1.9" \
-      --replace "python-dateutil~=2.6, <2.8.1" "python-dateutil~=2.6" \
+      --replace "boto3~=1.14.0, >=1.14.23" "boto3~=1.14" \
+      --replace "docker~=4.2.0" "docker~=4.3.1" \
       --replace "jmespath~=0.9.5" "jmespath~=0.10.0" \
-      --replace "tomlkit==0.5.8" "tomlkit~=0.7.0" \
-      --replace "requests==2.23.0" "requests~=2.24"
+      --replace "python-dateutil~=2.6, <2.8.1" "python-dateutil~=2.6" \
+      --replace "requests==2.23.0" "requests~=2.24" \
+      --replace "serverlessrepo==0.1.9" "serverlessrepo~=0.1.9" \
+      --replace "tomlkit==0.5.8" "tomlkit~=0.7.0"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

aws-sam-cli fails to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
