### PR TITLE
flake.nix: Make all nixosSystems overridable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
     in
     {
       lib = lib.extend (final: prev: {
-        nixosSystem = { modules, ... } @ args:
+        nixosSystem = final.makeOverridable ({ modules, ... } @ args:
           import ./nixos/lib/eval-config.nix (args // {
             modules =
               let
@@ -54,7 +54,7 @@
                   };
                 }
               ];
-          });
+          }));
       });
 
       checks.x86_64-linux.tarball = jobs.tarball;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

See https://github.com/nix-community/nixos-generators/pull/76. I don't
mean to say you should do it just because of this one project, but this
is an example of how it might be used - I'm sure there are other reasons
to override a nixosSystem


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
