### PR TITLE
pythonPackages.gevent: 20.5.2 -> 20.9.0

### DIFF
--- a/pkgs/development/python-modules/gevent/default.nix
+++ b/pkgs/development/python-modules/gevent/default.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "gevent";
-  version = "20.5.2";
+  version = "20.9.0";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2756de36f56b33c46f6cc7146a74ba65afcd1471922c95b6771ce87b279d689c";
+    sha256 = "13aw9x6imsy3b369kfjblqiwfni69pp32m4r13n62r9k3l2lhvaz";
   };
 
   buildInputs = [ libev ];

--- a/pkgs/development/python-modules/greenlet/default.nix
+++ b/pkgs/development/python-modules/greenlet/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "greenlet";
-  version = "0.4.16";
+  version = "0.4.17";
   disabled = isPyPy;  # builtin for pypy
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6e06eac722676797e8fce4adb8ad3dc57a1bb3adfb0dd3fdf8306c055a38456c";
+    sha256 = "0swdhrcq13bdszv3yz5645gi4ijbzmmhxpb6whcfg3d7d5f87n21";
   };
 
   propagatedBuildInputs = [ six ];


### PR DESCRIPTION
###### Motivation for this change
`gevent` now requires version 0.4.17 of greenlet, so I've updated that as well.

All packages broken seem to be unrelated to this change, as hydra marked them as failing as well.

Result of `nixpkgs-review pr 101440` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>7 packages marked as broken and skipped:</summary>
  <ul>
    <li>python27Packages.sipsimple</li>
    <li>python27Packages.zake</li>
    <li>python37Packages.qasm2image</li>
    <li>python37Packages.zake</li>
    <li>python38Packages.qasm2image</li>
    <li>python38Packages.zake</li>
    <li>rabbitvcs</li>
  </ul>
</details>
<details>
  <summary>13 packages failed to build:</summary>
  <ul>
    <li>babashka</li>
    <li>clj-kondo</li>
    <li>graalvm8</li>
    <li>jvmci8</li>
    <li>patroni</li>
    <li>python27Packages.cassandra-driver</li>
    <li>python27Packages.gipc</li>
    <li>python27Packages.locustio</li>
    <li>python37Packages.cassandra-driver</li>
    <li>python37Packages.gipc</li>
    <li>python37Packages.locustio</li>
    <li>python38Packages.cassandra-driver</li>
    <li>python38Packages.gipc</li>
  </ul>
