### PR TITLE
python3Packages.pygmt: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/pygmt/default.nix
+++ b/pkgs/development/python-modules/pygmt/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+, gmt
+, numpy
+, netcdf4
+, pandas
+, packaging
+, xarray
+}:
+
+buildPythonPackage rec {
+  pname = "pygmt";
+  version = "0.2.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "GenericMappingTools";
+    repo = "pygmt";
+    rev = "v${version}";
+    sha256 = "1yx1n6mxfmwg69ls5560nm6d3jxyghv27981iplz7m7990bbp468";
+  };
+
+  postPatch = ''
+    substituteInPlace pygmt/clib/loading.py \
+      --replace "env.get(\"GMT_LIBRARY_PATH\", \"\")" "env.get(\"GMT_LIBRARY_PATH\", \"${gmt}/lib\")"
+  '';
+
+  propagatedBuildInputs = [ numpy netcdf4 pandas packaging xarray ];
+
+  doCheck = false; # requires network access
+
+  postBuild = "export HOME=$TMP";
+
+  pythonImportsCheck = [ "pygmt" ];
+
+  meta = with lib; {
+    description = "A Python interface for the Generic Mapping Tools";
+    homepage = "https://github.com/GenericMappingTools/pygmt";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5022,6 +5022,8 @@ in {
 
   pygmo = callPackage ../development/python-modules/pygmo { };
 
+  pygmt = callPackage ../development/python-modules/pygmt { };
+
   pygobject2 = callPackage ../development/python-modules/pygobject { inherit (pkgs) pkgconfig; };
 
   pygobject3 = callPackage ../development/python-modules/pygobject/3.nix { inherit (pkgs) meson pkgconfig; };


### PR DESCRIPTION
###### Motivation for this change
[**PyGMT**](https://github.com/GenericMappingTools/pygmt) - A Python interface for the [Generic Mapping Tools](https://www.generic-mapping-tools.org/). 

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
