### PR TITLE
radeon-profile: 20190903 -> 20200824

### DIFF
--- a/pkgs/tools/misc/radeon-profile/default.nix
+++ b/pkgs/tools/misc/radeon-profile/default.nix
@@ -5,7 +5,7 @@
 mkDerivation rec {
 
   pname = "radeon-profile";
-  version = "20190903";
+  version = "20200824";
 
   nativeBuildInputs = [ qmake ];
   buildInputs = [ qtbase qtcharts libXrandr libdrm ];
@@ -14,7 +14,7 @@ mkDerivation rec {
     owner  = "marazmista";
     repo   = "radeon-profile";
     rev    = version;
-    sha256 = "0ax5417q03xjwi3pn7yyjdb90ssaygdprfgb1pz9nkyk6773ckx5";
+    sha256 = "0z6a9w79s5wiy8cvwcdp5wmgf6702d0wzw95f6176yhp4cwy4cq2";
   }) + "/radeon-profile";
 
   preConfigure = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

bump radeon-profile version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
