### PR TITLE
python3Packages.ftputil: fix tests on darwin

### DIFF
--- a/pkgs/development/python-modules/ftputil/default.nix
+++ b/pkgs/development/python-modules/ftputil/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder, pytest, freezegun }:
+{ stdenv, lib, buildPythonPackage, fetchPypi, pythonOlder, pytest, freezegun }:
 
 buildPythonPackage rec {
   version = "4.0.0";
@@ -18,12 +18,15 @@ buildPythonPackage rec {
     py.test test \
       -k "not test_public_servers and not test_real_ftp \
           and not test_set_parser and not test_repr \
-          and not test_conditional_upload and not test_conditional_download_with_older_target"
-  '';
+          and not test_conditional_upload and not test_conditional_download_with_older_target \
+  ''
+  # need until https://ftputil.sschwarzer.net/trac/ticket/140#ticket is fixed
+  + lib.optionalString stdenv.isDarwin ''and not test_error_message_reuse''
+  + ''"'';
 
   meta = with lib; {
     description = "High-level FTP client library (virtual file system and more)";
-    homepage    = "http://ftputil.sschwarzer.net/";
-    license     = licenses.bsd2; # "Modified BSD license, says pypi"
+    homepage = "http://ftputil.sschwarzer.net/";
+    license = licenses.bsd2; # "Modified BSD license, says pypi"
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://hydra.nixos.org/build/128502414

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
