### PR TITLE
radare2-cutter: Allow to use Python plugins

### DIFF
--- a/pkgs/development/tools/analysis/radare2/cutter.nix
+++ b/pkgs/development/tools/analysis/radare2/cutter.nix
@@ -30,17 +30,27 @@ mkDerivation rec {
       --replace "include(lib_radare2.pri)" ""
   '';
 
-  nativeBuildInputs = [ qmake pkgconfig ];
-  buildInputs = [ qtbase qtsvg qtwebengine r2-for-cutter python3 wrapQtAppsHook ];
+  nativeBuildInputs = [ qmake pkgconfig python3 wrapQtAppsHook ];
+  propagatedBuildInputs = [ python3.pkgs.pyside2 ];
+  buildInputs = [ qtbase qtsvg qtwebengine r2-for-cutter python3 ];
 
-  qmakeFlags = [
+  qmakeFlags = with python3.pkgs; [
     "CONFIG+=link_pkgconfig"
     "PKGCONFIG+=r_core"
     # Leaving this enabled doesn't break build but generates errors
     # at runtime (to console) about being unable to load needed bits.
     # Disable until can be looked at.
     "CUTTER_ENABLE_JUPYTER=false"
+    # Enable support for Python plugins
+    "CUTTER_ENABLE_PYTHON=true"
+    "CUTTER_ENABLE_PYTHON_BINDINGS=true"
+    "SHIBOKEN_EXTRA_OPTIONS+=-I${r2-for-cutter}/include/libr"
   ];
+
+  preBuild = ''
+    export NIX_LDFLAGS="$NIX_LDFLAGS $(pkg-config --libs python3-embed)"
+    qtWrapperArgs+=(--prefix PYTHONPATH : "$PYTHONPATH")
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/analysis/radare2/cutter.nix
+++ b/pkgs/development/tools/analysis/radare2/cutter.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ fetchFromGitHub, lib, mkDerivation
 # nativeBuildInputs
 , qmake, pkgconfig
 # Qt
@@ -8,7 +8,7 @@
 , python3
 , wrapQtAppsHook }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "radare2-cutter";
   version = "1.12.0";
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A Qt and C++ GUI for radare2 reverse engineering framework";
     homepage = src.meta.homepage;
     license = licenses.gpl3;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11735,7 +11735,7 @@ julia_15 = callPackage ../development/compilers/julia/1.5.nix {
     lua = lua5;
   } // (config.radare or {}))) radare2 r2-for-cutter;
 
-  radare2-cutter = libsForQt514.callPackage ../development/tools/analysis/radare2/cutter.nix { };
+  radare2-cutter = libsForQt515.callPackage ../development/tools/analysis/radare2/cutter.nix { };
 
   ragel = ragelStable;
 


### PR DESCRIPTION
###### Motivation for this change

Cutter is a GUI front-end for the `radare2` binary analysis tool; Its features can be extended using plugins, some of them written in Python.
However, for those to work, Cutter needs to have been compiled with specific flags.
See #101511 for details and references.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
