### PR TITLE
check-meta.nix: Fix message for `nix build` users as well

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -130,9 +130,14 @@ let
         { nixpkgs.config.allow${allow_attr} = true; }
       in configuration.nix to override this.
       ${rebuild_amendment attrs}
-      c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
+      c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command* you can add
         { allow${allow_attr} = true; }
       to ~/.config/nixpkgs/config.nix.
+
+      *: If you use nixUnstable's flakes syntax (e.g `nix profile install nixpkgs#<package>`),
+         and, you have set in your config `allow${allow_attr}`, it will fail unless you use
+         `--impure`. Note that this is not recommended as a proper solution, as it breaks
+         caching.
     '';
 
   remediate_insecure = attrs:


### PR DESCRIPTION
As discussed in:
https://discourse.nixos.org/t/why-isnt-config-nixpkgs-config-nix-evaluated-for-nix-build/9579

It's a bit nontrivial that `nix build` needs the `--impure` flag in
order to evaluate ~/.config/nixpkgs/config.nix.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
