### PR TITLE
rsync: Work around upstream cross-compilation issue

### DIFF
--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -35,7 +35,15 @@ stdenv.mkDerivation rec {
                 ++ stdenv.lib.optional enableXXHash xxHash;
   nativeBuildInputs = [perl];
 
-  configureFlags = ["--with-nobody-group=nogroup"];
+  configureFlags = ["--with-nobody-group=nogroup"]
+    # Work around issue with cross-compilation:
+    #     configure.sh: error: cannot run test program while cross compiling
+    # Remove once 3.2.4 or more recent is released.
+    # The following PR should fix the cross-compilation issue.
+    # Test using `nix-build -A pkgsCross.aarch64-multiplatform.rsync`.
+    # https://github.com/WayneD/rsync/commit/b7fab6f285ff0ff3816b109a8c3131b6ded0b484
+    ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--enable-simd=no"
+  ;
 
   passthru.tests = { inherit (nixosTests) rsyncd; };
 


### PR DESCRIPTION
It should be fixed by the next release:

 * https://github.com/WayneD/rsync/commit/b7fab6f285ff0ff3816b109a8c3131b6ded0b484

Already a part of the updates for 3.2.4

 * https://download.samba.org/pub/rsync/NEWS#3.2.4

Note that for non-cross, this is a no-op!

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
