### PR TITLE
wrap neovim but without its configuration file

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -1,0 +1,145 @@
+{ lib
+, vimUtils
+, nodejs
+, neovim-unwrapped
+, bundlerEnv
+, ruby
+, pythonPackages
+, python3Packages
+, writeText
+}:
+let
+  # vimWithRC pass it args
+  # need a function that generates wrapperArgs + customRC and then one can create its own package from that.
+  # should let the user write its own file.
+  makeNeovimConfig =
+    { extraMakeWrapperArgs ? ""
+    , withPython ? false
+    , extraPythonPackages ? (_: [ ]) /* the function you would have passed to python.withPackages */
+    , withPython3 ? true
+    , extraPython3Packages ? (_: [ ]) /* the function you would have passed to python.withPackages */
+    , withNodeJs ? false
+    , withRuby ? true
+    , configure ? { }
+
+    # whether to wrap the Rc file
+    # dont use it, should be discarded as we update neovim wrapper
+    , wrapRc ? true
+
+    # for forward compability, when adding features
+    , ...
+    }:
+    let
+      rubyEnv = bundlerEnv {
+        name = "neovim-ruby-env";
+        gemdir = ./ruby_provider;
+        postBuild = ''
+          ln -sf ${ruby}/bin/* $out/bin
+        '';
+      };
+
+      /* for compatibility with passing extraPythonPackages as a list; added 2018-07-11 */
+      compatFun = funOrList: (if builtins.isList funOrList then
+        (_: lib.warn "passing a list as extraPythonPackages to the neovim wrapper is deprecated, pass a function as to python.withPackages instead" funOrList)
+      else funOrList);
+      extraPythonPackagesFun = compatFun extraPythonPackages;
+      extraPython3PackagesFun = compatFun extraPython3Packages;
+
+      requiredPlugins = vimUtils.requiredPlugins configure;
+      getDeps = attrname: map (plugin: plugin.${attrname} or (_: [ ]));
+
+      pluginPythonPackages = getDeps "pythonDependencies" requiredPlugins;
+      pythonEnv = pythonPackages.python.withPackages (ps:
+        [ ps.pynvim ]
+        ++ (extraPythonPackagesFun ps)
+        ++ (lib.concatMap (f: f ps) pluginPythonPackages));
+
+      pluginPython3Packages = getDeps "python3Dependencies" requiredPlugins;
+      python3Env = python3Packages.python.withPackages (ps:
+        [ ps.pynvim ]
+        ++ (extraPython3PackagesFun ps)
+        ++ (lib.concatMap (f: f ps) pluginPython3Packages));
+
+      binPath = lib.makeBinPath (lib.optionals withRuby [ rubyEnv ] ++ lib.optionals withNodeJs [ nodejs ]);
+
+      # Mapping a boolean argument to a key that tells us whether to add or not to
+      # add to nvim's 'embedded rc' this:
+      #    let g:<key>_host_prog=$out/bin/nvim-<key>
+      # Or this:
+      #    let g:loaded_${prog}_provider=1
+      # While the later tells nvim that this provider is not available
+      hostprog_check_table = {
+        node = withNodeJs;
+        python = withPython;
+        python3 = withPython3;
+        ruby = withRuby;
+      };
+      ## Here we calculate all of the arguments to the 1st call of `makeWrapper`
+      # We start with the executable itself NOTE we call this variable "initial"
+      # because if configure != {} we need to call makeWrapper twice, in order to
+      # avoid double wrapping, see comment near finalMakeWrapperArgs
+      initialMakeWrapperArgs =
+        let
+          flags = lib.concatLists (lib.mapAttrsToList
+            (
+              prog:
+              withProg:
+              [
+                "--cmd"
+                (if withProg then
+                  "let g:${prog}_host_prog='${placeholder "out"}/bin/nvim-${prog}'"
+                else
+                  "let g:loaded_${prog}_provider=1"
+                )
+              ]
+            )
+            hostprog_check_table);
+        in
+        [
+          "--argv0"
+          "$0"
+          "--add-flags"
+          (lib.escapeShellArgs flags)
+        ] ++ lib.optionals withRuby [
+          "--set"
+          "GEM_HOME"
+          "${rubyEnv}/${rubyEnv.ruby.gemPath}"
+        ] ++ lib.optionals (binPath != "") [
+          "--suffix"
+          "PATH"
+          ":"
+          binPath
+        ];
+      # If configure != {}, we can't generate the rplugin.vim file with e.g
+      # NVIM_SYSTEM_RPLUGIN_MANIFEST *and* NVIM_RPLUGIN_MANIFEST env vars set in
+      # the wrapper. That's why only when configure != {} (tested both here and
+      # when postBuild is evaluated), we call makeWrapper once to generate a
+      # wrapper with most arguments we need, excluding those that cause problems to
+      # generate rplugin.vim, but still required for the final wrapper.
+      finalMakeWrapperArgs = initialMakeWrapperArgs
+        # this relies on a patched neovim, see
+        # https://github.com/neovim/neovim/issues/9413
+        ++ lib.optionals (configure != { }) [
+        "--set"
+        "NVIM_SYSTEM_RPLUGIN_MANIFEST"
+        "${placeholder "out"}/rplugin.vim"
+      ] ++ lib.optionals wrapRc [
+        "--add-flags"
+        "-u ${writeText "init.vim" neovimRcContent}"
+      ];
+
+      manifestRc = vimUtils.vimrcContent (configure // { customRC = ""; });
+      neovimRcContent = vimUtils.vimrcContent configure;
+    in
+    {
+      wrapperArgs = finalMakeWrapperArgs ++ extraMakeWrapperArgs;
+      neovimRc = neovimRcContent;
+      inherit manifestRc;
+      inherit rubyEnv;
+      inherit pythonEnv;
+      inherit python3Env;
+    };
+in
+{
+  inherit makeNeovimConfig;
+}

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -7,7 +7,7 @@
 , pythonPackages
 , python3Packages
 , writeText
-, wrapNeovim2
+, wrapNeovimUnstable
 }:
 let
   # returns everything needed for the caller to wrap its own neovim:
@@ -157,7 +157,7 @@ let
         inherit configure;
       };
     in
