### PR TITLE
pdal: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/development/libraries/pdal/default.nix
+++ b/pkgs/development/libraries/pdal/default.nix
@@ -3,7 +3,7 @@
 , fetchpatch
 , cmake
 , pkg-config
-# , openscenegraph
+, openscenegraph
 , curl
 , gdal
 , hdf5-cpp
@@ -20,26 +20,14 @@
 
 stdenv.mkDerivation rec {
   pname = "pdal";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "PDAL";
     repo = "PDAL";
     rev = version;
-    sha256 = "0zb3zjqgmjjryb648c1hmwh1nfa7893bjzbqpmr6shjxvzgnj9p6";
+    sha256 = "1i7nbfvv60jjlf3iq7a7xci4dycmg2wrd35dqvjwl6hpfynpb6wz";
   };
-
-  patches = [
-    # Fix duplicate paths like
-    #     /nix/store/7iafqfmjdlxqim922618wg87cclrpznr-PDAL-2.1.0//nix/store/7iafqfmjdlxqim922618wg87cclrpznr-PDAL-2.1.0/lib
-    # similar to https://github.com/NixOS/nixpkgs/pull/82654.
-    # TODO Remove on release > 2.1.0
-    (fetchpatch {
-      name = "pdal-Fixup-install-config.patch";
-      url = "https://github.com/PDAL/PDAL/commit/2f887ef624db50c6e20f091f34bb5d3e65b5c5c8.patch";
-      sha256 = "0pdw9v5ypq7w9i7qzgal110hjb9nqi386jvy3x2h4vf1dyalzid8";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -47,7 +35,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    # openscenegraph
+    openscenegraph
     curl
     gdal
     hdf5-cpp
@@ -67,11 +55,6 @@ stdenv.mkDerivation rec {
     "-DBUILD_PLUGIN_HDF=ON"
     "-DBUILD_PLUGIN_PGPOINTCLOUD=ON"
     "-DBUILD_PLUGIN_TILEDB=ON"
-
-    # Plugins that can probably be made working relatively easily:
-    # As of writing, seems to be incompatible (build error):
-    #     error: no matching function for call to 'osg::TriangleFunctor<pdal::CollectTriangles>::operator()(const Vec3&, const Vec3&, const Vec3&)'
-    "-DBUILD_PLUGIN_OPENSCENEGRAPH=OFF" # requires OpenGL
 
     # Plugins can probably not be made work easily:
     "-DBUILD_PLUGIN_CPD=OFF"


### PR DESCRIPTION
###### Motivation for this change

https://github.com/PDAL/PDAL/releases/tag/2.2.0

Changelog items are benign.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).