### PR TITLE
gcc9: add patches required for target musl

### DIFF
--- a/pkgs/development/compilers/gcc/9/0013-invalid-tls-model.diff
+++ b/pkgs/development/compilers/gcc/9/0013-invalid-tls-model.diff
@@ -1,0 +1,28 @@
+diff --git a/libgomp/configure.tgt b/libgomp/configure.tgt
+index b88bf72fe3d..747d0485bf8 100644
+--- a/libgomp/configure.tgt
++++ b/libgomp/configure.tgt
+@@ -17,6 +17,9 @@ if test $gcc_cv_have_tls = yes ; then
+     *-*-k*bsd*-gnu*)
+ 	;;
+ 
++    *-*-musl*)
++	;;
++
+     *-*-linux* | *-*-gnu*)
+ 	XCFLAGS="${XCFLAGS} -ftls-model=initial-exec -DUSING_INITIAL_EXEC_TLS"
+ 	;;
+diff --git a/libitm/configure.tgt b/libitm/configure.tgt
+index 4c0b602034b..65e1c83550a 100644
+--- a/libitm/configure.tgt
++++ b/libitm/configure.tgt
+@@ -31,6 +31,9 @@
+ if test "$gcc_cv_have_tls" = yes ; then
+   case "${target}" in
+ 
++    *-*-musl*)
++	;;
++
+     # For x86, we use slots in the TCB head for most of our TLS.
+     # The setup of those slots in beginTransaction can afford to
+     # use the global-dynamic model.

--- a/pkgs/development/compilers/gcc/9/0014-fix-gthr-weak-refs-for-libgcc.patch
+++ b/pkgs/development/compilers/gcc/9/0014-fix-gthr-weak-refs-for-libgcc.patch
@@ -1,0 +1,51 @@
+From 51a354a0fb54165d505bfed9819c0440027312d9 Mon Sep 17 00:00:00 2001
+From: Szabolcs Nagy <nsz@port70.net>
+Date: Sun, 22 Sep 2019 23:04:48 +0000
+Subject: [PATCH] fix gthr weak refs for libgcc
+
+ideally gthr-posix.h should be fixed not to use weak refs for
+single thread detection by default since that's unsafe.
+
+currently we have to opt out explicitly from the unsafe behaviour
+in the configure machinery of each target lib that uses gthr and
+musl missed libgcc previously.
+
+related bugs and discussions
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78017
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87189
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91737
+https://sourceware.org/bugzilla/show_bug.cgi?id=5784
+https://sourceware.org/ml/libc-alpha/2012-09/msg00192.html
+https://sourceware.org/ml/libc-alpha/2019-08/msg00438.html
+---
+ libgcc/config.host          | 7 +++++++
+ libgcc/config/t-gthr-noweak | 2 ++
+ 2 files changed, 9 insertions(+)
+ create mode 100644 libgcc/config/t-gthr-noweak
+
+diff --git a/libgcc/config.host b/libgcc/config.host
+index 122113fc519..fe1b9ab93d5 100644
+--- a/libgcc/config.host
++++ b/libgcc/config.host
+@@ -1500,3 +1500,10 @@ aarch64*-*-*)
+ 	tm_file="${tm_file} aarch64/value-unwind.h"
+ 	;;
+ esac
++
++case ${host} in
++*-*-musl*)
++  # The gthr weak references are unsafe with static linking
++  tmake_file="$tmake_file t-gthr-noweak"
++  ;;
++esac
+diff --git a/libgcc/config/t-gthr-noweak b/libgcc/config/t-gthr-noweak
+new file mode 100644
+index 00000000000..45a21e9361d
+--- /dev/null
++++ b/libgcc/config/t-gthr-noweak
+@@ -0,0 +1,2 @@
++# Don't use weak references for single-thread detection
++HOST_LIBGCC2_CFLAGS += -DGTHREAD_USE_WEAK=0
+-- 
+2.17.1
+

--- a/pkgs/development/compilers/gcc/9/0016-libstdc++-futex-time64.diff
+++ b/pkgs/development/compilers/gcc/9/0016-libstdc++-futex-time64.diff
@@ -1,0 +1,18 @@
+--- gcc-9.2.0/libstdc++-v3/src/c++11/futex.cc.orig	2020-01-20 14:55:05.507548334 -0500
++++ gcc-9.2.0/libstdc++-v3/src/c++11/futex.cc	2020-01-20 14:56:52.458268068 -0500
+@@ -61,7 +61,15 @@
+ 	struct timeval tv;
+ 	gettimeofday (&tv, NULL);
+ 	// Convert the absolute timeout value to a relative timeout
++#if defined(SYS_futex_time64) && SYS_futex_time64 != SYS_futex
++	struct
++	  {
++	    long tv_sec;
++	    long tv_nsec;
++	  } rt;
++#else
+ 	struct timespec rt;
++#endif
+ 	rt.tv_sec = __s.count() - tv.tv_sec;
+ 	rt.tv_nsec = __ns.count() - tv.tv_usec * 1000;
+ 	if (rt.tv_nsec < 0)

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -68,6 +68,11 @@ let majorVersion = "9";
       ++ optional langD ../libphobos.patch
       ++ optional langFortran ../gfortran-driving.patch
       ++ optional (targetPlatform.libc == "musl" && targetPlatform.isPower) ../ppc-musl.patch
+      ++ optionals (targetPlatform.libc == "musl") [
+        ./0013-invalid-tls-model.diff
+        ./0016-libstdc++-futex-time64.diff
+        ./0014-fix-gthr-weak-refs-for-libgcc.patch
+      ]
       ++ optional (!crossStageStatic && targetPlatform.isMinGW) (fetchpatch {
         url = "https://raw.githubusercontent.com/lhmouse/MINGW-packages/${import ../common/mfcgthreads-patches-repo.nix}/mingw-w64-gcc-git/9000-gcc-${majorVersion}-branch-Added-mcf-thread-model-support-from-mcfgthread.patch";
         sha256 = "1in5kvcknlpi9z1vvjw6jfmwy8k12zvbqlqfnq84qpm99r0rh00a";


### PR DESCRIPTION
These patches are taken from:
  https://github.com/richfelker/musl-cross-make/tree/master/patches/gcc-9.2.0
and based on a recommendation from the musl maintainers as these patches
are deemed critical for gcc9/musl to work correctly.

This started with an obscure bug I had while investigating the following
program which was getting unexpectedly aborted instead of catching the
exception:
```
#include <boost/thread.hpp>
#include <iostream>
#include <thread>

struct Foo {};

void foo() {
  try {
    std::cout << "entered thread" << std::endl;
    throw Foo();
  } catch (...) {
  }
}

void bar() {
  try {
    foo();
  } catch (...) {
  }
}

int main() {
  std::thread _bar(bar);
  boost::thread _foo(foo);
  _bar.join();
  _foo.join();
  std::cout << "should ignore exception" << std::endl;
  return 0;
}
```

Thanks to nsz and dalias in #musl freenode channel they traced down the
issue to be linked to a missing patch (0014-fix-gthr-weak-refs-for-libgcc.patch
in this case) which was needed. They also recommended adding the following
patches that I added as those are all critical.
I think these patches aren't really musl specific and could be applied
all the time, in fact 0014-fix-gthr-weak-refs-for-libgcc.patch is
already upstream in GCC 10 but I'm not sure if we should do that.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
