### PR TITLE
gnome: 3.38.0 → 3.38.1 stragglers

### DIFF
--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -40,11 +40,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-builder";
-  version = "3.38.0";
+  version = "3.38.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1olTi6+O+xrPfqYHJosaqhQY1VF9ktT2lGo9v4FOrlU=";
+    sha256 = "06wcyfrwcjyj2vcqyw0z3sy1r4qxpcdpwqq1qmpsaphpz8acycjn";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/core/gdm/default.nix
@@ -47,13 +47,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gdm";
-  version = "3.38.0";
+  version = "3.38.1";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gdm/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1fimhklb204rflz8k345756jikgbw8113hms3zlcwk6975f43m26";
+    sha256 = "0wkzy5mrxq963fm4pmn6bhml73zmc8bq61frm77a175046c590q8";
   };
 
   mesonFlags = [
@@ -122,13 +122,6 @@ stdenv.mkDerivation rec {
     # Set up the environment properly when launching sessions
     # https://github.com/NixOS/nixpkgs/issues/48255
     ./reset-environment.patch
-
-    # Fix runtime patch location.
-    # https://gitlab.gnome.org/GNOME/gdm/-/merge_requests/114
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gdm/-/commit/9d841d681f3d1c58e3df51a98421257f774cd185.patch";
-      sha256 = "0lf5kpz9ghylqlbybc0mpfsvr4i29z1ag8wf6j1918hjrfcipnxj";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-software/default.nix
@@ -2,7 +2,7 @@
 , glib, appstream-glib, libsoup, polkit, isocodes, gspell, libxslt, gobject-introspection, flatpak, fwupd
 , gtk3, gsettings-desktop-schemas, gnome-desktop, libxmlb, gnome-online-accounts
 , json-glib, libsecret, valgrind-light, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_43, gtk-doc, desktop-file-utils
-, sysprof }:
+, libsysprof-capture }:
 
 let
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     gtk3 glib packagekit appstream-glib libsoup
     gsettings-desktop-schemas gnome-desktop
     gspell json-glib libsecret ostree
-    polkit flatpak libxmlb gnome-online-accounts sysprof
+    polkit flatpak libxmlb gnome-online-accounts libsysprof-capture
   ] ++ stdenv.lib.optionals withFwupd [
     fwupd
   ];

--- a/pkgs/desktops/gnome-3/core/mutter/3.34/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/3.34/default.nix
@@ -35,7 +35,7 @@
 , xorgserver
 , python3
 , wrapGAppsHook
-, sysprof
+, libsysprof-capture
 , desktop-file-utils
 , libcap_ng
 , egl-wayland
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
     libxkbfile
     pango
     pipewire_0_2 # TODO: backport pipewire 0.3 support
-    sysprof
+    libsysprof-capture
     upower
     xkeyboard_config
     xwayland

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -32,7 +32,7 @@
 , xorgserver
 , python3
 , wrapGAppsHook
-, sysprof
+, libsysprof-capture
 , desktop-file-utils
 , libcap_ng
 , egl-wayland
