### PR TITLE
luxcorerender: fix compilation

### DIFF
--- a/pkgs/tools/graphics/luxcorerender/default.nix
+++ b/pkgs/tools/graphics/luxcorerender/default.nix
@@ -54,8 +54,8 @@ in stdenv.mkDerivation {
     "-DEMBREE_INCLUDE_PATH=${embree2}/include"
     "-DEMBREE_LIBRARY=${embree2}/lib/libembree.so"
     "-DBoost_PYTHON_LIBRARY_RELEASE=${boost_static}/lib/libboost_python3-mt.so"
-  ] ++ stdenv.lib.optional withOpenCL
-       "-DOPENCL_INCLUDE_DIR=${opencl-headers}/include";
+  ];
+
   preConfigure = ''
     NIX_CFLAGS_COMPILE+=" -isystem ${python}/include/python${python.pythonVersion}"
     NIX_LDFLAGS+=" -lpython3"


### PR DESCRIPTION
Nix overwrites the include path for the OpenCL headers. However, the
overwrite does not include the required headers. The compilation fails
due to missing header files (<CL/cl.hpp>). Removing the overwrite
allows CMake to find the required headers.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Luxcorerender currently can not be build from master and fails on Hydra 20.09. Should be backported after being merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
