### PR TITLE
ryujinx: 1.0.5346 -> 1.0.5551

### DIFF
--- a/pkgs/misc/emulators/ryujinx/default.nix
+++ b/pkgs/misc/emulators/ryujinx/default.nix
@@ -13,13 +13,13 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "ryujinx";
-  version = "1.0.5346";
+  version = "1.0.5551"; # Versioning is based off of the official appveyor builds: https://ci.appveyor.com/project/gdkchan/ryujinx
 
   src = fetchFromGitHub {
     owner = "Ryujinx";
     repo = "Ryujinx";
-    rev = "2ce59c44bcb2d789f4d6312b26cf41f36915d73c";
-    sha256 = "0hk8jdacg8ryhh0mpnfjbzrrpy8gv87f4hp0hybyypglmaxz8grm";
+    rev = "2dcc6333f8cbb959293832f52857bdaeab1918bf";
+    sha256 = "1hfa498fr9mdxas9s02y25ncb982wa1sqhl06jpnkhqsiicbkgcf";
   };
 
   nativeBuildInputs = [ dotnet-sdk_3 dotnetPackages.Nuget makeWrapper wrapGAppsHook gobject-introspection ];

--- a/pkgs/misc/emulators/ryujinx/deps.nix
+++ b/pkgs/misc/emulators/ryujinx/deps.nix
@@ -15,6 +15,11 @@
     sha256 = "0y5z444wrbhlmsqpy2sxmajl1fbf74843lvgj3y6vz260dn2q0l0";
   })
   (fetchNuGet {
+    name = "Crc32.NET";
+    version = "1.2.0";
+    sha256 = "0qaj3192k1vfji87zf50rhydn5mrzyzybrs2k4v7ap29k8i0vi5h";
+  })
+  (fetchNuGet {
     name = "DiscordRichPresence";
     version = "1.0.150";
     sha256 = "0qmbi4sccia3w80q8xfvj3bw62nvz047wq198n2b2aflkf47bq79";
@@ -236,8 +241,8 @@
   })
   (fetchNuGet {
     name = "OpenTK.NetStandard";
-    version = "1.0.5.12";
-    sha256 = "1n8j6k47189l5b6rnhyq391d84v6zkpiiqq41cccb6qizvrcgl69";
+    version = "1.0.5.22";
+    sha256 = "10bdhc4qbffac862zg03ab5j3iqrr33bydxmnmrxn82brldahm23";
   })
   (fetchNuGet {
     name = "PangoSharp";
@@ -488,6 +493,11 @@
     name = "Ryujinx.Graphics.Nvdec.Dependencies";
     version = "4.3.0";
     sha256 = "0szgbdhyhvzpw8nb9k2ww37p5qipab1pdll8idkk57y5xnl2f7ll";
+  })
+  (fetchNuGet {
+    name = "SharpZipLib";
+    version = "1.2.0";
+    sha256 = "0ynhx1qkjm723bwjwsrdviw1d2s9azndpa12dagrjshhma3igqm5";
   })
   (fetchNuGet {
     name = "System.AppContext";

--- a/pkgs/misc/emulators/ryujinx/log.patch
+++ b/pkgs/misc/emulators/ryujinx/log.patch
@@ -1,5 +1,5 @@
 diff --git a/Ryujinx.Common/Configuration/LoggerModule.cs b/Ryujinx.Common/Configuration/LoggerModule.cs
-index 20c0fb46..ce933730 100644
+index 20c0fb46..534576bc 100644
 --- a/Ryujinx.Common/Configuration/LoggerModule.cs
 +++ b/Ryujinx.Common/Configuration/LoggerModule.cs
 @@ -75,7 +75,7 @@ namespace Ryujinx.Configuration
@@ -7,7 +7,7 @@ index 20c0fb46..ce933730 100644
              {
                  Logger.AddTarget(new AsyncLogTargetWrapper(
 -                    new FileLogTarget(AppDomain.CurrentDomain.BaseDirectory, "file"),
-+		      new FileLogTarget(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Ryujinx"), "file"),
++                    new FileLogTarget(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Ryujinx"), "file"),
                      1000,
                      AsyncLogTargetOverflowAction.Block
                  ));


### PR DESCRIPTION
###### Things done
Updated to the latest version, added a comment explaining the versioning, and fix indentation in the log patch.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
