### PR TITLE
vkquake: fix the build

### DIFF
--- a/pkgs/games/quakespasm/vulkan.nix
+++ b/pkgs/games/quakespasm/vulkan.nix
@@ -1,4 +1,4 @@
-{ stdenv, SDL2, fetchFromGitHub, makeWrapper, gzip, libvorbis, libmad, vulkan-headers, vulkan-loader }:
+{ stdenv, fetchpatch, fetchFromGitHub, makeWrapper, SDL2, gzip, libvorbis, libmad, vulkan-headers, vulkan-loader }:
 
 stdenv.mkDerivation rec {
   pname = "vkquake";
@@ -11,14 +11,28 @@ stdenv.mkDerivation rec {
     sha256 = "1ry861pk3z02hy7i0yi3xwmd1zma802qzcnlm09w6pslayd9rwbf";
   };
 
+  # patches and patchFlags can be deleted with the next release
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/Novum/vkQuake/commit/a869a22d9b51c68e57646fa20e4c40fc6db36760.patch";
+      sha256 = "sha256-ea5lcXTTlJZnuOdF1W+GCYvVgj/gW10tDNyTgfl3Kfs=";
+    })
+  ];
+  patchFlags = "-p2";
+
   sourceRoot = "source/Quake";
 
   nativeBuildInputs = [
-    makeWrapper vulkan-headers
+    makeWrapper
+    vulkan-headers
   ];
 
   buildInputs = [
-    gzip SDL2 libvorbis libmad vulkan-loader
+    gzip
+    SDL2
+    libvorbis
+    libmad
+    vulkan-loader
   ];
 
   buildFlags = [ "DO_USERDIRS=1" ];
@@ -30,12 +44,13 @@ stdenv.mkDerivation rec {
   makeFlags = [ "prefix=$(out) bindir=$(out)/bin" ];
 
   postFixup = ''
-    wrapProgram $out/bin/vkquake --prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib
+    wrapProgram $out/bin/vkquake \
+      --prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib
   '';
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Vulkan Quake port based on QuakeSpasm";
     homepage = src.meta.homepage;
     longDescription = ''
@@ -47,7 +62,7 @@ stdenv.mkDerivation rec {
       specialization constants, CPU/GPU parallelism and memory pooling.
     '';
 
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.gnidorah ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ gnidorah ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Apply a patch currently in master to make things build again.

Minor cleanups as a consequence of nixpkgs-fmt running as part of the save.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).