### PR TITLE
arx-libertatis: 2019-07-22 -> 2020-10-20

### DIFF
--- a/pkgs/games/arx-libertatis/default.nix
+++ b/pkgs/games/arx-libertatis/default.nix
@@ -12,13 +12,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation {
   pname = "arx-libertatis";
-  version = "2019-07-22";
+  version = "2020-10-20";
 
   src = fetchFromGitHub {
     owner = "arx";
     repo = "ArxLibertatis";
-    rev = "db77aa26bb8612f711b65e72b1cd8cf6481700c7";
-    sha256 = "0c88djyzjna17wjcvkgsfx3011m1rba5xdzdldy1hjmafpqgb4jj";
+    rev = "21df2e37664de79e117eff2af164873f05600f4c";
+    sha256 = "06plyyh0ddqv1j04m1vclz9j72609pgrp61v8wfjdcln8djm376i";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24870,9 +24870,7 @@ in
 
   arena = callPackage ../games/arena {};
 
-  arx-libertatis = libsForQt5.callPackage ../games/arx-libertatis {
-    stdenv = gcc6Stdenv;
-  };
+  arx-libertatis = libsForQt5.callPackage ../games/arx-libertatis { };
 
   asc = callPackage ../games/asc {
     lua = lua5_1;


### PR DESCRIPTION
###### Motivation for this change
Finally fix the OpenGL crash. I figured it was an old override that prevented the right glibc from being used.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested the usual save and played a bit
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
