### PR TITLE
ocamlPackages.ezjsonm: 0.6.0 → 1.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/cow/default.nix
+++ b/pkgs/development/ocaml-modules/cow/default.nix
@@ -2,6 +2,7 @@
 , uri, xmlm, omd, ezjsonm }:
 
 buildDunePackage rec {
+  useDune2 = true;
   minimumOCamlVersion = "4.02.3";
 
   version = "2.4.0";

--- a/pkgs/development/ocaml-modules/ezjsonm/default.nix
+++ b/pkgs/development/ocaml-modules/ezjsonm/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchzip, buildDunePackage, jsonm, hex, sexplib }:
+{ stdenv, fetchurl, buildDunePackage, jsonm, hex, sexplib0 }:
 
 buildDunePackage rec {
   pname = "ezjsonm";
-  version = "0.6.0";
+  version = "1.2.0";
 
-  src = fetchzip {
-    url = "https://github.com/mirage/${pname}/archive/${version}.tar.gz";
-    sha256 = "18g64lhai0bz65b9fil12vlgfpwa9b5apj7x6d7n4zzm18qfazvj";
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/ezjsonm/releases/download/v${version}/ezjsonm-v${version}.tbz";
+    sha256 = "1q6cf63cc614lr141rzhm2w4rhi1snfqai6fmkhvfjs84hfbw2w7";
   };
 
-  propagatedBuildInputs = [ jsonm hex sexplib ];
+  propagatedBuildInputs = [ jsonm hex sexplib0 ];
 
   meta = {
     description = "An easy interface on top of the Jsonm library";

--- a/pkgs/development/ocaml-modules/mustache/default.nix
+++ b/pkgs/development/ocaml-modules/mustache/default.nix
@@ -3,6 +3,7 @@
 buildDunePackage rec {
   pname = "mustache";
   version = "3.1.0";
+  useDune2 = true;
   src = fetchFromGitHub {
     owner = "rgrinberg";
     repo = "ocaml-mustache";


### PR DESCRIPTION
###### Motivation for this change

Use dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
