### PR TITLE
nixosTests.ferm: fix network timeout

### DIFF
--- a/nixos/tests/ferm.nix
+++ b/nixos/tests/ferm.nix
@@ -56,6 +56,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       start_all()
 
       client.wait_for_unit("network-online.target")
+      server.wait_for_unit("network-online.target")
       server.wait_for_unit("ferm.service")
       server.wait_for_unit("nginx.service")
       server.wait_until_succeeds("ss -ntl | grep -q 80")


### PR DESCRIPTION
###### Motivation for this change

The subtests could start before the server has configured it's IP addresses and therefore randomly timeout.

Example failing Hydra build:
- https://hydra.nixos.org/build/128680160

Example Hydra jobs with regular failures:
- https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.ferm.x86_64-linux/all
- https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.ferm.i686-linux/all
- https://hydra.nixos.org/job/nixos/release-20.09/nixos.tests.ferm.i686-linux/all
- https://hydra.nixos.org/job/nixos/release-20.09/nixos.tests.ferm.x86_64-linux/all

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
