### PR TITLE
Add new meta-attributes to stdenv to permit URLs for screenshots

### DIFF
--- a/doc/stdenv/meta.xml
+++ b/doc/stdenv/meta.xml
@@ -310,8 +310,6 @@ meta.hydraPlatforms = [];
       This optional entry can be used to refer (with a URL) to a screenshot of the package's application. A good source of 
       appropriate screenshots is the website <link
           xlink:href="https://screenshots.debian.net/"> <filename>https://screenshots.debian.net/</filename></link>. The suggested size of an image is 800x600 pixels or less.
-     </para>.
-     <para>
        An example is provided in the pingus package:
        <programlisting>
          meta = {

--- a/doc/stdenv/meta.xml
+++ b/doc/stdenv/meta.xml
@@ -289,6 +289,26 @@ meta.hydraPlatforms = [];
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry>
+    <term>
+     <varname>screenshotThumb</varname>
+    </term>
+    <listitem>
+     <para>
+      This optional entry can be used to refer (with a URL) to a thumbnail sized screenshot of the package's application.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <varname>screenshotLarge</varname>
+    </term>
+    <listitem>
+     <para>
+      This optional entry can be used to refer (with a URL) to a screenshot of the package's application.
+     </para>
+    </listitem>
+   </varlistentry>
   </variablelist>
  </section>
  <section xml:id="sec-meta-license">

--- a/doc/stdenv/meta.xml
+++ b/doc/stdenv/meta.xml
@@ -295,8 +295,8 @@ meta.hydraPlatforms = [];
     </term>
     <listitem>
      <para>
-      This optional entry can be used to refer (with a URL) to a thumbnail sized screenshot of the package's application. A good source of 
-      appropriate screenshots is the website <link
+      This optional entry can be used to refer (with a URL) to a thumbnail sized screenshot of the package's application.
+      A good source of appropriate screenshots is the website <link
           xlink:href="https://screenshots.debian.net/"> <filename>https://screenshots.debian.net/</filename></link>. The suggested size of a thumbnail image is 160x120 pixels or less.
      </para>
     </listitem>
@@ -307,8 +307,8 @@ meta.hydraPlatforms = [];
     </term>
     <listitem>
      <para>
-      This optional entry can be used to refer (with a URL) to a screenshot of the package's application. A good source of 
-      appropriate screenshots is the website <link
+      This optional entry can be used to refer (with a URL) to a screenshot of the package's application.
+      A good source of appropriate screenshots is the website <link
           xlink:href="https://screenshots.debian.net/"> <filename>https://screenshots.debian.net/</filename></link>. The suggested size of an image is 800x600 pixels or less.
        An example is provided in the pingus package:
        <programlisting>

--- a/doc/stdenv/meta.xml
+++ b/doc/stdenv/meta.xml
@@ -295,7 +295,9 @@ meta.hydraPlatforms = [];
     </term>
     <listitem>
      <para>
-      This optional entry can be used to refer (with a URL) to a thumbnail sized screenshot of the package's application.
+      This optional entry can be used to refer (with a URL) to a thumbnail sized screenshot of the package's application. A good source of 
+      appropriate screenshots is the website <link
+          xlink:href="https://screenshots.debian.net/"> <filename>https://screenshots.debian.net/</filename></link>. The suggested size of a thumbnail image is 160x120 pixels or less.
      </para>
     </listitem>
    </varlistentry>
@@ -305,7 +307,19 @@ meta.hydraPlatforms = [];
     </term>
     <listitem>
      <para>
-      This optional entry can be used to refer (with a URL) to a screenshot of the package's application.
+      This optional entry can be used to refer (with a URL) to a screenshot of the package's application. A good source of 
+      appropriate screenshots is the website <link
+          xlink:href="https://screenshots.debian.net/"> <filename>https://screenshots.debian.net/</filename></link>. The suggested size of an image is 800x600 pixels or less.
+     </para>.
+     <para>
+       An example is provided in the pingus package:
+       <programlisting>
+         meta = {
+             [...]
+             screenshotThumb = "https://screenshots.debian.net/thumbnail/pingus";
+             screenshotLarge = "https://screenshots.debian.net/screenshot/pingus";
+         };
+       </programlisting>
      </para>
     </listitem>
    </varlistentry>

--- a/pkgs/games/pingus/default.nix
+++ b/pkgs/games/pingus/default.nix
@@ -18,5 +18,7 @@ stdenv.mkDerivation rec {
     platforms = stdenv.lib.platforms.linux;
     maintainers = [stdenv.lib.maintainers.raskin];
     license = stdenv.lib.licenses.gpl3;
+    screenshotThumb = "https://screenshots.debian.net/thumbnail/pingus";
+    screenshotLarge = "https://screenshots.debian.net/screenshot/pingus";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

If a meta-attribute for a Screenshot-URL were added to the package description, the search result could include a screenshot of the application in the result. There is no need to create new screenshots as http://screenshots.debian.net/ provides a public repository of screenshots already that could be reused.

I am aware that adding screenshots to the existing thousands of packages would be a major undertaking, but I think it would be a nice user experience enhancement and - of course - optional, since screenshots only make sense for graphical applications.

When the Screenshot-URL is provided for a package, the search result could fetch the image and show it alongside the package description.

The font packages could show a sample of the font instead.

###### Things done

Two paragraphs were added to the Nixpks-manual, section Stdenv -> Meta-attributes to explain the two new
attributes ScreenshotThumb and ScreenshotLarge.

In the package games/pingus the two attributes were added as an example.

The Nixpkgs-manual was rebuild to check correctness.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@garbas 

Discussed in https://github.com/NixOS/nixos-search/issues/211
