### PR TITLE
ceph: Fix build with glibc 2.32

### DIFF
--- a/pkgs/tools/filesystems/ceph/ceph-glibc-2-32-sigdescr_np.patch
+++ b/pkgs/tools/filesystems/ceph/ceph-glibc-2-32-sigdescr_np.patch
@@ -1,0 +1,63 @@
+From b9b6faf66ae67648626470cb4fc3f0850ac4d842 Mon Sep 17 00:00:00 2001
+From: David Disseldorp <ddiss@suse.de>
+Date: Tue, 1 Sep 2020 13:49:21 +0200
+Subject: [PATCH] cmake: detect and use sigdescr_np() if available
+
+sys_siglist is deprecated with glibc 2.32. A new thread-safe and
+async-signal safe sigdescr_np() function is provided, so use it if
+available.
+
+Fixes: https://tracker.ceph.com/issues/47187
+Signed-off-by: David Disseldorp <ddiss@suse.de>
+---
+ cmake/modules/CephChecks.cmake | 1 +
+ src/global/signal_handler.h    | 8 +++++---
+ src/include/config-h.in.cmake  | 3 +++
+ 3 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/cmake/modules/CephChecks.cmake b/cmake/modules/CephChecks.cmake
+index 23687283a7c6..ca86dcbc73de 100644
+--- a/cmake/modules/CephChecks.cmake
++++ b/cmake/modules/CephChecks.cmake
+@@ -24,6 +24,7 @@ check_function_exists(strerror_r HAVE_Strerror_R)
+ check_function_exists(name_to_handle_at HAVE_NAME_TO_HANDLE_AT)
+ check_function_exists(pipe2 HAVE_PIPE2)
+ check_function_exists(accept4 HAVE_ACCEPT4)
++check_function_exists(sigdescr_np HAVE_SIGDESCR_NP)
+ 
+ include(CMakePushCheckState)
+ cmake_push_check_state(RESET)
+diff --git a/src/global/signal_handler.h b/src/global/signal_handler.h
+index 476724201aa9..c101b2e28733 100644
+--- a/src/global/signal_handler.h
++++ b/src/global/signal_handler.h
+@@ -20,10 +20,12 @@
+ 
+ typedef void (*signal_handler_t)(int);
+ 
+-#ifndef HAVE_REENTRANT_STRSIGNAL
+-# define sig_str(signum) sys_siglist[signum]
+-#else
++#ifdef HAVE_SIGDESCR_NP
++# define sig_str(signum) sigdescr_np(signum)
++#elif HAVE_REENTRANT_STRSIGNAL
+ # define sig_str(signum) strsignal(signum)
++#else
++# define sig_str(signum) sys_siglist[signum]
+ #endif
+ 
+ void install_sighandler(int signum, signal_handler_t handler, int flags);
+diff --git a/src/include/config-h.in.cmake b/src/include/config-h.in.cmake
+index 1ea3703f620c..59bd4273511a 100644
+--- a/src/include/config-h.in.cmake
++++ b/src/include/config-h.in.cmake
+@@ -220,6 +220,9 @@
+ /* Define to 1 if you have sched.h. */
+ #cmakedefine HAVE_SCHED 1
+ 
++/* Define to 1 if you have sigdescr_np. */
++#cmakedefine HAVE_SIGDESCR_NP 1
++
+ /* Support SSE (Streaming SIMD Extensions) instructions */
+ #cmakedefine HAVE_SSE
+ 

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -133,6 +133,7 @@ in rec {
 
     patches = [
       ./0000-fix-SPDK-build-env.patch
+      ./ceph-glibc-2-32-sigdescr_np.patch
     ];
 
     nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

This adds a patch from upstream ceph to avoid using the deprecated
`sys_siglist` if `sigdescr_np` is available. This fixes the build with glibc 2.32

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notes

This is my first PR to nixpkgs, so please point out if I missed anything above. This does fix ceph builds and thus `nixos-rebuild` on my machine.