### PR TITLE
kdeApplications: Use latest qt515 by default

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -200,7 +200,7 @@ in
 
       security.wrappers = {
         kcheckpass.source = "${lib.getBin plasma5.kscreenlocker}/libexec/kcheckpass";
-        start_kdeinit.source = "${lib.getBin pkgs.kinit}/libexec/kf5/start_kdeinit";
+        start_kdeinit.source = "${lib.getBin pkgs.kdeFrameworks.kinit}/libexec/kf5/start_kdeinit";
         kwin_wayland = {
           source = "${lib.getBin plasma5.kwin}/bin/kwin_wayland";
           capabilities = "cap_sys_nice+ep";

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -9,7 +9,12 @@ let
   cfg = dmcfg.sddm;
   xEnv = config.systemd.services.display-manager.environment;
 
-  inherit (pkgs) sddm;
+  sddm = if config.services.xserver.desktopManager.lxqt.enable then
+    # TODO: Move lxqt to libsForQt515
+    pkgs.libsForQt514.sddm
+  else
+    pkgs.libsForQt5.sddm
+  ;
 
   xserverWrapper = pkgs.writeScript "xserver-wrapper" ''
     #!/bin/sh

--- a/pkgs/applications/editors/kile/default.nix
+++ b/pkgs/applications/editors/kile/default.nix
@@ -29,14 +29,17 @@ mkDerivation rec {
     sha256 = "BEmSEv/LJPs6aCkUmnyuTGrV15WYXwgIANbfcviMXfA=";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules wrapGAppsHook ];
+  nativeBuildInputs = [
+    extra-cmake-modules
+    wrapGAppsHook
+    kdoctools
+  ];
 
-  propagatedBuildInputs = [
+  buildInputs = [
     kconfig
     kcrash
     kdbusaddons
     kdelibs4support
-    kdoctools
     kguiaddons
     kiconthemes
     kinit
@@ -48,6 +51,10 @@ mkDerivation rec {
     poppler
     qtscript
   ];
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
 
   propagatedUserEnvPkgs = [ konsole ];
 

--- a/pkgs/applications/misc/tellico/default.nix
+++ b/pkgs/applications/misc/tellico/default.nix
@@ -1,7 +1,7 @@
 { lib
 , fetchurl
 , mkDerivation
-, kdeApplications
+, libkcddb
 , kinit
 , kdelibs4support
 , solid
@@ -46,7 +46,7 @@ mkDerivation rec {
     exempi
     extra-cmake-modules
     karchive
-    kdeApplications.libkcddb
+    libkcddb
     kdelibs4support
     kfilemetadata
     khtml

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -4,7 +4,7 @@
 , flashplayer, hal-flash
 , ffmpeg, xorg, alsaLib, libpulseaudio, libcanberra-gtk2, libglvnd
 , gnome3/*.gnome-shell*/
-, browserpass, chrome-gnome-shell, uget-integrator, plasma-browser-integration, bukubrow
+, browserpass, chrome-gnome-shell, uget-integrator, plasma5, bukubrow
 , tridactyl-native
 , fx_cast_bridge
 , udev
@@ -65,7 +65,7 @@ let
           ++ lib.optional (cfg.enableTridactylNative or false) tridactyl-native
           ++ lib.optional (cfg.enableGnomeExtensions or false) chrome-gnome-shell
           ++ lib.optional (cfg.enableUgetIntegrator or false) uget-integrator
-          ++ lib.optional (cfg.enablePlasmaBrowserIntegration or false) plasma-browser-integration
+          ++ lib.optional (cfg.enablePlasmaBrowserIntegration or false) plasma5.plasma-browser-integration
           ++ lib.optional (cfg.enableFXCastBridge or false) fx_cast_bridge
           ++ extraNativeMessagingHosts
         );

--- a/pkgs/data/icons/maia-icon-theme/default.nix
+++ b/pkgs/data/icons/maia-icon-theme/default.nix
@@ -1,4 +1,12 @@
-{ stdenv, fetchFromGitLab, cmake, extra-cmake-modules, gtk3, kdeFrameworks, hicolor-icon-theme }:
+{ stdenv
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, gtk3
+, plasma-framework
+, kwindowsystem
+, hicolor-icon-theme
+}:
 
 stdenv.mkDerivation {
   pname = "maia-icon-theme";
@@ -17,8 +25,8 @@ stdenv.mkDerivation {
     cmake
     extra-cmake-modules
     gtk3
-    kdeFrameworks.plasma-framework
-    kdeFrameworks.kwindowsystem
+    plasma-framework
+    kwindowsystem
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -43,7 +43,7 @@ let
 
     ### OPTIONAL
     qterminal = callPackage ./qterminal {};
-    compton-conf = pkgs.qt5.callPackage ./compton-conf {};
+    compton-conf = qt5.callPackage ./compton-conf {};
     obconf-qt = callPackage ./obconf-qt {};
     lximage-qt = callPackage ./lximage-qt {};
     qps = callPackage ./qps {};

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -36,7 +36,6 @@ let
   };
 
   mkDerivation = libsForQt5.callPackage ({ mkDerivation }: mkDerivation) {};
-  qtbase = libsForQt5.callPackage ({ qtbase }: qtbase) {};
 
   packages = self: with self;
     let
@@ -83,7 +82,6 @@ let
             setupHook = args.setupHook or defaultSetupHook;
 
             meta = {
-              broken = lib.versionAtLeast qtbase.version "5.15";
               license = with lib.licenses; [
                 lgpl21Plus lgpl3Plus bsd2 mit gpl2Plus gpl3Plus fdl12
               ];

--- a/pkgs/development/libraries/drumstick/default.nix
+++ b/pkgs/development/libraries/drumstick/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, alsaLib, cmake, docbook_xsl, docbook_xml_dtd_45, doxygen
-, fluidsynth, pkgconfig, qt5
+, fluidsynth, pkgconfig, qtbase, qtsvg
 }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkgconfig docbook_xsl docbook_xml_dtd_45 docbook_xml_dtd_45 ];
   buildInputs = [
-    alsaLib doxygen fluidsynth qt5.qtbase qt5.qtsvg
+    alsaLib doxygen fluidsynth qtbase qtsvg
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/kdiagram/default.nix
+++ b/pkgs/development/libraries/kdiagram/default.nix
@@ -1,14 +1,18 @@
 {
-  mkDerivation, fetchurl, lib,
+  mkDerivation, fetchFromGitLab, lib,
   extra-cmake-modules, qttools,
   qtbase, qtsvg,
 }:
 
-mkDerivation {
-  name = "kdiagram-2.6.0";
-  src = fetchurl {
-    url = "https://download.kde.org/stable/kdiagram/2.6.0/src/kdiagram-2.6.0.tar.xz";
-    sha256 = "10hqk12wwgbiq4q5145s8v7v96j621ckq1yil9s4pihmgsnqsy02";
+mkDerivation rec {
+  pname = "kdiagram";
+  version = "2.7.0";
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "graphics";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "NSBNHPr8JzBn3y3ivhL0RjiXjDuPwZsTTOeI22pq3vc=";
   };
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   propagatedBuildInputs = [ qtbase qtsvg ];

--- a/pkgs/development/libraries/kpmcore/default.nix
+++ b/pkgs/development/libraries/kpmcore/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, extra-cmake-modules
-, qtbase, kdeFrameworks
+, qtbase, kio
 , libatasmart, parted
 , utillinux }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     libatasmart
     parted # we only need the library
 
-    kdeFrameworks.kio
+    kio
 
     utillinux # needs blkid (note that this is not provided by utillinux-compat)
   ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -750,4 +750,57 @@ mapAliases ({
 
   ant-dracula-theme = throw "ant-dracula-theme is now dracula-theme, and theme name is Dracula instead of Ant-Dracula.";
 
+  /* If these are in the scope of all-packages.nix, they cause collisions
+  between mixed versions of qt. See:
+  https://github.com/NixOS/nixpkgs/pull/101369 */
+
+  inherit (kdeFrameworks) breeze-icons oxygen-icons5;
+  inherit (kdeApplications)
+    akonadi akregator ark
+    bomber bovo
+    dolphin dragon
+    elisa
+    ffmpegthumbs filelight
+    granatier gwenview
+    k3b
+    kaddressbook kalzium kapptemplate kapman kate katomic
+    kblackbox kblocks kbounce
+    kcachegrind kcalc kcharselect kcolorchooser
+    kdenlive kdf kdialog kdiamond
+    keditbookmarks
+    kfind kfloppy
+    kget kgpg
+    khelpcenter
+    kig kigo killbots kitinerary
+    kleopatra klettres klines
+    kmag kmail kmines kmix kmplot
+    knavalbattle knetwalk knights
+    kollision kolourpaint kompare konsole kontact korganizer
+    kpkpass
+    krdc kreversi krfb
+    kshisen ksquares ksystemlog
+    kteatime ktimer ktouch kturtle
+    kwalletmanager kwave
+    marble minuet
+    okular
+    picmi
+    spectacle
+    yakuake
+  ;
+  inherit (plasma5)
+    bluedevil breeze-gtk breeze-qt5 breeze-grub breeze-plymouth discover
+    kactivitymanagerd kde-cli-tools kde-gtk-config kdeplasma-addons kgamma5
+    kinfocenter kmenuedit kscreen kscreenlocker ksshaskpass ksysguard
+    kwallet-pam kwayland-integration kwin kwrited milou oxygen plasma-browser-integration
+    plasma-desktop plasma-integration plasma-nm plasma-pa plasma-vault plasma-workspace
+    plasma-workspace-wallpapers polkit-kde-agent powerdevil sddm-kcm
+    systemsettings user-manager xdg-desktop-portal-kde
+  ;
+  inherit (plasma5.thirdParty)
+    plasma-applet-caffeine-plus
+    kwin-dynamic-workspaces
+    kwin-tiling
+    krohnkite
+  ;
+
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -802,5 +802,8 @@ mapAliases ({
     kwin-tiling
     krohnkite
   ;
+  inherit (libsForQt5)
+    sddm
+  ;
 
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6216,8 +6216,6 @@ in
 
   packagekit = callPackage ../tools/package-management/packagekit { };
 
-  packagekit-qt = libsForQt5.callPackage ../tools/package-management/packagekit/qt.nix { };
-
   packetdrill = callPackage ../tools/networking/packetdrill { };
 
   pacman = callPackage ../tools/package-management/pacman { };
@@ -15273,6 +15271,8 @@ in
     liblastfm = callPackage ../development/libraries/liblastfm { };
 
     libopenshot = callPackage ../applications/video/openshot-qt/libopenshot.nix { };
+
+    packagekit-qt = callPackage ../tools/package-management/packagekit/qt.nix { };
 
     libopenshot-audio = callPackage ../applications/video/openshot-qt/libopenshot-audio.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15194,17 +15194,41 @@ in
       kwidgetsaddons kwindowsystem kxmlgui kxmlrpcclient modemmanager-qt
       networkmanager-qt plasma-framework prison qqc2-desktop-style solid sonnet
       syntax-highlighting syndication threadweaver kirigami2 kholidays kpurpose
-      kcontacts kquickcharts kdoctools kapidox kdesu;
+      kcontacts kquickcharts kdoctools kapidox kdesu kinit kded frameworkintegration
+      kdewebkit breeze-icons
+    ;
 
     ### KDE PLASMA 5
 
     inherit (plasma5.override { libsForQt5 = self; })
-      kdecoration khotkeys libkscreen libksysguard;
+      kdecoration khotkeys libkscreen libksysguard bluedevil
+      breeze-gtk breeze-qt5 breeze-grub breeze-plymouth discover kactivitymanagerd
+      kde-cli-tools kde-gtk-config kdeplasma-addons kgamma5 kinfocenter kmenuedit
+      kscreen kscreenlocker ksshaskpass ksysguard kwallet-pam kwayland-integration
+      kwin kwrited milou oxygen plasma-browser-integration plasma-desktop
+      plasma-integration plasma-nm plasma-pa plasma-vault plasma-workspace
+      plasma-workspace-wallpapers polkit-kde-agent powerdevil sddm-kcm
+      systemsettings user-manager xdg-desktop-portal-kde
+    ;
+
+    inherit ((plasma5.override { libsForQt5 = self; }).thirdParty)
+      plasma-applet-caffeine-plus kwin-dynamic-workspaces kwin-tiling krohnkite
+    ;
 
     ### KDE APPLICATIONS
 
     inherit (kdeApplications.override { libsForQt5 = self; })
-      libkdcraw libkexiv2 libkipi libkomparediff2 libksane;
+      libkdcraw libkexiv2 libkipi libkomparediff2 libksane libkcddb akonadi-contacts
+      akonadi-calendar akonadi-notes akonadi-search kidentitymanagement kontactinterface
+      kldap akonadi akregator ark bomber bovo dolphin dragon elisa ffmpegthumbs filelight
+      granatier gwenview k3b kaddressbook kalzium kapptemplate kapman kate katomic
+      kblackbox kblocks kbounce kcachegrind kcalc kcharselect kcolorchooser
+      kdenlive kdf kdialog kdiamond keditbookmarks kfind kfloppy kget kgpg khelpcenter
+      kig kigo killbots kitinerary kleopatra klettres klines kmag kmail kmines kmix kmplot
+      knavalbattle knetwalk knights kollision kolourpaint kompare konsole kontact korganizer
+      kpkpass krdc kreversi krfb kshisen ksquares ksystemlog kteatime ktimer ktouch kturtle
+      kwalletmanager kwave marble minuet okular picmi spectacle yakuake
+    ;
 
     ### LIBRARIES
 
@@ -18968,8 +18992,6 @@ in
 
   brise = callPackage ../data/misc/brise { };
 
-  inherit (kdeFrameworks) breeze-icons;
-
   cacert = callPackage ../data/misc/cacert { };
 
   caladea = callPackage ../data/fonts/caladea {};
@@ -19135,7 +19157,9 @@ in
 
   fira-mono = callPackage ../data/fonts/fira-mono { };
 
-  flat-remix-icon-theme = callPackage ../data/icons/flat-remix-icon-theme { };
+  flat-remix-icon-theme = callPackage ../data/icons/flat-remix-icon-theme {
+    inherit (kdeFrameworks) breeze-icons;
+  };
 
   font-awesome_4 = (callPackage ../data/fonts/font-awesome-5 { }).v4;
   font-awesome_5 = (callPackage ../data/fonts/font-awesome-5 { }).v5;
@@ -19294,7 +19318,9 @@ in
 
   luculent = callPackage ../data/fonts/luculent { };
 
-  luna-icons = callPackage ../data/icons/luna-icons { };
+  luna-icons = callPackage ../data/icons/luna-icons {
+    inherit (kdeFrameworks) breeze-icons;
+  };
 
   maia-icon-theme = callPackage ../data/icons/maia-icon-theme { };
 
@@ -19415,15 +19441,17 @@ in
 
   oxygenfonts = callPackage ../data/fonts/oxygenfonts { };
 
-  inherit (kdeFrameworks) oxygen-icons5;
-
   paper-gtk-theme = callPackage ../data/themes/paper-gtk { };
 
   paper-icon-theme = callPackage ../data/icons/paper-icon-theme { };
 
-  papirus-icon-theme = callPackage ../data/icons/papirus-icon-theme { };
+  papirus-icon-theme = callPackage ../data/icons/papirus-icon-theme {
+    inherit (kdeFrameworks) breeze-icons;
+  };
 
-  papirus-maia-icon-theme = callPackage ../data/icons/papirus-maia-icon-theme { };
+  papirus-maia-icon-theme = callPackage ../data/icons/papirus-maia-icon-theme {
+    inherit (kdeFrameworks) breeze-icons;
+  };
 
   papis = with python3Packages; toPythonApplication papis;
 
@@ -19453,7 +19481,9 @@ in
 
   pop-gtk-theme = callPackage ../data/themes/pop-gtk { };
 
-  pop-icon-theme = callPackage ../data/icons/pop-icon-theme { };
+  pop-icon-theme = callPackage ../data/icons/pop-icon-theme {
+    inherit (kdeFrameworks) breeze-icons;
+  };
 
   posix_man_pages = callPackage ../data/documentation/man-pages-posix { };
 
@@ -19733,7 +19763,9 @@ in
 
   yaru-theme = callPackage ../data/themes/yaru {};
 
-  zafiro-icons = callPackage ../data/icons/zafiro-icons { };
+  zafiro-icons = callPackage ../data/icons/zafiro-icons {
+    inherit (kdeFrameworks) breeze-icons;
+  };
 
   zeal = libsForQt514.callPackage ../data/documentation/zeal { };
 
@@ -20114,9 +20146,12 @@ in
   calibre = calibre-py3;
 
   calligra = libsForQt514.callPackage ../applications/office/calligra {
-    inherit (kdeApplications) akonadi-calendar akonadi-contacts;
     openjpeg = openjpeg_1;
-    poppler = poppler_0_61;
+    poppler = poppler_0_61.override {
+      qt5Support = true;
+      # Must be using the same qt version as calligra itself.
+      qtbase = qt514.qtbase;
+    };
   };
 
   perkeep = callPackage ../applications/misc/perkeep { };
@@ -21699,38 +21734,6 @@ in
     in
       recurseIntoAttrs (makeOverridable mkApplications attrs);
 
-  inherit (kdeApplications)
-    akonadi akregator ark
-    bomber bovo
-    dolphin dragon
-    elisa
-    ffmpegthumbs filelight
-    granatier gwenview
-    k3b
-    kaddressbook kalzium kapptemplate kapman kate katomic
-    kblackbox kblocks kbounce
-    kcachegrind kcalc kcharselect kcolorchooser
-    kdeconnect-kde kdenlive kdf kdialog kdiamond
-    keditbookmarks
-    kfind kfloppy
-    kget kgpg
-    khelpcenter
-    kig kigo killbots kitinerary
-    kleopatra klettres klines
-    kmag kmail kmines kmix kmplot
-    knavalbattle knetwalk knights
-    kollision kolourpaint kompare konsole kontact korganizer
-    kpkpass
-    krdc kreversi krfb
-    kshisen ksquares ksystemlog
-    kteatime ktimer ktouch kturtle
-    kwalletmanager kwave
-    marble minuet
-    okular
-    picmi
-    spectacle
-    yakuake;
-
   okteta = libsForQt5.callPackage ../applications/editors/okteta { };
 
   k4dirstat = libsForQt5.callPackage ../applications/misc/k4dirstat { };
@@ -21787,10 +21790,7 @@ in
 
   kmplayer = libsForQt5.callPackage ../applications/video/kmplayer { };
 
-  kmymoney = libsForQt5.callPackage ../applications/office/kmymoney {
-    inherit (kdeApplications) kidentitymanagement;
-    inherit (kdeFrameworks) kdewebkit;
-  };
+  kmymoney = libsForQt5.callPackage ../applications/office/kmymoney { };
 
   kodestudio = callPackage ../applications/editors/kodestudio { };
 
@@ -23867,9 +23867,7 @@ in
 
   tribler = callPackage ../applications/networking/p2p/tribler { };
 
-  trojita = libsForQt514.callPackage ../applications/networking/mailreaders/trojita {
-    inherit (kdeApplications) akonadi-contacts;
-  };
+  trojita = libsForQt514.callPackage ../applications/networking/mailreaders/trojita { };
 
   tudu = callPackage ../applications/office/tudu { };
 
@@ -24686,8 +24684,6 @@ in
   zam-plugins = callPackage ../applications/audio/zam-plugins { };
 
   zanshin = libsForQt514.callPackage ../applications/office/zanshin {
-    inherit (kdeApplications) akonadi-calendar akonadi-notes akonadi-search kidentitymanagement kontactinterface kldap;
-    inherit (kdeFrameworks) krunner kwallet kcalendarcore;
     boost = boost160;
   };
 
@@ -25029,9 +25025,6 @@ in
   dhewm3 = callPackage ../games/dhewm3 {};
 
   digikam = libsForQt514.callPackage ../applications/graphics/digikam {
-    inherit (plasma5) oxygen;
-    inherit (kdeApplications) akonadi-contacts;
-    inherit (kdeFrameworks) kcalendarcore;
     opencv3 = opencv3WithoutCuda;
   };
 
@@ -25952,25 +25945,6 @@ in
       };
     in
       recurseIntoAttrs (makeOverridable mkPlasma5 attrs);
-
-  inherit (kdeFrameworks) kded kinit frameworkintegration;
-
-  inherit (plasma5)
-    bluedevil breeze-gtk breeze-qt5 breeze-grub breeze-plymouth discover
-    kactivitymanagerd kde-cli-tools kde-gtk-config kdeplasma-addons kgamma5
-    kinfocenter kmenuedit kscreen kscreenlocker ksshaskpass ksysguard
-    kwallet-pam kwayland-integration kwin kwrited milou oxygen plasma-browser-integration
-    plasma-desktop plasma-integration plasma-nm plasma-pa plasma-vault plasma-workspace
-    plasma-workspace-wallpapers polkit-kde-agent powerdevil sddm-kcm
-    systemsettings user-manager xdg-desktop-portal-kde;
-
-  inherit (plasma5.thirdParty)
-    plasma-applet-caffeine-plus
-    kwin-dynamic-workspaces
-    kwin-tiling
-    krohnkite;
-
-  ### SCIENCE
 
   ### SCIENCE/CHEMISTY
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8751,8 +8751,6 @@ in
 
   dotty = callPackage ../development/compilers/scala/dotty.nix { jre = jre8;};
 
-  drumstick = callPackage ../development/libraries/drumstick { };
-
   ecl = callPackage ../development/compilers/ecl { };
   ecl_16_1_2 = callPackage ../development/compilers/ecl/16.1.2.nix { };
 
@@ -15239,6 +15237,8 @@ in
     appstream-qt = callPackage ../development/libraries/appstream/qt.nix { };
 
     dxflib = callPackage ../development/libraries/dxflib {};
+
+    drumstick = callPackage ../development/libraries/drumstick { };
 
     fcitx-qt5 = callPackage ../tools/inputmethods/fcitx/fcitx-qt5.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19322,7 +19322,7 @@ in
     inherit (kdeFrameworks) breeze-icons;
   };
 
-  maia-icon-theme = callPackage ../data/icons/maia-icon-theme { };
+  maia-icon-theme = libsForQt5.callPackage ../data/icons/maia-icon-theme { };
 
   mailcap = callPackage ../data/misc/mailcap { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13341,8 +13341,6 @@ in
     automake = automake111x;
   };
 
-  kf5gpgmepp = libsForQt5.callPackage ../development/libraries/kf5gpgmepp { };
-
   krb5 = callPackage ../development/libraries/kerberos/krb5.nix {
     inherit (buildPackages.darwin) bootstrap_cmds;
   };
@@ -15229,6 +15227,8 @@ in
     kdiagram = callPackage ../development/libraries/kdiagram { };
 
     kdsoap = callPackage ../development/libraries/kdsoap { };
+
+    kf5gpgmepp = callPackage ../development/libraries/kf5gpgmepp { };
 
     kproperty = callPackage ../development/libraries/kproperty { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21778,7 +21778,7 @@ in
 
   kid3 = libsForQt5.callPackage ../applications/audio/kid3 { };
 
-  kile = libsForQt514.callPackage ../applications/editors/kile { };
+  kile = libsForQt5.callPackage ../applications/editors/kile { };
 
   kino = callPackage ../applications/video/kino {
     inherit (gnome2) libglade;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25900,6 +25900,7 @@ in
   lumina = recurseIntoAttrs (callPackage ../desktops/lumina { });
 
   lxqt = recurseIntoAttrs (import ../desktops/lxqt {
+    # TODO: Update these to qt515 at some point
     qt5 = qt514;
     libsForQt5 = libsForQt514;
     inherit pkgs;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15136,8 +15136,6 @@ in
       inherit llvmPackages_5;
     });
 
-  libsForQt512 = recurseIntoAttrs (lib.makeScope qt512.newScope mkLibsForQt5);
-
   qt514 = recurseIntoAttrs (makeOverridable
     (import ../development/libraries/qt-5/5.14) {
       inherit newScope;
@@ -15167,6 +15165,8 @@ in
       inherit (gst_all_1) gstreamer gst-plugins-base;
       inherit llvmPackages_5;
     });
+
+  libsForQt512 = recurseIntoAttrs (lib.makeScope qt512.newScope mkLibsForQt5);
 
   libsForQt514 = recurseIntoAttrs (lib.makeScope qt514.newScope mkLibsForQt5);
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15196,7 +15196,7 @@ in
       kwidgetsaddons kwindowsystem kxmlgui kxmlrpcclient modemmanager-qt
       networkmanager-qt plasma-framework prison qqc2-desktop-style solid sonnet
       syntax-highlighting syndication threadweaver kirigami2 kholidays kpurpose
-      kcontacts kquickcharts kdoctools kapidox;
+      kcontacts kquickcharts kdoctools kapidox kdesu;
 
     ### KDE PLASMA 5
 
@@ -21734,8 +21734,6 @@ in
   okteta = libsForQt5.callPackage ../applications/editors/okteta { };
 
   k4dirstat = libsForQt5.callPackage ../applications/misc/k4dirstat { };
-
-  inherit (kdeFrameworks) kdesu;
 
   kdevelop-pg-qt = libsForQt514.callPackage ../applications/editors/kdevelop5/kdevelop-pg-qt.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15344,6 +15344,9 @@ in
 
     qtwebkit-plugins = callPackage ../development/libraries/qtwebkit-plugins { };
 
+    # Not a library, but we do want it to be built for every qt version there
+    # is, to allow users to choose the right build if needed.
+    sddm = callPackage ../applications/display-managers/sddm { };
   };
 
   qtEnv = qt5.env;
@@ -23484,8 +23487,6 @@ in
   super-slicer = callPackage ../applications/misc/prusa-slicer/super-slicer.nix { };
 
   robustirc-bridge = callPackage ../servers/irc/robustirc-bridge { };
-
-  sddm = libsForQt514.callPackage ../applications/display-managers/sddm { };
 
   skrooge = libsForQt514.callPackage ../applications/office/skrooge {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13326,7 +13326,7 @@ in
     let
       mkFrameworks = import ../development/libraries/kde-frameworks;
       attrs = {
-        libsForQt5 = libsForQt514;
+        inherit libsForQt5;
         inherit lib fetchurl;
       };
     in
@@ -21692,7 +21692,7 @@ in
     let
       mkApplications = import ../applications/kde;
       attrs = {
-        libsForQt5 = libsForQt514;
+        inherit libsForQt5;
         inherit lib fetchurl;
         inherit okteta;
       };
@@ -25947,7 +25947,7 @@ in
     let
       mkPlasma5 = import ../desktops/plasma-5;
       attrs = {
-        libsForQt5 = libsForQt514;
+        inherit libsForQt5;
         inherit lib fetchurl;
         gconf = gnome2.GConf;
         inherit gsettings-desktop-schemas;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25901,7 +25901,8 @@ in
   lumina = recurseIntoAttrs (callPackage ../desktops/lumina { });
 
   lxqt = recurseIntoAttrs (import ../desktops/lxqt {
-    # TODO: Update these to qt515 at some point
+    # TODO: Update these to qt515 at some point. When doing it, please remove
+    # the choice of libsForQt5*.sddm in sddm's module.
     qt5 = qt514;
     libsForQt5 = libsForQt514;
     inherit pkgs;


### PR DESCRIPTION
###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/100707 , Fix #102167 , Fix #100854 , Fix #98268. (cc @ttuegel ).

###### Things done

- [ ] Iterate all qt applications affected and make sure they work.

In order to do that, before building, one can verify whether incompatible versions are used using the following steps:

1. Download this script: https://paste.sr.ht/~jorsn/307bd7a99855c7d6f34923ebe2f41a9f2d0f6f8a and save it as `dep-ver-consistent.nix`.
2. Run the following to test for incompatible versions with `$pkg` substituted for the attribute path you want to test:

```sh
$(nix-build --no-out-link -A nixUnstable)/bin/nix eval --impure  --expr \
  'with import ./. {}; import ./dep-ver-consistent.nix lib false 4 "qtbase" '$pkg
```

You can use `1` or `2` or any other number instead of `4` in the command above to adjust the depth for which inputs of inputs will be checked. The command will print `true` if no issues are found, and `false` + a trace, if there _are _ incompatible qt versions used.

Given a list of attributes in a file you can iterate them all with:

```sh
cat broken-for-sure | while read pkg; do
 $(nix-build --no-out-link -A nixUnstable)/bin/nix eval --impure --expr 'with import ./. {}; import ./dep-ver-consistent.nix lib false 4 "qtbase" '$pkg
done
```

I think all of affected packages now have no mismatched versions used together, up to depth 4. Upcoming ofborg evals may tell differently.

Here's the current list of affected packages, `kdeFrameworks.` and `kdeApplications.` prefixes were cut in favor of maintaining uniqueness.

   - [ ] akonadi
   - [ ] akonadi-calendar
   - [ ] akonadiconsole
   - [ ] akonadi-contacts
   - [ ] akonadi-import-wizard
   - [ ] akonadi-mime
   - [ ] akonadi-notes
   - [ ] akonadi-search
   - [ ] akregator
   - [ ] alkimia
   - [ ] amarok
   - [ ] amarok-kf5
   - [ ] antimicroX
   - [ ] ark
   - [ ] attica
   - [ ] baloo
   - [ ] baloo-widgets
   - [ ] bcompare
   - [ ] bluedevil
   - [ ] bluez-qt
   - [ ] bomber
   - [ ] bovo
   - [ ] breeze-gtk
   - [ ] breeze-icons
   - [ ] breeze-plymouth
   - [ ] breeze-qt5
   - [ ] calamares
   - [ ] calendarsupport
   - [ ] calligra
   - [ ] colord-kde
   - [ ] digikam
   - [ ] discover
   - [ ] dolphin
   - [ ] dolphin-plugins
   - [ ] dragon
   - [ ] drawpile
   - [ ] drawpile-server-headless
   - [ ] elisa
   - [ ] espanso
   - [ ] eventviews
   - [ ] extra-cmake-modules
   - [ ] falkon
   - [ ] fcitx
   - [ ] fcitx-configtool
   - [ ] fcitx-engines.anthy
   - [ ] fcitx-engines.chewing
   - [ ] fcitx-engines.cloudpinyin
   - [ ] fcitx-engines.hangul
   - [ ] fcitx-engines.libpinyin
   - [ ] fcitx-engines.m17n
   - [ ] fcitx-engines.mozc
   - [ ] fcitx-engines.rime
   - [ ] fcitx-engines.skk
   - [ ] fcitx-engines.table-extra
   - [ ] fcitx-engines.table-other
   - [ ] fcitx-engines.unikey
   - [ ] fcitx-qt5
   - [ ] ffmpegthumbs
   - [ ] filelight
   - [ ] flat-remix-icon-theme
   - [ ] frameworkintegration
   - [ ] gmic-qt-krita
   - [ ] granatier
   - [ ] grantleetheme
   - [ ] gwenview
   - [ ] heaptrack
   - [ ] hotspot
   - [ ] incidenceeditor
   - [ ] k3b
   - [x] k4dirstat
   - [ ] k9copy
   - [ ] kactivities
   - [ ] kactivities-stats
   - [ ] kactivitymanagerd
   - [ ] kaddressbook
   - [ ] kalarm
   - [ ] kalarmcal
   - [ ] kalzium
   - [ ] kapidox
   - [ ] kapman
   - [ ] kapptemplate
   - [ ] karchive
   - [ ] kate
   - [ ] katomic
   - [ ] kauth
   - [ ] kblackbox
   - [ ] kblocks
   - [ ] kbookmarks
   - [ ] kbounce
   - [ ] kbreakout
   - [x] kcachegrind
   - [ ] kcalc
   - [ ] kcalendarcore
   - [ ] kcalutils
   - [ ] kcharselect
   - [ ] kcmutils
   - [ ] kcodecs
   - [ ] kcolorchooser
   - [ ] kcompletion
   - [ ] kconfig
   - [ ] kconfigwidgets
   - [ ] kcontacts
   - [ ] kcoreaddons
   - [ ] kcrash
   - [ ] kdav
   - [ ] kdb
   - [ ] kdbg
   - [ ] kdbusaddons
   - [ ] kde2-decoration
   - [ ] kdebugsettings
   - [ ] kdeclarative
   - [ ] kde-cli-tools
   - [ ] kdeconnect
   - [ ] kdecoration
   - [ ] kded
   - [ ] kdegraphics-mobipocket
   - [ ] kdegraphics-thumbnailers
   - [ ] kde-gtk-config
   - [ ] kdelibs4support
   - [ ] kdenetwork-filesharing
   - [ ] kdenlive
   - [ ] kdepim-addons
   - [ ] kdepim-apps-libs
   - [ ] kdepim-runtime
   - [ ] kdeplasma-addons
   - [ ] kdesignerplugin
   - [ ] kdesu
   - [ ] kdevelop
   - [ ] kdevelop-pg-qt
   - [ ] kdevelop-unwrapped
   - [ ] kdev-php
   - [ ] kdev-python
   - [ ] kdewebkit
   - [ ] kdf
   - [ ] kdiagram
   - [ ] kdialog
   - [ ] kdiamond
   - [ ] kdiff3
   - [ ] kdnssd
   - [ ] kdoctools
   - [ ] keditbookmarks
   - [ ] kemoticons
   - [ ] kexi
   - [ ] keysmith
   - [ ] kf5gpgmepp
   - [ ] kfilemetadata
   - [ ] kfind
   - [ ] kfloppy
   - [ ] kgamma5
   - [ ] kgeography
   - [ ] kget
   - [ ] kglobalaccel
   - [ ] kgpg
   - [ ] kgraphviewer
   - [ ] kguiaddons
   - [ ] khelpcenter
   - [ ] kholidays
   - [ ] khotkeys
   - [ ] khtml
   - [ ] ki18n
   - [ ] kiconthemes
   - [ ] kid3
   - [ ] kidentitymanagement
   - [ ] kidletime
   - [ ] kig
   - [ ] kigo
   - [x] kile
   - [ ] killbots
   - [ ] kimageformats
   - [ ] kimap
   - [ ] kinfocenter
   - [ ] kinit
   - [ ] kio
   - [ ] kio-extras
   - [ ] kipi-plugins
   - [ ] kirigami2
   - [ ] kitemmodels
   - [ ] kitemviews
   - [ ] kitinerary
   - [ ] kjobwidgets
   - [ ] kjs
   - [ ] kjsembed
   - [ ] kldap
   - [ ] kleopatra
   - [ ] klettres
   - [ ] klines
   - [ ] kmag
   - [ ] kmahjongg
   - [ ] kmail
   - [ ] kmail-account-wizard
   - [ ] kmailtransport
   - [ ] kmbox
   - [ ] kmediaplayer
   - [ ] kmenuedit
   - [ ] kmime
   - [ ] kmines
   - [ ] kmix
   - [ ] kmplayer
   - [ ] kmplot
   - [ ] kmymoney
   - [ ] knavalbattle
   - [ ] knetwalk
   - [ ] knewstuff
   - [ ] knights
   - [ ] knotes
   - [ ] knotifications
   - [ ] knotifyconfig
   - [ ] kolf
   - [ ] kollision
   - [ ] kolourpaint
   - [ ] kompare
   - [ ] konqueror
   - [ ] konquest
   - [ ] konsole
   - [ ] kontact
   - [ ] kontactinterface
   - [ ] konversation
   - [ ] korganizer
   - [ ] kpackage
   - [ ] kparts
   - [ ] kpat
   - [ ] kpeople
   - [ ] kpeoplevcard
   - [ ] kpimtextedit
   - [ ] kpkpass
   - [ ] kplotting
   - [ ] kpmcore
   - [ ] kproperty
   - [ ] kpty
   - [ ] kpurpose
   - [ ] kqtquickcharts
   - [ ] kquickcharts
   - [ ] krdc
   - [ ] krename
   - [ ] kreport
   - [ ] kreversi
   - [ ] krfb
   - [ ] krita
   - [ ] krohnkite
   - [ ] kronometer
   - [ ] kross
   - [ ] kruler
   - [ ] krunner
   - [ ] krunner-pass
   - [ ] krusader
   - [ ] kscreen
   - [ ] kscreenlocker
   - [ ] kservice
   - [ ] kshisen
   - [ ] ksmoothdock
   - [ ] ksmtp
   - [ ] kspaceduel
   - [ ] ksquares
   - [ ] ksshaskpass
   - [ ] kstars
   - [ ] ksudoku
   - [ ] ksysguard
   - [ ] ksystemlog
   - [ ] kteatime
   - [ ] ktexteditor
   - [ ] ktextwidgets
   - [ ] ktimer
   - [ ] ktimetracker
   - [ ] ktnef
   - [ ] ktorrent
   - [ ] ktouch
   - [ ] kturtle
   - [ ] kunitconversion
   - [ ] kwallet
   - [ ] kwalletcli
   - [ ] kwalletmanager
   - [ ] kwallet-pam
   - [ ] kwave
   - [ ] kwayland
   - [ ] kwayland-integration
   - [ ] kwidgetsaddons
   - [ ] kwin
   - [ ] kwindowsystem
   - [ ] kwin-dynamic-workspaces
   - [ ] kwin-tiling
   - [ ] kwrited
   - [ ] kxmlgui
   - [ ] kxmlrpcclient
   - [ ] latte-dock
   - [ ] libgravatar
   - [ ] libkcddb
   - [ ] libkdcraw
   - [ ] libkdegames
   - [ ] libkdepim
   - [ ] libkexiv2
   - [ ] libkgapi
   - [ ] libkipi
   - [ ] libkleo
   - [ ] libkmahjongg
   - [ ] libkomparediff2
   - [ ] libksane
   - [ ] libkscreen
   - [ ] libksieve
   - [ ] libksysguard
   - [ ] libktorrent
   - [ ] libqtav
   - [ ] libreoffice-qt
   - [ ] luna-icons
   - [ ] lxqt.lxqt-config
   - [ ] maia-icon-theme
   - [ ] mailcommon
   - [ ] mailimporter
   - [ ] marble
   - [ ] massif-visualizer
   - [ ] mbox-importer
   - [ ] messagelib
   - [ ] milou
   - [ ] minitube
   - [ ] minuet
   - [ ] mlterm
   - [ ] modemmanager-qt
   - [ ] networkmanager-qt
   - [x] okteta
   - [x] okular
   - [ ] oxygen
   - [ ] oxygen-icons5
   - [ ] papirus-icon-theme
   - [ ] papirus-maia-icon-theme
   - [ ] partition-manager
   - [ ] peruse
   - [ ] phonon
   - [ ] phonon-backend-gstreamer
   - [ ] phonon-backend-vlc
   - [ ] photoqt
   - [ ] picmi
   - [ ] pimcommon
   - [ ] pim-data-exporter
   - [ ] pim-sieve-editor
   - [ ] plasma-applet-caffeine-plus
   - [ ] plasma-applet-volumewin7mixer
   - [ ] plasma-browser-integration
   - [ ] plasma-desktop
   - [ ] plasma-framework
   - [ ] plasma-integration
   - [ ] plasma-nm
   - [ ] plasma-pa
   - [ ] plasma-vault
   - [ ] plasma-wayland-protocols
   - [ ] plasma-workspace
   - [ ] plasma-workspace-wallpapers
   - [ ] playbar2
   - [ ] polkit-kde-agent
   - [ ] pop-icon-theme
   - [ ] powerdevil
   - [ ] print-manager
   - [ ] prison
   - [ ] pulseaudio-qt
   - [ ] qqc2-desktop-style
   - [ ] qstopmotion
   - [ ] qtcurve
   - [ ] quassel
   - [ ] quasselClient
   - [ ] redshift-plasma-applet
   - [ ] rocs
   - [ ] rsibreak
   - [ ] sddm
   - [ ] sddm-kcm
   - [ ] skanlite
   - [ ] skrooge
   - [ ] solid
   - [ ] sonnet
   - [ ] soundkonverter
   - [ ] spectacle
   - [ ] syncthingtray
   - [ ] syndication
   - [ ] syntax-highlighting
   - [ ] systemsettings
   - [ ] tellico
   - [ ] threadweaver
   - [ ] tora
   - [ ] trojita
   - [ ] user-manager
   - [ ] virt-manager-qt
   - [ ] wacomtablet
   - [ ] x2goclient
   - [ ] xdg-desktop-portal-kde
   - [ ] yakuake
   - [ ] zafiro-icons
   - [ ] zanshin
   - [ ] zeal
   - [ ] zombietrackergps

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
