### PR TITLE
Add bazel_git and protobuf-java packages

### DIFF
--- a/pkgs/development/libraries/protobuf/3.13-java.nix
+++ b/pkgs/development/libraries/protobuf/3.13-java.nix
@@ -1,0 +1,7 @@
+{ callPackage, protobuf, ... }:
+
+callPackage ./java-v3.nix {
+  version = "3.13.0";
+  sha256 = "1nqsvi2yfr93kiwlinz8z7c68ilg1j75b2vcpzxzvripxx5h6xhd";
+  inherit protobuf;
+}

--- a/pkgs/development/libraries/protobuf/java-v3.nix
+++ b/pkgs/development/libraries/protobuf/java-v3.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook, zlib, gmock, buildPackages
+, version, sha256
+, maven, protobuf
+, ...
+}:
+
+let
+mkProtobufDerivation = buildProtobuf: stdenv: stdenv.mkDerivation {
+  pname = "protobuf-java";
+  inherit version;
+
+  # make sure you test also -A pythonPackages.protobuf
+  src = fetchFromGitHub {
+    owner = "protocolbuffers";
+    repo = "protobuf";
+    rev = "v${version}";
+    inherit sha256;
+  };
+
+  # mvn -Dprotoc= doesn't override ant runner plugin vars
+  patches = [ ./protoc-java.patch ];
+
+  postPatch = ''
+    rm -rf gmock
+    cp -r ${gmock.src}/googlemock gmock
+    cp -r ${gmock.src}/googletest googletest
+    chmod -R a+w gmock
+    chmod -R a+w googletest
+    ln -s ../googletest gmock/gtest
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace src/google/protobuf/testing/googletest.cc \
+      --replace 'tmpnam(b)' '"'$TMPDIR'/foo"'
+  '';
+
+  buildPhase = ''
+    cd java
+    mkdir $TMPDIR/.m2
+    mvn -Dmaven.repo.local=$TMPDIR/.m2 -DskipTests -Dprotoc2=${protobuf}/bin/protoc package -pl core,util,lite
+  '';
+  installPhase = ''
+    mkdir $out
+     find . -name "*.jar" -exec cp '{}' $out/ \;
+  '';
+
+  nativeBuildInputs = [ maven protobuf ];
+
+  buildInputs = [ zlib ];
+  configureFlags = if buildProtobuf == null then [] else [ "--with-protoc=${buildProtobuf}/bin/protoc" ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  dontDisableStatic = true;
+
+  meta = {
+    description = "Google's data interchange format";
+    longDescription =
+      ''Protocol Buffers are a way of encoding structured data in an efficient
+        yet extensible format. Google uses Protocol Buffers for almost all of
+        its internal RPC protocols and file formats.
+      '';
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.unix;
+    homepage = "https://developers.google.com/protocol-buffers/";
+  };
+
+  passthru.version = version;
+};
+in mkProtobufDerivation(if (stdenv.buildPlatform != stdenv.hostPlatform)
+                        then (mkProtobufDerivation null buildPackages.stdenv)
+                        else null) stdenv

--- a/pkgs/development/libraries/protobuf/protoc-java.patch
+++ b/pkgs/development/libraries/protobuf/protoc-java.patch
@@ -1,0 +1,79 @@
+diff --git a/java/core/generate-sources-build.xml b/java/core/generate-sources-build.xml
+index 0996e5fff..d96246e71 100644
+--- a/java/core/generate-sources-build.xml
++++ b/java/core/generate-sources-build.xml
+@@ -1,7 +1,7 @@
+ <project name="generate-sources">
+     <echo message="Running protoc ..."/>
+     <mkdir dir="${generated.sources.dir}"/>
+-    <exec executable="${protoc}">
++    <exec executable="${protoc2}">
+         <arg value="--java_out=${generated.sources.dir}"/>
+         <arg value="--proto_path=${protobuf.source.dir}"/>
+         <arg value="${protobuf.source.dir}/google/protobuf/any.proto"/>
+@@ -17,4 +17,4 @@
+         <arg value="${protobuf.source.dir}/google/protobuf/wrappers.proto"/>
+         <arg value="${protobuf.source.dir}/google/protobuf/compiler/plugin.proto"/>
+     </exec>
+-</project>
+\ No newline at end of file
++</project>
+diff --git a/java/core/generate-test-sources-build.xml b/java/core/generate-test-sources-build.xml
+index 71a88d07b..fcba6b07d 100644
+--- a/java/core/generate-test-sources-build.xml
++++ b/java/core/generate-test-sources-build.xml
+@@ -1,6 +1,6 @@
+ <project name="generate-test-sources">
+     <mkdir dir="${generated.testsources.dir}"/>
+-    <exec executable="${protoc}">
++    <exec executable="${protoc2}">
+         <arg value="--java_out=${generated.testsources.dir}"/>
+         <arg value="--proto_path=${protobuf.source.dir}"/>
+         <arg value="--proto_path=${test.proto.dir}"/>
+@@ -51,7 +51,7 @@
+         <arg value="${test.proto.dir}/com/google/protobuf/wrappers_test.proto"/>
+     </exec>
+     <!-- Also generate some Lite protos needed for ExtensionRegistryFactoryTest -->
+-    <exec executable="${protoc}">
++    <exec executable="${protoc2}">
+         <arg value="--java_out=lite:${generated.testsources.dir}"/>
+         <arg value="--proto_path=${protobuf.source.dir}"/>
+         <arg value="--proto_path=${test.proto.dir}"/>
+diff --git a/java/lite/generate-sources-build.xml b/java/lite/generate-sources-build.xml
+index 74d96a2f1..1c54cbe0b 100644
+--- a/java/lite/generate-sources-build.xml
++++ b/java/lite/generate-sources-build.xml
+@@ -1,7 +1,7 @@
+ <project name="generate-sources">
+     <echo message="Running protoc ..."/>
+     <mkdir dir="${generated.sources.dir}"/>
+-    <exec executable="${protoc}">
++    <exec executable="${protoc2}">
+         <arg value="--java_out=lite:${generated.sources.dir}"/>
+         <arg value="--proto_path=${protobuf.source.dir}"/>
+         <arg value="${protobuf.source.dir}/google/protobuf/any.proto"/>
+diff --git a/java/lite/generate-test-sources-build.xml b/java/lite/generate-test-sources-build.xml
+index 62bca93c8..4a617235b 100644
+--- a/java/lite/generate-test-sources-build.xml
++++ b/java/lite/generate-test-sources-build.xml
+@@ -1,6 +1,6 @@
+ <project name="generate-test-sources">
+     <mkdir dir="${generated.testsources.dir}"/>
+-    <exec executable="${protoc}">
++    <exec executable="${protoc2}">
+         <arg value="--java_out=lite:${generated.testsources.dir}"/>
+         <arg value="--proto_path=${protobuf.source.dir}"/>
+         <arg value="--proto_path=${protobuf.basedir}/java/core/${test.proto.dir}"/>
+diff --git a/java/util/pom.xml b/java/util/pom.xml
+index 54dcc8690..ad5cf76e4 100644
+--- a/java/util/pom.xml
++++ b/java/util/pom.xml
+@@ -76,7 +76,7 @@
+                 <ant antfile="../core/generate-test-sources-build.xml"/>
+ 
+                 <!-- Generate additional test protos for this module -->
+-                <exec executable="${protoc}">
++                <exec executable="${protoc2}">
+                   <arg value="--java_out=${generated.testsources.dir}"/>
+                   <arg value="--proto_path=${protobuf.source.dir}"/>
+                   <arg value="--proto_path=src/test/proto"/>

--- a/pkgs/development/tools/build-managers/bazel/bazel_git/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_git/default.nix
@@ -1,0 +1,624 @@
+{ stdenv, callPackage, lib, fetchurl, fetchFromGitHub, installShellFiles
+, runCommand, runCommandCC, makeWrapper, recurseIntoAttrs
+# this package (through the fixpoint glass)
+, bazel_self
+# needed only for the updater
+, bazel_3, cacert
+, lr, xe, zip, unzip, bash, writeCBin, coreutils
+, which, gawk, gnused, gnutar, gnugrep, gzip, findutils
+# updater
+, python27, python3, writeScript
+# Apple dependencies
+, cctools, libcxx, CoreFoundation, CoreServices, Foundation
+# Allow to independently override the jdks used to build and run respectively
+, buildJdk, runJdk
+, buildJdkName
+, runtimeShell
+# Downstream packages for tests
+, bazel-watcher
+# Always assume all markers valid (this is needed because we remove markers; they are non-deterministic).
+# Also, don't clean up environment variables (so that NIX_ environment variables are passed to compilers).
+, enableNixHacks ? false
+, gcc-unwrapped
+, buildPackages
+, autoPatchelfHook
+, file
+, substituteAll
+, writeTextFile
+, protobuf
+, protobuf-java
+}:
+
+let
+  version = "3.9999";
+  commit = "259930228cfe505c015055b0cec62a406b488191";
+  sourceRoot = "bazel-${commit}";
+  patchFlags = "-p1";
+
+  src = fetchurl {
+    url = "https://github.com/bazelbuild/bazel/archive/${commit}.zip";
+    sha256 = "0c26jgd6l33hdlxblz92b9c9sagph3mh1swmyi3sh9cgimpbyd0p";
+  };
+
+  # Update with `eval $(nix-build -A bazel.updater)`,
+  # then add new dependencies from the dict in ./src-deps.json as required.
+  srcDeps = lib.attrsets.attrValues srcDepsSet;
+  srcDepsSet =
+    let
+      srcs = (builtins.fromJSON (builtins.readFile ./src-deps.json));
+      toFetchurl = d: lib.attrsets.nameValuePair d.name (fetchurl {
+        urls = d.urls;
+        sha256 = d.sha256;
+        });
+        in builtins.listToAttrs (map toFetchurl [
+      srcs.desugar_jdk_libs
+      srcs.io_bazel_skydoc
+      srcs.bazel_skylib
+      srcs.io_bazel_rules_sass
+      srcs.platforms
+      (if stdenv.hostPlatform.isDarwin
+       then srcs."java_tools_javac11_darwin-v10.1.zip"
+       else srcs."java_tools_javac11_linux-v10.1.zip")
+      srcs."coverage_output_generator-v2.5.zip"
+      srcs.build_bazel_rules_nodejs
+      srcs."android_tools_pkg-0.19.0rc3.tar.gz"
+      srcs."bazel-toolchains-3.1.0.tar.gz"
+      srcs.rules_pkg
+      srcs.rules_cc
+      srcs.rules_java
+      srcs.rules_proto
+      ]);
+
+  distDir = runCommand "bazel-deps" {} ''
+    mkdir -p $out
+    for i in ${builtins.toString srcDeps}; do cp $i $out/$(stripHash $i); done
+  '';
+
+  defaultShellPath = lib.makeBinPath
+    # Keep this list conservative. For more exotic tools, prefer to use
+    # @rules_nixpkgs to pull in tools from the nix repository. Example:
+    #
+    # WORKSPACE:
+    #
+    #     nixpkgs_git_repository(
+    #         name = "nixpkgs",
+    #         revision = "def5124ec8367efdba95a99523dd06d918cb0ae8",
+    #     )
+    #
+    #     # This defines an external Bazel workspace.
+    #     nixpkgs_package(
+    #         name = "bison",
+    #         repositories = { "nixpkgs": "@nixpkgs//:default.nix" },
+    #     )
+    #
+    # some/BUILD.bazel:
+    #
+    #     genrule(
+    #        ...
+    #        cmd = "$(location @bison//:bin/bison) -other -args",
+    #        tools = [
+    #            ...
+    #            "@bison//:bin/bison",
+    #        ],
+    #     )
+    #
+    [ bash coreutils findutils gawk gnugrep gnutar gnused gzip which unzip file zip ];
+
+  # Java toolchain used for the build and tests
+  javaToolchain = "@bazel_tools//tools/jdk:toolchain_host${buildJdkName}";
+
+  platforms = lib.platforms.linux ++ lib.platforms.darwin;
+
+  # This repository is fetched by bazel at runtime
+  # however it contains prebuilt java binaries, with wrong interpreter
+  # and libraries path.
+  # We prefetch it, patch it, and override it in a global bazelrc.
+  system = if stdenv.hostPlatform.isDarwin then "darwin" else "linux";
+  arch = stdenv.hostPlatform.parsed.cpu.name;
+
+  remote_java_tools = stdenv.mkDerivation {
+    name = "remote_java_tools_${system}";
+
+    src = srcDepsSet."java_tools_javac11_${system}-v10.1.zip";
+
+    nativeBuildInputs = [ autoPatchelfHook unzip ];
+    buildInputs = [ gcc-unwrapped ];
+
+    sourceRoot = ".";
+
+    buildPhase = ''
+      mkdir $out;
+    '';
+
+    installPhase = ''
+      cp -Ra * $out/
+      touch $out/WORKSPACE
+    '';
+  };
+
+  bazelRC = writeTextFile {
+    name = "bazel-rc";
+    text = ''
+      build --override_repository=${remote_java_tools.name}=${remote_java_tools}
+      build --distdir=${distDir}
+      startup --server_javabase=${runJdk}
+
+      # load default location for the system wide configuration
+      try-import /etc/bazel.bazelrc
+    '';
+  };
+
+in
+stdenv.mkDerivation rec {
+  pname = "bazel";
+  inherit version;
+
+  meta = with lib; {
+    homepage = "https://github.com/bazelbuild/bazel/";
+    description = "Build tool that builds code quickly and reliably";
+    license = licenses.asl20;
+    maintainers = [ maintainers.mboes ];
+    inherit platforms;
+  };
+
+  inherit src;
+  inherit sourceRoot;
+  inherit patchFlags;
+  patches = [
+    # On Darwin, the last argument to gcc is coming up as an empty string. i.e: ''
+    # This is breaking the build of any C target. This patch removes the last
+    # argument if it's found to be an empty string.
+    ../trim-last-argument-to-gcc-if-empty.patch
+
+    # --experimental_strict_action_env (which may one day become the default
+    # see bazelbuild/bazel#2574) hardcodes the default
+    # action environment to a non hermetic value (e.g. "/usr/local/bin").
+    # This is non hermetic on non-nixos systems. On NixOS, bazel cannot find the required binaries.
+    # So we are replacing this bazel paths by defaultShellPath,
+    # improving hermeticity and making it work in nixos.
+    (substituteAll {
+      src = ../strict_action_env.patch;
+      strictActionEnvPatch = defaultShellPath;
+    })
+
+    # bazel reads its system bazelrc in /etc
+    # override this path to a builtin one
+    (substituteAll {
+      src = ../bazel_rc.patch;
+      bazelSystemBazelRCPath = bazelRC;
+    })
+  ] ++ lib.optional enableNixHacks ../nix-hacks.patch;
+
+
+  # Additional tests that check bazel’s functionality. Execute
+  #
+  #     nix-build . -A bazel.tests
+  #
+  # in the nixpkgs checkout root to exercise them locally.
+  passthru.tests =
+    let
+      runLocal = name: attrs: script:
+      let
+        attrs' = removeAttrs attrs [ "buildInputs" ];
+        buildInputs = [ python3 ] ++ (attrs.buildInputs or []);
+      in
+      runCommandCC name ({
+        inherit buildInputs;
+        preferLocalBuild = true;
+        meta.platforms = platforms;
+      } // attrs') script;
+
+      # bazel wants to extract itself into $install_dir/install every time it runs,
+      # so let’s do that only once.
+      extracted = bazelPkg:
+        let install_dir =
+          # `install_base` field printed by `bazel info`, minus the hash.
+          # yes, this path is kinda magic. Sorry.
+          "$HOME/.cache/bazel/_bazel_nixbld";
+        in runLocal "bazel-extracted-homedir" { passthru.install_dir = install_dir; } ''
+            export HOME=$(mktemp -d)
+            touch WORKSPACE # yeah, everything sucks
+            install_base="$(${bazelPkg}/bin/bazel info | grep install_base)"
+            # assert it’s actually below install_dir
+            [[ "$install_base" =~ ${install_dir} ]] \
+              || (echo "oh no! $install_base but we are \
+            trying to copy ${install_dir} to $out instead!"; exit 1)
+            cp -R ${install_dir} $out
+          '';
+
+      bazelTest = { name, bazelScript, workspaceDir, bazelPkg, buildInputs ? [] }:
+        let
+          be = extracted bazelPkg;
+        in runLocal name { inherit buildInputs; } (
+          # skip extraction caching on Darwin, because nobody knows how Darwin works
+          (lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+            # set up home with pre-unpacked bazel
+            export HOME=$(mktemp -d)
+            mkdir -p ${be.install_dir}
+            cp -R ${be}/install ${be.install_dir}
+
+            # https://stackoverflow.com/questions/47775668/bazel-how-to-skip-corrupt-installation-on-centos6
+            # Bazel checks whether the mtime of the install dir files
+            # is >9 years in the future, otherwise it extracts itself again.
+            # see PosixFileMTime::IsUntampered in src/main/cpp/util
+            # What the hell bazel.
+            ${lr}/bin/lr -0 -U ${be.install_dir} | ${xe}/bin/xe -N0 -0 touch --date="9 years 6 months" {}
+          '')
+          +
+          ''
+            # Note https://github.com/bazelbuild/bazel/issues/5763#issuecomment-456374609
+            # about why to create a subdir for the workspace.
+            cp -r ${workspaceDir} wd && chmod u+w wd && cd wd
+
+            ${bazelScript}
+
+            touch $out
+          '');
+
+      bazelWithNixHacks = bazel_self.override { enableNixHacks = true; };
+
+      bazel-examples = fetchFromGitHub {
+        owner = "bazelbuild";
+        repo = "examples";
+        rev = "5d8c8961a2516ebf875787df35e98cadd08d43dc";
+        sha256 = "03c1bwlq5bs3hg96v4g4pg2vqwhqq6w538h66rcpw02f83yy7fs8";
+      };
+
+    in (if !stdenv.hostPlatform.isDarwin then {
+      # `extracted` doesn’t work on darwin
+      shebang = callPackage ../shebang-test.nix { inherit runLocal extracted bazelTest distDir; };
+    } else {}) // {
+      bashTools = callPackage ../bash-tools-test.nix { inherit runLocal bazelTest distDir; };
+      cpp = callPackage ../cpp-test.nix { inherit runLocal bazelTest bazel-examples distDir; };
+      java = callPackage ../java-test.nix { inherit runLocal bazelTest bazel-examples distDir; };
+      protobuf = callPackage ../protobuf-test.nix { inherit runLocal bazelTest distDir; };
+      pythonBinPath = callPackage ../python-bin-path-test.nix { inherit runLocal bazelTest distDir; };
+
+      bashToolsWithNixHacks = callPackage ../bash-tools-test.nix { inherit runLocal bazelTest distDir; bazel = bazelWithNixHacks; };
+
+      cppWithNixHacks = callPackage ../cpp-test.nix { inherit runLocal bazelTest bazel-examples distDir; bazel = bazelWithNixHacks; };
+      javaWithNixHacks = callPackage ../java-test.nix { inherit runLocal bazelTest bazel-examples distDir; bazel = bazelWithNixHacks; };
+      protobufWithNixHacks = callPackage ../protobuf-test.nix { inherit runLocal bazelTest distDir; bazel = bazelWithNixHacks; };
+      pythonBinPathWithNixHacks = callPackage ../python-bin-path-test.nix { inherit runLocal bazelTest distDir; bazel = bazelWithNixHacks; };
+
+      # downstream packages using buildBazelPackage
+      # fixed-output hashes of the fetch phase need to be spot-checked manually
+      downstream = recurseIntoAttrs ({
+        inherit bazel-watcher;
+      }
+          # dm-sonnet is only packaged for linux
+      // (lib.optionalAttrs stdenv.isLinux {
+          # TODO(timokau) dm-sonnet is broken currently
+          # dm-sonnet-linux = python3.pkgs.dm-sonnet;
+      }));
+    };
+
+  src_for_updater = stdenv.mkDerivation rec {
+    name = "updater-sources"; 
+    inherit src;
+    buildInputs = [ unzip ];
+    inherit sourceRoot;
+    installPhase = ''
+      cp -r . "$out"
+    '';
+  };
+  # update the list of workspace dependencies
+  passthru.updater = writeScript "update-bazel-deps.sh" ''
+    #!${runtimeShell}
+    (cd "${src_for_updater}" &&
+        BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \
+        "${bazel_3}"/bin/bazel \
+            query 'kind(http_archive, //external:all) + kind(http_file, //external:all) + kind(distdir_tar, //external:all) + kind(git_repository, //external:all)' \
+            --loading_phase_threads=1 \
+            --output build) \
+    | "${python3}"/bin/python3 "${./update-srcDeps.py}" \
+      "${builtins.toString ./src-deps.json}"
+  '';
+
+  # Necessary for the tests to pass on Darwin with sandbox enabled.
+  # Bazel starts a local server and needs to bind a local address.
+  __darwinAllowLocalNetworking = true;
+
+  # Bazel expects several utils to be available in Bash even without PATH. Hence this hack.
+  customBash = writeCBin "bash" ''
+    #include <stdio.h>
+    #include <stdlib.h>
+    #include <string.h>
+    #include <unistd.h>
+
+    extern char **environ;
+
+    int main(int argc, char *argv[]) {
+      char *path = getenv("PATH");
+      char *pathToAppend = "${defaultShellPath}";
+      char *newPath;
+      if (path != NULL) {
+        int length = strlen(path) + 1 + strlen(pathToAppend) + 1;
+        newPath = malloc(length * sizeof(char));
+        snprintf(newPath, length, "%s:%s", path, pathToAppend);
+      } else {
+        newPath = pathToAppend;
+      }
+      setenv("PATH", newPath, 1);
+      execve("${bash}/bin/bash", argv, environ);
+      return 0;
+    }
+  '';
+
+  postPatch = let
+
+    darwinPatches = ''
+      bazelLinkFlags () {
+        eval set -- "$NIX_LDFLAGS"
+        local flag
+        for flag in "$@"; do
+          printf ' -Wl,%s' "$flag"
+        done
+      }
+
+      # Disable Bazel's Xcode toolchain detection which would configure compilers
+      # and linkers from Xcode instead of from PATH
+      export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
+
+      # Explicitly configure gcov since we don't have it on Darwin, so autodetection fails
+      export GCOV=${coreutils}/bin/false
+
+      # Framework search paths aren't added by bintools hook
+      # https://github.com/NixOS/nixpkgs/pull/41914
+      export NIX_LDFLAGS+=" -F${CoreFoundation}/Library/Frameworks -F${CoreServices}/Library/Frameworks -F${Foundation}/Library/Frameworks"
+
+      # libcxx includes aren't added by libcxx hook
+      # https://github.com/NixOS/nixpkgs/pull/41589
+      export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${libcxx}/include/c++/v1"
+
+      # don't use system installed Xcode to run clang, use Nix clang instead
+      sed -i -E "s;/usr/bin/xcrun (--sdk macosx )?clang;${stdenv.cc}/bin/clang $NIX_CFLAGS_COMPILE $(bazelLinkFlags) -framework CoreFoundation;g" \
+        scripts/bootstrap/compile.sh \
+        src/tools/xcode/realpath/BUILD \
+        src/tools/xcode/stdredirect/BUILD \
+        tools/osx/BUILD
+
+      # nixpkgs's libSystem cannot use pthread headers directly, must import GCD headers instead
+      sed -i -e "/#include <pthread\/spawn.h>/i #include <dispatch/dispatch.h>" src/main/cpp/blaze_util_darwin.cc
+
+      # clang installed from Xcode has a compatibility wrapper that forwards
+      # invocations of gcc to clang, but vanilla clang doesn't
+      sed -i -e 's;_find_generic(repository_ctx, "gcc", "CC", overriden_tools);_find_generic(repository_ctx, "clang", "CC", overriden_tools);g' tools/cpp/unix_cc_configure.bzl
+
+      sed -i -e 's;/usr/bin/libtool;${cctools}/bin/libtool;g' tools/cpp/unix_cc_configure.bzl
+      wrappers=( tools/cpp/osx_cc_wrapper.sh tools/cpp/osx_cc_wrapper.sh.tpl )
+      for wrapper in "''${wrappers[@]}"; do
+        sed -i -e "s,/usr/bin/install_name_tool,${cctools}/bin/install_name_tool,g" $wrapper
+      done
+    '';
+
+    genericPatches = ''
+      # Substitute j2objc and objc wrapper's python shebang to plain python path.
+      # These scripts explicitly depend on Python 2.7, hence we use python27.
+      # See also `postFixup` where python27 is added to $out/nix-support
+      substituteInPlace tools/j2objc/j2objc_header_map.py --replace "$!/usr/bin/python2.7" "#!${python27}/bin/python"
+      substituteInPlace tools/j2objc/j2objc_wrapper.py --replace "$!/usr/bin/python2.7" "#!${python27}/bin/python"
+      substituteInPlace tools/objc/j2objc_dead_code_pruner.py --replace "$!/usr/bin/python2.7" "#!${python27}/bin/python"
+
+      # md5sum is part of coreutils
+      sed -i 's|/sbin/md5|md5sum|' \
+        src/BUILD
+
+      # replace initial value of pythonShebang variable in BazelPythonSemantics.java
+      substituteInPlace src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java \
+        --replace '"#!/usr/bin/env " + pythonExecutableName' "\"#!${python3}/bin/python\""
+
+      # substituteInPlace is rather slow, so prefilter the files with grep
+      grep -rlZ /bin src/main/java/com/google/devtools | while IFS="" read -r -d "" path; do
+        # If you add more replacements here, you must change the grep above!
+        # Only files containing /bin are taken into account.
+        # We default to python3 where possible. See also `postFixup` where
+        # python3 is added to $out/nix-support
+        substituteInPlace "$path" \
+          --replace /bin/bash ${customBash}/bin/bash \
+          --replace "/usr/bin/env bash" ${customBash}/bin/bash \
+          --replace "/usr/bin/env python" ${python3}/bin/python \
+          --replace /usr/bin/env ${coreutils}/bin/env \
+          --replace /bin/true ${coreutils}/bin/true
+      done
+
+      # bazel test runner include references to /bin/bash
+      substituteInPlace tools/build_rules/test_rules.bzl \
+        --replace /bin/bash ${customBash}/bin/bash
+
+      for i in $(find tools/cpp/ -type f)
+      do
+        substituteInPlace $i \
+          --replace /bin/bash ${customBash}/bin/bash
+      done
+
+      # Fixup scripts that generate scripts. Not fixed up by patchShebangs below.
+      substituteInPlace scripts/bootstrap/compile.sh \
+          --replace /bin/bash ${customBash}/bin/bash
+
+      # add nix environment vars to .bazelrc
+      cat >> .bazelrc <<EOF
+      # Limit the resources Bazel is allowed to use during the build to 1/2 the
+      # available RAM and 3/4 the available CPU cores. This should help avoid
+      # overwhelming the build machine.
+      build --local_ram_resources=HOST_RAM*.5
+      build --local_cpu_resources=HOST_CPUS*.75
+
+      build --distdir=${distDir}
+      fetch --distdir=${distDir}
+      build --copt="$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --copt="/g')"
+      build --host_copt="$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt="/g')"
+      build --linkopt="$(echo $(< ${stdenv.cc}/nix-support/libcxx-ldflags) | sed -e 's/ /" --linkopt="/g')"
+      build --host_linkopt="$(echo $(< ${stdenv.cc}/nix-support/libcxx-ldflags) | sed -e 's/ /" --host_linkopt="/g')"
+      build --linkopt="-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt="-Wl,/g')"
+      build --host_linkopt="-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt="-Wl,/g')"
+      build --host_javabase='@local_jdk//:jdk'
+      build --host_java_toolchain='${javaToolchain}'
+      EOF
+
+      # add the same environment vars to compile.sh
+      sed -e "/\$command \\\\$/a --copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --copt=\"/g')\" \\\\" \
+          -e "/\$command \\\\$/a --host_copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt=\"/g')\" \\\\" \
+          -e "/\$command \\\\$/a --linkopt=\"$(echo $(< ${stdenv.cc}/nix-support/libcxx-ldflags) | sed -e 's/ /" --linkopt=\"/g')\" \\\\" \
+          -e "/\$command \\\\$/a --host_linkopt=\"$(echo $(< ${stdenv.cc}/nix-support/libcxx-ldflags) | sed -e 's/ /" --host_linkopt=\"/g')\" \\\\" \
+          -e "/\$command \\\\$/a --linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt=\"-Wl,/g')\" \\\\" \
+          -e "/\$command \\\\$/a --host_linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt=\"-Wl,/g')\" \\\\" \
+          -e "/\$command \\\\$/a --host_javabase='@local_jdk//:jdk' \\\\" \
+          -e "/\$command \\\\$/a --host_java_toolchain='${javaToolchain}' \\\\" \
+          -i scripts/bootstrap/compile.sh
+
+      # This is necessary to avoid:
+      # "error: no visible @interface for 'NSDictionary' declares the selector
+      # 'initWithContentsOfURL:error:'"
+      # This can be removed when the apple_sdk is upgraded beyond 10.13+
+      sed -i '/initWithContentsOfURL:versionPlistUrl/ {
+        N
+        s/error:nil\];/\];/
+      }' tools/osx/xcode_locator.m
+
+      # append the PATH with defaultShellPath in tools/bash/runfiles/runfiles.bash
+      echo "PATH=\$PATH:${defaultShellPath}" >> runfiles.bash.tmp
+      cat tools/bash/runfiles/runfiles.bash >> runfiles.bash.tmp
+      mv runfiles.bash.tmp tools/bash/runfiles/runfiles.bash
+
+      patchShebangs .
+    '';
+    in lib.optionalString stdenv.hostPlatform.isDarwin darwinPatches
+     + genericPatches;
+
+  buildInputs = [
+    buildJdk
+    python3
+  ];
+
+  # when a command can’t be found in a bazel build, you might also
+  # need to add it to `defaultShellPath`.
+  nativeBuildInputs = [
+    installShellFiles
+    zip
+    python3
+    unzip
+    makeWrapper
+    which
+    customBash
+  ] ++ lib.optionals (stdenv.isDarwin) [ cctools libcxx CoreFoundation CoreServices Foundation ];
+
+  # Bazel makes extensive use of symlinks in the WORKSPACE.
+  # This causes problems with infinite symlinks if the build output is in the same location as the
+  # Bazel WORKSPACE. This is why before executing the build, the source code is moved into a
+  # subdirectory.
+  # Failing to do this causes "infinite symlink expansion detected"
+  preBuildPhases = ["preBuildPhase"];
+  preBuildPhase = ''
+    mkdir bazel_src
+    shopt -s dotglob extglob
+    mv !(bazel_src) bazel_src
+  '';
+  # Needed to build fish completion
+  propagatedBuildInputs = [ python3.pkgs.absl-py ];
+  buildPhase = ''
+    # Increasing memory during compilation might be necessary.
+    # export BAZEL_JAVAC_OPTS="-J-Xmx2g -J-Xms200m"
+
+    # Since we're building bazel from git sources, we need to
+    # provide protoc needed to generate some bootstrap sources
+    mkdir -p ./bazel_src/derived/jars
+    cp ${protobuf-java}/protobuf-{java,java-util}-[0-9]*.jar ./bazel_src/derived/jars/
+    export PROTOC="${protobuf}/bin/protoc"
+    ${buildPackages.stdenv.cc}/bin/g++ -I "${protobuf}/include" -L "${protobuf}/lib" -lpthread -lm -lprotoc -lprotobuf bazel_src/third_party/grpc/compiler/src/java_plugin/cpp/{java_generator.h,java_generator.cpp,java_plugin.cpp} -o grpc-java-plugin
+    export GRPC_JAVA_PLUGIN="$(pwd)"/grpc-java-plugin
+
+    # Release bazel uses "version-date (short_rev)" format.
+    # What we build from git isn't exactly a release version.
+    # So let's produce label similar but not in identical format.
+    # Note that our .bazelversion is 3.9999 as determined by
+    # bazel executable name.
+    local version="$(grep -m 1 '## Release' bazel_src/CHANGELOG.md \
+                       | sed -E 's|.*Release (.*) \(.*\)|\1|')"
+    export EMBED_LABEL="${version} ~=$version (@${commit})"
+    ${customBash}/bin/bash ./bazel_src/compile.sh
+    ./bazel_src/scripts/generate_bash_completion.sh \
+        --bazel=./bazel_src/output/bazel \
+        --output=./bazel_src/output/bazel-complete.bash \
+        --prepend=./bazel_src/scripts/bazel-complete-header.bash \
+        --prepend=./bazel_src/scripts/bazel-complete-template.bash
+    ${python3}/bin/python3 ./bazel_src/scripts/generate_fish_completion.py \
+        --bazel=./bazel_src/output/bazel \
+        --output=./bazel_src/output/bazel-complete.fish
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    # official wrapper scripts that searches for $WORKSPACE_ROOT/tools/bazel
+    # if it can’t find something in tools, it calls $out/bin/bazel-{version}-{os_arch}
+    # The binary _must_ exist with this naming if your project contains a .bazelversion
+    # file.
+    cp ./bazel_src/scripts/packages/bazel.sh $out/bin/bazel
+    mv ./bazel_src/output/bazel $out/bin/bazel-${version}-${system}-${arch}
+
+    # shell completion files
+    installShellCompletion --bash \
+      --name bazel.bash \
+      ./bazel_src/output/bazel-complete.bash
+    installShellCompletion --zsh \
+      --name _bazel \
+      ./bazel_src/scripts/zsh_completion/_bazel
+    installShellCompletion --fish \
+      --name bazel.fish \
+      ./bazel_src/output/bazel-complete.fish
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    export TEST_TMPDIR=$(pwd)
+
+    hello_test () {
+      $out/bin/bazel test --distdir=${distDir} \
+        --test_output=errors \
+        --java_toolchain='${javaToolchain}' \
+        examples/cpp:hello-success_test \
+        examples/java-native/src/test/java/com/example/myproject:hello
+    }
+
+    cd ./bazel_src
+
+    # test whether $WORKSPACE_ROOT/tools/bazel works
+
+    mkdir -p tools
+    cat > tools/bazel <<"EOF"
+    #!${runtimeShell} -e
+    exit 1
+    EOF
+    chmod +x tools/bazel
+
+    # first call should fail if tools/bazel is used
+    ! hello_test
+
+    cat > tools/bazel <<"EOF"
+    #!${runtimeShell} -e
+    exec "$BAZEL_REAL" "$@"
+    EOF
+
+    # second call succeeds because it defers to $out/bin/bazel-{version}-{os_arch}
+    hello_test
+  '';
+
+  # Save paths to hardcoded dependencies so Nix can detect them.
+  postFixup = ''
+    mkdir -p $out/nix-support
+    echo "${customBash} ${defaultShellPath}" >> $out/nix-support/depends
+    # The templates get tar’d up into a .jar,
+    # so nix can’t detect python is needed in the runtime closure
+    # Some of the scripts explicitly depend on Python 2.7. Otherwise, we
+    # default to using python3. Therefore, both python27 and python3 are
+    # runtime dependencies.
+    echo "${python27}" >> $out/nix-support/depends
+    echo "${python3}" >> $out/nix-support/depends
+  '' + lib.optionalString stdenv.isDarwin ''
+    echo "${cctools}" >> $out/nix-support/depends
+  '';
+
+  dontStrip = true;
+  dontPatchELF = true;
+}

