### PR TITLE
material-shell: 7 -> 8

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/material-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/material-shell/default.nix
@@ -1,24 +1,15 @@
-{ stdenv, lib, fetchFromGitHub, gnome3, fetchpatch }:
+{ stdenv, lib, fetchFromGitHub, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-material-shell";
-  version = "7";
+  version = "8";
 
   src = fetchFromGitHub {
     owner = "material-shell";
     repo = "material-shell";
     rev = version;
-    sha256 = "076cv1l5qr5x71przjwvbzx0m91n4z0byc2gc3r48l8vsr2d0hwf";
+    sha256 = "08zc6xl2b7k7l5l6afr40ii3gnxxbysan3cqv2s9g614rbsmc62r";
   };
-
-  patches = [
-    # Fix for https://github.com/material-shell/material-shell/issues/284
-    # (Remove this patch when updating to version >= 8)
-    (fetchpatch {
-      url = "https://github.com/material-shell/material-shell/commit/fc27489a1ec503a4a5c7cb2f4e1eefa84a7ea2f1.patch";
-      sha256 = "0x2skg955c4jqgwbkfhk7plm8bh1qnk66cdds796bzkp3hb5syw8";
-    })
-  ];
 
   # This package has a Makefile, but it's used for building a zip for
   # publication to extensions.gnome.org. Disable the build phase so


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version 8.

###### Things done

Updated my extension to version 8 in GNOME to test.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
