### PR TITLE
fix package path for bioc server 

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -44,6 +44,7 @@ let
   deriveBioc = mkDerive {
     mkHomepage = {name, biocVersion, ...}: "https://bioconductor.org/packages/${biocVersion}/bioc/html/${name}.html";
     mkUrls = {name, version, biocVersion}: [ "mirror://bioc/${biocVersion}/bioc/src/contrib/${name}_${version}.tar.gz"
+                                             "mirror://bioc/${biocVersion}/bioc/src/contrib/Archive/${name}/${name}_${version}.tar.gz"
                                              "mirror://bioc/${biocVersion}/bioc/src/contrib/Archive/${name}_${version}.tar.gz" ];
   };
   deriveBiocAnn = mkDerive {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

The package download URL defined in r-modules/default.nix is missing a folder. Earlier it was like this: 

http://mirrors.ustc.edu.cn/bioc/3.11/bioc/src/contrib/Archive/${package}_${version}.tar.gz

However, now, the server changed its URL schema to 

http://mirrors.ustc.edu.cn/bioc/3.11/bioc/src/contrib/Archive/${package}/{package}_${version}.tar.gz

which resulted in the following error when building R packages

```
builder for '/nix/store/7y3lkisqkz46mbgqk7bizx32lqrzwj6c-INSPEcT_1.18.0.tar.gz.drv' failed with exit code 1; last 10 log lines:
                                   Dload  Upload   Total   Spent    Left  Speed
    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  curl: (7) Failed to connect to mirrors.ebi.ac.uk port 80: Connection refused
  
  trying http://mirrors.ustc.edu.cn/bioc/3.11/bioc/src/contrib/Archive/INSPEcT_1.18.0.tar.gz
```

Manually looking at the structure of the server files (just open http://mirrors.ustc.edu.cn/bioc/3.11/bioc/src/contrib/Archive/) confirms what I write above.
(The server address is defined (and taken from) mirrors.nix btw.)

This PR fixes this by adding the new schema, also keeping the old one for compatibility (e.g. I don't know if all R mirror servers changed the schema).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
