### PR TITLE
gtg: unstable-2020-09-16 -> unstable-2020-10-22

### DIFF
--- a/pkgs/applications/office/gtg/default.nix
+++ b/pkgs/applications/office/gtg/default.nix
@@ -11,17 +11,18 @@
 , pango
 , gdk-pixbuf
 , gobject-introspection
+, xvfb_run
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "gtg";
-  version = "unstable-2020-09-16";
+  version = "unstable-2020-10-22";
 
   src = fetchFromGitHub {
     owner = "getting-things-gnome";
     repo = "gtg";
-    rev = "1be991c6d7f7b2e4b8ac16f82e8a07f9dce4272f";
-    sha256 = "1f5acpjwnp08c78dds7xm22qjzcfnx2qs121yvm3rswkh27s4n23";
+    rev = "144814c16723fa9d00e17e047df5d79ab443fc5f";
+    sha256 = "1lpanfbj8y8b6cqp92lgbvfs8irrc5bsdffzcjcycazv19qm7z2n";
   };
 
 
@@ -45,7 +46,6 @@ python3Packages.buildPythonApplication rec {
     pycairo
     pygobject3
     lxml
-    dbus-python
     gst-python
     liblarch
   ];
@@ -53,12 +53,13 @@ python3Packages.buildPythonApplication rec {
   checkInputs = with python3Packages; [
     nose
     mock
+    xvfb_run
   ];
 
   format = "other";
   strictDeps = false; # gobject-introspection does not run with strictDeps (https://github.com/NixOS/nixpkgs/issues/56943)
 
-  checkPhase = "python3 ../run-tests";
+  checkPhase = "xvfb-run python3 ../run-tests";
 
   meta = with stdenv.lib; {
     description = " A personal tasks and TODO-list items organizer";


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
