### PR TITLE
ocamlPackages.safepass: 2.0 → 3.0

### DIFF
--- a/pkgs/development/ocaml-modules/safepass/default.nix
+++ b/pkgs/development/ocaml-modules/safepass/default.nix
@@ -1,33 +1,21 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild }:
+{ lib, fetchFromGitHub, buildDunePackage }:
 
-let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.02"
-  then {
-    version = "2.0";
-    url = "http://forge.ocamlcore.org/frs/download.php/1615/ocaml-safepass-2.0.tgz";
-    sha256 = "1zxx3wcyzhxxvm5w9c21y7hpa11h67paaaz9mfsyiqk6fs6hcvmw";
-  } else {
-    version = "1.3";
-    url = "http://forge.ocamlcore.org/frs/download.php/1432/ocaml-safepass-1.3.tgz";
-    sha256 = "0lb8xbpyc5d1zml7s7mmcr6y2ipwdp7qz73lkv9asy7dyi6cj15g";
+buildDunePackage rec {
+  pname = "safepass";
+  version = "3.0";
+
+  src = fetchFromGitHub {
+    owner = "darioteixeira";
+    repo = "ocaml-safepass";
+    rev = "v${version}";
+    sha256 = "0i127gs9x23wzwa1q3dxa2j6hby07hvxdg1c98fc3j09rg6vy2bs";
   };
-in
-
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-safepass-${param.version}";
-  src = fetchurl {
-    inherit (param) url sha256;
-  };
-
-  buildInputs = [ ocaml findlib ocamlbuild ];
-
-  createFindlibDestdir = true;
 
   meta = {
-    homepage = "http://ocaml-safepass.forge.ocamlcore.org/";
+    inherit (src.meta) homepage;
     description = "An OCaml library offering facilities for the safe storage of user passwords";
-    license = stdenv.lib.licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
+
 }


### PR DESCRIPTION
###### Motivation for this change

Current sources are no longer available.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
