### PR TITLE
[20.09] blugon: fix build on darwin

### DIFF
--- a/pkgs/applications/misc/blugon/default.nix
+++ b/pkgs/applications/misc/blugon/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ python3 libX11 libXrandr ];
 
+  # Remove at next release
+  # https://github.com/jumper149/blugon/commit/d262cd05
+  postPatch = ''
+    sed -i 's,CC = gcc,CC ?= gcc,g' backends/scg/Makefile
+  '';
+
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/101515
(cherry picked from commit c58233a34a0c005c0b1d73b3cc853c346dfd11da)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF 20.09 https://github.com/NixOS/nixpkgs/issues/97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
