### PR TITLE
xmlsec: fix build on macOS

### DIFF
--- a/pkgs/development/libraries/xmlsec/default.nix
+++ b/pkgs/development/libraries/xmlsec/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./lt_dladdsearchdir.patch
+    ./remove_bsd_base64_decode_flag.patch
   ];
   postPatch = ''
     substituteAllInPlace src/dl.c

--- a/pkgs/development/libraries/xmlsec/default.nix
+++ b/pkgs/development/libraries/xmlsec/default.nix
@@ -16,8 +16,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./lt_dladdsearchdir.patch
-    ./remove_bsd_base64_decode_flag.patch
-  ];
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ ./remove_bsd_base64_decode_flag.patch ];
   postPatch = ''
     substituteAllInPlace src/dl.c
   '';

--- a/pkgs/development/libraries/xmlsec/remove_bsd_base64_decode_flag.patch
+++ b/pkgs/development/libraries/xmlsec/remove_bsd_base64_decode_flag.patch
@@ -1,0 +1,12 @@
+--- a/tests/testEnc.sh	2020-04-20 14:30:32.000000000 -0400
++++ b/tests/testEnc.sh	2020-10-21 22:09:25.000000000 -0400
+@@ -405,9 +405,6 @@
+             else
+                 # generate binary file out of base64
+                 DECODE="-d"
+-                if [ "`uname`" = "Darwin" ]; then
+-		    DECODE="-D"
+-                fi
+                 cat "$topfolder/$base_test_name.data" | base64 $DECODE > $tmpfile.3
+                 execEncTest "$res_success" \
+                     "" \


### PR DESCRIPTION
xmlsec detects the Darwin platform and uses the -D flag with base64, but nix uses GNU base64 which requires -d.

This patch removes the platform test and always uses the -d flag.

###### Motivation for this change
The recent update of xmlsec to version 1.2.30 broke xmlsec on macOS. See the bug: https://github.com/NixOS/nixpkgs/issues/101276

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
