### PR TITLE
opa: build with OCaml 4.03

### DIFF
--- a/pkgs/development/compilers/opa/default.nix
+++ b/pkgs/development/compilers/opa/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "1qs91rq9xrafv2mf2v415k8lv91ab3ycz0xkpjh1mng5ca3pjlf3";
   };
 
+  patches = [ ./ocaml-4.03.patch ];
+
   # Paths so the opa compiler code generation will use the same programs as were
   # used to build opa.
   codeGeneratorPaths = stdenv.lib.makeBinPath [ ocamlPackages.ocaml gcc binutils gnumake nodejs ];
@@ -23,7 +25,7 @@ stdenv.mkDerivation rec {
     patchShebangs .
     (
     cat ./compiler/buildinfos/buildInfos.ml.pre
-    ./compiler/buildinfos/generate_buildinfos.sh . --release --version ./compiler/buildinfos/version_major.txt 
+    ./compiler/buildinfos/generate_buildinfos.sh . --release --version ./compiler/buildinfos/version_major.txt
     echo let opa_git_version = ${version}
     echo 'let opa_git_sha = "xxxx"'
     cat ./compiler/buildinfos/buildInfos.ml.post
@@ -34,6 +36,8 @@ stdenv.mkDerivation rec {
     done
     export CAMLP4O=${ocamlPackages.camlp4}/bin/camlp4o
     export CAMLP4ORF=${ocamlPackages.camlp4}/bin/camlp4orf
+    export OCAMLBUILD=${ocamlPackages.ocamlbuild}/bin/ocamlbuild
+    substituteInPlace _tags --replace ', warn_error_A' ""
   '';
 
   prefixKey = "-prefix ";

--- a/pkgs/development/compilers/opa/ocaml-4.03.patch
+++ b/pkgs/development/compilers/opa/ocaml-4.03.patch
@@ -1,0 +1,35 @@
+--- a/compiler/passes/surfaceAstRenaming.ml
++++ b/compiler/passes/surfaceAstRenaming.ml
+@@ -1110,7 +1110,7 @@ let find_opt_local_or_global name all_env =
+     | None -> find_opt_global name all_env
+     | v -> v
+ 
+-let path_expr_to_module_aux p = function
++let path_expr_to_module_aux p : _ -> _ result = function
+   | Some (OpenedIdent (tree, ident, path)) ->
+       (match Tree.get_path_opt tree p with
+            (* the path is not in the tree, which means a 'dot' access
+diff --git a/ocamllib/libbase/baseInt64.mli b/ocamllib/libbase/baseInt64.mli
+index fb544706..734437f9 100644
+--- a/ocamllib/libbase/baseInt64.mli
++++ b/ocamllib/libbase/baseInt64.mli
+@@ -40,7 +40,9 @@ external shift_right_logical : int64 -> int -> int64 = "%int64_lsr"
+ external of_int : int -> int64 = "%int64_of_int"
+ external to_int : int64 -> int = "%int64_to_int"
+ external of_float : float -> int64 = "caml_int64_of_float"
++ "caml_int64_of_float_unboxed" [@@unboxed] [@@noalloc]
+ external to_float : int64 -> float = "caml_int64_to_float"
++ "caml_int64_to_float_unboxed" [@@unboxed] [@@noalloc]
+ external of_int32 : int32 -> int64 = "%int64_of_int32"
+ external to_int32 : int64 -> int32 = "%int64_to_int32"
+ external of_nativeint : nativeint -> int64 = "%int64_of_nativeint"
+@@ -48,7 +50,9 @@ external to_nativeint : int64 -> nativeint = "%int64_to_nativeint"
+ external of_string : string -> int64 = "caml_int64_of_string"
+ val to_string : int64 -> string
+ external bits_of_float : float -> int64 = "caml_int64_bits_of_float"
++ "caml_int64_bits_of_float_unboxed" [@@unboxed] [@@noalloc]
+ external float_of_bits : int64 -> float = "caml_int64_float_of_bits"
++ "caml_int64_float_of_bits_unboxed" [@@unboxed] [@@noalloc]
+ type t = int64
+ val compare : t -> t -> int
+ external format : string -> int64 -> string = "caml_int64_format"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9594,7 +9594,7 @@ in
   ocsigen-i18n = callPackage ../development/tools/ocaml/ocsigen-i18n { };
 
   opa = callPackage ../development/compilers/opa {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_02;
+    ocamlPackages = ocaml-ng.ocamlPackages_4_03;
   };
 
   opaline = callPackage ../development/tools/ocaml/opaline { };


### PR DESCRIPTION
###### Motivation for this change

Recent versions of `cryptokit`, on which `opa` depends, are no longer compatible with OCaml 4.02.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
