### PR TITLE
parallel: fix calculation of max line length

### DIFF
--- a/pkgs/tools/misc/parallel/default.nix
+++ b/pkgs/tools/misc/parallel/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, perl, makeWrapper, procps }:
+{ fetchurl, stdenv, perl, makeWrapper, procps, coreutils }:
 
 stdenv.mkDerivation rec {
   name = "parallel-20200822";
@@ -7,6 +7,14 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/parallel/${name}.tar.bz2";
     sha256 = "02dy46g6f05p7s2qs8h6yg20p1zl3flxxf77n5jw74l3h1m24m4n";
   };
+
+  patches = [
+    ./fix-max-line-length-allowed.diff
+  ];
+
+  postPatch = ''
+    substituteInPlace src/parallel --subst-var-by coreutils ${coreutils}
+  '';
 
   outputs = [ "out" "man" ];
 

--- a/pkgs/tools/misc/parallel/fix-max-line-length-allowed.diff
+++ b/pkgs/tools/misc/parallel/fix-max-line-length-allowed.diff
@@ -1,0 +1,17 @@
+Correct path to coreutils echo to fix parallel --max-line-length-allowed.
+
+Author: Bjørn Forsman
+
+diff --git a/src/parallel b/src/parallel
+index a047fd94..9fc5f671 100755
+--- a/src/parallel
++++ b/src/parallel
+@@ -11580,7 +11580,7 @@ sub is_acceptable_command_line_length($$) {
+ 	$len += length $Global::parallel_env;
+     }
+     # Force using non-built-in command
+-    ::qqx("/bin/echo ".${string}x(($len-length "/bin/echo ")/length $string));
++    ::qqx("@coreutils@/bin/echo ".${string}x(($len-length "@coreutils@/bin/echo ")/length $string));
+     ::debug("init", "$len=$? ");
+     return not $?;
+ }


### PR DESCRIPTION
###### Motivation for this change

parallel >= 20200822 uses /bin/echo to calculate the max allowed line
length. Patch it to a correct path, so that it doesn't (silently) fail
and fall back to a low value of 324.

Before:
  $ parallel --max-line-length-allowed
  324

After:
  $ parallel --max-line-length-allowed
  131063

Fixes: 16ca8725ff ("parallel: 20200722 -> 20200822")


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
