### PR TITLE
terraform-providers.github: 2.8.0 -> 3.1.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -328,9 +328,9 @@
   "github": {
     "owner": "terraform-providers",
     "repo": "terraform-provider-github",
-    "rev": "v2.8.0",
-    "sha256": "11aw9wqnayl786hvbgnb9ijijaipaggj18vkn5y0kcj2v4dwq4wg",
-    "version": "2.8.0"
+    "rev": "v3.1.0",
+    "sha256": "1xl4fd1lfbn1vnrdmg2xljnv8hy6rmf0iv7g8pzbnzbvj2pi7w3b",
+    "version": "3.1.0"
   },
   "gitlab": {
     "owner": "terraform-providers",


### PR DESCRIPTION
###### Motivation for this change

Prior versions only support orgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
