### PR TITLE
signumone-ks: init at 3.1.2

### DIFF
--- a/pkgs/applications/misc/signumone-ks/default.nix
+++ b/pkgs/applications/misc/signumone-ks/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchurl, dpkg, autoPatchelfHook, makeWrapper,
+  atk, ffmpeg, ffmpeg_2, ffmpeg_3, gdk-pixbuf, glibc, gtk2-x11, gtk3, libav_0_8,
+  libXtst, pango }:
+
+stdenv.mkDerivation rec {
+  pname = "signumone-ks";
+  version = "3.1.2";
+
+  src = fetchurl {
+    url = "https://cdn-dist.signum.one/${version}/${pname}-${version}.deb";
+    sha256 = "4efd80e61619ccf26df1292194fcec68eb14d77dfcf0a1a673da4cf5bf41f4b7";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeWrapper
+  ];
+
+  buildInputs = [
+    atk glibc gdk-pixbuf stdenv.cc.cc ffmpeg ffmpeg_2 ffmpeg_3
+    libav_0_8 gtk2-x11 gtk3 pango libXtst
+  ];
+
+  libPath = stdenv.lib.makeLibraryPath buildInputs;
+
+  unpackPhase = ''
+    dpkg-deb -x ${src} ./
+  '';
+
+  installPhase = ''
+    DESKTOP_PATH=$out/share/applications/signumone-ks.desktop
+    LIB_DIR=$out/lib/signumone-ks
+
+    mkdir -p $out/{bin,share/applications,lib/signumone-ks}
+    mv opt/SignumOne-KS/SignumOne-KS.desktop $DESKTOP_PATH
+    mv opt $out
+
+    # Based on https://github.com/NixOS/nixpkgs/pull/50220/files
+    # Wasn't able to find them
+    ln -s ${ffmpeg_2.out}/lib/libavcodec.so.56 $LIB_DIR/libavcodec-ffmpeg.so.56
+    ln -s ${ffmpeg_2.out}/lib/libavcodec.so.56 $LIB_DIR/libavcodec.so.55
+    ln -s ${ffmpeg_2.out}/lib/libavcodec.so.56 $LIB_DIR/libavcodec.so.54
+    ln -s ${ffmpeg_2.out}/lib/libavformat.so.56 $LIB_DIR/libavformat-ffmpeg.so.56
+    ln -s ${ffmpeg_2.out}/lib/libavformat.so.56 $LIB_DIR/libavformat.so.55
+    ln -s ${ffmpeg_2.out}/lib/libavformat.so.56 $LIB_DIR/libavformat.so.54
+
+    sed -e "s|\(Exec=\)/opt/SignumOne-KS|\1$out/bin|g" -i $DESKTOP_PATH
+    sed -e "s|\(Icon=\)|\1$out|g" -i $DESKTOP_PATH
+
+    makeWrapper $out/opt/SignumOne-KS/SignumOne-KS \
+      $out/bin/SignumOne-KS \
+      --prefix LD_LIBRARY_PATH : ${libPath}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Software intended for usage with Costa Rica's \"Firma Digital\" requirements";
+    homepage = "https://signum.one/download.html";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7008,6 +7008,8 @@ in
   # aka., pgp-tools
   signing-party = callPackage ../tools/security/signing-party { };
 
+  signumone-ks = callPackage ../applications/misc/signumone-ks { };
+
   silc_client = callPackage ../applications/networking/instant-messengers/silc-client { };
 
   silc_server = callPackage ../servers/silc-server { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This software is required for all workers in Costa Rica for reporting taxes and marking vouchers with Digital Sign (Factura Digital).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
