### PR TITLE
Append '-unstable' to pname instead of prefixing to version

### DIFF
--- a/pkgs/applications/audio/ams/default.nix
+++ b/pkgs/applications/audio/ams/default.nix
@@ -12,8 +12,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "ams";
-  version = "unstable-2019-04-27";
+  name = "ams-unstable";
+  version = "2019-04-27";
 
   src = fetchgit {
     url = "https://git.code.sf.net/p/alsamodular/ams.git";

--- a/pkgs/applications/audio/artyFX/default.nix
+++ b/pkgs/applications/audio/artyFX/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchFromGitHub , cairomm, cmake, libjack2, libpthreadstubs, libXdmcp, libxshmfence, libsndfile, lv2, ntk, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  pname = "artyFX";
+  pname = "artyFX-unstable";
   # Fix build with lv2 1.18: https://github.com/openAVproductions/openAV-ArtyFX/pull/41/commits/492587461b50d140455aa3c98d915eb8673bebf0
-  version = "unstable-2020-04-28";
+  version = "2020-04-28";
 
   src = fetchFromGitHub {
     owner = "openAVproductions";

--- a/pkgs/applications/audio/cheesecutter/default.nix
+++ b/pkgs/applications/audio/cheesecutter/default.nix
@@ -7,8 +7,8 @@
 , SDL
 }:
 stdenv.mkDerivation rec {
-  pname = "cheesecutter";
-  version = "unstable-2020-04-03";
+  pname = "cheesecutter-unstable";
+  version = "2020-04-03";
 
   src = fetchFromGitHub {
     owner = "theyamo";

--- a/pkgs/applications/audio/csound/csound-manual/default.nix
+++ b/pkgs/applications/audio/csound/csound-manual/default.nix
@@ -5,8 +5,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "csound-manual";
-  version = "unstable-2019-02-22";
+  pname = "csound-manual-unstable";
+  version = "2019-02-22";
 
   src = fetchFromGitHub {
     owner = "csound";

--- a/pkgs/applications/audio/deadbeef/plugins/lyricbar.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/lyricbar.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, pkgconfig, deadbeef, gtkmm3, libxmlxx3 }:
 
 stdenv.mkDerivation {
-  pname = "deadbeef-lyricbar-plugin";
-  version = "unstable-2019-01-29";
+  pname = "deadbeef-lyricbar-plugin-unstable";
+  version = "2019-01-29";
 
   src = fetchFromGitHub {
     owner = "C0rn3j";

--- a/pkgs/applications/audio/distrho/default.nix
+++ b/pkgs/applications/audio/distrho/default.nix
@@ -8,8 +8,8 @@ let
               else if stdenv.hostPlatform.isWindows then "mingw"
               else "linux";
 in stdenv.mkDerivation rec {
-  pname = "distrho-ports";
-  version = "unstable-2019-10-09";
+  pname = "distrho-ports-unstable";
+  version = "2019-10-09";
 
   src = fetchFromGitHub {
     owner = "DISTRHO";

--- a/pkgs/applications/audio/ensemble-chorus/default.nix
+++ b/pkgs/applications/audio/ensemble-chorus/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, fltk, alsaLib, freetype, libXrandr, libXinerama, libXcursor, lv2, libjack2, cmake, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  pname = "ensemble-chorus";
-  version = "unstable-15-02-2019";
+  pname = "ensemble-chorus-unstable";
+  version = "15-02-2019";
 
   src = fetchFromGitHub {
     owner = "jpcima";
-    repo = pname;
+    repo = "ensemble-chorus";
     rev = "59baeb86b8851f521bc8162e22e3f15061662cc3";
     sha256 = "0c1y10vyhrihcjvxqpqf6b52yk5yhwh813cfp6nla5ax2w88dbhr";
     fetchSubmodules = true;

--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -20,7 +20,7 @@ with stdenv.lib.strings;
 
 let
 
-  version = "unstable-2020-08-27";
+  version = "2020-08-27";
 
   src = fetchFromGitHub {
     owner = "grame-cncm";
@@ -40,7 +40,7 @@ let
 
   faust = stdenv.mkDerivation {
 
-    pname = "faust";
+    pname = "faust-unstable";
     inherit version;
 
     inherit src;

--- a/pkgs/applications/audio/freqtweak/default.nix
+++ b/pkgs/applications/audio/freqtweak/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, autoconf, automake, pkg-config, fftwFloat, libjack2, libsigcxx, libxml2, wxGTK }:
 
 stdenv.mkDerivation rec {
-  pname = "freqtweak";
-  version = "unstable-2019-08-03";
+  pname = "freqtweak-unstable";
+  version = "2019-08-03";
 
   src = fetchFromGitHub {
     owner = "essej";
-    repo = pname;
+    repo = "freqtweak";
     rev = "d4205337558d36657a4ee6b3afb29358aa18c0fd";
     sha256 = "10cq27mdgrrc54a40al9ahi0wqd0p2c1wxbdg518q8pzfxaxs5fi";
   };

--- a/pkgs/applications/audio/friture/default.nix
+++ b/pkgs/applications/audio/friture/default.nix
@@ -3,12 +3,12 @@
 let
   py = python3Packages;
 in py.buildPythonApplication rec {
-  pname = "friture";
-  version = "unstable-2020-02-16";
+  pname = "friture-unstable";
+  version = "2020-02-16";
 
   src = fetchFromGitHub {
     owner = "tlecomte";
-    repo = pname;
+    repo = "friture";
     rev = "4460b4e72a9c55310d6438f294424b5be74fc0aa";
     sha256 = "1pmxzq78ibifby3gbir1ah30mgsqv0y7zladf5qf3sl5r1as0yym";
   };

--- a/pkgs/applications/audio/fverb/default.nix
+++ b/pkgs/applications/audio/fverb/default.nix
@@ -4,13 +4,13 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "fverb";
+  pname = "fverb-unstable";
   # no release yet: https://github.com/jpcima/fverb/issues/2
-  version = "unstable-2020-06-09";
+  version = "2020-06-09";
 
   src = fetchFromGitHub {
     owner = "jpcima";
-    repo = pname;
+    repo = "fverb";
     rev = "462020e33e24c0204a375dc95e2c28654cc917b8";
     sha256 = "12nl7qn7mnykk7v8q0j2n8kfq0xc46n0i45z6qcywspadwnncmd4";
     fetchSubmodules = true;

--- a/pkgs/applications/audio/ingen/default.nix
+++ b/pkgs/applications/audio/ingen/default.nix
@@ -5,9 +5,9 @@
 }:
 
 stdenv.mkDerivation  rec {
-  pname = "ingen";
-  version = "unstable-2019-12-09";
-  name = "${pname}-${version}";
+  pname = "ingen-unstable";
+  version = "2019-12-09";
+  name = "ingen-${version}";
 
   src = fetchgit {
     url = "https://gitlab.com/drobilla/ingen.git";

--- a/pkgs/applications/audio/littlegptracker/default.nix
+++ b/pkgs/applications/audio/littlegptracker/default.nix
@@ -6,8 +6,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "littlegptracker";
-  version = "unstable-2019-04-14";
+  pname = "littlegptracker-unstable";
+  version = "2019-04-14";
 
   src = fetchFromGitHub {
     owner = "Mdashdotdashn";

--- a/pkgs/applications/audio/molot-lite/default.nix
+++ b/pkgs/applications/audio/molot-lite/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, unzip, lv2 }:
 
 stdenv.mkDerivation {
-  pname = "molot-lite";
-  version = "unstable-2014-04-23";
+  pname = "molot-lite-unstable";
+  version = "2014-04-23";
 
   src = fetchurl {
     # fetchzip does not accept urls that do not end with .zip.

--- a/pkgs/applications/audio/mooSpace/default.nix
+++ b/pkgs/applications/audio/mooSpace/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
-  pname = "mooSpace";
-  version = "unstable-2020-06-10";
+  pname = "mooSpace-unstable";
+  version = "2020-06-10";
 
   src = fetchFromGitHub {
     owner = "modularev";
-    repo = pname;
+    repo = "mooSpace";
     rev = "e5440407ea6ef9f7fcca838383b2b9a388c22874";
     sha256 = "10vsbddf6d7i06040850v8xkmqh3bqawczs29kfgakair809wqxl";
   };

--- a/pkgs/applications/audio/musly/default.nix
+++ b/pkgs/applications/audio/musly/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, eigen, libav }:
 stdenv.mkDerivation {
-  pname = "musly";
-  version = "unstable-2017-04-26";
+  pname = "musly-unstable";
+  version = "2017-04-26";
   src = fetchFromGitHub {
     owner = "dominikschnitzer";
     repo = "musly";

--- a/pkgs/applications/audio/pulseaudio-dlna/default.nix
+++ b/pkgs/applications/audio/pulseaudio-dlna/default.nix
@@ -18,8 +18,8 @@ let
   zeroconf = pythonPackages.callPackage ./zeroconf.nix { };
 in
 pythonPackages.buildPythonApplication {
-  pname = "pulseaudio-dlna";
-  version = "unstable-2017-11-01";
+  pname = "pulseaudio-dlna-unstable";
+  version = "2017-11-01";
 
   src = fetchFromGitHub {
     owner = "masmu";

--- a/pkgs/applications/audio/real_time_config_quick_scan/default.nix
+++ b/pkgs/applications/audio/real_time_config_quick_scan/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, perlPackages, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  pname = "realTimeConfigQuickScan";
-  version = "unstable-2020-07-23";
+  pname = "realTimeConfigQuickScan-unstable";
+  version = "2020-07-23";
 
   src = fetchFromGitHub {
     owner  = "raboof";
-    repo   = pname;
+    repo   = "realTimeConfigQuickScan";
     rev    = "4697ba093d43d512b74a73b89531cb8c5adaa274";
     sha256 = "16kanzp5i353x972zjkwgi3m8z90wc58613mlfzb0n01djdnm6k5";
   };

--- a/pkgs/applications/audio/rhvoice/default.nix
+++ b/pkgs/applications/audio/rhvoice/default.nix
@@ -2,9 +2,9 @@
 , python, glibmm, libpulseaudio, libao }:
 
 let
-  version = "unstable-2018-02-10";
+  version = "2018-02-10";
 in stdenv.mkDerivation {
-  pname = "rhvoice";
+  pname = "rhvoice-unstable";
   inherit version;
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/speech-denoiser/default.nix
+++ b/pkgs/applications/audio/speech-denoiser/default.nix
@@ -9,8 +9,8 @@ let
   };
 
   rnnoise-nu = stdenv.mkDerivation {
-    pname = "rnnoise-nu";
-    version = "unstable-07-10-2019";
+    pname = "rnnoise-nu-unstable";
+    version = "07-10-2019";
     src = speech-denoiser-src;
     sourceRoot = "source/rnnoise";
     nativeBuildInputs = [ autoreconfHook ];
@@ -19,8 +19,8 @@ let
   };
 in
 stdenv.mkDerivation  {
-  pname = "speech-denoiser";
-  version = "unstable-07-10-2019";
+  pname = "speech-denoiser-unstable";
+  version = "07-10-2019";
 
   src = speech-denoiser-src;
 

--- a/pkgs/applications/audio/spek/default.nix
+++ b/pkgs/applications/audio/spek/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, autoreconfHook, intltool, pkgconfig, ffmpeg, wxGTK30-gtk3, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
-  pname = "spek";
-  version = "unstable-2018-12-29";
+  pname = "spek-unstable";
+  version = "2018-12-29";
 
   src = fetchFromGitHub {
     owner = "alexkay";

--- a/pkgs/applications/audio/string-machine/default.nix
+++ b/pkgs/applications/audio/string-machine/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, boost, cairo, lv2, pkg-config }:
 
 stdenv.mkDerivation rec {
-  pname = "string-machine";
-  version = "unstable-2020-01-20";
+  pname = "string-machine-unstable";
+  version = "2020-01-20";
 
   src = fetchFromGitHub {
     owner = "jpcima";
-    repo = pname;
+    repo = "string-machine";
     rev = "188082dd0beb9a3c341035604841c53675fe66c4";
     sha256 = "0l9xrzp3f0hk6h320qh250a0n1nbd6qhjmab21sjmrlb4ngy672v";
     fetchSubmodules = true;

--- a/pkgs/applications/audio/tamgamp.lv2/default.nix
+++ b/pkgs/applications/audio/tamgamp.lv2/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, pkg-config, lv2, zita-resampler }:
 
 stdenv.mkDerivation rec {
-  pname = "tamgamp.lv2";
-  version = "unstable-2020-06-14";
+  pname = "tamgamp.lv2-unstable";
+  version = "2020-06-14";
 
   src = fetchFromGitHub {
     owner = "sadko4u";
-    repo = pname;
+    repo = "tamgamp.lv2";
     rev = "426da74142fcb6b7687a35b2b1dda3392e171b92";
     sha256 = "0dqsnim7v79rx13bkkh143gqz0xg26cpf6ya3mrwwprpf5hns2bp";
   };

--- a/pkgs/applications/audio/tuijam/default.nix
+++ b/pkgs/applications/audio/tuijam/default.nix
@@ -6,12 +6,12 @@
 }:
 
 buildPythonApplication rec {
-  pname = "tuijam";
-  version = "unstable-2020-06-05";
+  pname = "tuijam-unstable";
+  version = "2020-06-05";
 
   src = fetchFromGitHub {
     owner = "cfangmeier";
-    repo = pname;
+    repo = "tuijam";
     rev = "7baec6f6e80ee90da0d0363b430dd7d5695ff03b";
     sha256 = "1l0s88jvj99jkxnczw5nfj78m8vihh29g815n4mg9jblad23mgx5";
   };

--- a/pkgs/applications/audio/tunefish/default.nix
+++ b/pkgs/applications/audio/tunefish/default.nix
@@ -3,8 +3,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "tunefish";
-  version = "unstable-2020-08-13";
+  pname = "tunefish-unstable";
+  version = "2020-08-13";
 
   src = fetchFromGitHub {
     owner = "jpcima";

--- a/pkgs/applications/audio/uhhyou.lv2/default.nix
+++ b/pkgs/applications/audio/uhhyou.lv2/default.nix
@@ -13,8 +13,8 @@
 stdenv.mkDerivation rec {
   # this is what upstream calls the package, see:
   # https://github.com/ryukau/LV2Plugins#uhhyou-plugins-lv2
-  pname = "uhhyou.lv2";
-  version = "unstable-2020-07-31";
+  pname = "uhhyou.lv2-unstable";
+  version = "2020-07-31";
 
   src = fetchFromGitHub {
     owner = "ryukau";

--- a/pkgs/applications/audio/yoshimi/default.nix
+++ b/pkgs/applications/audio/yoshimi/default.nix
@@ -5,13 +5,13 @@
 assert stdenv ? glibc;
 
 stdenv.mkDerivation  rec {
-  pname = "yoshimi";
+  pname = "yoshimi-unstable";
   # Fix build with lv2 1.18: https://github.com/Yoshimi/yoshimi/pull/102/commits/86996cbb235f0fe138ae814a6758c2c8ba1c2a38
-  version = "unstable-2020-05-10";
+  version = "2020-05-10";
 
   src = fetchFromGitHub {
     owner = "Yoshimi";
-    repo = pname;
+    repo = "yoshimi";
     rev = "86996cbb235f0fe138ae814a6758c2c8ba1c2a38";
     sha256 = "0bgcc5fbgwpdjircq00wlii30pakf45yzligpbnf02a554hh4j01";
   };

--- a/pkgs/applications/editors/kakoune/plugins/case.kak.nix
+++ b/pkgs/applications/editors/kakoune/plugins/case.kak.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitLab }:
 
 stdenv.mkDerivation {
-  name = "case.kak";
-  version = "unstable-2020-04-06";
+  name = "case.kak-unstable";
+  version = "2020-04-06";
 
   src = fetchFromGitLab {
     owner = "FlyingWombat";

--- a/pkgs/applications/editors/viw/default.nix
+++ b/pkgs/applications/editors/viw/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, ncurses }:
 
 stdenv.mkDerivation rec {
-  pname = "viw";
-  version = "unstable-20171029";
+  pname = "viw-unstable";
+  version = "2017-10-29";
 
   src = fetchFromGitHub {
     owner = "lpan";
-    repo = pname;
+    repo = "viw";
     rev = "2cf317f6d82a6fa58f284074400297b6dc0f44c2";
     sha256 = "0bnkh57v01zay6ggk0rbddaf75i48h8z06xsv33wfbjldclaljp1";
   };

--- a/pkgs/applications/graphics/c3d/default.nix
+++ b/pkgs/applications/graphics/c3d/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, cmake, itk4, Cocoa }:
 
 stdenv.mkDerivation rec {
-  pname   = "c3d";
-  version = "unstable-2020-10-05";
+  pname   = "c3d-unstable";
+  version = "2020-10-05";
 
   src = fetchFromGitHub {
     owner = "pyushkevich";
-    repo = pname;
+    repo = "c3d";
     rev = "0a87e3972ea403babbe2d05ec6d50855e7c06465";
     sha256 = "0wsmkifqrcfy13fnwvinmnq1m0lkqmpyg7bgbwnb37mbrlbq06wf";
   };

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -170,8 +170,8 @@ stdenv.lib.makeScope pkgs.newScope (self: with self; {
   ufraw = pkgs.ufraw.gimpPlugin;
 
   gimplensfun = pluginDerivation rec {
-    version = "unstable-2018-10-21";
-    name = "gimplensfun-${version}";
+    version = "2018-10-21";
+    name = "gimplensfun-unstable-${version}";
 
     src = fetchFromGitHub {
       owner = "seebk";

--- a/pkgs/applications/graphics/pick-colour-picker/default.nix
+++ b/pkgs/applications/graphics/pick-colour-picker/default.nix
@@ -11,8 +11,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "pick-colour-picker";
-  version = "unstable-2019-10-11"; # "1.5.0-3ec940"
+  pname = "pick-colour-picker-unstable";
+  version = "2019-10-11"; # "1.5.0-3ec940"
 
   src = fetchFromGitHub {
     owner = "stuartlangridge";

--- a/pkgs/applications/graphics/ufraw/default.nix
+++ b/pkgs/applications/graphics/ufraw/default.nix
@@ -25,8 +25,8 @@
 assert withGimpPlugin -> gimp != null;
 
 stdenv.mkDerivation {
-  pname = "ufraw";
-  version = "unstable-2019-06-12";
+  pname = "ufraw-unstable";
+  version = "2019-06-12";
 
   # The original ufraw repo is unmaintained and broken;
   # this is a fork that collects patches

--- a/pkgs/applications/misc/antfs-cli/default.nix
+++ b/pkgs/applications/misc/antfs-cli/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, python3Packages }:
 
 python3Packages.buildPythonApplication {
-  pname = "antfs-cli";
-  version = "unstable-2017-02-11";
+  pname = "antfs-cli-unstable";
+  version = "2017-02-11";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/Tigge/antfs-cli";

--- a/pkgs/applications/misc/autospotting/default.nix
+++ b/pkgs/applications/misc/autospotting/default.nix
@@ -1,8 +1,8 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage {
-  pname = "autospotting";
-  version = "unstable-2018-11-17";
+  pname = "autospotting-unstable";
+  version = "2018-11-17";
   goPackagePath = "github.com/AutoSpotting/AutoSpotting";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/misc/bicon/default.nix
+++ b/pkgs/applications/misc/bicon/default.nix
@@ -9,12 +9,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "bicon";
-  version = "unstable-2018-09-10";
+  pname = "bicon-unstable";
+  version = "2018-09-10";
 
   src = fetchFromGitHub {
     owner = "behdad";
-    repo = pname;
+    repo = "bicon-unstable";
     rev = "38725c062a83ab19c4e4b4bc20eb9535561aa76c";
     sha256 = "0hdslrci8pq300f3rrjsvl5psfrxdwyxf9g2m5g789sr049dksnq";
   };

--- a/pkgs/applications/misc/cataract/build.nix
+++ b/pkgs/applications/misc/cataract/build.nix
@@ -6,13 +6,14 @@
 , libxml2
 , exiv2
 , imagemagick
+, pname
 , version
 , sha256
 , rev }:
 
 stdenv.mkDerivation {
+  inherit pname;
   inherit version;
-  pname = "cataract";
 
   src = fetchgit {
     url = "git://git.bzatek.net/cataract";

--- a/pkgs/applications/misc/cataract/default.nix
+++ b/pkgs/applications/misc/cataract/default.nix
@@ -1,6 +1,7 @@
 { callPackage }:
 
 callPackage ./build.nix {
+  pname = "cataract";
   version = "1.1.0";
   rev = "675e647dc8ae918d29f520a29be9201ae85a94dd";
   sha256 = "13b9rvcy9k2ay8w36j28kc7f4lnxp4jc0494ck3xsmwgqsawmzdj";

--- a/pkgs/applications/misc/cataract/unstable.nix
+++ b/pkgs/applications/misc/cataract/unstable.nix
@@ -1,7 +1,8 @@
 { callPackage }:
 
 callPackage ./build.nix {
-  version = "unstable-2016-10-18";
+  pname = "cataract-unstable";
+  version = "2016-10-18";
   rev = "db3d992febbe703931840e9bdad95c43081694a5";
   sha256 = "04f85piy675lq36w1mw6mw66n8911mmn4ifj8h9x47z8z806h3rf";
 }

--- a/pkgs/applications/misc/kjv/default.nix
+++ b/pkgs/applications/misc/kjv/default.nix
@@ -17,12 +17,12 @@ add-install-target = fetchpatch {
 in
 
 stdenv.mkDerivation rec {
-  pname = "kjv";
-  version = "unstable-2018-12-25";
+  pname = "kjv-unstable";
+  version = "2018-12-25";
 
   src = fetchFromGitHub {
     owner = "bontibon";
-    repo = pname;
+    repo = "kjv";
     rev = "fda81a610e4be0e7c5cf242de655868762dda1d4";
     sha256 = "1favfcjvd3pzz1ywwv3pbbxdg7v37s8vplgsz8ag016xqf5ykqqf";
   };

--- a/pkgs/applications/misc/lifelines/default.nix
+++ b/pkgs/applications/misc/lifelines/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, gettext, libiconv, bison, ncurses, perl, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  pname = "lifelines";
-  version = "unstable-2019-05-07";
+  pname = "lifelines-unstable";
+  version = "2019-05-07";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "lifelines";
+    repo = "lifelines";
     rev = "43f29285ed46fba322b6a14322771626e6b02c59";
     sha256 = "1agszzlmkxmznpc1xj0vzxkskrcfagfjvqsdyw1yp5yg6bsq272y";
   };

--- a/pkgs/applications/misc/merkaartor/default.nix
+++ b/pkgs/applications/misc/merkaartor/default.nix
@@ -2,8 +2,8 @@
 , qtbase, qtsvg, qtwebview, qtwebkit }:
 
 stdenv.mkDerivation rec {
-  pname = "merkaartor";
-  version = "unstable-2019-11-12";
+  pname = "merkaartor-unstable";
+  version = "2019-11-12";
 
   src = fetchFromGitHub {
     owner = "openstreetmap";

--- a/pkgs/applications/misc/mps-youtube/default.nix
+++ b/pkgs/applications/misc/mps-youtube/default.nix
@@ -3,8 +3,8 @@
 with python3Packages;
 
 buildPythonApplication rec {
-  pname = "mps-youtube";
-  version = "unstable-2020-01-28";
+  pname = "mps-youtube-unstable";
+  version = "2020-01-28";
 
   src = fetchFromGitHub {
     owner = "mps-youtube";

--- a/pkgs/applications/misc/ola/default.nix
+++ b/pkgs/applications/misc/ola/default.nix
@@ -15,8 +15,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "ola";
-  version = "unstable-2020-07-17";
+  pname = "ola-unstable";
+  version = "2020-07-17";
 
   src = fetchFromGitHub {
     owner = "OpenLightingProject";

--- a/pkgs/applications/misc/pbpst/default.nix
+++ b/pkgs/applications/misc/pbpst/default.nix
@@ -7,8 +7,8 @@
 }:
 
 llvmPackages.stdenv.mkDerivation rec {
-  version = "unstable-2018-01-11";
-  name = "pbpst-${version}";
+  version = "2018-01-11";
+  name = "pbpst-unstable-${version}";
 
   src = fetchFromGitHub {
     owner = "HalosGhost";

--- a/pkgs/applications/misc/perkeep/default.nix
+++ b/pkgs/applications/misc/perkeep/default.nix
@@ -12,8 +12,8 @@ let
   };
 
 in buildGoPackage rec {
-  name = "perkeep-${version}";
-  version = "unstable-2020-03-23";
+  name = "perkeep-unstable-${version}";
+  version = "2020-03-23";
 
   src = fetchFromGitHub {
     owner = "perkeep";

--- a/pkgs/applications/misc/qt-box-editor/default.nix
+++ b/pkgs/applications/misc/qt-box-editor/default.nix
@@ -9,8 +9,8 @@
 }:
 
 mkDerivation {
-  pname = "qt-box-editor";
-  version = "unstable-2019-07-12";
+  pname = "qt-box-editor-unstable";
+  version = "2019-07-12";
 
   src = fetchFromGitHub {
     owner = "zdenop";

--- a/pkgs/applications/misc/slstatus/default.nix
+++ b/pkgs/applications/misc/slstatus/default.nix
@@ -3,8 +3,8 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  pname = "slstatus";
-  version = "unstable-2019-02-16";
+  pname = "slstatus-unstable";
+  version = "2019-02-16";
 
   src = fetchgit {
     url = "https://git.suckless.org/slstatus";

--- a/pkgs/applications/misc/ssocr/default.nix
+++ b/pkgs/applications/misc/ssocr/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, imlib2, libX11 }:
 
 stdenv.mkDerivation {
-  pname = "ssocr";
-  version = "unstable-2018-08-11";
+  pname = "ssocr-unstable";
+  version = "2018-08-11";
 
   src = fetchFromGitHub {
     owner = "auerswal";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "0yzprwflky9a7zxa3zic7gvdwqg0zy49zvrqkdxng2k1ng78k3s7";
   };
 
-  nativeBuildInputs = [ imlib2 libX11 ]; 
+  nativeBuildInputs = [ imlib2 libX11 ];
 
   installFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/applications/misc/tdrop/default.nix
+++ b/pkgs/applications/misc/tdrop/default.nix
@@ -3,8 +3,8 @@
 , gnugrep, procps }:
 
 stdenv.mkDerivation {
-  pname = "tdrop";
-  version = "unstable-2020-05-14";
+  pname = "tdrop-unstable";
+  version = "2020-05-14";
 
   src = fetchFromGitHub {
     owner = "noctuid";

--- a/pkgs/applications/misc/tilix/default.nix
+++ b/pkgs/applications/misc/tilix/default.nix
@@ -19,8 +19,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "tilix";
-  version = "unstable-2019-10-02";
+  pname = "tilix-unstable";
+  version = "2019-10-02";
 
   src = fetchFromGitHub {
     owner = "gnunn1";

--- a/pkgs/applications/misc/tipp10/default.nix
+++ b/pkgs/applications/misc/tipp10/default.nix
@@ -2,8 +2,8 @@
   qtmultimedia, qttools, ... }:
 
 mkDerivation rec {
-  pname = "tipp10";
-  version = "unstable-20200616";
+  pname = "tipp10-unstable";
+  version = "2020-06-16";
 
   src = fetchFromGitLab {
     owner = "tipp10";

--- a/pkgs/applications/misc/wego/default.nix
+++ b/pkgs/applications/misc/wego/default.nix
@@ -1,8 +1,8 @@
 { stdenv, buildGoPackage, fetchgit }:
 
 buildGoPackage rec {
-  pname = "wego";
-  version = "unstable-2019-02-11";
+  pname = "wego-unstable";
+  version = "2019-02-11";
   rev = "994e4f141759a1070d7b0c8fbe5fad2cc7ee7d45";
 
   goPackagePath = "github.com/schachmat/wego";

--- a/pkgs/applications/networking/flent/http-getter.nix
+++ b/pkgs/applications/networking/flent/http-getter.nix
@@ -2,8 +2,8 @@
 , curl, pkgconfig }:
 
 stdenv.mkDerivation {
-  pname = "http-getter";
-  version = "unstable-2018-06-06";
+  pname = "http-getter-unstable";
+  version = "2018-06-06";
 
   src = fetchFromGitHub {
     owner = "tohojo";

--- a/pkgs/applications/networking/instant-messengers/go-neb/default.nix
+++ b/pkgs/applications/networking/instant-messengers/go-neb/default.nix
@@ -1,8 +1,8 @@
 { lib, buildGoModule, fetchFromGitHub, nixosTests }:
 
 buildGoModule {
-  pname = "go-neb";
-  version = "unstable-2020-04-09";
+  pname = "go-neb-unstable";
+  version = "2020-04-09";
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "go-neb";

--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -3,8 +3,8 @@
 with ocamlPackages;
 
 buildDunePackage rec {
-  pname = "jackline";
-  version = "unstable-2020-09-03";
+  pname = "jackline-unstable";
+  version = "2020-09-03";
 
   minimumOCamlVersion = "4.08";
 

--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -91,16 +91,16 @@ let
   };
 in
 mkDerivation rec {
-  pname = "linphone-desktop";
+  pname = "linphone-desktop-unstable";
   # Latest release is 4.1.1 old and doesn't build with the latest releases of
   # some of the dependencies so let's use the latest commit.
-  version = "unstable-2020-03-06";
+  version = "2020-03-06";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
     owner = "public";
     group = "BC";
-    repo = pname;
+    repo = "linphone-desktop";
     rev = "971997e162558d37051f89c9c34bbc240135f704";
     sha256 = "02ji4r8bpcm2kyisn9d3054m026l33g2574i1ag1cmb2dz2p8i1c";
   };

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-discord/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, pkgconfig, pidgin, json-glib }:
 
 stdenv.mkDerivation {
-  pname = "purple-discord";
-  version = "unstable-2018-04-10";
+  pname = "purple-discord-unstable";
+  version = "2018-04-10";
 
   src = fetchFromGitHub {
     owner = "EionRobb";

--- a/pkgs/applications/networking/mailreaders/trojita/default.nix
+++ b/pkgs/applications/networking/mailreaders/trojita/default.nix
@@ -28,8 +28,8 @@ let
     sha256 = "0y45fjib153za085la3hqpryycx33dkj3cz8kwzn2w31kvldfl1q";
   };
 in mkDerivation rec {
-  pname = "trojita";
-  version = "unstable-2020-07-06";
+  pname = "trojita-unstable";
+  version = "2020-07-06";
 
   src = fetchgit {
     url = "https://anongit.kde.org/trojita.git";

--- a/pkgs/applications/networking/ps2client/default.nix
+++ b/pkgs/applications/networking/ps2client/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  version = "unstable-2018-10-18";
-  pname = "ps2client";
+  pname = "ps2client-unstable";
+  version = "2018-10-18";
 
   src = fetchFromGitHub {
     owner = "ps2dev";
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   patchPhase = ''
    sed -i -e "s|-I/usr/include||g" -e "s|-I/usr/local/include||g" Makefile
   '';
-  
+
   installPhase = ''
     make PREFIX=$out install
   '';

--- a/pkgs/applications/networking/remote/x2goclient/default.nix
+++ b/pkgs/applications/networking/remote/x2goclient/default.nix
@@ -2,8 +2,8 @@
 , mkDerivation, qtbase, qtsvg, qtx11extras, qttools, phonon, pkgconfig }:
 
 mkDerivation {
-  pname = "x2goclient";
-  version = "unstable-2019-07-24";
+  pname = "x2goclient-unstable";
+  version = "2019-07-24";
 
   src = fetchgit {
    url = "git://code.x2go.org/x2goclient.git";

--- a/pkgs/applications/office/gtg/default.nix
+++ b/pkgs/applications/office/gtg/default.nix
@@ -14,8 +14,8 @@
 }:
 
 python3Packages.buildPythonApplication rec {
-  pname = "gtg";
-  version = "unstable-2020-09-16";
+  pname = "gtg-unstable";
+  version = "2020-09-16";
 
   src = fetchFromGitHub {
     owner = "getting-things-gnome";

--- a/pkgs/applications/office/planner/default.nix
+++ b/pkgs/applications/office/planner/default.nix
@@ -10,10 +10,10 @@
 , python2
 }:
 
-let version = "unstable-2019-02-13";
+let version = "2019-02-13";
 
 in stdenv.mkDerivation {
-  pname = "planner";
+  pname = "planner-unstable";
   inherit version;
 
   src = fetchFromGitLab {

--- a/pkgs/applications/science/biology/EZminc/default.nix
+++ b/pkgs/applications/science/biology/EZminc/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, libminc, bicpl, itk4, fftwFloat, gsl }:
 
 stdenv.mkDerivation rec {
-  pname = "EZminc";
-  version = "unstable-2019-03-12";
+  pname = "EZminc-unstable";
+  version = "2019-03-12";
 
   src = fetchFromGitHub {
     owner  = "BIC-MNI";
-    repo   = pname;
+    repo   = "EZminc";
     rev    = "5e3333ee356f914d34d66d33ea8df809c7f7fa51";
     sha256 = "0wy8cppf5xpgfqvgb3mqs1cjh81n6qzkk6zxv29wvng8nar9wsy4";
   };

--- a/pkgs/applications/science/biology/N3/default.nix
+++ b/pkgs/applications/science/biology/N3/default.nix
@@ -3,12 +3,12 @@
   libminc, EBTKS }:
 
 stdenv.mkDerivation rec {
-  pname = "N3";
-  version = "unstable-2018-08-09";
+  pname = "N3-unstable";
+  version = "2018-08-09";
 
   src = fetchFromGitHub {
     owner  = "BIC-MNI";
-    repo   = pname;
+    repo   = "N3";
     rev    = "010fc2ac58ce1d67b8e6a863fac0809d3203cb9b";
     sha256 = "06hci7gzhy8p34ggvx7gah2k9yxpwhgmq1cgw8pcd1r82g4rg6kd";
   };

--- a/pkgs/applications/science/biology/conglomerate/default.nix
+++ b/pkgs/applications/science/biology/conglomerate/default.nix
@@ -2,12 +2,12 @@
   makeWrapper }:
 
 stdenv.mkDerivation rec {
-  pname = "conglomerate";
-  version = "unstable-2017-09-10";
+  pname = "conglomerate-unstable";
+  version = "2017-09-10";
 
   src = fetchFromGitHub {
     owner  = "BIC-MNI";
-    repo   = pname;
+    repo   = "conglomerate";
     rev    = "7343238bc6215942c7ecc885a224f24433a291b0";
     sha256 = "1mlqgmy3jc13bv7d01rjwldxq0p4ayqic85xcl222hhifi3w2prr";
   };

--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -2,12 +2,12 @@
   libminc, libjpeg, nifticlib, zlib }:
 
 stdenv.mkDerivation rec {
-  pname   = "minc-tools";
-  version = "unstable-2020-07-25";
+  pname   = "minc-tools-unstable";
+  version = "2020-07-25";
 
   src = fetchFromGitHub {
     owner  = "BIC-MNI";
-    repo   = pname;
+    repo   = "minc-tools";
     rev    = "fb0a68a07d281e4e099c5d54df29925240de14c1";
     sha256 = "0zcv2sdj3k6k0xjqdq8j5bxq8smm48dzai90vwsmz8znmbbm6kvw";
   };

--- a/pkgs/applications/science/biology/mni_autoreg/default.nix
+++ b/pkgs/applications/science/biology/mni_autoreg/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, cmake, makeWrapper, perlPackages, libminc }:
 
 stdenv.mkDerivation rec {
-  pname = "mni_autoreg";
-  version = "unstable-2017-09-22";
+  pname = "mni_autoreg-unstable";
+  version = "2017-09-22";
 
   src = fetchFromGitHub {
     owner = "BIC-MNI";
-    repo = pname;
+    repo = "mni_autoreg";
     rev = "ab99e29987dc029737785baebf24896ec37a2d76";
     sha256 = "0axl069nv57vmb2wvqq7s9v3bfxwspzmk37bxm4973ai1irgppjq";
   };

--- a/pkgs/applications/science/biology/poretools/default.nix
+++ b/pkgs/applications/science/biology/poretools/default.nix
@@ -1,11 +1,11 @@
 { stdenv, pythonPackages, fetchFromGitHub }:
 
 pythonPackages.buildPythonPackage rec {
-  pname = "poretools";
-  version = "unstable-2016-07-10";
+  pname = "poretools-unstable";
+  version = "2016-07-10";
 
   src = fetchFromGitHub {
-    repo = pname;
+    repo = "poretools";
     owner = "arq5x";
     rev = "e426b1f09e86ac259a00c261c79df91510777407";
     sha256 = "0bglj833wxpp3cq430p1d3xp085ls221js2y90w7ir2x5ay8l7am";

--- a/pkgs/applications/science/electronics/appcsxcad/default.nix
+++ b/pkgs/applications/science/electronics/appcsxcad/default.nix
@@ -15,8 +15,8 @@
 }:
 
 mkDerivation {
-  pname = "appcsxcad";
-  version = "unstable-2020-01-04";
+  pname = "appcsxcad-unstable";
+  version = "2020-01-04";
 
   src = fetchFromGitHub {
     owner = "thliebig";

--- a/pkgs/applications/science/electronics/csxcad/default.nix
+++ b/pkgs/applications/science/electronics/csxcad/default.nix
@@ -12,8 +12,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "csxcad";
-  version = "unstable-2020-02-08";
+  pname = "csxcad-unstable";
+  version = "2020-02-08";
 
   src = fetchFromGitHub {
     owner = "thliebig";

--- a/pkgs/applications/science/electronics/fparser/default.nix
+++ b/pkgs/applications/science/electronics/fparser/default.nix
@@ -4,8 +4,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "fparser";
-  version = "unstable-2015-09-25";
+  pname = "fparser-unstable";
+  version = "2015-09-25";
 
   src = fetchFromGitHub {
     owner = "thliebig";

--- a/pkgs/applications/science/electronics/fped/default.nix
+++ b/pkgs/applications/science/electronics/fped/default.nix
@@ -5,8 +5,8 @@
 
 with lib;
 stdenv.mkDerivation {
-  pname = "fped";
-  version = "unstable-2017-05-11";
+  pname = "fped-unstable";
+  version = "2017-05-11";
 
   src = fetchgit {
     url = "git://projects.qi-hardware.com/fped.git";

--- a/pkgs/applications/science/electronics/openems/default.nix
+++ b/pkgs/applications/science/electronics/openems/default.nix
@@ -24,8 +24,8 @@ assert withMPI -> openmpi != null;
 assert withHyp2mat -> hyp2mat != null;
 
 stdenv.mkDerivation {
-  pname = "openems";
-  version = "unstable-2020-02-15";
+  pname = "openems-unstable";
+  version = "2020-02-15";
 
   src = fetchFromGitHub {
     owner = "thliebig";

--- a/pkgs/applications/science/electronics/qcsxcad/default.nix
+++ b/pkgs/applications/science/electronics/qcsxcad/default.nix
@@ -10,8 +10,8 @@
 }:
 
 mkDerivation {
-  pname = "qcsxcad";
-  version = "unstable-2020-01-04";
+  pname = "qcsxcad-unstable";
+  version = "2020-01-04";
 
   src = fetchFromGitHub {
     owner = "thliebig";

--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -13,12 +13,12 @@ let
   };
 in
 stdenv.mkDerivation rec {
-  pname = "iverilog";
-  version = "unstable-2020-08-24";
+  pname = "iverilog-unstable";
+  version = "2020-08-24";
 
   src = fetchFromGitHub {
     owner = "steveicarus";
-    repo = pname;
+    repo = "iverilog";
     rev = "d8556e4c86e1465b68bdc8d5ba2056ba95a42dfd";
     sha256 = "sha256-sT9j/0Q2FD5MOGpH/quMGvAuM7t7QavRHKD9lX7Elfs=";
   };

--- a/pkgs/applications/science/electronics/vhd2vl/default.nix
+++ b/pkgs/applications/science/electronics/vhd2vl/default.nix
@@ -6,12 +6,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "vhd2vl";
-  version = "unstable-2018-09-01";
+  pname = "vhd2vl-unstable";
+  version = "2018-09-01";
 
   src = fetchFromGitHub {
     owner = "ldoolitt";
-    repo = pname;
+    repo = "vhd2vl";
     rev = "37e3143395ce4e7d2f2e301e12a538caf52b983c";
     sha256 = "17va2pil4938j8c93anhy45zzgnvq3k71a7glj02synfrsv6fs8n";
   };

--- a/pkgs/applications/science/logic/beluga/default.nix
+++ b/pkgs/applications/science/logic/beluga/default.nix
@@ -1,8 +1,8 @@
 { lib, fetchFromGitHub, ocamlPackages, rsync }:
 
 ocamlPackages.buildDunePackage {
-  pname = "beluga";
-  version = "unstable-2020-03-11";
+  pname = "beluga-unstable";
+  version = "2020-03-11";
 
   src = fetchFromGitHub {
     owner  = "Beluga-lang";

--- a/pkgs/applications/version-management/git-and-tools/git-remote-hg/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-hg/default.nix
@@ -3,8 +3,8 @@
 }:
 
 python3Packages.buildPythonApplication rec {
-  pname = "git-remote-hg";
-  version = "unstable-2020-06-12";
+  pname = "git-remote-hg-unstable";
+  version = "2020-06-12";
 
   src = fetchFromGitHub {
     owner = "mnauw";

--- a/pkgs/applications/version-management/git-and-tools/git-reparent/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-reparent/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, makeWrapper, git, gnused }:
 
 stdenv.mkDerivation rec {
-  pname = "git-reparent";
-  version = "unstable-2017-09-03";
+  pname = "git-reparent-unstable";
+  version = "2017-09-03";
 
   src = fetchFromGitHub {
     owner  = "MarkLodato";

--- a/pkgs/applications/version-management/git-and-tools/git-vanity-hash/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-vanity-hash/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "git-vanity-hash";
-  version = "2020-02-26-unstable";
+  pname = "git-vanity-hash-unstable";
+  version = "2020-02-26";
 
   src = fetchFromGitHub {
     owner = "prasmussen";

--- a/pkgs/applications/video/mjpg-streamer/default.nix
+++ b/pkgs/applications/video/mjpg-streamer/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, cmake, libjpeg }:
 
 stdenv.mkDerivation {
-  pname = "mjpg-streamer";
-  version = "unstable-2019-05-24";
+  pname = "mjpg-streamer-unstable";
+  version = "2019-05-24";
 
   src = fetchFromGitHub {
     owner = "jacksonliam";

--- a/pkgs/applications/video/mpv/scripts/sponsorblock.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock.nix
@@ -2,8 +2,8 @@
 
 # Usage: `pkgs.mpv.override { scripts = [ pkgs.mpvScripts.sponsorblock ]; }`
 stdenv.mkDerivation {
-  pname = "mpv_sponsorblock";
-  version = "unstable-2020-07-05";
+  pname = "mpv_sponsorblock-unstable";
+  version = "2020-07-05";
 
   src = fetchFromGitHub {
     owner = "po5";

--- a/pkgs/applications/window-managers/i3/layout-manager.nix
+++ b/pkgs/applications/window-managers/i3/layout-manager.nix
@@ -5,12 +5,12 @@ let
 in
 
 stdenv.mkDerivation rec {
-  pname = "i3-layout-manager";
-  version = "unstable-2019-12-06";
+  pname = "i3-layout-manager-unstable";
+  version = "2019-12-06";
 
   src = fetchFromGitHub {
     owner = "klaxalk";
-    repo = pname;
+    repo = "i3-layout-manager";
     rev = "064e13959413ba2d706185478a394e5852c0dc53";
     sha256 = "1qm35sp1cfi3xj5j7xwa05dkb3353gwq4xh69ryc6382xx3wszg6";
   };

--- a/pkgs/applications/window-managers/i3/pystatus.nix
+++ b/pkgs/applications/window-managers/i3/pystatus.nix
@@ -10,8 +10,8 @@
 python3Packages.buildPythonApplication rec {
   # i3pystatus moved to rolling release:
   # https://github.com/enkore/i3pystatus/issues/584
-  version = "unstable-2020-06-12";
-  pname = "i3pystatus";
+  pname = "i3pystatus-unstable";
+  version = "2020-06-12";
 
   src = fetchFromGitHub {
     owner = "enkore";

--- a/pkgs/applications/window-managers/kbdd/default.nix
+++ b/pkgs/applications/window-managers/kbdd/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, pkgconfig, dbus-glib, autoreconfHook, xorg }:
 
 stdenv.mkDerivation {
-  pname = "kbdd";
-  version = "unstable-2017-01-29";
+  pname = "kbdd-unstable";
+  version = "2017-01-29";
 
   src = fetchFromGitHub {
     owner = "qnikst";

--- a/pkgs/applications/window-managers/xmonad/log-applet/default.nix
+++ b/pkgs/applications/window-managers/xmonad/log-applet/default.nix
@@ -8,13 +8,13 @@
 assert desktopSupport == "gnomeflashback" || desktopSupport == "mate"  || desktopSupport == "xfce4";
 
 stdenv.mkDerivation rec {
-  version = "unstable-2017-09-15";
-  pname = "xmonad-log-applet";
+  pname = "xmonad-log-applet-unstable";
+  version = "2017-09-15";
   name = "${pname}-${desktopSupport}-${version}";
 
   src = fetchFromGitHub {
     owner = "kalj";
-    repo = pname;
+    repo = "xmonad-log-applet";
     rev = "a1b294cad2f266e4f18d9de34167fa96a0ffdba8";
     sha256 = "042307grf4zvn61gnflhsj5xsjykrk9sjjsprprm4iij0qpybxcw";
   };

--- a/pkgs/applications/window-managers/yabar/build.nix
+++ b/pkgs/applications/window-managers/yabar/build.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchFromGitHub, cairo, gdk-pixbuf, libconfig, pango, pkgconfig
 , xcbutilwm, alsaLib, wirelesstools, asciidoc, libxslt, makeWrapper, docbook_xsl
 , configFile ? null, lib
-, rev, sha256, version, patches ? []
+, rev, sha256, pname, version, patches ? []
 }:
 
 stdenv.mkDerivation {
-  pname = "yabar";
+  inherit pname;
   inherit version;
 
   src = fetchFromGitHub {

--- a/pkgs/applications/window-managers/yabar/default.nix
+++ b/pkgs/applications/window-managers/yabar/default.nix
@@ -2,6 +2,7 @@
 
 let
   overrides = rec {
+    pname = "yabar";
     version = "0.4.0";
 
     rev = version;

--- a/pkgs/applications/window-managers/yabar/unstable.nix
+++ b/pkgs/applications/window-managers/yabar/unstable.nix
@@ -2,7 +2,8 @@
 
 let
   pkg = callPackage ./build.nix ({
-    version = "unstable-2018-01-18";
+    pname = "yabar-unstable";
+    version = "2018-01-18";
 
     rev    = "c516e8e78d39dd2b339acadc4c175347171150bb";
     sha256 = "1p9lx78cayyn7qc2q66id2xfs76jyddnqv2x1ypsvixaxwcvqgdb";

--- a/pkgs/data/fonts/gelasio/default.nix
+++ b/pkgs/data/fonts/gelasio/default.nix
@@ -1,9 +1,9 @@
 { lib, fetchFromGitHub }:
 
 let
-  version = "unstable-2018-08-12";
+  version = "2018-08-12";
 in fetchFromGitHub {
-  name = "gelasio-${version}";
+  name = "gelasio-unstable-${version}";
   owner = "SorkinType";
   repo = "Gelasio";
   rev = "5bced461d54bcf8e900bb3ba69455af35b0d2ff1";

--- a/pkgs/data/fonts/ir-standard-fonts/default.nix
+++ b/pkgs/data/fonts/ir-standard-fonts/default.nix
@@ -1,12 +1,12 @@
 { lib, fetchFromGitHub }:
 
 let
-  pname = "ir-standard-fonts";
-  version = "unstable-2017-01-21";
+  pname = "ir-standard-fonts-unstable";
+  version = "2017-01-21";
 in fetchFromGitHub {
   name = "${pname}-${version}";
   owner = "morealaz";
-  repo = pname;
+  repo = "ir-standard-fonts";
   rev = "d36727d6c38c23c01b3074565667a2fe231fe18f";
 
   postFetch = ''

--- a/pkgs/data/fonts/lalezar-fonts/default.nix
+++ b/pkgs/data/fonts/lalezar-fonts/default.nix
@@ -1,8 +1,8 @@
 { lib, fetchFromGitHub }:
 
 let
-  pname = "lalezar-fonts";
-  version = "unstable-2017-02-28";
+  pname = "lalezar-fonts-unstable";
+  version = "2017-02-28";
 in fetchFromGitHub {
   name = "${pname}-${version}";
   owner = "BornaIz";

--- a/pkgs/data/fonts/xkcd-font/default.nix
+++ b/pkgs/data/fonts/xkcd-font/default.nix
@@ -1,13 +1,13 @@
 { lib, fetchFromGitHub }:
 
 let
-  pname = "xkcd-font";
-  version = "unstable-2017-08-24";
+  pname = "xkcd-font-unstable";
+  version = "2017-08-24";
 in fetchFromGitHub {
   name = "${pname}-${version}";
 
   owner = "ipython";
-  repo = pname;
+  repo = "xkcd-font";
   rev = "5632fde618845dba5c22f14adc7b52bf6c52d46d";
 
   postFetch = ''

--- a/pkgs/data/icons/bibata-cursors/translucent.nix
+++ b/pkgs/data/icons/bibata-cursors/translucent.nix
@@ -1,8 +1,8 @@
 { stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen }:
 
 stdenvNoCC.mkDerivation rec {
-  pname = "bibata-cursors-translucent";
-  version = "unstable-2019-09-13";
+  pname = "bibata-cursors-translucent-unstable";
+  version = "2019-09-13";
 
   src = fetchFromGitHub {
     owner = "Silicasandwhich";

--- a/pkgs/data/icons/iso-flags/default.nix
+++ b/pkgs/data/icons/iso-flags/default.nix
@@ -9,8 +9,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "iso-flags";
-  version = "unstable-18012020";
+  pname = "iso-flags-unstable";
+  version = "18012020";
 
   src = fetchFromGitHub {
     owner = "joielechong";

--- a/pkgs/desktops/gnome-2/platform/gtkglext/default.nix
+++ b/pkgs/desktops/gnome-2/platform/gtkglext/default.nix
@@ -16,13 +16,13 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "gtkglext";
-  version = "unstable-2019-12-19";
+  pname = "gtkglext-unstable";
+  version = "2019-12-19";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "Archive";
-    repo = pname;
+    repo = "gtkglext";
     # build fixes
     # https://gitlab.gnome.org/Archive/gtkglext/merge_requests/1
     rev = "ad95fbab68398f81d7a5c895276903b0695887e2";

--- a/pkgs/desktops/gnome-3/extensions/drop-down-terminal/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/drop-down-terminal/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, substituteAll, gjs, vte, gnome3 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-extension-drop-down-terminal";
-  version = "unstable-2020-03-25";
+  pname = "gnome-shell-extension-drop-down-terminal-unstable";
+  version = "2020-03-25";
 
   src = fetchFromGitHub {
     owner = "zzrough";

--- a/pkgs/desktops/gnome-3/extensions/impatience/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/impatience/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, glib }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-impatience";
-  version = "unstable-2019-09-23";
+  pname = "gnome-shell-impatience-unstable";
+  version = "2019-09-23";
 
   src = fetchFromGitHub {
     owner = "timbertson";

--- a/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
@@ -1,8 +1,8 @@
 { stdenv, substituteAll, fetchpatch, fetchFromGitHub, glib, glib-networking, libgtop, gnome3 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-system-monitor";
-  version = "2020-04-27-unstable";
+  pname = "gnome-shell-system-monitor-unstable";
+  version = "2020-04-27";
 
   src = fetchFromGitHub {
     owner = "paradoxxxzero";

--- a/pkgs/desktops/gnome-3/extensions/tilingnome/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/tilingnome/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-tilingnome-unstable";
-  version = "unstable-2019-09-19";
+  version = "2019-09-19";
 
   src = fetchFromGitHub {
     owner = "rliang";

--- a/pkgs/desktops/gnome-3/extensions/timepp/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/timepp/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, gnome3 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-extension-timepp";
-  version = "unstable-2020-03-15";
+  pname = "gnome-shell-extension-timepp-unstable";
+  version = "2020-03-15";
 
   src = fetchFromGitHub {
     owner = "zagortenay333";

--- a/pkgs/desktops/gnome-3/extensions/window-corner-preview/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/window-corner-preview/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, gnome3 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-extension-window-corner-preview";
-  version = "unstable-2019-04-03";
+  pname = "gnome-shell-extension-window-corner-preview-unstable";
+  version = "2019-04-03";
 
   src = fetchFromGitHub {
     owner = "medenagan";

--- a/pkgs/desktops/pantheon/apps/elementary-dock/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-dock/default.nix
@@ -27,8 +27,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "elementary-dock";
-  version = "unstable-2020-06-11";
+  pname = "elementary-dock-unstable";
+  version = "2020-06-11";
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/desktops/pantheon/artwork/elementary-redacted-script/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-redacted-script/default.nix
@@ -4,8 +4,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "elementary-redacted-script";
-  version = "unstable-2016-06-03";
+  pname = "elementary-redacted-script-unstable";
+  version = "2016-06-03";
 
   src = fetchFromGitHub {
     owner = "png2378";

--- a/pkgs/desktops/pantheon/services/elementary-notifications/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-notifications/default.nix
@@ -15,8 +15,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "elementary-notifications";
-  version = "unstable-2020-03-31";
+  pname = "elementary-notifications-unstable";
+  version = "2020-03-31";
 
   repoName = "notifications";
 

--- a/pkgs/desktops/surf-display/default.nix
+++ b/pkgs/desktops/surf-display/default.nix
@@ -3,8 +3,8 @@
 , xorg, pulseaudio, xprintidle-ng }:
 
 stdenv.mkDerivation rec {
-  pname = "surf-display";
-  version = "unstable-2019-04-15";
+  pname = "surf-display-unstable";
+  version = "2019-04-15";
 
   src = fetchgit {
     url = "https://code.it-zukunft-schule.de/cgit/surf-display";

--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -22,8 +22,8 @@ let
 
   ghcWithPackages = ghc.withPackages (g: (with g; [old-time regex-compat syb]));
 in stdenv.mkDerivation rec {
-  pname = "bluespec";
-  version = "unstable-2020.02.09";
+  pname = "bluespec-unstable";
+  version = "2020.02.09";
 
   src = fetchFromGitHub {
     owner  = "B-Lang-org";

--- a/pkgs/development/compilers/crystal/crystal2nix.nix
+++ b/pkgs/development/compilers/crystal/crystal2nix.nix
@@ -1,8 +1,8 @@
 { lib, crystal, nix-prefetch-git }:
 
 crystal.buildCrystalPackage {
-  pname = "crystal2nix";
-  version = "unstable-2018-07-31";
+  pname = "crystal2nix-unstable";
+  version = "2018-07-31";
 
   nixPrefetchGit = "${lib.getBin nix-prefetch-git}/bin/nix-prefetch-git";
   unpackPhase = "substituteAll ${./crystal2nix.cr} crystal2nix.cr";

--- a/pkgs/development/compilers/gerbil/build.nix
+++ b/pkgs/development/compilers/gerbil/build.nix
@@ -1,6 +1,6 @@
 { pkgs, gccStdenv, lib, coreutils, bash, # makeStaticLibraries,
   openssl, zlib, sqlite, libxml2, libyaml, libmysqlclient, lmdb, leveldb, postgresql,
-  version, git-version,
+  pname, version, git-version,
   gambit-support,
   gambit ? pkgs.gambit, gambit-params ? pkgs.gambit-support.stable-params, src }:
 
@@ -8,7 +8,7 @@
 let stdenv = gccStdenv; in
 
 stdenv.mkDerivation rec {
-  pname = "gerbil";
+  inherit pname;
   inherit version;
   inherit src;
 

--- a/pkgs/development/compilers/gerbil/default.nix
+++ b/pkgs/development/compilers/gerbil/default.nix
@@ -1,6 +1,7 @@
 { callPackage, fetchFromGitHub }:
 
 callPackage ./build.nix rec {
+  pname = "gerbil";
   version = "0.16";
   git-version = version;
   src = fetchFromGitHub {

--- a/pkgs/development/compilers/gerbil/gerbil-crypto.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-crypto.nix
@@ -1,8 +1,8 @@
 { pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
 
 gerbil-support.gerbilPackage {
-  pname = "gerbil-crypto";
-  version = "unstable-2020-08-01";
+  pname = "gerbil-crypto-unstable";
+  version = "2020-08-01";
   git-version = "0.0-6-ga228862";
   gerbil-package = "clan/crypto";
   gerbil = gerbil-unstable;

--- a/pkgs/development/compilers/gerbil/gerbil-ethereum.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-ethereum.nix
@@ -1,8 +1,8 @@
 { pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
 
 gerbil-support.gerbilPackage {
-  pname = "gerbil-ethereum";
-  version = "unstable-2020-08-02";
+  pname = "gerbil-ethereum-unstable";
+  version = "2020-08-02";
   git-version = "0.0-15-g7cd2dd7";
   gerbil-package = "mukn/ethereum";
   gerbil = gerbil-unstable;

--- a/pkgs/development/compilers/gerbil/gerbil-persist.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-persist.nix
@@ -1,8 +1,8 @@
 { pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
 
 gerbil-support.gerbilPackage {
-  pname = "gerbil-persist";
-  version = "unstable-2020-08-02";
+  pname = "gerbil-persist-unstable";
+  version = "2020-08-02";
   git-version = "0.0-4-ga3b2bd1";
   gerbil-package = "clan/persist";
   gerbil = gerbil-unstable;

--- a/pkgs/development/compilers/gerbil/gerbil-poo.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-poo.nix
@@ -1,8 +1,8 @@
 { pkgs, lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
 
 gerbil-support.gerbilPackage {
-  pname = "gerbil-ethereum";
-  version = "unstable-2020-08-02";
+  pname = "gerbil-ethereum-unstable";
+  version = "2020-08-02";
   git-version = "0.0-13-g1014154";
   gerbil-package = "clan/poo";
   gerbil = gerbil-unstable;

--- a/pkgs/development/compilers/gerbil/gerbil-utils.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-utils.nix
@@ -1,8 +1,8 @@
 { lib, fetchFromGitHub, gerbil-unstable, gerbil-support, gambit-support }:
 
 gerbil-support.gerbilPackage {
-  pname = "gerbil-utils";
-  version = "unstable-2020-08-02";
+  pname = "gerbil-utils-unstable";
+  version = "2020-08-02";
   git-version = "0.2-21-g7e7d053";
   gerbil-package = "clan";
   gerbil = gerbil-unstable;

--- a/pkgs/development/compilers/gerbil/unstable.nix
+++ b/pkgs/development/compilers/gerbil/unstable.nix
@@ -1,7 +1,8 @@
 { callPackage, fetchFromGitHub, gambit-unstable, gambit-support }:
 
 callPackage ./build.nix rec {
-  version = "unstable-2020-08-02";
+  pname = "gerbil-unstable";
+  version = "2020-08-02";
   git-version = "0.16-120-g3f248e13";
   src = fetchFromGitHub {
     owner = "vyzo";

--- a/pkgs/development/compilers/lobster/default.nix
+++ b/pkgs/development/compilers/lobster/default.nix
@@ -17,12 +17,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "lobster";
-  version = "unstable-2020-10-04";
+  pname = "lobster-unstable";
+  version = "2020-10-04";
 
   src = fetchFromGitHub {
     owner = "aardappel";
-    repo = pname;
+    repo = "lobster";
     rev = "4c5e78f021ce9d06592fb3a66388e5e31fac1adb";
     sha256 = "1wnbc8kr1dyfs53nlcxah22ghphmazzrlcj9z47cgkdsj1qfy84x";
   };

--- a/pkgs/development/compilers/openspin/default.nix
+++ b/pkgs/development/compilers/openspin/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  pname = "openspin";
-  version = "unstable-2018-10-02";
+  pname = "openspin-unstable";
+  version = "2018-10-02";
 
   src = fetchFromGitHub {
     owner = "parallaxinc";

--- a/pkgs/development/compilers/qbe/default.nix
+++ b/pkgs/development/compilers/qbe/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchgit }:
 
 stdenv.mkDerivation {
-  pname = "qbe";
-  version = "unstable-2019-07-11";
+  pname = "qbe-unstable";
+  version = "2019-07-11";
 
   src = fetchgit {
     url = "git://c9x.me/qbe.git";

--- a/pkgs/development/libraries/adslib/default.nix
+++ b/pkgs/development/libraries/adslib/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  pname = "adslib";
-  version = "unstable-2020-08-28";
+  pname = "adslib-unstable";
+  version = "2020-08-28";
 
   src = fetchFromGitHub {
     owner = "stlehmann";

--- a/pkgs/development/libraries/alure2/default.nix
+++ b/pkgs/development/libraries/alure2/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, cmake, openal, libvorbis, opusfile, libsndfile }:
 
 stdenv.mkDerivation rec {
-  pname = "alure2";
-  version = "unstable-2020-02-06";
+  pname = "alure2-unstable";
+  version = "2020-02-06";
 
   src = fetchFromGitHub {
     owner = "kcat";

--- a/pkgs/development/libraries/audio/raul/default.nix
+++ b/pkgs/development/libraries/audio/raul/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchgit, boost, gtk2, pkgconfig, python, wafHook }:
 
 stdenv.mkDerivation rec {
-  pname = "raul";
-  version = "unstable-2019-12-09";
+  pname = "raul-unstable";
+  version = "2019-12-09";
   name = "${pname}-${version}";
 
   src = fetchgit {

--- a/pkgs/development/libraries/beignet/default.nix
+++ b/pkgs/development/libraries/beignet/default.nix
@@ -18,8 +18,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "beignet";
-  version = "unstable-2018.08.20";
+  pname = "beignet-unstable";
+  version = "2018.08.20";
 
   src = fetchFromGitHub {
     owner  = "intel";

--- a/pkgs/development/libraries/belle-sip/default.nix
+++ b/pkgs/development/libraries/belle-sip/default.nix
@@ -10,16 +10,16 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "belle-sip";
+  pname = "belle-sip-unstable";
   # Using master branch for linphone-desktop caused a chain reaction that many
   # of its dependencies needed to use master branch too.
-  version = "unstable-2020-02-18";
+  version = "2020-02-18";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
     owner = "public";
     group = "BC";
-    repo = pname;
+    repo = "belle-sip";
     rev = "0dcb13416eae87edf140771b886aedaf6be8cf60";
     sha256 = "0pzxk8mkkg6zsnmj1bwggbdjv864psx89gglfm51h8s501kg11fv";
   };

--- a/pkgs/development/libraries/belr/default.nix
+++ b/pkgs/development/libraries/belr/default.nix
@@ -5,16 +5,16 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "belr";
+  pname = "belr-unstable";
   # Using master branch for linphone-desktop caused a chain reaction that many
   # of its dependencies needed to use master branch too.
-  version = "unstable-2020-03-09";
+  version = "2020-03-09";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
     owner = "public";
     group = "BC";
-    repo = pname;
+    repo = "belr";
     rev = "326d030ca9db12525c2a6d2a65f386f36f3c2ed5";
     sha256 = "1cdblb9smncq3al0crqp5651b02k1g6whlw1ib769p61gad0rs3v";
   };

--- a/pkgs/development/libraries/boxfort/default.nix
+++ b/pkgs/development/libraries/boxfort/default.nix
@@ -2,8 +2,8 @@
 , nanomsg, python37Packages }:
 
 stdenv.mkDerivation rec {
-  version = "unstable-2019-09-19";
-  pname = "boxfort";
+  version = "2019-09-19";
+  pname = "boxfort-unstable";
 
   src = fetchFromGitHub {
     owner = "Snaipe";

--- a/pkgs/development/libraries/dee/default.nix
+++ b/pkgs/development/libraries/dee/default.nix
@@ -12,8 +12,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "dee";
-  version = "unstable-2017-06-16";
+  pname = "dee-unstable";
+  version = "2017-06-16";
 
   outputs = [ "out" "dev" "py" ];
 

--- a/pkgs/development/libraries/ganv/default.nix
+++ b/pkgs/development/libraries/ganv/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchgit, graphviz, gtk2, gtkmm2, pkgconfig, python, wafHook }:
 
 stdenv.mkDerivation rec {
-  pname = "ganv";
-  version = "unstable-2019-12-30";
+  pname = "ganv-unstable";
+  version = "2019-12-30";
 
   src = fetchgit {
-    url = "https://gitlab.com/drobilla/${pname}.git";
+    url = "https://gitlab.com/drobilla/ganv.git";
     fetchSubmodules = true;
     rev = "90bd022f8909f92cc5290fdcfc76c626749e1186";
     sha256 = "01znnalirbqxpz62fbw2c14c8xn117jc92xv6dhb3hln92k9x37f";

--- a/pkgs/development/libraries/gdk-pixbuf/xlib.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/xlib.nix
@@ -11,8 +11,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "gdk-pixbuf-xlib";
-  version = "2020-06-11-unstable";
+  pname = "gdk-pixbuf-xlib-unstable";
+  version = "2020-06-11";
 
   outputs = [ "out" "dev" "devdoc" ];
 

--- a/pkgs/development/libraries/gsmlib/default.nix
+++ b/pkgs/development/libraries/gsmlib/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, autoreconfHook }:
 stdenv.mkDerivation rec {
-  pname = "gsmlib";
-  version = "unstable-2017-10-06";
+  pname = "gsmlib-unstable";
+  version = "2017-10-06";
   src = fetchFromGitHub {
     owner = "x-logLT";
     repo = "gsmlib";

--- a/pkgs/development/libraries/libcbor/default.nix
+++ b/pkgs/development/libraries/libcbor/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, cmake, cmocka }:
 
 stdenv.mkDerivation rec {
-  pname = "libcbor";
-  version = "unstable-2019-07-25";
+  pname = "libcbor-unstable";
+  version = "2019-07-25";
 
   src = fetchFromGitHub {
     owner = "PJK";
-    repo = pname;
+    repo = "libcbor";
     rev = "82512d851205fbc7f65d96a0b4a8e1bad2e4f3c6";
     sha256 = "01hy7n21gxz4gp3gdwm2ywz822p415bj2k9ccxgwz3plvncs4xa1";
   };

--- a/pkgs/development/libraries/libelfin/default.nix
+++ b/pkgs/development/libraries/libelfin/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, python3, substituteAll }:
 
 stdenv.mkDerivation rec {
-  pname = "libelfin";
-  version = "unstable-2018-08-25";
+  pname = "libelfin-unstable";
+  version = "2018-08-25";
 
   src = fetchFromGitHub {
     owner = "aclements";
-    repo = pname;
+    repo = "libelfin";
     rev = "ac45a094fadba77ad840063fb7aab82571546be0";
     sha256 = "143x680c6hsy51kngs04ypg4ql3lp498llcwj4lh1v0qp5qvjhyz";
   };

--- a/pkgs/development/libraries/liberio/default.nix
+++ b/pkgs/development/libraries/liberio/default.nix
@@ -6,8 +6,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "liberio";
-  version = "unstable-2019-12-11";
+  pname = "liberio-unstable";
+  version = "2019-12-11";
 
   src = fetchFromGitHub {
     owner = "EttusResearch";

--- a/pkgs/development/libraries/libevdevplus/default.nix
+++ b/pkgs/development/libraries/libevdevplus/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  pname = "libevdevplus";
-  version = "unstable-2019-10-01";
+  pname = "libevdevplus-unstable";
+  version = "2019-10-01";
 
   src  = fetchFromGitHub {
     owner  = "YukiWorkshop";

--- a/pkgs/development/libraries/libgumath/default.nix
+++ b/pkgs/development/libraries/libgumath/default.nix
@@ -5,8 +5,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "libgumath";
-  version = "unstable-2019-08-01";
+  pname = "libgumath-unstable";
+  version = "2019-08-01";
 
   src = fetchFromGitHub {
     owner = "xnd-project";

--- a/pkgs/development/libraries/liblinphone/default.nix
+++ b/pkgs/development/libraries/liblinphone/default.nix
@@ -71,16 +71,16 @@ let
   );
 in
 stdenv.mkDerivation rec {
-  pname = "liblinphone";
+  pname = "liblinphone-unstable";
   # Using master branch for linphone-desktop caused a chain reaction that many
   # of its dependencies needed to use master branch too.
-  version = "unstable-2020-03-20";
+  version = "2020-03-20";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
     owner = "public";
     group = "BC";
-    repo = pname;
+    repo = "liblinphone";
     rev = "1d762a3e0e304aa579798aed4400d2cee2c1ffa0";
     sha256 = "0ja38payyqbd8z6q5l5w6hi7xarmfj5021gh0qdk0j832br4c6c3";
   };

--- a/pkgs/development/libraries/libminc/default.nix
+++ b/pkgs/development/libraries/libminc/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, zlib, netcdf, nifticlib, hdf5 }:
 
 stdenv.mkDerivation rec {
-  pname   = "libminc";
-  version = "unstable-2020-07-17";
+  pname   = "libminc-unstable";
+  version = "2020-07-17";
 
   owner = "BIC-MNI";
 
   src = fetchFromGitHub {
     inherit owner;
-    repo   = pname;
+    repo   = "libminc";
     rev    = "ffb5fb234a852ea7e8da8bb2b3b49f67acbe56ca";
     sha256 = "0yr4ksghpvxh9zg0a4p7hvln3qirsi08plvjp5kxx2qiyj96zsdm";
   };

--- a/pkgs/development/libraries/libndtypes/default.nix
+++ b/pkgs/development/libraries/libndtypes/default.nix
@@ -3,8 +3,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "libndtypes";
-  version = "unstable-2019-08-01";
+  pname = "libndtypes-unstable";
+  version = "2019-08-01";
 
   src = fetchFromGitHub {
     owner = "xnd-project";

--- a/pkgs/development/libraries/libtgvoip/default.nix
+++ b/pkgs/development/libraries/libtgvoip/default.nix
@@ -5,8 +5,8 @@
 with lib;
 
 stdenv.mkDerivation rec {
-  pname = "libtgvoip";
-  version = "unstable-2020-03-02";
+  pname = "libtgvoip-unstable";
+  version = "2020-03-02";
 
   src = fetchFromGitHub {
     owner = "telegramdesktop";

--- a/pkgs/development/libraries/libubox/default.nix
+++ b/pkgs/development/libraries/libubox/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchgit, cmake, pkgconfig, json_c }:
 
 stdenv.mkDerivation {
-  pname = "libubox";
-  version = "unstable-2020-01-20";
+  pname = "libubox-unstable";
+  version = "2020-01-20";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/libubox.git";

--- a/pkgs/development/libraries/libunity/default.nix
+++ b/pkgs/development/libraries/libunity/default.nix
@@ -13,8 +13,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "libunity";
-  version = "unstable-2019-03-19";
+  pname = "libunity-unstable";
+  version = "2019-03-19";
 
   outputs = [ "out" "dev" "py" ];
 

--- a/pkgs/development/libraries/libxnd/default.nix
+++ b/pkgs/development/libraries/libxnd/default.nix
@@ -5,8 +5,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "libxnd";
-  version = "unstable-2019-08-01";
+  pname = "libxnd-unstable";
+  version = "2019-08-01";
 
   src = fetchFromGitHub {
     owner = "xnd-project";

--- a/pkgs/development/libraries/libykclient/default.nix
+++ b/pkgs/development/libraries/libykclient/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, help2man, curl }:
 
 stdenv.mkDerivation {
-  pname = "libykclient";
-  version = "unstable-2019-03-18";
+  pname = "libykclient-unstable";
+  version = "2019-03-18";
   src = fetchFromGitHub {
     owner = "Yubico";
     repo = "yubico-c-client";

--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -32,16 +32,16 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "mediastreamer2";
+  pname = "mediastreamer2-unstable";
   # Using master branch for linphone-desktop caused a chain reaction that many
   # of its dependencies needed to use master branch too.
-  version = "unstable-2020-03-20";
+  version = "2020-03-20";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
     owner = "public";
     group = "BC";
-    repo = pname;
+    repo = "mediastreamer2";
     rev = "c5eecb72cb44376d142949051dd0cb7c982608fb";
     sha256 = "1vp260jxvjlmrmjdl4p23prg4cjln20a7z6zq8dqvfh4iq3ya033";
   };

--- a/pkgs/development/libraries/mediastreamer/msopenh264.nix
+++ b/pkgs/development/libraries/mediastreamer/msopenh264.nix
@@ -9,16 +9,16 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "msopenh264";
+  pname = "msopenh264-unstable";
   # Using master branch for linphone-desktop caused a chain reaction that many
   # of its dependencies needed to use master branch too.
-  version = "unstable-2020-03-03";
+  version = "2020-03-03";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
     owner = "public";
     group = "BC";
-    repo = pname;
+    repo = "msopenh264";
     rev = "2c3abf52824ad23a4caae7565ef158ef91767704";
     sha256 = "140hs5lzpshzswvl39klcypankq3v2qck41696j22my7s4wsa0hr";
   };

--- a/pkgs/development/libraries/multipart-parser-c/default.nix
+++ b/pkgs/development/libraries/multipart-parser-c/default.nix
@@ -3,12 +3,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "multipart-parser-c";
-  version = "unstable-2015-12-14";
+  pname = "multipart-parser-c-unstable";
+  version = "2015-12-14";
 
   src = fetchFromGitHub {
     owner = "iafonov";
-    repo = pname;
+    repo = "multipart-parser-c";
     rev = "772639cf10db6d9f5a655ee9b7eb20b815fab396";
     sha256 = "056r63vj8f1rwf3wk7jmwhm8ba25l6h1gs6jnkh0schbwcvi56xl";
   };

--- a/pkgs/development/libraries/mumlib/default.nix
+++ b/pkgs/development/libraries/mumlib/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkgconfig
 , boost, openssl, log4cpp, libopus, protobuf }:
 with lib; stdenv.mkDerivation {
-  pname = "mumlib";
-  version = "unstable-2018-12-12";
+  pname = "mumlib-unstable";
+  version = "2018-12-12";
 
   src = fetchFromGitHub {
     owner = "slomkowski";

--- a/pkgs/development/libraries/mutest/default.nix
+++ b/pkgs/development/libraries/mutest/default.nix
@@ -5,8 +5,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "mutest";
-  version = "unstable-2019-08-26";
+  pname = "mutest-unstable";
+  version = "2019-08-26";
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/libraries/nvidia-texture-tools/default.nix
+++ b/pkgs/development/libraries/nvidia-texture-tools/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, cmake, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  pname = "nvidia-texture-tools";
-  version = "unstable-2019-10-27";
+  pname = "nvidia-texture-tools-unstable";
+  version = "2019-10-27";
 
   src = fetchFromGitHub {
     owner = "castano";

--- a/pkgs/development/libraries/opencl-clang/default.nix
+++ b/pkgs/development/libraries/opencl-clang/default.nix
@@ -55,8 +55,8 @@ let
     inherit (if buildWithPatches then passthru else llvmPkgs) clang-unwrapped spirv-llvm-translator;
   in
     stdenv.mkDerivation rec {
-      pname = "opencl-clang";
-      version = "unstable-2019-08-16";
+      pname = "opencl-clang-unstable";
+      version = "2019-08-16";
 
       inherit passthru;
 

--- a/pkgs/development/libraries/ortp/default.nix
+++ b/pkgs/development/libraries/ortp/default.nix
@@ -5,16 +5,16 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "ortp";
+  pname = "ortp-unstable";
   # Using master branch for linphone-desktop caused a chain reaction that many
   # of its dependencies needed to use master branch too.
-  version = "unstable-2020-03-17";
+  version = "2020-03-17";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
     owner = "public";
     group = "BC";
-    repo = pname;
+    repo = "ortp";
     rev = "804dfc4f90d1a4301127c7af10a74fd2935dd5d8";
     sha256 = "1yr8j8am68spyy5d9vna8zcq3qn039mi16cv9jf5n4chs9rxf7xx";
   };

--- a/pkgs/development/libraries/rapidcheck/default.nix
+++ b/pkgs/development/libraries/rapidcheck/default.nix
@@ -1,8 +1,8 @@
 { stdenv, cmake, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  pname = "rapidcheck";
-  version = "unstable-2018-09-27";
+  pname = "rapidcheck-unstable";
+  version = "2018-09-27";
 
   src = fetchFromGitHub {
     owner = "emil-e";

--- a/pkgs/development/libraries/science/biology/bicgl/default.nix
+++ b/pkgs/development/libraries/science/biology/bicgl/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, libminc, bicpl, freeglut, mesa_glu }:
 
 stdenv.mkDerivation rec {
-  pname = "bicgl";
-  version = "unstable-2018-04-06";
+  pname = "bicgl-unstable";
+  version = "2018-04-06";
 
   owner = "BIC-MNI";
 
   src = fetchFromGitHub {
     inherit owner;
-    repo   = pname;
+    repo   = "bicgl";
     rev    = "61a035751c9244fcca1edf94d6566fa2a709ce90";
     sha256 = "0lzirdi1mf4yl8srq7vjn746sbydz7h0wjh7wy8gycy6hq04qrg4";
   };

--- a/pkgs/development/libraries/science/biology/bicpl/default.nix
+++ b/pkgs/development/libraries/science/biology/bicpl/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchFromGitHub, cmake, libminc, netpbm }:
 
 stdenv.mkDerivation rec {
-  pname = "bicpl";
-  version = "unstable-2017-09-10";
+  pname = "bicpl-unstable";
+  version = "2017-09-10";
 
   owner = "BIC-MNI";
 
   # current master is significantly ahead of most recent release, so use Git version:
   src = fetchFromGitHub {
     inherit owner;
-    repo   = pname;
+    repo   = "bicpl";
     rev    = "612a63e740fadb162fcf27ee00da6a18dec4d5a9";
     sha256 = "1vv9gi184bkvp3f99v9xmmw1ly63ip5b09y7zdjn39g7kmwzrga7";
   };

--- a/pkgs/development/libraries/science/biology/gifticlib/default.nix
+++ b/pkgs/development/libraries/science/biology/gifticlib/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, cmake, expat, nifticlib, zlib }:
 
 stdenv.mkDerivation rec {
-  pname = "gifticlib";
-  version = "unstable-2020-07-07";
+  pname = "gifticlib-unstable";
+  version = "2020-07-07";
 
   src = fetchFromGitHub {
     owner = "NIFTI-Imaging";

--- a/pkgs/development/libraries/science/biology/oobicpl/default.nix
+++ b/pkgs/development/libraries/science/biology/oobicpl/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, libminc, bicpl, arguments, pcre-cpp }:
 
 stdenv.mkDerivation rec {
-  pname = "oobicpl";
-  version = "unstable-2016-03-02";
+  pname = "oobicpl-unstable";
+  version = "2016-03-02";
 
   owner = "BIC-MNI";
 
   src = fetchFromGitHub {
     inherit owner;
-    repo   = pname;
+    repo   = "oobicpl";
     rev    = "bc062a65dead2e58461f5afb37abedfa6173f10c";
     sha256 = "05l4ml9djw17bgdnrldhcxydrzkr2f2scqlyak52ph5azj5n4zsx";
   };

--- a/pkgs/development/libraries/soxt/default.nix
+++ b/pkgs/development/libraries/soxt/default.nix
@@ -1,8 +1,8 @@
 { fetchhg, stdenv, cmake, coin3d, motif, xlibsWrapper, libXmu, libGLU, libGL }:
 
 stdenv.mkDerivation {
-  pname = "soxt";
-  version = "unstable-2019-06-14";
+  pname = "soxt-unstable";
+  version = "2019-06-14";
 
   src = fetchhg {
     url = "https://bitbucket.org/Coin3D/soxt";

--- a/pkgs/development/libraries/sycl-info/default.nix
+++ b/pkgs/development/libraries/sycl-info/default.nix
@@ -12,8 +12,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "sycl-info";
-  version = "unstable-2019-11-19";
+  pname = "sycl-info-unstable";
+  version = "2019-11-19";
 
   src = fetchFromGitHub {
     owner = "codeplaysoftware";

--- a/pkgs/development/libraries/ticpp/default.nix
+++ b/pkgs/development/libraries/ticpp/default.nix
@@ -4,8 +4,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "ticpp";
-  version = "unstable-2019-01-09";
+  pname = "ticpp-unstable";
+  version = "2019-01-09";
 
   src = fetchFromGitHub {
     owner = "wxFormBuilder";

--- a/pkgs/development/libraries/ubus/default.nix
+++ b/pkgs/development/libraries/ubus/default.nix
@@ -1,8 +1,8 @@
 { stdenv, cmake, fetchgit, libubox, libjson }:
 
 stdenv.mkDerivation {
-  pname = "ubus";
-  version = "unstable-2020-01-05";
+  pname = "ubus-unstable";
+  version = "2020-01-05";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/ubus.git";

--- a/pkgs/development/libraries/uci/default.nix
+++ b/pkgs/development/libraries/uci/default.nix
@@ -1,8 +1,8 @@
 { stdenv, cmake, fetchgit, pkgconfig, libubox }:
 
 stdenv.mkDerivation {
-  pname = "uci";
-  version = "unstable-2020-04-27";
+  pname = "uci-unstable";
+  version = "2020-04-27";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/uci.git";

--- a/pkgs/development/libraries/yubico-pam/default.nix
+++ b/pkgs/development/libraries/yubico-pam/default.nix
@@ -3,11 +3,11 @@
 , pam, yubikey-personalization, libyubikey, libykclient }:
 
 stdenv.mkDerivation rec {
-  pname = "yubico-pam";
-  version = "unstable-2019-07-01";
+  pname = "yubico-pam-unstable";
+  version = "2019-07-01";
   src = fetchFromGitHub {
     owner = "Yubico";
-    repo = pname;
+    repo = "yubico-pam";
     rev = "b5bd00db81e0e0e0ecced65c684080bb56ddc35b";
     sha256 = "10dq8dqi3jldllj6p8r9hldx9sank9n82c44w8akxrs1vli6nj3m";
   };

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -88,7 +88,8 @@ with super;
   });
 
   ljsyscall = super.ljsyscall.override(rec {
-    version = "unstable-20180515";
+    pname = "ljsyscall-unstable";
+    version = "2018-05-15";
     # package hasn't seen any release for a long time
     src = pkgs.fetchFromGitHub {
       owner = "justincormack";

--- a/pkgs/development/misc/rappel/default.nix
+++ b/pkgs/development/misc/rappel/default.nix
@@ -6,8 +6,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "rappel";
-  version = "unstable-2019-09-09";
+  pname = "rappel-unstable";
+  version = "2019-09-09";
 
   src = fetchFromGitHub {
     owner = "yrp604";

--- a/pkgs/development/ocaml-modules/curly/default.nix
+++ b/pkgs/development/ocaml-modules/curly/default.nix
@@ -2,8 +2,8 @@
 , result, alcotest, cohttp-lwt-unix, odoc, curl }:
 
 buildDunePackage rec {
-  pname = "curly";
-  version = "unstable-2019-11-14";
+  pname = "curly-unstable";
+  version = "2019-11-14";
 
   minimumOCamlVersion = "4.02";
 
@@ -11,7 +11,7 @@ buildDunePackage rec {
 
   src = fetchFromGitHub {
     owner  = "rgrinberg";
-    repo   = pname;
+    repo   = "curly";
     rev    = "33a538c89ef8279d4591454a7f699a4183dde5d0";
     sha256 = "10pxbvf5xrsajaxrccxh2lqhgp3yaf61z9w03rvb2mq44nc2dggz";
   };

--- a/pkgs/development/ocaml-modules/npy/default.nix
+++ b/pkgs/development/ocaml-modules/npy/default.nix
@@ -1,14 +1,14 @@
 { lib, buildDunePackage, fetchFromGitHub, numpy, camlzip }:
 
 buildDunePackage rec {
-  pname = "npy";
-  version = "unstable-2019-04-02";
+  pname = "npy-unstable";
+  version = "2019-04-02";
 
   minimumOCamlVersion = "4.06";
 
   src = fetchFromGitHub {
     owner = "LaurentMazare";
-    repo   = "${pname}-ocaml";
+    repo   = "npy-ocaml";
     rev    = "c051086bfea6bee58208098bcf1c2f725a80a1fb";
     sha256 = "06mgrnm7xiw2lhqvbdv2zmd65sqfdnjd7j4qmcswanmplm17yhvb";
   };

--- a/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchgit, libvirt, autoconf, ocaml, findlib }:
 
 stdenv.mkDerivation rec {
-  pname = "ocaml-libvirt";
+  pname = "ocaml-libvirt-unstable";
   rev = "bab7f84ade84ceaddb08b6948792d49b3d04b897";
-  version = "0.6.1.4.2017-11-08-unstable"; # libguestfs-1.34+ needs ocaml-libvirt newer than the latest release 0.6.1.4
+  version = "0.6.1.4.2017-11-08"; # libguestfs-1.34+ needs ocaml-libvirt newer than the latest release 0.6.1.4
 
   src = fetchgit {
     url = "git://git.annexia.org/git/ocaml-libvirt.git";

--- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
+++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
@@ -2,14 +2,14 @@
 , alcotest, biocaml, gnuplot, lacaml, menhir, ocaml-r, owl, printbox }:
 
 buildDunePackage rec {
-  pname = "phylogenetics";
-  version = "unstable-2020-01-25";
+  pname = "phylogenetics-unstable";
+  version = "2020-01-25";
 
   useDune2 = true;
 
   src = fetchFromGitHub {
     owner  = "biocaml";
-    repo   = pname;
+    repo   = "phylogenetics";
     rev    = "752a7d0324709ba919ef43630a270afd45d6b734";
     sha256 = "1zsxpl1yjbw6y6n1q7qk3h0l7c0lxhh8yp8bkxlwnpzlkqq28ycg";
   };

--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -13,7 +13,8 @@ let param =
     version = "5.0+4.03.0";
     sha256 = "061v1fl5z7z3ywi4ppryrlcywnvnqbsw83ppq72qmkc7ma4603jg"; };
   "4.04" = {
-    version = "unstable-20161114";
+    pname = "ppx_tools-unstable";
+    version = "2016-11-14";
     rev = "49c08e2e4ea8fef88692cd1dcc1b38a9133f17ac";
     sha256 = "0ywzfkf5brj33nwh49k9if8x8v433ral25f3nbklfc9vqr06zrfl"; };
   "4.05" = {
@@ -38,7 +39,7 @@ let src = fetchFromGitHub {
       rev = param.rev or param.version;
       inherit (param) sha256;
     };
-    pname = "ppx_tools";
+    pname = param.pname or "ppx_tools";
     meta = with stdenv.lib; {
       description = "Tools for authors of ppx rewriters";
       homepage = "https://www.lexifi.com/ppx_tools";

--- a/pkgs/development/python-modules/backports_shutil_get_terminal_size/default.nix
+++ b/pkgs/development/python-modules/backports_shutil_get_terminal_size/default.nix
@@ -6,8 +6,8 @@
 }:
 
 if !(pythonOlder "3.3") then null else buildPythonPackage {
-  pname = "backports.shutil_get_terminal_size";
-  version = "unstable-2016-02-21";
+  pname = "backports.shutil_get_terminal_size-unstable";
+  version = "2016-02-21";
 
   # there have been numerous fixes commited since the initial release.
   # Most notably fixing a problem where the backport would always return

--- a/pkgs/development/python-modules/glasgow/default.nix
+++ b/pkgs/development/python-modules/glasgow/default.nix
@@ -17,8 +17,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "glasgow";
-  version = "unstable-2020-06-29";
+  pname = "glasgow-unstable";
+  version = "2020-06-29";
   # python software/setup.py --version
   realVersion = "0.1.dev1352+g${lib.substring 0 7 src.rev}";
 

--- a/pkgs/development/python-modules/google_cloud_testutils/default.nix
+++ b/pkgs/development/python-modules/google_cloud_testutils/default.nix
@@ -6,8 +6,8 @@
 }:
 
 buildPythonPackage {
-  pname = "google-cloud-testutils";
-  version = "unstable-36ffa923c7037e8b4fdcaa76272cb6267e908a9d";
+  pname = "google-cloud-testutils-unstable";
+  version = "36ffa923c7037e8b4fdcaa76272cb6267e908a9d";
 
   # google-cloud-testutils is not "really"
   # released as a python package

--- a/pkgs/development/python-modules/gpyopt/default.nix
+++ b/pkgs/development/python-modules/gpyopt/default.nix
@@ -2,12 +2,12 @@
 , numpy, scipy, gpy, emcee, nose }:
 
 buildPythonPackage rec {
-  pname = "GPyOpt";
-  version = "unstable-2019-09-25";
+  pname = "GPyOpt-unstable";
+  version = "2019-09-25";
 
   src = fetchFromGitHub {
-    repo   = pname;
     owner  = "SheffieldML";
+    repo   = "GPyOpt";
     rev    = "249b8ff29c52c12ed867f145a627d529372022d8";
     sha256 = "1ywaw1kpdr7dv4s4cr7afmci86sw7w61178gs45b0lq08652zdlb";
   };

--- a/pkgs/development/python-modules/gtimelog/default.nix
+++ b/pkgs/development/python-modules/gtimelog/default.nix
@@ -5,12 +5,12 @@
 }:
 
 buildPythonPackage rec {
-  pname = "gtimelog";
-  version = "unstable-2020-05-16";
+  pname = "gtimelog-unstable";
+  version = "2020-05-16";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "gtimelog";
+    repo = "gtimelog";
     rev = "80682ddbf9e0d68b8c67257289784f3b49b543d8";
     sha256 = "0qv2kv7vc3qqlzxsisgg31cmrkkqgnmxspbj10c5fhdmwzzwi0i9";
   };

--- a/pkgs/development/python-modules/kinparse/default.nix
+++ b/pkgs/development/python-modules/kinparse/default.nix
@@ -7,8 +7,8 @@
 }:
 
 buildPythonPackage {
-  pname = "kinparse";
-  version = "unstable-2019-12-18";
+  pname = "kinparse-unstable";
+  version = "2019-12-18";
 
   src = fetchFromGitHub {
     owner = "xesscorp";

--- a/pkgs/development/python-modules/mesa/default.nix
+++ b/pkgs/development/python-modules/mesa/default.nix
@@ -3,9 +3,9 @@
 , pytest }:
 
 buildPythonPackage rec {
-  pname = "mesa";
+  pname = "mesa-unstable";
   # contains several fixes for networkx 2.4 bump
-  version = "unstable-2019-12-09";
+  version = "2019-12-09";
 
   # According to their docs, this library is for Python 3+.
   disabled = isPy27;

--- a/pkgs/development/python-modules/nbmerge/default.nix
+++ b/pkgs/development/python-modules/nbmerge/default.nix
@@ -6,12 +6,12 @@
 }:
 
 buildPythonPackage rec {
-  pname = "nbmerge";
-  version = "unstable-2017-10-23";
+  pname = "nbmerge-unstable";
+  version = "2017-10-23";
 
   src = fetchFromGitHub {
     owner = "jbn";
-    repo = pname;
+    repo = "nbmerge";
     rev = "fc0ba95e8422340317358ffec4404235defbc06a";
     sha256 = "1cn550kjadnxc1sx2xy814248fpzrj3lgvrmsbrwmk03vwaa2hmi";
   };

--- a/pkgs/development/python-modules/nix-kernel/default.nix
+++ b/pkgs/development/python-modules/nix-kernel/default.nix
@@ -7,8 +7,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "nix-kernel";
-  version = "unstable-2020-04-26";
+  pname = "nix-kernel-unstable";
+  version = "2020-04-26";
 
   src = fetchFromGitHub {
     owner = "GTrunSec";

--- a/pkgs/development/python-modules/nmigen-boards/default.nix
+++ b/pkgs/development/python-modules/nmigen-boards/default.nix
@@ -7,8 +7,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "nmigen-boards";
-  version = "unstable-2020-02-06";
+  pname = "nmigen-boards-unstable";
+  version = "2020-02-06";
   # python setup.py --version
   realVersion = "0.1.dev92+g${lib.substring 0 7 src.rev}";
 

--- a/pkgs/development/python-modules/nmigen-soc/default.nix
+++ b/pkgs/development/python-modules/nmigen-soc/default.nix
@@ -7,8 +7,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "nmigen-soc";
-  version = "unstable-2020-02-08";
+  pname = "nmigen-soc-unstable";
+  version = "2020-02-08";
   # python setup.py --version
   realVersion = "0.1.dev24+g${lib.substring 0 7 src.rev}";
 

--- a/pkgs/development/python-modules/nmigen/default.nix
+++ b/pkgs/development/python-modules/nmigen/default.nix
@@ -15,8 +15,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "nmigen";
-  version = "unstable-2020-04-02";
+  pname = "nmigen-unstable";
+  version = "2020-04-02";
   # python setup.py --version
   realVersion = "0.2.dev49+g${lib.substring 0 7 src.rev}";
   disabled = pythonOlder "3.6";

--- a/pkgs/development/python-modules/nxt-python/default.nix
+++ b/pkgs/development/python-modules/nxt-python/default.nix
@@ -9,8 +9,8 @@
 }:
 
 buildPythonPackage {
-  version = "unstable-20160819";
-  pname = "nxt-python";
+  pname = "nxt-python-unstable";
+  version = "20160819";
   disabled = isPy3k;
 
   src = fetchgit {

--- a/pkgs/development/python-modules/oauthlib/default.nix
+++ b/pkgs/development/python-modules/oauthlib/default.nix
@@ -9,13 +9,13 @@
 }:
 
 buildPythonPackage rec {
-  pname = "oauthlib";
-  version = "unstable-2020-05-08";
+  pname = "oauthlib-unstable";
+  version = "2020-05-08";
 
   # master supports pyjwt==1.7.1
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "oauthlib";
+    repo = "oauthlib";
     rev = "46647402896db5f0d979eba9594623e889739060";
     sha256 = "1wrdjdvlfcd74lckcgascnasrffg8sip0z673si4ag5kv4afiz3l";
   };

--- a/pkgs/development/python-modules/ptable/default.nix
+++ b/pkgs/development/python-modules/ptable/default.nix
@@ -1,8 +1,8 @@
 { stdenv, buildPythonPackage, fetchFromGitHub, nose }:
 
 buildPythonPackage {
-  pname = "ptable";
-  version = "unstable-2019-06-14";
+  pname = "ptable-unstable";
+  version = "2019-06-14";
 
   # https://github.com/kxxoling/PTable/issues/27
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/py3buddy/default.nix
+++ b/pkgs/development/python-modules/py3buddy/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "py3buddy";
-  version = "unstable-2019-09-29";
+  pname = "py3buddy-unstable";
+  version = "2019-09-29";
 
   src = fetchFromGitHub {
     owner = "armijnhemel";
-    repo = pname;
+    repo = "py3buddy";
     rev = "2b28908454645117368ca56df67548c93f4e0b03";
     sha256 = "12ar4kbplavndarkrbibxi5i607f5sfia5myscvalqy78lc33798";
   };

--- a/pkgs/development/python-modules/pybluez/default.nix
+++ b/pkgs/development/python-modules/pybluez/default.nix
@@ -5,14 +5,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "unstable-20160819";
-  pname = "pybluez";
+  pname = "pybluez-unstable";
+  version = "2016-08-19";
 
   propagatedBuildInputs = [ pkgs.bluez ];
 
   src = fetchFromGitHub {
     owner = "karulis";
-    repo = pname;
+    repo = "pybluez";
     rev = "a0b226a61b166e170d48539778525b31e47a4731";
     sha256 = "104dm5ngfhqisv1aszdlr3szcav2g3bhsgzmg4qfs09b3i5zj047";
   };

--- a/pkgs/development/python-modules/pyelftools/default.nix
+++ b/pkgs/development/python-modules/pyelftools/default.nix
@@ -5,12 +5,12 @@
 }:
 
 buildPythonPackage rec {
-  pname = "pyelftools";
-  version = "unstable-2020-09-23";
+  pname = "pyelftools-unstable";
+  version = "2020-09-23";
 
   src = fetchFromGitHub {
     owner = "eliben";
-    repo = pname;
+    repo = "pyelftools";
     rev = "ab84e68837113b2d700ad379d94c1dd4a73125ea";
     sha256 = "sha256-O7l1kj0k8bOSOtZJVzS674oVnM+X3oP00Ybs0qjb64Q=";
   };

--- a/pkgs/development/python-modules/pyfantom/default.nix
+++ b/pkgs/development/python-modules/pyfantom/default.nix
@@ -4,8 +4,8 @@
 }:
 
 buildPythonPackage {
-  pname = "pyfantom";
-  version = "unstable-2013-12-18";
+  pname = "pyfantom-unstable";
+  version = "2013-12-18";
 
   src = fetchgit {
     url = "http://git.ni.fr.eu.org/pyfantom.git";

--- a/pkgs/development/python-modules/pymaging/default.nix
+++ b/pkgs/development/python-modules/pymaging/default.nix
@@ -4,8 +4,8 @@
 }:
 
 buildPythonPackage {
-  pname = "pymaging";
-  version = "unstable-2016-11-16";
+  pname = "pymaging-unstable";
+  version = "2016-11-16";
 
   src = fetchFromGitHub {
     owner = "ojii";

--- a/pkgs/development/python-modules/pymaging_png/default.nix
+++ b/pkgs/development/python-modules/pymaging_png/default.nix
@@ -5,8 +5,8 @@
 }:
 
 buildPythonPackage {
-  pname = "pymaging-png";
-  version = "unstable-2016-11-16";
+  pname = "pymaging-png-unstable";
+  version = "2016-11-16";
 
   src = fetchFromGitHub {
     owner = "ojii";

--- a/pkgs/development/python-modules/pyspinel/default.nix
+++ b/pkgs/development/python-modules/pyspinel/default.nix
@@ -3,13 +3,13 @@
 }:
 
 buildPythonPackage rec {
-  pname = "pyspinel";
-  version = "unstable-2020-06-19";  # no versioned release since 2018
+  pname = "pyspinel-unstable";
+  version = "2020-06-19";  # no versioned release since 2018
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "openthread";
-    repo = pname;
+    repo = "pyspinel";
     rev = "e0bb3f8e6f49b593ab248a75de04a71626ae8101";
     sha256 = "0nfmdkgbhmkl82dfxjpwiiarxngm6a3fvdrzpaqp60a4b17pipqg";
   };

--- a/pkgs/development/python-modules/pytest-ordering/default.nix
+++ b/pkgs/development/python-modules/pytest-ordering/default.nix
@@ -2,14 +2,14 @@
 , pytest }:
 
 buildPythonPackage rec {
-  pname = "pytest-ordering";
-  version = "unstable-2019-06-19";
+  pname = "pytest-ordering-unstable";
+  version = "2019-06-19";
 
   # Pypi lacks tests/
   # Resolves PytestUnknownMarkWarning from pytest
   src = fetchFromGitHub {
     owner = "ftobia";
-    repo = pname;
+    repo = "pytest-ordering";
     rev = "492697ee26633cc31d329c1ceaa468375ee8ee9c";
     sha256 = "1xim0kj5g37p1skgvp8gdylpx949krmx60w3pw6j1m1h7sakmddn";
   };

--- a/pkgs/development/python-modules/python-csxcad/default.nix
+++ b/pkgs/development/python-modules/python-csxcad/default.nix
@@ -9,8 +9,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "python-csxcad";
-  version = "unstable-2020-02-18";
+  pname = "python-csxcad-unstable";
+  version = "2020-02-18";
 
   src = fetchFromGitHub {
     owner = "thliebig";

--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -17,8 +17,8 @@ let
   };
 
 in buildPythonPackage rec {
-  pname = "python-mapnik";
-  version = "unstable-2020-02-24";
+  pname = "python-mapnik-unstable";
+  version = "2020-02-24";
 
   src = pkgs.fetchFromGitHub {
     owner = "mapnik";

--- a/pkgs/development/python-modules/python-openems/default.nix
+++ b/pkgs/development/python-modules/python-openems/default.nix
@@ -11,8 +11,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "python-openems";
-  version = "unstable-2020-02-15";
+  pname = "python-openems-unstable";
+  version = "2020-02-15";
 
   src = fetchFromGitHub {
     owner = "thliebig";

--- a/pkgs/development/python-modules/python-unshare/default.nix
+++ b/pkgs/development/python-modules/python-unshare/default.nix
@@ -4,10 +4,10 @@
 }:
 
 buildPythonPackage {
-  pname = "python-unshare";
+  pname = "python-unshare-unstable";
   # pypi version doesn't support Python 3 and the package didn't update for a long time:
   # https://github.com/TheTincho/python-unshare/pull/8
-  version = "unstable-2018-05-20";
+  version = "2018-05-20";
 
   src = fetchFromGitHub {
     owner = "TheTincho";

--- a/pkgs/development/python-modules/pytricia/default.nix
+++ b/pkgs/development/python-modules/pytricia/default.nix
@@ -4,12 +4,12 @@
 }:
 
 buildPythonPackage rec {
-  pname = "pytricia";
-  version = "unstable-2019-01-16";
+  pname = "pytricia-unstable";
+  version = "2019-01-16";
 
   src = fetchFromGitHub {
     owner = "jsommers";
-    repo = pname;
+    repo = "pytricia";
     rev = "4ba88f68c3125f789ca8cd1cfae156e1464bde87";
     sha256 = "0qp5774xkm700g35k5c76pck8pdzqlyzbaqgrz76a1yh67s2ri8h";
   };

--- a/pkgs/development/python-modules/skidl/default.nix
+++ b/pkgs/development/python-modules/skidl/default.nix
@@ -12,8 +12,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "skidl";
-  version = "unstable-2020-09-15";
+  pname = "skidl-unstable";
+  version = "2020-09-15";
 
   src = fetchFromGitHub {
     owner = "xesscorp";

--- a/pkgs/development/python-modules/slob/default.nix
+++ b/pkgs/development/python-modules/slob/default.nix
@@ -7,8 +7,8 @@
 }:
 
 buildPythonPackage {
-  pname = "slob";
-  version = "unstable-2016-11-03";
+  pname = "slob-unstable";
+  version = "2016-11-03";
   disabled = !isPy3k;
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/tess/default.nix
+++ b/pkgs/development/python-modules/tess/default.nix
@@ -7,8 +7,8 @@
 }:
 
 buildPythonPackage {
-  pname = "tess";
-  version = "unstable-2019-05-07";
+  pname = "tess-unstable";
+  version = "2019-05-07";
 
   src = fetchFromGitHub {
     owner = "wackywendell";

--- a/pkgs/development/python-modules/traittypes/default.nix
+++ b/pkgs/development/python-modules/traittypes/default.nix
@@ -13,14 +13,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "traittypes";
-  version = "unstable-2019-06-23";
+  pname = "traittypes-unstable";
+  version = "2019-06-23";
 
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "jupyter-widgets";
-    repo = pname;
+    repo = "traittypes";
     rev = "0a030b928991dec732c17a7a1cb13acbcd7650a2";
     sha256 = "0rlm5krmq6n8yi47dgdsjyrkz3m079pndpbzkz2gx98pb3jd9pjs";
   };

--- a/pkgs/development/python-modules/transforms3d/default.nix
+++ b/pkgs/development/python-modules/transforms3d/default.nix
@@ -9,15 +9,15 @@
 }:
 
 buildPythonPackage rec {
-  pname = "transforms3d";
-  version = "unstable-2019-12-17";
+  pname = "transforms3d-unstable";
+  version = "2019-12-17";
 
   disabled = isPy27;
 
   # no Git tag or PyPI release in some time
   src = fetchFromGitHub {
     owner = "matthew-brett";
-    repo = pname;
+    repo = "transform3d";
     rev = "6b20250c610249914ca5e3a3a2964c36ca35c19a";
     sha256 = "1z789hgk71a6rj6mqp9srpzamg06g58hs2p1l1p344cfnkj5a4kc";
   };

--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -27,14 +27,14 @@
 # Packaging documentation at:
 # https://github.com/untitaker/vdirsyncer/blob/master/docs/packaging.rst
 buildPythonPackage rec {
-  version = "unstable-2018-08-05";
-  pname = "vdirsyncer";
+  version = "2018-08-05";
+  pname = "vdirsyncer-unstable";
   name = "${pname}-${version}";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "spk";
-    repo = pname;
+    repo = "vdirsyncer";
     # fix-build-style branch, see https://github.com/pimutils/vdirsyncer/pull/798
     rev = "2c62d03bd73f8b44a47c2e769ade046697896ae9";
     sha256 = "1q6xvzz5rf5sqdaj3mdvhpgwy5b16isavgg7vardgjwqwv1yal28";

--- a/pkgs/development/tools/analysis/panopticon/default.nix
+++ b/pkgs/development/tools/analysis/panopticon/default.nix
@@ -2,12 +2,12 @@
 , pkgconfig, makeWrapper }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "panopticon";
-  version = "unstable-20171202";
+  pname = "panopticon-unstable";
+  version = "20171202";
 
   src = fetchFromGitHub {
     owner = "das-labor";
-    repo = pname;
+    repo = "panopticon";
     rev = "33ffec0d6d379d51b38d6ea00d040f54b1356ae4";
     sha256 = "1zv87nqhrzsxx0m891df4vagzssj3kblfv9yp7j96dw0vn9950qa";
   };

--- a/pkgs/development/tools/analysis/rr/unstable.nix
+++ b/pkgs/development/tools/analysis/rr/unstable.nix
@@ -12,7 +12,8 @@ let
 in
 
   rr.overrideAttrs (old: {
-    version = "unstable-2020-10-04";
+    pname = "rr-unstable";
+    version = "2020-10-04";
 
     src = fetchFromGitHub {
       owner = "mozilla";

--- a/pkgs/development/tools/dep2nix/default.nix
+++ b/pkgs/development/tools/dep2nix/default.nix
@@ -2,14 +2,14 @@
 , makeWrapper, nix-prefetch-scripts }:
 
 buildGoPackage rec {
-  pname = "dep2nix";
-  version = "unstable-2019-04-02";
+  pname = "dep2nix-unstable";
+  version = "2019-04-02";
 
   goPackagePath = "github.com/nixcloud/dep2nix";
 
   src = fetchFromGitHub {
     owner = "nixcloud";
-    repo = pname;
+    repo = "dep2nix";
     rev = "830684f920333b8ff0946d6b807e8be642eec3ef";
     sha256 = "17sjxhzhmz4893x3x054anp4xvqd1px15nv3fj2m7i6r0vbgpm0j";
   };

--- a/pkgs/development/tools/easyjson/default.nix
+++ b/pkgs/development/tools/easyjson/default.nix
@@ -1,8 +1,8 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage {
-  pname = "easyjson";
-  version = "unstable-2019-06-26";
+  pname = "easyjson-unstable";
+  version = "2019-06-26";
   goPackagePath = "github.com/mailru/easyjson";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/fusee-launcher/default.nix
+++ b/pkgs/development/tools/fusee-launcher/default.nix
@@ -7,8 +7,8 @@
 } :
 
 stdenv.mkDerivation {
-  pname = "fusee-launcher";
-  version = "unstable-2018-07-14";
+  pname = "fusee-launcher-unstable";
+  version = "2018-07-14";
 
   src = fetchFromGitHub {
     owner = "Cease-and-DeSwitch";

--- a/pkgs/development/tools/glpaper/default.nix
+++ b/pkgs/development/tools/glpaper/default.nix
@@ -2,8 +2,8 @@
 , libX11, libGL }:
 
 stdenv.mkDerivation {
-  name = "glpaper";
-  version = "unstable-2020-03-30";
+  name = "glpaper-unstable";
+  version = "2020-03-30";
 
   src = fetchhg {
     url = "https://hg.sr.ht/~scoopta/glpaper";

--- a/pkgs/development/tools/gnome-desktop-testing/default.nix
+++ b/pkgs/development/tools/gnome-desktop-testing/default.nix
@@ -7,8 +7,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-desktop-testing";
-  version = "unstable-2019-12-11";
+  pname = "gnome-desktop-testing-unstable";
+  version = "2019-12-11";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";

--- a/pkgs/development/tools/go-bindata/default.nix
+++ b/pkgs/development/tools/go-bindata/default.nix
@@ -1,8 +1,8 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage {
-  pname = "go-bindata";
-  version = "unstable-2015-10-23";
+  pname = "go-bindata-unstable";
+  version = "2015-10-23";
 
   goPackagePath = "github.com/jteeuwen/go-bindata";
 

--- a/pkgs/development/tools/go-outline/default.nix
+++ b/pkgs/development/tools/go-outline/default.nix
@@ -1,8 +1,8 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  pname = "go-outline";
-  version = "unstable-2018-11-22";
+  pname = "go-outline-unstable";
+  version = "2018-11-22";
   rev = "7182a932836a71948db4a81991a494751eccfe77";
 
   goPackagePath = "github.com/ramya-rao-a/go-outline";

--- a/pkgs/development/tools/hobbes/default.nix
+++ b/pkgs/development/tools/hobbes/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, cmake, llvm_6, ncurses, readline, zlib }:
 
 stdenv.mkDerivation {
-  name = "hobbes";
-  version = "unstable-2020-05-19";
+  name = "hobbes-unstable";
+  version = "2020-05-19";
 
   src = fetchFromGitHub {
     owner = "morgan-stanley";

--- a/pkgs/development/tools/misc/blackmagic/default.nix
+++ b/pkgs/development/tools/misc/blackmagic/default.nix
@@ -6,8 +6,8 @@
 with lib;
 
 stdenv.mkDerivation rec {
-  pname = "blackmagic";
-  version = "unstable-2020-08-05";
+  pname = "blackmagic-unstable";
+  version = "2020-08-05";
   # `git describe --always`
   firmwareVersion = "v1.6.1-539-gdd74ec8";
 

--- a/pkgs/development/tools/misc/cc-tool/default.nix
+++ b/pkgs/development/tools/misc/cc-tool/default.nix
@@ -7,12 +7,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "cc-tool";
-  version = "unstable-2020-05-19";
+  pname = "cc-tool-unstable";
+  version = "2020-05-19";
 
   src = fetchFromGitHub {
     owner = "dashesy";
-    repo = pname;
+    repo = "cc-tool";
     rev = "19e707eafaaddee8b996ad27a9f3e1aafcb900d2";
     hash = "sha256:1f78j498fdd36xbci57jkgh25gq14g3b6xmp76imdpar0jkpyljv";
   };

--- a/pkgs/development/tools/misc/itm-tools/default.nix
+++ b/pkgs/development/tools/misc/itm-tools/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, rustPlatform, pkg-config }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "itm-tools";
-  version = "unstable-2019-11-15";
+  pname = "itm-tools-unstable";
+  version = "2019-11-15";
 
   src = fetchFromGitHub {
     owner = "japaric";
-    repo = pname;
+    repo = "itm-tools";
     rev = "e94155e44019d893ac8e6dab51cc282d344ab700";
     sha256 = "19xkjym0i7y52cfhvis49c59nzvgw4906cd8bkz8ka38mbgfqgiy";
   };

--- a/pkgs/development/tools/misc/universal-ctags/default.nix
+++ b/pkgs/development/tools/misc/universal-ctags/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, perl, pythonPackages, libiconv, jansson }:
 
 stdenv.mkDerivation {
-  pname = "universal-ctags";
-  version = "unstable-2019-07-30";
+  pname = "universal-ctags-unstable";
+  version = "2019-07-30";
 
   src = fetchFromGitHub {
     owner = "universal-ctags";

--- a/pkgs/development/tools/ofono-phonesim/default.nix
+++ b/pkgs/development/tools/ofono-phonesim/default.nix
@@ -7,8 +7,8 @@
 }:
 
 mkDerivation {
-  pname = "ofono-phonesim";
-  version = "unstable-2019-11-18";
+  pname = "ofono-phonesim-unstable";
+  version = "2019-11-18";
 
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/network/ofono/phonesim.git";

--- a/pkgs/development/tools/osslsigncode/default.nix
+++ b/pkgs/development/tools/osslsigncode/default.nix
@@ -8,12 +8,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "osslsigncode";
-  version = "unstable-2020-08-02";
+  pname = "osslsigncode-unstable";
+  version = "2020-08-02";
 
   src = fetchFromGitHub {
     owner = "mtrojnar";
-    repo = pname;
+    repo = "osslsigncode";
     rev = "01b3fb5b542ed0b41e3860aeee7a85b735491ff2";
     sha256 = "03ynm1ycbi86blglma3xiwadck8kc5yb0gawjzlhyv90jidn680l";
   };

--- a/pkgs/development/tools/quicktemplate/default.nix
+++ b/pkgs/development/tools/quicktemplate/default.nix
@@ -1,8 +1,8 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage {
-  pname = "quicktemplate";
-  version = "unstable-2019-07-08";
+  pname = "quicktemplate-unstable";
+  version = "2019-07-08";
   goPackagePath = "github.com/valyala/quicktemplate";
   goDeps = ./deps.nix;
 

--- a/pkgs/development/tools/rdocker/default.nix
+++ b/pkgs/development/tools/rdocker/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, makeWrapper, openssh }:
 
 stdenv.mkDerivation {
-  pname = "rdocker";
-  version = "unstable-2018-07-17";
+  pname = "rdocker-unstable";
+  version = "2018-07-17";
 
   src = fetchFromGitHub {
     owner = "dvddarias";

--- a/pkgs/development/tools/rust/racerd/default.nix
+++ b/pkgs/development/tools/rust/racerd/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, fetchpatch, rustPlatform, makeWrapper, Security }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "racerd";
-  version = "unstable-2019-09-02";
+  pname = "racerd-unstable";
+  version = "2019-09-02";
 
   src = fetchFromGitHub {
     owner = "jwilm";

--- a/pkgs/development/tools/statik/default.nix
+++ b/pkgs/development/tools/statik/default.nix
@@ -1,8 +1,8 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage {
-  pname = "statik";
-  version = "unstable-2019-07-31";
+  pname = "statik-unstable";
+  version = "2019-07-31";
   goPackagePath = "github.com/rakyll/statik";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/vgo2nix/default.nix
+++ b/pkgs/development/tools/vgo2nix/default.nix
@@ -8,8 +8,8 @@
 }:
 
 buildGoPackage {
-  pname = "vgo2nix";
-  version = "unstable-2020-05-05";
+  pname = "vgo2nix-unstable";
+  version = "2020-05-05";
   goPackagePath = "github.com/adisbladis/vgo2nix";
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/development/tools/wxformbuilder/default.nix
+++ b/pkgs/development/tools/wxformbuilder/default.nix
@@ -6,8 +6,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "wxFormBuilder";
-  version = "unstable-2020-08-18";
+  pname = "wxFormBuilder-unstable";
+  version = "2020-08-18";
 
   src = fetchFromGitHub {
     owner = "wxFormBuilder";

--- a/pkgs/development/tools/yaml2json/default.nix
+++ b/pkgs/development/tools/yaml2json/default.nix
@@ -2,8 +2,8 @@
 
 
 buildGoPackage {
-  pname = "yaml2json";
-  version = "unstable-2017-05-03";
+  pname = "yaml2json-unstable";
+  version = "2017-05-03";
   goPackagePath = "github.com/bronze1man/yaml2json";
 
   goDeps = ./deps.nix;

--- a/pkgs/games/assaultcube/default.nix
+++ b/pkgs/games/assaultcube/default.nix
@@ -7,8 +7,8 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   # master branch has legacy (1.2.0.2) protocol 1201 and gcc 6 fix.
-  pname = "assaultcube";
-  version = "unstable-2018-05-20";
+  pname = "assaultcube-unstable";
+  version = "2018-05-20";
 
   src = fetchFromGitHub {
     owner = "assaultcube";
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
       cp ${desktop}/share/applications/* $out/share/applications
       install -Dpm644 packages/misc/icon.png $out/share/icons/assaultcube.png
       install -Dpm644 packages/misc/icon.png $out/share/pixmaps/assaultcube.png
-      
+
       makeWrapper $out/bin/ac_client $out/bin/${pname} \
         --run "cd $out/$gamedatadir" --add-flags "--home=\$HOME/.assaultcube/v1.2next --init"
     fi

--- a/pkgs/games/frogatto/data.nix
+++ b/pkgs/games/frogatto/data.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchFromGitHub }:
-  
+
 stdenv.mkDerivation {
-  pname = "frogatto-data";
-  version = "unstable-2018-12-18";
-  
+  pname = "frogatto-data-unstable";
+  version = "2018-12-18";
+
   src = fetchFromGitHub {
     owner = "frogatto";
     repo = "frogatto";

--- a/pkgs/games/frogatto/default.nix
+++ b/pkgs/games/frogatto/default.nix
@@ -14,9 +14,9 @@ let
     genericName = "frogatto";
     categories = "Game;ArcadeGame;";
   };
-  version = "unstable-2018-12-18";
+  version = "2018-12-18";
 in buildEnv {
-  name = "frogatto-${version}";
+  name = "frogatto-unstable-${version}";
 
   buildInputs = [ makeWrapper ];
   paths = [ engine data desktopItem ];

--- a/pkgs/games/frogatto/engine.nix
+++ b/pkgs/games/frogatto/engine.nix
@@ -3,8 +3,8 @@
 , glew, zlib, icu, pkgconfig, cairo, libvpx }:
 
 stdenv.mkDerivation {
-  pname = "anura-engine";
-  version = "unstable-2018-11-28";
+  pname = "anura-engine-unstable";
+  version = "2018-11-28";
 
   src = fetchFromGitHub {
     owner = "anura-engine";

--- a/pkgs/games/gnome-hexgl/default.nix
+++ b/pkgs/games/gnome-hexgl/default.nix
@@ -10,8 +10,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-hexgl";
-  version = "unstable-2020-07-24";
+  pname = "gnome-hexgl-unstable";
+  version = "2020-07-24";
 
   src = fetchFromGitHub {
     owner = "alexlarsson";

--- a/pkgs/games/gscrabble/default.nix
+++ b/pkgs/games/gscrabble/default.nix
@@ -3,8 +3,8 @@
 , python3Packages, gnome3 }:
 
 buildPythonApplication {
-  pname = "gscrabble";
-  version = "unstable-2019-03-11";
+  pname = "gscrabble-unstable";
+  version = "2019-03-11";
 
   src = fetchFromGitHub {
     owner = "RaaH";

--- a/pkgs/games/gweled/default.nix
+++ b/pkgs/games/gweled/default.nix
@@ -3,8 +3,8 @@
 , libmikmod, librsvg, libcanberra-gtk2, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
-  pname = "gweled";
-  version = "unstable-2018-02-15";
+  pname = "gweled-unstable";
+  version = "2018-02-15";
 
   src = fetchbzr {
     url = "lp:gweled";

--- a/pkgs/games/pingus/default.nix
+++ b/pkgs/games/pingus/default.nix
@@ -1,8 +1,8 @@
 {stdenv, fetchgit, cmake, SDL2, SDL2_image, boost, libpng, SDL2_mixer
 , pkgconfig, libGLU, libGL, git, jsoncpp }:
 stdenv.mkDerivation rec {
-  pname = "pingus";
-  version = "unstable-0.7.6.0.20191104";
+  pname = "pingus-unstable";
+  version = "0.7.6.0.20191104";
 
   nativeBuildInputs = [ cmake pkgconfig git ];
   buildInputs = [ SDL2 SDL2_image boost libpng SDL2_mixer libGLU libGL jsoncpp ];

--- a/pkgs/games/qgo/default.nix
+++ b/pkgs/games/qgo/default.nix
@@ -8,8 +8,8 @@
 }:
 
 mkDerivation {
-  pname = "qgo";
-  version = "unstable-2017-12-18";
+  pname = "qgo-unstable";
+  version = "2017-12-18";
 
   meta = with lib; {
     description = "A Go client based on Qt5";

--- a/pkgs/games/sm64ex/default.nix
+++ b/pkgs/games/sm64ex/default.nix
@@ -25,8 +25,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "sm64ex";
-  version = "unstable-2020-06-19";
+  pname = "sm64ex-unstable";
+  version = "2020-06-19";
 
   src = fetchFromGitHub {
     owner = "sm64pc";

--- a/pkgs/games/warmux/default.nix
+++ b/pkgs/games/warmux/default.nix
@@ -5,8 +5,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "warmux";
-  version = "unstable-2017-10-20";
+  pname = "warmux-unstable";
+  version = "2017-10-20";
 
   src = fetchFromGitHub {
     owner = "fluxer";

--- a/pkgs/misc/emulators/emu2/default.nix
+++ b/pkgs/misc/emulators/emu2/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  pname = "emu2";
-  version = "unstable-2020-06-04";
+  pname = "emu2-unstable";
+  version = "2020-06-04";
 
   src = fetchFromGitHub {
     owner  = "dmsc";

--- a/pkgs/misc/emulators/simplenes/default.nix
+++ b/pkgs/misc/emulators/simplenes/default.nix
@@ -5,8 +5,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "simplenes";
-  version = "unstable-2019-03-13";
+  pname = "simplenes-unstable";
+  version = "2019-03-13";
 
   src = fetchFromGitHub {
     owner = "amhndu";

--- a/pkgs/misc/lguf-brightness/default.nix
+++ b/pkgs/misc/lguf-brightness/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, cmake, libusb1, ncurses5 }:
 
 stdenv.mkDerivation rec {
-  pname = "lguf-brightness";
+  pname = "lguf-brightness-unstable";
 
-  version = "unstable-2018-02-11";
+  version = "2018-02-11";
 
   src = fetchFromGitHub  {
     owner = "periklis";
-    repo = pname;
+    repo = "lguf-brightness";
     rev = "fcb2bc1738d55c83b6395c24edc27267a520a725";
     sha256 = "0cf7cn2kpmlvz00qxqj1m5zxmh7i2x75djbj4wqk7if7a0nlrd5m";
   };

--- a/pkgs/misc/rkdeveloptool/default.nix
+++ b/pkgs/misc/rkdeveloptool/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libusb1 }:
 
 stdenv.mkDerivation {
-  pname = "rkdeveloptool";
-  version = "unstable-2019-07-01";
+  pname = "rkdeveloptool-unstable";
+  version = "2019-07-01";
 
   src = fetchFromGitHub {
     owner = "rockchip-linux";

--- a/pkgs/misc/uq/default.nix
+++ b/pkgs/misc/uq/default.nix
@@ -4,8 +4,8 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "uq";
-  version = "unstable-2018-05-27";
+  pname = "uq-unstable";
+  version = "2018-05-27";
 
   src = fetchFromGitHub {
     owner = "lostutils";

--- a/pkgs/os-specific/linux/anbox/default.nix
+++ b/pkgs/os-specific/linux/anbox/default.nix
@@ -44,12 +44,12 @@ let
 in
 
 stdenv.mkDerivation rec {
-  pname = "anbox";
-  version = "unstable-2019-11-15";
+  pname = "anbox-unstable";
+  version = "2019-11-15";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "anbox";
+    repo = "anbox";
     rev = "0a49ae08f76de7f886a3dbed4422711c2fa39d10";
     sha256 = "09l56nv9cnyhykclfmvam6bkcxlamwbql6nrz9n022553w92hkjf";
   };

--- a/pkgs/os-specific/linux/asus-wmi-sensors/default.nix
+++ b/pkgs/os-specific/linux/asus-wmi-sensors/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, kernel }:
 
 stdenv.mkDerivation rec {
-  name = "asus-wmi-sensors-${version}-${kernel.version}";
-  version = "unstable-2019-11-07";
+  name = "asus-wmi-sensors-unstable-${version}-${kernel.version}";
+  version = "2019-11-07";
 
   # The original was deleted from github, but this seems to be an active fork
   src = fetchFromGitHub {

--- a/pkgs/os-specific/linux/digimend/default.nix
+++ b/pkgs/os-specific/linux/digimend/default.nix
@@ -3,8 +3,8 @@
 assert stdenv.lib.versionAtLeast kernel.version "3.5";
 
 stdenv.mkDerivation rec {
-  pname = "digimend";
-  version = "unstable-2019-06-18";
+  pname = "digimend-unstable";
+  version = "2019-06-18";
 
   src = fetchFromGitHub {
     owner = "digimend";

--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, fetchpatch, kernel, libdrm }:
 
 stdenv.mkDerivation rec {
-  pname = "evdi";
-  version = "unstable-20200416";
+  pname = "evdi-unstable";
+  version = "20200416";
 
   src = fetchFromGitHub {
     owner = "DisplayLink";
-    repo = pname;
+    repo = "evdi";
     rev = "dc595db636845aef39490496bc075f6bf067106c";
     sha256 = "1yrny6jj9403z0rxbd3nxf49xc4w0rfpl7xsq03pq32pb3vlbqw7";
   };

--- a/pkgs/os-specific/linux/kmscon/default.nix
+++ b/pkgs/os-specific/linux/kmscon/default.nix
@@ -14,8 +14,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "kmscon";
-  version = "unstable-2018-09-07";
+  pname = "kmscon-unstable";
+  version = "2018-09-07";
 
   src = fetchFromGitHub {
     owner = "Aetf";

--- a/pkgs/os-specific/linux/ledger-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/ledger-udev-rules/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  pname = "ledger-udev-rules";
-  version = "unstable-2019-05-30";
+  pname = "ledger-udev-rules-unstable";
+  version = "2019-05-30";
 
   src = fetchFromGitHub {
     owner = "LedgerHQ";

--- a/pkgs/os-specific/linux/numworks-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/numworks-udev-rules/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  pname = "numworks-udev-rules";
-  version = "unstable-2020-08-31";
+  pname = "numworks-udev-rules-unstable";
+  version = "2020-08-31";
 
   udevRules = ./50-numworks-calculator.rules;
   dontUnpack = true;

--- a/pkgs/os-specific/linux/rtl8821cu/default.nix
+++ b/pkgs/os-specific/linux/rtl8821cu/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, kernel, bc }:
 stdenv.mkDerivation rec {
-  name = "rtl8821cu-${kernel.version}-${version}";
-  version = "unstable-2020-08-21";
+  name = "rtl8821cu-${kernel.version}-unstable-${version}";
+  version = "2020-08-21";
 
   src = fetchFromGitHub {
     owner = "brektrou";

--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, fetchpatch, kernel, bc }:
 
 stdenv.mkDerivation rec {
-  name = "rtl88x2bu-${kernel.version}-${version}";
-  version = "unstable-2020-08-20";
+  name = "rtl88x2bu-${kernel.version}-unstable-${version}";
+  version = "2020-08-20";
 
   src = fetchFromGitHub {
     owner = "cilynx";

--- a/pkgs/os-specific/linux/syslinux/default.nix
+++ b/pkgs/os-specific/linux/syslinux/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchgit, fetchurl, fetchpatch, nasm, perl, python3, libuuid, mtools, makeWrapper }:
 
 stdenv.mkDerivation {
-  pname = "syslinux";
-  version = "unstable-20190207";
+  pname = "syslinux-unstable";
+  version = "2019-02-07";
 
   # This is syslinux-6.04-pre3^1; syslinux-6.04-pre3 fails to run.
   # Same issue here https://www.syslinux.org/archives/2019-February/026330.html

--- a/pkgs/os-specific/linux/trezor-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/trezor-udev-rules/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  pname = "trezor-udev-rules";
-  version = "unstable-2019-07-17";
+  pname = "trezor-udev-rules-unstable";
+  version = "2019-07-17";
 
   udevRules = fetchurl {
     # let's pin the latest commit in the repo which touched the udev rules file

--- a/pkgs/servers/demoit/default.nix
+++ b/pkgs/servers/demoit/default.nix
@@ -4,8 +4,8 @@
 }:
 
 buildGoModule {
-  pname = "demoit";
-  version = "unstable-2020-06-11";
+  pname = "demoit-unstable";
+  version = "2020-06-11";
   goPackagePath = "github.com/dgageot/demoit";
 
   src = fetchFromGitHub {

--- a/pkgs/servers/dns/https-dns-proxy/default.nix
+++ b/pkgs/servers/dns/https-dns-proxy/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchFromGitHub, cmake, gtest, c-ares, curl, libev }:
 
 stdenv.mkDerivation rec {
-  pname = "https-dns-proxy";
+  pname = "https-dns-proxy-unstable";
   # there are no stable releases (yet?)
-  version = "unstable-20200419";
+  version = "2020-04-19";
 
   src = fetchFromGitHub {
     owner = "aarond10";

--- a/pkgs/servers/echoip/default.nix
+++ b/pkgs/servers/echoip/default.nix
@@ -1,8 +1,8 @@
 { lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule {
-  pname = "echoip";
-  version = "unstable-2019-07-12";
+  pname = "echoip-unstable";
+  version = "2019-07-12";
 
   src = fetchFromGitHub {
     owner = "mpolden";

--- a/pkgs/servers/gemini/molly-brown/default.nix
+++ b/pkgs/servers/gemini/molly-brown/default.nix
@@ -1,8 +1,8 @@
 { lib, buildGoPackage, fetchgit, nixosTests }:
 
 buildGoPackage rec {
-  pname = "molly-brown";
-  version = "unstable-2020-08-19";
+  pname = "molly-brown-unstable";
+  version = "2020-08-19";
   rev = "48f9a206c03c0470e1c132b9667c6daa3583dada";
 
   goPackagePath = "tildegit.org/solderpunk/molly-brown";

--- a/pkgs/servers/http/apache-modules/mod_tile/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_tile/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, autoreconfHook, apacheHttpd, apr, cairo, iniparser, mapnik }:
 
 stdenv.mkDerivation rec {
-  pname = "mod_tile";
-  version = "unstable-2017-01-08";
+  pname = "mod_tile-unstable";
+  version = "2017-01-08";
 
   src = fetchFromGitHub {
     owner = "openstreetmap";

--- a/pkgs/servers/isso/default.nix
+++ b/pkgs/servers/isso/default.nix
@@ -2,15 +2,15 @@
 
 with python3Packages; buildPythonApplication rec {
 
-  pname = "isso";
+  pname = "isso-unstable";
   # Can not use 0.12.2 because of:
   # https://github.com/posativ/isso/issues/617
-  version = "unstable-2020-09-14";
+  version = "2020-09-14";
 
   # no tests on PyPI
   src = fetchFromGitHub {
     owner = "posativ";
-    repo = pname;
+    repo = "isso";
     rev = "f4d2705d4f1b51f444d0629355a6fcbcec8d57b5";
     sha256 = "02jgfzq3svd54zj09jj7lm2r7ypqqjynzxa9dgnnm0pqvq728wzr";
   };

--- a/pkgs/servers/monitoring/prometheus/json-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/json-exporter.nix
@@ -2,8 +2,8 @@
 { buildGoPackage, fetchFromGitHub, fetchpatch, lib, nixosTests }:
 
 buildGoPackage {
-  pname = "prometheus-json-exporter";
-  version = "unstable-2017-10-06";
+  pname = "prometheus-json-exporter-unstable";
+  version = "2017-10-06";
 
   goPackagePath = "github.com/kawamuray/prometheus-json-exporter";
 

--- a/pkgs/servers/monitoring/prometheus/varnish-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/varnish-exporter.nix
@@ -1,8 +1,8 @@
 { lib, buildGoModule, fetchFromGitHub, makeWrapper, varnish, nixosTests }:
 
 buildGoModule rec {
-  pname = "prometheus_varnish_exporter";
-  version = "unstable-2020-03-26";
+  pname = "prometheus_varnish_exporter-unstable";
+  version = "2020-03-26";
 
   src = fetchFromGitHub {
     owner = "jonnenauha";

--- a/pkgs/servers/mumsi/default.nix
+++ b/pkgs/servers/mumsi/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkgconfig, boost
 , log4cpp, pjsip, openssl, alsaLib, mumlib }:
 with lib; stdenv.mkDerivation {
-  pname = "mumsi";
-  version = "unstable-2018-12-12";
+  pname = "mumsi-unstable";
+  version = "2018-12-12";
 
   src = fetchFromGitHub {
     owner = "slomkowski";

--- a/pkgs/servers/sql/postgresql/ext/pgjwt.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgjwt.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, postgresql }:
 
 stdenv.mkDerivation {
-  pname = "pgjwt";
-  version = "unstable-2017-04-24";
+  pname = "pgjwt-unstable";
+  version = "2017-04-24";
 
   src = fetchFromGitHub {
     owner  = "michelp";

--- a/pkgs/servers/webmetro/default.nix
+++ b/pkgs/servers/webmetro/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "webmetro";
-  version = "unstable-20180426";
+  pname = "webmetro-unstable";
+  version = "20180426";
 
   src = fetchFromGitHub {
     owner = "Tangent128";
-    repo = pname;
+    repo = "webmetro";
     rev = "4f6cc00fe647bd311d00a8a4cb53ab08f20a04f9";
     sha256 = "1n2c7ygs8qsd5zgii6fqqcwg427bsij082bg4ijnzkq5630dx651";
   };

--- a/pkgs/shells/ion/default.nix
+++ b/pkgs/shells/ion/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "ion";
-  version = "unstable-2020-03-22";
+  pname = "ion-unstable";
+  version = "2020-03-22";
 
   src = fetchFromGitHub {
     owner = "redox-os";

--- a/pkgs/tools/X11/xcape/default.nix
+++ b/pkgs/tools/X11/xcape/default.nix
@@ -2,12 +2,12 @@
 libXi }:
 
 stdenv.mkDerivation rec {
-  pname = "xcape";
-  version = "unstable-2018-03-01";
+  pname = "xcape-unstable";
+  version = "2018-03-01";
 
   src = fetchFromGitHub {
     owner = "alols";
-    repo = pname;
+    repo = "xcape";
     rev = "a34d6bae27bbd55506852f5ed3c27045a3c0bd9e";
     sha256 = "04grs4w9kpfzz25mqw82zdiy51g0w355gpn5b170p7ha5972ykc8";
   };

--- a/pkgs/tools/backup/diskrsync/default.nix
+++ b/pkgs/tools/backup/diskrsync/default.nix
@@ -1,12 +1,12 @@
 { buildGoPackage, fetchFromGitHub, stdenv, openssh, makeWrapper }:
 
 buildGoPackage rec {
-  pname = "diskrsync";
-  version = "unstable-2019-01-02";
+  pname = "diskrsync-unstable";
+  version = "2019-01-02";
 
   src = fetchFromGitHub {
     owner = "dop251";
-    repo = pname;
+    repo = "diskrsync";
     rev = "e8598ef71038527a8a77d1a6cf2a73cfd96d9139";
     sha256 = "1dqpmc4hp81knhdk3mrmwdr66xiibsvj5lagbm5ciajg9by45mcs";
   };

--- a/pkgs/tools/backup/easysnap/default.nix
+++ b/pkgs/tools/backup/easysnap/default.nix
@@ -1,8 +1,8 @@
 {stdenv, fetchFromGitHub, zfs }:
 
 stdenv.mkDerivation {
-  pname = "easysnap";
-  version = "unstable-2020-04-04";
+  pname = "easysnap-unstable";
+  version = "2020-04-04";
 
   src = fetchFromGitHub {
     owner = "sjau";

--- a/pkgs/tools/backup/iceshelf/default.nix
+++ b/pkgs/tools/backup/iceshelf/default.nix
@@ -1,14 +1,14 @@
 { stdenv, lib, fetchFromGitHub, git, awscli, python3 }:
 
 python3.pkgs.buildPythonApplication rec {
-  pname = "iceshelf";
-  version = "unstable-2019-07-03";
+  pname = "iceshelf-unstable";
+  version = "2019-07-03";
 
   format = "other";
 
 	src = fetchFromGitHub {
 		owner = "mrworf";
-		repo = pname;
+		repo = "iceshelf";
 		rev = "26768dde3fc54fa412e523eb8f8552e866b4853b";
 		sha256 = "08rcbd14vn7312rmk2hyvdzvhibri31c4r5lzdrwb1n1y9q761qm";
   };

--- a/pkgs/tools/backup/zfsbackup/default.nix
+++ b/pkgs/tools/backup/zfsbackup/default.nix
@@ -1,8 +1,8 @@
 { lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  pname = "zfsbackup";
-  version = "unstable-2019-03-05";
+  pname = "zfsbackup-unstable";
+  version = "2019-03-05";
   rev = "78fea6e99f0a5a4c8513d3a3d1d45fb6750cfddf";
 
   goPackagePath = "github.com/someone1/zfsbackup-go";

--- a/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
+++ b/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, substituteAll }:
 
 stdenv.mkDerivation rec {
-  pname = "srt-to-vtt-cl";
-  version = "unstable-2019-01-03";
+  pname = "srt-to-vtt-cl-unstable";
+  version = "2019-01-03";
 
   src = fetchFromGitHub {
     owner = "nwoltman";
-    repo = pname;
+    repo = "srt-to-vtt-cl";
     rev = "ce3d0776906eb847c129d99a85077b5082f74724";
     sha256 = "0qxysj08gjr6npyvg148llmwmjl2n9cyqjllfnf3gxb841dy370n";
   };

--- a/pkgs/tools/compression/flips/default.nix
+++ b/pkgs/tools/compression/flips/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, gtk3, libdivsufsort, pkg-config, wrapGAppsHook }:
 
 stdenv.mkDerivation {
-  pname = "flips";
-  version = "unstable-2020-10-02";
+  pname = "flips-unstable";
+  version = "2020-10-02";
 
   src = fetchFromGitHub {
     owner = "Alcaro";

--- a/pkgs/tools/filesystems/ubidump/default.nix
+++ b/pkgs/tools/filesystems/ubidump/default.nix
@@ -2,12 +2,12 @@
 
 python3.pkgs.buildPythonApplication rec {
 
-  pname = "ubidump";
-  version = "unstable-2019-09-11";
+  pname = "ubidump-unstable";
+  version = "2019-09-11";
 
   src = fetchFromGitHub {
     owner = "nlitsme";
-    repo = pname;
+    repo = "ubidump";
     rev = "0691f1a9a38604c2baf8c9af6b826eb2632af74a";
     sha256 = "1hiivlgni4r3nd5n2rzl5qzw6y2wpjpmyls5lybrc8imd6rmj3w2";
   };

--- a/pkgs/tools/graphics/amber/default.nix
+++ b/pkgs/tools/graphics/amber/default.nix
@@ -44,12 +44,12 @@ let
 
 in
 stdenv.mkDerivation rec {
-  pname = "amber";
-  version = "unstable-2020-09-23";
+  pname = "amber-unstable";
+  version = "2020-09-23";
 
   src = fetchFromGitHub {
     owner = "google";
-    repo = pname;
+    repo = "amber";
     rev = "0eee2d45d053dfc566baa58442a9b1b708e4f2a7";
     sha256 = "1rrbvmn9hvhj7xj89yqvy9mx0vg1qapdm5fkca8mkd3516d9f5pw";
   };

--- a/pkgs/tools/graphics/jpegexiforient/default.nix
+++ b/pkgs/tools/graphics/jpegexiforient/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl }:
 stdenv.mkDerivation {
-  pname = "jpegexiforient";
-  version = "unstable-2002-02-17";
+  pname = "jpegexiforient-unstable";
+  version = "2002-02-17";
   src = fetchurl {
     url = "http://sylvana.net/jpegcrop/jpegexiforient.c";
     sha256 = "1v0f42cvs0397g9v46p294ldgxwbp285npg6npgnlnvapk6nzh5s";

--- a/pkgs/tools/graphics/yaxg/default.nix
+++ b/pkgs/tools/graphics/yaxg/default.nix
@@ -2,8 +2,8 @@
   maim, slop, ffmpeg_3, byzanz, libnotify, xdpyinfo }:
 
 stdenv.mkDerivation rec {
-  pname = "yaxg";
-  version = "unstable-2018-05-03";
+  pname = "yaxg-unstable";
+  version = "2018-05-03";
 
   src = fetchFromGitHub {
     owner = "DanielFGray";

--- a/pkgs/tools/inputmethods/hime/default.nix
+++ b/pkgs/tools/inputmethods/hime/default.nix
@@ -6,8 +6,8 @@ stdenv, fetchFromGitHub, pkgconfig, which, gtk2, gtk3, qt4, qt5, libXtst, lib,
 # so we do not enable these input method at this moment
 
 stdenv.mkDerivation {
-  name = "hime";
-  version = "unstable-2020-06-27";
+  name = "hime-unstable";
+  version = "2020-06-27";
 
   src = fetchFromGitHub {
     owner = "hime-ime";

--- a/pkgs/tools/misc/bcunit/default.nix
+++ b/pkgs/tools/misc/bcunit/default.nix
@@ -4,17 +4,17 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "bcunit";
+  pname = "bcunit-unstable";
   # Latest release 3.0.2 is missing some functions needed by bctoolbox. See:
   # https://gitlab.linphone.org/BC/public/bcunit/issues/1
-  version = "unstable-2019-11-19";
+  version = "2019-11-19";
 
   buildInputs = [ cmake ];
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
     owner = "public";
     group = "BC";
-    repo = pname;
+    repo = "bcunit";
     rev = "3c720fbf67dd3c02b0c7011ed4036982b2c93532";
     sha256 = "1237hpmkls2igp60gdfkbknxpgwvxn1vmv2m41vyl25xw1d3g35w";
   };

--- a/pkgs/tools/misc/bonfire/default.nix
+++ b/pkgs/tools/misc/bonfire/default.nix
@@ -3,14 +3,14 @@
 with python3Packages;
 
 buildPythonApplication rec {
-  pname = "bonfire";
-  version = "unstable-2017-01-19";
+  pname = "bonfire-unstable";
+  version = "2017-01-19";
 
   # use latest git version with --endpoint flag
   # https://github.com/blue-yonder/bonfire/pull/18
   src = fetchFromGitHub {
     owner = "blue-yonder";
-    repo = pname;
+    repo = "bonfire";
     rev = "d0af9ca10394f366cfa3c60f0741f1f0918011c2";
     sha256 = "193zcvzbhxwwkwbgmnlihhhazwkajycxf4r71jz1m12w301sjhq5";
   };

--- a/pkgs/tools/misc/cht.sh/default.nix
+++ b/pkgs/tools/misc/cht.sh/default.nix
@@ -8,8 +8,8 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "cht.sh";
-  version = "unstable-2020-08-06";
+  pname = "cht.sh-unstable";
+  version = "2020-08-06";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/misc/cod/default.nix
+++ b/pkgs/tools/misc/cod/default.nix
@@ -1,14 +1,14 @@
 { lib, fetchFromGitHub, buildGoModule }:
 
 buildGoModule rec {
-  pname = "cod";
-  version = "unstable-2020-09-10";
+  pname = "cod-unstable";
+  version = "2020-09-10";
 
   goPackagePath = "cod";
 
   src = fetchFromGitHub {
     owner = "dim-an";
-    repo = pname;
+    repo = "cod";
     rev = "ae68da08339471dd278d6df79abbfd6fe89a10fe";
     sha256 = "1l3gn9v8dcy72f5xq9hwbkvkis0vp4dp8qyinsrii3acmhksg9v6";
   };

--- a/pkgs/tools/misc/dpt-rp1-py/default.nix
+++ b/pkgs/tools/misc/dpt-rp1-py/default.nix
@@ -1,11 +1,11 @@
 { lib, python3Packages, fetchFromGitHub }:
 python3Packages.buildPythonApplication rec {
-  pname = "dpt-rp1-py";
-  version = "unstable-2018-10-16";
+  pname = "dpt-rp1-py-unstable";
+  version = "2018-10-16";
 
   src = fetchFromGitHub {
     owner = "janten";
-    repo = pname;
+    repo = "dpt-rp1-py";
     rev = "4551b4432f8470de5f2ad9171105f731a6259395";
     sha256 = "176y5j31aci1vpi8v6r5ki55432fbdsazh9bsyzr90im9zimkffl";
   };

--- a/pkgs/tools/misc/edid-generator/default.nix
+++ b/pkgs/tools/misc/edid-generator/default.nix
@@ -7,9 +7,9 @@
 , modelines ? [] # Modeline "1280x800"   83.50  1280 1352 1480 1680  800 803 809 831 -hsync +vsync
 }:
 let
-  version = "unstable-2018-03-15";
+  version = "2018-03-15";
 in stdenv.mkDerivation {
-  pname = "edid-generator";
+  pname = "edid-generator-unstable";
   inherit version;
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/fffuu/default.nix
+++ b/pkgs/tools/misc/fffuu/default.nix
@@ -1,8 +1,8 @@
 { mkDerivation, haskellPackages, fetchFromGitHub, lib }:
 
 mkDerivation {
-  pname = "fffuu";
-  version = "unstable-2018-05-26";
+  pname = "fffuu-unstable";
+  version = "2018-05-26";
 
   src = fetchFromGitHub {
     owner = "diekmann";

--- a/pkgs/tools/misc/g933-utils/default.nix
+++ b/pkgs/tools/misc/g933-utils/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, rustPlatform, udev, pkgconfig }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "g933-utils";
-  version = "unstable-2019-08-04";
+  pname = "g933-utils-unstable";
+  version = "2019-08-04";
 
   src = fetchFromGitHub {
     owner = "ashkitten";

--- a/pkgs/tools/misc/gif-for-cli/default.nix
+++ b/pkgs/tools/misc/gif-for-cli/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, python3Packages, ffmpeg_3, zlib, libjpeg }:
 
 python3Packages.buildPythonApplication {
-  pname = "gif-for-cli";
-  version = "unstable-2018-08-14";
+  pname = "gif-for-cli-unstable";
+  version = "2018-08-14";
 
   src = fetchFromGitHub {
     owner = "google";

--- a/pkgs/tools/misc/loop/default.nix
+++ b/pkgs/tools/misc/loop/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage {
-  pname = "loop";
-  version = "unstable-2020-07-08";
+  pname = "loop-unstable";
+  version = "2020-07-08";
 
   src = fetchFromGitHub {
     owner = "Miserlou";

--- a/pkgs/tools/misc/ltunify/default.nix
+++ b/pkgs/tools/misc/ltunify/default.nix
@@ -4,8 +4,8 @@
 # adding this to services.udev.packages on NixOS
 
 stdenv.mkDerivation {
-  pname = "ltunify";
-  version = "unstable-20180330";
+  pname = "ltunify-unstable";
+  version = "20180330";
 
   src = fetchFromGitHub {
     owner  = "Lekensteyn";

--- a/pkgs/tools/misc/sta/default.nix
+++ b/pkgs/tools/misc/sta/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, autoreconfHook }:
 stdenv.mkDerivation {
-  pname = "sta";
-  version = "unstable-2016-01-25";
+  pname = "sta-unstable";
+  version = "2016-01-25";
 
   src = fetchFromGitHub {
     owner = "simonccarter";

--- a/pkgs/tools/misc/venus/default.nix
+++ b/pkgs/tools/misc/venus/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, python, pythonPackages, libxslt, libxml2, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  pname = "venus";
-  version = "unstable-2011-02-18";
+  pname = "venus-unstable";
+  version = "2011-02-18";
 
   src = fetchFromGitHub {
     owner = "rubys";

--- a/pkgs/tools/misc/xilinx-bootgen/default.nix
+++ b/pkgs/tools/misc/xilinx-bootgen/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, openssl }:
 
 stdenv.mkDerivation {
-  pname = "xilinx-bootgen";
-  version = "unstable-2019-10-23";
+  pname = "xilinx-bootgen-unstable";
+  version = "2019-10-23";
 
   src = fetchFromGitHub {
     owner = "xilinx";

--- a/pkgs/tools/misc/zabbixctl/default.nix
+++ b/pkgs/tools/misc/zabbixctl/default.nix
@@ -1,8 +1,8 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  pname = "zabbixctl";
-  version = "unstable-2019-07-06";
+  pname = "zabbixctl-unstable";
+  version = "2019-07-06";
 
   goPackagePath = "github.com/kovetskiy/zabbixctl";
 

--- a/pkgs/tools/networking/iodine/default.nix
+++ b/pkgs/tools/networking/iodine/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, zlib, nettools, nixosTests }:
 
 stdenv.mkDerivation rec {
-  pname = "iodine";
-  version = "unstable-2019-09-27";
+  pname = "iodine-unstable";
+  version = "2019-09-27";
 
   src = fetchFromGitHub {
     owner = "yarrick";

--- a/pkgs/tools/networking/linkchecker/default.nix
+++ b/pkgs/tools/networking/linkchecker/default.nix
@@ -3,12 +3,12 @@
 with python3Packages;
 
 buildPythonApplication rec {
-  pname = "linkchecker";
-  version = "unstable-2020-08-15";
+  pname = "linkchecker-unstable";
+  version = "2020-08-15";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "linkchecker";
+    repo = "linkchecker";
     rev = "0086c28b3a419faa60562f2713346996062c03c2";
     sha256 = "0am5id8vqlqn1gb9jri0vjgiq5ffgrjq8yzdk1zc98gn2n0397wl";
   };

--- a/pkgs/tools/networking/mmsd/default.nix
+++ b/pkgs/tools/networking/mmsd/default.nix
@@ -7,8 +7,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "mmsd";
-  version = "unstable-2019-07-15";
+  pname = "mmsd-unstable";
+  version = "2019-07-15";
 
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/network/ofono/mmsd.git";

--- a/pkgs/tools/networking/netifd/default.nix
+++ b/pkgs/tools/networking/netifd/default.nix
@@ -1,8 +1,8 @@
 { runCommand, stdenv, cmake, fetchgit, libnl, libubox, uci, ubus, json_c }:
 
 stdenv.mkDerivation {
-  pname = "netifd";
-  version = "unstable-2020-07-11";
+  pname = "netifd-unstable";
+  version = "2020-07-11";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/netifd.git";

--- a/pkgs/tools/networking/network-manager/iodine/default.nix
+++ b/pkgs/tools/networking/network-manager/iodine/default.nix
@@ -2,8 +2,8 @@
 , withGnome ? true, gnome3, fetchpatch, libnma, glib }:
 
 let
-  pname = "NetworkManager-iodine";
-  version = "unstable-2019-11-05";
+  pname = "NetworkManager-iodine-unstable";
+  version = "2019-11-05";
 in stdenv.mkDerivation {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
 

--- a/pkgs/tools/networking/openconnect_pa/default.nix
+++ b/pkgs/tools/networking/openconnect_pa/default.nix
@@ -3,16 +3,16 @@
 assert (openssl != null) == (gnutls == null);
 
 stdenv.mkDerivation {
-  version = "unstable-2018-10-08";
-  pname = "openconnect_pa";
-  
+  pname = "openconnect_pa-unstable";
+  version = "2018-10-08";
+
   outputs = [ "out" "dev" ];
 
   src = fetchFromGitHub {
     owner = "dlenski";
     repo = "openconnect";
     rev = "e5fe063a087385c5b157ad7a9a3fa874181f6e3b";
-    sha256 = "0ywacqs3nncr2gpjjcz2yc9c6v4ifjssh0vb07h0qff06whqhdax"; 
+    sha256 = "0ywacqs3nncr2gpjjcz2yc9c6v4ifjssh0vb07h0qff06whqhdax";
   };
 
   preConfigure = ''
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   propagatedBuildInputs = [ vpnc openssl gnutls gmp libxml2 stoken zlib ];
-  
+
   meta = with stdenv.lib; {
     description = "OpenConnect client extended to support Palo Alto Networks' GlobalProtect VPN";
     homepage = "https://github.com/dlenski/openconnect/";

--- a/pkgs/tools/networking/p2p/amule/default.nix
+++ b/pkgs/tools/networking/p2p/amule/default.nix
@@ -9,8 +9,8 @@ assert httpServer -> libpng != null;
 assert client -> libX11 != null;
 
 stdenv.mkDerivation rec {
-  pname = "amule";
-  version = "unstable-20201006";
+  pname = "amule-unstable";
+  version = "20201006";
 
   src = fetchFromGitHub {
     owner = "amule-project";

--- a/pkgs/tools/networking/packetdrill/default.nix
+++ b/pkgs/tools/networking/packetdrill/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, bison, flex, cmake, libpcap }:
 stdenv.mkDerivation rec {
-  pname = "packetdrill";
-  version = "unstable-2020-08-22";
+  pname = "packetdrill-unstable";
+  version = "2020-08-22";
 
   src = fetchFromGitHub {
     owner = "google";

--- a/pkgs/tools/networking/py-wmi-client/default.nix
+++ b/pkgs/tools/networking/py-wmi-client/default.nix
@@ -1,12 +1,12 @@
 { lib, pythonPackages, fetchFromGitHub }:
 
 pythonPackages.buildPythonApplication rec {
-  pname = "py-wmi-client";
-  version = "unstable-20160601";
+  pname = "py-wmi-client-unstable";
+  version = "20160601";
 
   src = fetchFromGitHub {
     owner = "dlundgren";
-    repo = pname;
+    repo = "py-wmi-client";
     rev = "9702b036df85c3e0ecdde84a753b353069f58208";
     sha256 = "1kd12gi1knqv477f1shzqr0h349s5336vzp3fpfp3xl0b502ld8d";
   };

--- a/pkgs/tools/networking/uqmi/default.nix
+++ b/pkgs/tools/networking/uqmi/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchgit, cmake, perl, libubox, json_c }:
 
 stdenv.mkDerivation {
-  pname = "uqmi";
-  version = "unstable-2019-06-27";
+  pname = "uqmi-unstable";
+  version = "2019-06-27";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/uqmi.git";

--- a/pkgs/tools/networking/wstunnel/default.nix
+++ b/pkgs/tools/networking/wstunnel/default.nix
@@ -7,12 +7,12 @@
 }:
 
 mkDerivation rec {
-  pname = "wstunnel";
-  version = "unstable-2020-07-12";
+  pname = "wstunnel-unstable";
+  version = "2020-07-12";
 
   src = fetchFromGitHub {
     owner = "erebe";
-    repo = pname;
+    repo = "wstunnel";
     rev = "093a01fa3a34eee5efd8f827900e64eab9d16c05";
     sha256 = "17p9kq0ssz05qzl6fyi5a5fjbpn4bxkkwibb9si3fhzrxc508b59";
   };

--- a/pkgs/tools/security/b2sum/default.nix
+++ b/pkgs/tools/security/b2sum/default.nix
@@ -3,8 +3,8 @@
 with stdenv.lib;
 
 stdenv.mkDerivation {
-  pname = "b2sum";
-  version = "unstable-2018-06-11";
+  pname = "b2sum-unstable";
+  version = "2018-06-11";
 
   src = fetchzip {
     url = "https://github.com/BLAKE2/BLAKE2/archive/320c325437539ae91091ce62efec1913cd8093c2.tar.gz";

--- a/pkgs/tools/security/crowbar/default.nix
+++ b/pkgs/tools/security/crowbar/default.nix
@@ -8,12 +8,12 @@
 }:
 
 python3Packages.buildPythonApplication rec {
-  pname = "crowbar";
-  version = "unstable-2020-04-23";
+  pname = "crowbar-unstable";
+  version = "2020-04-23";
 
   src = fetchFromGitHub {
     owner = "galkan";
-    repo = pname;
+    repo = "crowbar";
     rev = "500d633ff5ddfcbc70eb6d0b4d2181e5b8d3c535";
     sha256 = "05m9vywr9976pc7il0ak8nl26mklzxlcqx0p8rlfyx1q766myqzf";
   };

--- a/pkgs/tools/security/doona/default.nix
+++ b/pkgs/tools/security/doona/default.nix
@@ -4,12 +4,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "doona";
-  version = "unstable-2019-03-08";
+  pname = "doona-unstable";
+  version = "2019-03-08";
 
   src = fetchFromGitHub {
     owner = "wireghoul";
-    repo = pname;
+    repo = "doona";
     rev = "master";
     sha256 = "0x9irwrw5x2ia6ch6gshadrlqrgdi1ivkadmr7j4m75k04a7nvz1";
   };

--- a/pkgs/tools/security/hash_extender/default.nix
+++ b/pkgs/tools/security/hash_extender/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, openssl }:
 
 stdenv.mkDerivation {
-  pname = "hash_extender";
-  version = "unstable-2020-03-24";
+  pname = "hash_extender-unstable";
+  version = "2020-03-24";
 
   src = fetchFromGitHub {
     owner = "iagox86";

--- a/pkgs/tools/security/onesixtyone/default.nix
+++ b/pkgs/tools/security/onesixtyone/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  pname = "onesixtyone";
-  version = "unstable-2019-12-26";
+  pname = "onesixtyone-unstable";
+  version = "2019-12-26";
 
   src = fetchFromGitHub {
     owner = "trailofbits";

--- a/pkgs/tools/system/yeshup/default.nix
+++ b/pkgs/tools/system/yeshup/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  pname = "yeshup";
-  version = "unstable-2013-10-29";
+  pname = "yeshup-unstable";
+  version = "2013-10-29";
 
   src = fetchFromGitHub {
     owner = "RhysU";

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -8,8 +8,8 @@ let
     ({ name, gawkextlib, extraBuildInputs ? [ ], doCheck ? true }:
       let is_extension = !isNull gawkextlib;
       in stdenv.mkDerivation rec {
-        pname = "gawkextlib-${name}";
-        version = "unstable-2019-11-21";
+        pname = "gawkextlib-${name}-unstable";
+        version = "2019-11-21";
 
         src = fetchgit {
           url = "git://git.code.sf.net/p/gawkextlib/code";

--- a/pkgs/tools/text/rosie/default.nix
+++ b/pkgs/tools/text/rosie/default.nix
@@ -6,8 +6,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "rosie";
-  version = "unstable-2020-01-11";
+  pname = "rosie-unstable";
+  version = "2020-01-11";
   src = fetchgit {
     url = "https://gitlab.com/rosie-pattern-language/rosie";
     rev = "670e9027563609ba2ea31e14e2621a1302742795";

--- a/pkgs/tools/typesetting/docbookrx/default.nix
+++ b/pkgs/tools/typesetting/docbookrx/default.nix
@@ -24,8 +24,8 @@ let
 
 in stdenv.mkDerivation {
 
-  pname = "docbookrx";
-  version = "unstable-2018-05-02";
+  pname = "docbookrx-unstable";
+  version = "2018-05-02";
 
   buildInputs = [ env.wrappedRuby ];
 

--- a/pkgs/tools/typesetting/tex/latexrun/default.nix
+++ b/pkgs/tools/typesetting/tex/latexrun/default.nix
@@ -1,8 +1,8 @@
 { stdenvNoCC, fetchFromGitHub, python3 }:
 
 stdenvNoCC.mkDerivation {
-  pname = "latexrun";
-  version = "unstable-2015-11-18";
+  pname = "latexrun-unstable";
+  version = "2015-11-18";
   src = fetchFromGitHub {
     owner = "aclements";
     repo = "latexrun";

--- a/pkgs/tools/typesetting/tex/pplatex/default.nix
+++ b/pkgs/tools/typesetting/tex/pplatex/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, pcre }:
 
 stdenv.mkDerivation {
-  pname = "pplatex";
-  version = "unstable-2015-09-14";
+  pname = "pplatex-unstable";
+  version = "2015-09-14";
 
   src = fetchFromGitHub {
     owner = "stefanhepp";

--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -81,8 +81,8 @@ rec {
     });            
   
   xmlmirror = pkgs.buildEmscriptenPackage rec {
-    pname = "xmlmirror";
-    version = "unstable-2016-06-05";
+    pname = "xmlmirror-unstable";
+    version = "2016-06-05";
 
     buildInputs = [ pkgconfig autoconf automake libtool gnumake libxml2 nodejs openjdk json_c ];
     nativeBuildInputs = [ pkgconfig zlib ];


### PR DESCRIPTION
As documented in https://nixos.org/manual/nixpkgs/stable/#sec-package-naming
the '-unstable' should be appended to the pname, not prepended to the version.

###### Motivation for this change

For consistency. Confirmed by @niksnut on IRC that this is still the consensus.

I tried to check 'pname' wasn't used for other things, but I'm sure I missed a
few spots. Will fix those based on CI results.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
