### PR TITLE
lispPackages: more Nyxt deps

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/acclimation.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/acclimation.nix
@@ -1,0 +1,25 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''acclimation'';
+  version = ''20200925-git'';
+
+  description = ''Library supporting internationalization'';
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/acclimation/2020-09-25/acclimation-20200925-git.tgz'';
+    sha256 = ''11vw1h5zxicj5qxb1smiyjxafw8xk0isnzcf5g0lqis3y9ssqxbw'';
+  };
+
+  packageName = "acclimation";
+
+  asdFilesToKeep = ["acclimation.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM acclimation DESCRIPTION Library supporting internationalization
+    SHA256 11vw1h5zxicj5qxb1smiyjxafw8xk0isnzcf5g0lqis3y9ssqxbw URL
+    http://beta.quicklisp.org/archive/acclimation/2020-09-25/acclimation-20200925-git.tgz
+    MD5 8ce10864baef6fb0e11c78e2ee0b0ddb NAME acclimation FILENAME acclimation
+    DEPS NIL DEPENDENCIES NIL VERSION 20200925-git SIBLINGS
+    (acclimation-temperature) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clump-2-3-tree.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clump-2-3-tree.nix
@@ -1,0 +1,26 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''clump-2-3-tree'';
+  version = ''clump-20160825-git'';
+
+  description = ''System lacks description'';
+
+  deps = [ args."acclimation" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/clump/2016-08-25/clump-20160825-git.tgz'';
+    sha256 = ''1mngxmwklpi52inihkp4akzdi7y32609spfi70yamwgzc1wijbrl'';
+  };
+
+  packageName = "clump-2-3-tree";
+
+  asdFilesToKeep = ["clump-2-3-tree.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM clump-2-3-tree DESCRIPTION System lacks description SHA256
+    1mngxmwklpi52inihkp4akzdi7y32609spfi70yamwgzc1wijbrl URL
+    http://beta.quicklisp.org/archive/clump/2016-08-25/clump-20160825-git.tgz
+    MD5 5132d2800138d435ef69f7e68b025c8f NAME clump-2-3-tree FILENAME
+    clump-2-3-tree DEPS ((NAME acclimation FILENAME acclimation)) DEPENDENCIES
+    (acclimation) VERSION clump-20160825-git SIBLINGS
+    (clump-binary-tree clump-test clump) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clump-binary-tree.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clump-binary-tree.nix
@@ -1,0 +1,26 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''clump-binary-tree'';
+  version = ''clump-20160825-git'';
+
+  description = ''System lacks description'';
+
+  deps = [ args."acclimation" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/clump/2016-08-25/clump-20160825-git.tgz'';
+    sha256 = ''1mngxmwklpi52inihkp4akzdi7y32609spfi70yamwgzc1wijbrl'';
+  };
+
+  packageName = "clump-binary-tree";
+
+  asdFilesToKeep = ["clump-binary-tree.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM clump-binary-tree DESCRIPTION System lacks description SHA256
+    1mngxmwklpi52inihkp4akzdi7y32609spfi70yamwgzc1wijbrl URL
+    http://beta.quicklisp.org/archive/clump/2016-08-25/clump-20160825-git.tgz
+    MD5 5132d2800138d435ef69f7e68b025c8f NAME clump-binary-tree FILENAME
+    clump-binary-tree DEPS ((NAME acclimation FILENAME acclimation))
+    DEPENDENCIES (acclimation) VERSION clump-20160825-git SIBLINGS
+    (clump-2-3-tree clump-test clump) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clump.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clump.nix
@@ -1,0 +1,29 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''clump'';
+  version = ''20160825-git'';
+
+  description = ''Library for operations on different kinds of trees'';
+
+  deps = [ args."acclimation" args."clump-2-3-tree" args."clump-binary-tree" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/clump/2016-08-25/clump-20160825-git.tgz'';
+    sha256 = ''1mngxmwklpi52inihkp4akzdi7y32609spfi70yamwgzc1wijbrl'';
+  };
+
+  packageName = "clump";
+
+  asdFilesToKeep = ["clump.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM clump DESCRIPTION Library for operations on different kinds of trees
+    SHA256 1mngxmwklpi52inihkp4akzdi7y32609spfi70yamwgzc1wijbrl URL
+    http://beta.quicklisp.org/archive/clump/2016-08-25/clump-20160825-git.tgz
+    MD5 5132d2800138d435ef69f7e68b025c8f NAME clump FILENAME clump DEPS
+    ((NAME acclimation FILENAME acclimation)
+     (NAME clump-2-3-tree FILENAME clump-2-3-tree)
+     (NAME clump-binary-tree FILENAME clump-binary-tree))
+    DEPENDENCIES (acclimation clump-2-3-tree clump-binary-tree) VERSION
+    20160825-git SIBLINGS (clump-2-3-tree clump-binary-tree clump-test)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -156,3 +156,5 @@ cl-cffi-gtk
 enchant
 trivial-main-thread
 cl-webkit2
+acclimation
+clump

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -90,6 +90,24 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "clump-binary-tree" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."clump-binary-tree" or (x: {}))
+       (import ./quicklisp-to-nix-output/clump-binary-tree.nix {
+         inherit fetchurl;
+           "acclimation" = quicklisp-to-nix-packages."acclimation";
+       }));
+
+
+  "clump-2-3-tree" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."clump-2-3-tree" or (x: {}))
+       (import ./quicklisp-to-nix-output/clump-2-3-tree.nix {
+         inherit fetchurl;
+           "acclimation" = quicklisp-to-nix-packages."acclimation";
+       }));
+
+
   "simple-tasks" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."simple-tasks" or (x: {}))
@@ -1391,6 +1409,25 @@ let quicklisp-to-nix-packages = rec {
            "split-sequence" = quicklisp-to-nix-packages."split-sequence";
            "usocket" = quicklisp-to-nix-packages."usocket";
            "usocket-server" = quicklisp-to-nix-packages."usocket-server";
+       }));
+
+
+  "clump" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."clump" or (x: {}))
+       (import ./quicklisp-to-nix-output/clump.nix {
+         inherit fetchurl;
+           "acclimation" = quicklisp-to-nix-packages."acclimation";
+           "clump-2-3-tree" = quicklisp-to-nix-packages."clump-2-3-tree";
+           "clump-binary-tree" = quicklisp-to-nix-packages."clump-binary-tree";
+       }));
+
+
+  "acclimation" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."acclimation" or (x: {}))
+       (import ./quicklisp-to-nix-output/acclimation.nix {
+         inherit fetchurl;
        }));
 
 


### PR DESCRIPTION

###### Motivation for this change

Nyxt needs more

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
