### PR TITLE
pythonPackages.pystray: mark linux only

### DIFF
--- a/pkgs/development/python-modules/pystray/default.nix
+++ b/pkgs/development/python-modules/pystray/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/moses-palmer/pystray";
     description = "This library allows you to create a system tray icon";
     license = licenses.lgpl3;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ jojosch ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fails to build on Darwin and pyobjc-framework seems like a large collection of packages which should be treated specially and not be introduced one by one to nixpkgs.

```
installing
Executing pipInstallPhase
/private/var/folders/r4/k85s52jx3555ckj0wty615s00000gp/T/nix-build-python3.8-pystray-0.16.0.drv-0/source/dist /private/var/folders/r4/k85s52jx3555ckj0wty615s00000gp/T/nix-build-python3.8-pystray-0.16.0.drv-0/source
Processing ./pystray-0.16.0-py2.py3-none-any.whl
ERROR: Could not find a version that satisfies the requirement pyobjc-framework-Quartz>=3.0; sys_platform == "darwin" (from pystray==0.16.0) (from versions: none)
ERROR: No matching distribution found for pyobjc-framework-Quartz>=3.0; sys_platform == "darwin" (from pystray==0.16.0)
builder for '/nix/store/a7xs4l3hvvqa54nvv865rcz81jws1jbr-python3.8-pystray-0.16.0.drv' failed with exit code 1
error: build of '/nix/store/a7xs4l3hvvqa54nvv865rcz81jws1jbr-python3.8-pystray-0.16.0.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
