### PR TITLE
nixos/tests: only apply qemu parameters if the options are defined

### DIFF
--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -45,15 +45,21 @@ with import ../../lib/qemu-flags.nix { inherit pkgs; };
     systemd.services."serial-getty@${qemuSerialDevice}".enable = false;
     systemd.services."serial-getty@hvc0".enable = false;
 
-    # Only use a serial console, no TTY.
-    # NOTE: optionalAttrs
-    #       test-instrumentation.nix appears to be used without qemu-vm.nix, so
-    #       we avoid defining consoles if not possible.
-    # TODO: refactor such that test-instrumentation can import qemu-vm
-    #       or declare virtualisation.qemu.console option in a module that's always imported
-    virtualisation.qemu = {
-      consoles = lib.optional (options ? virtualisation.qemu.consoles) qemuSerialDevice;
-      package  = lib.mkDefault pkgs.qemu_test;
+    # Only set these settings when the options exist. Some tests (e.g. those
+    # that do not specify any nodes, or an empty attr set as nodes) will not
+    # have the QEMU module loaded and thuse these options can't and should not
+    # be set.
+    virtualisation = lib.optionalAttrs (options ? virtualisation.qemu) {
+      qemu = {
+        # Only use a serial console, no TTY.
+        # NOTE: optionalAttrs
+        #       test-instrumentation.nix appears to be used without qemu-vm.nix, so
+        #       we avoid defining consoles if not possible.
+        # TODO: refactor such that test-instrumentation can import qemu-vm
+        #       or declare virtualisation.qemu.console option in a module that's always imported
+        consoles = [ qemuSerialDevice ];
+        package  = lib.mkDefault pkgs.qemu_test;
+      };
     };
 
     boot.initrd.preDeviceCommands =


### PR DESCRIPTION
###### Motivation for this change
This fixes an eval error that occurred on hydra with the small channel
and the `nixos.tests.boot.biosCdrom.x86_64-linux` attribute:

> $ nix-instantiate nixos/release-small.nix -A nixos.tests.boot.biosCdrom.x86_64-linux
> warning: unknown setting 'experimental-features'
> error: The option `virtualisation.qemu' does not exist. Definition values:
> - In `/home/andi/dev/nixos/nixpkgs/nixos/modules/testing/test-instrumentation.nix':
>     {
>       consoles = [ ];
>       package = {
> 	_type = "override";
> 	content = <derivation /nix/store/q72h2cdcb9zjgiay5gdgzwddjkbjr7xq-qemu-host-cpu-only-for-vm-tests-5.1.0.drv>;
>     ...
> (use '--show-trace' to show detailed location information)

In bc2188b we changed test test-instrumentation to also set the QEMU
package that is being used. That change unfortunately caused us to
always assing values to the virtualisation.qemu.package option even when
the option is not defined. The original code was explicitly testing for
the consoles case but the then newly extended version did not adjust the
check as the intention was probably not clear.

With this commit we are always ensuring the entire virtualisation.qemu
section exists and can thus drop the individual tests for each of the
sections since the QEMU module always defines both the package and the
consoles option when it's root is defined..


###### Things done

- [x] Instantiated all the tests from the release-small.nix jobset as that is where the error did appear:
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.channel"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.dummy.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.iso_minimal.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.manual.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.boot.biosCdrom.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.containers-imperative.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.containers-ip.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.firewall.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.installer.lvm.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.installer.separateBoot.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.installer.simple.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.ipv6.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.login.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.misc.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.nat.firewall-conntrack.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.nat.firewall.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.nat.standalone.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.nfs3.simple.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.openssh.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.php.fpm.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.php.pcre.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.predictable-interface-names.predictable.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.predictable-interface-names.predictableNetworkd.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.predictable-interface-names.unpredictable.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.predictable-interface-names.unpredictableNetworkd.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.proxy.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixos.tests.simple.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixpkgs.jdk.x86_64-linux"`
  - [x] `nix-instantiate nixos/release-small.nix -A "nixpkgs.tarball"`


This is the outcome of a discussion over at https://github.com/NixOS/nixpkgs/pull/101598#issuecomment-716133973

cc @xaverdh 