### PR TITLE
qgis: 3.10.9 -> 3.14.16

### DIFF
--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -1,6 +1,6 @@
 { mkDerivation, lib, fetchFromGitHub, cmake, ninja, flex, bison, proj, geos, xlibsWrapper, sqlite, gsl
 , qwt, fcgi, python3Packages, libspatialindex, libspatialite, postgresql
-, txt2tags, openssl, libzip, hdf5, netcdf, exiv2
+, txt2tags, openssl, libzip, hdf5, netcdf, exiv2, protobuf
 , qtbase, qtwebkit, qtsensors, qca-qt5, qtkeychain, qscintilla, qtserialport, qtxmlpatterns
 , withGrass ? true, grass
 }:
@@ -10,7 +10,7 @@ let
     [ qscintilla-qt5 gdal jinja2 numpy psycopg2
       chardet dateutil pyyaml pytz requests urllib3 pygments pyqt5 sip owslib six ];
 in mkDerivation rec {
-  version = "3.10.10";
+  version = "3.14.16";
   pname = "qgis";
   name = "${pname}-unwrapped-${version}";
 
@@ -18,7 +18,7 @@ in mkDerivation rec {
     owner = "qgis";
     repo = "QGIS";
     rev = "final-${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "yZBG+bpJA7iKkUEjVo45d+bmRp9WS7mk8z96FLf0ZQ0=";
+    sha256 = "0pzqx3jkaryszssw6zjgabiy82y36k131v6pifmkiwvl0qki0cnz";
   };
 
   passthru = {
@@ -27,7 +27,7 @@ in mkDerivation rec {
   };
 
   buildInputs = [ openssl proj geos xlibsWrapper sqlite gsl qwt exiv2
-    fcgi libspatialindex libspatialite postgresql txt2tags libzip hdf5 netcdf
+    fcgi libspatialindex libspatialite postgresql txt2tags libzip hdf5 netcdf protobuf
     qtbase qtwebkit qtsensors qca-qt5 qtkeychain qscintilla qtserialport qtxmlpatterns] ++
     (lib.optional withGrass grass) ++ pythonBuildInputs;
 


### PR DESCRIPTION
###### Motivation for this change

Keep `qgis` up-to-date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
