### PR TITLE
ghc:8.10.2Binary bootstrap for 8.8 on aarch64 (NixOS#97407)

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -82,7 +82,6 @@ stdenv.mkDerivation rec {
       patchShebangs ghc-${version}/utils/
       patchShebangs ghc-${version}/configure
     '' +
-
     # We have to patch the GMP paths for the integer-gmp package.
     ''
       find . -name integer-gmp.buildinfo \
@@ -90,6 +89,12 @@ stdenv.mkDerivation rec {
     '' + stdenv.lib.optionalString stdenv.isDarwin ''
       find . -name base.buildinfo \
           -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${libiconv}/lib@" {} \;
+    '' +
+    # aarch64 does HAVE_NUMA so -lnuma requires it in library-dirs in rts/package.conf.in
+    # FFI_LIB_DIR is a good indication of places it must be needed.
+    stdenv.lib.optionalString stdenv.hostPlatform.isAarch64 ''
+      find . -name package.conf.in \
+          -exec sed -i "s@FFI_LIB_DIR@FFI_LIB_DIR ${numactl.out}/lib@g" {} \;
     '' +
     # Rename needed libraries and binaries, fix interpreter
     stdenv.lib.optionalString stdenv.isLinux ''
@@ -128,14 +133,35 @@ stdenv.mkDerivation rec {
 
   # On Linux, use patchelf to modify the executables so that they can
   # find editline/gmp.
-  postFixup = stdenv.lib.optionalString stdenv.isLinux ''
-    for p in $(find "$out" -type f -executable); do
-      if isELF "$p"; then
-        echo "Patchelfing $p"
-        patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
-      fi
-    done
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  postFixup = stdenv.lib.optionalString stdenv.isLinux
+    (if stdenv.hostPlatform.isAarch64 then
+      # Keep rpath as small as possible on aarch64 for patchelf#244.  All Elfs
+      # are 2 directories deep from $out/lib, so pooling symlinks there makes
+      # a short rpath.
+      ''
+      (cd $out/lib; ln -s ${ncurses6.out}/lib/libtinfo.so.6)
+      (cd $out/lib; ln -s ${gmp.out}/lib/libgmp.so.10)
+      (cd $out/lib; ln -s ${numactl.out}/lib/libnuma.so.1)
+      for p in $(find "$out/lib" -type f -name "*\.so*"); do
+        (cd $out/lib; ln -s $p)
+      done
+
+      for p in $(find "$out/lib" -type f -executable); do
+        if isELF "$p"; then
+          echo "Patchelfing $p"
+          patchelf --set-rpath "\$ORIGIN:\$ORIGIN/../.." $p
+        fi
+      done
+      ''
+    else
+      ''
+      for p in $(find "$out" -type f -executable); do
+        if isELF "$p"; then
+          echo "Patchelfing $p"
+          patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
+        fi
+      done
+    '') + stdenv.lib.optionalString stdenv.isDarwin ''
     # not enough room in the object files for the full path to libiconv :(
     for exe in $(find "$out" -type f -executable); do
       isScript $exe && continue
@@ -169,6 +195,11 @@ stdenv.mkDerivation rec {
     enableShared = true;
   };
 
-  meta.license = stdenv.lib.licenses.bsd3;
-  meta.platforms = ["x86_64-linux" "armv7l-linux" "aarch64-linux" "i686-linux" "x86_64-darwin"];
+  meta = {
+    homepage = "http://haskell.org/ghc";
+    description = "The Glasgow Haskell Compiler";
+    license = stdenv.lib.licenses.bsd3;
+    platforms = ["x86_64-linux" "armv7l-linux" "aarch64-linux" "i686-linux" "x86_64-darwin"];
+    maintainers = with stdenv.lib.maintainers; [ lostnet ];
+  };
 }

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -119,7 +119,11 @@ stdenv.mkDerivation (rec {
   postPatch = "patchShebangs .";
 
   # GHC is a bit confused on its cross terminology.
-  preConfigure = ''
+  preConfigure = stdenv.lib.optionalString stdenv.isAarch64 ''
+    # Aarch64 allow backward bootstrapping since earlier versions are unstable.
+    find . -name \*\.cabal\* -exec sed -i -e 's/\(base.*\)4.14/\14.16/' {} \; \
+      -exec sed -i -e 's/\(prim.*\)0.6/\10.8/' {} \;
+  '' + ''
     for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
       export "''${env#TARGET_}=''${!env}"
     done

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1,4 +1,4 @@
-{ buildPackages, pkgs, newScope }:
+{ buildPackages, pkgs, newScope, stdenv }:
 
 let
   # These are attributes in compiler and packages that don't support integer-simple.
@@ -73,7 +73,11 @@ in {
       llvmPackages = pkgs.llvmPackages_7;
     };
     ghc884 = callPackage ../development/compilers/ghc/8.8.4.nix {
-      bootPkgs = packages.ghc865Binary;
+      # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
+      bootPkgs = if stdenv.isAarch64 then
+          packages.ghc8102Binary
+        else
+          packages.ghc865Binary;
       inherit (buildPackages.python3Packages) sphinx;
       buildLlvmPackages = buildPackages.llvmPackages_7;
       llvmPackages = pkgs.llvmPackages_7;
@@ -85,7 +89,11 @@ in {
       llvmPackages = pkgs.llvmPackages_9;
     };
     ghc8102 = callPackage ../development/compilers/ghc/8.10.2.nix {
-      bootPkgs = packages.ghc865Binary;
+      # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
+      bootPkgs = if stdenv.isAarch64 then
+          packages.ghc8102Binary
+        else
+          packages.ghc865Binary;
       inherit (buildPackages.python3Packages) sphinx;
       buildLlvmPackages = buildPackages.llvmPackages_9;
       llvmPackages = pkgs.llvmPackages_9;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This is a collection of workarounds for aarch64 to bootstrap ghc8.8.4(default) and ghc8.10.2 using a ghc8.10.2Binary. With these changes these versions of ghc should work as they do on other architectures to the extent that they work on aarch64 (these versions of ghc are considered experimental on Aarch64, and in particular can have race conditions. etc, with parallel builds, discussion of these problems is in issue #97407.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
(tested some sample packages, this is the bootstrap for all of the standard ghc collection on aarch64. I tested on a small machine(rock64) and @vcunat tested on aarch64.nixos.community which is faster and more likely to surface parallel build problems as they may occur on hydra.)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
(ghc-8.10.2-binary is very large ~2.9gb on aarch64; large libraries sensative to stripping.)
- [x] Ensured that relevant documentation is up to date
(avoided any changes to other platforms and workaround specific bugs without changing default versions on aarch64, etc)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
