### PR TITLE
cozy-audiobooks: 0.6.7 -> 0.7.2

### DIFF
--- a/pkgs/applications/audio/cozy-audiobooks/default.nix
+++ b/pkgs/applications/audio/cozy-audiobooks/default.nix
@@ -20,7 +20,7 @@ python3Packages.buildPythonApplication rec {
   format = "other"; # no setup.py
 
   pname = "cozy";
-  version = "0.6.7";
+  version = "0.7.2";
 
   # Temporary fix
   # See https://github.com/NixOS/nixpkgs/issues/57029
@@ -31,7 +31,7 @@ python3Packages.buildPythonApplication rec {
     owner = "geigi";
     repo = pname;
     rev = version;
-    sha256 = "0f8dyqj6111czn8spgsnic1fqs3kimjwl1b19mw55fa924b9bhsa";
+    sha256 = "0fmbddi4ga0bppwg3rm3yjmf7jgqc6zfslmavnr1pglbzkjhy9fs";
   };
 
   nativeBuildInputs = [
@@ -55,18 +55,23 @@ python3Packages.buildPythonApplication rec {
   ]);
 
   propagatedBuildInputs = with python3Packages; [
-    gst-python
-    pygobject3
+    apsw
+    cairo
     dbus-python
-    mutagen
-    peewee
+    distro
+    gst-python
     magic
+    mutagen
+    packaging
+    peewee
+    pygobject3
+    pytz
+    requests
   ];
 
   postPatch = ''
-    chmod +x data/meson_post_install.py
-    patchShebangs data/meson_post_install.py
-    substituteInPlace cozy/magic/magic.py --replace "ctypes.util.find_library('magic')" "'${file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}'"
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
   '';
 
   postInstall = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

update cozy to latest version. some internal structuring changes, this is reflected in this PR. Also a couple of python libraries were added as new dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