@@ -110,7 +110,7 @@ let self = stdenv.mkDerivation rec {
     libxkbfile
     pango
     pipewire
-    sysprof
+    libsysprof-capture
     xkeyboard_config
     xwayland
     wayland-protocols

--- a/pkgs/desktops/gnome-3/core/sushi/default.nix
+++ b/pkgs/desktops/gnome-3/core/sushi/default.nix
@@ -25,11 +25,11 @@
 
 stdenv.mkDerivation rec {
   pname = "sushi";
-  version = "3.34.0";
+  version = "3.38.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/sushi/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1zcr8wi5bgvvpb5ha1v96aiaz4vqqrsn6cvvalwzah6am85k78m8";
+    sha256 = "0vlqqk916dymv4asbyvalp1m096a5hh99nx23i4xavzvgygh4h2h";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/misc/gnome-applets/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-applets/default.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-applets";
-  version = "3.37.2";
+  version = "3.38.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0l1mc9ymjg0bgk92a08zd85hx1vaqrzdj0dwzmna20rp51vf0l4a";
+    sha256 = "04qrzycwm7pz556agl08xw3d0r1mmr4ja9n9jfijjxs9inrhp5yc";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
@@ -29,7 +29,7 @@
 }:
 let
   pname = "gnome-flashback";
-  version = "3.37.2";
+  version = "3.38.0";
 
   # From data/sessions/Makefile.am
   requiredComponentsCommon = [
@@ -60,7 +60,7 @@ let
 
     src = fetchurl {
       url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-      sha256 = "0lz6icgng8ri4sdi3lkdsyvxzfvlkayn85b5346g76vc1w5y03db";
+      sha256 = "1r51yqdqichp4jv54kiaqrh0xhykngr4ymlvrkjhzdhivwadsg4m";
     };
 
     # make .desktop Execs absolute

--- a/pkgs/desktops/gnome-3/misc/gnome-panel/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-panel/default.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-panel";
-  version = "3.37.1";
+  version = "3.38.0";
 
   outputs = [ "out" "dev" "man" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-HVmP1okz52AY8vsRanhxy8ADPB8Qm/v+CKHstWBn0VI=";
+    hash = "sha256-GosVrvCgKmyqm5IJyNP7Q+e5h6OAB2aRwj8DFOwwLxU=";
   };
 
   # make .desktop Exec absolute

--- a/pkgs/development/libraries/gcr/default.nix
+++ b/pkgs/development/libraries/gcr/default.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gcr";
-  version = "3.36.0";
+  version = "3.38.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "00b6bzpr8rj8mvj66r2273r417wg2y21m6n88mhkq9m22z8bxyda";
+    sha256 = "1q97pba4bzjndm1vlvicyv8mrl0n589qsw71dp8jrz2payvcfk56";
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/gjs/default.nix
+++ b/pkgs/development/libraries/gjs/default.nix
@@ -29,11 +29,11 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "gjs";
-  version = "1.66.0";
+  version = "1.66.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1y5m7as3jwhb3svb4xgk443hyxhijralk5q5s3ywidkd047gj37k";
+    sha256 = "0k1ld2bc4c3zbyjpfgx15v5n02iywdvm106rys5jqr7zbr2l0hld";
   };
 
   outputs = [ "out" "dev" "installedTests" ];

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -4,14 +4,14 @@
 
 let
   pname = "librsvg";
-  version = "2.50.0";
+  version = "2.50.1";
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "s/rbokDwm5yYmKsgy3MRRnJD5gfPj5KLfF+EJHTuPfQ=";
+    sha256 = "02csvx2nzygh8kyal2qiy3y6xb7d52vszxxr37dzav704a9pkncv";
   };
 
   outputs = [ "out" "dev" "installedTests" ];

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, glib, libxml2, meson, ninja, pkgconfig, gnome3, sysprof
+{ stdenv, lib, fetchurl, glib, libxml2, meson, ninja, pkgconfig, gnome3, libsysprof-capture
 , gnomeSupport ? true, sqlite, glib-networking, gobject-introspection, vala
 , libpsl, python3, brotli }:
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     libpsl
     brotli
   ] ++ lib.optionals stdenv.isLinux [
-    sysprof
+    libsysprof-capture
   ];
   nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection vala glib ];
   propagatedBuildInputs = [ glib libxml2 ];

