### PR TITLE
among-sus: init at 2020-10-22

### DIFF
--- a/pkgs/games/among-sus/default.nix
+++ b/pkgs/games/among-sus/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchgit, port ? "1234" }:
+
+stdenv.mkDerivation {
+  pname = "among-sus-unstable";
+  version = "2020-10-29";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~martijnbraam/among-sus";
+    rev = "1f4c8d800d025d36ac66826937161be3252fbc57";
+    sha256 = "19jq7ygh9l11dl1h6702bg57m04y35nqd6yqx1rgp1kxwhp45xyh";
+  };
+
+  patchPhase = ''
+    sed -i 's/port = 1234/port = ${port}/g' main.c
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -Dm755 among-sus $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://git.sr.ht/~martijnbraam/among-sus";
+    description = "Among us, but it's a text adventure";
+    license = licenses.agpl3Plus;
+    maintainers = [ maintainers.eyjhb ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -140,6 +140,8 @@ in
 
   alda = callPackage ../development/interpreters/alda { };
 
+  among-sus = callPackage ../games/among-sus { };
+
   ankisyncd = callPackage ../servers/ankisyncd { };
 
   avro-tools = callPackage ../development/tools/avro-tools { };


### PR DESCRIPTION
Not sure if this works on Mac OS X as well?
I see no reason why it sholudn't.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
