### PR TITLE
pythonPackages.feedparser: 5.2.1 -> 6.0.1

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -109,7 +109,7 @@ let
                 semantic-version
                 psutil
                 click
-                feedparser
+                feedparser5
                 future
                 websocket_client
                 wrapt

--- a/pkgs/applications/networking/feedreaders/rawdog/default.nix
+++ b/pkgs/applications/networking/feedreaders/rawdog/default.nix
@@ -9,7 +9,7 @@ python2Packages.buildPythonApplication rec {
     sha256 = "18nyg19mwxyqdnykplkqmzb4n27vvrhvp639zai8f81gg9vdbsjp";
   };
 
-  propagatedBuildInputs = with python2Packages; [ feedparser ];
+  propagatedBuildInputs = with python2Packages; [ feedparser5 ];
 
   namePrefix = "";
 

--- a/pkgs/applications/networking/feedreaders/rss2email/default.nix
+++ b/pkgs/applications/networking/feedreaders/rss2email/default.nix
@@ -6,7 +6,7 @@ buildPythonApplication rec {
   pname = "rss2email";
   version = "3.12.2";
 
-  propagatedBuildInputs = [ feedparser html2text ];
+  propagatedBuildInputs = [ feedparser5 html2text ];
   checkInputs = [ beautifulsoup4 ];
 
   src = fetchurl {

--- a/pkgs/development/python-modules/feedparser/5.x.nix
+++ b/pkgs/development/python-modules/feedparser/5.x.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "feedparser";
+  version = "5.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ycva69bqssalhqg45rbrfipz3l6hmycszy26k0351fhq990c0xx";
+  };
+
+  # lots of networking failures
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/kurtmckee/feedparser";
+    description = "Universal feed parser";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ domenkozar ];
+  };
+
+}

--- a/pkgs/development/python-modules/feedparser/default.nix
+++ b/pkgs/development/python-modules/feedparser/default.nix
@@ -1,16 +1,22 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy3k
+, sgmllib3k
 }:
 
 buildPythonPackage rec {
   pname = "feedparser";
-  version = "5.2.1";
+  version = "6.0.1";
+
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ycva69bqssalhqg45rbrfipz3l6hmycszy26k0351fhq990c0xx";
+    sha256 = "0k77c66ia4m64kmdfa2yv8z8887hhwx91pv8b4s2ix23mbf8xa3c";
   };
+
+  propagatedBuildInputs = [ sgmllib3k ];
 
   # lots of networking failures
   doCheck = false;

--- a/pkgs/development/python-modules/feedparser/default.nix
+++ b/pkgs/development/python-modules/feedparser/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , isPy3k
 , sgmllib3k
+, tox
 }:
 
 buildPythonPackage rec {
@@ -18,8 +19,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ sgmllib3k ];
 
-  # lots of networking failures
-  doCheck = false;
+  checkPhase = "python tests/runtests.py";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/kurtmckee/feedparser";

--- a/pkgs/development/python-modules/sgmllib3k/default.nix
+++ b/pkgs/development/python-modules/sgmllib3k/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "sgmllib3k";
+  version = "1.0.0";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1s8jm3dgqabgf8x96931scji679qkhvczlv3qld4qxpsicfgns3q";
+  };
+
+  doCheck = false;  # No tests.
+
+  meta = with stdenv.lib; {
+    homepage = "https://pypi.org/project/sgmllib3k/";
+    description = "Py3k port of sgmllib";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ delroth ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2032,6 +2032,7 @@ in {
   feedgenerator = callPackage ../development/python-modules/feedgenerator { inherit (pkgs) glibcLocales; };
 
   feedparser = callPackage ../development/python-modules/feedparser { };
+  feedparser5 = callPackage ../development/python-modules/feedparser/5.x.nix { };  # For Python 2.x compatibility.
 
   fenics = callPackage ../development/libraries/science/math/fenics {
     inherit (pkgs) pkg-config;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6527,6 +6527,8 @@ in {
 
   sfepy = callPackage ../development/python-modules/sfepy { };
 
+  sgmllib3k = callPackage ../development/python-modules/sgmllib3k { };
+
   shamir-mnemonic = callPackage ../development/python-modules/shamir-mnemonic { };
 
   shapely = callPackage ../development/python-modules/shapely { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Feedparser 6.0.1 was released on Sept 15. The 6.x branch is not compatible with Python 2.x anymore.

I found two packages in nixpkgs that do not work with 6.x at this point, with no upstream fix for either of them. To minimize breakage, I've kept feedparser 5.2.1 (current version) in nixpkgs as `pythonPackages.feedparser5`. I don't feel strongly about this (anything that doesn't have a plan to support Py3k in 2020 is probably not actively maintained anyway...), let me know if you'd rather me remove the relevant commits and break the reverse dependencies.

I've also fixed the derivation to add a checkPhase.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
