### PR TITLE
nixos-generate-config: Change how auto-generated swap files are detected

### DIFF
--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -124,6 +124,12 @@ let
         internal = true;
       };
 
+      autoDetected = mkOption {
+        default = false;
+        type = types.bool;
+        internal = true;
+      };
+
     };
 
     config = rec {

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -265,6 +265,13 @@ in
         )}
       '';
 
+    # Provide a list of manually configured swap devices to exclude from hardware-configuration.nix
+    environment.etc.swapDevices-manually-configured = {
+      text = concatMapStrings
+        (sw: "${sw.realDevice}\n")
+        (filter (sw: !sw.autoDetected) config.swapDevices);
+    };
+
     # Provide a target that pulls in all filesystems.
     systemd.targets.fs =
       { description = "All File Systems";


### PR DESCRIPTION
###### Motivation for this change
`nixos-generate-config.pl` currently does not have enough information to intelligently decide which swap devices should be automatically configured and which should not. The current logic is fairly basic, and results in edge cases: https://github.com/NixOS/nixpkgs/issues/86353

This patch makes NixOS record at rebuild time which swap devices were manually configured, so the script doesn't have to guess later.

-----

Looking for feedback. This patch does work, but is it the best solution to the problem? Can anyone think of a better one?

The /etc/* file is just a placeholder. The file probably belongs somewhere else.

<!--
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
-->