### PR TITLE
chromium: 86.0.4240.75 -> 86.0.4240.111 (CVE-2020-16000 CVE-2020-16001 CVE-2020-16002 CVE-2020-15999 CVE-2020-16003)

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -1,13 +1,13 @@
 {
   "stable": {
-    "version": "86.0.4240.75",
-    "sha256": "1ddw4p9zfdzhi5hrd8x14k4w326znljzprnpfi2f917rlpnl2ynx",
-    "sha256bin64": "17isxkd80rccqim6izzl08vw4yr52qsk6djp1rmhhijzg9rsvghz"
+    "version": "86.0.4240.111",
+    "sha256": "05y7lwr89awkhvgmwkx3br9j4ap2aypg2wsc0nz8mi7kxc1dnyzj",
+    "sha256bin64": "10aqiiydw4i3jxnw8xxdgkgcqbfqc67n1fbrg40y54kg0v5dz8l6"
   },
   "beta": {
-    "version": "87.0.4280.20",
-    "sha256": "1lqdxy6pm72h8ym5ij713rp055csqn19agy3sp6wnmp3pj688ic8",
-    "sha256bin64": "0r9wk2kgn7z0jjzpppr799jp5izxvh1ig4mv12iadz4y7dl47kaw"
+    "version": "87.0.4280.27",
+    "sha256": "0w0asxj7jlsw69cssfia8km4q9cx1c2mliks2rmhf4jk0hsghasm",
+    "sha256bin64": "1lsx4mhy8nachfb8c9f3mrx5nqw2bi046dqirb4lnv7y80jjjs1k"
   },
   "dev": {
     "version": "88.0.4292.2",


### PR DESCRIPTION
###### Motivation for this change
https://chromereleases.googleblog.com/2020/10/stable-channel-update-for-desktop_20.html

CVE-2020-16000 CVE-2020-16001 CVE-2020-16002 CVE-2020-15999 CVE-2020-16003

Google is aware of reports that an **exploit for CVE-2020-15999 exists in the wild**.
###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).