### PR TITLE
firefox: place alsaLib in lib search patch

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -332,6 +332,7 @@ buildStdenv.mkDerivation ({
     version = ffversion;
     isFirefox3Like = true;
     gtk = gtk2;
+    inherit alsaSupport;
     inherit nspr;
     inherit ffmpegSupport;
     inherit gssSupport;

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -2,7 +2,7 @@
 
 ## various stuff that can be plugged in
 , flashplayer, hal-flash
-, ffmpeg, xorg, libpulseaudio, libcanberra-gtk2, libglvnd
+, ffmpeg, xorg, alsaLib, libpulseaudio, libcanberra-gtk2, libglvnd
 , gnome3/*.gnome-shell*/
 , browserpass, chrome-gnome-shell, uget-integrator, plasma-browser-integration, bukubrow
 , tridactyl-native
@@ -39,6 +39,7 @@ let
       enableAdobeFlash = cfg.enableAdobeFlash or false;
       ffmpegSupport = browser.ffmpegSupport or false;
       gssSupport = browser.gssSupport or false;
+      alsaSupport = browser.alsaSupport or false;
 
       plugins =
         let
@@ -76,6 +77,7 @@ let
             (with xorg; [ stdenv.cc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib ])
             ++ lib.optional (enableAdobeFlash && (cfg.enableAdobeFlashDRM or false)) hal-flash
             ++ lib.optional (config.pulseaudio or true) libpulseaudio
+            ++ lib.optional alsaSupport alsaLib
             ++ pkcs11Modules;
       gtk_modules = [ libcanberra-gtk2 ];
 


### PR DESCRIPTION
###### Motivation for this change
libcubeb has dlopened libraries for awhile now. In nixpkgs there was
support for the PulseAudio backend doing this, however the ALSA backend
support was missed and caused issue #79310 (no sound with ALSA). This
gives ALSA users the ability to hear sound once again.


