### PR TITLE
apk-tools: fix build on darwin

### DIFF
--- a/pkgs/tools/package-management/apk-tools/default.nix
+++ b/pkgs/tools/package-management/apk-tools/default.nix
@@ -10,9 +10,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [ lua openssl zlib ];
 
   makeFlags = [
+    "CC=cc"
     "SBINDIR=$(out)/bin"
     "LIBDIR=$(out)/lib"
     "LUA_LIBDIR=$(out)/lib/lua/${lib.versions.majorMinor lua.version}"
@@ -25,6 +27,17 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = [ "-Wno-error=unused-result" ];
 
   enableParallelBuilding = true;
+
+  patchPhase = lib.optionals stdenv.isDarwin ''
+    substituteInPlace libfetch/common.c --replace 'MSG_NOSIGNAL' 'MSG_HAVEMORE'
+    substituteInPlace src/archive.c --replace '#include <sys/sysmacros.h>' ""
+    substituteInPlace src/archive.c --replace 'mknodat' "mknod"
+    substituteInPlace src/common.c --replace 'malloc.h' "stdlib.h"
+    substituteInPlace src/blob.c --replace 'malloc.h' "stdlib.h"
+    substituteInPlace src/blob.c --replace 'memrchr' "memchr"
+    substituteInPlace src/apk_defines.h --replace 'endian.h' "stdlib.h"
+    substituteInPlace libfetch/http.c --replace 'strdupa' 'strdup'
+  '';
 
   meta = with lib; {
     homepage = "https://gitlab.alpinelinux.org/alpine/apk-tools";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
