### PR TITLE
qemu: use shared libslirp instead of vendored

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchpatch, python, zlib, pkgconfig, glib
 , perl, pixman, vde2, alsaLib, texinfo, flex
-, bison, lzo, snappy, libaio, gnutls, nettle, curl
+, bison, lzo, snappy, libaio, gnutls, nettle, curl, libslirp
 , makeWrapper
 , attr, libcap, libcap_ng
 , CoreServices, Cocoa, Hypervisor, rez, setfile
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ zlib glib perl pixman
       vde2 texinfo makeWrapper lzo snappy
-      gnutls nettle curl
+      gnutls nettle curl libslirp
     ]
     ++ optionals ncursesSupport [ ncurses ]
     ++ optionals stdenv.isDarwin [ CoreServices Cocoa Hypervisor rez setfile ]
@@ -114,6 +114,7 @@ stdenv.mkDerivation rec {
       "--enable-docs"
       "--enable-tools"
       "--enable-guest-agent"
+      "--enable-slirp=system"
     ]
     # disable sysctl check on darwin.
     ++ optional stdenv.isDarwin "--cpu=x86_64"

--- a/pkgs/development/libraries/libslirp/default.nix
+++ b/pkgs/development/libraries/libslirp/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     description = "General purpose TCP-IP emulator";
     homepage = "https://gitlab.freedesktop.org/slirp/libslirp";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ orivej ];
+    maintainers = with maintainers; [ orivej zowoq ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libslirp/default.nix
+++ b/pkgs/development/libraries/libslirp/default.nix
@@ -4,6 +4,7 @@
 , ninja
 , pkg-config
 , glib
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -18,6 +19,14 @@ stdenv.mkDerivation rec {
     sha256 = "0pzgjj2x2vrjshrzrl2x39xp5lgwg4b4y9vs8xvadh1ycl10v3fv";
   };
 
+  patches = [
+    # fix meson.build on darwin
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/slirp/libslirp/-/commit/9f82a47b81f2864422b82c1e40e51a2ed9c6ac32.patch";
+      sha256 = "13mfhfi6scchy9l9ri4cvvic1i0jh0mwcv0pkvrf667wzllsjxll";
+    })
+  ];
+
   nativeBuildInputs = [ meson ninja pkg-config ];
 
   buildInputs = [ glib ];
@@ -31,6 +40,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.freedesktop.org/slirp/libslirp";
     license = licenses.bsd3;
     maintainers = with maintainers; [ orivej ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

So we don't need to patch the vendored `libslirp`.

https://github.com/NixOS/nixpkgs/pull/76065
https://github.com/NixOS/nixpkgs/pull/79050

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @risicle 
