### PR TITLE
lispPackages.nyxt: build a binary

### DIFF
--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -129,6 +129,19 @@ let lispPackages = rec {
     buildSystems = [ "nyxt" "nyxt-ext" ];
 
     description = "Browser";
+
+    overrides = x: {
+      postInstall = ''
+        echo "Building nyxt binary"
+        NIX_LISP_PRELAUNCH_HOOK='
+          nix_lisp_build_system nyxt/gtk-application \
+           "(asdf/system:component-entry-point (asdf:find-system :nyxt/gtk-application))" \
+           "" "(format *error-output* \"Alien objects:~%~s~%\" sb-alien::*shared-objects*)"
+        ' "$out/bin/nyxt-lisp-launcher.sh"
+        cp "$out/lib/common-lisp/nyxt/nyxt" "$out/bin/"
+      '';
+    };
+
     deps = with pkgs.lispPackages; [
       alexandria
       bordeaux-threads


### PR DESCRIPTION

###### Motivation for this change

Make Nyxt runnable

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
