### PR TITLE
lispPackages: more Nyxt deps

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-cairo.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-cairo.nix
@@ -1,0 +1,39 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-cffi-gtk-cairo'';
+  version = ''cl-cffi-gtk-20201016-git'';
+
+  description = ''A Lisp binding to Cairo'';
+
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-glib" args."iterate" args."trivial-features" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz'';
+    sha256 = ''1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55'';
+  };
+
+  packageName = "cl-cffi-gtk-cairo";
+
+  asdFilesToKeep = ["cl-cffi-gtk-cairo.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-cffi-gtk-cairo DESCRIPTION A Lisp binding to Cairo SHA256
+    1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55 URL
+    http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz
+    MD5 7eef130d69af506c68b2d98271215fbd NAME cl-cffi-gtk-cairo FILENAME
+    cl-cffi-gtk-cairo DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cffi FILENAME cffi)
+     (NAME cl-cffi-gtk-glib FILENAME cl-cffi-gtk-glib)
+     (NAME iterate FILENAME iterate)
+     (NAME trivial-features FILENAME trivial-features))
+    DEPENDENCIES
+    (alexandria babel bordeaux-threads cffi cl-cffi-gtk-glib iterate
+     trivial-features)
+    VERSION cl-cffi-gtk-20201016-git SIBLINGS
+    (cl-cffi-gtk-demo-cairo cl-cffi-gtk-demo-glib cl-cffi-gtk-demo-gobject
+     cl-cffi-gtk-example-gtk cl-cffi-gtk-opengl-demo cl-cffi-gtk-gdk-pixbuf
+     cl-cffi-gtk-gdk cl-cffi-gtk-gio cl-cffi-gtk-glib cl-cffi-gtk-gobject
+     cl-cffi-gtk cl-cffi-gtk-pango)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gdk-pixbuf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gdk-pixbuf.nix
@@ -1,0 +1,41 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-cffi-gtk-gdk-pixbuf'';
+  version = ''cl-cffi-gtk-20201016-git'';
+
+  description = ''A Lisp binding to GDK Pixbuf 2'';
+
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz'';
+    sha256 = ''1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55'';
+  };
+
+  packageName = "cl-cffi-gtk-gdk-pixbuf";
+
+  asdFilesToKeep = ["cl-cffi-gtk-gdk-pixbuf.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-cffi-gtk-gdk-pixbuf DESCRIPTION A Lisp binding to GDK Pixbuf 2
+    SHA256 1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55 URL
+    http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz
+    MD5 7eef130d69af506c68b2d98271215fbd NAME cl-cffi-gtk-gdk-pixbuf FILENAME
+    cl-cffi-gtk-gdk-pixbuf DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cffi FILENAME cffi)
+     (NAME cl-cffi-gtk-glib FILENAME cl-cffi-gtk-glib)
+     (NAME cl-cffi-gtk-gobject FILENAME cl-cffi-gtk-gobject)
+     (NAME closer-mop FILENAME closer-mop) (NAME iterate FILENAME iterate)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-garbage FILENAME trivial-garbage))
+    DEPENDENCIES
+    (alexandria babel bordeaux-threads cffi cl-cffi-gtk-glib
+     cl-cffi-gtk-gobject closer-mop iterate trivial-features trivial-garbage)
+    VERSION cl-cffi-gtk-20201016-git SIBLINGS
+    (cl-cffi-gtk-cairo cl-cffi-gtk-demo-cairo cl-cffi-gtk-demo-glib
+     cl-cffi-gtk-demo-gobject cl-cffi-gtk-example-gtk cl-cffi-gtk-opengl-demo
+     cl-cffi-gtk-gdk cl-cffi-gtk-gio cl-cffi-gtk-glib cl-cffi-gtk-gobject
+     cl-cffi-gtk cl-cffi-gtk-pango)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gdk.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gdk.nix
@@ -1,0 +1,47 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-cffi-gtk-gdk'';
+  version = ''cl-cffi-gtk-20201016-git'';
+
+  description = ''A Lisp binding to GDK 3'';
+
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-cairo" args."cl-cffi-gtk-gdk-pixbuf" args."cl-cffi-gtk-gio" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."cl-cffi-gtk-pango" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz'';
+    sha256 = ''1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55'';
+  };
+
+  packageName = "cl-cffi-gtk-gdk";
+
+  asdFilesToKeep = ["cl-cffi-gtk-gdk.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-cffi-gtk-gdk DESCRIPTION A Lisp binding to GDK 3 SHA256
+    1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55 URL
+    http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz
+    MD5 7eef130d69af506c68b2d98271215fbd NAME cl-cffi-gtk-gdk FILENAME
+    cl-cffi-gtk-gdk DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cffi FILENAME cffi)
+     (NAME cl-cffi-gtk-cairo FILENAME cl-cffi-gtk-cairo)
+     (NAME cl-cffi-gtk-gdk-pixbuf FILENAME cl-cffi-gtk-gdk-pixbuf)
+     (NAME cl-cffi-gtk-gio FILENAME cl-cffi-gtk-gio)
+     (NAME cl-cffi-gtk-glib FILENAME cl-cffi-gtk-glib)
+     (NAME cl-cffi-gtk-gobject FILENAME cl-cffi-gtk-gobject)
+     (NAME cl-cffi-gtk-pango FILENAME cl-cffi-gtk-pango)
+     (NAME closer-mop FILENAME closer-mop) (NAME iterate FILENAME iterate)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-garbage FILENAME trivial-garbage))
+    DEPENDENCIES
+    (alexandria babel bordeaux-threads cffi cl-cffi-gtk-cairo
+     cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gio cl-cffi-gtk-glib
+     cl-cffi-gtk-gobject cl-cffi-gtk-pango closer-mop iterate trivial-features
+     trivial-garbage)
+    VERSION cl-cffi-gtk-20201016-git SIBLINGS
+    (cl-cffi-gtk-cairo cl-cffi-gtk-demo-cairo cl-cffi-gtk-demo-glib
+     cl-cffi-gtk-demo-gobject cl-cffi-gtk-example-gtk cl-cffi-gtk-opengl-demo
+     cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gio cl-cffi-gtk-glib
+     cl-cffi-gtk-gobject cl-cffi-gtk cl-cffi-gtk-pango)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gio.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gio.nix
@@ -1,0 +1,41 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-cffi-gtk-gio'';
+  version = ''cl-cffi-gtk-20201016-git'';
+
+  description = ''A Lisp binding to GIO 2'';
+
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz'';
+    sha256 = ''1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55'';
+  };
+
+  packageName = "cl-cffi-gtk-gio";
+
+  asdFilesToKeep = ["cl-cffi-gtk-gio.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-cffi-gtk-gio DESCRIPTION A Lisp binding to GIO 2 SHA256
+    1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55 URL
+    http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz
+    MD5 7eef130d69af506c68b2d98271215fbd NAME cl-cffi-gtk-gio FILENAME
+    cl-cffi-gtk-gio DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cffi FILENAME cffi)
+     (NAME cl-cffi-gtk-glib FILENAME cl-cffi-gtk-glib)
+     (NAME cl-cffi-gtk-gobject FILENAME cl-cffi-gtk-gobject)
+     (NAME closer-mop FILENAME closer-mop) (NAME iterate FILENAME iterate)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-garbage FILENAME trivial-garbage))
+    DEPENDENCIES
+    (alexandria babel bordeaux-threads cffi cl-cffi-gtk-glib
+     cl-cffi-gtk-gobject closer-mop iterate trivial-features trivial-garbage)
+    VERSION cl-cffi-gtk-20201016-git SIBLINGS
+    (cl-cffi-gtk-cairo cl-cffi-gtk-demo-cairo cl-cffi-gtk-demo-glib
+     cl-cffi-gtk-demo-gobject cl-cffi-gtk-example-gtk cl-cffi-gtk-opengl-demo
+     cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gdk cl-cffi-gtk-glib
+     cl-cffi-gtk-gobject cl-cffi-gtk cl-cffi-gtk-pango)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-glib.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-glib.nix
@@ -1,0 +1,36 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-cffi-gtk-glib'';
+  version = ''cl-cffi-gtk-20201016-git'';
+
+  description = ''A Lisp binding to GLib 2'';
+
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."iterate" args."trivial-features" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz'';
+    sha256 = ''1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55'';
+  };
+
+  packageName = "cl-cffi-gtk-glib";
+
+  asdFilesToKeep = ["cl-cffi-gtk-glib.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-cffi-gtk-glib DESCRIPTION A Lisp binding to GLib 2 SHA256
+    1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55 URL
+    http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz
+    MD5 7eef130d69af506c68b2d98271215fbd NAME cl-cffi-gtk-glib FILENAME
+    cl-cffi-gtk-glib DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cffi FILENAME cffi) (NAME iterate FILENAME iterate)
+     (NAME trivial-features FILENAME trivial-features))
+    DEPENDENCIES
+    (alexandria babel bordeaux-threads cffi iterate trivial-features) VERSION
+    cl-cffi-gtk-20201016-git SIBLINGS
+    (cl-cffi-gtk-cairo cl-cffi-gtk-demo-cairo cl-cffi-gtk-demo-glib
+     cl-cffi-gtk-demo-gobject cl-cffi-gtk-example-gtk cl-cffi-gtk-opengl-demo
+     cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gdk cl-cffi-gtk-gio cl-cffi-gtk-gobject
+     cl-cffi-gtk cl-cffi-gtk-pango)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gobject.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-gobject.nix
@@ -1,0 +1,40 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-cffi-gtk-gobject'';
+  version = ''cl-cffi-gtk-20201016-git'';
+
+  description = ''A Lisp binding GObject 2'';
+
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-glib" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz'';
+    sha256 = ''1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55'';
+  };
+
+  packageName = "cl-cffi-gtk-gobject";
+
+  asdFilesToKeep = ["cl-cffi-gtk-gobject.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-cffi-gtk-gobject DESCRIPTION A Lisp binding GObject 2 SHA256
+    1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55 URL
+    http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz
+    MD5 7eef130d69af506c68b2d98271215fbd NAME cl-cffi-gtk-gobject FILENAME
+    cl-cffi-gtk-gobject DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cffi FILENAME cffi)
+     (NAME cl-cffi-gtk-glib FILENAME cl-cffi-gtk-glib)
+     (NAME closer-mop FILENAME closer-mop) (NAME iterate FILENAME iterate)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-garbage FILENAME trivial-garbage))
+    DEPENDENCIES
+    (alexandria babel bordeaux-threads cffi cl-cffi-gtk-glib closer-mop iterate
+     trivial-features trivial-garbage)
+    VERSION cl-cffi-gtk-20201016-git SIBLINGS
+    (cl-cffi-gtk-cairo cl-cffi-gtk-demo-cairo cl-cffi-gtk-demo-glib
+     cl-cffi-gtk-demo-gobject cl-cffi-gtk-example-gtk cl-cffi-gtk-opengl-demo
+     cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gdk cl-cffi-gtk-gio cl-cffi-gtk-glib
+     cl-cffi-gtk cl-cffi-gtk-pango)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-pango.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk-pango.nix
@@ -1,0 +1,42 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-cffi-gtk-pango'';
+  version = ''cl-cffi-gtk-20201016-git'';
+
+  description = ''A Lisp binding to Pango'';
+
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-cairo" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz'';
+    sha256 = ''1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55'';
+  };
+
+  packageName = "cl-cffi-gtk-pango";
+
+  asdFilesToKeep = ["cl-cffi-gtk-pango.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-cffi-gtk-pango DESCRIPTION A Lisp binding to Pango SHA256
+    1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55 URL
+    http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz
+    MD5 7eef130d69af506c68b2d98271215fbd NAME cl-cffi-gtk-pango FILENAME
+    cl-cffi-gtk-pango DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cffi FILENAME cffi)
+     (NAME cl-cffi-gtk-cairo FILENAME cl-cffi-gtk-cairo)
+     (NAME cl-cffi-gtk-glib FILENAME cl-cffi-gtk-glib)
+     (NAME cl-cffi-gtk-gobject FILENAME cl-cffi-gtk-gobject)
+     (NAME closer-mop FILENAME closer-mop) (NAME iterate FILENAME iterate)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-garbage FILENAME trivial-garbage))
+    DEPENDENCIES
+    (alexandria babel bordeaux-threads cffi cl-cffi-gtk-cairo cl-cffi-gtk-glib
+     cl-cffi-gtk-gobject closer-mop iterate trivial-features trivial-garbage)
+    VERSION cl-cffi-gtk-20201016-git SIBLINGS
+    (cl-cffi-gtk-cairo cl-cffi-gtk-demo-cairo cl-cffi-gtk-demo-glib
+     cl-cffi-gtk-demo-gobject cl-cffi-gtk-example-gtk cl-cffi-gtk-opengl-demo
+     cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gdk cl-cffi-gtk-gio cl-cffi-gtk-glib
+     cl-cffi-gtk-gobject cl-cffi-gtk)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-cffi-gtk.nix
@@ -1,0 +1,48 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-cffi-gtk'';
+  version = ''20201016-git'';
+
+  description = ''A Lisp binding to GTK 3'';
+
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk-cairo" args."cl-cffi-gtk-gdk" args."cl-cffi-gtk-gdk-pixbuf" args."cl-cffi-gtk-gio" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."cl-cffi-gtk-pango" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz'';
+    sha256 = ''1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55'';
+  };
+
+  packageName = "cl-cffi-gtk";
+
+  asdFilesToKeep = ["cl-cffi-gtk.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-cffi-gtk DESCRIPTION A Lisp binding to GTK 3 SHA256
+    1m91597nwwrps32awvk57k3h4jjq603ja0kf395n2jxvckfz0a55 URL
+    http://beta.quicklisp.org/archive/cl-cffi-gtk/2020-10-16/cl-cffi-gtk-20201016-git.tgz
+    MD5 7eef130d69af506c68b2d98271215fbd NAME cl-cffi-gtk FILENAME cl-cffi-gtk
+    DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cffi FILENAME cffi)
+     (NAME cl-cffi-gtk-cairo FILENAME cl-cffi-gtk-cairo)
+     (NAME cl-cffi-gtk-gdk FILENAME cl-cffi-gtk-gdk)
+     (NAME cl-cffi-gtk-gdk-pixbuf FILENAME cl-cffi-gtk-gdk-pixbuf)
+     (NAME cl-cffi-gtk-gio FILENAME cl-cffi-gtk-gio)
+     (NAME cl-cffi-gtk-glib FILENAME cl-cffi-gtk-glib)
+     (NAME cl-cffi-gtk-gobject FILENAME cl-cffi-gtk-gobject)
+     (NAME cl-cffi-gtk-pango FILENAME cl-cffi-gtk-pango)
+     (NAME closer-mop FILENAME closer-mop) (NAME iterate FILENAME iterate)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-garbage FILENAME trivial-garbage))
+    DEPENDENCIES
+    (alexandria babel bordeaux-threads cffi cl-cffi-gtk-cairo cl-cffi-gtk-gdk
+     cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gio cl-cffi-gtk-glib
+     cl-cffi-gtk-gobject cl-cffi-gtk-pango closer-mop iterate trivial-features
+     trivial-garbage)
+    VERSION 20201016-git SIBLINGS
+    (cl-cffi-gtk-cairo cl-cffi-gtk-demo-cairo cl-cffi-gtk-demo-glib
+     cl-cffi-gtk-demo-gobject cl-cffi-gtk-example-gtk cl-cffi-gtk-opengl-demo
+     cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gdk cl-cffi-gtk-gio cl-cffi-gtk-glib
+     cl-cffi-gtk-gobject cl-cffi-gtk-pango)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-webkit2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-webkit2.nix
@@ -1,0 +1,43 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-webkit2'';
+  version = ''cl-webkit-20201016-git'';
+
+  description = ''An FFI binding to WebKit2GTK+'';
+
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk" args."cl-cffi-gtk-cairo" args."cl-cffi-gtk-gdk" args."cl-cffi-gtk-gdk-pixbuf" args."cl-cffi-gtk-gio" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."cl-cffi-gtk-pango" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-webkit/2020-10-16/cl-webkit-20201016-git.tgz'';
+    sha256 = ''15xykhjz3j7ad3m853x1hriv3mz6zsgaqdnlc3wk664ka0f7k0vh'';
+  };
+
+  packageName = "cl-webkit2";
+
+  asdFilesToKeep = ["cl-webkit2.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-webkit2 DESCRIPTION An FFI binding to WebKit2GTK+ SHA256
+    15xykhjz3j7ad3m853x1hriv3mz6zsgaqdnlc3wk664ka0f7k0vh URL
+    http://beta.quicklisp.org/archive/cl-webkit/2020-10-16/cl-webkit-20201016-git.tgz
+    MD5 d7b482185cf5a403d5211626560d2f66 NAME cl-webkit2 FILENAME cl-webkit2
+    DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cffi FILENAME cffi) (NAME cl-cffi-gtk FILENAME cl-cffi-gtk)
+     (NAME cl-cffi-gtk-cairo FILENAME cl-cffi-gtk-cairo)
+     (NAME cl-cffi-gtk-gdk FILENAME cl-cffi-gtk-gdk)
+     (NAME cl-cffi-gtk-gdk-pixbuf FILENAME cl-cffi-gtk-gdk-pixbuf)
+     (NAME cl-cffi-gtk-gio FILENAME cl-cffi-gtk-gio)
+     (NAME cl-cffi-gtk-glib FILENAME cl-cffi-gtk-glib)
+     (NAME cl-cffi-gtk-gobject FILENAME cl-cffi-gtk-gobject)
+     (NAME cl-cffi-gtk-pango FILENAME cl-cffi-gtk-pango)
+     (NAME closer-mop FILENAME closer-mop) (NAME iterate FILENAME iterate)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-garbage FILENAME trivial-garbage))
+    DEPENDENCIES
+    (alexandria babel bordeaux-threads cffi cl-cffi-gtk cl-cffi-gtk-cairo
+     cl-cffi-gtk-gdk cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gio cl-cffi-gtk-glib
+     cl-cffi-gtk-gobject cl-cffi-gtk-pango closer-mop iterate trivial-features
+     trivial-garbage)
+    VERSION cl-webkit-20201016-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/enchant.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/enchant.nix
@@ -1,0 +1,29 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''enchant'';
+  version = ''cl-20190521-git'';
+
+  description = ''Programming interface for Enchant spell-checker library'';
+
+  deps = [ args."alexandria" args."babel" args."cffi" args."trivial-features" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-enchant/2019-05-21/cl-enchant-20190521-git.tgz'';
+    sha256 = ''16ag48fr74m536an8fak5z0lfjdb265gv1ajai1lqg0vq2l5mr14'';
+  };
+
+  packageName = "enchant";
+
+  asdFilesToKeep = ["enchant.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM enchant DESCRIPTION
+    Programming interface for Enchant spell-checker library SHA256
+    16ag48fr74m536an8fak5z0lfjdb265gv1ajai1lqg0vq2l5mr14 URL
+    http://beta.quicklisp.org/archive/cl-enchant/2019-05-21/cl-enchant-20190521-git.tgz
+    MD5 2a868c280fd5a74f9c298c384567e31b NAME enchant FILENAME enchant DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME cffi FILENAME cffi)
+     (NAME trivial-features FILENAME trivial-features))
+    DEPENDENCIES (alexandria babel cffi trivial-features) VERSION
+    cl-20190521-git SIBLINGS (enchant-autoload) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-tasks.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-tasks.nix
@@ -1,0 +1,30 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''simple-tasks'';
+  version = ''20190710-git'';
+
+  description = ''A very simple task scheduling framework.'';
+
+  deps = [ args."alexandria" args."array-utils" args."bordeaux-threads" args."dissect" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/simple-tasks/2019-07-10/simple-tasks-20190710-git.tgz'';
+    sha256 = ''12y5phnbj9s2fsrz1ab6xj857zf1fv8kjk7jj2mdjs6k2d8gk8v3'';
+  };
+
+  packageName = "simple-tasks";
+
+  asdFilesToKeep = ["simple-tasks.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM simple-tasks DESCRIPTION A very simple task scheduling framework.
+    SHA256 12y5phnbj9s2fsrz1ab6xj857zf1fv8kjk7jj2mdjs6k2d8gk8v3 URL
+    http://beta.quicklisp.org/archive/simple-tasks/2019-07-10/simple-tasks-20190710-git.tgz
+    MD5 8e88a9a762bc8691f92217d256baa55e NAME simple-tasks FILENAME
+    simple-tasks DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME array-utils FILENAME array-utils)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME dissect FILENAME dissect))
+    DEPENDENCIES (alexandria array-utils bordeaux-threads dissect) VERSION
+    20190710-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-main-thread.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-main-thread.nix
@@ -1,0 +1,34 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''trivial-main-thread'';
+  version = ''20190710-git'';
+
+  description = ''Compatibility library to run things in the main thread.'';
+
+  deps = [ args."alexandria" args."array-utils" args."bordeaux-threads" args."dissect" args."simple-tasks" args."trivial-features" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/trivial-main-thread/2019-07-10/trivial-main-thread-20190710-git.tgz'';
+    sha256 = ''1zj12rc29rrff5grmi7sjxfzdv78khbb4sg43hy2cb33hykpvg2h'';
+  };
+
+  packageName = "trivial-main-thread";
+
+  asdFilesToKeep = ["trivial-main-thread.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM trivial-main-thread DESCRIPTION
+    Compatibility library to run things in the main thread. SHA256
+    1zj12rc29rrff5grmi7sjxfzdv78khbb4sg43hy2cb33hykpvg2h URL
+    http://beta.quicklisp.org/archive/trivial-main-thread/2019-07-10/trivial-main-thread-20190710-git.tgz
+    MD5 ab95906f1831aa5b40f271eebdfe11a3 NAME trivial-main-thread FILENAME
+    trivial-main-thread DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME array-utils FILENAME array-utils)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME dissect FILENAME dissect) (NAME simple-tasks FILENAME simple-tasks)
+     (NAME trivial-features FILENAME trivial-features))
+    DEPENDENCIES
+    (alexandria array-utils bordeaux-threads dissect simple-tasks
+     trivial-features)
+    VERSION 20190710-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -233,4 +233,5 @@ $out/lib/common-lisp/query-fs"
   cl-cffi-gtk-pango = addNativeLibs [pkgs.pango];
   cl-cffi-gtk-gdk = addNativeLibs [pkgs.gtk3];
   cl-cffi-gtk-gtk3 = addNativeLibs [pkgs.gtk3];
