### PR TITLE
slurp: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/tools/misc/slurp/default.nix
+++ b/pkgs/tools/misc/slurp/default.nix
@@ -1,27 +1,28 @@
-{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig
-, cairo, wayland, wayland-protocols
+{ stdenv, fetchFromGitHub, meson, ninja, pkg-config
+, cairo, libxkbcommon, wayland, wayland-protocols
 , buildDocs ? true, scdoc
 }:
 
 stdenv.mkDerivation rec {
   pname = "slurp";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "emersion";
     repo = "slurp";
     rev = "v${version}";
-    sha256 = "0580m6kaiilgsrcj608r837r37sl6a25y7w21p7d6ij20fs3gvg1";
+    sha256 = "191yjn909dax8z66ks58wjadrycpbwryirkfjcy99dhq7dijg9fh";
   };
 
   nativeBuildInputs = [
     meson
     ninja
-    pkgconfig
+    pkg-config
   ] ++ stdenv.lib.optional buildDocs scdoc;
 
   buildInputs = [
     cairo
+    libxkbcommon
     wayland
     wayland-protocols
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
[Changelog](https://github.com/emersion/slurp/compare/v1.2.0...v1.3.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
