### PR TITLE
[20.09] spooles: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/science/math/spooles/default.nix
+++ b/pkgs/development/libraries/science/math/spooles/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
     ./spooles.patch
   ];
 
+  postPatch = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace makefile --replace '-Wl,-soname' '-Wl,-install_name'
+  '';
+
   buildPhase = ''
     make lib
   '';

--- a/pkgs/development/libraries/science/math/spooles/spooles.patch
+++ b/pkgs/development/libraries/science/math/spooles/spooles.patch
@@ -166,7 +166,7 @@ index f014c7d..7c8042a 100755
  #cd MPI              ; make lib
 -#cd MT               ; make lib
 +	cd MT               ; make lib
-+	gcc -shared */*/*.lo -Wl,-soname,libspooles.so.2.2 -o libspooles.so.2.2 -lpthread -lm
++	$(CC) -shared */*/*.lo -Wl,-soname,libspooles.so.2.2 -o libspooles.so.2.2 -lpthread -lm
 +	ln -s libspooles.so.2.2 libspooles.so
  
  global :


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/101031
(cherry picked from commit c04219a9d5af1fbe7254352e6d61a38552161015)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF 20.09 https://github.com/NixOS/nixpkgs/issues/97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
