### PR TITLE
terraform-providers.time: init at 0.6.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -934,6 +934,14 @@
     "sha256": "1cl83afm00fflsd3skynjvncid3r74fkxfznrs1v8qypcg1j79g1",
     "version": "0.18.0"
   },
+  "time": {
+    "owner": "hashicorp",
+    "provider-source-address": "registry.terraform.io/hashicorp/time",
+    "repo": "terraform-provider-time",
+    "rev": "v0.6.0",
+    "sha256": "0fb81hisjicib9rzbn51jqfrchyjd3hzq98adnf22cbra8wlnxlm",
+    "version": "0.6.0"
+  },
   "tls": {
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/tls",


### PR DESCRIPTION
###### Motivation for this change

It exists.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