-    wrapNeovim2 neovim (res // {
+    wrapNeovimUnstable neovim (res // {
       wrapperArgs = res.wrapperArgs
       ++ [
         "--add-flags" "-u ${writeText "init.vim" res.neovimRcContent}"

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -13,9 +13,10 @@ neovim:
 
 let
   wrapper = {
+      # should contain all args but the binary
       wrapperArgs ? []
     , manifestRc ? null
-    , withPython ? true, pythonEnv ? null
+    , withPython2 ? true, python2Env ? null
     , withPython3 ? true,  python3Env ? null
     , withNodeJs? false
     , withRuby ? true, rubyEnv ? null
@@ -42,8 +43,8 @@ let
           --replace 'TryExec=nvim' "TryExec=$out/bin/nvim" \
           --replace 'Name=Neovim' 'Name=WrappedNeovim'
       ''
-      + optionalString withPython ''
-        makeWrapper ${pythonEnv}/bin/python $out/bin/nvim-python --unset PYTHONPATH
+      + optionalString withPython2 ''
+        makeWrapper ${python2Env}/bin/python $out/bin/nvim-python --unset PYTHONPATH
       ''
       + optionalString withPython3 ''
         makeWrapper ${python3Env}/bin/python3 $out/bin/nvim-python3 --unset PYTHONPATH

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -13,107 +13,23 @@ neovim:
 
 let
   wrapper = {
-      extraMakeWrapperArgs ? ""
-    , withPython ? true,  extraPythonPackages ? (_: []) /* the function you would have passed to python.withPackages */
-    , withPython3 ? true,  extraPython3Packages ? (_: []) /* the function you would have passed to python.withPackages */
+      wrapperArgs ? []
+    , neovimRc ? null
+    , manifestRc ? null
+    , withPython ? true, pythonEnv ? null
+    , withPython3 ? true,  python3Env ? null
     , withNodeJs? false
-    , withRuby ? true
+    , withRuby ? true, rubyEnv ? null
     , vimAlias ? false
     , viAlias ? false
-    , configure ? {}
+
+    # deprecate
   }:
   let
 
-  rubyEnv = bundlerEnv {
-    name = "neovim-ruby-env";
-    gemdir = ./ruby_provider;
-    postBuild = ''
-      ln -sf ${ruby}/bin/* $out/bin
-    '';
-  };
-
-  /* for compatibility with passing extraPythonPackages as a list; added 2018-07-11 */
-  compatFun = funOrList: (if builtins.isList funOrList then
-    (_: lib.warn "passing a list as extraPythonPackages to the neovim wrapper is deprecated, pass a function as to python.withPackages instead" funOrList)
-    else funOrList);
-  extraPythonPackagesFun = compatFun extraPythonPackages;
-  extraPython3PackagesFun = compatFun extraPython3Packages;
-
-  requiredPlugins = vimUtils.requiredPlugins configure;
-  getDeps = attrname: map (plugin: plugin.${attrname} or (_:[]));
-
-  pluginPythonPackages = getDeps "pythonDependencies" requiredPlugins;
-  pythonEnv = pythonPackages.python.withPackages(ps:
-        [ ps.pynvim ]
-        ++ (extraPythonPackagesFun ps)
-        ++ (concatMap (f: f ps) pluginPythonPackages));
-
-  pluginPython3Packages = getDeps "python3Dependencies" requiredPlugins;
-  python3Env = python3Packages.python.withPackages (ps:
-        [ ps.pynvim ]
-        ++ (extraPython3PackagesFun ps)
-        ++ (concatMap (f: f ps) pluginPython3Packages));
-
-  binPath = makeBinPath (optionals withRuby [rubyEnv] ++ optionals withNodeJs [nodejs]);
-
-  # Mapping a boolean argument to a key that tells us whether to add or not to
-  # add to nvim's 'embedded rc' this:
-  #
-  #    let g:<key>_host_prog=$out/bin/nvim-<key>
-  #
-  # Or this:
-  #
-  #    let g:loaded_${prog}_provider=1
-  #
-  # While the later tells nvim that this provider is not available
-  #
-  hostprog_check_table = {
-    node = withNodeJs;
-    python = withPython;
-    python3 = withPython3;
-    ruby = withRuby;
-  };
-  ## Here we calculate all of the arguments to the 1st call of `makeWrapper`
-  # We start with the executable itself NOTE we call this variable "initial"
-  # because if configure != {} we need to call makeWrapper twice, in order to
-  # avoid double wrapping, see comment near finalMakeWrapperArgs
-  initialMakeWrapperArgs =
-    let
-      flags = lib.concatLists (lib.mapAttrsToList (
-        prog:
-        withProg:
-        [
-          "--cmd"
-          (if withProg then
-            "let g:${prog}_host_prog='${placeholder "out"}/bin/nvim-${prog}'"
-          else
-            "let g:loaded_${prog}_provider=1"
-            )
-        ]
-      ) hostprog_check_table);
-    in [
-      "${neovim}/bin/nvim" "${placeholder "out"}/bin/nvim"
-      "--argv0" "$0"
-      "--add-flags" (lib.escapeShellArgs flags)
-    ] ++ lib.optionals withRuby [
-      "--set" "GEM_HOME" "${rubyEnv}/${rubyEnv.ruby.gemPath}"
-    ] ++ lib.optionals (binPath != "") [
-      "--suffix" "PATH" ":" binPath
-    ];
-  # If configure != {}, we can't generate the rplugin.vim file with e.g
-  # NVIM_SYSTEM_RPLUGIN_MANIFEST *and* NVIM_RPLUGIN_MANIFEST env vars set in
-  # the wrapper. That's why only when configure != {} (tested both here and
-  # when postBuild is evaluated), we call makeWrapper once to generate a
-  # wrapper with most arguments we need, excluding those that cause problems to
-  # generate rplugin.vim, but still required for the final wrapper.
-  finalMakeWrapperArgs = initialMakeWrapperArgs
-    # this relies on a patched neovim, see
-    # https://github.com/neovim/neovim/issues/9413
-    ++ lib.optionals (configure != {}) [
-      "--set" "NVIM_SYSTEM_RPLUGIN_MANIFEST" "${placeholder "out"}/rplugin.vim"
-      "--add-flags" "-u ${configFile}"
-    ];
-   configFile = writeText "init.vim" "${vimUtils.vimrcContent configure}";
+  finalMakeWrapperArgs =
+    [ "${neovim}/bin/nvim" "${placeholder "out"}/bin/nvim" ] ++ wrapperArgs
+  ;
   in
   symlinkJoin {
       name = "neovim-${stdenv.lib.getVersion neovim}";
@@ -121,7 +37,6 @@ let
       # extra actions upon
       postBuild = ''
         rm $out/bin/nvim
-        makeWrapper ${lib.escapeShellArgs initialMakeWrapperArgs} ${extraMakeWrapperArgs}
       ''
       + lib.optionalString stdenv.isLinux ''
         rm $out/share/applications/nvim.desktop
@@ -147,7 +62,7 @@ let
       + optionalString viAlias ''
         ln -s $out/bin/nvim $out/bin/vi
       ''
-      + optionalString (configure != {}) ''
+      + optionalString (manifestRc != null) ''
         echo "Generating remote plugin manifest"
         export NVIM_RPLUGIN_MANIFEST=$out/rplugin.vim
         # Some plugins assume that the home directory is accessible for
@@ -166,7 +81,7 @@ let
         # Only display the log on error since it will contain a few normally
         # irrelevant messages.
         if ! $out/bin/nvim \
-          -u ${vimUtils.vimrcFile (configure // { customRC = ""; })} \
+          -u ${writeFile "manifest.vim" manifestRc} \
           -i NONE -n \
           -E -V1rplugins.log -s \
           +UpdateRemotePlugins +quit! > outfile 2>&1; then
@@ -174,7 +89,9 @@ let
           echo -e "\nGenerating rplugin.vim failed!"
           exit 1
         fi
-        makeWrapper ${lib.escapeShellArgs finalMakeWrapperArgs} ${extraMakeWrapperArgs}
+      ''
+      + ''
+        makeWrapper ${lib.escapeShellArgs finalMakeWrapperArgs}
       '';
 
     paths = [ neovim ];
@@ -182,7 +99,7 @@ let
     preferLocalBuild = true;
 
     buildInputs = [makeWrapper];
-    passthru = { unwrapped = neovim; inherit configFile; };
+    passthru = { unwrapped = neovim; };
 
     meta = neovim.meta // {
       # To prevent builds on hydra

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -14,7 +14,6 @@ neovim:
 let
   wrapper = {
       wrapperArgs ? []
-    , neovimRc ? null
     , manifestRc ? null
     , withPython ? true, pythonEnv ? null
     , withPython3 ? true,  python3Env ? null
@@ -22,8 +21,7 @@ let
     , withRuby ? true, rubyEnv ? null
     , vimAlias ? false
     , viAlias ? false
-
-    # deprecate
+    , ...
   }:
   let
 
@@ -36,7 +34,7 @@ let
       # Remove the symlinks created by symlinkJoin which we need to perform
       # extra actions upon
       postBuild = ''
-        rm $out/bin/nvim
+        # rm $out/bin/nvim
       ''
       + lib.optionalString stdenv.isLinux ''
         rm $out/share/applications/nvim.desktop
@@ -81,7 +79,7 @@ let
         # Only display the log on error since it will contain a few normally
         # irrelevant messages.
         if ! $out/bin/nvim \
-          -u ${writeFile "manifest.vim" manifestRc} \
+          -u ${writeText "manifest.vim" manifestRc} \
           -i NONE -n \
           -E -V1rplugins.log -s \
           +UpdateRemotePlugins +quit! > outfile 2>&1; then
@@ -91,6 +89,7 @@ let
         fi
       ''
       + ''
+        rm $out/bin/nvim
         makeWrapper ${lib.escapeShellArgs finalMakeWrapperArgs}
       '';
 

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -34,10 +34,7 @@ let
       name = "neovim-${stdenv.lib.getVersion neovim}";
       # Remove the symlinks created by symlinkJoin which we need to perform
       # extra actions upon
-      postBuild = ''
-        # rm $out/bin/nvim
-      ''
-      + lib.optionalString stdenv.isLinux ''
+      postBuild = lib.optionalString stdenv.isLinux ''
         rm $out/share/applications/nvim.desktop
         substitute ${neovim}/share/applications/nvim.desktop $out/share/applications/nvim.desktop \
           --replace 'TryExec=nvim' "TryExec=$out/bin/nvim" \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23912,7 +23912,7 @@ in
 
   vimpc = callPackage ../applications/audio/vimpc { };
 
-  wrapNeovim2 = callPackage ../applications/editors/neovim/wrapper.nix { };
+  wrapNeovimUnstable = callPackage ../applications/editors/neovim/wrapper.nix { };
   wrapNeovim = neovimUtils.legacyWrapper;
   neovim-unwrapped = callPackage ../applications/editors/neovim {
     lua =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23912,10 +23912,8 @@ in
 
   vimpc = callPackage ../applications/audio/vimpc { };
 
-  wrapNeovim = callPackage ../applications/editors/neovim/wrapper.nix { };
-  # wrapNeovim = callPackage ../applications/editors/neovim/wrap_legacy.nix {
-  #   inherit (neovimUtils) makeNeovimConfig;
-  # };
+  wrapNeovim2 = callPackage ../applications/editors/neovim/wrapper.nix { };
+  wrapNeovim = neovimUtils.legacyWrapper;
   neovim-unwrapped = callPackage ../applications/editors/neovim {
     lua =
       # neovim doesn't work with luajit on aarch64: https://github.com/neovim/neovim/issues/7879

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23913,7 +23913,9 @@ in
   vimpc = callPackage ../applications/audio/vimpc { };
 
   wrapNeovim = callPackage ../applications/editors/neovim/wrapper.nix { };
-
+  # wrapNeovim = callPackage ../applications/editors/neovim/wrap_legacy.nix {
+  #   inherit (neovimUtils) makeNeovimConfig;
+  # };
   neovim-unwrapped = callPackage ../applications/editors/neovim {
     lua =
       # neovim doesn't work with luajit on aarch64: https://github.com/neovim/neovim/issues/7879
@@ -23921,6 +23923,7 @@ in
       luajit;
   };
 
+  neovimUtils = callPackage ../applications/editors/neovim/utils.nix { };
   neovim = wrapNeovim neovim-unwrapped { };
 
   neovim-qt = libsForQt5.callPackage ../applications/editors/neovim/qt.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23912,6 +23912,9 @@ in
 
   vimpc = callPackage ../applications/audio/vimpc { };
 
+  # this is a lower-level alternative to wrapNeovim conceived to handle
+  # more usecases when wrapping neovim. The interface is being actively worked on
+  # so expect breakage. use wrapNeovim instead if you want a stable alternative
   wrapNeovimUnstable = callPackage ../applications/editors/neovim/wrapper.nix { };
   wrapNeovim = neovimUtils.legacyWrapper;
   neovim-unwrapped = callPackage ../applications/editors/neovim {


### PR DESCRIPTION

###### Motivation for this change
Follow up of https://github.com/NixOS/nixpkgs/pull/101100. 

Wrapping the init.vim has some sideeffects https://github.com/NixOS/nixpkgs/issues/55376 . 
This PR allows to call wrapNeovim without wrapping its configuration file. Makes sense for home-manager where it can just drop the init.vim in the correct position (also for hackers who would prefer `--cmd "source generatedinit.vim` instead of the current `-u generatedinit.vim`.

I've tried to make commits valid on their own but if we agree on the architecture I can squash them:
- first commit introduces neovimUtils.makeNeovimConfig which returns (mostly) { neovimRcContent (so that home-manager can choose where to write it), wrappedArgs (arguments to pass to the wrapper) }, these arguments can then be completed by the caller depending on the needs.
- second commit introduces wrapNeovim2 (a lower level wrapper), and neovimUtils.legacyWrapper in order not to break older configurations.

I haven't thoroughly tested the part with the manifest generation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
