### PR TITLE
pythonPackages.diagrams: init at 0.17.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -176,6 +176,12 @@
     githubId = 1773511;
     name = "Adrien Devresse";
   };
+  addict3d = {
+    email = "nickbathum@gmail.com";
+    github = "addict3d";
+    githubId = 49227;
+    name = "Nick Bathum";
+  };
   adisbladis = {
     email = "adis@blad.is";
     github = "adisbladis";

--- a/pkgs/development/python-modules/diagrams/default.nix
+++ b/pkgs/development/python-modules/diagrams/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, graphviz
+}:
+
+buildPythonPackage rec {
+  pname = "diagrams";
+  version = "0.17.0";
+  disabled = ! isPy3k;
+
+  # TODO consider packaging from Github: https://github.com/mingrammer/diagrams
+  # note: outscale package is broken, __init__.py is missing
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17v5nzswva74bawxrvkza8a5d9aqyhb2gkncp3fqv6rszmk62hw6";
+  };
+
+  patches = [
+    ./diags_fix_aliases.patch
+  ];
+
+  # This script is patching setup.py from the pypi tarball, to retain
+  # the png images which this library uses to generate diagrams.
+  postPatch = ''
+    # fix resource lookup path
+    sed -i \
+    -e "/basedir = Path(os.path.abspath(os.path.dirname(__file__)))/d" \
+    -e "s|join(basedir.parent|join('$out'|" \
+    diagrams/__init__.py
+
+    # for setup.py: get all directories which contain any '.png' files
+    png_dirs=$(find resources -type f -name "*.png" -printf '%h\n' | sort -u)
+    dirs=($png_dirs)
+
+    # rewrite 'setup(...)' to add data_files
+    spacedSetup=$(echo -e "setup(\n    **setup_kwargs,")
+
+    substituteInPlace setup.py \
+      --replace 'setup(**setup_kwargs)' "''${spacedSetup}" \
+      --replace 'graphviz>=0.13.2,<0.14.0' 'graphviz>=0.14.0,<0.15.0' \
+      --replace ", 'jinja2>=2.10,<3.0'" ""  # not used when building from the source tarball
+
+    # scan dirs for pngs, building up the (directory, files) structure for data_files
+    {
+      echo "    data_files=["
+      for d in ''${dirs[*]}
+      do
+        echo "        (''\'''${d}''\', ["
+        printf "            "
+        find "''${d}" -type f -name "*.png" -printf "'%p', " | sed 's/, $//'
+        echo "]),"
+      done
+      echo "    ],)"
+    } >> setup.py
+  '';
+
+  buildInputs = [ graphviz ];
+
+  meta = with lib; {
+    description = "Generate infrastructure images from code";
+    homepage    = "https://diagrams.mingrammer.com/";
+    license     = licenses.mit;
+    maintainers =  with maintainers; [ addict3d ];
+  };
+}

--- a/pkgs/development/python-modules/diagrams/diags_fix_aliases.patch
+++ b/pkgs/development/python-modules/diagrams/diags_fix_aliases.patch
@@ -1,0 +1,11 @@
+diff -u diagrams-0.17.0/diagrams/oci/database.py diagrams-0.17.0/diagrams/oci/database.py
+--- diagrams-0.17.0/diagrams/oci/database.py	2020-08-26 10:58:57.950195800 -0400
++++ diagrams-0.17.0/diagrams/oci/database.py	2020-08-26 10:58:57.950195800 -0400
+@@ -82,7 +82,3 @@
+ 
+ # Aliases
+ 
+-ADB = AutonomousDatabase
+-ADBWhite = AutonomousDatabaseWhite
+-DBService = Databaseservice
+-DBServiceWhite = DatabaseserviceWhite

--- a/pkgs/development/python-modules/diagrams/diags_fix_resource_path.patch
+++ b/pkgs/development/python-modules/diagrams/diags_fix_resource_path.patch
@@ -1,0 +1,20 @@
+diff -u diagrams-0.17.0/diagrams/__init__.py.old diagrams-0.17.0/diagrams/__init__.py
+--- diagrams-0.17.0/diagrams/__init__.py.old	2020-10-09 22:26:31.459051230 -0400
++++ diagrams-0.17.0/diagrams/__init__.py	2020-10-09 22:26:07.970999273 -0400
+@@ -1,5 +1,6 @@
+ import contextvars
+ import os
++import sys
+ import uuid
+ from pathlib import Path
+ from typing import List, Union, Dict
+@@ -412,8 +413,7 @@
+         return uuid.uuid4().hex
+ 
+     def _load_icon(self):
+-        basedir = Path(os.path.abspath(os.path.dirname(__file__)))
+-        return os.path.join(basedir.parent, self._icon_dir, self._icon)
++        return os.path.join(sys.exec_prefix, self._icon_dir, self._icon)
+ 
+ 
+ class Edge:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1553,6 +1553,8 @@ in {
 
   dftfit = callPackage ../development/python-modules/dftfit { };
 
+  diagrams = callPackage ../development/python-modules/diagrams { };
+
   diceware = callPackage ../development/python-modules/diceware { };
 
   dicom2nifti = callPackage ../development/python-modules/dicom2nifti { };


### PR DESCRIPTION
###### Motivation for this change
Add python diagrams library. Generate nice architecture diagrams
with python code, allowing for rapid iteration.

The images are rendered using dot from graphviz. It outputs your choice of `[png jpg svg pdf]`

Closes #101532

###### Things done
I generated some diagrams using this library, with both of the following shell expressions. There are [many examples](https://diagrams.mingrammer.com/docs/getting-started/examples) on the project's website.

```
nix-shell -I nixpkgs=./ -p python3 python3Packages.diagrams python3Packages.graphviz
```
```
nix-shell -I nixpkgs=./ -E 'with import <nixpkgs> {}; (python3.withPackages (ps: [ps.diagrams ps.graphviz])).env'
```

The closure size is ~150M.
The library itself has ~20M in images.
