### PR TITLE
sonar-scanner-bin: rename to sonar-scanner-cli, 3.3.0.1492 -> 4.5.0.2216

### DIFF
--- a/pkgs/tools/security/sonar-scanner-cli/default.nix
+++ b/pkgs/tools/security/sonar-scanner-cli/default.nix
@@ -2,22 +2,22 @@
 
 let
 
-  version = "3.3.0.1492";
+  version = "4.5.0.2216";
 
   sonarScannerArchPackage = {
     "x86_64-linux" = {
       url = "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${version}-linux.zip";
-      sha256 = "1vn22d1i14440wlym0kxzbmjlxd9x9b0wc2ifm8fwig1xvnwpjwd";
+      sha256 = "sha256-rmvDb5l2BGV8j94Uhu2kJXwoDAHA3VncAahqGvLY3I0=";
     };
     "x86_64-darwin" = {
       url = "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${version}-macosx.zip";
-      sha256 = "1m7cplak63m2rmad7f2s1iksi1qn43m2h1jm0qh3m219xcpl632i";
+      sha256 = "1g3lldpkrjlvwld9h82hlwclyplxpbk4q3nq59ylw4dhp26kb993";
     };
   };
 
 in stdenv.mkDerivation rec {
   inherit version;
-  name = "sonar-scanner-bin-${version}";
+  pname = "sonar-scanner-cli";
 
   src = fetchurl sonarScannerArchPackage.${stdenv.hostPlatform.system};
 
@@ -38,9 +38,9 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = https://github.com/SonarSource/sonar-scanner-cli;
+    homepage = "https://github.com/SonarSource/sonar-scanner-cli";
     description = "SonarQube Scanner used to start code analysis";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ peterromfeldhk ];
     platforms = builtins.attrNames sonarScannerArchPackage;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7114,7 +7114,7 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  sonar-scanner-bin = callPackage ../tools/security/sonar-scanner-bin { };
+  sonar-scanner-cli = callPackage ../tools/security/sonar-scanner-cli { };
 
   solr = callPackage ../servers/search/solr { };
   solr_7 = solr;


### PR DESCRIPTION
also fix up meta info

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @peterromfeldhk
