### PR TITLE
Fixes missing configure script

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -797,6 +797,9 @@ let
     });
 
     openssl = old.openssl.overrideDerivation (attrs: {
+      preConfigure = ''
+        patchShebangs configure
+        '';
       PKGCONFIG_CFLAGS = "-I${pkgs.openssl.dev}/include";
       PKGCONFIG_LIBS = "-Wl,-rpath,${pkgs.openssl.out}/lib -L${pkgs.openssl.out}/lib -lssl -lcrypto";
     });


### PR DESCRIPTION
###### Motivation for this change

After the upgrade to R 4.0.2 and bioconductor 3.11, openssl doesn't build anymore with the following error:
```
builder for '/nix/store/jwalx9lmy481nmpc29lbpi5zmmgpd9bq-r-openssl-1.4.2.drv' failed with exit code 1; last 10 log lines:
  building
  running tests
  installing
  * installing *source* package 'openssl' ...
  ** package 'openssl' successfully unpacked and MD5 sums checked
  ** using staged installation
  sh: ./configure: not found
  Warning in system(cmd) : error in running command
  ERROR: configuration failed for package 'openssl'
  * removing '/nix/store/anqns7mfinwsh0iamm45isigiw4ykqw5-r-openssl-1.4.2/library/openssl'
```

This had already been fixed in https://github.com/NixOS/nixpkgs/pull/93590, however that PR seems to have been superseeded by another PR that was faster in updating R and bioconductor (however without the necessary fix to openssl).

@lblasc can you confirm that this PR fixes the issue?


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
