### PR TITLE
plasma-workspace: add glib-networking and gstreamer as dependancies (for environment variable)

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-workspace/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-workspace/default.nix
@@ -16,6 +16,8 @@
 
   qtgraphicaleffects, qtquickcontrols, qtquickcontrols2, qtscript, qttools,
   qtwayland, qtx11extras,
+
+  wrapGAppsHook, glib-networking, gst_all_1,
 }:
 
 let inherit (lib) getBin getLib; in
@@ -35,6 +37,7 @@ mkDerivation {
     kholidays kquickcharts appstream-qt
 
     qtgraphicaleffects qtquickcontrols qtquickcontrols2 qtscript qtwayland qtx11extras
+    wrapGAppsHook glib-networking gst_all_1.gstreamer
   ];
   propagatedUserEnvPkgs = [ qtgraphicaleffects ];
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I wanted to use the radio plugin for plasma desktop. It use qtmultimediaplayer, who need gstreamer plugins and glib-networking as runtime dependancies. As I was unable to find how to make glib depend on glib-networking at compile time (cycling dependancies, althought some stuff should be doable by compiling a minimal glib-networking version in the same derivation of glib, I decended it may be a subject for another day). With this, I can play the radio I want, which use https. (I also need to load the vaapi gst plugin at runtime, via a global environment variable).

Some more info about my research to have those depencies: https://github.com/NixOS/nixpkgs/issues/72579
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) (nixos/tests/plasma5.nix)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) (haven't done this manually, but I switched my system to my fork, and it have no problem).
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

A question I have is: Should I add the vaapi plugin for gst here ? My audio stream also require it, but it isn't a default installation of wrapGApps, and may add unwanted use of storage.