### PR TITLE
nanovna-saver: init at 0.3.7

### DIFF
--- a/pkgs/applications/science/electronics/nanovna-saver/default.nix
+++ b/pkgs/applications/science/electronics/nanovna-saver/default.nix
@@ -1,0 +1,51 @@
+{ lib, mkDerivationWith, wrapQtAppsHook, python3Packages, fetchFromGitHub
+, qtbase }:
+
+let
+  version = "0.3.7";
+  pname = "nanovna-saver";
+
+in mkDerivationWith python3Packages.buildPythonApplication {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "NanoVNA-Saver";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0c22ckyypg91gfb2sdc684msw28nnb6r8cq3b362gafvv00a35mi";
+  };
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
+
+  propagatedBuildInputs = with python3Packages; [
+    cython
+    scipy_1_4
+    pyqt5
+    pyserial
+    numpy
+  ];
+
+  doCheck = false;
+
+  dontWrapGApps = true;
+  dontWrapQtApps = true;
+
+  postFixup = ''
+    wrapProgram $out/bin/NanoVNASaver \
+      "''${gappsWrapperArgs[@]}" \
+      "''${qtWrapperArgs[@]}"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/NanoVNA-Saver/nanovna-saver";
+    description =
+      "A tool for reading, displaying and saving data from the NanoVNA";
+    longDescription = ''
+      A multiplatform tool to save Touchstone files from the NanoVNA, sweep
+      frequency spans in segments to gain more than 101 data points, and
+      generally display and analyze the resulting data.
+    '';
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ zaninime ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14603,6 +14603,8 @@ in
 
   nanomsg = callPackage ../development/libraries/nanomsg { };
 
+  nanovna-saver = libsForQt5.callPackage ../applications/science/electronics/nanovna-saver { };
+
   ndpi = callPackage ../development/libraries/ndpi { };
 
   nifticlib = callPackage ../development/libraries/science/biology/nifticlib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6389,6 +6389,16 @@ in {
     disabled = !isPy3k;
   });
 
+  scipy_1_4 = self.scipy.overridePythonAttrs (oldAttrs: rec {
+    version = "1.4.1";
+    src = oldAttrs.src.override {
+      inherit version;
+      sha256 = "0ndw7zyxd2dj37775mc75zm4fcyiipnqxclc45mkpxy8lvrvpqfy";
+    };
+    doCheck = false;
+    disabled = !isPy3k;
+  });
+
   scipy = let
     scipy_ = callPackage ../development/python-modules/scipy { };
     scipy_1_2 = scipy_.overridePythonAttrs (oldAttrs: rec {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add package `nanovna-saver`. It depends on scipy 1.4, so I needed to add the dependency in `pythonPackages`. I'm not sure if that needed a separate PR.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