--- a/pkgs/development/libraries/mm-common/default.nix
+++ b/pkgs/development/libraries/mm-common/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mm-common";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1jasx9a9g7nqf7jcv3mrg4qh5cp9sq724jxjaz4wa1dzmxsxg8i8";
+    sha256 = "07b4s5ckcz9q5gwx8vchim19mhfgl8wysqwi30pndks3m4zrzad2";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/tracker-miners/default.nix
+++ b/pkgs/development/libraries/tracker-miners/default.nix
@@ -48,11 +48,11 @@
 
 stdenv.mkDerivation rec {
   pname = "tracker-miners";
-  version = "3.0.0";
+  version = "3.0.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0hj0ixrladm7sxcmi0hr6d7wdlg9zcq0cyk22prg9pn54dy1lj5v";
+    sha256 = "1kfi5d6pccqx28hbnja6k1mpwjd53k5zs704sg01rlzmbshz1zn6";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/tracker/default.nix
+++ b/pkgs/development/libraries/tracker/default.nix
@@ -29,13 +29,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tracker";
-  version = "3.0.0";
+  version = "3.0.1";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0drqsfqc4smfbpjk74iap114yww5cpldfhn4z6b0aavmylalb1kh";
+    sha256 = "1rhcs75axga7p7hl37h6jzb2az89jddlcwc7ykrnb2khyhka78rr";
   };
 
   patches = [

--- a/pkgs/development/tools/profiling/sysprof/capture.nix
+++ b/pkgs/development/tools/profiling/sysprof/capture.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, meson
+, ninja
+, sysprof
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libsysprof-capture";
+
+  inherit (sysprof) src version;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  mesonFlags = [
+    "-Dwith_sysprofd=none"
+    "-Dlibsysprof=false"
+    "-Dhelp=false"
+    "-Denable_tools=false"
+    "-Denable_tests=false"
+    "-Denable_examples=false"
+  ];
+
+  meta = sysprof.meta // {
+    description = "Static library for Sysprof capture data generation";
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sysprof";
-  version = "3.38.0";
+  version = "3.38.1";
 
   outputs = [ "out" "lib" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1kj1yb7sfd874jm0666cnf5lc0c83gxhsdqhjic6ykppqa6p5kcb";
+    sha256 = "1z2i9187f2jx456l7h07wy8m9a0p7pj3xiv1aji3snq7rjb1lkj0";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18621,6 +18621,8 @@ in
 
   sysprof = callPackage ../development/tools/profiling/sysprof { };
 
+  libsysprof-capture = callPackage ../development/tools/profiling/sysprof/capture.nix { };
+
   sysklogd = callPackage ../os-specific/linux/sysklogd { };
 
   syslinux = callPackage ../os-specific/linux/syslinux { };


### PR DESCRIPTION
Few more changes

> e6b66c48bf5559a7903c126b80010af4af9d5201: mm-common: 1.0.1 → 1.0.2
> 	(https://ftp.gnome.org/pub/GNOME/sources/mm-common/1.0/mm-common-1.0.2.news)
> 	mm-common 1.0.2 (2020-09-25)
> 	
> 	* util/doc-install.pl: Update for Doxygen >= 1.8.16
> 	  (Kjell Ahlstedt)
> 	* doc-reference.py: Don't include DESTDIR in the DevHelp base path
> 	  (Kjell Ahlstedt) Issue [#2](https://gitlab.gnome.org/GNOME/mm-common/issues/2) (Mart Raudsepp)
> 	* dist-build-scripts.py: Remove files from distribution, if requested
> 	  (Kjell Ahlstedt)
> 	
> 	
> 	
> 72ac086be52f1c42854b2a4328ced9771ac48c04: tracker-miners: 3.0.0 → 3.0.1
> 	(https://ftp.gnome.org/pub/GNOME/sources/tracker-miners/3.0/tracker-miners-3.0.1.news)
> 	NEW in 3.0.1 - 2020-10-02
> 	=========================
> 	  * Fix moving files and directories leaving stale data
> 	  * Better handling of faulty SPARQL from tracker-extract
> 	  * Fix chromaprint tag extraction in gstreamer extractor causing
> 	    bad SPARQL.
> 	  * Reference Discourse instead of the mailing list
> 	  * Forward tracker-extract state
> 	  * Use specific Meson options to enable debug flags
> 	  * Fix stop words location when building with system Tracker
> 	  * Small libtracker-miners-common clean ups
> 	  * Check for malloc_trim function being available
> 	  * Fixes for Coverity warnings
> 	  * Compiler warning fixes
> 	
> 	Translations: fr, fur, he, nl, sk
> 	
> 	
> d5bb67bc092b7cd8a05e029a988cee87dd547c71: tracker: 3.0.0 → 3.0.1
> 	(https://ftp.gnome.org/pub/GNOME/sources/tracker/3.0/tracker-3.0.1.news)
> 	NEW in 3.0.1 - 2020-10-02
> 	=========================
> 	  * Reference Discourse instead of the mailing list
> 	  * Use specific Meson options to enable debug flags
> 	  * Reduce in use by TrackerSparqlStatement
> 	  * Fix tracker:title-sort
> 	  * Fix stale graphs with WITH clauses
> 	  * Cleanup libtracker-common
> 	  * Several fixes for Coverity warnings
> 	  * More tests
> 	  * Build fixes
> 	
> 	Translations: he, nl, pt, sk
> 	
> 	
> a6553d5882fca30ecfe49058197224f26eb3b4e9: sysprof: 3.38.0 → 3.38.1
> 	(https://ftp.gnome.org/pub/GNOME/sources/sysprof/3.38/sysprof-3.38.1.news)
> 	Overview of changes in Sysprof 3.38.1
> 	=====================================
> 	
> 	 * Support for translating paths to binary symbols has been improved when using
> 	   Btrfs subvolumes.
> 	 * Build system fixes
> 	 * Fixes for sysprof_capture_reader_list_files() to match expectations
> 	 * Load proper speedtrack library in LD_PRELOAD
> 	 * **Fixes when generating pkg-config files** [just some ugly meson hacks [!38](https://gitlab.gnome.org/GNOME/sysprof/-/merge_requests/38) [!39](https://gitlab.gnome.org/GNOME/sysprof/-/merge_requests/39)]
> 	 * Fixes when using musl libc
> 	 * Translation updates
> 	
> 	
> 1e0b649bef2991f83c25db20ce312252db4e8a75: librsvg: 2.50.0 → 2.50.1
> 	(https://ftp.gnome.org/pub/GNOME/sources/librsvg/2.50/librsvg-2.50.1.news)
> 	Version 2.50.1
> 	
> 	- [#615](https://gitlab.gnome.org/GNOME/librsvg/issues/615): SVG2: Support a chain of uri() filters in the "filter" property
> 	  (John Ledbetter, Sven Neumann).
> 	
> 	- [#483](https://gitlab.gnome.org/GNOME/librsvg/issues/483): Support CSS selectors for attribute matching, like rect[attr^="prefix"]
> 	
> 	- [#554](https://gitlab.gnome.org/GNOME/librsvg/issues/554): Fixed the geometry_for_layer() APIs to not ignore the passed viewport.
> 	
> 	- Fixed CSS "import" so it allows only files from the same base directory
> 	  (Lars Schmertmann).
> 	
> 	- [#623](https://gitlab.gnome.org/GNOME/librsvg/issues/623) - The pkg-config files (*.pc) do not define the 'svgz_supported' and
> 	  'css_supported' variables anymore.  These variables were hardcoded
> 	  to 'true' and unchanged since 2011.
> 	
> 	- [#624](https://gitlab.gnome.org/GNOME/librsvg/issues/624) - The source repository no longer produces a librsvg-uninstalled.pc file.
> 	
> 	
> bc3dd58bc8ca62e3c9fc2071360e8ecc1033dabf: gjs: 1.66.0 → 1.66.1
> 	(https://ftp.gnome.org/pub/GNOME/sources/gjs/1.66/gjs-1.66.1.news)
> 	Version 1.66.1
> 	--------------
> 	
> 	- Closed bugs and merge requests:
> 	
> 	  * Throws on Unsupported caller allocates [[!495](https://gitlab.gnome.org/GNOME/gjs/merge_requests/495), Marco Trevisan]
> 	  * arg: Fix MIN/MAX safe big integer limits [[!492](https://gitlab.gnome.org/GNOME/gjs/merge_requests/492), Marco Trevisan]
> 	  * Fix leak when virtual function is unimplemented [[!498](https://gitlab.gnome.org/GNOME/gjs/merge_requests/498), Evan Welsh]
> 	  * Cannot compile GJS 1.66.0 on macOS with llvm/clang 10.0.1 [[#347](https://gitlab.gnome.org/GNOME/gjs/issues/347), [!499](https://gitlab.gnome.org/GNOME/gjs/merge_requests/499),
> 	    Marc-Antoine Perennou]
> 	  * console: fix typo in command-line option [[!500](https://gitlab.gnome.org/GNOME/gjs/merge_requests/500), Andy Holmes]
> 	  * Prevent passing null pointers when not nullable [[!503](https://gitlab.gnome.org/GNOME/gjs/merge_requests/503), Evan Welsh]
> 	  * Passing fundamentals to functions no longer works [[#353](https://gitlab.gnome.org/GNOME/gjs/issues/353), [!506](https://gitlab.gnome.org/GNOME/gjs/merge_requests/506), Evan Welsh]
> 	
> 	- Fixed examples/clutter.js to work with more recent Clutter [Philip Chimento]
> 	
> 	
> 4df18b79f10f0aff0802f3c8a0cf8ad16b169891: gcr: 3.36.0 → 3.38.0
> 	(https://ftp.gnome.org/pub/GNOME/sources/gcr/3.37/gcr-3.37.91.news)
> 	gcr 3.37.91:
> 	- meson: missing dependency on generated oids header [[GNOME/gcr#48](https://gitlab.gnome.org/GNOME/gcr/issues/48), [GNOME/gcr!57](https://gitlab.gnome.org/GNOME/gcr/merge_requests/57)]
> 	- Correct display of key usage extensions [[GNOME/gcr#47](https://gitlab.gnome.org/GNOME/gcr/issues/47), [GNOME/gcr!56](https://gitlab.gnome.org/GNOME/gcr/merge_requests/56)]
> 	- meson: Correctly set internal vapi dependencies [[GNOME/gcr!55](https://gitlab.gnome.org/GNOME/gcr/merge_requests/55)]
> 	- Cleanup GType boilerplate [[GNOME/gcr!53](https://gitlab.gnome.org/GNOME/gcr/merge_requests/53)]
> 	- gck: Fixed test failures [[GNOME/gcr#42](https://gitlab.gnome.org/GNOME/gcr/issues/42), [GNOME/gcr!51](https://gitlab.gnome.org/GNOME/gcr/merge_requests/51), [GNOME/gcr!52](https://gitlab.gnome.org/GNOME/gcr/merge_requests/52)]
> 	- Updated translations
> 	
> 	
> 	
> 	(https://ftp.gnome.org/pub/GNOME/sources/gcr/3.38/gcr-3.38.0.news)
> 	gcr 3.38.0:
> 	- No changes from 3.37.91
> 	
> 	
> 60df789c064d8ebe8087d5cd2c87341e184d0108: gnome-builder: 3.38.0 → 3.38.1
> 	(https://ftp.gnome.org/pub/GNOME/sources/gnome-builder/3.38/gnome-builder-3.38.1.news)
> 	==============
> 	Version 3.38.1
> 	==============
> 	
> 	 • Fix block font to load with recent fontconfig
> 	 • Fix eslint to support typescript
> 	 • Reduce delay in showing hover tooltips on code
> 	 • Fix various runtime warnings
> 	 • Fix running project after rebuild
> 	 • Update templates to use 3.38 SDKs
> 	 • Translation updates
> 	
> 	
> 9da22e00395521f9f36dd35e9fb2b01bffead3dc: gnome3.sushi: 3.34.0 → 3.38.0
> 	(https://ftp.gnome.org/pub/GNOME/sources/sushi/3.38/sushi-3.38.0.news)
> 	3.38.0
> 	======
> 	
> 	- Fix build when Wayland is disabled (Ting-Wei Lan)
> 	- **Make X11 and Wayland configurable at build time** ([!12](https://gitlab.gnome.org/GNOME/sushi/merge_requests/12), David Heidelberg) [actually [!13](https://gitlab.gnome.org/GNOME/sushi/-/merge_requests/13) and it is just different variants of GTK)
> 	- Sync font-widget with gnome-font-viewer
> 	- Fix various meson build issues
> 	- Sandbox webkitgtk
> 	- Fix crash caused by the lack of getters for viewers' properties
> 	
> 	
> 116668cdc87c325d92ed49f9a6fe3c9ffeb8260d: gnome3.gnome-panel: 3.37.1 → 3.38.0
> 	(https://ftp.gnome.org/pub/GNOME/sources/gnome-panel/3.38/gnome-panel-3.38.0.news)
> 	Version 3.38.0
> 	==============
> 	- Fix ssh/sftp bookmarks in Places menu. ([#27](https://gitlab.gnome.org/GNOME/gnome-panel/issues/27))
> 	- Updated translations.
> 	
> 	
> 9961fabb994dcc9f2debe50507452ae7449b2b5c: gnome3.gnome-flashback: 3.37.2 → 3.38.0
> 	(https://ftp.gnome.org/pub/GNOME/sources/gnome-flashback/3.37/gnome-flashback-3.37.3.news)
> 	Version 3.37.3
> 	==============
> 	- Update lock screen window on monitor changes. ([LP:#1891855](https://bugs.launchpad.net/launchpad/+bug/1891855))
> 	- Don't lock screen on suspend if automatic screen lock
> 	  is disabled. ([LP:#1891681](https://bugs.launchpad.net/launchpad/+bug/1891681))
> 	- Updated translations. ([LP:#1882531](https://bugs.launchpad.net/launchpad/+bug/1882531))
> 	
> 	
> 	
> 	(https://ftp.gnome.org/pub/GNOME/sources/gnome-flashback/3.38/gnome-flashback-3.38.0.news)
> 	Version 3.38.0
> 	==============
> 	- Configure systemd session using a drop-in.
> 	- Get session path from logind manager. ([#67](https://gitlab.gnome.org/GNOME/gnome-flashback/issues/67))
> 	- Updated translations.
> 	
> 	
> 157865250fbb037552126bcd531b651f9f4f0054: gnome3.gnome-applets: 3.37.2 → 3.38.0
> 	(https://ftp.gnome.org/pub/GNOME/sources/gnome-applets/3.38/gnome-applets-3.38.0.news)
> 	Version 3.38.0
> 	==============
> 	- Create sticky notes file per-applet. ([!61](https://gitlab.gnome.org/GNOME/gnome-applets/merge_requests/61))
> 	- Updated translations.
> 	
> 	
> f084d8e5a90a3cf0480fb6c024c312a8005bef27: gnome3.gdm: 3.38.0 → 3.38.1
> 	(https://ftp.gnome.org/pub/GNOME/sources/gdm/3.38/gdm-3.38.1.news)
> 	==============
> 	Version 3.38.1
> 	==============
> 	- **Fix bug leading to users /etc/gdm/custom.conf getting overwritten on nvidia systems.** [patch removed]
> 	- Fix typo in comment
> 	- Translation updates