### PR TITLE
pythonPackages.ndjson: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6109,6 +6109,12 @@
     githubId = 818502;
     name = "Nathan Yong";
   };
+  nbke = {
+    email = "nicolai@kellerer.me";
+    github = "nbke";
+    githubId = 8681657;
+    name = "Nicolai Kellerer";
+  };
   nckx = {
     email = "github@tobias.gr";
     github = "nckx";

--- a/pkgs/development/python-modules/ndjson/default.nix
+++ b/pkgs/development/python-modules/ndjson/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestrunner
+, pytest
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "ndjson";
+  version = "0.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mp556r9ddw9wvj430zjbxk6sy3wq1ag39ydfb8m7jxidg5ld5xz";
+  };
+
+  checkInputs = [ pytestrunner pytest six ];
+
+  meta = with lib; {
+    homepage = "https://github.com/rhgrant10/ndjson";
+    description = "JsonDecoder for ndjson";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ nbke ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3970,6 +3970,8 @@ in {
 
   ndg-httpsclient = callPackage ../development/python-modules/ndg-httpsclient { };
 
+  ndjson = callPackage ../development/python-modules/ndjson { };
+
   ndtypes = callPackage ../development/python-modules/ndtypes { };
 
   neo = callPackage ../development/python-modules/neo { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
labelbox 2.4.6 depends on ndjson

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
