### PR TITLE
python2Packages.pc-ble-driver: disable for <3.6

### DIFF
--- a/pkgs/development/python-modules/pc-ble-driver-py/default.nix
+++ b/pkgs/development/python-modules/pc-ble-driver-py/default.nix
@@ -1,9 +1,10 @@
-{ stdenv, fetchFromGitHub, cmake, git, swig, boost, udev, pc-ble-driver
+{ stdenv, fetchFromGitHub, cmake, git, swig, boost, udev, pc-ble-driver, pythonOlder
 , buildPythonPackage, enum34, wrapt, future, setuptools, scikit-build }:
 
 buildPythonPackage rec {
   pname = "pc-ble-driver-py";
   version = "0.14.2";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "NordicSemiconductor";


### PR DESCRIPTION
###### Motivation for this change
  Executing setuptoolsBuildPhase
  pc-ble-driver-py only supports Python version 3.6 and newer


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
