### PR TITLE
uboot: init (firmwareOdroidC2/C4, ubootOdroidC4) Hardkernel's Odroid C4 and Odroid C2 board support, drop Armbian dependency

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -106,6 +106,12 @@
     githubId = 7755101;
     name = "Aaron Andersen";
   };
+  aarapov = {
+    email = "anton@deadbeef.mx";
+    github = "arapov";
+    githubId = 1823164;
+    name = "Anton Arapov";
+  };
   aaronjanse = {
     email = "aaron@ajanse.me";
     github = "aaronjanse";

--- a/pkgs/misc/meson64-tools/default.nix
+++ b/pkgs/misc/meson64-tools/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub, buildPackages }:
+
+stdenv.mkDerivation rec {
+  pname = "meson64-tools";
+  version = "unstable-2020-08-03";
+
+  src = fetchFromGitHub {
+    owner = "angerman";
+    repo = pname;
+    rev = "a2d57d11fd8b4242b903c10dca9d25f7f99d8ff0";
+    sha256 = "1487cr7sv34yry8f0chaj6s2g3736dzq0aqw239ahdy30yg7hb2v";
+  };
+
+  buildInputs = with buildPackages; [ openssl bison yacc flex bc python3 ];
+
+  preBuild = ''
+    patchShebangs .
+    substituteInPlace mbedtls/programs/fuzz/Makefile --replace "python2" "python"
+    substituteInPlace mbedtls/tests/Makefile --replace "python2" "python"
+  '';
+
+  makeFlags = [ "PREFIX=$(out)/bin" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/angerman/meson64-tools";
+    description = "Tools for Amlogic Meson ARM64 platforms";
+    license = licenses.unfree; # https://github.com/angerman/meson64-tools/issues/2
+    maintainers = with maintainers; [ aarapov ];
+  };
+}

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -8,7 +8,6 @@
 , flex
 , openssl
 , swig
-, meson-tools
 , armTrustedFirmwareAllwinner
 , armTrustedFirmwareRK3328
 , armTrustedFirmwareRK3399
@@ -248,60 +247,27 @@ in {
     extraMeta.platforms = ["aarch64-linux"];
   };
 
-  ubootOdroidC4 = let in
-  assert
-    (lib.assertMsg (stdenv.buildPlatform.isx86_64)
-    "U-Boot for Odroid C4 must be cross-compiled on x86_64-linux system. Once built, U-Boot image must be signed by 'aml_encrypt_g12a' tool, which is available for x86_64-linux platform only.");
-  buildUBoot {
+  ubootOdroidC4 = buildUBoot {
     defconfig = "odroid-c4_defconfig";
 
     postBuild = ''
-      # blx_fix() resembles function from:
-      # - https://github.com/hardkernel/u-boot/blob/e0725c1dce0c3dbbae47478c13d968c41014fac8/fip/Makefile#L44
-      blx_fix() {
-        case $7 in
-          "bl30")
-            declare blx_bin_limit=40960
-            declare blx01_bin_limit=13312
-          ;;
-          "bl2")
-            declare blx_bin_limit=57344
-            declare blx01_bin_limit=4096
-          ;;
-        esac
+      ${buildPackages.meson64-tools}/bin/pkg --type bl30 --output bl30_new.bin \
+        ${firmwareOdroidC4}/bl30.bin ${firmwareOdroidC4}/bl301.bin
+      ${buildPackages.meson64-tools}/bin/pkg --type bl2 --output bl2_new.bin \
+        ${firmwareOdroidC4}/bl2.bin ${firmwareOdroidC4}/acs.bin
 
-        declare -i blx_size=`du -b $1 | awk '{print int($1)}'`
-        declare -i zero_size=$blx_bin_limit-$blx_size
-        dd if=/dev/zero of=$2 bs=1 count=$zero_size
-        cat $1 $2 > $3
-
-        declare -i blx01_size=`du -b $4 | awk '{print int($1)}'`
-        declare -i zero_size_01=$blx01_bin_limit-$blx01_size
-        dd if=/dev/zero of=$2 bs=1 count=$zero_size_01
-        cat $4 $2 > $5
-
-        cat $3 $5 > $6
-      }
-
-      blx_fix ${firmwareOdroidC4}/bl30.bin zero_tmp bl30_zero.bin \
-              ${firmwareOdroidC4}/bl301.bin bl301_zero.bin \
-              bl30_new.bin bl30
-      blx_fix ${firmwareOdroidC4}/bl2.bin zero_tmp bl2_zero.bin \
-              ${firmwareOdroidC4}/acs.bin bl21_zero.bin \
-              bl2_new.bin bl2
-
-      ${firmwareOdroidC4}/aml_encrypt_g12a --bl30sig --input bl30_new.bin \
+      ${buildPackages.meson64-tools}/bin/bl30sig --input bl30_new.bin \
         --output bl30_new.bin.g12a.enc --level v3