--- a/pkgs/development/tools/build-managers/bazel/bazel_git/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_git/default.nix
@@ -294,7 +294,7 @@ stdenv.mkDerivation rec {
     };
 
   src_for_updater = stdenv.mkDerivation rec {
-    name = "updater-sources"; 
+    name = "updater-sources";
     inherit src;
     buildInputs = [ unzip ];
     inherit sourceRoot;

--- a/pkgs/development/tools/build-managers/bazel/bazel_git/src-deps.json
+++ b/pkgs/development/tools/build-managers/bazel/bazel_git/src-deps.json
@@ -1,0 +1,1452 @@
+{
+    "1.25.0.zip": {
+        "name": "1.25.0.zip",
+        "sha256": "c78be58f5e0a29a04686b628cf54faaee0094322ae0ac99da5a8a8afca59a647",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.25.0.zip",
+            "https://github.com/bazelbuild/rules_sass/archive/1.25.0.zip"
+        ]
+    },
+    "1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz": {
+        "name": "1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz",
+        "sha256": "5a725b777976b77aa122b707d1b6f0f39b6020f66cd427bb111a585599c857b1",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/archive/1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz",
+            "https://github.com/bazelbuild/stardoc/archive/1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz"
+        ]
+    },
+    "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": {
+        "name": "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
+        "sha256": "c00ceec469dbcf7929972e3c79f20c14033824538038a554952f5c31d8832f96",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/archive/2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz"
+        ]
+    },
+    "382d5afc60e05470c23e8de19b19fc5ad231e732.tar.gz": {
+        "name": "382d5afc60e05470c23e8de19b19fc5ad231e732.tar.gz",
+        "sha256": "7992217989f3156f8109931c1fc6db3434b7414957cb82371552377beaeb9d6c",
+        "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/upb/archive/382d5afc60e05470c23e8de19b19fc5ad231e732.tar.gz",
+            "https://github.com/protocolbuffers/upb/archive/382d5afc60e05470c23e8de19b19fc5ad231e732.tar.gz"
+        ]
+    },
+    "46993efdd33b73649796c5fc5c9efb193ae19d51.zip": {
+        "name": "46993efdd33b73649796c5fc5c9efb193ae19d51.zip",
+        "sha256": "66184688debeeefcc2a16a2f80b03f514deac8346fe888fb7e691a52c023dd88",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/archive/46993efdd33b73649796c5fc5c9efb193ae19d51.zip",
+            "https://github.com/bazelbuild/platforms/archive/46993efdd33b73649796c5fc5c9efb193ae19d51.zip"
+        ]
+    },
+    "7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip": {
+        "name": "7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+        "sha256": "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+            "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip"
+        ]
+    },
+    "8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0.zip": {
+        "name": "8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0.zip",
+        "sha256": "1d4dbbd1e1e9b57d40bb0ade51c9e882da7658d5bfbf22bbd15b68e7879d761f",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0.zip",
+            "https://github.com/bazelbuild/rules_cc/archive/8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0.zip"
+        ]
+    },
+    "97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz": {
+        "name": "97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        "sha256": "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+            "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz"
+        ]
+    },
+    "aecba11114cf1fac5497aeb844b6966106de3eb6.tar.gz": {
+        "name": "aecba11114cf1fac5497aeb844b6966106de3eb6.tar.gz",
+        "sha256": "9f385e146410a8150b6f4cb1a57eab7ec806ced48d427554b1e754877ff26c3e",
+        "urls": [
+            "https://mirror.bazel.build/github.com/google/re2/archive/aecba11114cf1fac5497aeb844b6966106de3eb6.tar.gz",
+            "https://github.com/google/re2/archive/aecba11114cf1fac5497aeb844b6966106de3eb6.tar.gz"
+        ]
+    },
+    "android_tools": {
+        "name": "android_tools",
+        "sha256": "761e997a9055fe5e2b70aba8d64e78d4c2113feafaa8ac81909cb63e403f3087",
+        "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc1.tar.gz"
+    },
+    "android_tools_for_testing": {
+        "name": "android_tools_for_testing",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "ea5c0589a01e2a9f43c20e5c145d3530e3b3bdbe7322789bc5da38d0ca49b837",
+        "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc3.tar.gz"
+    },
+    "android_tools_pkg-0.19.0rc3.tar.gz": {
+        "name": "android_tools_pkg-0.19.0rc3.tar.gz",
+        "sha256": "ea5c0589a01e2a9f43c20e5c145d3530e3b3bdbe7322789bc5da38d0ca49b837",
+        "urls": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc3.tar.gz"
+        ]
+    },
+    "bazel-toolchains-3.1.0.tar.gz": {
+        "name": "bazel-toolchains-3.1.0.tar.gz",
+        "sha256": "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz"
+        ]
+    },
+    "bazel_j2objc": {
+        "name": "bazel_j2objc",
+        "sha256": "8d3403b5b7db57e347c943d214577f6879e5b175c2b59b7e075c0b6453330e9b",
+        "strip_prefix": "j2objc-2.5",
+        "urls": [
+            "https://mirror.bazel.build/github.com/google/j2objc/releases/download/2.5/j2objc-2.5.zip",
+            "https://github.com/google/j2objc/releases/download/2.5/j2objc-2.5.zip"
+        ]
+    },
+    "bazel_skylib": {
+        "name": "bazel_skylib",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "c00ceec469dbcf7929972e3c79f20c14033824538038a554952f5c31d8832f96",
+        "strip_prefix": "bazel-skylib-2d4c9528e0f453b5950eeaeac11d8d09f5a504d4",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/archive/2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz"
+        ]
+    },
+    "bazel_toolchains": {
+        "name": "bazel_toolchains",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
+        "strip_prefix": "bazel-toolchains-3.1.0",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz"
+        ]
+    },
+    "bazel_website": {
+        "build_file_content": "\nexports_files([\"_sass/style.scss\"])\n",
+        "name": "bazel_website",
+        "sha256": "a5f531dd1d62e6947dcfc279656ffc2fdf6f447c163914c5eabf7961b4cb6eb4",
+        "strip_prefix": "bazel-website-c174fa288aa079b68416d2ce2cc97268fa172f42",
+        "urls": [
+            "https://github.com/bazelbuild/bazel-website/archive/c174fa288aa079b68416d2ce2cc97268fa172f42.tar.gz"
+        ]
+    },
+    "boringssl": {
+        "generator_function": "grpc_deps",
+        "generator_name": "boringssl",
+        "name": "boringssl",
+        "sha256": "81333e496d7b74a60aa6fa622c028ba382a0a6b9c815cc6ccb221042383b9a9b",
+        "strip_prefix": "boringssl-412844d75b14b9090b58423fd5f5ed8c2fd80212",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/boringssl/archive/412844d75b14b9090b58423fd5f5ed8c2fd80212.tar.gz",
+            "https://github.com/google/boringssl/archive/412844d75b14b9090b58423fd5f5ed8c2fd80212.tar.gz"
+        ]
+    },
+    "build_bazel_apple_support": {
+        "generator_function": "grpc_deps",
+        "generator_name": "build_bazel_apple_support",
+        "name": "build_bazel_apple_support",
+        "sha256": "122ebf7fe7d1c8e938af6aeaee0efe788a3a2449ece5a8d6a428cb18d6f88033",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/apple_support/releases/download/0.7.1/apple_support.0.7.1.tar.gz",
+            "https://github.com/bazelbuild/apple_support/releases/download/0.7.1/apple_support.0.7.1.tar.gz"
+        ]
+    },
+    "build_bazel_rules_apple": {
+        "generator_function": "grpc_deps",
+        "generator_name": "build_bazel_rules_apple",
+        "name": "build_bazel_rules_apple",
+        "sha256": "bdc8e66e70b8a75da23b79f1f8c6207356df07d041d96d2189add7ee0780cf4e",
+        "strip_prefix": "rules_apple-b869b0d3868d78a1d4ffd866ccb304fb68aa12c3",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_apple/archive/b869b0d3868d78a1d4ffd866ccb304fb68aa12c3.tar.gz",
+            "https://github.com/bazelbuild/rules_apple/archive/b869b0d3868d78a1d4ffd866ccb304fb68aa12c3.tar.gz"
+        ]
+    },
+    "build_bazel_rules_nodejs": {
+        "name": "build_bazel_rules_nodejs",
+        "sha256": "b6670f9f43faa66e3009488bbd909bc7bc46a5a9661a33f6bc578068d1837f37",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz",
+            "https://github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz"
+        ]
+    },
+    "com_github_cares_cares": {
+        "build_file": "@com_github_grpc_grpc//third_party:cares/cares.BUILD",
+        "generator_function": "grpc_deps",
+        "generator_name": "com_github_cares_cares",
+        "name": "com_github_cares_cares",
+        "sha256": "e8c2751ddc70fed9dc6f999acd92e232d5846f009ee1674f8aee81f19b2b915a",
+        "strip_prefix": "c-ares-e982924acee7f7313b4baa4ee5ec000c5e373c30",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/c-ares/c-ares/archive/e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz",
+            "https://github.com/c-ares/c-ares/archive/e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz"
+        ]
+    },
+    "com_github_gflags_gflags": {
+        "generator_function": "grpc_deps",
+        "generator_name": "com_github_gflags_gflags",
+        "name": "com_github_gflags_gflags",
+        "sha256": "63ae70ea3e05780f7547d03503a53de3a7d2d83ad1caaa443a31cb20aea28654",
+        "strip_prefix": "gflags-28f50e0fed19872e0fd50dd23ce2ee8cd759338e",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/gflags/gflags/archive/28f50e0fed19872e0fd50dd23ce2ee8cd759338e.tar.gz",
+            "https://github.com/gflags/gflags/archive/28f50e0fed19872e0fd50dd23ce2ee8cd759338e.tar.gz"
+        ]
+    },
+    "com_github_google_benchmark": {
+        "generator_function": "grpc_deps",
+        "generator_name": "com_github_google_benchmark",
+        "name": "com_github_google_benchmark",
+        "sha256": "f68aec93154d010324c05bcd8c5cc53468b87af88d87acb5ddcfaa1bba044837",
+        "strip_prefix": "benchmark-090faecb454fbd6e6e17a75ef8146acb037118d4",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/benchmark/archive/090faecb454fbd6e6e17a75ef8146acb037118d4.tar.gz",
+            "https://github.com/google/benchmark/archive/090faecb454fbd6e6e17a75ef8146acb037118d4.tar.gz"
+        ]
+    },
+    "com_github_google_re2": {
+        "generator_function": "grpc_deps",
+        "generator_name": "com_github_google_re2",
+        "name": "com_github_google_re2",
+        "sha256": "9f385e146410a8150b6f4cb1a57eab7ec806ced48d427554b1e754877ff26c3e",
+        "strip_prefix": "re2-aecba11114cf1fac5497aeb844b6966106de3eb6",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/re2/archive/aecba11114cf1fac5497aeb844b6966106de3eb6.tar.gz",
+            "https://github.com/google/re2/archive/aecba11114cf1fac5497aeb844b6966106de3eb6.tar.gz"
+        ]
+    },
+    "com_github_grpc_grpc": {
+        "name": "com_github_grpc_grpc",
+        "patch_args": [
+            "-p1"
+        ],
+        "patches": [
+            "//third_party/grpc:grpc_1.32.0.patch"
+        ],
+        "sha256": "f880ebeb2ccf0e47721526c10dd97469200e40b5f101a0d9774eb69efa0bd07a",
+        "strip_prefix": "grpc-1.32.0",
+        "urls": [
+            "https://github.com/grpc/grpc/archive/v1.32.0.tar.gz"
+        ]
+    },
+    "com_google_absl": {
+        "generator_function": "grpc_deps",
+        "generator_name": "com_google_absl",
+        "name": "com_google_absl",
+        "sha256": "f368a8476f4e2e0eccf8a7318b98dafbe30b2600f4e3cf52636e5eb145aba06a",
+        "strip_prefix": "abseil-cpp-df3ea785d8c30a9503321a3d35ee7d35808f190d",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
+            "https://github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz"
+        ]
+    },
+    "com_google_googletest": {
+        "name": "com_google_googletest",
+        "sha256": "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
+        "strip_prefix": "googletest-release-1.10.0",
+        "urls": [
+            "https://mirror.bazel.build/github.com/google/googletest/archive/release-1.10.0.tar.gz",
+            "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
+        ]
+    },
+    "com_google_protobuf": {
+        "name": "com_google_protobuf",
+        "patch_args": [
+            "-p1"
+        ],
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "patches": [
+            "//third_party/protobuf:3.13.0.patch"
+        ],
+        "sha256": "9b4ee22c250fe31b16f1a24d61467e40780a3fbb9b91c3b65be2a376ed913a1a",
+        "strip_prefix": "protobuf-3.13.0",
+        "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz"
+        ]
+    },
+    "coverage_output_generator-v2.5.zip": {
+        "name": "coverage_output_generator-v2.5.zip",
+        "sha256": "cd14f1cb4559e4723e63b7e7b06d09fcc3bd7ba58d03f354cdff1439bd936a7d",
+        "urls": [
+            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.5.zip"
+        ]
+    },
+    "cython": {
+        "build_file": "@com_github_grpc_grpc//third_party:cython.BUILD",
+        "generator_function": "grpc_deps",
+        "generator_name": "cython",
+        "name": "cython",
+        "sha256": "d68138a2381afbdd0876c3cb2a22389043fa01c4badede1228ee073032b07a27",
+        "strip_prefix": "cython-c2b80d87658a8525ce091cbe146cb7eaa29fed5c",
+        "urls": [
+            "https://github.com/cython/cython/archive/c2b80d87658a8525ce091cbe146cb7eaa29fed5c.tar.gz"
+        ]
+    },
+    "desugar_jdk_libs": {
+        "name": "desugar_jdk_libs",
+        "sha256": "fe2e04f91ce8c59d49d91b8102edc6627c6fa2906c1b0e7346f01419ec4f419d",
+        "strip_prefix": "desugar_jdk_libs-e0b0291b2c51fbe5a7cfa14473a1ae850f94f021",
+        "urls": [
+            "https://mirror.bazel.build/github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
+            "https://github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip"
+        ]
+    },
+    "df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz": {
+        "name": "df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
+        "sha256": "f368a8476f4e2e0eccf8a7318b98dafbe30b2600f4e3cf52636e5eb145aba06a",
+        "urls": [
+            "https://mirror.bazel.build/github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
+            "https://github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz"
+        ]
+    },
+    "e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip": {
+        "name": "e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
+        "sha256": "fe2e04f91ce8c59d49d91b8102edc6627c6fa2906c1b0e7346f01419ec4f419d",
+        "urls": [
+            "https://mirror.bazel.build/github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
+            "https://github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip"
+        ]
+    },
+    "e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz": {
+        "name": "e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz",
+        "sha256": "e8c2751ddc70fed9dc6f999acd92e232d5846f009ee1674f8aee81f19b2b915a",
+        "urls": [
+            "https://mirror.bazel.build/github.com/c-ares/c-ares/archive/e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz",
+            "https://github.com/c-ares/c-ares/archive/e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz"
+        ]
+    },
+    "enum34": {
+        "build_file": "@com_github_grpc_grpc//third_party:enum34.BUILD",
+        "generator_function": "grpc_deps",
+        "generator_name": "enum34",
+        "name": "enum34",
+        "sha256": "8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1",
+        "strip_prefix": "enum34-1.1.6",
+        "urls": [
+            "https://files.pythonhosted.org/packages/bf/3e/31d502c25302814a7c2f1d3959d2a3b3f78e509002ba91aea64993936876/enum34-1.1.6.tar.gz"
+        ]
+    },
+    "envoy_api": {
+        "generator_function": "grpc_deps",
+        "generator_name": "envoy_api",
+        "name": "envoy_api",
+        "sha256": "9150f920abd3e710e0e58519cd769822f13d7a56988f2c34c2008815ec8d9c88",
+        "strip_prefix": "data-plane-api-8dcc476be69437b505af181a6e8b167fdb101d7e",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/envoyproxy/data-plane-api/archive/8dcc476be69437b505af181a6e8b167fdb101d7e.tar.gz",
+            "https://github.com/envoyproxy/data-plane-api/archive/8dcc476be69437b505af181a6e8b167fdb101d7e.tar.gz"
+        ]
+    },
+    "futures": {
+        "build_file": "@com_github_grpc_grpc//third_party:futures.BUILD",
+        "generator_function": "grpc_deps",
+        "generator_name": "futures",
+        "name": "futures",
+        "sha256": "7e033af76a5e35f58e56da7a91e687706faf4e7bdfb2cbc3f2cca6b9bcda9794",
+        "strip_prefix": "futures-3.3.0",
+        "urls": [
+            "https://files.pythonhosted.org/packages/47/04/5fc6c74ad114032cd2c544c575bffc17582295e9cd6a851d6026ab4b2c00/futures-3.3.0.tar.gz"
+        ]
+    },
+    "io_bazel_rules_go": {
+        "generator_function": "grpc_deps",
+        "generator_name": "io_bazel_rules_go",
+        "name": "io_bazel_rules_go",
+        "sha256": "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz",
+            "https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz"
+        ]
+    },
+    "io_bazel_rules_python": {
+        "generator_function": "grpc_deps",
+        "generator_name": "io_bazel_rules_python",
+        "name": "io_bazel_rules_python",
+        "sha256": "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161",
+        "url": "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz"
+    },
+    "io_bazel_rules_sass": {
+        "name": "io_bazel_rules_sass",
+        "sha256": "c78be58f5e0a29a04686b628cf54faaee0094322ae0ac99da5a8a8afca59a647",
+        "strip_prefix": "rules_sass-1.25.0",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.25.0.zip",
+            "https://github.com/bazelbuild/rules_sass/archive/1.25.0.zip"
+        ]
+    },
+    "io_bazel_skydoc": {
+        "name": "io_bazel_skydoc",
+        "sha256": "5a725b777976b77aa122b707d1b6f0f39b6020f66cd427bb111a585599c857b1",
+        "strip_prefix": "stardoc-1ef781ced3b1443dca3ed05dec1989eca1a4e1cd",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/archive/1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz",
+            "https://github.com/bazelbuild/stardoc/archive/1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz"
+        ]
+    },
+    "io_opencensus_cpp": {
+        "generator_function": "grpc_deps",
+        "generator_name": "io_opencensus_cpp",
+        "name": "io_opencensus_cpp",
+        "sha256": "90d6fafa8b1a2ea613bf662731d3086e1c2ed286f458a95c81744df2dbae41b1",
+        "strip_prefix": "opencensus-cpp-c9a4da319bc669a772928ffc55af4a61be1a1176",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-cpp/archive/c9a4da319bc669a772928ffc55af4a61be1a1176.tar.gz",
+            "https://github.com/census-instrumentation/opencensus-cpp/archive/c9a4da319bc669a772928ffc55af4a61be1a1176.tar.gz"
+        ]
+    },
+    "java_tools_javac11_darwin-v10.1.zip": {
+        "name": "java_tools_javac11_darwin-v10.1.zip",
+        "sha256": "6a258df035a756eb721855980d6dbdb11ef818d9d293740dd9327f9e2b018bcf",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.1/java_tools_javac11_darwin-v10.1.zip"
+        ]
+    },
+    "java_tools_javac11_linux-v10.1.zip": {
+        "name": "java_tools_javac11_linux-v10.1.zip",
+        "sha256": "01e6912f7638c2ada1149fcf52979102c06982732a82044d925fc454d31998d8",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.1/java_tools_javac11_linux-v10.1.zip"
+        ]
+    },
+    "java_tools_javac11_windows-v10.1.zip": {
+        "name": "java_tools_javac11_windows-v10.1.zip",
+        "sha256": "48bda6ed98762de16cc25bb5d104fd1eacefc2b7c4470c72609a745c12b8870b",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.1/java_tools_javac11_windows-v10.1.zip"
+        ]
+    },
+    "java_tools_langtools_javac11": {
+        "name": "java_tools_langtools_javac11",
+        "sha256": "cf0814fa002ef3d794582bb086516d8c9ed0958f83f19799cdb08949019fe4c7",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk11_v2.zip"
+        ]
+    },
+    "jekyll_tree_0_17_1": {
+        "name": "jekyll_tree_0_17_1",
+        "sha256": "02256ddd20eeaf70cf8fcfe9b2cdddd7be87aedd5848d549474fb0358e0031d3",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.17.1.tar"
+        ]
+    },
+    "jekyll_tree_0_17_2": {
+        "name": "jekyll_tree_0_17_2",
+        "sha256": "13b35dd309a0d52f0a2518a1193f42729c75255f5fae40cea68e4d4224bfaa2e",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.17.2.tar"
+        ]
+    },
+    "jekyll_tree_0_18_1": {
+        "name": "jekyll_tree_0_18_1",
+        "sha256": "98b77f48e37a50fc6f83100bf53f661e10732bb3ddbc226e02d0225cb7a9a7d8",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.18.1.tar"
+        ]
+    },
+    "jekyll_tree_0_19_1": {
+        "name": "jekyll_tree_0_19_1",
+        "sha256": "ec892c59ba18bb8de1f9ae2bde937db144e45f28d6d1c32a2cee847ee81b134d",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.19.1.tar"
+        ]
+    },
+    "jekyll_tree_0_19_2": {
+        "name": "jekyll_tree_0_19_2",
+        "sha256": "3c2d9f21ec2fd1c0b8a310f6eb6043027c838810cdfc2457d4346a0e5cdcaa7a",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.19.2.tar"
+        ]
+    },
+    "jekyll_tree_0_20_0": {
+        "name": "jekyll_tree_0_20_0",
+        "sha256": "bb79a63810bf1b0aa1f89bd3bbbeb4a547a30ab9af70c9be656cc6866f4b015b",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.20.0.tar"
+        ]
+    },
+    "jekyll_tree_0_21_0": {
+        "name": "jekyll_tree_0_21_0",
+        "sha256": "23ec39c0138d358c544151e5c81586716d5d1c6124f10a742bead70516e6eb93",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.21.0.tar"
+        ]
+    },
+    "jekyll_tree_0_22_0": {
+        "name": "jekyll_tree_0_22_0",
+        "sha256": "bec5cfaa5560e082e41e33bde276cf93f0f7bcfd2914a3e868f921df8b3ab725",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.22.0.tar"
+        ]
+    },
+    "jekyll_tree_0_23_0": {
+        "name": "jekyll_tree_0_23_0",
+        "sha256": "56c80fcf49dc606fab8ed5e737a7409e9a486585b7b98673be69b5a4984dd774",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.23.0.tar"
+        ]
+    },
+    "jekyll_tree_0_24_0": {
+        "name": "jekyll_tree_0_24_0",
+        "sha256": "988fa567906a73e50d3669909285187ef88c76ecd4aa277f4d1f355fc06a90c8",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.24.0.tar"
+        ]
+    },
+    "jekyll_tree_0_25_0": {
+        "name": "jekyll_tree_0_25_0",
+        "sha256": "e8ab61c047225e808982a564ecd692fd63bd243dccc88a8768ed069a5362a685",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.25.0.tar"
+        ]
+    },
+    "jekyll_tree_0_26_0": {
+        "name": "jekyll_tree_0_26_0",
+        "sha256": "3907dfc6fb27d246e67877e553e8951fac239bb49f2dec7e06b6b09cb0b98b8d",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.26.0.tar"
+        ]
+    },
+    "jekyll_tree_0_27_0": {
+        "name": "jekyll_tree_0_27_0",
+        "sha256": "97e2633fefee389daade775da43907aa68699b32212f4e48cb095abe18aa7e65",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.27.0.tar"
+        ]
+    },
+    "jekyll_tree_0_28_0": {
+        "name": "jekyll_tree_0_28_0",
+        "sha256": "64b3fc267fb1f4c56345d96f0ad9f07a2efe43bd15361f818368849cf941b3b7",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.28.0.tar"
+        ]
+    },
+    "jekyll_tree_0_29_0": {
+        "name": "jekyll_tree_0_29_0",
+        "sha256": "99d7a6bf9ef0145c59c54b4319fb31cb855681782080a5490909c4a5463c7215",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.29.0.tar"
+        ]
+    },
+    "jekyll_tree_0_29_1": {
+        "name": "jekyll_tree_0_29_1",
+        "sha256": "cf0a517f1660a7c4fd26a7ef6f3594bbefcf2b670bc0ed610bf3bb6ec3a9fdc3",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.29.1.tar"
+        ]
+    },
+    "jekyll_tree_1_0_0": {
+        "name": "jekyll_tree_1_0_0",
+        "sha256": "61ef65c738a8cd65059f58f2ee5f7eef493136ac4d5e5c3464787d17043febdf",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-1.0.0.tar"
+        ]
+    },
+    "jekyll_tree_1_1_0": {
+        "name": "jekyll_tree_1_1_0",
+        "sha256": "46d82c9249896903ee6be2295fc52a1346a9ee82f61f89b8a2181232c3bd999b",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-1.1.0.tar"
+        ]
+    },
+    "jekyll_tree_1_2_0": {
+        "name": "jekyll_tree_1_2_0",
+        "sha256": "d402a8391ca2624673f124ff42ba8d0d40d4139e5d23111f3995dc6c5f70f63d",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-1.2.0.tar"
+        ]
+    },
+    "jekyll_tree_2_0_0": {
+        "name": "jekyll_tree_2_0_0",
+        "sha256": "7d7c424ede503856c61b645d8fdc2513ec6ea8600d76c5e87c45a9a45c16de3e",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-2.0.0.tar"
+        ]
+    },
+    "jekyll_tree_2_1_0": {
+        "name": "jekyll_tree_2_1_0",
+        "sha256": "b0fd257b1d6b1b05705742d55a13b9a20d3e99f49c89334750c872d620e5b88f",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-2.1.0.tar"
+        ]
+    },
+    "jekyll_tree_2_2_0": {
+        "name": "jekyll_tree_2_2_0",
+        "sha256": "4c1506786ab98df8039ec7354b82da7b586b2ae4ab7f7e7d08f3caf74ff28e3d",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-2.2.0.tar"
+        ]
+    },
+    "jekyll_tree_3_0_0": {
+        "name": "jekyll_tree_3_0_0",
+        "sha256": "bd1096ad609c253fa7b1473edf4a3aa51f36243e188dbb62c68d8ed4aca2419d",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-3.0.0.tar"
+        ]
+    },
+    "jekyll_tree_3_1_0": {
+        "name": "jekyll_tree_3_1_0",
+        "sha256": "f9d2e22e24af426d6c9de163d91abe6d8af7eb1eabb1d7ff5e9cf4bededf465a",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-3.1.0-807b377.tar"
+        ]
+    },
+    "jekyll_tree_3_2_0": {
+        "name": "jekyll_tree_3_2_0",
+        "sha256": "6cff8654e739a0c3062183a5a6cc82fcf9a77323051f8c007866d7f4101052a6",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-3.2.0.tar"
+        ]
+    },
+    "jekyll_tree_3_3_0": {
+        "name": "jekyll_tree_3_3_0",
+        "sha256": "36b81e8ddf4f3caccf41acc82d9e49f000c1be9e92c9cc82793d60ff70636176",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-3.3.0.tar"
+        ]
+    },
+    "jekyll_tree_3_4_0": {
+        "name": "jekyll_tree_3_4_0",
+        "sha256": "af82e775d911135bcff76e500bb003c4a9fccb949f8ddf4d93c58eca195bf5e8",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-3.4.0.tar"
+        ]
+    },
+    "jekyll_tree_3_5_0": {
+        "name": "jekyll_tree_3_5_0",
+        "sha256": "aa96cbad14cfab0b422d1d17eac3107a75eb05854d40ab4f1379a6fc87b2e1f8",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-3.5.0.tar"
+        ]
+    },
+    "jekyll_tree_3_5_1": {
+        "name": "jekyll_tree_3_5_1",
+        "sha256": "1c949ba8da353c93c74a70638e5cb321ea1cd5582eda1b6ad88c6d2d0b569f2f",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-3.5.1.tar"
+        ]
+    },
+    "jekyll_tree_3_6_0": {
+        "name": "jekyll_tree_3_6_0",
+        "sha256": "1b7a16a2098ca0c290c208a11db886e950d6c523b2cac2d0a0cba4a04aa832f3",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-3.6.0.tar"
+        ]
+    },
+    "jekyll_tree_3_7_0": {
+        "name": "jekyll_tree_3_7_0",
+        "sha256": "a534d37ef3867c92fae8692852f92820a34f63a5f9092bbbec6505c0f69d8094",
+        "urls": [
+            "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-3.7.0.tar"
+        ]
+    },
+    "openjdk11_darwin_archive": {
+        "build_file_content": "\njava_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])\nexports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])\n",
+        "name": "openjdk11_darwin_archive",
+        "sha256": "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",
+        "strip_prefix": "zulu11.37.17-ca-jdk11.0.6-macosx_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz"
+        ]
+    },
+    "openjdk11_linux_archive": {
+        "build_file_content": "\njava_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])\nexports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])\n",
+        "name": "openjdk11_linux_archive",
+        "sha256": "360626cc19063bc411bfed2914301b908a8f77a7919aaea007a977fa8fb3cde1",
+        "strip_prefix": "zulu11.37.17-ca-jdk11.0.6-linux_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz"
+        ]
+    },
+    "openjdk11_windows_archive": {
+        "build_file_content": "\njava_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])\nexports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])\n",
+        "name": "openjdk11_windows_archive",
+        "sha256": "a9695617b8374bfa171f166951214965b1d1d08f43218db9a2a780b71c665c18",
+        "strip_prefix": "zulu11.37.17-ca-jdk11.0.6-win_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64.zip"
+        ]
+    },
+    "openjdk14_darwin_archive": {
+        "build_file_content": "\njava_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])\nexports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])\n",
+        "name": "openjdk14_darwin_archive",
+        "sha256": "088bd4d0890acc9f032b738283bf0f26b2a55c50b02d1c8a12c451d8ddf080dd",
+        "strip_prefix": "zulu14.28.21-ca-jdk14.0.1-macosx_x64",
+        "urls": [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-macosx_x64.tar.gz"
+        ]
+    },
+    "openjdk14_linux_archive": {
+        "build_file_content": "\njava_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])\nexports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])\n",
+        "name": "openjdk14_linux_archive",
+        "sha256": "48bb8947034cd079ad1ef83335e7634db4b12a26743a0dc314b6b861480777aa",
+        "strip_prefix": "zulu14.28.21-ca-jdk14.0.1-linux_x64",
+        "urls": [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-linux_x64.tar.gz"
+        ]
+    },
+    "openjdk14_windows_archive": {
+        "build_file_content": "\njava_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])\nexports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])\n",
+        "name": "openjdk14_windows_archive",
+        "sha256": "9cb078b5026a900d61239c866161f0d9558ec759aa15c5b4c7e905370e868284",
+        "strip_prefix": "zulu14.28.21-ca-jdk14.0.1-win_x64",
+        "urls": [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-win_x64.zip"
+        ]
+    },
+    "openjdk15_darwin_archive": {
+        "build_file_content": "\njava_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])\nexports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])\n",
+        "name": "openjdk15_darwin_archive",
+        "sha256": "f80b2e0512d9d8a92be24497334c974bfecc8c898fc215ce0e76594f00437482",
+        "strip_prefix": "zulu15.27.17-ca-jdk15.0.0-macosx_x64",
+        "urls": [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-macosx_x64.tar.gz",
+            "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-macosx_x64.tar.gz"
+        ]
+    },
+    "openjdk15_linux_archive": {
+        "build_file_content": "\njava_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])\nexports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])\n",
+        "name": "openjdk15_linux_archive",
+        "sha256": "0a38f1138c15a4f243b75eb82f8ef40855afcc402e3c2a6de97ce8235011b1ad",
+        "strip_prefix": "zulu15.27.17-ca-jdk15.0.0-linux_x64",
+        "urls": [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz",
+            "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz"
+        ]
+    },
+    "openjdk15_windows_archive": {
+        "build_file_content": "\njava_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])\nexports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])\n",
+        "name": "openjdk15_windows_archive",
+        "sha256": "f535a530151e6c20de8a3078057e332b08887cb3ba1a4735717357e72765cad6",
+        "strip_prefix": "zulu15.27.17-ca-jdk15.0.0-win_x64",
+        "urls": [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-win_x64.zip",
+            "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-win_x64.zip"
+        ]
+    },
+    "openjdk_linux": {
+        "downloaded_file_path": "zulu-linux.tar.gz",
+        "name": "openjdk_linux",
+        "sha256": "65bfe4e0ffa74a680ee4410db46b17e30cd9397b664a92a886599fe1f3530969",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64-linux_x64-allmodules-b23d4e05466f2aa1fdcd72d3d3a8e962206b64bf-1581689070.tar.gz"
+        ]
+    },
+    "openjdk_linux_aarch64": {
+        "downloaded_file_path": "zulu-linux-aarch64.tar.gz",
+        "name": "openjdk_linux_aarch64",
+        "sha256": "6b245793087300db3ee82ab0d165614f193a73a60f2f011e347756c1e6ca5bac",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.48-ca-jdk11.0.6/zulu11.37.48-ca-jdk11.0.6-linux_aarch64-allmodules-b23d4e05466f2aa1fdcd72d3d3a8e962206b64bf-1581690750.tar.gz"
+        ]
+    },
+    "openjdk_linux_aarch64_minimal": {
+        "downloaded_file_path": "zulu-linux-aarch64-minimal.tar.gz",
+        "name": "openjdk_linux_aarch64_minimal",
+        "sha256": "06f6520a877704c77614bcfc4f846cc7cbcbf5eaad149bf7f19f4f16e285c9de",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.48-ca-jdk11.0.6/zulu11.37.48-ca-jdk11.0.6-linux_aarch64-minimal-b23d4e05466f2aa1fdcd72d3d3a8e962206b64bf-1581690750.tar.gz"
+        ]
+    },
+    "openjdk_linux_aarch64_vanilla": {
+        "downloaded_file_path": "zulu-linux-aarch64-vanilla.tar.gz",
+        "name": "openjdk_linux_aarch64_vanilla",
+        "sha256": "a452f1b9682d9f83c1c14e54d1446e1c51b5173a3a05dcb013d380f9508562e4",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.48-ca-jdk11.0.6/zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz"
+        ]
+    },
+    "openjdk_linux_minimal": {
+        "downloaded_file_path": "zulu-linux-minimal.tar.gz",
+        "name": "openjdk_linux_minimal",
+        "sha256": "91f7d52f695c681d4e21499b4319d548aadef249a6b3053e306308992e1e29ae",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64-minimal-b23d4e05466f2aa1fdcd72d3d3a8e962206b64bf-1581689068.tar.gz"
+        ]
+    },
+    "openjdk_linux_ppc64le_vanilla": {
+        "downloaded_file_path": "adoptopenjdk-ppc64le-vanilla.tar.gz",
+        "name": "openjdk_linux_ppc64le_vanilla",
+        "sha256": "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+            "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz"
+        ]
+    },
+    "openjdk_linux_s390x_vanilla": {
+        "downloaded_file_path": "adoptopenjdk-s390x-vanilla.tar.gz",
+        "name": "openjdk_linux_s390x_vanilla",
+        "sha256": "d9b72e87a1d3ebc0c9552f72ae5eb150fffc0298a7cb841f1ce7bfc70dcd1059",
+        "urls": [
+            "https://mirror.bazel.build/github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz",
+            "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz"
+        ]
+    },
+    "openjdk_linux_vanilla": {
+        "downloaded_file_path": "zulu-linux-vanilla.tar.gz",
+        "name": "openjdk_linux_vanilla",
+        "sha256": "360626cc19063bc411bfed2914301b908a8f77a7919aaea007a977fa8fb3cde1",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz"
+        ]
+    },
+    "openjdk_macos": {
+        "downloaded_file_path": "zulu-macos.tar.gz",
+        "name": "openjdk_macos",
+        "sha256": "8e283cfd23c7555be8e17295ed76eb8f00324c88ab904b8de37bbe08f90e569b",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64-allmodules-b23d4e05466f2aa1fdcd72d3d3a8e962206b64bf-1581689066.tar.gz"
+        ]
+    },
+    "openjdk_macos_minimal": {
+        "downloaded_file_path": "zulu-macos-minimal.tar.gz",
+        "name": "openjdk_macos_minimal",
+        "sha256": "1bacb1c07035d4066d79f0b65b4ea0ebd1954f3662bdfe3618da382ac8fd23a6",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64-minimal-b23d4e05466f2aa1fdcd72d3d3a8e962206b64bf-1581689063.tar.gz"
+        ]
+    },
+    "openjdk_macos_vanilla": {
+        "downloaded_file_path": "zulu-macos-vanilla.tar.gz",
+        "name": "openjdk_macos_vanilla",
+        "sha256": "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz"
+        ]
+    },
+    "openjdk_win": {
+        "downloaded_file_path": "zulu-win.zip",
+        "name": "openjdk_win",
+        "sha256": "8e1604b3a27dcf639bc6d1a73103f1211848139e4cceb081d0a74a99e1e6f995",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64-allmodules-b23d4e05466f2aa1fdcd72d3d3a8e962206b64bf-1581689080.zip"
+        ]
+    },
+    "openjdk_win_minimal": {
+        "downloaded_file_path": "zulu-win-minimal.zip",
+        "name": "openjdk_win_minimal",
+        "sha256": "b90a713c9c2d9ea23cad44d2c2dfcc9af22faba9bde55dedc1c3bb9f556ac1ae",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64-minimal-b23d4e05466f2aa1fdcd72d3d3a8e962206b64bf-1581689080.zip"
+        ]
+    },
+    "openjdk_win_vanilla": {
+        "downloaded_file_path": "zulu-win-vanilla.zip",
+        "name": "openjdk_win_vanilla",
+        "sha256": "a9695617b8374bfa171f166951214965b1d1d08f43218db9a2a780b71c665c18",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64.zip"
+        ]
+    },
+    "platforms": {
+        "name": "platforms",
+        "sha256": "66184688debeeefcc2a16a2f80b03f514deac8346fe888fb7e691a52c023dd88",
+        "strip_prefix": "platforms-46993efdd33b73649796c5fc5c9efb193ae19d51",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/archive/46993efdd33b73649796c5fc5c9efb193ae19d51.zip",
+            "https://github.com/bazelbuild/platforms/archive/46993efdd33b73649796c5fc5c9efb193ae19d51.zip"
+        ]
+    },
+    "remote_coverage_tools": {
+        "name": "remote_coverage_tools",
+        "sha256": "96ac6bc9b9fbc67b532bcae562da1642409791e6a4b8e522f04946ee5cc3ff8e",
+        "urls": [
+            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.1.zip"
+        ]
+    },
+    "remote_coverage_tools_for_testing": {
+        "name": "remote_coverage_tools_for_testing",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "cd14f1cb4559e4723e63b7e7b06d09fcc3bd7ba58d03f354cdff1439bd936a7d",
+        "urls": [
+            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.5.zip"
+        ]
+    },
+    "remote_java_tools_darwin": {
+        "generator_function": "maybe",
+        "generator_name": "remote_java_tools_darwin",
+        "name": "remote_java_tools_darwin",
+        "sha256": "e0291e8956ac295143da4a673ca50727f7376665ee82b649a4ee810b64ff76c1",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v8.0/java_tools_javac11_darwin-v8.0.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/javac11_v8.0/java_tools_javac11_darwin-v8.0.zip"
+        ]
+    },
+    "remote_java_tools_darwin_for_testing": {
+        "name": "remote_java_tools_darwin_for_testing",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "6a258df035a756eb721855980d6dbdb11ef818d9d293740dd9327f9e2b018bcf",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.1/java_tools_javac11_darwin-v10.1.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/javac11_v10.1/java_tools_javac11_darwin-v10.1.zip"
+        ]
+    },
+    "remote_java_tools_javac11_test_darwin": {
+        "name": "remote_java_tools_javac11_test_darwin",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "6a258df035a756eb721855980d6dbdb11ef818d9d293740dd9327f9e2b018bcf",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.1/java_tools_javac11_darwin-v10.1.zip"
+        ]
+    },
+    "remote_java_tools_javac11_test_linux": {
+        "name": "remote_java_tools_javac11_test_linux",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "01e6912f7638c2ada1149fcf52979102c06982732a82044d925fc454d31998d8",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.1/java_tools_javac11_linux-v10.1.zip"
+        ]
+    },
+    "remote_java_tools_javac11_test_windows": {
+        "name": "remote_java_tools_javac11_test_windows",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "48bda6ed98762de16cc25bb5d104fd1eacefc2b7c4470c72609a745c12b8870b",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.1/java_tools_javac11_windows-v10.1.zip"
+        ]
+    },
+    "remote_java_tools_linux": {
+        "generator_function": "maybe",
+        "generator_name": "remote_java_tools_linux",
+        "name": "remote_java_tools_linux",
+        "sha256": "c24aef916cc5a8e9f6d53db1f93c54fe5790a58996a1099592e1dfe992acc81e",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v8.0/java_tools_javac11_linux-v8.0.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/javac11_v8.0/java_tools_javac11_linux-v8.0.zip"
+        ]
+    },
+    "remote_java_tools_linux_for_testing": {
+        "name": "remote_java_tools_linux_for_testing",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "01e6912f7638c2ada1149fcf52979102c06982732a82044d925fc454d31998d8",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.1/java_tools_javac11_linux-v10.1.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/javac11_v10.1/java_tools_javac11_linux-v10.1.zip"
+        ]
+    },
+    "remote_java_tools_windows": {
+        "generator_function": "maybe",
+        "generator_name": "remote_java_tools_windows",
+        "name": "remote_java_tools_windows",
+        "sha256": "444c391977e50af4e10549a28d021069d2ca7745a0e7b9b968a7b153fe3ea430",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v8.0/java_tools_javac11_windows-v8.0.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/javac11_v8.0/java_tools_javac11_windows-v8.0.zip"
+        ]
+    },
+    "remote_java_tools_windows_for_testing": {
+        "name": "remote_java_tools_windows_for_testing",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "48bda6ed98762de16cc25bb5d104fd1eacefc2b7c4470c72609a745c12b8870b",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.1/java_tools_javac11_windows-v10.1.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/javac11_v10.1/java_tools_javac11_windows-v10.1.zip"
+        ]
+    },
+    "remotejdk11_linux": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "generator_function": "maybe",
+        "generator_name": "remotejdk11_linux",
+        "name": "remotejdk11_linux",
+        "sha256": "360626cc19063bc411bfed2914301b908a8f77a7919aaea007a977fa8fb3cde1",
+        "strip_prefix": "zulu11.37.17-ca-jdk11.0.6-linux_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz"
+        ]
+    },
+    "remotejdk11_linux_aarch64": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "generator_function": "maybe",
+        "generator_name": "remotejdk11_linux_aarch64",
+        "name": "remotejdk11_linux_aarch64",
+        "sha256": "a452f1b9682d9f83c1c14e54d1446e1c51b5173a3a05dcb013d380f9508562e4",
+        "strip_prefix": "zulu11.37.48-ca-jdk11.0.6-linux_aarch64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.48-ca-jdk11.0.6/zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz"
+        ]
+    },
+    "remotejdk11_linux_aarch64_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk11_linux_aarch64_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "a452f1b9682d9f83c1c14e54d1446e1c51b5173a3a05dcb013d380f9508562e4",
+        "strip_prefix": "zulu11.37.48-ca-jdk11.0.6-linux_aarch64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.48-ca-jdk11.0.6/zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz"
+        ]
+    },
+    "remotejdk11_linux_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk11_linux_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "360626cc19063bc411bfed2914301b908a8f77a7919aaea007a977fa8fb3cde1",
+        "strip_prefix": "zulu11.37.17-ca-jdk11.0.6-linux_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz"
+        ]
+    },
+    "remotejdk11_linux_ppc64le": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "generator_function": "maybe",
+        "generator_name": "remotejdk11_linux_ppc64le",
+        "name": "remotejdk11_linux_ppc64le",
+        "sha256": "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
+        "strip_prefix": "jdk-11.0.7+10",
+        "urls": [
+            "https://mirror.bazel.com/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+            "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz"
+        ]
+    },
+    "remotejdk11_linux_ppc64le_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk11_linux_ppc64le_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
+        "strip_prefix": "jdk-11.0.7+10",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+            "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz"
+        ]
+    },
+    "remotejdk11_linux_s390x_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk11_linux_s390x_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "d9b72e87a1d3ebc0c9552f72ae5eb150fffc0298a7cb841f1ce7bfc70dcd1059",
+        "strip_prefix": "jdk-11.0.7+10",
+        "urls": [
+            "https://mirror.bazel.build/github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz",
+            "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz"
+        ]
+    },
+    "remotejdk11_macos": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "generator_function": "maybe",
+        "generator_name": "remotejdk11_macos",
+        "name": "remotejdk11_macos",
+        "sha256": "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",
+        "strip_prefix": "zulu11.37.17-ca-jdk11.0.6-macosx_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz"
+        ]
+    },
+    "remotejdk11_macos_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk11_macos_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",
+        "strip_prefix": "zulu11.37.17-ca-jdk11.0.6-macosx_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz"
+        ]
+    },
+    "remotejdk11_win": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "generator_function": "maybe",
+        "generator_name": "remotejdk11_win",
+        "name": "remotejdk11_win",
+        "sha256": "a9695617b8374bfa171f166951214965b1d1d08f43218db9a2a780b71c665c18",
+        "strip_prefix": "zulu11.37.17-ca-jdk11.0.6-win_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64.zip"
+        ]
+    },
+    "remotejdk11_win_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk11_win_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "a9695617b8374bfa171f166951214965b1d1d08f43218db9a2a780b71c665c18",
+        "strip_prefix": "zulu11.37.17-ca-jdk11.0.6-win_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64.zip"
+        ]
+    },
+    "remotejdk14_linux_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk14_linux_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "48bb8947034cd079ad1ef83335e7634db4b12a26743a0dc314b6b861480777aa",
+        "strip_prefix": "zulu14.28.21-ca-jdk14.0.1-linux_x64",
+        "urls": [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-linux_x64.tar.gz"
+        ]
+    },
+    "remotejdk14_macos_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk14_macos_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "088bd4d0890acc9f032b738283bf0f26b2a55c50b02d1c8a12c451d8ddf080dd",
+        "strip_prefix": "zulu14.28.21-ca-jdk14.0.1-macosx_x64",
+        "urls": [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-macosx_x64.tar.gz"
+        ]
+    },
+    "remotejdk14_win_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk14_win_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "9cb078b5026a900d61239c866161f0d9558ec759aa15c5b4c7e905370e868284",
+        "strip_prefix": "zulu14.28.21-ca-jdk14.0.1-win_x64",
+        "urls": [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-win_x64.zip"
+        ]
+    },
+    "remotejdk15_linux_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk15_linux_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "0a38f1138c15a4f243b75eb82f8ef40855afcc402e3c2a6de97ce8235011b1ad",
+        "strip_prefix": "zulu15.27.17-ca-jdk15.0.0-linux_x64",
+        "urls": [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz",
+            "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz"
+        ]
+    },
+    "remotejdk15_macos_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk15_macos_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "f80b2e0512d9d8a92be24497334c974bfecc8c898fc215ce0e76594f00437482",
+        "strip_prefix": "zulu15.27.17-ca-jdk15.0.0-macosx_x64",
+        "urls": [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-macosx_x64.tar.gz",
+            "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-macosx_x64.tar.gz"
+        ]
+    },
+    "remotejdk15_win_for_testing": {
+        "build_file": "@local_jdk//:BUILD.bazel",
+        "name": "remotejdk15_win_for_testing",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "f535a530151e6c20de8a3078057e332b08887cb3ba1a4735717357e72765cad6",
+        "strip_prefix": "zulu15.27.17-ca-jdk15.0.0-win_x64",
+        "urls": [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-win_x64.zip",
+            "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-win_x64.zip"
+        ]
+    },
+    "rules_cc": {
+        "name": "rules_cc",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "1d4dbbd1e1e9b57d40bb0ade51c9e882da7658d5bfbf22bbd15b68e7879d761f",
+        "strip_prefix": "rules_cc-8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0.zip",
+            "https://github.com/bazelbuild/rules_cc/archive/8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0.zip"
+        ]
+    },
+    "rules_java": {
+        "name": "rules_java",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
+        "strip_prefix": "rules_java-7cf3cefd652008d0a64a419c34c13bdca6c8f178",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+            "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip"
+        ]
+    },
+    "rules_nodejs-1.3.0.tar.gz": {
+        "name": "rules_nodejs-1.3.0.tar.gz",
+        "sha256": "b6670f9f43faa66e3009488bbd909bc7bc46a5a9661a33f6bc578068d1837f37",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz",
+            "https://github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz"
+        ]
+    },
+    "rules_pkg": {
+        "name": "rules_pkg",
+        "patch_cmds": [
+            "test -f BUILD && chmod u+w BUILD || true",
+            "echo >> BUILD",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "4ba8f4ab0ff85f2484287ab06c0d871dcb31cc54d439457d28fd4ae14b18450a",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.2.4/rules_pkg-0.2.4.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.4/rules_pkg-0.2.4.tar.gz"
+        ]
+    },
+    "rules_pkg-0.2.4.tar.gz": {
+        "name": "rules_pkg-0.2.4.tar.gz",
+        "sha256": "4ba8f4ab0ff85f2484287ab06c0d871dcb31cc54d439457d28fd4ae14b18450a",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.2.4/rules_pkg-0.2.4.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.4/rules_pkg-0.2.4.tar.gz"
+        ]
+    },
+    "rules_proto": {
+        "name": "rules_proto",
+        "patch_cmds": [
+            "test -f BUILD.bazel && chmod u+w BUILD.bazel || true",
+            "echo >> BUILD.bazel",
+            "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD.bazel"
+        ],
+        "patch_cmds_win": [
+            "Add-Content -Path BUILD.bazel -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force"
+        ],
+        "sha256": "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
+        "strip_prefix": "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+            "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz"
+        ]
+    },
+    "six": {
+        "build_file": "@com_github_grpc_grpc//third_party:six.BUILD",
+        "generator_function": "grpc_deps",
+        "generator_name": "six",
+        "name": "six",
+        "sha256": "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73",
+        "urls": [
+            "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz"
+        ]
+    },
+    "upb": {
+        "generator_function": "grpc_deps",
+        "generator_name": "upb",
+        "name": "upb",
+        "sha256": "7992217989f3156f8109931c1fc6db3434b7414957cb82371552377beaeb9d6c",
+        "strip_prefix": "upb-382d5afc60e05470c23e8de19b19fc5ad231e732",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/protocolbuffers/upb/archive/382d5afc60e05470c23e8de19b19fc5ad231e732.tar.gz",
+            "https://github.com/protocolbuffers/upb/archive/382d5afc60e05470c23e8de19b19fc5ad231e732.tar.gz"
+        ]
+    },
+    "v1.32.0.tar.gz": {
+        "name": "v1.32.0.tar.gz",
+        "sha256": "f880ebeb2ccf0e47721526c10dd97469200e40b5f101a0d9774eb69efa0bd07a",
+        "urls": [
+            "https://github.com/grpc/grpc/archive/v1.32.0.tar.gz"
+        ]
+    },
+    "v3.13.0.tar.gz": {
+        "name": "v3.13.0.tar.gz",
+        "sha256": "9b4ee22c250fe31b16f1a24d61467e40780a3fbb9b91c3b65be2a376ed913a1a",
+        "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz"
+        ]
+    },
+    "zlib": {
+        "build_file": "@com_github_grpc_grpc//third_party:zlib.BUILD",
+        "generator_function": "grpc_deps",
+        "generator_name": "zlib",
+        "name": "zlib",
+        "sha256": "6d4d6640ca3121620995ee255945161821218752b551a1a180f4215f7d124d45",
+        "strip_prefix": "zlib-cacf7f1d4e3d44d871b605da3b647f07d718623f",
+        "urls": [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/madler/zlib/archive/cacf7f1d4e3d44d871b605da3b647f07d718623f.tar.gz",
+            "https://github.com/madler/zlib/archive/cacf7f1d4e3d44d871b605da3b647f07d718623f.tar.gz"
+        ]
+    },
+    "zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz": {
+        "name": "zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz",
+        "sha256": "360626cc19063bc411bfed2914301b908a8f77a7919aaea007a977fa8fb3cde1",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz"
+        ]
+    },
+    "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz": {
+        "name": "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz",
+        "sha256": "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz"
+        ]
+    },
+    "zulu11.37.17-ca-jdk11.0.6-win_x64.zip": {
+        "name": "zulu11.37.17-ca-jdk11.0.6-win_x64.zip",
+        "sha256": "a9695617b8374bfa171f166951214965b1d1d08f43218db9a2a780b71c665c18",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64.zip"
+        ]
+    },
+    "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz": {
+        "name": "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz",
+        "sha256": "a452f1b9682d9f83c1c14e54d1446e1c51b5173a3a05dcb013d380f9508562e4",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.37.48-ca-jdk11.0.6/zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz"
+        ]
+    }
+}

