### PR TITLE
todoist-electron: 1.23.0 -> 1.24.0, update license, use desktop icon

### DIFF
--- a/pkgs/applications/misc/todoist-electron/default.nix
+++ b/pkgs/applications/misc/todoist-electron/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation rec {
 
   desktopItem = makeDesktopItem {
     name = "Todoist";
-    exec = "todoist";
+    exec = "todoist %U";
+    icon = "todoist";
+    comment = "Todoist for Linux";
     desktopName = "Todoist";
     categories = "Utility";
   };
@@ -35,6 +37,7 @@ stdenv.mkDerivation rec {
   in ''
     mkdir -p "$out/bin"
     mv opt "$out/"
+    mv usr/share "$out/share"
 
     # Patch binary
     patchelf \
@@ -48,7 +51,8 @@ stdenv.mkDerivation rec {
 
     # Desktop item
     mkdir -p "$out/share"
-    ln -s "${desktopItem}/share/applications" "$out/share/applications"
+    rm -r "$out/share/applications"
+    cp -r "${desktopItem}/share/applications" "$out/share/applications"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/todoist-electron/default.nix
+++ b/pkgs/applications/misc/todoist-electron/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "todoist-electron";
-  version = "1.23.0";
+  version = "1.24.0";
 
   src = fetchurl {
     url = "https://github.com/KryDos/todoist-linux/releases/download/${version}/Todoist_${version}_amd64.deb";
-    sha256 = "1yxa0fdc3fnffny6jf1hm7545792pw7828mc27il17l4kn346g98";
+    sha256 = "0g35518z6nf6pnfyx4ax75rq8b8br72mi6wv6jzgac9ric1q4h2s";
   };
 
   desktopItem = makeDesktopItem {

--- a/pkgs/applications/misc/todoist-electron/default.nix
+++ b/pkgs/applications/misc/todoist-electron/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/KryDos/todoist-linux";
     description = "The Linux wrapper for Todoist web version";
     platforms = [ "x86_64-linux" ];
-    license = licenses.isc;
+    license = licenses.mit;
     maintainers = with maintainers; [ i077 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream repo added an MIT license. Also copies the icon over to $out so it's used in the .desktop file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
