### PR TITLE
radeon-profile-daemon: init at 20190603

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -363,6 +363,7 @@
   ./services/hardware/pcscd.nix
   ./services/hardware/pommed.nix
   ./services/hardware/ratbagd.nix
+  ./services/hardware/radeon-profile.nix
   ./services/hardware/sane.nix
   ./services/hardware/sane_extra_backends/brscan4.nix
   ./services/hardware/sane_extra_backends/dsseries.nix

--- a/nixos/modules/services/hardware/radeon-profile.nix
+++ b/nixos/modules/services/hardware/radeon-profile.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.hardware.radeon-profile;
+in
+{
+  options.services.hardware.radeon-profile = {
+    enable = mkEnableOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        radeon-profile daemon
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.radeon-profile ];
+
+    systemd.services.radeon-profile = {
+      description = "radeon-profile daemon";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.radeon-profile-daemon}/bin/radeon-profile-daemon";
+        PrivateTmp = "yes";
+        PrivateDevices = "yes";
+      };
+    };
+  };
+}

--- a/pkgs/tools/misc/radeon-profile-daemon/default.nix
+++ b/pkgs/tools/misc/radeon-profile-daemon/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub
+, qtbase, qtcharts, qmake, libXrandr, libdrm
+}:
+
+stdenv.mkDerivation rec {
+  pname = "radeon-profile-daemon";
+  version = "20190603";
+
+  nativeBuildInputs = [ qmake ];
+  buildInputs = [ qtbase qtcharts libXrandr libdrm ];
+
+  src = (fetchFromGitHub {
+    owner  = "marazmista";
+    repo   = "radeon-profile-daemon";
+    rev    = version;
+    sha256 = "06qxq2hv3l9shna8x5d9awbdm9pbwlc6vckcr63kf37rrs8ykk0j";
+  }) + "/radeon-profile-daemon";
+
+  preConfigure = ''
+    substituteInPlace radeon-profile-daemon.pro \
+      --replace "/usr/" "$out/"
+  '';
+
+  meta = with lib; {
+    description = "Application to read current clocks of AMD Radeon cards";
+    homepage    = "https://github.com/marazmista/radeon-profile";
+    license     = licenses.gpl2Plus;
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6791,6 +6791,8 @@ in
 
   radeon-profile = libsForQt5.callPackage ../tools/misc/radeon-profile { };
 
+  radeon-profile-daemon = libsForQt5.callPackage ../tools/misc/radeon-profile-daemon { };
+
   radsecproxy = callPackage ../tools/networking/radsecproxy { };
 
   radvd = callPackage ../tools/networking/radvd { };


### PR DESCRIPTION
Closes #100158

System daemon for reading info about Radeon GPU clocks and volts as well as control card power profiles so the GUI [radeon-profile](https://github.com/marazmista/radeon-profile) application can be run as normal user.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
