### PR TITLE
linbox: backport upstream fixes

### DIFF
--- a/pkgs/development/libraries/linbox/default.nix
+++ b/pkgs/development/libraries/linbox/default.nix
@@ -14,8 +14,7 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "linbox";
-  version = "1.6.3";
-
+  version = "1.6.3"; # TODO: Check postPatch script on update
 
   src = fetchFromGitHub {
     owner = "linbox-team";
@@ -35,6 +34,20 @@ stdenv.mkDerivation rec {
     gmpxx
     fflas-ffpack
   ];
+
+  patches = [
+    # Remove inappropriate `const &` qualifiers on data members that can be
+    # modified via member functions.
+    # See also: https://github.com/linbox-team/linbox/pull/256
+    ./patches/linbox-pr256-part2.patch # TODO: Remove on 1.7.0 update
+  ];
+
+  postPatch = ''
+    # Remove @LINBOXSAGE_LIBS@ that is actually undefined.
+    # See also: https://github.com/linbox-team/linbox/pull/249
+    # TODO: Remove on 1.7.0 update
+    find . -type f -exec sed -e 's/@LINBOXSAGE_LIBS@//' -i {} \;
+  '';
 
   configureFlags = [
     "--with-blas-libs=-lblas"

--- a/pkgs/development/libraries/linbox/patches/linbox-pr256-part2.patch
+++ b/pkgs/development/libraries/linbox/patches/linbox-pr256-part2.patch
@@ -1,0 +1,13 @@
+--- a/linbox/algorithms/det-rational.h
++++ b/linbox/algorithms/det-rational.h
+@@ -79,8 +79,8 @@
+ 	struct MyRationalModularDet {
+ 		const Blackbox &A;
+ 		const MyMethod &M;
+-		const Integer &mul;//multiplicative prec;
+-		const Integer &div;
++		Integer mul;//multiplicative prec;
++		Integer div;
+ 
+ 		MyRationalModularDet(const Blackbox& b, const MyMethod& n,
+ 				     const Integer & p1, const Integer & p2) :


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This change backports part of the following upstream commits.

- https://github.com/linbox-team/linbox/commit/f78117d9c365efd46f5ea2903b553a08c4029aeb
- https://github.com/linbox-team/linbox/commit/4ff828e20053ab2ef9adc4ce6931d159fd513cef

These patches are also backported by SageMath and required to build that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - `sage` still fails to build
  - `doCheck = true` and passes all tests.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
