### PR TITLE
[20.09] python38Packages.scrapy-fake-useragent: fix build

### DIFF
--- a/pkgs/development/python-modules/scrapy-fake-useragent/default.nix
+++ b/pkgs/development/python-modules/scrapy-fake-useragent/default.nix
@@ -1,17 +1,20 @@
-{ stdenv, fetchPypi, buildPythonPackage, pytest, fake-useragent, scrapy }:
+{ stdenv, fetchFromGitHub, buildPythonPackage, pytestCheckHook, pytestcov, pytest-mock, fake-useragent, faker, scrapy }:
 
 buildPythonPackage rec {
   pname = "scrapy-fake-useragent";
   version = "1.4.4";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "3b17e982e646918dc25080da0672812d07bfb7a92a58377c014c74e0182c665e";
+  # PyPi tarball is corrupted
+  src = fetchFromGitHub {
+    owner = "alecxe";
+    repo = pname;
+    rev = "59c20d38c58c76618164760d546aa5b989a79b8b"; # no tags
+    sha256 = "0yb7d51jws665rdfqkmi077w0pjxmb2ni7ysphj7lx7b18whq54j";
   };
 
-  propagatedBuildInputs = [ fake-useragent ];
+  propagatedBuildInputs = [ fake-useragent faker ];
 
-  checkInputs = [ pytest scrapy ];
+  checkInputs = [ pytestCheckHook scrapy pytestcov pytest-mock ];
 
   meta = with stdenv.lib; {
     description = "Random User-Agent middleware based on fake-useragent";


### PR DESCRIPTION
backport to `release-20.09` of 71e7f74ca669e6ed16833a63201d98f70462219d, which entered `master` as part of PR #99513

###### Motivation for this change

ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix run nixpkgs.nixpkgs-
review -c nixpkgs-review wip -b release-20.09`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - (there are none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  - Is `license = licenses.bsd3;` correct? Looks like the license was changed to MIT in alecxe/scrapy-fake-useragent@0ea76148be2b9366bb97853a36942d93d73ef663, which precedes alecxe/scrapy-fake-useragent@59c20d38c58c76618164760d546aa5b989a79b8b (the commit used for 1.4.4 here)
