### PR TITLE
tailscale: Include version in build flags

### DIFF
--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -21,6 +21,13 @@ buildGoModule rec {
 
   subPackages = [ "cmd/tailscale" "cmd/tailscaled" ];
 
+  preBuild = ''
+    export buildFlagsArray=(
+      -tags="xversion"
+      -ldflags="-X tailscale.com/version.LONG=${version} -X tailscale.com/version.SHORT=${version}"
+    )
+  '';
+
   postInstall = ''
     wrapProgram $out/bin/tailscaled --prefix PATH : ${
       lib.makeBinPath [ iproute iptables ]


### PR DESCRIPTION

###### Motivation for this change

This commit adds the user-facing version to the tailscale version
output.

Prior to this change, it used a hardcoded fallback that is fairly
infrequently updated (https://github.com/tailscale/tailscale/commits/main/version/version.go).

After this change, we print the user-friendlier tag version, which is
helpful when wanting to e.g check to see if you have a version that is
compatible with a feature like [magic dns][magic-dns].

E.g:

```
[nixpkgs(dani/tailscale-version)] $ ./result/bin/tailscale version
1.0.5
```

[magic-dns]: https://tailscale.com/kb/1081/magic-dns

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
