### PR TITLE
fetchfossil: Depend on cacert

### DIFF
--- a/pkgs/build-support/fetchfossil/default.nix
+++ b/pkgs/build-support/fetchfossil/default.nix
@@ -1,11 +1,11 @@
-{stdenv, fossil}:
+{stdenv, fossil, cacert}:
 
 {name ? null, url, rev, sha256}:
 
 stdenv.mkDerivation {
   name = "fossil-archive" + (if name != null then "-${name}" else "");
   builder = ./builder.sh;
-  nativeBuildInputs = [fossil];
+  nativeBuildInputs = [fossil cacert];
 
   # Envvar docs are hard to find. A link for the future:
   # https://www.fossil-scm.org/index.html/doc/trunk/www/env-opts.md


### PR DESCRIPTION
Without it, it'll not able to verify SSL certificates, rendering
it mostly useless

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Without this, a derivation like following:

```
fetchfossil {
      name = "fossil";
      url = "https://fossil-scm.org/home";
      rev = "68a78b895e91f10d97ff33c5ea8e143ef32a6c8b";
      # please ignore the sha256, it's dummy, and not the right checksum
      sha256 = "140jp7xzskik0sb6aqjsw7z477a124cxl7dkm80m2nyzjng4pzg5";
}
```

results in:

```
building '/nix/store/inrwc972basshq180bvwzylhn6wlgpbz-fossil-archive-fossil.drv'...
Cloning Fossil https://fossil-scm.org/home [68a78b895e91f10d97ff33c5ea8e143ef32a6c8b] into /nix/store/xkmwlay3pbdqsgawlyq96bgrx77bbnxg-fossil-archive-fossil
Unable to verify SSL cert from fossil-scm.org
  subject: CN = sqlite.org
  issuer:  C = US, O = Let's Encrypt, CN = Let's Encrypt Authority X3
  sha256:  6c8ef57dd980f70468e7b70c93380b54fed4319f06e80a708aa0b700dfeed736
accept this cert and continue (y/N)?
SSL cert declined
Clone done, sent: 0  received: 0  ip:
server returned an error - clone aborted
builder for '/nix/store/inrwc972basshq180bvwzylhn6wlgpbz-fossil-archive-fossil.drv' failed with exit code 1
```

FTR, other builders also depend on `cacert`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
