### PR TITLE
Faust: fix build

### DIFF
--- a/pkgs/applications/audio/faust/faust2jack.nix
+++ b/pkgs/applications/audio/faust/faust2jack.nix
@@ -2,7 +2,7 @@
 , gtk2
 , jack2Full
 , alsaLib
-, opencv2
+, opencv
 , libsndfile
 , which
 }:
@@ -20,7 +20,7 @@ faust.wrapWithBuildEnv {
     gtk2
     jack2Full
     alsaLib
-    opencv2
+    opencv
     libsndfile
     which
   ];

--- a/pkgs/applications/audio/faust/faust2jaqt.nix
+++ b/pkgs/applications/audio/faust/faust2jaqt.nix
@@ -1,6 +1,5 @@
 { faust
 , jack2Full
-, opencv2
 , qt4
 , libsndfile
 , alsaLib
@@ -18,7 +17,6 @@ faust.wrapWithBuildEnv {
 
   propagatedBuildInputs = [
     jack2Full
-    opencv2
     qt4
     libsndfile
     alsaLib


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

@doronbehar Changed opencv to opencv2 and that got marked broken.
These commits remove opencv2 where it seems unneeded and changes it back to opencv where it *is* needed.

@doronbehar You [implied](https://github.com/NixOS/nixpkgs/pull/86808#issuecomment-624115843) you got errors in faust2jack  when using opencv instead of opencv2.
I am not getting any, any idea why?
Are you ok with this change?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
