### PR TITLE
arrow-cpp: 1.0.1 -> 2.0.0

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -7,25 +7,25 @@ let
   arrow-testing = fetchFromGitHub {
     owner = "apache";
     repo = "arrow-testing";
-    rev = "f552c4dcd2ae3d14048abd20919748cce5276ade";
-    sha256 = "1smaidk5k2q6xdav7qp74ak34vvwv5qyfqw0szi573awsrsrahr8";
+    rev = "860376d4e586a3ac34ec93089889da624ead6c2a";
+    sha256 = "16k3lz4ji4y3qcjhr765q14jwwlac8iqscwndwd8ll3zr0vy69b0";
   };
 
   parquet-testing = fetchFromGitHub {
     owner = "apache";
     repo = "parquet-testing";
-    rev = "bcd9ebcf9204a346df47204fe21b85c8d0498816";
-    sha256 = "0m16pqzbvxiaradq088q5ai6fwnz9srbap996397znwppvva479b";
+    rev = "d914f9d289488c7db1759d7a88a4a1b8f062c7dd";
+    sha256 = "0xj3ynck2wv6l70xnmvs13bz1jycqjrl5k4lwhhwgag338048als";
   };
 
 in stdenv.mkDerivation rec {
   pname = "arrow-cpp";
-  version = "1.0.1";
+  version = "2.0.0";
 
   src = fetchurl {
     url =
       "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    sha256 = "0p67dni8dwqbwq96gfdq3pyk799id6dgdl9h7cpp9icsjsmad70l";
+    sha256 = "1ghzqw0rx4rxa2d7i76y3szisv0bd9cl7vzadbc41cvvhk6440xy";
   };
   sourceRoot = "apache-arrow-${version}/cpp";
 
@@ -43,26 +43,13 @@ in stdenv.mkDerivation rec {
     # ./cpp/cmake_modules/ThirdpartyToolchain.cmake
     # ./cpp/thirdparty/versions.txt
     url =
-      "https://github.com/microsoft/mimalloc/archive/v1.6.3.tar.gz";
-    sha256 = "0pia8b4acv1w8qzcpc9i1a2fasnn3rmp996k0l87p2di0lbls0w5";
+      "https://github.com/microsoft/mimalloc/archive/v1.6.4.tar.gz";
+    sha256 = "1b8av0974q70alcmaw5cwzbn6n9blnpmj721ik1qwmbbwwd6nqgs";
   };
 
   patches = [
     # patch to fix python-test
     ./darwin.patch
-    # Properly exported static targets. Remove at the next version bump.
-    (fetchpatch {
-      url = "https://github.com/apache/arrow/commit/b040600b39a4f803b704934252665f9440dd1276.patch";
-      sha256 = "1mvw29ybcsz77zprmsk41blxmrj8ywayg7ghf6xkkf98907ws8m8";
-      includes = [ "*.cmake" ];
-      stripLen = 1;
-    })
-    (fetchpatch {
-      url = "https://github.com/apache/arrow/commit/81d3f2657b17436d6d5a6af9aaf6f36c3f5e4ac9.patch";
-      sha256 = "18fmzr5f79hvx2qpyfgvvl98p4zgzfxrmrd1d2basp0w0da1ciqs";
-      includes = [ "*CMakeLists.txt" "*.cmake" "*.cmake.in" ];
-      stripLen = 1;
-    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
https://arrow.apache.org/release/2.0.0.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
