### PR TITLE
redshift-plasma-applet: add patch for compatibility with redshift 1.12 update

### DIFF
--- a/pkgs/applications/misc/redshift-plasma-applet/default.nix
+++ b/pkgs/applications/misc/redshift-plasma-applet/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, cmake, extra-cmake-modules, plasma-framework, kwindowsystem, redshift, fetchFromGitHub, }:
+{ lib, stdenv, cmake, extra-cmake-modules, plasma-framework, kwindowsystem, redshift, fetchFromGitHub, fetchpatch, }:
 
 let version = "1.0.18"; in
 
@@ -12,6 +12,17 @@ stdenv.mkDerivation {
     rev = "v${version}";
     sha256 = "122nnbafa596rxdxlfshxk45lzch8c9342bzj7kzrsjkjg0xr9pq";
   };
+
+  patches = [
+    # This patch fetches from out-of-source repo because the GitHub copy is frozen,
+    #     the active fork is now on invent.kde.org. Remove this patch when a new version is released and src is updated
+    # Redshift version >= 1.12 requires the -P option to clear the existing effects before applying shading.
+    #     Without it scrolling makes the screen gets darker and darker until it is impossible to see anything.
+    (fetchpatch {
+      url = "https://invent.kde.org/plasma/plasma-redshift-control/-/commit/898c3a4cfc6c317915f1e664078d8606497c4049.patch";
+      sha256 =  "0b6pa3fcj698mgqnc85jbbmcl3qpf418mh06qgsd3c4v237my0nv";
+    })
+  ];
 
   patchPhase = ''
     substituteInPlace package/contents/ui/main.qml \


### PR DESCRIPTION
No version update. Latest source fixes a very annoying
issue where the widget cannot be turned down lower
https://github.com/NixOS/nixpkgs/issues/83250

Patch every redshift to ${redshift}/bin/redshift and
Patch killall to pkill so it actually kills the right process.

The redshift binary hides behind a python wrapper called
.redshift-wrapp (run `ps e | grep redshift` to find it),
but killall doesn't fix this. Using pkill kills it correctly

Is using `procps` here appropriate?

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This issue: https://github.com/NixOS/nixpkgs/issues/83250

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
