### PR TITLE
geogebra: 5-0-593-0 -> 5-0-609-0, geogebra6: 6-0-600-0 -> 6-0-609-0

### DIFF
--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -1,18 +1,7 @@
-{ stdenv, fetchurl, jre, makeDesktopItem, makeWrapper, language ? "en_US" }:
-
-stdenv.mkDerivation rec {
+{ stdenv, fetchurl, jre, makeDesktopItem, makeWrapper, unzip, language ? "en_US" }:
+let
   pname = "geogebra";
-  version = "5-0-593-0";
-
-  preferLocalBuild = true;
-
-  src = fetchurl {
-    urls = [
-      "https://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2"
-      "http://web.archive.org/https://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2"
-    ];
-    sha256 = "d84c27a3299e6df08881733d22215a18decedcba4c2d97a9e5424c39cd57db35";
-  };
+  version = "5-0-609-0";
 
   srcIcon = fetchurl {
     url = "http://static.geogebra.org/images/geogebra-logo.svg";
@@ -30,23 +19,6 @@ stdenv.mkDerivation rec {
     mimeType = "application/vnd.geogebra.file;application/vnd.geogebra.tool;";
   };
 
-  buildInputs = [ makeWrapper ];
-
-  installPhase = ''
-    install -D geogebra/* -t "$out/libexec/geogebra/"
-
-    makeWrapper "$out/libexec/geogebra/geogebra" "$out/bin/geogebra" \
-      --set JAVACMD "${jre}/bin/java" \
-      --set GG_PATH "$out/libexec/geogebra" \
-      --add-flags "--language=${language}"
-
-    install -Dm644 "${desktopItem}/share/applications/"* \
-      -t $out/share/applications/
-
-    install -Dm644 "${srcIcon}" \
-      "$out/share/icons/hicolor/scalable/apps/geogebra.svg"
-  '';
-
   meta = with stdenv.lib; {
     description = "Dynamic mathematics software with graphics, algebra and spreadsheets";
     longDescription = ''
@@ -57,7 +29,61 @@ stdenv.mkDerivation rec {
     homepage = "https://www.geogebra.org/";
     maintainers = with maintainers; [ ma27 ];
     license = with licenses; [ gpl3 cc-by-nc-sa-30 geogebra ];
-    platforms = platforms.all;
+    platforms = with platforms; linux ++ darwin;
     hydraPlatforms = [];
   };
-}
+
+  linuxPkg = stdenv.mkDerivation {
+    inherit pname version meta srcIcon desktopItem;
+
+    preferLocalBuild = true;
+
+    src = fetchurl {
+      urls = [
+        "https://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2"
+        "http://web.archive.org/web/20201022200454/https://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2"
+      ];
+      sha256 = "0xbhg8hm3dqm3qkraj48pqwslrnjyxpq9mcgylr2m8i1gmqw7xwf";
+    };
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    installPhase = ''
+      install -D geogebra/* -t "$out/libexec/geogebra/"
+
+      makeWrapper "$out/libexec/geogebra/geogebra" "$out/bin/geogebra" \
+        --set JAVACMD "${jre}/bin/java" \
+        --set GG_PATH "$out/libexec/geogebra" \
+        --add-flags "--language=${language}"
+
+      install -Dm644 "${desktopItem}/share/applications/"* \
+        -t $out/share/applications/
+
+      install -Dm644 "${srcIcon}" \
+        "$out/share/icons/hicolor/scalable/apps/geogebra.svg"
+    '';
+  };
+
+  darwinPkg = stdenv.mkDerivation {
+    inherit pname version meta;
+
+    preferLocalBuild = true;
+
+    src = fetchurl {
+      url = "https://download.geogebra.org/installers/5.0/GeoGebra-MacOS-Installer-withJava-${version}.zip";
+      sha256 = "16fgqwxz31cfmia0pyzpk05aqzrqr11sjbw37q9zb3xfh3p1r4gz";
+    };
+
+    dontUnpack = true;
+
+    nativeBuildInputs = [ unzip ];
+
+    installPhase = ''
+      install -dm755 $out/Applications
+      unzip $src -d $out/Applications
+    '';
+  };
+in
+if stdenv.isDarwin
+then darwinPkg
+else linuxPkg

--- a/pkgs/applications/science/math/geogebra/geogebra6.nix
+++ b/pkgs/applications/science/math/geogebra/geogebra6.nix
@@ -1,46 +1,70 @@
 { stdenv, unzip, fetchurl, electron_6, makeWrapper, geogebra }:
-stdenv.mkDerivation rec{
-
-  name = "geogebra-${version}";
-  version = "6-0-600-0";
-
-  src = fetchurl {
-    urls = [
-        "https://download.geogebra.org/installers/6.0/GeoGebra-Linux64-Portable-${version}.zip"
-        "https://web.archive.org/web/20200904093945/https://download.geogebra.org/installers/6.0/GeoGebra-Linux64-Portable-${version}.zip"
-      ];
-    sha256 = "1l49rvfkil2cz6r7sa2mi0p6hvb6p66jv3x6xj8hjqls4l3sfhkm";
-  };
-
-  dontConfigure = true;
-  dontBuild = true;
-
-  nativeBuildInputs = [
-    unzip
-    makeWrapper
-  ];
-
-  unpackPhase = ''
-    unzip $src
-  '';
-
-  installPhase = ''
-    mkdir -p $out/libexec/geogebra/ $out/bin
-    cp -r GeoGebra-linux-x64/{resources,locales} "$out/"
-    makeWrapper ${stdenv.lib.getBin electron_6}/bin/electron $out/bin/geogebra --add-flags "$out/resources/app"
-    install -Dm644 "${desktopItem}/share/applications/"* \
-      -t $out/share/applications/
-
-    install -Dm644 "${srcIcon}" \
-      "$out/share/icons/hicolor/scalable/apps/geogebra.svg"
-  '';
+let
+  pname = "geogebra";
+  version = "6-0-609-0";
 
   srcIcon = geogebra.srcIcon;
-
   desktopItem = geogebra.desktopItem;
+
   meta = with stdenv.lib; geogebra.meta // {
     license = licenses.geogebra;
     maintainers = with maintainers; [ voidless ];
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
   };
-}
+
+  linuxPkg = stdenv.mkDerivation {
+    inherit pname version meta;
+
+    src = fetchurl {
+      urls = [
+          "https://download.geogebra.org/installers/6.0/GeoGebra-Linux64-Portable-${version}.zip"
+          "https://web.archive.org/web/20201022200156/https://download.geogebra.org/installers/6.0/GeoGebra-Linux64-Portable-${version}.zip"
+        ];
+      sha256 = "0rzcbq587x8827g9v03awa9hz27vyfjc0cz45ymbchqp31lsx49b";
+    };
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    nativeBuildInputs = [
+      unzip
+      makeWrapper
+    ];
+
+    unpackPhase = ''
+      unzip $src
+    '';
+
+    installPhase = ''
+      mkdir -p $out/libexec/geogebra/ $out/bin
+      cp -r GeoGebra-linux-x64/{resources,locales} "$out/"
+      makeWrapper ${stdenv.lib.getBin electron_6}/bin/electron $out/bin/geogebra --add-flags "$out/resources/app"
+      install -Dm644 "${desktopItem}/share/applications/"* \
+        -t $out/share/applications/
+
+      install -Dm644 "${srcIcon}" \
+        "$out/share/icons/hicolor/scalable/apps/geogebra.svg"
+    '';
+  };
+
+  darwinPkg = stdenv.mkDerivation {
+    inherit pname version meta;
+
+    src = fetchurl {
+      url = "https://download.geogebra.org/installers/6.0/GeoGebra-Classic-6-MacOS-Portable-${version}.zip";
+      sha256 = "0275869zgwbl1qjj593q6629hnxbwk9c15rkm29a3lh10pinb099";
+    };
+
+    dontUnpack = true;
+
+    nativeBuildInputs = [ unzip ];
+
+    installPhase = ''
+      install -dm755 $out/Applications
+      unzip $src -d $out/Applications
+    '';
+  };
+in
+if stdenv.isDarwin
+then darwinPkg
+else linuxPkg


### PR DESCRIPTION
###### Motivation for this change
* geogebra: 5-0-593-0 -> 5-0-609-0, enable on darwin
* geogebra6: 6-0-600-0 -> 6-0-609-0, enable on darwin

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
