### PR TITLE
hdl-dump: init at 2020-07-28

### DIFF
--- a/pkgs/tools/misc/hdl-dump/default.nix
+++ b/pkgs/tools/misc/hdl-dump/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, upx }:
+
+stdenv.mkDerivation rec {
+  version = "0.9.2.20202807";
+  pname = "hdl_dump";
+
+  # playstation2/hdl-dump is outdated
+  src = fetchFromGitHub {
+    owner = "AKuHAK";
+    repo = "hdl-dump";
+    rev = "be37e112a44772a1341c867dc3dfee7381ce9e59";
+    sha256 = "0akxak6hm11h8z6jczxgr795s4a8czspwnhl3swqxp803dvjdx41";
+  };
+
+  buildInputs = [ upx ];
+
+  makeFlags = [ "RELEASE=yes" ];
+
+  installPhase = ''
+    install -Dm755 hdl_dump -t $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "PlayStation 2 HDLoader image dump/install utility";
+    platforms = platforms.linux;
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ makefu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21163,6 +21163,8 @@ in
 
   hdhomerun-config-gui = callPackage ../applications/video/hdhomerun-config-gui { };
 
+  hdl-dump = callPackage ../tools/misc/hdl-dump { };
+
   heimer = libsForQt5.callPackage ../applications/misc/heimer { };
 
   hello = callPackage ../applications/misc/hello { };


### PR DESCRIPTION
###### Motivation for this change

init hdl-dump, which is being used in the tutorial for https://nixos.wiki/wiki/Playstation2 

ref: #91714 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
