### PR TITLE
python3Packages.pysideShiboken: fix build

### DIFF
--- a/pkgs/development/python-modules/pyside/shiboken.nix
+++ b/pkgs/development/python-modules/pyside/shiboken.nix
@@ -1,29 +1,30 @@
-{ lib, fetchurl, buildPythonPackage
+{ lib, fetchFromGitHub, buildPythonPackage
 , cmake
-, libxml2
-, pkg-config
-, libxslt
-, pysideApiextractor
-, pysideGeneratorrunner
-, python
-, sphinx
-, qt4
-, isPy3k
 , isPy35
 , isPy36
 , isPy37
+, isPy3k
+, libxml2
+, libxslt
+, pkg-config
+, pysideApiextractor
+, pysideGeneratorrunner
+, python
+, qt4
+, sphinx
 }:
 
 buildPythonPackage rec {
   pname = "pyside-shiboken";
   version = "1.2.4";
+  format = "other";
   disabled = !isPy3k;
 
-  format = "other";
-
-  src = fetchurl {
-    url = "https://github.com/PySide/Shiboken/archive/${version}.tar.gz";
-    sha256 = "1536f73a3353296d97a25e24f9554edf3e6a48126886f8d21282c3645ecb96a4";
+  src = fetchFromGitHub {
+    owner = "PySide";
+    repo = "Shiboken";
+    rev = version;
+    sha256 = "0x2lyg52m6a0vn0665pgd1z1qrydglyfxxcggw6xzngpnngb6v5v";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION

###### Motivation for this change
not sure why, but fix this build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
