### PR TITLE
octoprint: miscellaneous maintenance

### DIFF
--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -202,13 +202,13 @@ in {
 
   simpleemergencystop = buildPlugin rec {
     pname = "SimpleEmergencyStop";
-    version = "0.2.5";
+    version = "1.0.3";
 
     src = fetchFromGitHub {
       owner = "Sebclem";
       repo = "OctoPrint-${pname}";
       rev = version;
-      sha256 = "10wadv09wv2h96igvq3byw9hz1si82n3c7v5y0ii3j7hm2d06y8p";
+      sha256 = "0hhh5grmn32abkix1b9fr1d0pcpdi2r066iypcxdxcza9qzwjiyi";
     };
 
     meta = with stdenv.lib; {

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -165,12 +165,12 @@ in {
 
   abl-expert = buildPlugin rec {
     pname = "ABL_Expert";
-    version = "2019-12-21";
+    version = "0.6";
 
     src = fetchgit {
       url = "https://framagit.org/razer/Octoprint_ABL_Expert/";
-      rev = "f11fbe05088ad618bfd9d064ac3881faec223f33";
-      sha256 = "026r4prkyvwzxag5pv36455q7s3gaig37nmr2nbvhwq3d2lbi5s4";
+      rev = version;
+      sha256 = "0ij3rvdwya1sbymwm5swlh2j4jagb6fal945g88zrzh5xf26hzjh";
     };
 
     meta = with stdenv.lib; {

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -200,6 +200,25 @@ in {
     };
   };
 
+  themeify = buildPlugin rec {
+    pname = "Themeify";
+    version = "1.2.2";
+
+    src = fetchFromGitHub {
+      owner = "Birkbjo";
+      repo = "Octoprint-${pname}";
+      rev = "v${version}";
+      sha256 = "0j1qs6kyh947npdy7pqda25fjkqinpas3sy0qyscqlxi558lhvx2";
+    };
+
+    meta = with stdenv.lib; {
+      description = "Beautiful themes for OctoPrint";
+      homepage = "https://github.com/birkbjo/OctoPrint-Themeify";
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ lovesegfault ];
+    };
+  };
+
   titlestatus = buildPlugin rec {
     pname = "TitleStatus";
     version = "0.0.5";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -13,62 +13,21 @@ self: super: let
 in {
   inherit buildPlugin;
 
-  mqtt = buildPlugin rec {
-    pname = "MQTT";
-    version = "0.8.7";
+  abl-expert = buildPlugin rec {
+    pname = "ABL_Expert";
+    version = "0.6";
 
-    src = fetchFromGitHub {
-      owner = "OctoPrint";
-      repo = "OctoPrint-MQTT";
+    src = fetchgit {
+      url = "https://framagit.org/razer/Octoprint_ABL_Expert/";
       rev = version;
-      sha256 = "0k82h7wafbcqdvk5wjw4dp9lydwszfj1lf8vvymwbqdn7pf5h0dy";
-    };
-
-    propagatedBuildInputs = with super; [ paho-mqtt ];
-
-    meta = with stdenv.lib; {
-      description = "Publish printer status MQTT";
-      homepage = "https://github.com/OctoPrint/OctoPrint-MQTT";
-      license = licenses.agpl3;
-      maintainers = with maintainers; [ peterhoeg ];
-    };
-  };
-
-  titlestatus = buildPlugin rec {
-    pname = "TitleStatus";
-    version = "0.0.5";
-
-    src = fetchFromGitHub {
-      owner = "MoonshineSG";
-      repo = "OctoPrint-TitleStatus";
-      rev = version;
-      sha256 = "10nxjrixg0i6n6x8ghc1ndshm25c97bvkcis5j9kmlkkzs36i2c6";
+      sha256 = "0ij3rvdwya1sbymwm5swlh2j4jagb6fal945g88zrzh5xf26hzjh";
     };
 
     meta = with stdenv.lib; {
-      description = "Show printers status in window title";
-      homepage = "https://github.com/MoonshineSG/OctoPrint-TitleStatus";
+      description = "Marlin auto bed leveling control, mesh correction, and z probe handling";
+      homepage = "https://framagit.org/razer/Octoprint_ABL_Expert/";
       license = licenses.agpl3;
-      maintainers = with maintainers; [ abbradar ];
-    };
-  };
-
-  stlviewer = buildPlugin rec {
-    pname = "STLViewer";
-    version = "0.4.2";
-
-    src = fetchFromGitHub {
-      owner = "jneilliii";
-      repo = "OctoPrint-STLViewer";
-      rev = version;
-      sha256 = "0mkvh44fn2ch4z2avsdjwi1rp353ylmk9j5fln4x7rx8ph8y7g2b";
-    };
-
-    meta = with stdenv.lib; {
-      description = "A simple stl viewer tab for OctoPrint";
-      homepage = "https://github.com/jneilliii/Octoprint-STLViewer";
-      license = licenses.agpl3;
-      maintainers = with maintainers; [ abbradar ];
+      maintainers = with maintainers; [ WhittlesJr ];
     };
   };
 
@@ -91,46 +50,62 @@ in {
     };
   };
 
-  touchui = buildPlugin rec {
-    pname = "TouchUI";
-    version = "0.3.16";
+  displaylayerprogress = buildPlugin rec {
+    pname = "OctoPrint-DisplayLayerProgress";
+    version = "1.24.0";
 
     src = fetchFromGitHub {
-      owner = "BillyBlaze";
-      repo = "OctoPrint-${pname}";
+      owner = "OllisGit";
+      repo = pname;
       rev = version;
-      sha256 = "1jlqjirc4ygl4k7jp93l2h6b18jap3mzz8sf2g61j9w0kgv9l365";
+      sha256 = "1lbivg3rcjzv8zqvp8n8gcaczxdm7gvd5ihjb6jq0fgf958lv59n";
     };
 
     meta = with stdenv.lib; {
-      description = "Touch friendly interface for a small TFT module or phone for OctoPrint";
-      homepage = "https://github.com/BillyBlaze/OctoPrint-TouchUI";
+      description = "OctoPrint-Plugin that sends the current progress of a print via M117 command";
+      homepage = "https://github.com/OllisGit/OctoPrint-DisplayLayerProgress";
       license = licenses.agpl3;
-      maintainers = with maintainers; [ gebner ];
+      maintainers = with maintainers; [ j0hax ];
     };
   };
 
-  psucontrol = buildPlugin rec {
-    pname = "PSUControl";
-    version = "0.1.9";
+  gcodeeditor = buildPlugin rec {
+    pname = "GcodeEditor";
+    version = "0.2.9";
 
     src = fetchFromGitHub {
-      owner = "kantlivelong";
+      owner = "ieatacid";
       repo = "OctoPrint-${pname}";
       rev = version;
-      sha256 = "1cn009bdgn6c9ba9an5wfj8z02wi0xcsmbhkqggiqlnqy1fq45ca";
+      sha256 = "1yjj9lmxbzmzrn7gahw9lj7554fphalbjjp8ns0rr9py3rshwxkm";
     };
 
-    preConfigure = ''
-      # optional; RPi.GPIO is broken on vanilla kernels
-      sed /RPi.GPIO/d -i requirements.txt
-    '';
+    meta = with stdenv.lib; {
+      description = "Edit gcode on OctoPrint";
+      homepage = "https://github.com/ieatacid/OctoPrint-GcodeEditor";
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ WhittlesJr ];
+    };
+  };
+
+  mqtt = buildPlugin rec {
+    pname = "MQTT";
+    version = "0.8.7";
+
+    src = fetchFromGitHub {
+      owner = "OctoPrint";
+      repo = "OctoPrint-MQTT";
+      rev = version;
+      sha256 = "0k82h7wafbcqdvk5wjw4dp9lydwszfj1lf8vvymwbqdn7pf5h0dy";
+    };
+
+    propagatedBuildInputs = with super; [ paho-mqtt ];
 
     meta = with stdenv.lib; {
-      description = "OctoPrint plugin to control ATX/AUX power supply";
-      homepage = "https://github.com/kantlivelong/OctoPrint-PSUControl";
+      description = "Publish printer status MQTT";
+      homepage = "https://github.com/OctoPrint/OctoPrint-MQTT";
       license = licenses.agpl3;
-      maintainers = with maintainers; [ gebner ];
+      maintainers = with maintainers; [ peterhoeg ];
     };
   };
 
@@ -163,40 +138,27 @@ in {
     };
   };
 
-  abl-expert = buildPlugin rec {
-    pname = "ABL_Expert";
-    version = "0.6";
-
-    src = fetchgit {
-      url = "https://framagit.org/razer/Octoprint_ABL_Expert/";
-      rev = version;
-      sha256 = "0ij3rvdwya1sbymwm5swlh2j4jagb6fal945g88zrzh5xf26hzjh";
-    };
-
-    meta = with stdenv.lib; {
-      description = "Marlin auto bed leveling control, mesh correction, and z probe handling";
-      homepage = "https://framagit.org/razer/Octoprint_ABL_Expert/";
-      license = licenses.agpl3;
-      maintainers = with maintainers; [ WhittlesJr ];
-    };
-  };
-
-  gcodeeditor = buildPlugin rec {
-    pname = "GcodeEditor";
-    version = "0.2.9";
+  psucontrol = buildPlugin rec {
+    pname = "PSUControl";
+    version = "0.1.9";
 
     src = fetchFromGitHub {
-      owner = "ieatacid";
+      owner = "kantlivelong";
       repo = "OctoPrint-${pname}";
       rev = version;
-      sha256 = "1yjj9lmxbzmzrn7gahw9lj7554fphalbjjp8ns0rr9py3rshwxkm";
+      sha256 = "1cn009bdgn6c9ba9an5wfj8z02wi0xcsmbhkqggiqlnqy1fq45ca";
     };
 
+    preConfigure = ''
+      # optional; RPi.GPIO is broken on vanilla kernels
+      sed /RPi.GPIO/d -i requirements.txt
+    '';
+
     meta = with stdenv.lib; {
-      description = "Edit gcode on OctoPrint";
-      homepage = "https://github.com/ieatacid/OctoPrint-GcodeEditor";
+      description = "OctoPrint plugin to control ATX/AUX power supply";
+      homepage = "https://github.com/kantlivelong/OctoPrint-PSUControl";
       license = licenses.agpl3;
-      maintainers = with maintainers; [ WhittlesJr ];
+      maintainers = with maintainers; [ gebner ];
     };
   };
 
@@ -219,22 +181,60 @@ in {
     };
   };
 
-  displaylayerprogress = buildPlugin rec {
-    pname = "OctoPrint-DisplayLayerProgress";
-    version = "1.24.0";
+  stlviewer = buildPlugin rec {
+    pname = "STLViewer";
+    version = "0.4.2";
 
     src = fetchFromGitHub {
-      owner = "OllisGit";
-      repo = pname;
+      owner = "jneilliii";
+      repo = "OctoPrint-STLViewer";
       rev = version;
-      sha256 = "1lbivg3rcjzv8zqvp8n8gcaczxdm7gvd5ihjb6jq0fgf958lv59n";
+      sha256 = "0mkvh44fn2ch4z2avsdjwi1rp353ylmk9j5fln4x7rx8ph8y7g2b";
     };
 
     meta = with stdenv.lib; {
-      description = "OctoPrint-Plugin that sends the current progress of a print via M117 command";
-      homepage = "https://github.com/OllisGit/OctoPrint-DisplayLayerProgress";
+      description = "A simple stl viewer tab for OctoPrint";
+      homepage = "https://github.com/jneilliii/Octoprint-STLViewer";
       license = licenses.agpl3;
-      maintainers = with maintainers; [ j0hax ];
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
+  titlestatus = buildPlugin rec {
+    pname = "TitleStatus";
+    version = "0.0.5";
+
+    src = fetchFromGitHub {
+      owner = "MoonshineSG";
+      repo = "OctoPrint-TitleStatus";
+      rev = version;
+      sha256 = "10nxjrixg0i6n6x8ghc1ndshm25c97bvkcis5j9kmlkkzs36i2c6";
+    };
+
+    meta = with stdenv.lib; {
+      description = "Show printers status in window title";
+      homepage = "https://github.com/MoonshineSG/OctoPrint-TitleStatus";
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
+  touchui = buildPlugin rec {
+    pname = "TouchUI";
+    version = "0.3.16";
+
+    src = fetchFromGitHub {
+      owner = "BillyBlaze";
+      repo = "OctoPrint-${pname}";
+      rev = version;
+      sha256 = "1jlqjirc4ygl4k7jp93l2h6b18jap3mzz8sf2g61j9w0kgv9l365";
+    };
+
+    meta = with stdenv.lib; {
+      description = "Touch friendly interface for a small TFT module or phone for OctoPrint";
+      homepage = "https://github.com/BillyBlaze/OctoPrint-TouchUI";
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ gebner ];
     };
   };
 

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -15,13 +15,13 @@ in {
 
   mqtt = buildPlugin rec {
     pname = "MQTT";
-    version = "0.8.6";
+    version = "0.8.7";
 
     src = fetchFromGitHub {
       owner = "OctoPrint";
       repo = "OctoPrint-MQTT";
       rev = version;
-      sha256 = "0y1jnfplcy8mh3szrfbbvngl02j49cbdizglrfsry4fvqg50zjxd";
+      sha256 = "0k82h7wafbcqdvk5wjw4dp9lydwszfj1lf8vvymwbqdn7pf5h0dy";
     };
 
     propagatedBuildInputs = with super; [ paho-mqtt ];

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -36,13 +36,13 @@ in {
 
   titlestatus = buildPlugin rec {
     pname = "TitleStatus";
-    version = "0.0.4";
+    version = "0.0.5";
 
     src = fetchFromGitHub {
       owner = "MoonshineSG";
       repo = "OctoPrint-TitleStatus";
       rev = version;
-      sha256 = "1l78xrabn5hcly2mgxwi17nwgnp2s6jxi9iy4wnw8k8icv74ag7k";
+      sha256 = "10nxjrixg0i6n6x8ghc1ndshm25c97bvkcis5j9kmlkkzs36i2c6";
     };
 
     meta = with stdenv.lib; {

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -74,13 +74,13 @@ in {
 
   curaenginelegacy = buildPlugin rec {
     pname = "CuraEngineLegacy";
-    version = "1.0.2";
+    version = "1.1.1";
 
     src = fetchFromGitHub {
       owner = "OctoPrint";
       repo = "OctoPrint-${pname}";
       rev = version;
-      sha256 = "1cdb276wfyf3wcfj5g3migd6b6aqmkrxncrqjfcfx4j4k3xac965";
+      sha256 = "1a7pxlmj1a7blkv97sn1k390pbjcxx2860011pbjcdnli74zpvv5";
     };
 
     meta = with stdenv.lib; {

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -31,6 +31,27 @@ in {
     };
   };
 
+  bedlevelvisualizer = buildPlugin rec {
+    pname = "BedLevelVisualizer";
+    version = "0.1.15";
+
+    src = fetchFromGitHub {
+      owner = "jneilliii";
+      repo = "OctoPrint-${pname}";
+      rev = version;
+      sha256 = "1bq39fnarnpk8phxfbpx6l4n9anf358z1cgid5r89nadmn2a0cny";
+    };
+
+    propagatedBuildInputs = with super; [ numpy ];
+
+    meta = with stdenv.lib; {
+      description = "Displays 3D mesh of bed topography report";
+      homepage = "https://github.com/jneilliii/OctoPrint-BedLevelVisualizer";
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ lovesegfault ];
+    };
+  };
+
   curaenginelegacy = buildPlugin rec {
     pname = "CuraEngineLegacy";
     version = "1.1.1";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -136,13 +136,13 @@ in {
 
   printtimegenius = buildPlugin rec {
     pname = "PrintTimeGenius";
-    version = "2.2.1";
+    version = "2.2.6";
 
     src = fetchFromGitHub {
       owner = "eyal0";
       repo = "OctoPrint-${pname}";
       rev = version;
-      sha256 = "1dr93vbpxgxw3b1q4rwam8f4dmiwr5vnfr9796g6jx8xkpfzzy1h";
+      sha256 = "04zfgd3x3lbriyzwhpqnwdcfdm19fsqgsb7l2ix5d0ssmqxwg2r6";
     };
 
     preConfigure = ''

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -13,40 +13,6 @@ self: super: let
 in {
   inherit buildPlugin;
 
-  # Deprecated alias
-  m3d-fio = self.m33-fio; # added 2016-08-13
-
-  m33-fio = buildPlugin rec {
-    pname = "M33-Fio";
-    version = "1.21";
-
-    src = fetchFromGitHub {
-      owner = "donovan6000";
-      repo = "M33-Fio";
-      rev = "V${version}";
-      sha256 = "1la3611kkqn8yiwjn6cizc45ri8pnk6ckld1na4nk6mqk88jvjq7";
-    };
-
-    patches = [
-      ./m33-fio-one-library.patch
-    ];
-
-    postPatch = ''
-      rm -rf octoprint_m33fio/static/libraries/*
-      (
-        cd 'shared library source'
-        make
-      )
-    '';
-
-    meta = with stdenv.lib; {
-      description = "OctoPrint plugin for the Micro 3D printer";
-      homepage = "https://github.com/donovan6000/M33-Fio";
-      license = licenses.gpl3;
-      maintainers = with maintainers; [ abbradar ];
-    };
-  };
-
   mqtt = buildPlugin rec {
     pname = "MQTT";
     version = "0.8.6";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -183,13 +183,13 @@ in {
 
   gcodeeditor = buildPlugin rec {
     pname = "GcodeEditor";
-    version = "0.2.6";
+    version = "0.2.9";
 
     src = fetchFromGitHub {
       owner = "ieatacid";
       repo = "OctoPrint-${pname}";
       rev = version;
-      sha256 = "0c6p78r3vd6ys3kld308pyln09zjbr9yif1ljvcx6wlml2i5l1vh";
+      sha256 = "1yjj9lmxbzmzrn7gahw9lj7554fphalbjjp8ns0rr9py3rshwxkm";
     };
 
     meta = with stdenv.lib; {

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -93,13 +93,13 @@ in {
 
   touchui = buildPlugin rec {
     pname = "TouchUI";
-    version = "0.3.14";
+    version = "0.3.16";
 
     src = fetchFromGitHub {
       owner = "BillyBlaze";
       repo = "OctoPrint-${pname}";
       rev = version;
-      sha256 = "033b9nk3kpnmjw9nggcaxy39hcgfviykcy2cx0j6m411agvmqbzf";
+      sha256 = "1jlqjirc4ygl4k7jp93l2h6b18jap3mzz8sf2g61j9w0kgv9l365";
     };
 
     meta = with stdenv.lib; {

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -259,13 +259,13 @@ in {
 
   octoprint-dashboard = buildPlugin rec {
     pname = "OctoPrint-Dashboard";
-    version = "1.15.1";
+    version = "1.15.2";
 
     src = fetchFromGitHub {
       owner = "StefanCohen";
       repo = pname;
       rev = version;
-      sha256 = "1psk069g8xdpgbzmna51dh978vrildh33dn7kbbi5y31ry5c3gx6";
+      sha256 = "0p94jwd7kagh3sixhcrqmsgbay4aaf9l1pgyi2b45jym8pvld5n4";
     };
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This is just more misc octoprint maintenance. Basically removing a long-abandoned and now incompatible plugin, and then bumping all other plugins.

I also sorted the plugin file, and added a couple plugins I need.

Regardless, it's pretty vanilla stuff.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