+  cl-webkit2 = addNativeLibs [pkgs.webkitgtk];
 }

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -227,4 +227,10 @@ $out/lib/common-lisp/query-fs"
           true))
       x.deps;
   };
+  cl-cffi-gtk-glib = addNativeLibs [pkgs.glib];
+  cl-cffi-gtk-gdk-pixbuf = addNativeLibs [pkgs.gdk_pixbuf];
+  cl-cffi-gtk-cairo = addNativeLibs [pkgs.cairo];
+  cl-cffi-gtk-pango = addNativeLibs [pkgs.pango];
+  cl-cffi-gtk-gdk = addNativeLibs [pkgs.gtk3];
+  cl-cffi-gtk-gtk3 = addNativeLibs [pkgs.gtk3];
 }

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -152,3 +152,6 @@ cl-containers
 moptilities
 osicat
 trivial-package-local-nicknames
+cl-cffi-gtk
+enchant
+trivial-main-thread

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -155,3 +155,4 @@ trivial-package-local-nicknames
 cl-cffi-gtk
 enchant
 trivial-main-thread
+cl-webkit2

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -90,6 +90,141 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "simple-tasks" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."simple-tasks" or (x: {}))
+       (import ./quicklisp-to-nix-output/simple-tasks.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "array-utils" = quicklisp-to-nix-packages."array-utils";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "dissect" = quicklisp-to-nix-packages."dissect";
+       }));
+
+
+  "cl-cffi-gtk-pango" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-cffi-gtk-pango" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-cffi-gtk-pango.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "cl-cffi-gtk-cairo" = quicklisp-to-nix-packages."cl-cffi-gtk-cairo";
+           "cl-cffi-gtk-glib" = quicklisp-to-nix-packages."cl-cffi-gtk-glib";
+           "cl-cffi-gtk-gobject" = quicklisp-to-nix-packages."cl-cffi-gtk-gobject";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+       }));
+
+
+  "cl-cffi-gtk-gobject" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-cffi-gtk-gobject" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-cffi-gtk-gobject.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "cl-cffi-gtk-glib" = quicklisp-to-nix-packages."cl-cffi-gtk-glib";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+       }));
+
+
+  "cl-cffi-gtk-glib" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-cffi-gtk-glib" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-cffi-gtk-glib.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+       }));
+
+
+  "cl-cffi-gtk-gio" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-cffi-gtk-gio" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-cffi-gtk-gio.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "cl-cffi-gtk-glib" = quicklisp-to-nix-packages."cl-cffi-gtk-glib";
+           "cl-cffi-gtk-gobject" = quicklisp-to-nix-packages."cl-cffi-gtk-gobject";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+       }));
+
+
+  "cl-cffi-gtk-gdk-pixbuf" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-cffi-gtk-gdk-pixbuf" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-cffi-gtk-gdk-pixbuf.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "cl-cffi-gtk-glib" = quicklisp-to-nix-packages."cl-cffi-gtk-glib";
+           "cl-cffi-gtk-gobject" = quicklisp-to-nix-packages."cl-cffi-gtk-gobject";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+       }));
+
+
+  "cl-cffi-gtk-gdk" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-cffi-gtk-gdk" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-cffi-gtk-gdk.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "cl-cffi-gtk-cairo" = quicklisp-to-nix-packages."cl-cffi-gtk-cairo";
+           "cl-cffi-gtk-gdk-pixbuf" = quicklisp-to-nix-packages."cl-cffi-gtk-gdk-pixbuf";
+           "cl-cffi-gtk-gio" = quicklisp-to-nix-packages."cl-cffi-gtk-gio";
+           "cl-cffi-gtk-glib" = quicklisp-to-nix-packages."cl-cffi-gtk-glib";
+           "cl-cffi-gtk-gobject" = quicklisp-to-nix-packages."cl-cffi-gtk-gobject";
+           "cl-cffi-gtk-pango" = quicklisp-to-nix-packages."cl-cffi-gtk-pango";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+       }));
+
+
+  "cl-cffi-gtk-cairo" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-cffi-gtk-cairo" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-cffi-gtk-cairo.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "cl-cffi-gtk-glib" = quicklisp-to-nix-packages."cl-cffi-gtk-glib";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+       }));
+
+
   "metatilities-base" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."metatilities-base" or (x: {}))