</details>
<details>
  <summary>168 packages built:</summary>
  <ul>
    <li>appdaemon</li>
    <li>azure-cli</li>
    <li>breezy (python38Packages.breezy)</li>
    <li>buku</li>
    <li>cabal2nix</li>
    <li>dep2nix</li>
    <li>devpi-client</li>
    <li>dune-release</li>
    <li>eolie</li>
    <li>errbot</li>
    <li>flatpak-builder</li>
    <li>gdbgui</li>
    <li>gitAndTools.git-cinnabar</li>
    <li>gitAndTools.git-fast-export</li>
    <li>gitAndTools.git-remote-hg</li>
    <li>gnvim</li>
    <li>haskell-language-server</li>
    <li>hound</li>
    <li>http-prompt</li>
    <li>httpie</li>
    <li>hydra-unstable</li>
    <li>klaus (python38Packages.klaus)</li>
    <li>klipper</li>
    <li>lexicon</li>
    <li>mbed-cli</li>
    <li>mercurial (python38Packages.mercurial)</li>
    <li>mercurialFull</li>
    <li>mercurial_4</li>
    <li>mx</li>
    <li>nbstripout</li>
    <li>neovim</li>
    <li>neovim-qt</li>
    <li>neovim-remote</li>
    <li>nix-prefetch-bzr</li>
    <li>nix-prefetch-hg</li>
    <li>nix-prefetch-scripts</li>
    <li>nix-update-source</li>
    <li>nvchecker (python38Packages.nvchecker)</li>
    <li>papis (python38Packages.papis)</li>
    <li>powerline (python38Packages.powerline)</li>
    <li>python27Packages.aioeventlet</li>
    <li>python27Packages.dulwich</li>
    <li>python27Packages.eventlet</li>
    <li>python27Packages.eventlib</li>
    <li>python27Packages.flask-sockets</li>
    <li>python27Packages.gevent</li>
    <li>python27Packages.gevent-socketio</li>
    <li>python27Packages.gevent-websocket</li>
    <li>python27Packages.geventhttpclient</li>
    <li>python27Packages.greenlet</li>
    <li>python27Packages.grequests</li>
    <li>python27Packages.hg-git</li>
    <li>python27Packages.kazoo</li>
    <li>python27Packages.meinheld</li>
    <li>python27Packages.msrplib</li>
    <li>python27Packages.mwlib</li>
    <li>python27Packages.mwlib-rl</li>
    <li>python27Packages.opentracing</li>
    <li>python27Packages.pyfxa</li>
    <li>python27Packages.pynvim</li>
    <li>python27Packages.pytest-twisted</li>
    <li>python27Packages.ruffus</li>
    <li>python27Packages.xcaplib</li>
    <li>python27Packages.zerorpc</li>
    <li>python37Packages.bpython</li>
    <li>python37Packages.breezy</li>
    <li>python37Packages.check-manifest</li>
    <li>python37Packages.debugpy</li>
    <li>python37Packages.duecredit</li>
    <li>python37Packages.dulwich</li>
    <li>python37Packages.eventlet</li>
    <li>python37Packages.flask-common</li>
    <li>python37Packages.flask-socketio</li>
    <li>python37Packages.flask-sockets</li>
    <li>python37Packages.gevent</li>
    <li>python37Packages.gevent-socketio</li>
    <li>python37Packages.gevent-websocket</li>
    <li>python37Packages.geventhttpclient</li>
    <li>python37Packages.graphql-core</li>
    <li>python37Packages.graphql-server-core</li>
    <li>python37Packages.greenlet</li>
    <li>python37Packages.grequests</li>
    <li>python37Packages.habanero</li>
    <li>python37Packages.hglib</li>
    <li>python37Packages.httpbin</li>
    <li>python37Packages.kazoo</li>
    <li>python37Packages.klaus</li>
    <li>python37Packages.knack</li>
    <li>python37Packages.meinheld</li>
    <li>python37Packages.mercurial</li>
    <li>python37Packages.nvchecker</li>
    <li>python37Packages.opentracing</li>
    <li>python37Packages.papis</li>
    <li>python37Packages.powerline</li>
    <li>python37Packages.promise</li>
    <li>python37Packages.pyalgotrade</li>
    <li>python37Packages.pyfxa</li>
    <li>python37Packages.pynvim</li>
    <li>python37Packages.pytest-httpbin</li>
    <li>python37Packages.pytest-twisted</li>
    <li>python37Packages.python-engineio</li>
    <li>python37Packages.python-socketio</li>
    <li>python37Packages.qiskit</li>
    <li>python37Packages.qiskit-ibmq-provider</li>
    <li>python37Packages.ruffus</li>
    <li>python37Packages.runway-python</li>
    <li>python37Packages.scrapy</li>
    <li>python37Packages.scrapy-deltafetch</li>
    <li>python37Packages.scrapy-fake-useragent</li>
    <li>python37Packages.scrapy-splash</li>
    <li>python37Packages.vcrpy</li>
    <li>python37Packages.ws4py</li>
    <li>python37Packages.zerorpc</li>
    <li>python38Packages.bpython</li>
    <li>python38Packages.check-manifest</li>
    <li>python38Packages.debugpy</li>
    <li>python38Packages.duecredit</li>
    <li>python38Packages.dulwich</li>
    <li>python38Packages.eventlet</li>
    <li>python38Packages.flask-common</li>
    <li>python38Packages.flask-socketio</li>
    <li>python38Packages.flask-sockets</li>
    <li>python38Packages.gevent</li>
    <li>python38Packages.gevent-socketio</li>
    <li>python38Packages.gevent-websocket</li>
    <li>python38Packages.geventhttpclient</li>
    <li>python38Packages.graphql-core</li>
    <li>python38Packages.graphql-server-core</li>
    <li>python38Packages.greenlet</li>
    <li>python38Packages.grequests</li>
    <li>python38Packages.habanero</li>
    <li>python38Packages.hglib</li>
    <li>python38Packages.httpbin</li>
    <li>python38Packages.kazoo</li>
    <li>python38Packages.knack</li>
    <li>python38Packages.meinheld</li>
    <li>python38Packages.opentracing</li>
    <li>python38Packages.promise</li>
    <li>python38Packages.pyalgotrade</li>
    <li>python38Packages.pyfxa</li>
    <li>python38Packages.pynvim</li>
    <li>python38Packages.pytest-httpbin</li>
    <li>python38Packages.pytest-twisted</li>
    <li>python38Packages.python-engineio</li>
    <li>python38Packages.python-socketio</li>
    <li>python38Packages.qiskit</li>
    <li>python38Packages.qiskit-ibmq-provider</li>
    <li>python38Packages.ruffus</li>
    <li>python38Packages.runway-python</li>
    <li>python38Packages.scrapy</li>
    <li>python38Packages.scrapy-deltafetch</li>
    <li>python38Packages.scrapy-fake-useragent</li>
    <li>python38Packages.scrapy-splash</li>
    <li>python38Packages.vcrpy</li>
    <li>python38Packages.ws4py</li>
    <li>python38Packages.zerorpc</li>
    <li>reno</li>
    <li>searx</li>
    <li>sourcehut.hgsrht</li>
    <li>termpdfpy</li>
    <li>theharvester</li>
    <li>tortoisehg</li>
    <li>vcstool</li>
    <li>vimPlugins.sved</li>
    <li>wal_e</li>
    <li>xandikos</li>
    <li>zeronet</li>
    <li>zk-shell</li>
  </ul>
</details>



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
