### PR TITLE
pythonPackages.django-oauth-toolkit,django_lts,paperless: Fix evaluation

### DIFF
--- a/pkgs/applications/office/paperless/python-modules/default.nix
+++ b/pkgs/applications/office/paperless/python-modules/default.nix
@@ -1,6 +1,6 @@
 pyPkgs: fetchFromGitHub:
 {
-  django_2_0 = pyPkgs.django_2_2.overridePythonAttrs (old: rec {
+  django_2_0 = pyPkgs.django_2.overridePythonAttrs (old: rec {
     version = "2.0.12";
     src = pyPkgs.fetchPypi {
       inherit (old) pname;

--- a/pkgs/development/python-modules/django-oauth-toolkit/default.nix
+++ b/pkgs/development/python-modules/django-oauth-toolkit/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchFromGitHub
-, django_2_2, requests, oauthlib
+, django_2, requests, oauthlib
 }:
 
 buildPythonPackage rec {
@@ -13,7 +13,7 @@ buildPythonPackage rec {
     sha256 = "1zbksxrcxlqnapmlvx4rgvpqc4plgnq0xnf45cjwzwi1626zs8g6";
   };
 
-  propagatedBuildInputs = [ django_2_2 requests oauthlib ];
+  propagatedBuildInputs = [ django_2 requests oauthlib ];
 
   # django.core.exceptions.ImproperlyConfigured: Requested setting OAUTH2_PROVIDER, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings
   doCheck = false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1662,7 +1662,7 @@ in {
 
   django-logentry-admin = callPackage ../development/python-modules/django-logentry-admin { };
 
-  django_lts = self.django_2_2;
+  django_lts = self.django_2;
 
   django-mailman3 = callPackage ../development/python-modules/django-mailman3 { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

nixpkgs-review failed in https://github.com/NixOS/nixpkgs/pull/101635 because of the changes in https://github.com/NixOS/nixpkgs/commit/00d5a1332234de8f0b8ac947f06a025689894e8c

###### Things done

Tested using ``nix-env -f . -qa``.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@delroth 