--- a/pkgs/development/tools/build-managers/bazel/bazel_git/update-srcDeps.py
+++ b/pkgs/development/tools/build-managers/bazel/bazel_git/update-srcDeps.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import sys
+import json
+
+if len(sys.argv) != 2:
+    print("usage: ./this-script src-deps.json < WORKSPACE", file=sys.stderr)
+    print("Takes the bazel WORKSPACE file and reads all archives into a json dict (by evaling it as python code)", file=sys.stderr)
+    print("Hail Eris.", file=sys.stderr)
+    sys.exit(1)
+
+http_archives = []
+
+# just the kw args are the dict { name, sha256, urls … }
+def http_archive(**kw):
+    http_archives.append(kw)
+# like http_file
+def http_file(**kw):
+    http_archives.append(kw)
+
+# this is inverted from http_archive/http_file and bundles multiple archives
+def distdir_tar(**kw):
+    for archive_name in kw['archives']:
+        http_archives.append({
+            "name": archive_name,
+            "sha256": kw['sha256'][archive_name],
+            "urls": kw['urls'][archive_name]
+        })
+
+# TODO?
+def git_repository(**kw):
+    print(json.dumps(kw, sort_keys=True, indent=4), file=sys.stderr)
+    sys.exit(1)
+
+# execute the WORKSPACE like it was python code in this module,
+# using all the function stubs from above.
+exec(sys.stdin.read())
+
+# transform to a dict with the names as keys
+d = { el['name']: el for el in http_archives }
+
+def has_urls(el):
+    return ('url' in el and el['url']) or ('urls' in el and el['urls'])
+def has_sha256(el):
+    return 'sha256' in el and el['sha256']
+bad_archives = list(filter(lambda el: not has_urls(el) or not has_sha256(el), d.values()))
+if bad_archives:
+    print('Following bazel dependencies are missing url or sha256', file=sys.stderr)
+    print('Check bazel sources for master or non-checksummed dependencies', file=sys.stderr)
+    for el in bad_archives:
+        print(json.dumps(el, sort_keys=True, indent=4), file=sys.stderr)
+    sys.exit(1)
+
+with open(sys.argv[1], "w") as f:
+    print(json.dumps(d, sort_keys=True, indent=4), file=f)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10675,6 +10675,16 @@ in
     bazel_self = bazel_3;
   };
 
