### PR TITLE
firefox: disable LTO by default due to segfaults with wayland

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -23,7 +23,8 @@
 , ffmpegSupport ? true
 , gtk3Support ? true, gtk2, gtk3, wrapGAppsHook
 , waylandSupport ? true, libxkbcommon
-, ltoSupport ? stdenv.isLinux, overrideCC, buildPackages
+# LTO is disabled since it caused segfaults on wayland see https://github.com/NixOS/nixpkgs/issues/10142
+, ltoSupport ? false, overrideCC, buildPackages
 , gssSupport ? true, kerberos
 , pipewireSupport ? waylandSupport && webrtcSupport, pipewire
 


### PR DESCRIPTION
###### Motivation for this change

As discussed in #101429 firefox 82 started crashing when used with
wayland. A brief investigation showed that this appears to be rooted
within the LTO support that was recently added to the package. For the
time being, until someone figures out where the crashes are coming from,
we can just disable LTO.

cc @artemist


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS