### PR TITLE
[20.09] pythonPackages.pyotp: disable on Python27

### DIFF
--- a/pkgs/development/python-modules/pyotp/default.nix
+++ b/pkgs/development/python-modules/pyotp/default.nix
@@ -1,17 +1,16 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, urllib3 }:
+{ lib, buildPythonPackage, fetchPypi, isPy27 }:
 
 buildPythonPackage rec {
   pname = "pyotp";
   version = "2.4.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "01eceab573181188fe038d001e42777884a7f5367203080ef5bda0e30fe82d28";
   };
 
-  doCheck = (!isPy27); # Tests import urllib3 in a way python27 does not support
-
-  checkInputs = [ urllib3 ];
+  pythonImportsCheck = [ "pyotp" ];
 
   meta = with lib; {
     description = "Python One Time Password Library";


### PR DESCRIPTION
(cherry picked from commit 7a348085020e35f7f8bbe7f7fad59081f2aad025)

###### Motivation for this change
I got the backport for this (#100025) merged before it got merged to master, and because of that it missed a few fixes from review comments (oops).

ZHF: #97479 
PR to master: #100023 

cc @mweinelt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
