### PR TITLE
pantheon.wingpanel-indicator-session: 2.2.8 -> 2020-09-13

### DIFF
--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/session/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/session/default.nix
@@ -16,27 +16,14 @@
 
 stdenv.mkDerivation rec {
   pname = "wingpanel-indicator-session";
-  version = "2.2.8";
+  version = "unstable-2020-09-13";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-iBbYOeGlv2lUFSK1qcd+4UJlCP/KCtdkx6i73jq6Ngo=";
+    rev = "e65c95f46adbfd598ad61933394d7bc3c5998278";
+    sha256 = "sha256-QKOfgAc6pDQYpETrFunZB6+rF1P8XIf0pjft/t9aWW0=";
   };
-
-  patches = [
-    # build failure in vala 0.48.7
-    # https://github.com/elementary/gala/pull/869#issuecomment-657147695
-    (fetchpatch {
-      url = "https://github.com/elementary/wingpanel-indicator-session/commit/ead6971c708eed8b844bd9acd7eed2ab8a97e803.patch";
-      sha256 = "1v7w7zdia82d38ycr5zhckaxgf7gr15hsv05cv5khlki8frryn2x";
-    })
-    (fetchpatch {
-      url = "https://github.com/elementary/wingpanel-indicator-session/commit/85347e676054635ac878fc542bd057398ca70d3e.patch";
-      sha256 = "1vw4zx0qbhxmfzqhdcmwdp4fxvij7n3f5lwcplf5v3k9qsr3wm0n";
-    })
-  ];
 
   passthru = {
     updateScript = nix-update-script {


### PR DESCRIPTION
Lots of bugfixes but mostly https://github.com/elementary/wingpanel-indicator-session/pull/126
which fixes https://github.com/NixOS/nixpkgs/issues/95658

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/95658

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
