### PR TITLE
rspamd: add passthru.tests

### DIFF
--- a/pkgs/servers/mail/rspamd/default.nix
+++ b/pkgs/servers/mail/rspamd/default.nix
@@ -4,6 +4,7 @@
 , withBlas ? true
 , withHyperscan ? stdenv.isx86_64
 , withLuaJIT ? stdenv.isx86_64
+, nixosTests
 }:
 
 assert withHyperscan -> stdenv.isx86_64;
@@ -33,6 +34,8 @@ stdenv.mkDerivation rec {
     "-DLOCAL_CONFDIR=/etc/rspamd"
     "-DENABLE_JEMALLOC=ON"
   ] ++ lib.optional withHyperscan "-DENABLE_HYPERSCAN=ON";
+
+  passthru.tests.rspamd = nixosTests.rspamd;
 
   meta = with stdenv.lib; {
     homepage = "https://rspamd.com";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/100207#issuecomment-713178193

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
