### PR TITLE
ocamlPackages.mirage-net: init at 3.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-net/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-net/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchurl, buildDunePackage
+, cstruct, fmt, lwt, macaddr, mirage-device
+}:
+
+buildDunePackage rec {
+  pname = "mirage-net";
+  version = "3.0.1";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-net/releases/download/v${version}/mirage-net-v${version}.tbz";
+    sha256 = "0yfvl0fgs7xy5i7kkparaa7a315a2h7kb1z24fmmnwnyaji57dg3";
+  };
+
+  propagatedBuildInputs = [ cstruct fmt lwt macaddr mirage-device ];
+
+  meta = {
+    description = "Network signatures for MirageOS";
+    homepage = "https://github.com/mirage/mirage-net";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -563,6 +563,8 @@ let
 
     mirage-kv = callPackage ../development/ocaml-modules/mirage-kv { };
 
+    mirage-net = callPackage ../development/ocaml-modules/mirage-net { };
+
     mirage-protocols = callPackage ../development/ocaml-modules/mirage-protocols { };
 
     mirage-random = callPackage ../development/ocaml-modules/mirage-random { };


### PR DESCRIPTION
###### Motivation for this change

#23955

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
