### PR TITLE
ptcollab: init at 0.3.4.1

### DIFF
--- a/pkgs/applications/audio/ptcollab/default.nix
+++ b/pkgs/applications/audio/ptcollab/default.nix
@@ -1,0 +1,34 @@
+{ mkDerivation
+, stdenv
+, fetchFromGitHub
+, qmake
+, qtbase
+, qtmultimedia
+, libvorbis
+}:
+
+mkDerivation rec {
+  pname = "ptcollab";
+  version = "0.3.4.1";
+
+  src = fetchFromGitHub {
+    owner = "yuxshao";
+    repo = "ptcollab";
+    rev = "v${version}";
+    sha256 = "0rjyhxfad864w84n0bxyhc1jjxhzwwdx26r6psba2582g90cv024";
+  };
+
+  nativeBuildInputs = [ qmake ];
+
+  buildInputs = [ qtbase qtmultimedia libvorbis ];
+
+  meta = with stdenv.lib; {
+    description = "Experimental pxtone editor where you can collaborate with friends";
+    homepage = "https://yuxshao.github.io/ptcollab/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+    # Requires Qt5.15
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19804,6 +19804,8 @@ in
 
   milkytracker = callPackage ../applications/audio/milkytracker { };
 
+  ptcollab = libsForQt5.callPackage ../applications/audio/ptcollab { };
+
   schismtracker = callPackage ../applications/audio/schismtracker { };
 
   jnetmap = callPackage ../applications/networking/jnetmap {};


### PR DESCRIPTION
###### Motivation for this change
[FOSS music tracker packaging](https://github.com/NixOS/nixpkgs/issues/81815), cc @fgaz 

Adding [ptcollab](https://yuxshao.github.io/ptcollab/): a music editor for the pxtone format with the capability of collaborative editing over the network. Basically [Drawpile](https://drawpile.net/about/) but for music.

~~Packaged here is the latest commit instead of the latest release due to https://github.com/yuxshao/ptcollab/issues/3 adding various install-time improvements.~~ Bumped to version 0.3.4.1.

Tested on NixOS & Ubuntu, including the networking part. Darwin is supported upstream, but needs Qt5.15 afaict which we're currently lacking on that platform. I hence marked it broken on Darwin - or would marking it broken for something like `lib.strings.versionOlder qtbase.version "5.15.0"` be the better approach here?

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
