### PR TITLE
nixos/lightdm: make lightdm user shell bash

### DIFF
--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -308,6 +308,7 @@ in
       home = "/var/lib/lightdm";
       group = "lightdm";
       uid = config.ids.uids.lightdm;
+      shell = pkgs.bash;
     };
 
     systemd.tmpfiles.rules = [


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/issues/100119 pantheon's greeter
has g-s-d running which allows brightness controls via pkexec.
This is changed in newer versions of g-s-d (pantheon uses a fork currently),
but whenever brightness is changed with a shell of `shadow` we get
```
Oct 10 23:51:44 kirXps pkexec[18722]: lightdm: Executing command [USER=root] [TTY=unknown] [CWD=/var/lib/lightdm] [COMMAND=/run/current-system/sw/bin/elementary-settings-daemon/gsd-backlight-helper /sys/devices/pci0000:00/0000:00:02.0/drm/card0/card0-eDP-1/intel_backlight 65587]
```

I'm not sure this should be strictly needed, so we should try to
revert later on when pantheon's g-s-d is updated.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix https://github.com/NixOS/nixpkgs/issues/100119

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
