### PR TITLE
haskellPackages.trifecta: dontCheck on darwin

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -392,7 +392,9 @@ self: super: {
   tickle = dontCheck super.tickle;
   tpdb = dontCheck super.tpdb;
   translatable-intset = dontCheck super.translatable-intset;
-  trifecta = if pkgs.stdenv.hostPlatform.isAarch64 then dontCheck super.trifecta else super.trifecta; # affected by this bug https://gitlab.haskell.org/ghc/ghc/-/issues/15275#note_295461
+  # Aarch64 affected by this bug https://gitlab.haskell.org/ghc/ghc/-/issues/15275#note_295461
+  # Darwin https://hydra.nixos.org/build/129070963/nixlog/1
+  trifecta = if (pkgs.stdenv.hostPlatform.isAarch64 || pkgs.stdenv.isDarwin) then dontCheck super.trifecta else super.trifecta;
   ua-parser = dontCheck super.ua-parser;
   unagi-chan = dontCheck super.unagi-chan;
   wai-logger = dontCheck super.wai-logger;


### PR DESCRIPTION
https://hydra.nixos.org/build/129070963/nixlog/1

This unblocks `nixpkgs-unstable` while we're trying to get the `cctools` problems resolved.

https://github.com/NixOS/nixpkgs/pull/101442
https://github.com/NixOS/nixpkgs/pull/101441
https://github.com/NixOS/nixpkgs/issues/101330

Built shellcheck (and pandoc) on darwin.

cc @vcunat 