### PR TITLE
pfsshell: init at 1.1.1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -18,6 +18,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "Abstyles License";
   };
 
+  afl20 = spdx {
+    spdxId = "AFL-2.0";
+    fullName = "Academic Free License v2.0";
+  };
+
   afl21 = spdx {
     spdxId = "AFL-2.1";
     fullName = "Academic Free License v2.1";

--- a/pkgs/tools/misc/pfsshell/default.nix
+++ b/pkgs/tools/misc/pfsshell/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, meson, ninja }:
+
+stdenv.mkDerivation rec {
+  version = "1.1.1";
+  pname = "pfsshell";
+
+  src = fetchFromGitHub {
+    owner = "uyjulian";
+    repo = "pfsshell";
+    rev = "v${version}";
+    sha256 = "0cr91al3knsbfim75rzl7rxdsglcc144x0nizn7q4jx5cad3zbn8";
+  };
+
+  nativeBuildInputs = [ meson ninja ];
+
+  # Build errors since 1.1.1 when format hardening is enabled:
+  #   cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
+  hardeningDisable = [ "format" ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "PFS (PlayStation File System) shell for POSIX-based systems";
+    platforms = platforms.unix;
+    license = with licenses; [
+      gpl2Only # the pfsshell software itself
+      afl20    # APA, PFS, and iomanX libraries which are compiled together with this package
+    ];
+    maintainers = with maintainers; [ makefu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23171,6 +23171,8 @@ in
 
   pflask = callPackage ../os-specific/linux/pflask {};
 
+  pfsshell = callPackage ../tools/misc/pfsshell { };
+
   photoqt = libsForQt5.callPackage ../applications/graphics/photoqt { };
 
   photoflare = libsForQt5.callPackage ../applications/graphics/photoflare { };


### PR DESCRIPTION
###### Motivation for this change

init pfsshell, which is being used in the tutorial for https://nixos.wiki/wiki/Playstation2
#79142

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
