### PR TITLE
libreswan: Unbreak the package

### DIFF
--- a/pkgs/tools/networking/libreswan/default.nix
+++ b/pkgs/tools/networking/libreswan/default.nix
@@ -29,6 +29,10 @@ stdenv.mkDerivation rec {
     "-Wno-error=format-truncation"
     "-Wno-error=pointer-compare"
     "-Wno-error=stringop-truncation"
+    # The following flag allows libreswan v3.32 to work with NSS 3.22, see
+    # https://github.com/libreswan/libreswan/issues/334.
+    # This flag should not be needed for libreswan v3.33 (which is not yet released).
+    "-DNSS_PKCS11_2_0_COMPAT=1"
   ];
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];

--- a/pkgs/tools/networking/libreswan/default.nix
+++ b/pkgs/tools/networking/libreswan/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://libreswan.org";
     description = "A free software implementation of the VPN protocol based on IPSec and the Internet Key Exchange";
-    platforms = platforms.linux ++ platforms.darwin ++ platforms.freebsd;
+    platforms = platforms.linux ++ platforms.freebsd;
     license = licenses.gpl2;
     maintainers = [ maintainers.afranchuk ];
   };


### PR DESCRIPTION
On current unstable, libreswan compiles but then doesn't run because of an ABI
change in NSS.

There is an easy fix which is to land in the next version of libreswan, see
https://github.com/libreswan/libreswan/issues/334; in the meantime, we can copy
this fix so that libreswan works again on unstable.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
