### PR TITLE
boost: fix segfaults on ppc64

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -1,4 +1,5 @@
 { stdenv, icu, expat, zlib, bzip2, python, fixDarwinDylibNames, libiconv
+, fetchpatch
 , which
 , buildPackages
 , toolset ? /**/ if stdenv.cc.isClang  then "clang"
@@ -113,6 +114,14 @@ stdenv.mkDerivation {
     if version == "1.55.0"
     then ./darwin-1.55-no-system-python.patch
     else ./darwin-no-system-python.patch)
+  # Fix boost-context segmentation faults on ppc64 due to ABI violation
+  ++ optional (versionAtLeast version "1.61" &&
+               versionOlder version "1.71") (fetchpatch {
+    url = "https://github.com/boostorg/context/commit/2354eca9b776a6739112833f64754108cc0d1dc5.patch";
+    sha256 = "067m4bjpmcanqvg28djax9a10avmdwhlpfx6gn73kbqqq70dnz29";
+    stripLen = 1;
+    extraPrefix = "libs/context/";
+  })
   ++ optional (and (versionAtLeast version "1.70") (!versionAtLeast version "1.73")) ./cmake-paths.patch
   ++ optional (versionAtLeast version "1.73") ./cmake-paths-173.patch;
 


### PR DESCRIPTION
(Previous attempt: https://github.com/NixOS/nixpkgs/pull/98822)

Fixes https://github.com/NixOS/nix/issues/2517

See also:
https://github.com/boostorg/context/issues/72
https://github.com/boostorg/fiber/issues/193

These issues have been resolved by:
https://github.com/boostorg/context/pull/106
https://github.com/boostorg/context/commit/d4608a4e8ba2e8a0bdd45613243e6c53a23d23dc
which is merged into boost as of v1.71.0.

This feature was introduced (with the bug) in
boost v1.61 and was fixed in v1.71. So we apply
the patch to all versions in that range.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
