### PR TITLE
fribidi: 1.0.7 -> 1.0.10

### DIFF
--- a/pkgs/development/libraries/fribidi/default.nix
+++ b/pkgs/development/libraries/fribidi/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , fetchurl
-, fetchpatch
 , meson
 , ninja
 , pkgconfig
@@ -10,23 +9,15 @@
 
 stdenv.mkDerivation rec {
   pname = "fribidi";
-  version = "1.0.7";
+  version = "1.0.10";
 
   outputs = [ "out" "devdoc" ];
 
   # NOTE: Only URL tarball has "Have pre-generated man pages: true", which works-around upstream usage of some rare ancient `c2man` fossil application.
   src = fetchurl {
-    url = "https://github.com/fribidi/fribidi/releases/download/v${version}/${pname}-${version}.tar.bz2";
-    sha256 = "0pckda4fcn0aw32lpycwdp25r2m7vca8zspq815ppi9gkwgg5das";
+    url = "https://github.com/fribidi/fribidi/releases/download/v${version}/${pname}-${version}.tar.xz";
+    sha256 = "009wcpgk4jj5x52skjkfs6xar6x38mcngs75rb59nj9ig1y6h73z";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2019-18397.patch";
-      url = "https://github.com/fribidi/fribidi/commit/034c6e9a1d296286305f4cfd1e0072b879f52568.patch";
-      sha256 = "102xrbf1l5gvavkxd6csx8pj3rlgcw10c0y4h4d40yhn84b1p0y8";
-    })
-  ];
 
   postPatch = ''
     patchShebangs test


### PR DESCRIPTION
###### Motivation for this change
https://github.com/fribidi/fribidi/releases/tag/v1.0.8
https://github.com/fribidi/fribidi/releases/tag/v1.0.9
https://github.com/fribidi/fribidi/releases/tag/v1.0.10

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).