### PR TITLE
redshift-plasma-applet: update patchPhase to fix manual updates, don't use upstream

### DIFF
--- a/pkgs/applications/misc/redshift-plasma-applet/default.nix
+++ b/pkgs/applications/misc/redshift-plasma-applet/default.nix
@@ -18,7 +18,9 @@ stdenv.mkDerivation {
       --replace "redshiftCommand: 'redshift'" \
                 "redshiftCommand: '${redshift}/bin/redshift'" \
       --replace "redshiftOneTimeCommand: 'redshift -O " \
-                "redshiftOneTimeCommand: '${redshift}/bin/redshift -O "
+                "redshiftOneTimeCommand: '${redshift}/bin/redshift -P -O " \
+      --replace "redshift -x" \
+                "${redshift}/bin/redshift -x"
 
     substituteInPlace package/contents/ui/config/ConfigAdvanced.qml \
       --replace "'redshift -V'" \

--- a/pkgs/applications/misc/redshift-plasma-applet/default.nix
+++ b/pkgs/applications/misc/redshift-plasma-applet/default.nix
@@ -6,6 +6,8 @@ stdenv.mkDerivation {
   pname = "redshift-plasma-applet";
   inherit version;
 
+  # most recent source is https://invent.kde.org/plasma/plasma-redshift-control
+  # but it breaks toggling off.
   src = fetchFromGitHub {
     owner = "kotelnik";
     repo = "plasma-applet-redshift-control";
@@ -17,10 +19,14 @@ stdenv.mkDerivation {
     substituteInPlace package/contents/ui/main.qml \
       --replace "redshiftCommand: 'redshift'" \
                 "redshiftCommand: '${redshift}/bin/redshift'" \
-      --replace "redshiftOneTimeCommand: 'redshift -O " \
-                "redshiftOneTimeCommand: '${redshift}/bin/redshift -P -O " \
       --replace "redshift -x" \
                 "${redshift}/bin/redshift -x"
+
+    # change this line when src is updated
+    # upstream adds -P option, but breaks toggling the applet off
+    substituteInPlace package/contents/ui/main.qml \
+      --replace "redshiftOneTimeCommand: 'redshift -O " \
+                "redshiftOneTimeCommand: '${redshift}/bin/redshift -P -O "
 
     substituteInPlace package/contents/ui/config/ConfigAdvanced.qml \
       --replace "'redshift -V'" \


### PR DESCRIPTION
Need to patch every `redshift` to `${redshift }/bin/redshift` so
Nix can use the right binary. Current patch misses one.

Upstream applied https://invent.kde.org/plasma/plasma-redshift-control/-/commit/898c3a4cfc6c317915f1e664078d8606497c4049 to add `-P` to onetime color settings on redshift version >= 1.12

Since nixpkgs uses 1.12, and upstream seems to break manually toggling the applet off, I applied this fix inline in the patches, and took note of it.

I tested this with a local override, and it works on NixOS+KDE

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Issue https://github.com/NixOS/nixpkgs/issues/83250 has been a large blocker from me using NixOS more. I finally dove into fix it.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
