### PR TITLE
terraform-providers: vultr 1.3.0 -> 1.4.1

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -149,6 +149,16 @@ let
       '';
     });
 
+    # provider was moved to the `vultr` organization, but kept the old references:
+    # https://github.com/vultr/terraform-provider-vultr/pull/67
+    # this override should be removed as soon as new version (>1.4.1) is released.
+    vultr = automated-providers.vultr.overrideAttrs (attrs: {
+      prePatch = attrs.prePatch or "" + ''
+        substituteInPlace go.mod --replace terraform-providers/terraform-provider-vultr vultr/terraform-provider-vultr
+        substituteInPlace main.go --replace terraform-providers/terraform-provider-vultr vultr/terraform-provider-vultr
+      '';
+    });
+
     # Packages that don't fit the default model
     ansible = callPackage ./ansible {};
     elasticsearch = callPackage ./elasticsearch {};

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -1014,11 +1014,11 @@
     "version": "0.1.0"
   },
   "vultr": {
-    "owner": "terraform-providers",
+    "owner": "vultr",
     "repo": "terraform-provider-vultr",
-    "rev": "v1.3.0",
-    "sha256": "0swc2fvp83d6w0cqvyxs346c756wr48xbn8m8jqkmma5s4ab2y4k",
-    "version": "1.3.0"
+    "rev": "v1.4.1",
+    "sha256": "1jx9p4bwpa5zxig6gfk4akfsnbivvyhwcw8id2ch2ga9a67pwald",
+    "version": "1.4.1"
   },
   "wavefront": {
     "owner": "terraform-providers",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Update vultr terraform provider to the latest release. Tiny piece of https://github.com/NixOS/nixpkgs/pull/98760.
The override can be removed once https://github.com/vultr/terraform-provider-vultr/pull/67 is incorporated in a newer (>1.4.1) release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