@@ -1256,6 +1391,55 @@ let quicklisp-to-nix-packages = rec {
            "split-sequence" = quicklisp-to-nix-packages."split-sequence";
            "usocket" = quicklisp-to-nix-packages."usocket";
            "usocket-server" = quicklisp-to-nix-packages."usocket-server";
+       }));
+
+
+  "trivial-main-thread" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."trivial-main-thread" or (x: {}))
+       (import ./quicklisp-to-nix-output/trivial-main-thread.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "array-utils" = quicklisp-to-nix-packages."array-utils";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "dissect" = quicklisp-to-nix-packages."dissect";
+           "simple-tasks" = quicklisp-to-nix-packages."simple-tasks";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+       }));
+
+
+  "enchant" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."enchant" or (x: {}))
+       (import ./quicklisp-to-nix-output/enchant.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+       }));
+
+
+  "cl-cffi-gtk" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-cffi-gtk" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-cffi-gtk.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "cl-cffi-gtk-cairo" = quicklisp-to-nix-packages."cl-cffi-gtk-cairo";
+           "cl-cffi-gtk-gdk" = quicklisp-to-nix-packages."cl-cffi-gtk-gdk";
+           "cl-cffi-gtk-gdk-pixbuf" = quicklisp-to-nix-packages."cl-cffi-gtk-gdk-pixbuf";
+           "cl-cffi-gtk-gio" = quicklisp-to-nix-packages."cl-cffi-gtk-gio";
+           "cl-cffi-gtk-glib" = quicklisp-to-nix-packages."cl-cffi-gtk-glib";
+           "cl-cffi-gtk-gobject" = quicklisp-to-nix-packages."cl-cffi-gtk-gobject";
+           "cl-cffi-gtk-pango" = quicklisp-to-nix-packages."cl-cffi-gtk-pango";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
        }));
 
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -1394,6 +1394,30 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "cl-webkit2" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-webkit2" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-webkit2.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "cl-cffi-gtk" = quicklisp-to-nix-packages."cl-cffi-gtk";
+           "cl-cffi-gtk-cairo" = quicklisp-to-nix-packages."cl-cffi-gtk-cairo";
+           "cl-cffi-gtk-gdk" = quicklisp-to-nix-packages."cl-cffi-gtk-gdk";
+           "cl-cffi-gtk-gdk-pixbuf" = quicklisp-to-nix-packages."cl-cffi-gtk-gdk-pixbuf";
+           "cl-cffi-gtk-gio" = quicklisp-to-nix-packages."cl-cffi-gtk-gio";
+           "cl-cffi-gtk-glib" = quicklisp-to-nix-packages."cl-cffi-gtk-glib";
+           "cl-cffi-gtk-gobject" = quicklisp-to-nix-packages."cl-cffi-gtk-gobject";
+           "cl-cffi-gtk-pango" = quicklisp-to-nix-packages."cl-cffi-gtk-pango";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+       }));
+
+
   "trivial-main-thread" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."trivial-main-thread" or (x: {}))

