### PR TITLE
rtss: init at 0.6.1

### DIFF
--- a/pkgs/development/tools/misc/rtss/default.nix
+++ b/pkgs/development/tools/misc/rtss/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rtss";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "Freaky";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1936w161mkbcwicrxn51b42pgir5yjiw85s74lbfq70nddw18nyn";
+  };
+
+  cargoSha256 = "0nll5gg7fjh6sz3cscarknb0gaivmzkcxhwdb2li47r74rcbrj36";
+
+  meta = with lib; {
+    description = "Annotate output with relative durations between lines";
+    homepage = "https://github.com/Freaky/rtss";
+    license = licenses.mit;
+    maintainers = with maintainers; [ djanatyn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6658,6 +6658,8 @@ in
 
   rtptools = callPackage ../tools/networking/rtptools { };
 
+  rtss = callPackage ../development/tools/misc/rtss { };
+
   reaverwps = callPackage ../tools/networking/reaver-wps {};
 
   reaverwps-t6x = callPackage ../tools/networking/reaver-wps-t6x {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
rtss provides a way to understand the performance of complex shell pipelines and loops.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
