### PR TITLE
darling-dmg: 1.0.4+git20180914 -> 1.0.4+git20200427

### DIFF
--- a/pkgs/tools/filesystems/darling-dmg/default.nix
+++ b/pkgs/tools/filesystems/darling-dmg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, fuse, zlib, bzip2, openssl, libxml2, icu } :
+{ stdenv, fetchFromGitHub, cmake, fuse, zlib, bzip2, openssl, libxml2, icu, lzfse }:
 
 stdenv.mkDerivation rec {
   pname = "darling-dmg";
@@ -12,8 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ fuse openssl zlib bzip2 libxml2 icu ];
+  buildInputs = [ fuse openssl zlib bzip2 libxml2 icu lzfse ];
 
+  CXXFLAGS = [
+    "-DCOMPILE_WITH_LZFSE=1"
+    "-llzfse"
+  ];
 
   meta = with stdenv.lib; {
     homepage = "https://www.darlinghq.org/";

--- a/pkgs/tools/filesystems/darling-dmg/default.nix
+++ b/pkgs/tools/filesystems/darling-dmg/default.nix
@@ -2,25 +2,23 @@
 
 stdenv.mkDerivation rec {
   pname = "darling-dmg";
-  version = "1.0.4+git20180914";
+  version = "1.0.4+git20200427";
 
   src = fetchFromGitHub {
     owner = "darlinghq";
     repo = "darling-dmg";
-    rev = "97a92a6930e43cdbc9dedaee62716e3223deb027";
-    sha256 = "1bngr4827qnl4s2f7z39wjp13nfm3zzzykjshb43wvjz536bnqdj";
+    rev = "71cc76c792db30328663272788c0b64aca27fdb0";
+    sha256 = "08iphkxlmjddrxpbm13gxyqwcrd0k65z3l1944n4pccb6qbyj8gv";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ fuse openssl zlib bzip2 libxml2 icu ];
 
-  # compat with icu61+ https://github.com/unicode-org/icu/blob/release-64-2/icu4c/readme.html#L554
-  CXXFLAGS = [ "-DU_USING_ICU_NAMESPACE=1" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "https://www.darlinghq.org/";
     description = "Darling lets you open macOS dmgs on Linux";
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.gpl3;
+    platforms = platforms.linux;
+    license = licenses.gpl3;
   };
 }

--- a/pkgs/tools/filesystems/darling-dmg/default.nix
+++ b/pkgs/tools/filesystems/darling-dmg/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation rec {
     description = "Darling lets you open macOS dmgs on Linux";
     platforms = platforms.linux;
     license = licenses.gpl3;
+    maintainers = with maintainers; [ Luflosi ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update darling-dmg to the latest git version, enable LZFSE support to be able to decompress DMGs compressed with LZFSE and add myself as maintainer.
I tried to execute the test built into darling-dmg but that would have added boost as a build-time-dependency, which is huge. Adding such a large dependency for a single test is not worth it in my opinion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).