### PR TITLE
fluffychat: init at v0.20.0 [major wip]

### DIFF
--- a/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, fetchFromGitLab
+, cmake
+, utillinux
+, ninja
+, pkgconfig
+, gtk3
+, flutter, dart, android-studio
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fluffychat";
+  version = "0.20.0";
+
+  src = fetchFromGitLab {
+    owner = "ChristianPauly";
+    repo = "fluffychat-flutter";
+    rev = "v${version}";
+    sha256 = "sha256-YlUb4zu/Wq1vKW2ZBtxa6UbMJRSe0cBi/F5pwnqe5fE=";
+  };
+
+  sourceRoot = "source/linux";
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkgconfig
+    flutter dart android-studio
+
+    utillinux
+  ];
+
+  buildInputs = [
+    gtk3
+  ];
+}
+
+# see: https://github.com/NixOS/nixpkgs/issues/36759
+# seems related: https://github.com/flutter/flutter/pull/50599
+
+# presumably we'd need to package/import/symlink the flutter sdk?
+
+/*
+error: --- Error --- nix-daemon
+builder for '/nix/store/7nw07dajgxg4v27qyzhrzakpn0bpgin3-fluffychat-6569c16060587353d94ae4e4919440bbf2f05e61.drv' failed with exit code 1; last 10 log lines:
+  CMake Error at flutter/generated_plugins.cmake:13 (add_subdirectory):
+    add_subdirectory given source
+    "flutter/ephemeral/.plugin_symlinks/url_launcher_linux/linux" which is not
+    an existing directory.
+  Call Stack (most recent call first):
+    CMakeLists.txt:59 (include)
+
+
+  -- Configuring incomplete, errors occurred!
+  See also "/build/source/linux/build/CMakeFiles/CMakeOutput.log".
+*/

--- a/pkgs/applications/networking/instant-messengers/fluffychat/metadata.nix
+++ b/pkgs/applications/networking/instant-messengers/fluffychat/metadata.nix
@@ -1,0 +1,6 @@
+{
+  repo_git = "https://gitlab.com/ChristianPauly/fluffychat-flutter.git/";
+  branch = "main";
+  rev = "6569c16060587353d94ae4e4919440bbf2f05e61";
+  sha256 = "sha256-Nr50z6leyN6PpM6b5WYXW79T5piQFmQvzH+aNFBoRrE=";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1038,6 +1038,8 @@ in
 
   fitnesstrax = callPackage ../applications/misc/fitnesstrax/default.nix { };
 
+  fluffychat = callPackage  ../applications/networking/instant-messengers/fluffychat { };
+
   fxlinuxprintutil = callPackage ../tools/misc/fxlinuxprintutil { };
 
   genpass = callPackage ../tools/security/genpass {


### PR DESCRIPTION
##### Motivation for this change

Fixes #101111. Major WIP. I don't think there's any Flutter packages in tree, I think due to SDK freedom issues. (Another case where getting some things from Robotnix into nixpkgs might be useful? Or a new "flake-flutter" or "flake-android" with these tools available?)

status: probably not even close to building, probably needs someone familiar with Flutter to help fix this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
