### PR TITLE
pythonPackages.imdbpy: init at 2020.9.25

### DIFF
--- a/pkgs/development/python-modules/imdbpy/default.nix
+++ b/pkgs/development/python-modules/imdbpy/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, lxml, sqlalchemy }:
+
+buildPythonPackage rec {
+  pname = "IMDbPY";
+  version = "2020.9.25";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1p3j9j1jcgbw4626cvgpryhvczy9gzlg0laz6lflgq17m129gin2";
+  };
+
+  patches = [ ./sql_error.patch ]; # Already fixed in master, but not yet in the current release. This can be removed upon the next version update
+
+  propagatedBuildInputs = [ lxml sqlalchemy ];
+
+  doCheck = false; # Tests require networking, and https://github.com/alberanid/imdbpy/issues/240
+  pythonImportsCheck = [ "imdb" ];
+
+  meta = with lib; {
+    homepage = "https://imdbpy.github.io/";
+    description = "A Python package for retrieving and managing the data of the IMDb database";
+    maintainers = [ maintainers.ivar ];
+    license = licenses.gpl2Only;
+  };
+}

--- a/pkgs/development/python-modules/imdbpy/sql_error.patch
+++ b/pkgs/development/python-modules/imdbpy/sql_error.patch
@@ -1,0 +1,39 @@
+diff --git a/imdb/parser/sql/__init__.py b/imdb/parser/sql/__init__.py
+index cd4a3e3..3fcfdd4 100644
+--- a/imdb/parser/sql/__init__.py
++++ b/imdb/parser/sql/__init__.py
+@@ -557,7 +557,6 @@ class IMDbSqlAccessSystem(IMDbBase):
+     """The class used to access IMDb's data through a SQL database."""
+
+     accessSystem = 'sql'
+-    _sql_logger = logging.getLogger('imdbpy.parser.sql')
+
+     def __init__(self, uri, adultSearch=True, *arguments, **keywords):
+         """Initialize the access system."""
+@@ -582,7 +581,7 @@ class IMDbSqlAccessSystem(IMDbBase):
+         except ImportError as e:
+             raise IMDbError('unable to import SQLAlchemy')
+         # Set the connection to the database.
+-        self._sql_logger.debug('connecting to %s', uri)
++        logger.debug('connecting to %s', uri)
+         try:
+             self._connection = setConnection(uri, DB_TABLES)
+         except AssertionError as e:
+@@ -593,7 +592,7 @@ class IMDbSqlAccessSystem(IMDbBase):
+         # Maps some IDs to the corresponding strings.
+         self._kind = {}
+         self._kindRev = {}
+-        self._sql_logger.debug('reading constants from the database')
++        logger.debug('reading constants from the database')
+         try:
+             for kt in KindType.select():
+                 self._kind[kt.id] = kt.kind
+@@ -1616,7 +1615,7 @@ class IMDbSqlAccessSystem(IMDbBase):
+         return
+         if not hasattr(self, '_connection'):
+             return
+-        self._sql_logger.debug('closing connection to the database')
++        logger.debug('closing connection to the database')
+         try:
+             self._connection.close()
+         except:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2874,6 +2874,8 @@ in {
   else
     callPackage ../development/python-modules/imbalanced-learn { };
 
+  imdbpy = callPackage ../development/python-modules/imdbpy { };
+
   img2pdf = callPackage ../development/python-modules/img2pdf { };
 
   imgaug = callPackage ../development/python-modules/imgaug { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
