### PR TITLE
gopls: don't build integration tests or documentation generator

### DIFF
--- a/pkgs/development/tools/gopls/default.nix
+++ b/pkgs/development/tools/gopls/default.nix
@@ -15,6 +15,9 @@ buildGoModule rec {
 
   doCheck = false;
 
+  # Only build gopls, and not the integration tests or documentation generator.
+  subPackages = [ "." ];
+
   meta = with stdenv.lib; {
     description = "Official language server for the Go language";
     homepage = "https://github.com/golang/tools/tree/master/gopls";


### PR DESCRIPTION
Not only are these not used, but they also have super generic names,
which is confusing when they appear on the path, and possibly leads
to conflicts with other binaries.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The "gopls" package currently produces a directory containing three integration test binaries and a binary simply named "doc". The "doc" binary is particularly frustratating because it also conflicts with a similarly named binary in gotools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
Before:
$ nix path-info -f ./ -S gopls
/nix/store/373wla596ndqxygi0mr60q8wfid3y5bs-gopls-0.4.1	   62052208

After:
$ nix path-info -f ./ -S gopls
/nix/store/zb07swkmqckrk9jqzhrz9xvjpcpkfs0h-gopls-0.4.1	   53274680
```