### PR TITLE
iozone: 3.471 -> 3.490

### DIFF
--- a/pkgs/development/tools/misc/iozone/default.nix
+++ b/pkgs/development/tools/misc/iozone/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gnuplot }:
+{ stdenv, lib, fetchurl, gnuplot }:
 
 let
   target = if stdenv.hostPlatform.system == "i686-linux" then
@@ -13,11 +13,12 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "iozone-3.471";
+  pname = "iozone";
+  version = "3.490";
 
   src = fetchurl {
-    url = "http://www.iozone.org/src/current/iozone3_471.tar";
-    sha256 = "0w63b3d4ws1sm52lpdd08sl7n4ay438dl3wy0q9la12iq81rglid";
+    url = "http://www.iozone.org/src/current/iozone${lib.replaceStrings ["."] ["_"] version}.tar";
+    sha256 = "1vagmm2k2bzlpahl2a2arpfmk3cd5nzhxi842a8mdag2b8iv9bay";
   };
 
   license = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

update iozone to latest upstream
generate url instead of hardcoding the version in the url
this should make auto-updating possible via nixpkgs-update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
