### PR TITLE
lispPackages: more stuff (for Nyxt)

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/chanl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/chanl.nix
@@ -1,0 +1,31 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''chanl'';
+  version = ''20201016-git'';
+
+  parasites = [ "chanl/examples" "chanl/tests" ];
+
+  description = ''Communicating Sequential Process support for Common Lisp'';
+
+  deps = [ args."alexandria" args."bordeaux-threads" args."fiveam" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/chanl/2020-10-16/chanl-20201016-git.tgz'';
+    sha256 = ''13kmk6q20kkwy8z3fy0sv57076xf5nls3qx31yp47vaxhn9p11a1'';
+  };
+
+  packageName = "chanl";
+
+  asdFilesToKeep = ["chanl.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM chanl DESCRIPTION
+    Communicating Sequential Process support for Common Lisp SHA256
+    13kmk6q20kkwy8z3fy0sv57076xf5nls3qx31yp47vaxhn9p11a1 URL
+    http://beta.quicklisp.org/archive/chanl/2020-10-16/chanl-20201016-git.tgz
+    MD5 7870137f4c905f64290634ae3d0aa3fd NAME chanl FILENAME chanl DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME fiveam FILENAME fiveam))
+    DEPENDENCIES (alexandria bordeaux-threads fiveam) VERSION 20201016-git
+    SIBLINGS NIL PARASITES (chanl/examples chanl/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-containers.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-containers.nix
@@ -1,0 +1,33 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-containers'';
+  version = ''20200427-git'';
+
+  parasites = [ "cl-containers/with-moptilities" "cl-containers/with-utilities" ];
+
+  description = ''A generic container library for Common Lisp'';
+
+  deps = [ args."asdf-system-connections" args."metatilities-base" args."moptilities" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-containers/2020-04-27/cl-containers-20200427-git.tgz'';
+    sha256 = ''0llaymnlss0dhwyqgr2s38w1hjb2as1x1nn57qcvdphnm7qs50fy'';
+  };
+
+  packageName = "cl-containers";
+
+  asdFilesToKeep = ["cl-containers.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-containers DESCRIPTION
+    A generic container library for Common Lisp SHA256
+    0llaymnlss0dhwyqgr2s38w1hjb2as1x1nn57qcvdphnm7qs50fy URL
+    http://beta.quicklisp.org/archive/cl-containers/2020-04-27/cl-containers-20200427-git.tgz
+    MD5 bb0e03a581e9b617dd166a3f511eaf6a NAME cl-containers FILENAME
+    cl-containers DEPS
+    ((NAME asdf-system-connections FILENAME asdf-system-connections)
+     (NAME metatilities-base FILENAME metatilities-base)
+     (NAME moptilities FILENAME moptilities))
+    DEPENDENCIES (asdf-system-connections metatilities-base moptilities)
+    VERSION 20200427-git SIBLINGS (cl-containers-test) PARASITES
+    (cl-containers/with-moptilities cl-containers/with-utilities)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/metatilities-base.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/metatilities-base.nix
@@ -1,0 +1,26 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''metatilities-base'';
+  version = ''20191227-git'';
+
+  description = ''These are metabang.com's Common Lisp basic utilities.'';
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/metatilities-base/2019-12-27/metatilities-base-20191227-git.tgz'';
+    sha256 = ''1mal51p7mknya2ljcwl3wdjvnirw5vvzic6qcnci7qhmfrb1awil'';
+  };
+
+  packageName = "metatilities-base";
+
+  asdFilesToKeep = ["metatilities-base.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM metatilities-base DESCRIPTION
+    These are metabang.com's Common Lisp basic utilities. SHA256
+    1mal51p7mknya2ljcwl3wdjvnirw5vvzic6qcnci7qhmfrb1awil URL
+    http://beta.quicklisp.org/archive/metatilities-base/2019-12-27/metatilities-base-20191227-git.tgz
+    MD5 7968829ca353c4a42784a151317029f1 NAME metatilities-base FILENAME
+    metatilities-base DEPS NIL DEPENDENCIES NIL VERSION 20191227-git SIBLINGS
+    (metatilities-base-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/moptilities.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/moptilities.nix
@@ -1,0 +1,25 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''moptilities'';
+  version = ''20170403-git'';
+
+  description = ''Common Lisp MOP utilities'';
+
+  deps = [ args."closer-mop" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/moptilities/2017-04-03/moptilities-20170403-git.tgz'';
+    sha256 = ''0az01wx60ll3nybqlp21f5bps3fnpqhvvfg6d9x84969wdj7q4q8'';
+  };
+
+  packageName = "moptilities";
+
+  asdFilesToKeep = ["moptilities.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM moptilities DESCRIPTION Common Lisp MOP utilities SHA256
+    0az01wx60ll3nybqlp21f5bps3fnpqhvvfg6d9x84969wdj7q4q8 URL
+    http://beta.quicklisp.org/archive/moptilities/2017-04-03/moptilities-20170403-git.tgz
+    MD5 b118397be325e60a772ea3631c4f19a4 NAME moptilities FILENAME moptilities
+    DEPS ((NAME closer-mop FILENAME closer-mop)) DEPENDENCIES (closer-mop)
+    VERSION 20170403-git SIBLINGS (moptilities-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/osicat.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/osicat.nix
@@ -1,0 +1,32 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''osicat'';
+  version = ''20200925-git'';
+
+  parasites = [ "osicat/tests" ];
+
+  description = ''A lightweight operating system interface'';
+
+  deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."rt" args."trivial-features" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/osicat/2020-09-25/osicat-20200925-git.tgz'';
+    sha256 = ''191ncd5arfx6i9cw3iny4a473wsrr3dpv2lwb9jr02p6qpmqwysk'';
+  };
+
+  packageName = "osicat";
+
+  asdFilesToKeep = ["osicat.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM osicat DESCRIPTION A lightweight operating system interface SHA256
+    191ncd5arfx6i9cw3iny4a473wsrr3dpv2lwb9jr02p6qpmqwysk URL
+    http://beta.quicklisp.org/archive/osicat/2020-09-25/osicat-20200925-git.tgz
+    MD5 5d0a254f2b8041a71fa6fa90eabaed70 NAME osicat FILENAME osicat DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
+     (NAME cffi-toolchain FILENAME cffi-toolchain) (NAME rt FILENAME rt)
+     (NAME trivial-features FILENAME trivial-features))
+    DEPENDENCIES
+    (alexandria babel cffi cffi-grovel cffi-toolchain rt trivial-features)
+    VERSION 20200925-git SIBLINGS NIL PARASITES (osicat/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-package-local-nicknames.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-package-local-nicknames.nix
@@ -1,0 +1,26 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''trivial-package-local-nicknames'';
+  version = ''20200610-git'';
+
+  description = ''Portability library for package-local nicknames'';
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/trivial-package-local-nicknames/2020-06-10/trivial-package-local-nicknames-20200610-git.tgz'';
+    sha256 = ''1wabkcwz0v144rb2w3rvxlcj264indfnvlyigk1wds7nq0c8lwk5'';
+  };
+
+  packageName = "trivial-package-local-nicknames";
+
+  asdFilesToKeep = ["trivial-package-local-nicknames.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM trivial-package-local-nicknames DESCRIPTION
+    Portability library for package-local nicknames SHA256
+    1wabkcwz0v144rb2w3rvxlcj264indfnvlyigk1wds7nq0c8lwk5 URL
+    http://beta.quicklisp.org/archive/trivial-package-local-nicknames/2020-06-10/trivial-package-local-nicknames-20200610-git.tgz
+    MD5 b3620521d3400ad5910878139bc86fcc NAME trivial-package-local-nicknames
+    FILENAME trivial-package-local-nicknames DEPS NIL DEPENDENCIES NIL VERSION
+    20200610-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -147,3 +147,8 @@ xkeyboard
 xmls
 xsubseq
 yason
+chanl
+cl-containers
+moptilities
+osicat
+trivial-package-local-nicknames

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -90,6 +90,14 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "metatilities-base" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."metatilities-base" or (x: {}))
+       (import ./quicklisp-to-nix-output/metatilities-base.nix {
+         inherit fetchurl;
+       }));
+
+
   "mgl-pax" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."mgl-pax" or (x: {}))
@@ -1248,6 +1256,60 @@ let quicklisp-to-nix-packages = rec {
            "split-sequence" = quicklisp-to-nix-packages."split-sequence";
            "usocket" = quicklisp-to-nix-packages."usocket";
            "usocket-server" = quicklisp-to-nix-packages."usocket-server";
+       }));
+
+
+  "trivial-package-local-nicknames" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."trivial-package-local-nicknames" or (x: {}))
+       (import ./quicklisp-to-nix-output/trivial-package-local-nicknames.nix {
+         inherit fetchurl;
+       }));
+
+
+  "osicat" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."osicat" or (x: {}))
+       (import ./quicklisp-to-nix-output/osicat.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "cffi-grovel" = quicklisp-to-nix-packages."cffi-grovel";
+           "cffi-toolchain" = quicklisp-to-nix-packages."cffi-toolchain";
+           "rt" = quicklisp-to-nix-packages."rt";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+       }));
+
+
+  "moptilities" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."moptilities" or (x: {}))
+       (import ./quicklisp-to-nix-output/moptilities.nix {
+         inherit fetchurl;
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+       }));
+
+
+  "cl-containers" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-containers" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-containers.nix {
+         inherit fetchurl;
+           "asdf-system-connections" = quicklisp-to-nix-packages."asdf-system-connections";
+           "metatilities-base" = quicklisp-to-nix-packages."metatilities-base";
+           "moptilities" = quicklisp-to-nix-packages."moptilities";
+       }));
+
+
+  "chanl" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."chanl" or (x: {}))
+       (import ./quicklisp-to-nix-output/chanl.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "fiveam" = quicklisp-to-nix-packages."fiveam";
        }));
 
 


### PR DESCRIPTION

###### Motivation for this change

#92763

will self-merge

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
