### PR TITLE
[20.03] backport yed updates

### DIFF
--- a/pkgs/applications/graphics/yed/default.nix
+++ b/pkgs/applications/graphics/yed/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "yEd";
-  version = "3.19.1.1";
+  version = "3.20";
 
   src = fetchzip {
     url = "https://www.yworks.com/resources/yed/demo/${pname}-${version}.zip";
-    sha256 = "0px88rc1slf7n1n8lpk56hf29ppbnnd4lrqfyggihcr0pxmw157c";
+    sha256 = "08j8lpn2nd41gavgrj03rlrxl04wcamq1y02f1x1569ykbhycb3m";
   };
 
   nativeBuildInputs = [ makeWrapper unzip ];

--- a/pkgs/applications/graphics/yed/default.nix
+++ b/pkgs/applications/graphics/yed/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "yEd";
-  version = "3.20";
+  version = "3.20.1";
 
   src = fetchzip {
     url = "https://www.yworks.com/resources/yed/demo/${pname}-${version}.zip";
-    sha256 = "08j8lpn2nd41gavgrj03rlrxl04wcamq1y02f1x1569ykbhycb3m";
+    sha256 = "0sd73s700f3gqq5zq1psrqjg6ff2gv49f8vd37v6bv65vdxqxryq";
   };
 
   nativeBuildInputs = [ makeWrapper unzip ];


### PR DESCRIPTION
###### Motivation for this change

`yed` does not build on 20.03 due to 

```

builder for '/nix/store/ysgcm7y0m861bk6ncpb1rvp7jmvl848j-source.drv' failed with exit code 1; last 10 log lines:
  100 29261  100 29261    0     0   111k      0 --:--:-- --:--:-- --:--:--  111k
  unpacking source archive /build/yEd-3.19.1.1.zip
  [/build/yEd-3.19.1.1.zip]
    End-of-central-directory signature not found.  Either this file is not
    a zipfile, or it constitutes one disk of a multi-part archive.  In the
    latter case the central directory and zipfile comment will be found on
    the last disk(s) of this archive.
  unzip:  cannot find zipfile directory in one of /build/yEd-3.19.1.1.zip or
          /build/yEd-3.19.1.1.zip.zip, and cannot find /build/yEd-3.19.1.1.zip.ZIP, period.
  do not know how to unpack source archive /build/yEd-3.19.1.1.zip
cannot build derivation '/nix/store/g0j9kvrq06jaqy6vbqij7jackvdqij5s-yEd-3.19.1.1.drv': 1 dependencies couldn't be built
```

And I hope this fixes the issue.

###### Things done

`git cherry-pick -x -s ...`

---

@abbradar (pkg maintainer)