### PR TITLE
zalgo: init at unstable-2020-08-26

### DIFF
--- a/pkgs/tools/misc/zalgo/default.nix
+++ b/pkgs/tools/misc/zalgo/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "zalgo";
+  version = "unstable-2020-08-26";
+
+  src = fetchFromGitHub {
+    owner = "lunasorcery";
+    repo = "zalgo";
+    rev = "6aa1f66cfe183f8164a666730dfeaf39133cf01a";
+    sha256 = "00q56yvfcj2f89wllrckvizihivqmd6l77nihb52ffqd99rdd24w";
+  };
+
+  installPhase = ''
+    install -Dm755 zalgo -t $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Read stdin and corrupt it with combining diacritics";
+    homepage = "https://github.com/lunasorcery/zalgo";
+    license = licenses.unfree;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ djanatyn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28342,6 +28342,8 @@ in
 
   navidrome = callPackage ../servers/misc/navidrome {};
 
+  zalgo = callPackage ../tools/misc/zalgo { };
+
   zettlr = callPackage ../applications/misc/zettlr { };
 
   unifi-poller = callPackage ../servers/monitoring/unifi-poller {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I need a way to generate text that looks haunted on NixOS this month.
T͕h̢̤̲í̙̞s t̡o̳̙o̳͢ļ̭̦̘ w̛̺il̞l s͖̗úf͓̮͜f̫̟͞i͉̟̠cẹ̩̱͝.

Z̛̼̩̤̲̘͜͞Ą̟͈̳̥̙ͅL̵͈̪̲̣̺̮G̢̪̞̦̱͖͓̳O̮̜̬̳̻̫͜͞.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
