### PR TITLE
openjdk15-bootstrap: fix i686 build

### DIFF
--- a/pkgs/development/compilers/openjdk/12.nix
+++ b/pkgs/development/compilers/openjdk/12.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, bash, pkg-config, autoconf, cpio, file, which, unzip
 , zip, perl, cups, freetype, alsaLib, libjpeg, giflib, libpng, zlib, lcms2
 , libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama
-, libXcursor, libXrandr, fontconfig, openjdk11
+, libXcursor, libXrandr, fontconfig, openjdk11, fetchpatch
 , setJavaClassPath
 , headless ? false
 , enableJavaFX ? openjfx.meta.available, openjfx
@@ -43,6 +43,11 @@ let
       (fetchurl {
         url = "https://src.fedoraproject.org/rpms/java-openjdk/raw/06c001c7d87f2e9fe4fedeef2d993bcd5d7afa2a/f/rh1673833-remove_removal_of_wformat_during_test_compilation.patch";
         sha256 = "082lmc30x64x583vqq00c8y0wqih3y4r0mp1c4bqq36l22qv6b6r";
+      })
+      # Fix gnumake 4.3 incompatibility
+      (fetchpatch {
+        url = "https://github.com/openjdk/panama-foreign/commit/af5c725b8109ce83fc04ef0f8bf6aaf0b50c0441.patch";
+        sha256 = "0ja84kih5wkjn58pml53s59qnavb1z92dc88cbgw7vcyqwc1gs0h";
       })
     ] ++ lib.optionals (!headless && enableGnome2) [
       ./swing-use-gtk-jdk10.patch

--- a/pkgs/development/compilers/openjdk/13.nix
+++ b/pkgs/development/compilers/openjdk/13.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, bash, pkg-config, autoconf, cpio, file, which, unzip
 , zip, perl, cups, freetype, alsaLib, libjpeg, giflib, libpng, zlib, lcms2
 , libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama
-, libXcursor, libXrandr, fontconfig, openjdk13-bootstrap
+, libXcursor, libXrandr, fontconfig, openjdk13-bootstrap, fetchpatch
 , setJavaClassPath
 , headless ? false
 , enableJavaFX ? openjfx.meta.available, openjfx
@@ -43,6 +43,11 @@ let
       (fetchurl {
         url = "https://src.fedoraproject.org/rpms/java-openjdk/raw/06c001c7d87f2e9fe4fedeef2d993bcd5d7afa2a/f/rh1673833-remove_removal_of_wformat_during_test_compilation.patch";
         sha256 = "082lmc30x64x583vqq00c8y0wqih3y4r0mp1c4bqq36l22qv6b6r";
+      })
+      # Fix gnumake 4.3 incompatibility
+      (fetchpatch {
+        url = "https://github.com/openjdk/panama-foreign/commit/af5c725b8109ce83fc04ef0f8bf6aaf0b50c0441.patch";
+        sha256 = "0ja84kih5wkjn58pml53s59qnavb1z92dc88cbgw7vcyqwc1gs0h";
       })
     ] ++ lib.optionals (!headless && enableGnome2) [
       ./swing-use-gtk-jdk13.patch

--- a/pkgs/development/compilers/openjdk/openjfx/15.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/15.nix
@@ -65,9 +65,7 @@ let
     # Downloaded AWT jars differ by platform.
     outputHash = {
       x86_64-linux = "0hmyr5nnjgwyw3fcwqf0crqg9lny27jfirycg3xmkzbcrwqd6qkw";
-      # The build-time dependencies don't currently build for i686, so no
-      # reason to fetch this one correctly either...
-      i686-linux = "0000000000000000000000000000000000000000000000000000";
+      i686-linux = "0hx69p2z96p7jbyq4r20jykkb8gx6r8q2cj7m30pldlsw3650bqx";
     }.${stdenv.system} or (throw "Unsupported platform");
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10140,6 +10140,7 @@ in
           headless = true;
           inherit (gnome2) GConf gnome_vfs;
           openjdk13-bootstrap = callPackage ../development/compilers/openjdk/12.nix {
+            stdenv = gcc8Stdenv; /* build segfaults with gcc9 or newer, so use gcc8 like Debian does */
             openjfx = openjfx11; /* need this despite next line :-( */
             enableJavaFX = false;
             headless = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The following tests are currently blocked, because `openjdk14` fail to build on `i686-linux`:

- [nixos:trunk-combined:nixos.tests.ergo.i686-linux](https://hydra.nixos.org/build/128855029)
- [nixos:trunk-combined:nixos.tests.gerrit.i686-linux](https://hydra.nixos.org/build/128853674)
- [nixos:trunk-combined:nixos.tests.gocd-agent.i686-linux](https://hydra.nixos.org/build/128855473)
- [nixos:trunk-combined:nixos.tests.gocd-server.i686-linux](https://hydra.nixos.org/build/128852288)
- [nixos:trunk-combined:nixos.tests.jitsi-meet.i686-linux](https://hydra.nixos.org/build/128852253)
- [nixos:trunk-combined:nixos.tests.kafka.kafka_0_10.i686-linux](https://hydra.nixos.org/build/128852975)
- [nixos:trunk-combined:nixos.tests.kafka.kafka_0_11.i686-linux](https://hydra.nixos.org/build/128853587)
- [nixos:trunk-combined:nixos.tests.kafka.kafka_0_9.i686-linux](https://hydra.nixos.org/build/128853286)
- [nixos:trunk-combined:nixos.tests.kafka.kafka_1_0.i686-linux](https://hydra.nixos.org/build/128850699)
- [nixos:trunk-combined:nixos.tests.kafka.kafka_1_1.i686-linux](https://hydra.nixos.org/build/128856593)
- [nixos:trunk-combined:nixos.tests.kafka.kafka_2_0.i686-linux](https://hydra.nixos.org/build/128857326)
- [nixos:trunk-combined:nixos.tests.kafka.kafka_2_1.i686-linux](https://hydra.nixos.org/build/128854790)
- [nixos:trunk-combined:nixos.tests.kafka.kafka_2_2.i686-linux](https://hydra.nixos.org/build/128856945)
- [nixos:trunk-combined:nixos.tests.kafka.kafka_2_3.i686-linux](https://hydra.nixos.org/build/128853597)
- [nixos:trunk-combined:nixos.tests.kafka.kafka_2_4.i686-linux](https://hydra.nixos.org/build/128853212)
- [nixos:trunk-combined:nixos.tests.kafka.kafka_2_5.i686-linux](https://hydra.nixos.org/build/128854651)
- [nixos:trunk-combined:nixos.tests.metabase.i686-linux](https://hydra.nixos.org/build/128854095)
- [nixos:trunk-combined:nixos.tests.munin.i686-linux](https://hydra.nixos.org/build/128856804)
- [nixos:trunk-combined:nixos.tests.mxisd.i686-linux](https://hydra.nixos.org/build/128852713)
- [nixos:trunk-combined:nixos.tests.shattered-pixel-dungeon.i686-linux](https://hydra.nixos.org/build/128851026)
- [nixos:trunk-combined:nixos.tests.solr.i686-linux](https://hydra.nixos.org/build/128852677)
- [nixos:trunk-combined:nixos.tests.zookeeper.i686-linux](https://hydra.nixos.org/build/128851983)

This happens because of an incompatibility of older openjdk versions used during bootstrap with `gmumake-4.3` ( [upstream issue](https://bugs.openjdk.java.net/browse/JDK-8237879) ). Newer version of openjdk already include the used patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
