### PR TITLE
home-assistant: pythonPackages.zigpy-znp: init at 0.2.2; pythonPackages.zigpy: 0.22.2 -> 0.26.0; pythonPackages.zigpy-cc: 0.5.1 -> 0.5.2; pythonPackages.zigpy-xbee: 0.12.1 -> 0.13.0; pythonPackages.zigpy-zigate: 0.6.1 -> 0.6.2

### DIFF
--- a/pkgs/development/python-modules/zigpy-cc/default.nix
+++ b/pkgs/development/python-modules/zigpy-cc/default.nix
@@ -1,22 +1,44 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, pyserial, pyserial-asyncio, zigpy
-, asynctest, pytest, pytest-asyncio }:
+{ lib
+, asynctest
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+, pyserial-asyncio
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+, zigpy }:
 
 buildPythonPackage rec {
   pname = "zigpy-cc";
-  version = "0.5.1";
+  version = "0.5.2";
+  # https://github.com/Martiusweb/asynctest/issues/152
+  # broken by upstream python bug with asynctest and
+  # is used exclusively by home-assistant with python 3.8
+  disabled = pythonOlder "3.8";
 
-  propagatedBuildInputs = [ pyserial pyserial-asyncio zigpy ];
-  checkInputs = [ asynctest pytest pytest-asyncio ];
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "06759615b28c45beaa5f03e594769a373d41674b96aeafefccd5c4e1c67e25ca";
+  src = fetchFromGitHub {
+    owner = "zigpy";
+    repo = "zigpy-cc";
+    rev = version;
+    sha256 = "U3S8tQ3zPlexZDt5GvCd+rOv7CBVeXJJM1NGe7nRl2o=";
   };
 
-  meta = with stdenv.lib; {
+  propagatedBuildInputs = [
+    pyserial
+    pyserial-asyncio
+    zigpy
+  ];
+
+  checkInputs = [
+    asynctest
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
     description = "A library which communicates with Texas Instruments CC2531 radios for zigpy";
-    homepage = "http://github.com/sanyatuning/zigpy-cc";
+    homepage = "https://github.com/zigpy/zigpy-cc";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ etu mvnetbiz ];
     platforms = platforms.linux;

--- a/pkgs/development/python-modules/zigpy-xbee/default.nix
+++ b/pkgs/development/python-modules/zigpy-xbee/default.nix
@@ -1,20 +1,42 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, pyserial, pyserial-asyncio, zigpy
-, pytest }:
+{ lib
+, asynctest
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+, pyserial-asyncio
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+, zigpy }:
 
 buildPythonPackage rec {
   pname = "zigpy-xbee";
-  version = "0.12.1";
+  version = "0.13.0";
+  # https://github.com/Martiusweb/asynctest/issues/152
+  # broken by upstream python bug with asynctest and
+  # is used exclusively by home-assistant with python 3.8
+  disabled = pythonOlder "3.8";
 
-  buildInputs = [ pyserial pyserial-asyncio zigpy ];
-  checkInputs = [ pytest ];
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "09488hl27qjv8shw38iiyzvzwcjkc0k4n00l2bfn1ac443xzw0vh";
+  src = fetchFromGitHub {
+    owner = "zigpy";
+    repo = "zigpy-xbee";
+    rev = version;
+    sha256 = "Krdqb9bYKwUC2cdNppB2+tLwWjzmzIHhXnQ1KRduofU=";
   };
 
-  meta = with stdenv.lib; {
+  buildInputs = [
+    pyserial
+    pyserial-asyncio
+    zigpy
+  ];
+
+  checkInputs = [
+    asynctest
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
     description = "A library which communicates with XBee radios for zigpy";
     homepage = "http://github.com/zigpy/zigpy-xbee";
     license = licenses.gpl3Plus;

--- a/pkgs/development/python-modules/zigpy-zigate/default.nix
+++ b/pkgs/development/python-modules/zigpy-zigate/default.nix
@@ -1,22 +1,44 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, pyserial, pyserial-asyncio, zigpy
-, pytest }:
+{ lib
+, asynctest
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+, pyserial-asyncio
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+, zigpy }:
 
 buildPythonPackage rec {
   pname = "zigpy-zigate";
-  version = "0.6.1";
+  version = "0.6.2";
+  # https://github.com/Martiusweb/asynctest/issues/152
+  # broken by upstream python bug with asynctest and
+  # is used exclusively by home-assistant with python 3.8
+  disabled = pythonOlder "3.8";
 
-  buildInputs = [ pyserial pyserial-asyncio zigpy ];
-  checkInputs = [ pytest ];
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0xxqv65drrr96b9ncwsx9ayd369lpwimj1jjb0d7j6l9lil0wmf5";
+  src = fetchFromGitHub {
+    owner = "zigpy";
+    repo = "zigpy-zigate";
+    rev = version;
+    sha256 = "EV6DV+BytUcPMtzYVKDnq/Uv2efg3stjL5uVlL62II4=";
   };
 
-  meta = with stdenv.lib; {
+  buildInputs = [
+    pyserial
+    pyserial-asyncio
+    zigpy
+  ];
+
+  checkInputs = [
+    asynctest
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
     description = "A library which communicates with ZiGate radios for zigpy";
-    homepage = "http://github.com/doudz/zigpy-zigate";
+    homepage = "https://github.com/zigpy/zigpy-zigate";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ etu mvnetbiz ];
     platforms = platforms.linux;

--- a/pkgs/development/python-modules/zigpy-znp/default.nix
+++ b/pkgs/development/python-modules/zigpy-znp/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, async-timeout
+, asynctest
+, buildPythonPackage
+, coloredlogs
+, coveralls
+, fetchFromGitHub
+, pyserial
+, pyserial-asyncio
+, pytest-asyncio
+, pytest-mock
+, pytest-timeout
+, pytestcov
+, pytestCheckHook
+, voluptuous
+, zigpy }:
+
+buildPythonPackage rec {
+  pname = "zigpy-znp";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "zha-ng";
+    repo = "zigpy-znp";
+    rev = "v${version}";
+    sha256 = "a98RYPvcYE1NPERmPo1jPwMf86N+0297u4pOKuaB6u4=";
+  };
+
+  propagatedBuildInputs = [
+    async-timeout
+    coloredlogs
+    pyserial
+    pyserial-asyncio
+    voluptuous
+    zigpy
+  ];
+
+  checkInputs = [
+    asynctest
+    coveralls
+    pytest-asyncio
+    pytest-mock
+    pytest-timeout
+    pytestcov
+    pytestCheckHook
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A library for zigpy which communicates with TI ZNP radios";
+    homepage = "https://github.com/zha-ng/zigpy-znp";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ mvnetbiz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -1,20 +1,44 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, aiohttp, crccheck, pycryptodome, pycrypto, voluptuous
-, pytest, pytest-asyncio, asynctest }:
+{ lib
+, aiohttp
+, asynctest
+, buildPythonPackage
+, crccheck
+, fetchFromGitHub
+, pycrypto
+, pycryptodome
+, pytest-aiohttp
+, pytest-asyncio
+, pytestCheckHook
+, tox
+, voluptuous }:
 
 buildPythonPackage rec {
   pname = "zigpy";
-  version = "0.22.2";
+  version = "0.26.0";
 
-  propagatedBuildInputs = [ aiohttp crccheck pycrypto pycryptodome voluptuous ];
-  checkInputs = [ pytest pytest-asyncio asynctest ];
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "a43129932c6e4af0d2d57542218faf7695e2424ce18a5a8915d016e1303f5e44";
+  src = fetchFromGitHub {
+    owner = "zigpy";
+    repo = "zigpy";
+    rev = version;
+    sha256 = "ba8Ru6RCbFOHhctFtklnrxVD3uEpxF4XDvO5RMgXPBs=";
   };
 
-  meta = with stdenv.lib; {
+  propagatedBuildInputs = [
+    aiohttp
+    crccheck
+    pycrypto
+    pycryptodome
+    voluptuous
+  ];
+
+  checkInputs = [
+    asynctest
+    pytest-aiohttp
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
     description = "Library implementing a ZigBee stack";
     homepage = "https://github.com/zigpy/zigpy";
     license = licenses.gpl3Plus;

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -36,7 +36,7 @@
     "apcupsd" = ps: with ps; [ ]; # missing inputs: apcaccess
     "api" = ps: with ps; [ aiohttp-cors ];
     "apns" = ps: with ps; [ ]; # missing inputs: apns2
-    "apple_tv" = ps: with ps; [ aiohttp-cors netdisco zeroconf ]; # missing inputs: pyatv
+    "apple_tv" = ps: with ps; [ aiohttp-cors netdisco pyatv zeroconf ];
     "apprise" = ps: with ps; [ apprise ];
     "aprs" = ps: with ps; [ ]; # missing inputs: aprslib geopy
     "aqualogic" = ps: with ps; [ ]; # missing inputs: aqualogic
@@ -956,7 +956,7 @@
     "zeroconf" = ps: with ps; [ aiohttp-cors zeroconf ];
     "zerproc" = ps: with ps; [ ]; # missing inputs: pyzerproc
     "zestimate" = ps: with ps; [ xmltodict ];
-    "zha" = ps: with ps; [ bellows pyserial zha-quirks zigpy-cc zigpy-deconz zigpy-xbee zigpy-zigate zigpy ]; # missing inputs: zigpy-znp
+    "zha" = ps: with ps; [ bellows pyserial zha-quirks zigpy-cc zigpy-deconz zigpy-xbee zigpy-zigate zigpy-znp zigpy ];
     "zhong_hong" = ps: with ps; [ ]; # missing inputs: zhong_hong_hvac
     "ziggo_mediabox_xl" = ps: with ps; [ ]; # missing inputs: ziggo-mediabox-xl
     "zodiac" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7808,6 +7808,8 @@ in {
 
   zigpy-zigate = callPackage ../development/python-modules/zigpy-zigate { };
 
+  zigpy-znp = callPackage ../development/python-modules/zigpy-znp { };
+
   zimports = callPackage ../development/python-modules/zimports { };
 
   zipfile36 = callPackage ../development/python-modules/zipfile36 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Home Assistant update broke ZHA component by adding a new zigpy module zigpy-znp.

###### Things done
Init package pythonPackages.zigpy-znp.
This requires updating zigpy, and the other zigpy python modules.

I have checked to make sure this works on my H-A server.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