+  bazel_git = callPackage ../development/tools/build-managers/bazel/bazel_git {
+    inherit (darwin) cctools;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation CoreServices Foundation;
+    buildJdk = jdk8_headless;
+    buildJdkName = "jdk8";
+    runJdk = jdk11_headless;
+    stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
+    bazel_self = bazel_git;
+  };
+
   bazel-buildtools = callPackage ../development/tools/build-managers/bazel/buildtools { };
   buildifier = bazel-buildtools;
   buildozer = bazel-buildtools;
@@ -14929,7 +14939,9 @@ in
   };
 
   protobuf = protobuf3_13;
+  protobuf-java = protobuf-java3_13;
 
+  protobuf-java3_13 = callPackage ../development/libraries/protobuf/3.13-java.nix { };
   protobuf3_13 = callPackage ../development/libraries/protobuf/3.13.nix { };
   protobuf3_12 = callPackage ../development/libraries/protobuf/3.12.nix { };
   protobuf3_11 = callPackage ../development/libraries/protobuf/3.11.nix { };


### PR DESCRIPTION
bazel_git is built from fixed recent git sources.

There are several bootstrap options
https://docs.bazel.build/versions/master/install-compile-source.html
- use release dist sources and compile without bazel installed
- use git sources and compile with some bazel version
- use git sources and supply extra bootstrap jars&tools

We could compile with stable versions but this can cause more
expensive rebuilds and we can't expand same compile method to
all bazel versions in nixpkgs.

Few extra changes that were needed to make bootstrap compilation work:
- provide protobuf-java package
- change update-srcDeps to depend on "bazel query" output as newer
  versions have more complex dependencies setup with quite some Starlark
  involved
- don't rewrite src-deps.json on update-srcDeps.py errors

Notes:
- bazel version is set to 3.9999, which makes sense because there's
  no single version yet, similar to say 3.7.0-SNAPSHOT but keeping
  the numeric format. This may affect .bazelversion or version_check()
- hopefully we can bump bazel_3 to 3.8.0 once that release is
  available. Versions 3.4 to 3.7.0 have issues with dependencies
  without sha256 or even @master dependencies
- we can also switch release versions compilation to same bootstrap
  process not relying on dist archives. Potentially may introduce
  differences from binary releases, but we'd be testing full bootstrap
  and rely on git sources.
- "bazel version" reports
  Build label: 3.9999 ~=3.7.0 (@259930228cfe505c015055b0cec62a406b4881910)
  bazel_3 output is
  Build label: 3.3.1- (@non-git)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
