### PR TITLE
3proxy: 0.8.13 -> 0.9.3

### DIFF
--- a/pkgs/applications/networking/3proxy/default.nix
+++ b/pkgs/applications/networking/3proxy/default.nix
@@ -1,21 +1,27 @@
-{ stdenv, fetchFromGitHub, coreutils }:
+{ stdenv, fetchFromGitHub, coreutils, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "3proxy";
-  version = "0.8.13";
+  version = "0.9.3";
+
   src = fetchFromGitHub {
     owner = "z3APA3A";
     repo = pname;
     rev = version;
-    sha256 = "1k5rqldiyakhwhplazlhswkgy3psdkpxhn85605ncwaqx49qy8vk";
+    sha256 = "0vx6cf3jdlg1h8755ryvfzqh9ld3r5i62ygw9vc6clzl5k1jkapm";
   };
-  makeFlags = [
-    "INSTALL=${coreutils}/bin/install"
-    "prefix=$(out)"
-  ];
+
   preConfigure = ''
     ln -s Makefile.Linux Makefile
   '';
+
+  installPhase = ''
+    mkdir -p $out/libexec
+    make INSTALL=${coreutils}/bin/install CHROOTDIR=$out prefix=$out man_prefix=$out install-bin install-man
+  '';
+
+  passthru.tests._3proxy = nixosTests._3proxy;
+
   meta = with stdenv.lib; {
     description = "Tiny free proxy server";
     homepage = "https://github.com/z3APA3A/3proxy";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/z3APA3A/3proxy/releases/tag/0.9.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
