### PR TITLE
gdal: fix S57 data directory

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -66,6 +66,17 @@ stdenv.mkDerivation rec {
 
   CXXFLAGS = "-fpermissive";
 
+  # N.B. the S-57 driver needs s57objectclasses.csv and
+  # s57attributes.csv, which it would usually find via the S57_CSV environment
+  # variable. We rather apply a patch (./fix-57-directory.patch) and
+  # hard-code this directory to point into the nix store.
+  patches = [ ./fix-s57-directory.patch ];
+
+  postPatch = ''
+    substituteInPlace ogr/ogrsf_frmts/s57/s57classregistrar.cpp \
+      --replace NIX_S57_CSV \"$out/share/gdal\"
+  '';
+
   # - Unset CC and CXX as they confuse libtool.
   # - teach gdal that libdf is the legacy name for libhdf
   preConfigure = ''

--- a/pkgs/development/libraries/gdal/fix-s57-directory.patch
+++ b/pkgs/development/libraries/gdal/fix-s57-directory.patch
@@ -1,0 +1,13 @@
+diff --git a/ogr/ogrsf_frmts/s57/s57classregistrar.cpp b/ogr/ogrsf_frmts/s57/s57classregistrar.cpp
+index bfd8853246..9726c7da0b 100644
+--- a/ogr/ogrsf_frmts/s57/s57classregistrar.cpp
++++ b/ogr/ogrsf_frmts/s57/s57classregistrar.cpp
+@@ -174,6 +174,8 @@ bool S57ClassRegistrar::LoadInfo( const char * pszDirectory,
+ {
+     if( pszDirectory == nullptr )
+         pszDirectory = CPLGetConfigOption("S57_CSV",nullptr);
++    if( pszDirectory == nullptr )
++        pszDirectory = NIX_S57_CSV;
+ 
+ /* ==================================================================== */
+ /*      Read the s57objectclasses file.                                 */


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

GDAL's S57 driver [expects][1] to be able to find various files in its data
directory. Usually this would be located via the `S57_CSV` environment variable. We obviously don't want to have to set this in every downstream use of GDAL so consequently I instead patch the driver to rather hard-code the path to the data directory.

[1]: https://gdal.org/drivers/vector/s57.html#vector-s57

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
