### PR TITLE
surf: 2.0 -> unstable-2019-02-08

### DIFF
--- a/pkgs/applications/networking/browsers/surf/default.nix
+++ b/pkgs/applications/networking/browsers/surf/default.nix
@@ -1,21 +1,22 @@
-{ lib, stdenv, fetchurl
+{ lib, stdenv, fetchgit
 , pkgconfig, wrapGAppsHook
-, glib, glib-networking, gsettings-desktop-schemas, gtk, libsoup, webkitgtk
+, glib, gcr, glib-networking, gsettings-desktop-schemas, gtk, libsoup, webkitgtk
 , xorg, dmenu, findutils, gnused, coreutils
 , patches ? null
 }:
 
 stdenv.mkDerivation rec {
   pname = "surf";
-  version = "2.0";
+  version = "unstable-2019-02-08";
 
-  src = fetchurl {
-    url = "https://dl.suckless.org/surf/surf-${version}.tar.gz";
-    sha256 = "07cmajyafljigy10d21kkyvv5jf3hxkx06pz3rwwk3y3c9x4rvps";
+  src = fetchgit {
+    url = "git://git.suckless.org/surf";
+    rev = "d068a3878b6b9f2841a49cd7948cdf9d62b55585";
+    sha256 = "0pjsv2q8c74sdmqsalym8wa2lv55lj4pd36miam5wd12769xw68m";
   };
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
-  buildInputs = [ glib glib-networking gsettings-desktop-schemas gtk libsoup webkitgtk ];
+  buildInputs = [ glib gcr glib-networking gsettings-desktop-schemas gtk libsoup webkitgtk ];
 
   inherit patches;
 
@@ -32,9 +33,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A simple web browser based on WebKit/GTK";
+    description = "A simple web browser based on WebKitGTK";
     longDescription = ''
-      Surf is a simple web browser based on WebKit/GTK. It is able to display
+      surf is a simple web browser based on WebKitGTK. It is able to display
       websites and follow links. It supports the XEmbed protocol which makes it
       possible to embed it in another application. Furthermore, one can point
       surf to another URI by setting its XProperties.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #81629

@alexherbo2 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
