### PR TITLE
rtl8822ce: init at v5.9.0.3b

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6711,6 +6711,12 @@
     githubId = 627831;
     name = "Hoang Xuan Phu";
   };
+  pickfire = {
+    email = "pickfire@riseup.net";
+    github = "pickfire";
+    githubId = 4687791;
+    name = "Ivan Tham";
+  };
   pierrechevalier83 = {
     email = "pierrechevalier83@gmail.com";
     github = "pierrechevalier83";

--- a/pkgs/os-specific/linux/rtl8822ce/default.nix
+++ b/pkgs/os-specific/linux/rtl8822ce/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, kernel, bc }:
+
+stdenv.mkDerivation rec {
+  # this is already available on newer kernels such as zen
+  name = "rtl8822ce";
+  version = "v5.9.0.3b";
+
+  src = fetchFromGitHub {
+    owner = "rtlwifi-linux";
+    repo = "rtk_wifi_driver_rtl8822ce";
+    rev = version;
+    sha256 = "0cplb37r9dzmzcs9h283478z4szqs7w9ypd8r8pdzhzaa5057fqx";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = [ bc ];
+  buildInputs = kernel.moduleBuildDependencies;
+
+  prePatch = ''
+    substituteInPlace ./Makefile \
+      --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
+      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
+      --replace /sbin/depmod \# \
+      --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  preInstall = ''
+    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Realtek rtl8822ce driver";
+    homepage = "https://github.com/rtlwifi-linux/rtk_wifi_driver_rtl8822ce";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ pickfire ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18000,6 +18000,8 @@ in
 
     rtl8821cu = callPackage ../os-specific/linux/rtl8821cu { };
 
+    rtl8822ce = callPackage ../os-specific/linux/rtl8822ce { };
+
     rtlwifi_new = callPackage ../os-specific/linux/rtlwifi_new { };
 
     openafs = callPackage ../servers/openafs/1.6/module.nix { };


### PR DESCRIPTION
This is already available on newer kernels like zen.
Note: build fails on newer kernels due to crc32, but either way never kernels should already have this.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
