### PR TITLE
vscode-extensions: recurse into publishers

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -10,6 +10,7 @@ in
 # So an extension's attribute name should be of the form:
 # "${mktplcRef.publisher}.${mktplcRef.name}".
 #
+stdenv.lib.mapAttrs (_n: stdenv.lib.recurseIntoAttrs)
 {
 
   alanz.vscode-hie-server = buildVscodeMarketplaceExtension {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The `vscode-extensions` set is already marked as `recurseIntoAttrs`, but this has no effect, since this set is two layers deep instead of the usual one which `recurseIntoAttrs` applies to.

By applying `recurseIntoAttrs` to all publishers, the extensions will be considered by nix tools (e.g. `nixpkgs-review`) when listing packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
<details>
  <summary>nixpkgs-review.log</summary>
  
```
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 96, done.
remote: Counting objects: 100% (96/96), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 113 (delta 91), reused 92 (delta 91), pack-reused 17
Empfange Objekte: 100% (113/113), 207.61 KiB | 5.32 MiB/s, Fertig.
Löse Unterschiede auf: 100% (91/91), abgeschlossen mit 19 lokalen Objekten.
Von https://github.com/NixOS/nixpkgs
 + 45a4ff10330...c12e01724a2 master     -> refs/nixpkgs-review/0  (Aktualisierung erzwungen)
$ git worktree add /home/fabian/.cache/nixpkgs-review/rev-2c2d3d1bd5529d02da3cd27fc0da6e32dd42a18e/nixpkgs c12e01724a275f3612e645a2cac08c67b2c94a19
Bereite Arbeitsverzeichnis vor (losgelöster HEAD c12e01724a2)
HEAD ist jetzt bei c12e01724a2 .github/CODEOWNERS: add myself to rust
$ nix-env -f /home/fabian/.cache/nixpkgs-review/rev-2c2d3d1bd5529d02da3cd27fc0da6e32dd42a18e/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 2c2d3d1bd5529d02da3cd27fc0da6e32dd42a18e
Automatischer Merge abgeschlossen; halte, wie gewünscht, vor dem Commit an
$ nix-env -f /home/fabian/.cache/nixpkgs-review/rev-2c2d3d1bd5529d02da3cd27fc0da6e32dd42a18e/nixpkgs -qaP --xml --out-path --show-trace --meta
23 packages added:
vscode-extensions.alanz.vscode-hie-server (init at 0.0.27) vscode-extensions.bbenoist.Nix (init at 1.0.1) vscode-extensions.cmschuetz12.wal (init at 0.1.0) vscode-extensions.formulahendry.auto-close-tag (init at 0.5.6) vscode-extensions.haskell.haskell (init at 1.1.0) vscode-extensions.james-yu.latex-workshop (init at 8.2.0) vscode-extensions.justusadam.language-haskell (init at 3.2.1) vscode-extensions.ms-azuretools.vscode-docker (init at 0.8.1) vscode-extensions.ms-kubernetes-tools.vscode-kubernetes-tools (init at 1.0.6) vscode-extensions.ms-python.python (init at 2020.9.114305) vscode-extensions.ms-vscode.cpptools (init at 1.0.1) vscode-extensions.ms-vscode.Go (init at 0.11.7) vscode-extensions.ms-vscode-remote.remote-ssh (init at 0.50.0) vscode-extensions.ms-vsliveshare.vsliveshare (init at 1.0.2902) vscode-extensions.redhat.vscode-yaml (init at 0.5.3) vscode-extensions.matklad.rust-analyzer (init at 2020-10-19) vscode-extensions.scala-lang.scala (init at 0.3.8) vscode-extensions.scalameta.metals (init at 1.9.4) vscode-extensions.skyapps.fish-vscode (init at 0.2.1) vscode-extension-vscode-lldb vscode-extensions.vscodevim.vim (init at 1.11.3) vscode-extensions.WakaTime.vscode-wakatime (init at 4.0.9) vscode-extensions.xaver.clang-format (init at 1.9.0)

$ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/fabian/.cache/nixpkgs-review/rev-2c2d3d1bd5529d02da3cd27fc0da6e32dd42a18e/build.nix
error: --- Error --- nix-daemon
builder for '/nix/store/64mj93rl2hrlxz0alm0kmw1slphjblfp-node_vscode-lldb-1.5.3.drv' failed with exit code 1; last 10 log lines:
  readdirp@2.2.1 /nix/store/cl9ynhp66qmnp3cslwcqxpa38ljf7akb-node_vscode-lldb-1.5.3/lib/node_modules/vscode-lldb/node_modules/watchpack-chokidar2/node_modules/readdirp
  readable-stream@2.3.7 /nix/store/cl9ynhp66qmnp3cslwcqxpa38ljf7akb-node_vscode-lldb-1.5.3/lib/node_modules/vscode-lldb/node_modules/watchpack-chokidar2/node_modules/readable-stream
  isarray@1.0.0 /nix/store/cl9ynhp66qmnp3cslwcqxpa38ljf7akb-node_vscode-lldb-1.5.3/lib/node_modules/vscode-lldb/node_modules/watchpack-chokidar2/node_modules/isarray
  string_decoder@1.1.1 /nix/store/cl9ynhp66qmnp3cslwcqxpa38ljf7akb-node_vscode-lldb-1.5.3/lib/node_modules/vscode-lldb/node_modules/watchpack-chokidar2/node_modules/string_decoder
  fsevents@1.2.13 /nix/store/cl9ynhp66qmnp3cslwcqxpa38ljf7akb-node_vscode-lldb-1.5.3/lib/node_modules/vscode-lldb/node_modules/watchpack-chokidar2/node_modules/fsevents
  npm ERR! Maximum call stack size exceededoadAllDepsIntoIdealTreemK

  npm ERR! A complete log of this run can be found in:
  npm ERR!     /build/.npm/_logs/2020-10-21T10_39_03_727Z-debug.log

error: --- Error --- nix-daemon
1 dependencies of derivation '/nix/store/qhqjfwplign3lhap708ffmk5j2dpb4si-vscode-lldb-1.5.3-vsix.drv' failed to build
error: --- Error --- nix-daemon
1 dependencies of derivation '/nix/store/jsxng705isdiq74agsqkbl3vhjy63w37-vscode-extension-vscode-lldb.drv' failed to build
[0 built (1 failed), 0.0 MiB DL]
error: error: --- Error --- nix-daemon
1 dependencies of derivation '/nix/store/46s963h4sls8jzg6ia5fjdr5cf2sc1v6-env.drv' failed to build
3 packages marked as broken and skipped:
vscode-extensions.ms-vscode-remote.remote-ssh vscode-extensions.ms-vscode.cpptools vscode-extensions.ms-vsliveshare.vsliveshare

1 package failed to build:
vscode-extensions.vadimcn.vscode-lldb

19 packages built:
vscode-extensions.WakaTime.vscode-wakatime vscode-extensions.alanz.vscode-hie-server vscode-extensions.bbenoist.Nix vscode-extensions.cmschuetz12.wal vscode-extensions.formulahendry.auto-close-tag vscode-extensions.haskell.haskell vscode-extensions.james-yu.latex-workshop vscode-extensions.justusadam.language-haskell vscode-extensions.matklad.rust-analyzer vscode-extensions.ms-azuretools.vscode-docker vscode-extensions.ms-kubernetes-tools.vscode-kubernetes-tools vscode-extensions.ms-python.python vscode-extensions.ms-vscode.Go vscode-extensions.redhat.vscode-yaml vscode-extensions.scala-lang.scala vscode-extensions.scalameta.metals vscode-extensions.skyapps.fish-vscode vscode-extensions.vscodevim.vim vscode-extensions.xaver.clang-format

$ git worktree prune
```
</details>

- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
