### PR TITLE
nasm: 2.14.02 -> 2.15.05 (CVE-2019-6290 CVE-2019-6291 CVE-2019-8343 CVE-2019-14248 CVE-2019-20334)

### DIFF
--- a/pkgs/development/compilers/nasm/default.nix
+++ b/pkgs/development/compilers/nasm/default.nix
@@ -1,26 +1,24 @@
-{ stdenv, fetchFromRepoOrCz, autoreconfHook, perl, asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl }:
+{ stdenv, fetchurl, perl }:
 
 stdenv.mkDerivation rec {
   pname = "nasm";
-  version = "2.14.02";
+  version = "2.15.05";
 
-  src = fetchFromRepoOrCz {
-    repo = "nasm";
-    rev = "${pname}-${version}";
-    sha256 = "15z6ybnzlsrqs2964h6czqhpmr7vc3ln4y4h0z9vrznk4mqcwbsa";
+  src = fetchurl {
+    url = "https://www.nasm.us/pub/nasm/releasebuilds/${version}/${pname}-${version}.tar.xz";
+    sha256 = "0gqand86b0r86k3h46dh560lykxmxqqywz5m55kgjfq7q4lngbrw";
   };
 
-  nativeBuildInputs = [ autoreconfHook perl asciidoc xmlto docbook_xml_dtd_45 docbook_xsl ];
+  nativeBuildInputs = [ perl ];
 
-  postBuild = "make manpages";
+  enableParallelBuilding = true;
 
   doCheck = true;
 
   checkPhase = ''
-    make golden && make test
+    make golden
+    make test
   '';
-
-  NIX_CFLAGS_COMPILE="-Wno-error=attributes";
 
   meta = with stdenv.lib; {
     homepage = "https://www.nasm.us/";


### PR DESCRIPTION
###### Motivation for this change
https://nasm.us/doc/nasmdocc.html
https://nvd.nist.gov/vuln/detail/CVE-2019-6290
https://nvd.nist.gov/vuln/detail/CVE-2019-6291
https://nvd.nist.gov/vuln/detail/CVE-2019-8343
https://nvd.nist.gov/vuln/detail/CVE-2019-14248
https://nvd.nist.gov/vuln/detail/CVE-2019-20334

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).