### PR TITLE
ocamlPackages.ocp-build: 1.99.19-beta → 1.99.21-beta

### DIFF
--- a/pkgs/development/ocaml-modules/re/default.nix
+++ b/pkgs/development/ocaml-modules/re/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchzip, buildDunePackage, ocaml, ounit, seq }:
+{ lib, fetchurl, buildDunePackage, ocaml, ounit, seq }:
 
 buildDunePackage rec {
   pname = "re";
@@ -6,9 +6,9 @@ buildDunePackage rec {
 
   minimumOCamlVersion = "4.02";
 
-  src = fetchzip {
-    url = "https://github.com/ocaml/ocaml-re/archive/${version}.tar.gz";
-    sha256 = "07ycb103mr4mrkxfd63cwlsn023xvcjp0ra0k7n2gwrg0mwxmfss";
+  src = fetchurl {
+    url = "https://github.com/ocaml/ocaml-re/releases/download/${version}/re-${version}.tbz";
+    sha256 = "1gas4ky49zgxph3870nffzkr6y41kkpqp4nj38pz1gh49zcf12aj";
   };
 
   buildInputs = lib.optional doCheck ounit;

--- a/pkgs/development/tools/ocaml/ocp-build/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-build/default.nix
@@ -1,24 +1,19 @@
-{ stdenv, fetchpatch, fetchFromGitHub, ocaml, findlib, ncurses }:
+{ stdenv, fetchFromGitHub, ocaml, findlib, ncurses, cmdliner, re }:
 let
-  version = "1.99.19-beta";
+  version = "1.99.21";
 in
 stdenv.mkDerivation {
 
-  name = "ocaml${ocaml.version}-ocp-build-${version}";
+  name = "ocaml${ocaml.version}-ocp-build-${version}-beta";
 
   src = fetchFromGitHub {
     owner = "OCamlPro";
     repo = "ocp-build";
-    rev = version;
-    sha256 = "162k5l0cxyqanxlml5v8mqapdq5qbqc9m4b8wdjq7mf523b3h2zj";
+    rev = "v${version}";
+    sha256 = "1641xzik98c7xnjwxpacijd6d9jzx340fmdn6i372z8h554jjlg9";
   };
 
-  patches = stdenv.lib.optional (stdenv.lib.versionAtLeast ocaml.version "4.08") (fetchpatch {
-    url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/ocp-pp/ocp-pp.1.99.19-beta/files/0001-Fix-ocp-pp-for-changes-in-compiler-libs.patch";
-    sha256 = "0s0s2hh4d7cmwd6i7ixjgb79vij0r1v54m0vwwi26b3fips09qyn";
-  });
-
-  buildInputs = [ ocaml findlib ];
+  buildInputs = [ ocaml findlib cmdliner re ];
   propagatedBuildInputs = [ ncurses ];
   preInstall = "mkdir -p $out/bin";
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

Fix build with OCaml 4.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
