### PR TITLE
opensc: patch for CVE-2020-26570, CVE-2020-26572

### DIFF
--- a/pkgs/tools/security/opensc/default.nix
+++ b/pkgs/tools/security/opensc/default.nix
@@ -16,6 +16,21 @@ stdenv.mkDerivation rec {
     sha256 = "0mg8qmhww3li1isfgvn5hang1hq58zra057ilvgci88csfziv5lv";
   };
 
+  patches = [
+    (fetchpatch {
+      # https://nvd.nist.gov/vuln/detail/CVE-2020-26570
+      name = "CVE-2020-26570.patch";
+      url = "https://github.com/OpenSC/OpenSC/commit/6903aebfddc466d966c7b865fae34572bf3ed23e.patch";
+      sha256 = "sha256-aB9iCVcdp9zFhZiSv5A399Ttj7NUHRVgXr0EfmMwKN4=";
+    })
+    (fetchpatch {
+      # https://nvd.nist.gov/vuln/detail/CVE-2020-26572
+      name = "CVE-2020-26572.patch";
+      url = "https://github.com/OpenSC/OpenSC/commit/9d294de90d1cc66956389856e60b6944b27b4817.patch";
+      sha256 = "sha256-gKJaR5K+NaXh4NeTkGpzHzHCdpt6n54Hnt1GAq0tA9o=";
+    })
+  ];
+
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [
     zlib readline openssl libassuan


### PR DESCRIPTION


###### Motivation for this change

Address https://github.com/NixOS/nixpkgs/issues/101166.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
