### PR TITLE
pantheon.switchboard-plug-about: patch some bugfixes

### DIFF
--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pantheon
 , substituteAll
@@ -47,6 +48,20 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
+    # Get OS Info from GLib.Environment
+    # https://github.com/elementary/switchboard-plug-about/pull/128
+    (fetchpatch {
+      url = "https://github.com/elementary/switchboard-plug-about/commit/5ed29988e3a895b2df66e5529df0f12a94d5517c.patch";
+      sha256 = "1ipDxnpDZjpSEzZdtOeNe5U+QOXiB5M+hC3yDAsl/rQ=";
+    })
+
+    # Use Pretty Name
+    # https://github.com/elementary/switchboard-plug-about/pull/134
+    (fetchpatch {
+      url = "https://github.com/elementary/switchboard-plug-about/commit/653d131dc8fac10ae7523f2bf6b179ffffa9c0fd.patch";
+      sha256 = "AsM49Dc9/yn2tG6fqjfedeOlDXUu+iEoyNUmNYLH+zE=";
+    })
+
     (substituteAll {
       src = ./fix-paths.patch;
       inherit pciutils;


### PR DESCRIPTION
Hopefully fix https://github.com/NixOS/nixpkgs/issues/101221.
Though that issue is flaky on the reproducibility.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
