### PR TITLE
nixos/dbus: re-add a dummy socketActivated option

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -719,7 +719,7 @@ rec {
 
        mkRemovedOptionModule [ "boot" "loader" "grub" "bootDevice" ] "<replacement instructions>"
 
-     causes a warning if the user defines boot.loader.grub.bootDevice.
+     causes a assertion if the user defines boot.loader.grub.bootDevice.
 
      replacementInstructions is a string that provides instructions on
      how to achieve the same functionality without the removed option,

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -1,6 +1,6 @@
 # D-Bus configuration and system bus daemon.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, options, pkgs, ... }:
 
 with lib;
 
@@ -18,13 +18,6 @@ let
 in
 
 {
-
-  imports = [
-    (mkRemovedOptionModule
-      [ "services" "dbus" "socketActivated" ]
-      "The user D-Bus session is now always socket activated and this option can safely be removed.")
-  ];
-
   ###### interface
 
   options = {
@@ -57,12 +50,29 @@ in
           <filename><replaceable>pkg</replaceable>/share/dbus-1/services</filename>
         '';
       };
+
+      socketActivated = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        visible = false;
+        description = ''
+          Removed option, do not use.
+        '';
+      };
     };
   };
 
   ###### implementation
 
   config = mkIf cfg.enable {
+    warnings = optional (cfg.socketActivated != null) (
+      let
+        files = showFiles options.services.dbus.socketActivated.files;
+      in
+        "The option 'services.dbus.socketActivated' in ${files} no longer has"
+        + " any effect and can be safely removed: the user D-Bus session is"
+        + " now always socket activated."
+    );
 
     environment.systemPackages = [ pkgs.dbus.daemon pkgs.dbus ];
 


### PR DESCRIPTION
An alternative to #101408. Also see #97801.