### PR TITLE
python3Packages.scrapy-fake-useragent: fix license

### DIFF
--- a/pkgs/development/python-modules/scrapy-fake-useragent/default.nix
+++ b/pkgs/development/python-modules/scrapy-fake-useragent/default.nix
@@ -16,6 +16,6 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "Random User-Agent middleware based on fake-useragent";
     homepage = "https://github.com/alecxe/scrapy-fake-useragent";
-    license = licenses.bsd3;
+    license = licenses.mit;
   };
 }


### PR DESCRIPTION
change `meta.license` to `licenses.mit`

###### Motivation for this change

Upstream changed to MIT with alecxe/scrapy-fake-useragent@0ea7614 (so with Version 1.4.0, it seems), but looks like it got overlooked in b5d6f771c2636933757d85aeddc4992dc977bdbe, which entered `master` as part of PR #95609.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  - [x] `meta.description` is capitalized
  - [x] `meta.description` doesn't start with the package name
  - [x] `meta.description` doesn't have a period at the end
  - [x] `meta.license` is set and fits the upstream license
  - [ ] `meta.maintainers` is set