### PR TITLE
gpscorrelate: wrap to avoid crashing due to lack of schemas

### DIFF
--- a/pkgs/applications/misc/gpscorrelate/default.nix
+++ b/pkgs/applications/misc/gpscorrelate/default.nix
@@ -1,5 +1,5 @@
 { fetchFromGitHub, stdenv, fetchpatch, pkgconfig, exiv2, libxml2, gtk3
-, libxslt, docbook_xsl, docbook_xml_dtd_42, desktop-file-utils }:
+, libxslt, docbook_xsl, docbook_xml_dtd_42, desktop-file-utils, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "gpscorrelate";
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     docbook_xsl
     libxslt
     pkgconfig
+    wrapGAppsHook
   ];
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
`gpscorrelate-gui` crashes when trying to add photos or choose gps data:
```bash
(gpscorrelate-gui:30432): Gtk-WARNING **: 15:28:57.629: Could not load a pixbuf from /org/gtk/libgtk/theme/Adwaita/assets/check-symbolic.svg.
This may indicate that pixbuf loaders or the mime database could not be found.

(gpscorrelate-gui:30432): GLib-GIO-ERROR **: 15:28:59.403: No GSettings schemas are installed on the system
bash: 'result/bin/gpscorrelate-gui' terminated by signal SIGTRAP (Trace or breakpoint trap)
```

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
