### PR TITLE
yamale: init at 3.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7419,6 +7419,12 @@
     githubId = 1387224;
     name = "Richard Szibele";
   };
+  rtburns-jpl = {
+    email = "rtburns@jpl.nasa.gov";
+    github = "rtburns-jpl";
+    githubId = 47790121;
+    name = "Ryan Burns";
+  };
   rtreffer = {
     email = "treffer+nixos@measite.de";
     github = "rtreffer";

--- a/pkgs/development/python-modules/yamale/default.nix
+++ b/pkgs/development/python-modules/yamale/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, pytest
+, pyyaml
+, ruamel_yaml
+}:
+
+buildPythonPackage rec {
+  pname = "yamale";
+  version = "3.0.4";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "23andMe";
+    repo = pname;
+    rev = version;
+    sha256 = "1xjvah4r3gpwk4zxql3c9jpllb34k175fm6iq1zvsd2vv2fwf8s2";
+  };
+
+  propagatedBuildInputs = [
+    pyyaml
+    ruamel_yaml
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  meta = with lib; {
+    description = "A schema and validator for YAML.";
+    homepage = "https://github.com/23andMe/Yamale";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rtburns-jpl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27986,6 +27986,8 @@ in
 
   yadm = callPackage ../applications/version-management/yadm { };
 
+  yamale = with python3Packages; toPythonApplication yamale;
+
   yamdi = callPackage ../tools/video/yamdi { };
 
   yandex-disk = callPackage ../tools/filesystems/yandex-disk { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7687,6 +7687,8 @@ in {
 
   yahooweather = callPackage ../development/python-modules/yahooweather { };
 
+  yamale = callPackage ../development/python-modules/yamale { };
+
   yamllint = callPackage ../development/python-modules/yamllint { };
 
   yamlordereddictloader = callPackage ../development/python-modules/yamlordereddictloader { };


### PR DESCRIPTION
Adds Yamale, an MIT-licensed schema and validator for YAML developed by 23andMe.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
