### PR TITLE
discordpy: 1.3.4 -> 1.5.1

### DIFF
--- a/pkgs/development/python-modules/discordpy/default.nix
+++ b/pkgs/development/python-modules/discordpy/default.nix
@@ -5,12 +5,11 @@
 , withVoice ? true, libopus
 , aiohttp
 , websockets
-, pynacl
 }:
 
 buildPythonPackage rec {
   pname = "discord.py";
-  version = "1.3.4";
+  version = "1.5.1";
   disabled = pythonOlder "3.5.3";
 
   # only distributes wheels on pypi now
@@ -18,7 +17,7 @@ buildPythonPackage rec {
     owner = "Rapptz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1i4h6vq681x8s05wi0n3ykavsxjh9hxdxn6banwjcqzhxzkyhsxi";
+    sha256 = "1bidyclwv20p1kfphj21r5gm3kr2vxx0zd151wg7fcngbbx7gmza";
   };
 
   propagatedBuildInputs = [ aiohttp websockets ];
@@ -30,7 +29,6 @@ buildPythonPackage rec {
     substituteInPlace "discord/opus.py" \
       --replace "ctypes.util.find_library('opus')" "'${libopus}/lib/libopus.so.0'"
   '';
-
 
   # only have integration tests with discord
   doCheck = false;
@@ -46,9 +44,10 @@ buildPythonPackage rec {
     "discord.ext.commands.bot"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "A python wrapper for the Discord API";
-    homepage    = "https://discordpy.rtfd.org/";
-    license     = lib.licenses.mit;
+    homepage = "https://discordpy.rtfd.org/";
+    maintainers = [ maintainers.ivar ];
+    license = licenses.mit;
   };
 }


### PR DESCRIPTION
###### Things done
Updated the package to the latest version, added myself as a maintainer and removed the seemingly unused `pynacl` call.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
