### PR TITLE
pango: 1.45.3 -> 1.45.5

### DIFF
--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -9,25 +9,14 @@ with stdenv.lib;
 
 let
   pname = "pango";
-  version = "1.45.3";
+  version = "1.45.5";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0zg6gvzk227q997jf1c9p7j5ra87nm008hlgq6q8na9xmgmw2x8z";
+    sha256 = "018p3j5dy1lcj9w47vm1328nz91p2qkvsmmw7fs1hcrdvq8xj7gn";
   };
-
-  patches = [
-    # Fix issue with Pango loading unsupported formats that
-    # breaks mixed x11/opentype font packages.
-    # See https://gitlab.gnome.org/GNOME/pango/issues/457
-    # Remove on next release.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/pango/commit/fe1ee773310bac83d8e5d3c062b13a51fb5fb4ad.patch";
-      sha256 = "1px66g31l2jx4baaqi4md59wlmvw0ywgspn6zr919fxl4h1kkh0h";
-    })
-  ];
 
   # FIXME: docs fail on darwin
   outputs = [ "bin" "dev" "out" ] ++ optional (!stdenv.isDarwin) "devdoc";


### PR DESCRIPTION
###### Motivation for this change
Version bump with a bugfix, see https://github.com/NixOS/nixpkgs/issues/101458

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (aarch64-linux, x86_64-linux, i686-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
