### PR TITLE
nixos: fix qemu_test being used in normal VMs

### DIFF
--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -18,9 +18,6 @@ rec {
 
   inherit pkgs;
 
-  qemu = pkgs.qemu_test;
-
-
   # Build a virtual network from an attribute set `{ machine1 =
   # config1; ... machineN = configN; }', where `machineX' is the
   # hostname and `configX' is a NixOS system configuration.  Each
@@ -39,7 +36,6 @@ rec {
         [ ../modules/virtualisation/qemu-vm.nix
           ../modules/testing/test-instrumentation.nix # !!! should only get added for automated test runs
           { key = "no-manual"; documentation.nixos.enable = false; }
-          { key = "qemu"; system.build.qemu = qemu; }
           { key = "nodes"; _module.args.nodes = nodes; }
         ] ++ optional minimal ../modules/testing/minimal-kernel.nix;
     };

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -51,7 +51,10 @@ with import ../../lib/qemu-flags.nix { inherit pkgs; };
     #       we avoid defining consoles if not possible.
     # TODO: refactor such that test-instrumentation can import qemu-vm
     #       or declare virtualisation.qemu.console option in a module that's always imported
-    virtualisation = lib.optionalAttrs (options ? virtualisation.qemu.consoles) { qemu.consoles = [ qemuSerialDevice ]; };
+    virtualisation.qemu = {
+      consoles = lib.optional (options ? virtualisation.qemu.consoles) qemuSerialDevice;
+      package  = pkgs.qemu_test;
+    };
 
     boot.initrd.preDeviceCommands =
       ''

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -14,9 +14,10 @@ with import ../../lib/qemu-flags.nix { inherit pkgs; };
 
 let
 
-  qemu = config.system.build.qemu or pkgs.qemu_test;
 
   cfg = config.virtualisation;
+
+  qemu = cfg.qemu.package;
 
   consoles = lib.concatMapStringsSep " " (c: "console=${c}") cfg.qemu.consoles;
 
@@ -401,6 +402,14 @@ in
       };
 
     virtualisation.qemu = {
+      package =
+        mkOption {
+          type = types.package;
+          default = pkgs.qemu;
+          example = "pkgs.qemu_test";
+          description = "QEMU package to use.";
+        };
+
       options =
         mkOption {
           type = types.listOf types.unspecified;


### PR DESCRIPTION
###### Motivation for this change
It looks like since PR #49403 the VMs built by `nixos-rebuild built-vm` are using the stripped-down qemu package, which lacks gtk and spice support.

###### Things done

- [x] Tested that `nixosTests` uses `qemu_test` package
- [x] Tested that `build-vm` uses the normal `qemu` package
- [x] Test I have not broken more things by removing `config.system.build.qemu`