### PR TITLE
open-sans: fix revision: remove URL encoding

### DIFF
--- a/pkgs/data/fonts/open-sans/default.nix
+++ b/pkgs/data/fonts/open-sans/default.nix
@@ -9,7 +9,7 @@ in fetchFromGitLab {
   domain = "salsa.debian.org";
   owner = "fonts-team";
   repo = "fonts-open-sans";
-  rev = "debian%2F1.11-1"; # URL-encoded form of "debian/1.11-1" tag
+  rev = "debian/1.11-1";
   postFetch = ''
     tar xf $downloadedFile --strip=1
     mkdir -p $out/share/fonts/truetype


### PR DESCRIPTION
Fix fetching `open-sans` by removing unwanted URL encoding of `rev`.

###### Motivation for this change

Currently `fetchFromGitLab` call in `open-sans` package fails. Apparently `fetchFromGitLab` doesn't need `rev` to be pre-URL-encoded anymore. I don't know if it ever did. With current `master`, building `open-sans` results in the following error (note revision in the final URL is double-encoded):

```bash
# nix-build -A open-sans --no-link --check
checking outputs of '/nix/store/4d4jcvhgwp896g71anr9jb3kwlin1zj7-open-sans-1.11.drv'...

trying https://salsa.debian.org/api/v4/projects/fonts-team%2Ffonts-open-sans/repository/archive.tar.gz?sha=debian%252F1.11-1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
error: cannot download open-sans-1.11 from any mirror
builder for '/nix/store/4d4jcvhgwp896g71anr9jb3kwlin1zj7-open-sans-1.11.drv' failed with exit code 1
error: build of '/nix/store/4d4jcvhgwp896g71anr9jb3kwlin1zj7-open-sans-1.11.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
