### PR TITLE
jabref: 3.8.1 -> 5.1

### DIFF
--- a/pkgs/applications/office/jabref/default.nix
+++ b/pkgs/applications/office/jabref/default.nix
@@ -1,13 +1,16 @@
-{ stdenv, fetchurl, makeWrapper, makeDesktopItem, jdk, jre, wrapGAppsHook, gtk3, gsettings-desktop-schemas }:
+{ stdenv, fetchurl, makeWrapper, makeDesktopItem, wrapGAppsHook, gtk3, gsettings-desktop-schemas
+, zlib , libX11, libXext, libXi, libXrender, libXtst, libGL, alsaLib, libav, cairo, freetype, pango, gdk-pixbuf, glib }:
 
 stdenv.mkDerivation rec {
-  version = "3.8.1";
+  version = "5.1";
   pname = "jabref";
 
   src = fetchurl {
-    url = "https://github.com/JabRef/jabref/releases/download/v${version}/JabRef-${version}.jar";
-    sha256 = "11asfym74zdq46i217z5n6vc79gylcx8xn7nvwacfqmym0bz79cg";
+    url = "https://github.com/JabRef/jabref/releases/download/v${version}/JabRef-${version}-portable_linux.tar.gz";
+    sha256 = "04f612byrq3agzy26byg1sgrjyhcpa8xfj0ssh8dl8d8vnhx9742";
   };
+
+  preferLocalBuild = true;
 
   desktopItem = makeDesktopItem {
     comment =  meta.description;
@@ -19,21 +22,44 @@ stdenv.mkDerivation rec {
     exec = "jabref";
   };
 
-  buildInputs = [ makeWrapper jdk wrapGAppsHook gtk3 gsettings-desktop-schemas ];
+  nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
+  buildInputs = [ gsettings-desktop-schemas ] ++ systemLibs;
 
-  dontUnpack = true;
+  systemLibs = [ gtk3 zlib libX11 libXext libXi libXrender libXtst libGL alsaLib libav cairo freetype pango gdk-pixbuf glib ];
+  systemLibPaths = stdenv.lib.makeLibraryPath systemLibs;
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/java $out/share/icons
+    mkdir -p $out/share/java $out/share/icons
+
+    cp -r lib $out/lib
+
+    for f in $out/lib/runtime/bin/j*; do
+      patchelf \
+        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${ stdenv.lib.makeLibraryPath [ zlib ]}:$out/lib/runtime/lib:$out/lib/runtime/lib/server" $f
+    done
+
+    for f in $out/lib/runtime/lib/*.so; do
+      patchelf \
+        --set-rpath "${systemLibPaths}:$out/lib/runtime/lib:$out/lib/runtime/lib/server" $f
+    done
+
+    # patching the libs in the JImage runtime image is quite impossible as there is no documented way
+    # of rebuilding the image after it has been extracted
+    # the image format itself is "intendedly not documented" - maybe one of the reasons the
+    # devolpers constantly broke "jimage recreate" and dropped it in OpenJDK 9 Build 116 Early Access
+    # so, for now just copy the image and provide our lib paths through the wrapper
+
+    makeWrapper $out/lib/runtime/bin/java $out/bin/jabref \
+      --add-flags '-Djava.library.path=${systemLibPaths}' --add-flags "-p $out/lib/app -m org.jabref/org.jabref.JabRefLauncher" \
+      --run 'export LD_LIBRARY_PATH=${systemLibPaths}:$LD_LIBRARY_PATH'
 
     cp -r ${desktopItem}/share/applications $out/share/
 
-    jar xf $src images/icons/JabRef-icon-mac.svg
-    cp images/icons/JabRef-icon-mac.svg $out/share/icons/jabref.svg
-
-    ln -s $src $out/share/java/jabref-${version}.jar
-    makeWrapper ${jre}/bin/java $out/bin/jabref \
-      --add-flags "-jar $out/share/java/jabref-${version}.jar"
+    # we still need to unpack the runtime image to get the icon
+    mkdir unpacked
+    $out/lib/runtime/bin/jimage extract --dir=./unpacked lib/runtime/lib/modules
+    cp unpacked/org.jabref/icons/jabref.svg $out/share/icons/jabref.svg
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

This still feels a bit hacky, so feel free to give it a try with `gradle2nix` and an `openjdk-14` sans `openjfx`. Meanwhile, this is a step forward to get this overdue version bump.

###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/86331
Closes https://github.com/NixOS/nixpkgs/issues/90850
Closes https://github.com/NixOS/nixpkgs/pull/72423/files

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