-      ${firmwareOdroidC4}/aml_encrypt_g12a --bl3sig --input bl30_new.bin.g12a.enc \
+      ${buildPackages.meson64-tools}/bin/bl3sig --input  bl30_new.bin.g12a.enc \
         --output bl30_new.bin.enc --level v3 --type bl30
-      ${firmwareOdroidC4}/aml_encrypt_g12a --bl3sig --input ${firmwareOdroidC4}/bl31.img \
+      ${buildPackages.meson64-tools}/bin/bl3sig --input ${firmwareOdroidC4}/bl31.img \
         --output bl31.img.enc --level v3 --type bl31
-      ${firmwareOdroidC4}/aml_encrypt_g12a --bl3sig --input u-boot.bin --compress lz4 \
+      ${buildPackages.meson64-tools}/bin/bl3sig --input u-boot.bin --compress lz4 \
         --output bl33.bin.enc --level v3 --type bl33 --compress lz4
-      ${firmwareOdroidC4}/aml_encrypt_g12a --bl2sig --input bl2_new.bin \
+      ${buildPackages.meson64-tools}/bin/bl2sig --input bl2_new.bin \
         --output bl2.n.bin.sig
 
-      ${firmwareOdroidC4}/aml_encrypt_g12a --bootmk --output u-boot.bin \
+      ${buildPackages.meson64-tools}/bin/bootmk --output u-boot.bin \
         --bl2 bl2.n.bin.sig --bl30 bl30_new.bin.enc --bl31 bl31.img.enc --bl33 bl33.bin.enc \
         --ddrfw1 ${firmwareOdroidC4}/ddr4_1d.fw \
         --ddrfw2 ${firmwareOdroidC4}/ddr4_2d.fw \

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -210,15 +210,6 @@ in {
   ubootOdroidC2 = buildUBoot {
     defconfig = "odroid-c2_defconfig";
 
-    # Fix eMMC boot issue on meson-gxbb boards
-    # Patches are queued for U-Boot 2021.01 release
-    patches = [
-      (fetchurl { #0001-pinctrl-meson-fix-bit-manipulation-of-pin-bias-confi.patch
-        url = "https://gitlab.denx.de/u-boot/custodians/u-boot-amlogic/-/commit/5ccd5d2cc98224108ae9fb09593a862c9caa5e80.patch";
-        sha256 = "19jvfqm1gkcmgd07wyv2srpg88a42zz2x46i7kxxybvi1vx8qkyl";
-      })
-    ];
-
     postBuild = ''
       # BL301 image needs at least 64 bytes of padding after it to place
       # signing headers (with amlbootsig)
@@ -263,23 +254,6 @@ in {
     "U-Boot for Odroid C4 must be cross-compiled on x86_64-linux system. Once built, U-Boot image must be signed by 'aml_encrypt_g12a' tool, which is available for x86_64-linux platform only.");
   buildUBoot {
     defconfig = "odroid-c4_defconfig";
-
-    # Fix eMMC/SD read issues on meson-sm1/meson-gx boards.
-    # Patches are queued for U-Boot 2021.01 release
-    patches = [
-      (fetchurl { #0001-mmc-meson-gx-move-arch-header-to-local-header.patch
-        url = "https://gitlab.denx.de/u-boot/custodians/u-boot-amlogic/-/commit/77863d43eb2b40319619bbb4f781270d8f027189.patch";
-        sha256 = "10nf0klspqmy15a8bb8ybhl53x11v1cqvh20i6bxyqm10zwlqbhl";
-      })
-      (fetchurl { #0002-mmc-meson-gx-change-clock-phase-value-on-SM1-SoCs.patch
-        url = "https://gitlab.denx.de/u-boot/custodians/u-boot-amlogic/-/commit/0dbb54eb3257c243c7968f967a6b183b1edb56c8.patch";
-        sha256 = "1xwj67h50gc32y7lrj7mh56s0zhwrd1vvxrpvhb2yhf1y17jf7rc";
-      })
-      (fetchurl { #0003-ARM-dts-meson-sm1-add-u-boot-specific-MMC-controller.patch
-        url = "https://gitlab.denx.de/u-boot/custodians/u-boot-amlogic/-/commit/c87eab81616d671a6004ffc95847bad21b7eb005.patch";
-        sha256 = "11l19vx8q2a8j95liv1nwkn9cjryxk9qgmj68ya4lr4j0c5qzh7c";
-      })
-    ];
 
     postBuild = ''
       # blx_fix() resembles function from:

--- a/pkgs/misc/uboot/hardkernel-firmware.nix
+++ b/pkgs/misc/uboot/hardkernel-firmware.nix
@@ -128,15 +128,9 @@ in {
       "fip/g12a/ddr3_1d.fw" "fip/g12a/ddr4_1d.fw" "fip/g12a/ddr4_2d.fw"
       "fip/g12a/lpddr3_1d.fw" "fip/g12a/lpddr4_1d.fw" "fip/g12a/lpddr4_2d.fw"
       "fip/g12a/diag_lpddr4.fw" "fip/g12a/piei.fw" "fip/g12a/aml_ddr.fw"
-      "fip/g12a/aml_encrypt_g12a" "sd_fuse/sd_fusing.sh"
+      "sd_fuse/sd_fusing.sh"
     ];
 
-    # Even though Odroid C4 firmware blobs are buildable on aarch64, we can not
-    # use it to produce U-Boot loader binary on aarch64 machines. This is
-    # because we do not have "aml_encrypt_g12a" binary compiled for aarch64.
-    # So that "x86_64-linux" makes more sense here, though we have to keep
-    # "aarch64-linux" in order to make this derivative consumable by ubootOdroidC4
-    # derivative.
-    extraMeta.platforms = [ "aarch64-linux" "x86_64-linux" ];
+    extraMeta.platforms = [ "aarch64-linux" ];
   };
 }

--- a/pkgs/misc/uboot/hardkernel-firmware.nix
+++ b/pkgs/misc/uboot/hardkernel-firmware.nix
@@ -98,8 +98,11 @@ in {
     '';
 
     filesToInstall = [
-      "build/scp_task/bl301.bin" "fip/gxb/bl30.bin" "fip/gxb/bl2.package"
-      "sd_fuse/sd_fusing.sh" "sd_fuse/bl1.bin.hardkernel"
+      "build/scp_task/bl301.bin"
+      "fip/gxb/bl2.package"
+      "fip/gxb/bl30.bin"
+      "sd_fuse/bl1.bin.hardkernel"
+      "sd_fuse/sd_fusing.sh"
     ];
 
     extraMeta.platforms = [ "aarch64-linux" ];
@@ -123,11 +126,20 @@ in {
     '';
 
     filesToInstall = [
-      "build/board/hardkernel/odroidc4/firmware/acs.bin" "build/scp_task/bl301.bin"
-      "fip/g12a/bl2.bin" "fip/g12a/bl30.bin" "fip/g12a/bl31.img"
-      "fip/g12a/ddr3_1d.fw" "fip/g12a/ddr4_1d.fw" "fip/g12a/ddr4_2d.fw"
-      "fip/g12a/lpddr3_1d.fw" "fip/g12a/lpddr4_1d.fw" "fip/g12a/lpddr4_2d.fw"
-      "fip/g12a/diag_lpddr4.fw" "fip/g12a/piei.fw" "fip/g12a/aml_ddr.fw"
+      "build/board/hardkernel/odroidc4/firmware/acs.bin"
+      "build/scp_task/bl301.bin"
+      "fip/g12a/aml_ddr.fw"
+      "fip/g12a/bl2.bin"
+      "fip/g12a/bl30.bin"
+      "fip/g12a/bl31.img"
+      "fip/g12a/ddr3_1d.fw"
+      "fip/g12a/ddr4_1d.fw"
+      "fip/g12a/ddr4_2d.fw"
+      "fip/g12a/diag_lpddr4.fw"
+      "fip/g12a/lpddr3_1d.fw"
+      "fip/g12a/lpddr4_1d.fw"
+      "fip/g12a/lpddr4_2d.fw"
+      "fip/g12a/piei.fw"
       "sd_fuse/sd_fusing.sh"
     ];
 

--- a/pkgs/misc/uboot/hardkernel-firmware.nix
+++ b/pkgs/misc/uboot/hardkernel-firmware.nix
@@ -1,0 +1,129 @@
+{ stdenv
+, lib
+, fetchgit
+, buildPackages
+, pkgsCross
+}:
+
+let
+  buildHardkernelFirmware = {
+    version ? null
+    , src ? null
+    , name ? ""
+    , filesToInstall
+    , installDir ? "$out"
+    , defconfig
+    , extraMeta ? {}
+    , ... } @ args: stdenv.mkDerivation ({
+      pname = "uboot-hardkernel-firmware-${name}";
+
+      nativeBuildInputs = [
+        buildPackages.git
+        buildPackages.hostname
+        pkgsCross.arm-embedded.stdenv.cc
+      ];
+
+      depsBuildBuild = [
+        buildPackages.gcc49
+      ] ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) buildPackages.stdenv.cc
+        ++ lib.optional (!stdenv.isAarch64) pkgsCross.aarch64-multiplatform.buildPackages.gcc49;
+
+      postPatch = ''
+        substituteInPlace Makefile --replace "/bin/pwd" "pwd"
+      '';
+
+      makeFlags = [
+        "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+        "CROSS_COMPILE_32=${pkgsCross.arm-embedded.stdenv.cc.targetPrefix}"
+        "${defconfig}" "bl301.bin"
+      ]
+      ++ lib.optional (!stdenv.isAarch64) "CROSS_COMPILE=${pkgsCross.aarch64-multiplatform.stdenv.cc.targetPrefix}";
+
+      installPhase = ''
+        mkdir -p ${installDir}
+        cp ${lib.concatStringsSep " " filesToInstall} ${installDir}
+      '';
+
+      meta = with lib; {
+        homepage = "https://www.hardkernel.com/";
+        description = "Das U-Boot from Hardkernel with Odroid embedded devices firmware and support";
+        license = licenses.unfreeRedistributableFirmware;
+        maintainers = with maintainers; [ aarapov ];
+      } // extraMeta;
+    } // removeAttrs args [ "extraMeta" ]);
+in {
+  inherit buildHardkernelFirmware;
+
+  # https://wiki.odroid.com/odroid-c2/software/building_u-boot
+  firmwareOdroidC2 = let
+    name = "odroidc2";
+    odroidc2-bl301 = fetchgit {
+      url = "https://github.com/hardkernel/u-boot_firmware.git";
+      rev = "b7b90c1099b057d35ebae886b7846b5d9bfb4143"; # "odroidc2-bl301"
+      sha256 = "0kdb1mg5zd7qyabfpbh98cs07icfzpkywvva13ybf4mf5g50g0n3";
+      deepClone = true;
+    };
+  in buildHardkernelFirmware {
+    defconfig = "odroidc2_config";
+    name = "firmware-odroid-c2";
+    version = "2015.01";
+    src = fetchgit {
+      url = "https://github.com/hardkernel/u-boot.git";
+      rev = "fac4d2da0a1b61dfdeaca0034a45151ff5983fb8"; # "odroidc2-v2015.01"
+      sha256 = "0jrpd7vww659nazyrv5af6n165akhz0h9hnxajq7gz906igc5raz";
+      leaveDotGit = true;
+    };
+
+    prePatch = ''
+      git remote add u-boot_firmware ${odroidc2-bl301}/
+      git fetch u-boot_firmware
+      git cherry-pick --no-commit \
+        5ce504067bb83de03d17173d5585e849df5d5a33^..${odroidc2-bl301.rev}
+
+      substituteInPlace ./arch/arm/cpu/armv8/gxb/firmware/scp_task/Makefile \
+        --replace "CROSS_COMPILE" "CROSS_COMPILE_32"
+    '';
+
+    filesToInstall = [
+      "build/scp_task/bl301.bin" "fip/gxb/bl30.bin" "fip/gxb/bl2.package"
+      "sd_fuse/sd_fusing.sh" "sd_fuse/bl1.bin.hardkernel"
+    ];
+
+    extraMeta.platforms = [ "aarch64-linux" ];
+  };
+
+  # https://wiki.odroid.com/odroid-c4/software/building_u-boot
+  firmwareOdroidC4 = buildHardkernelFirmware {
+    name = "firmware-odroid-c4";
+    defconfig = "odroidc4_defconfig";
+    version = "2015.01";
+    src = fetchgit {
+      url = "https://github.com/hardkernel/u-boot.git";
+      rev = "90ebb7015c1bfbbf120b2b94273977f558a5da46"; # "odroidg12-v2015.01"
+      sha256 = "1v8z5m0k6a9iw0qbkn6qcwh02rsdsfax29l2ilshr39a3nj40i96";
+      leaveDotGit = true;
+    };
+
+    prePatch = ''
+      substituteInPlace ./arch/arm/cpu/armv8/g12a/firmware/scp_task/Makefile \
+        --replace "CROSS_COMPILE" "CROSS_COMPILE_32"
+    '';
+
+    filesToInstall = [
+      "build/board/hardkernel/odroidc4/firmware/acs.bin" "build/scp_task/bl301.bin"
+      "fip/g12a/bl2.bin" "fip/g12a/bl30.bin" "fip/g12a/bl31.img"
+      "fip/g12a/ddr3_1d.fw" "fip/g12a/ddr4_1d.fw" "fip/g12a/ddr4_2d.fw"
+      "fip/g12a/lpddr3_1d.fw" "fip/g12a/lpddr4_1d.fw" "fip/g12a/lpddr4_2d.fw"
+      "fip/g12a/diag_lpddr4.fw" "fip/g12a/piei.fw" "fip/g12a/aml_ddr.fw"
+      "fip/g12a/aml_encrypt_g12a" "sd_fuse/sd_fusing.sh"
+    ];
+
+    # Even though Odroid C4 firmware blobs are buildable on aarch64, we can not
+    # use it to produce U-Boot loader binary on aarch64 machines. This is
+    # because we do not have "aml_encrypt_g12a" binary compiled for aarch64.
+    # So that "x86_64-linux" makes more sense here, though we have to keep
+    # "aarch64-linux" in order to make this derivative consumable by ubootOdroidC4
+    # derivative.
+    extraMeta.platforms = [ "aarch64-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/misc/uboot/hardkernel-firmware.nix
+++ b/pkgs/misc/uboot/hardkernel-firmware.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
-, fetchgit
+, fetchpatch
+, fetchFromGitHub
 , buildPackages
 , pkgsCross
 }:
@@ -54,31 +55,43 @@ let
 in {
   inherit buildHardkernelFirmware;
 
-  # https://wiki.odroid.com/odroid-c2/software/building_u-boot
-  firmwareOdroidC2 = let
-    name = "odroidc2";
-    odroidc2-bl301 = fetchgit {
-      url = "https://github.com/hardkernel/u-boot_firmware.git";
-      rev = "b7b90c1099b057d35ebae886b7846b5d9bfb4143"; # "odroidc2-bl301"
-      sha256 = "0kdb1mg5zd7qyabfpbh98cs07icfzpkywvva13ybf4mf5g50g0n3";
-      deepClone = true;
-    };
-  in buildHardkernelFirmware {
+  firmwareOdroidC2 = buildHardkernelFirmware {
     defconfig = "odroidc2_config";
     name = "firmware-odroid-c2";
     version = "2015.01";
-    src = fetchgit {
-      url = "https://github.com/hardkernel/u-boot.git";
-      rev = "fac4d2da0a1b61dfdeaca0034a45151ff5983fb8"; # "odroidc2-v2015.01"
-      sha256 = "0jrpd7vww659nazyrv5af6n165akhz0h9hnxajq7gz906igc5raz";
-      leaveDotGit = true;
+    src = fetchFromGitHub {
+      owner = "hardkernel";
+      repo = "u-boot";
+      rev = "fac4d2da0a1b61dfdeaca0034a45151ff5983fb8";
+      sha256 = "09s0y69ilrwnvqi1g11axsnhylq8kfljwqxdfjifa227mi0kzq37";
     };
 
+    # https://wiki.odroid.com/odroid-c2/software/building_u-boot
     prePatch = ''
-      git remote add u-boot_firmware ${odroidc2-bl301}/
-      git fetch u-boot_firmware
-      git cherry-pick --no-commit \
-        5ce504067bb83de03d17173d5585e849df5d5a33^..${odroidc2-bl301.rev}
+      patch -p1 < ${fetchpatch {
+        url = "https://github.com/hardkernel/u-boot_firmware/commit/5ce504067bb83de03d17173d5585e849df5d5a33.patch";
+        sha256 = "0m9slsv7lwm2cf2akmx1x6mqzmfckrvw1r0nls91w6g40982qwly";
+      }}
+      patch -p1 < ${fetchpatch {
+        url = "https://github.com/hardkernel/u-boot_firmware/commit/0002fa877ca919e808e5fb7675194f17abde5d8d.patch";
+        sha256 = "0hr6037xl69v9clch8i3vr80vgfn453wcvza630mzifkkn2d1fh8";
+      }}
+      patch -p1 < ${fetchpatch {
+        url = "https://github.com/hardkernel/u-boot_firmware/commit/b129006d2bdd0aee3bc78593f9401b0873e6baf9.patch";
+        sha256 = "1bj7mb6h8njpvimjbjgv801ay97gwdgg9cd1hlv39fwqvv1nzfir";
+      }}
+      patch -p1 < ${fetchpatch {
+        url = "https://github.com/hardkernel/u-boot_firmware/commit/d3642b8329a605f641046cf25aeba935fa2f06dc.patch";
+        sha256 = "0iw06zvw8407s3r3n6v89z6jj8r6lwy0qm1izhf815qi3wxh55pq";
+      }}
+      patch -p1 < ${fetchpatch {
+        url = "https://github.com/hardkernel/u-boot_firmware/commit/911ab14f86b7c820aa3fe310b7eb7be0398292b1.patch";
+        sha256 = "1sq4mynw6iivx2xm0hp55x7r58bvfgav62d169q5mwgi9imbv6kg";
+      }}
+      patch -p1 < ${fetchpatch {
+        url = "https://github.com/hardkernel/u-boot_firmware/commit/b7b90c1099b057d35ebae886b7846b5d9bfb4143.patch";
+        sha256 = "17x5fc2rphgz6jybya7yk35j4h9iq0b7cnq2qhkq3lpw2060ldlg";
+      }}
 
       substituteInPlace ./arch/arm/cpu/armv8/gxb/firmware/scp_task/Makefile \
         --replace "CROSS_COMPILE" "CROSS_COMPILE_32"
@@ -97,11 +110,11 @@ in {
     name = "firmware-odroid-c4";
     defconfig = "odroidc4_defconfig";
     version = "2015.01";
-    src = fetchgit {
-      url = "https://github.com/hardkernel/u-boot.git";
-      rev = "90ebb7015c1bfbbf120b2b94273977f558a5da46"; # "odroidg12-v2015.01"
-      sha256 = "1v8z5m0k6a9iw0qbkn6qcwh02rsdsfax29l2ilshr39a3nj40i96";
-      leaveDotGit = true;
+    src = fetchFromGitHub {
+      owner = "hardkernel";
+      repo = "u-boot";
+      rev = "90ebb7015c1bfbbf120b2b94273977f558a5da46";
+      sha256 = "0kv9hpsgpbikp370wknbyj6r6cyhp7hng3ng6xzzqaw13yy4qiz9";
     };
 
     prePatch = ''

--- a/pkgs/misc/uboot/hardkernel-firmware.nix
+++ b/pkgs/misc/uboot/hardkernel-firmware.nix
@@ -48,11 +48,11 @@ let
         maintainers = with maintainers; [ aarapov ];
       } // extraMeta;
     } // removeAttrs args [ "extraMeta" ]);
-    postPatch = ''
+    preBuild = ''
         substituteInPlace Makefile --replace "/bin/pwd" "pwd"
       '';
 in {
-  inherit buildHardkernelFirmware postPatch;
+  inherit buildHardkernelFirmware preBuild;
 
   firmwareOdroidC2 = buildHardkernelFirmware {
     defconfig = "odroidc2_config";
@@ -65,36 +65,37 @@ in {
       sha256 = "09s0y69ilrwnvqi1g11axsnhylq8kfljwqxdfjifa227mi0kzq37";
     };
 
-    # https://wiki.odroid.com/odroid-c2/software/building_u-boot
-    postPatch = ''
-      patch -p1 < ${fetchpatch {
+    patches = [ # https://wiki.odroid.com/odroid-c2/software/building_u-boot
+      (fetchpatch {
         url = "https://github.com/hardkernel/u-boot_firmware/commit/5ce504067bb83de03d17173d5585e849df5d5a33.patch";
         sha256 = "0m9slsv7lwm2cf2akmx1x6mqzmfckrvw1r0nls91w6g40982qwly";
-      }}
-      patch -p1 < ${fetchpatch {
+      })
+      (fetchpatch {
         url = "https://github.com/hardkernel/u-boot_firmware/commit/0002fa877ca919e808e5fb7675194f17abde5d8d.patch";
         sha256 = "0hr6037xl69v9clch8i3vr80vgfn453wcvza630mzifkkn2d1fh8";
-      }}
-      patch -p1 < ${fetchpatch {
+      })
+      (fetchpatch {
         url = "https://github.com/hardkernel/u-boot_firmware/commit/b129006d2bdd0aee3bc78593f9401b0873e6baf9.patch";
         sha256 = "1bj7mb6h8njpvimjbjgv801ay97gwdgg9cd1hlv39fwqvv1nzfir";
-      }}
-      patch -p1 < ${fetchpatch {
+      })
+      (fetchpatch {
         url = "https://github.com/hardkernel/u-boot_firmware/commit/d3642b8329a605f641046cf25aeba935fa2f06dc.patch";
         sha256 = "0iw06zvw8407s3r3n6v89z6jj8r6lwy0qm1izhf815qi3wxh55pq";
-      }}
-      patch -p1 < ${fetchpatch {
+      })
+      (fetchpatch {
         url = "https://github.com/hardkernel/u-boot_firmware/commit/911ab14f86b7c820aa3fe310b7eb7be0398292b1.patch";
         sha256 = "1sq4mynw6iivx2xm0hp55x7r58bvfgav62d169q5mwgi9imbv6kg";
-      }}
-      patch -p1 < ${fetchpatch {
+      })
+      (fetchpatch {
         url = "https://github.com/hardkernel/u-boot_firmware/commit/b7b90c1099b057d35ebae886b7846b5d9bfb4143.patch";
         sha256 = "17x5fc2rphgz6jybya7yk35j4h9iq0b7cnq2qhkq3lpw2060ldlg";
-      }}
+      })
+    ];
 
+    preBuild = ''
       substituteInPlace ./arch/arm/cpu/armv8/gxb/firmware/scp_task/Makefile \
         --replace "CROSS_COMPILE" "CROSS_COMPILE_32"
-    '' + postPatch;
+    '' + preBuild;
 
     filesToInstall = [
       "build/scp_task/bl301.bin"
@@ -119,10 +120,10 @@ in {
       sha256 = "0kv9hpsgpbikp370wknbyj6r6cyhp7hng3ng6xzzqaw13yy4qiz9";
     };
 
-    postPatch = ''
+    preBuild = ''
       substituteInPlace ./arch/arm/cpu/armv8/g12a/firmware/scp_task/Makefile \
         --replace "CROSS_COMPILE" "CROSS_COMPILE_32"
-    '' + postPatch;
+    '' + preBuild;
 
     filesToInstall = [
       "build/board/hardkernel/odroidc4/firmware/acs.bin"

--- a/pkgs/misc/uboot/hardkernel-firmware.nix
+++ b/pkgs/misc/uboot/hardkernel-firmware.nix
@@ -29,10 +29,6 @@ let
       ] ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) buildPackages.stdenv.cc
         ++ lib.optional (!stdenv.isAarch64) pkgsCross.aarch64-multiplatform.buildPackages.gcc49;
 
-      postPatch = ''
-        substituteInPlace Makefile --replace "/bin/pwd" "pwd"
-      '';
-
       makeFlags = [
         "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
         "CROSS_COMPILE_32=${pkgsCross.arm-embedded.stdenv.cc.targetPrefix}"
@@ -52,8 +48,11 @@ let
         maintainers = with maintainers; [ aarapov ];
       } // extraMeta;
     } // removeAttrs args [ "extraMeta" ]);
+    postPatch = ''
+        substituteInPlace Makefile --replace "/bin/pwd" "pwd"
+      '';
 in {
-  inherit buildHardkernelFirmware;
+  inherit buildHardkernelFirmware postPatch;
 
   firmwareOdroidC2 = buildHardkernelFirmware {
     defconfig = "odroidc2_config";
@@ -67,7 +66,7 @@ in {
     };
 
     # https://wiki.odroid.com/odroid-c2/software/building_u-boot
-    prePatch = ''
+    postPatch = ''
       patch -p1 < ${fetchpatch {
         url = "https://github.com/hardkernel/u-boot_firmware/commit/5ce504067bb83de03d17173d5585e849df5d5a33.patch";
         sha256 = "0m9slsv7lwm2cf2akmx1x6mqzmfckrvw1r0nls91w6g40982qwly";
@@ -95,7 +94,7 @@ in {
 
       substituteInPlace ./arch/arm/cpu/armv8/gxb/firmware/scp_task/Makefile \
         --replace "CROSS_COMPILE" "CROSS_COMPILE_32"
-    '';
+    '' + postPatch;
 
     filesToInstall = [
       "build/scp_task/bl301.bin"
@@ -120,10 +119,10 @@ in {
       sha256 = "0kv9hpsgpbikp370wknbyj6r6cyhp7hng3ng6xzzqaw13yy4qiz9";
     };
 
-    prePatch = ''
+    postPatch = ''
       substituteInPlace ./arch/arm/cpu/armv8/g12a/firmware/scp_task/Makefile \
         --replace "CROSS_COMPILE" "CROSS_COMPILE_32"
-    '';
+    '' + postPatch;
 
     filesToInstall = [
       "build/board/hardkernel/odroidc4/firmware/acs.bin"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2753,6 +2753,8 @@ in
 
   meson-tools = callPackage ../misc/meson-tools { };
 
+  meson64-tools = callPackage ../misc/meson64-tools { };
+
   metabase = callPackage ../servers/metabase { };
 
   midicsv = callPackage ../tools/audio/midicsv { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20753,6 +20753,12 @@ in
     ubootWandboard
     ;
 
+  # Hardkernel Odroid devices firmware:
+  inherit (callPackage ../misc/uboot/hardkernel-firmware.nix {})
+    firmwareOdroidC2
+    firmwareOdroidC4
+  ;
+
   # Upstream Barebox:
   inherit (callPackage ../misc/barebox {})
     buildBarebox

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20725,6 +20725,7 @@ in
     ubootNanoPCT4
     ubootNovena
     ubootOdroidC2
+    ubootOdroidC4
     ubootOdroidXU3
     ubootOrangePiPc
     ubootOrangePiZeroPlus2H5


### PR DESCRIPTION
###### Motivation for this change

This enables Odroid C4 board in NixOS with Linux kernel version 5.8+.
Also retires dependency on 3rd-party repository from Armbian.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested Odroid C2/C4 actually boots from produced u-boot.
- [x] Odroid C4 boot from SD tested.
- [x] Odroid C4 boot from eMMC tested.
- [x] Odroid C2 boot from SD tested.
- [x] Odroid C2 boot from eMMC tested.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
