### PR TITLE
Add a bunch of Jane Street OCaml packages at 0.13

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.13.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.13.nix
@@ -498,6 +498,51 @@ rec {
     meta.description = "Process library and s-expression based shell";
   };
 
+  csvfields = janePackage {
+    pname = "csvfields";
+    hash = "19pnq9m9lkdgqfy9l21w779d6c8djr1dvvjq7r9kbgfwb04symmr";
+    propagatedBuildInputs = [ core expect_test_helpers ];
+    meta.description = "Runtime support for ppx_xml_conv and ppx_csv_conv";
+  };
+
+  sexp_diff_kernel = janePackage {
+    pname = "sexp_diff_kernel";
+    hash = "125gssd24vfcfbkpjlqbxijlc4jyw2n0wv1cnddcfvpn1f7cghzb";
+    propagatedBuildInputs = [ core_kernel ];
+    meta.description = "Code for computing the diff of two sexps";
+  };
+
+  sexp_macro = janePackage {
+    pname = "sexp_macro";
+    hash = "1rqs2r2ihwsqzgnqsdr0db6dqzz4q6s9hi1hvnwf0cb2vnkhsjln";
+    propagatedBuildInputs = [ async sexplib ];
+    meta.description = "Sexp macros";
+  };
+
+  sexp_select = janePackage {
+    pname = "sexp_select";
+    hash = "02yckmin937scqs2i45r2qqp56rqa6j2q04nfhnnxvn3bkb0qnb1";
+    propagatedBuildInputs = [ base ppx_jane ];
+    meta.description = "A library to use CSS-style selectors to traverse sexp trees";
+  };
+
+  sexp = janePackage {
+    pname = "sexp";
+    hash = "0cqp6syc4ap2nxgg1mvwwz2pmib48kp3gigzpjwh20wr38qq0p1r";
+    propagatedBuildInputs = [
+      async
+      core
+      csvfields
+      re2
+      sexp_diff_kernel
+      sexp_macro
+      sexp_pretty
+      sexp_select
+    ];
+    patches = ./sexp.patch;
+    meta.description = "S-expression swiss knife";
+  };
+
   ### Packages at version 0.11, with dependencies at version 0.12
 
   configurator = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/0.13.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.13.nix
@@ -6,6 +6,7 @@
 , ppxlib
 , re
 , openssl
+, zarith
 }:
 
 rec {
@@ -541,6 +542,19 @@ rec {
     ];
     patches = ./sexp.patch;
     meta.description = "S-expression swiss knife";
+  };
+
+  zarith_stubs_js = janePackage {
+    pname = "zarith_stubs_js";
+    hash = "0dldnf85rfyx8z63qjly9n8plj8nnkw4i5zrj5vbm7s2wjcfjzj1";
+    meta.description = "Javascripts stubs for the Zarith library";
+  };
+
+  bignum = janePackage {
+    pname = "bignum";
+    hash = "0qldyl5mhlffnyps7n9y8qykm0ylrdiw5ii8zlww82zmmpp8zv5x";
+    propagatedBuildInputs = [ core_kernel zarith zarith_stubs_js ];
+    meta.description = "Core-flavoured wrapper around zarith's arbitrary-precision rationals";
   };
 
   ### Packages at version 0.11, with dependencies at version 0.12

--- a/pkgs/development/ocaml-modules/janestreet/0.13.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.13.nix
@@ -557,6 +557,13 @@ rec {
     meta.description = "Core-flavoured wrapper around zarith's arbitrary-precision rationals";
   };
 
+  delimited_parsing = janePackage {
+    pname = "delimited_parsing";
+    hash = "0siz746q28241wk0sv435lfvvips7sl151z5a1sbqanr3lm4s17w";
+    propagatedBuildInputs = [ async core_extended ];
+    meta.description = "Parsing of character (e.g., comma) separated and fixed-width values";
+  };
+
   ### Packages at version 0.11, with dependencies at version 0.12
 
   configurator = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/sexp.patch
+++ b/pkgs/development/ocaml-modules/janestreet/sexp.patch
@@ -1,0 +1,30 @@
+diff --git a/lazy_list/src/dune b/lazy_list/src/dune
+index f1650ad..df90914 100644
+--- a/lazy_list/src/dune
++++ b/lazy_list/src/dune
+@@ -1,2 +1,3 @@
+ (library (name lazy_list) (libraries core_kernel)
++ (public_name sexp.lazy_list)
+  (preprocess (pps ppx_jane)))
+\ No newline at end of file
+diff --git a/sexp_app/pattern/dune b/sexp_app/pattern/dune
+index b7d2c3b..baf136b 100644
+--- a/sexp_app/pattern/dune
++++ b/sexp_app/pattern/dune
+@@ -1,4 +1,5 @@
+ (library (name sexp_app_pattern) (libraries core re2 sexplib str)
++ (public_name sexp.sexp_app_pattern)
+  (preprocess (pps ppx_jane)))
+ 
+ (ocamllex lexer)
+diff --git a/sexp_app/src/dune b/sexp_app/src/dune
+index b91ff40..a07a4e7 100644
+--- a/sexp_app/src/dune
++++ b/sexp_app/src/dune
+@@ -1,4 +1,5 @@
+ (library (name sexp_app) (libraries core lazy_list re2 sexplib str)
++ (public_name sexp.sexp_app)
+  (preprocess (pps ppx_jane -allow-unannotated-ignores)))
+ 
+ (ocamllex csv_lexeme)
+\ No newline at end of file

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1029,7 +1029,7 @@ let
     janeStreet =
     if lib.versionOlder "4.08" ocaml.version
     then import ../development/ocaml-modules/janestreet/0.13.nix {
-      inherit ctypes dune-configurator janePackage num octavius ppxlib re;
+      inherit ctypes dune-configurator janePackage num octavius ppxlib re zarith;
       inherit (pkgs) openssl;
     }
     else if lib.versionOlder "4.07" ocaml.version


### PR DESCRIPTION
###### Motivation for this change

I stumbled across these missing packages when trying to compile some OCaml projects using nix.  These changes are hopefully straightforward.  I'm also planning on making a PR for Jane Street packages version 0.14.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