--- a/pkgs/development/lisp-modules/shell.nix
+++ b/pkgs/development/lisp-modules/shell.nix
@@ -11,6 +11,6 @@ self = rec {
     lispPackages.quicklisp-to-nix lispPackages.quicklisp-to-nix-system-info
   ];
   CPATH = "${libfixposix}/include";
-  LD_LIBRARY_PATH = "${openssl.out}/lib:${fuse}/lib:${libuv}/lib:${libev}/lib:${libmysqlclient}/lib:${libmysqlclient}/lib/mysql:${postgresql.lib}/lib:${sqlite.out}/lib:${libfixposix}/lib:${freetds}/lib:${openssl_lib_marked}/lib";
+  LD_LIBRARY_PATH = "${openssl.out}/lib:${fuse}/lib:${libuv}/lib:${libev}/lib:${libmysqlclient}/lib:${libmysqlclient}/lib/mysql:${postgresql.lib}/lib:${sqlite.out}/lib:${libfixposix}/lib:${freetds}/lib:${openssl_lib_marked}/lib:${glib.out}/lib:${gdk_pixbuf}/lib:${cairo}/lib:${pango.out}/lib:${gtk3}/lib";
 };
 in stdenv.mkDerivation self

--- a/pkgs/development/lisp-modules/shell.nix
+++ b/pkgs/development/lisp-modules/shell.nix
@@ -11,6 +11,6 @@ self = rec {
     lispPackages.quicklisp-to-nix lispPackages.quicklisp-to-nix-system-info
   ];
   CPATH = "${libfixposix}/include";
-  LD_LIBRARY_PATH = "${openssl.out}/lib:${fuse}/lib:${libuv}/lib:${libev}/lib:${libmysqlclient}/lib:${libmysqlclient}/lib/mysql:${postgresql.lib}/lib:${sqlite.out}/lib:${libfixposix}/lib:${freetds}/lib:${openssl_lib_marked}/lib:${glib.out}/lib:${gdk_pixbuf}/lib:${cairo}/lib:${pango.out}/lib:${gtk3}/lib";
+  LD_LIBRARY_PATH = "${openssl.out}/lib:${fuse}/lib:${libuv}/lib:${libev}/lib:${libmysqlclient}/lib:${libmysqlclient}/lib/mysql:${postgresql.lib}/lib:${sqlite.out}/lib:${libfixposix}/lib:${freetds}/lib:${openssl_lib_marked}/lib:${glib.out}/lib:${gdk_pixbuf}/lib:${cairo}/lib:${pango.out}/lib:${gtk3}/lib:${webkitgtk}/lib";
 };
 in stdenv.mkDerivation self


### PR DESCRIPTION

###### Motivation for this change

#92763

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
