### PR TITLE
valgrind: disable on darwin

### DIFF
--- a/pkgs/development/libraries/libpsl/default.nix
+++ b/pkgs/development/libraries/libpsl/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     lzip
     pkgconfig
     python3
-    valgrind
+    (stdenv.lib.optionalString (!stdenv.isDarwin) valgrind)
     libxslt
   ];
 

--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -86,5 +86,6 @@ stdenv.mkDerivation rec {
       "riscv32-linux" "riscv64-linux"
       "alpha-linux"
     ];
+    broken = stdenv.isDarwin; # https://hydra.nixos.org/build/128521440/nixlog/2
   };
 }


### PR DESCRIPTION
Our macOS SDKs are from 10.12 but our cctools is from 10.14 so I think that basically kills off `valgrind` on darwin as upstream doesn't support it on >= 10.13 and no one seems to be building it on >= 10.14.

> https://valgrind.org/
> 22 June 2020: valgrind-3.16.1 is available. This release supports: .... X86/MacOSX 10.12 and AMD64/MacOSX 10.12.

> [homebrew valgrind](https://github.com/Homebrew/homebrew-core/blob/bc253ed78337eaa551bc5abfb4a3a4753b3c5c8b/Formula/valgrind.rb#L10)
> depends_on maximum_macos: :high_sierra

> [macports valgrind](https://github.com/macports/macports-ports/blob/3125ff6b29f31c7ab1612ddce69a59d7bbb1a4b3/devel/valgrind/Portfile#L123)
>  is not presently compatible with macOS Mojave or newer
___

The `libpsl` commit should be enough to unblock `nixpkgs-unstable`.
