### PR TITLE
yed: wrap With wrapGAppsHook - fixes #101135

### DIFF
--- a/pkgs/applications/graphics/yed/default.nix
+++ b/pkgs/applications/graphics/yed/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, makeWrapper, unzip, jre }:
+{ stdenv, fetchzip, makeWrapper, unzip, jre, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "yEd";
@@ -9,16 +9,25 @@ stdenv.mkDerivation rec {
     sha256 = "0sd73s700f3gqq5zq1psrqjg6ff2gv49f8vd37v6bv65vdxqxryq";
   };
 
-  nativeBuildInputs = [ makeWrapper unzip ];
+  nativeBuildInputs = [ makeWrapper unzip wrapGAppsHook ];
+  # For wrapGAppsHook setup hook
+  buildInputs = [ jre.gtk3 ];
 
-  installPhase = ''
+  dontConfigure = true;
+  dontBuild = true;
+  dontInstall = true;
+
+  preFixup = ''
     mkdir -p $out/yed
     cp -r * $out/yed
     mkdir -p $out/bin
 
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
     makeWrapper ${jre}/bin/java $out/bin/yed \
+      ''${makeWrapperArgs[@]} \
       --add-flags "-jar $out/yed/yed.jar --"
   '';
+  dontWrapGApps = true;
 
   meta = with stdenv.lib; {
     license = licenses.unfree;

--- a/pkgs/development/compilers/openjdk/default.nix
+++ b/pkgs/development/compilers/openjdk/default.nix
@@ -31,6 +31,10 @@ let
       gtk3 gnome_vfs GConf glib
     ];
 
+    passthru = {
+      inherit gtk3;
+    };
+
     patches = [
       ./fix-java-home-jdk10.patch
       ./read-truststore-from-env-jdk10.patch


### PR DESCRIPTION
Use preFixup to setup the wrapper properly, without double wrapping.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/101135 (cc @bluescreen303 ).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
