### PR TITLE
fiche: init at version 0.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6751,6 +6751,16 @@
       fingerprint = "A3A3 65AE 16ED A7A0 C29C  88F1 9712 452E 8BE3 372E";
     }];
   };
+  pinpox = {
+    email = "mail@pablo.tools";
+    github = "pinpox";
+    githubId = 1719781;
+    name = "Pablo Ovelleiro Corral";
+    keys = [{
+      longkeyid = "sa4096/0x823A6154426408D3";
+      fingerprint = "D03B 218C AE77 1F77 D7F9  20D9 823A 6154 4264 08D3";
+    }];
+  };
   piotr = {
     email = "ppietrasa@gmail.com";
     name = "Piotr Pietraszkiewicz";

--- a/pkgs/servers/fiche/default.nix
+++ b/pkgs/servers/fiche/default.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/bin
     install -Dm755 fiche -t $out/bin
   '';
 

--- a/pkgs/servers/fiche/default.nix
+++ b/pkgs/servers/fiche/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    install -m 0755 fiche $out/bin
+    install -Dm755 fiche -t $out/bin
   '';
 
   doCheck = true;

--- a/pkgs/servers/fiche/default.nix
+++ b/pkgs/servers/fiche/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "fiche";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "solusipse";
+    repo = "fiche";
+    rev = version;
+    sha256 = "1102r39xw17kip7mjp987jy8na333gw9vxv31f7v8q05cr7d7kfb";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m 0755 fiche $out/bin
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Command line pastebin for sharing terminal output";
+    longDescription = ''
+      Fiche is a command line pastebin server for sharing terminal output.
+      It can be used without any graphical tools from a TTY and has minimal requirements.
+      A live instance can be found at https://termbin.com.
+
+      Example usage:
+      echo just testing! | nc termbin.com 9999
+    '';
+
+    homepage = "https://github.com/solusipse/fiche";
+    changelog = "https://github.com/solusipse/fiche/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = [ maintainers.pinpox ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -142,6 +142,8 @@ in
 
   ankisyncd = callPackage ../servers/ankisyncd { };
 
+  fiche = callPackage ../servers/fiche { };
+
   avro-tools = callPackage ../development/tools/avro-tools { };
 
   # Zip file format only allows times after year 1980, which makes e.g. Python wheel building fail with:


### PR DESCRIPTION
###### Motivation for this change
Include [fiche](https://github.com/solusipse/fiche), a command line pastebin service for sharing terminal output with minimal dependencies.

**Note**: this is my first PR to nixpkgs, feedback is welcome so please let me know what has to be changed!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
