### PR TITLE
fmt: 6.2.1 -> 7.0.3

### DIFF
--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -1,37 +1,76 @@
 { stdenv, fetchFromGitHub, fetchpatch, cmake, enableShared ? true }:
 
-stdenv.mkDerivation rec {
-  pname = "fmt";
-  version = "7.0.3";
+let
+  generic = { version, sha256, patches ? [ ] }:
+    stdenv.mkDerivation {
+      pname = "fmt";
+      inherit version;
 
-  outputs = [ "out" "dev" ];
+      outputs = [ "out" "dev" ];
 
-  src = fetchFromGitHub {
-    owner = "fmtlib";
-    repo = "fmt";
-    rev = version;
-    sha256 = "17q2fdzakk5p0s3fx3724gs5k2b5ylp8f1d6j2m3wgvlfldx9k9a";
+      src = fetchFromGitHub {
+        owner = "fmtlib";
+        repo = "fmt";
+        rev = version;
+        inherit sha256;
+      };
+
+      inherit patches;
+
+      nativeBuildInputs = [ cmake ];
+
+      cmakeFlags = [
+        "-DBUILD_SHARED_LIBS=${if enableShared then "ON" else "OFF"}"
+        "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
+      ];
+
+      doCheck = true;
+
+      meta = with stdenv.lib; {
+        description = "Small, safe and fast formatting library";
+        longDescription = ''
+          fmt (formerly cppformat) is an open-source formatting library. It can be
+          used as a fast and safe alternative to printf and IOStreams.
+        '';
+        homepage = "http://fmtlib.net/";
+        downloadPage = "https://github.com/fmtlib/fmt/";
+        maintainers = [ maintainers.jdehaas ];
+        license = licenses.bsd2;
+        platforms = platforms.all;
+      };
+    };
+in
+{
+  fmt_6 = generic {
+    version = "6.2.1";
+    sha256 = "1i6nfxazq4d05r3sxyc3ziwkqq7s8rdbv9p16afv66aqmsbqqqic";
+
+    patches = [
+      # Fix BC break breaking Kodi
+      # https://github.com/xbmc/xbmc/issues/17629
+      # https://github.com/fmtlib/fmt/issues/1620
+      (fetchpatch {
+        url = "https://github.com/fmtlib/fmt/commit/7d01859ef16e6b65bc023ad8bebfedecb088bf81.patch";
+        sha256 = "0v8hm5958ih1bmnjr16fsbcmdnq4ykyf6b0hg6dxd5hxd126vnxx";
+      })
+
+      # Fix paths in pkg-config file
+      # https://github.com/fmtlib/fmt/pull/1657
+      (fetchpatch {
+        url = "https://github.com/fmtlib/fmt/commit/78f041ab5b40a1145ba686aeb8013e8788b08cd2.patch";
+        sha256 = "1hqp96zl9l3qyvsm7pxl6ah8c26z035q2mz2pqhqa0wvzd1klcc6";
+      })
+
+      # Fix cmake config paths.
+      (fetchpatch {
+        url = "https://github.com/fmtlib/fmt/pull/1702.patch";
+        sha256 = "18cadqi7nac37ymaz3ykxjqs46rvki396g6qkqwp4k00cmic23y3";
+      })
+    ];
   };
 
-  nativeBuildInputs = [ cmake ];
-
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=${if enableShared then "ON" else "OFF"}"
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
-  ];
-
-  doCheck = true;
-
-  meta = with stdenv.lib; {
-    description = "Small, safe and fast formatting library";
-    longDescription = ''
-      fmt (formerly cppformat) is an open-source formatting library. It can be
-      used as a fast and safe alternative to printf and IOStreams.
-    '';
-    homepage = "http://fmtlib.net/";
-    downloadPage = "https://github.com/fmtlib/fmt/";
-    maintainers = [ maintainers.jdehaas ];
-    license = licenses.bsd2;
-    platforms = platforms.all;
+  fmt_7 = generic {
+    version = "7.0.3";
+    sha256 = "17q2fdzakk5p0s3fx3724gs5k2b5ylp8f1d6j2m3wgvlfldx9k9a";
   };
 }

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "fmt";
-  version = "6.2.1";
+  version = "7.0.3";
 
   outputs = [ "out" "dev" ];
 
@@ -10,31 +10,8 @@ stdenv.mkDerivation rec {
     owner = "fmtlib";
     repo = "fmt";
     rev = version;
-    sha256 = "1i6nfxazq4d05r3sxyc3ziwkqq7s8rdbv9p16afv66aqmsbqqqic";
+    sha256 = "17q2fdzakk5p0s3fx3724gs5k2b5ylp8f1d6j2m3wgvlfldx9k9a";
   };
-
-  patches = [
-    # Fix BC break breaking Kodi
-    # https://github.com/xbmc/xbmc/issues/17629
-    # https://github.com/fmtlib/fmt/issues/1620
-    (fetchpatch {
-      url = "https://github.com/fmtlib/fmt/commit/7d01859ef16e6b65bc023ad8bebfedecb088bf81.patch";
-      sha256 = "0v8hm5958ih1bmnjr16fsbcmdnq4ykyf6b0hg6dxd5hxd126vnxx";
-    })
-
-    # Fix paths in pkg-config file
-    # https://github.com/fmtlib/fmt/pull/1657
-    (fetchpatch {
-      url = "https://github.com/fmtlib/fmt/commit/78f041ab5b40a1145ba686aeb8013e8788b08cd2.patch";
-      sha256 = "1hqp96zl9l3qyvsm7pxl6ah8c26z035q2mz2pqhqa0wvzd1klcc6";
-    })
-
-    # Fix cmake config paths.
-    (fetchpatch {
-      url = "https://github.com/fmtlib/fmt/pull/1702.patch";
-      sha256 = "18cadqi7nac37ymaz3ykxjqs46rvki396g6qkqwp4k00cmic23y3";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16547,7 +16547,9 @@ in
 
   grafana_reporter = callPackage ../servers/monitoring/grafana-reporter { };
 
-  gerbera = callPackage ../servers/gerbera { };
+  gerbera = callPackage ../servers/gerbera {
+    fmt = fmt_6;
+  };
 
   gobetween = callPackage ../servers/gobetween { };
 
@@ -21301,7 +21303,9 @@ in
 
   swaylock-effects = callPackage ../applications/window-managers/sway/lock-effects.nix { };
 
-  waybar = callPackage ../applications/misc/waybar { };
+  waybar = callPackage ../applications/misc/waybar {
+    fmt = fmt_6;
+  };
 
   hikari = callPackage ../applications/window-managers/hikari { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12461,7 +12461,10 @@ in
 
   flyway = callPackage ../development/tools/flyway { };
 
-  fmt = callPackage ../development/libraries/fmt/default.nix { };
+  inherit (callPackages ../development/libraries/fmt { })
+    fmt_6 fmt_7;
+
+  fmt = fmt_7;
 
   fplll = callPackage ../development/libraries/fplll {};
   fplll_20160331 = callPackage ../development/libraries/fplll/20160331.nix {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
`pcsx2` master depends on `fmt` 7.0.3 and up, it'd be best to update `fmt` before `pcsx2`'s next release, so we aren't stuck on an older version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
