### PR TITLE
devilutionx: 1.0.1 -> 1.1.0 @ 1432fbc8e 

### DIFF
--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -1,19 +1,25 @@
 { lib, stdenv, fetchFromGitHub, cmake, SDL2, SDL2_mixer, SDL2_ttf, libsodium, pkg-config }:
 stdenv.mkDerivation rec {
-  version = "1.0.1";
-  pname = "devilutionx";
+  version = "2020-10-20";
+  pname = "devilutionx-unstable";
 
   src = fetchFromGitHub {
     owner = "diasurgical";
     repo = "devilutionX";
-    rev = version;
-    sha256 = "1jvjlch9ql5s5jx9g5y5pkc2xn62199qylsmzpqzx1jc3k2vmw5i";
+    rev = "432fbc8ef7b98e567b08e44ce91b198374a5ff01";
+    sha256 = "03w3bgmzwsbycx3fzvn47fsmabl069gw77yn2fqg89wlgaw1yrr9";
   };
 
   NIX_CFLAGS_COMPILE = [
     "-I${SDL2_ttf}/include/SDL2"
     ''-DTTF_FONT_PATH="${placeholder "out"}/share/fonts/truetype/CharisSILB.ttf"''
   ];
+
+  cmakeFlags = [
+    "-DBINARY_RELEASE=ON"
+  ];
+
+  enableParallelBuilding = true;
 
   nativeBuildInputs = [ pkg-config cmake ];
   buildInputs = [ libsodium SDL2 SDL2_mixer SDL2_ttf ];
@@ -40,6 +46,6 @@ stdenv.mkDerivation rec {
     longDescription = "In order to play this game a copy of diabdat.mpq is required. Place a copy of diabdat.mpq in ~/.local/share/diasurgical/devilution before executing the game.";
     license = licenses.unlicense;
     maintainers = [ maintainers.karolchmist ];
-    platforms = platforms.linux ++ platforms.darwin ++ platforms.windows;
+    platforms = platforms.linux ++ platforms.windows;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This fixes the [issue](https://github.com/NixOS/nixpkgs/issues/98242) of devilutionx build failing. 

The [fix](https://github.com/diasurgical/devilutionX/commit/432fbc8e) was committed upstream, and there is not yet an official release containing it, so I used this commit temporarily. As soon as a new release is available, we should update  to it.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
