### PR TITLE
pythonPackages.imutils: refactor

### DIFF
--- a/pkgs/development/python-modules/imutils/default.nix
+++ b/pkgs/development/python-modules/imutils/default.nix
@@ -2,6 +2,8 @@
 , buildPythonPackage
 , fetchPypi
 , opencv3
+, opencv4
+, withOpenCV3 ? false
 }:
 
 buildPythonPackage rec {
@@ -13,15 +15,17 @@ buildPythonPackage rec {
     sha256 = "857af6169d90e4a0a814130b9b107f5d611150ce440107e1c1233521c6fb1e2b";
   };
 
-  propagatedBuildInputs = [ opencv3 ];
+  propagatedBuildInputs = [ (if withOpenCV3 then opencv3 else opencv4) ];
 
   # no tests
   doCheck = false;
+
+  pythonImportsCheck = [ "imutils" ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/jrosebr1/imutils";
     description = "A series of convenience functions to make basic image processing functions";
     license = licenses.mit;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc mtrsk ];
   };
 }


### PR DESCRIPTION
Make sure imutils can be built with both opencv3 and opencv4. This would also close an [old issue of mine](https://github.com/NixOS/nixpkgs/issues/74914).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
