### PR TITLE
rocksdb: 6.10.2 -> 6.12.7

### DIFF
--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -26,7 +26,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ninja ];
 
-  buildInputs = [ bzip2 lz4 snappy zlib zstd ] ++ stdenv.lib.optional enableJemalloc jemalloc;
+  propagatedBuildInputs = [ bzip2 lz4 snappy zlib zstd ];
+
+  buildInputs = stdenv.lib.optional enableJemalloc jemalloc;
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isGNU "-Wno-error=deprecated-copy -Wno-error=pessimizing-move";
 

--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -15,28 +15,18 @@
 
 stdenv.mkDerivation rec {
   pname = "rocksdb";
-  version = "6.10.2";
+  version = "6.12.7";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1f2wqb6px812ijcivq3rsknqgkv01wblc6sd8wavhrw8qljgr3s1";
+    sha256 = "0cpi0v691xsh20hj5x2y2z7dmjvhd3brr0swszv0xqjg2q0f7zdb";
   };
 
   nativeBuildInputs = [ cmake ninja ];
 
   buildInputs = [ bzip2 lz4 snappy zlib zstd ] ++ stdenv.lib.optional enableJemalloc jemalloc;
-
-  patches = [
-    # Without this change private dependencies are exported.
-    # Can be removed after the next release.
-    # https://github.com/facebook/rocksdb/pull/6790
-    (fetchpatch {
-      url = "https://github.com/facebook/rocksdb/commit/07204837ce8d66e1e6e4893178f3fd040f9c1044.patch";
-      sha256 = "17097ybkhy0i089zzkpvcj65c7g5skvjvdzi1k09x4i1d719wm39";
-    })
-  ];
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isGNU "-Wno-error=deprecated-copy -Wno-error=pessimizing-move";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/facebook/rocksdb/blob/v6.12.7/HISTORY.md#6127-2020-10-14

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
