### PR TITLE
mediatomb: Allow users to customize duktape/js script imports

### DIFF
--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -65,6 +65,14 @@ let
     </transcoding>
 '';
 
+  virtualLayout =
+    let toCustomImportScript = import-script-path: "<import-script>${import-script-path}</import-script>\n";
+    in if ((builtins.length cfg.customImportJS) > 0) then ''
+        <virtual-layout type="js">${concatMapStrings toCustomImportScript cfg.customImportJS}</virtual-layout>
+      '' else ''
+        <virtual-layout type="builtin"><import-script>${pkg}/share/${name}/js/import.js</import-script></virtual-layout>
+      '';
+
   configText = optionalString (! cfg.customCfg) ''
 <?xml version="1.0" encoding="UTF-8"?>
 <config version="2" xmlns="http://mediatomb.cc/config/2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://mediatomb.cc/config/2 http://mediatomb.cc/config/2.xsd">
@@ -113,9 +121,7 @@ let
       <scripting script-charset="UTF-8">
         <common-script>${pkg}/share/${name}/js/common.js</common-script>
         <playlist-script>${pkg}/share/${name}/js/playlists.js</playlist-script>
-        <virtual-layout type="builtin">
-          <import-script>${pkg}/share/${name}/js/import.js</import-script>
-        </virtual-layout>
+        ${virtualLayout}
       </scripting>
       <mappings>
         <extension-mimetype ignore-unknown="no">
@@ -332,6 +338,18 @@ in {
         example = [
           { path = "/data/pictures"; recursive = false; hidden-files = false; }
           { path = "/data/audio"; recursive = true; hidden-files = false; }
+        ];
+      };
+
+      customImportJS = mkOption {
+        type = with types; listOf path;
+        default = [];
+        description = ''
+          A list of user customized javascript files to import. If unspecified,
+          the default, this uses the default builtin engine.
+        '';
+        example = [
+          ./import.js
         ];
       };
 


### PR DESCRIPTION
# Motivation

With no customization, the default behavior is kept (virtual-layout using the
builtin engine with the default import.js provided by gerbera).

This allows user to develop and provide their own list of customized
duktape/javascript scripts [1]

[1] http://docs.gerbera.io/en/latest/scripting.html

# Actions

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS: odroid [2]
   - [ ] macOS
   - [x] other Linux distributions: debian with nix
- [x] Tested via one or more NixOS test(s) [3]
- [x] nixpkgs-review wip [4]
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

[2] https://gitlab.com/ardumont/nixos/-/blob/master/odroid/mediatomb/default.nix#L24

[3]
```
$ cd nixos/tests
$ nix-build mediatomb.nix
...
(0.60 seconds)
(13.88 seconds)
test script finished in 13.88s
cleaning up
(0.00 seconds)
/nix/store/pd3wqv8pxjn2fd6r0fv592cz20a5x38x-vm-test-run-mediatomb
```

[4]
```
$ nixpkgs-review wip
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 29, done.
remote: Counting objects: 100% (29/29), done.
remote: Total 49 (delta 29), reused 29 (delta 29), pack-reused 20
Unpacking objects: 100% (49/49), 48.46 KiB | 431.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   7c4305be84a..02daf3f0768  master     -> refs/nixpkgs-review/0
$ git worktree add /home/tony/.cache/nixpkgs-review/rev-7c389b0c3ff80affc676793e0f17c8f7dfb1a670-dirty/nixpkgs 02daf3f07688e89d41bbcafca3788edf648a6b31
Preparing worktree (detached HEAD 02daf3f0768)
Updating files: 100% (22980/22980), done.
HEAD is now at 02daf3f0768 Merge pull request #101284 from r-ryantm/auto-update/bdf2psf
$ nix-env -f /home/tony/.cache/nixpkgs-review/rev-7c389b0c3ff80affc676793e0f17c8f7dfb1a670-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune

nixpkgs-review pr 101296
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0 pull/101296/head:refs/nixpkgs-review/1
From https://github.com/NixOS/nixpkgs
   37d6d5a32c8..7c389b0c3ff  refs/pull/101296/head -> refs/nixpkgs-review/1
$ git worktree add /home/tony/.cache/nixpkgs-review/pr-101296/nixpkgs 02daf3f07688e89d41bbcafca3788edf648a6b31
Preparing worktree (detached HEAD 02daf3f0768)
Updating files: 100% (22980/22980), done.
HEAD is now at 02daf3f0768 Merge pull request #101284 from r-ryantm/auto-update/bdf2psf
$ nix-env -f /home/tony/.cache/nixpkgs-review/pr-101296/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 7c389b0c3ff80affc676793e0f17c8f7dfb1a670
Automatic merge went well; stopped before committing as requested
$ nix-env -f /home/tony/.cache/nixpkgs-review/pr-101296/nixpkgs -qaP --xml --out-path --show-trace --meta
Nothing to be built.
https://github.com/NixOS/nixpkgs/pull/101296
$ nix-shell /home/tony/.cache/nixpkgs-review/pr-101296/shell.nix

[nix-shell:~/.cache/nixpkgs-review/pr-101296]$ exit
$ git worktree prune
```
