### PR TITLE
[20.09] pitivi: Fix .svg loading at startup, see #56943 #89691

### DIFF
--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -147,6 +147,12 @@ in python3Packages.buildPythonApplication rec {
     mv data/org.pitivi.Pitivi-mime.xml data/org.pitivi.Pitivi-mime.xml.in
   '';
 
+  # Fixes error
+  #     Couldn’t recognize the image file format for file ".../share/pitivi/pixmaps/asset-proxied.svg"
+  # at startup, see https://github.com/NixOS/nixpkgs/issues/56943
+  # and https://github.com/NixOS/nixpkgs/issues/89691#issuecomment-714398705.
+  strictDeps = false;
+
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = "pitivi";


### PR DESCRIPTION
###### Motivation for this change

Backport of #101398, without it pitivi does not start.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).