### PR TITLE
.github/workflows/editorconfig.yml: check indent_style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -76,10 +76,12 @@ trim_trailing_whitespace = unset
 
 [pkgs/build-support/dotnetenv/Wrapper/**]
 end_of_line = unset
+indent_style = unset
 insert_final_newline = unset
 trim_trailing_whitespace = unset
 
 [pkgs/build-support/upstream-updater/**]
+indent_style = unset
 trim_trailing_whitespace = unset
 
 [pkgs/development/compilers/elm/registry.dat]
@@ -95,6 +97,9 @@ trim_trailing_whitespace = unset
 
 [pkgs/development/node-packages/composition.nix]
 insert_final_newline = unset
+
+[pkgs/development/{perl-modules,ocaml-modules,tools/ocaml}/**]
+indent_style = unset
 
 [pkgs/servers/dict/wordnet_structures.py]
 trim_trailing_whitespace = unset

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -23,5 +23,5 @@ jobs:
     - name: Checking EditorConfig
       if: env.GIT_DIFF
       run: |
-        ./bin/editorconfig-checker -disable-indentation \
+        ./bin/editorconfig-checker -disable-indent-size \
         ${{ env.GIT_DIFF }}

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -2,6 +2,8 @@ name: "Checking EditorConfig"
 
 on:
   pull_request:
+    branches-ignore:
+      - 'release-**'
 
 jobs:
   tests:


### PR DESCRIPTION
When we first started with this `editorconfig-checker` only supported disabling the indentation check, upstream has since added support for disabling `indent_size` which would allow us to check only `indent_style` (spaces vs tabs).

`indent_size` would still be a bit disruptive to enable but I think `indent_style` would be fine.

|check|errors|files in `pkgs/*`|
|---|---|---|
|Current|~700|~400|
|Current + indent_style|~2000|~550|
|Current + indent_style (with excludes)|~1400|~500|
|Current + indent_{size,style}|~60000|~1950|

I'll fix everything outside `pkgs` (`doc`, `nixos`, etc) which is an extra ~250 errors in ~20 files.