### PR TITLE
libtapi: fix build for linux

### DIFF
--- a/pkgs/os-specific/darwin/libtapi/default.nix
+++ b/pkgs/os-specific/darwin/libtapi/default.nix
@@ -1,7 +1,9 @@
 { lib, stdenv, fetchFromGitHub, cmake, python3, ncurses }:
 
-stdenv.mkDerivation {
-  name = "libtapi-1000.10.8";
+stdenv.mkDerivation rec {
+  pname = "libtapi";
+  version = "1000.10.8"; # determined by looking at VERSION.txt
+
   src = fetchFromGitHub {
     owner = "tpoechtrager";
     repo = "apple-libtapi";
@@ -33,11 +35,13 @@ stdenv.mkDerivation {
 
   installTargets = [ "install-libtapi" "install-tapi-headers" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString stdenv.isDarwin ''
     install_name_tool -id $out/lib/libtapi.dylib $out/lib/libtapi.dylib
   '';
 
   meta = with lib; {
+    description = "Replaces the Mach-O Dynamic Library Stub files in Apple's SDKs to reduce the size";
+    homepage = "https://github.com/tpoechtrager/apple-libtapi";
     license = licenses.apsl20;
     maintainers = with maintainers; [ matthewbauer ];
   };


### PR DESCRIPTION
###### Motivation for this change

noticed when reviewing #101215

```
/nix/store/ajq5dfwn4hzlx1qf2xxwb6rj8a7s65nm-stdenv-linux/setup: line 81: install_name_tool: command not found
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
