### PR TITLE
treewide: remove periods from end of package descriptions (part 2)

### DIFF
--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -110,8 +110,7 @@ in runCommand drvName {
   allowSubstitutes = false;
   passthru = { unwrapped = flutter; };
   meta = with stdenv.lib; {
-    description =
-      "Flutter is Google's SDK for building mobile, web and desktop with Dart.";
+    description = "Flutter is Google's SDK for building mobile, web and desktop with Dart";
     longDescription = ''
       Flutter is Google’s UI toolkit for building beautiful,
       natively compiled applications for mobile, web, and desktop from a single codebase.

--- a/pkgs/development/libraries/libfishsound/default.nix
+++ b/pkgs/development/libraries/libfishsound/default.nix
@@ -14,7 +14,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://xiph.org/fishsound/";
-    description = ''libfishsound by itself is designed to handle raw codec streams from a lower level layer such as UDP datagrams. When these codecs are used in files, they are commonly encapsulated in Ogg to produce Ogg FLAC, Speex and Ogg Vorbis files.
+    description = "A simple programming interface for decoding and encoding audio data using Xiph.org codecs (FLAC, Speex and Vorbis)";
+    longDescription = ''libfishsound by itself is designed to handle raw codec streams from a lower level layer such as UDP datagrams. When these codecs are used in files, they are commonly encapsulated in Ogg to produce Ogg FLAC, Speex and Ogg Vorbis files.
 
 libfishsound is a wrapper around the existing codec libraries and provides a consistent, higher-level programming interface. It has been designed for use in a wide variety of applications; it has no direct dependencies on Ogg encapsulation, though it is most commonly used in conjunction with liboggz to decode or encode FLAC, Speex or Vorbis audio tracks in Ogg files, including Ogg Theora and Annodex.
 

--- a/pkgs/development/python-modules/yamale/default.nix
+++ b/pkgs/development/python-modules/yamale/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "A schema and validator for YAML.";
+    description = "A schema and validator for YAML";
     homepage = "https://github.com/23andMe/Yamale";
     license = licenses.mit;
     maintainers = with maintainers; [ rtburns-jpl ];

--- a/pkgs/development/tools/database/ephemeralpg/default.nix
+++ b/pkgs/development/tools/database/ephemeralpg/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/pg_tmp --prefix PATH : ${stdenv.lib.makeBinPath [ postgresql getopt ]}
   '';
   meta = with stdenv.lib; {
-    description = ''Run tests on an isolated, temporary PostgreSQL database.'';
+    description = "Run tests on an isolated, temporary PostgreSQL database";
     license = licenses.isc;
     homepage = "http://ephemeralpg.org/";
     platforms = platforms.all;

--- a/pkgs/games/pro-office-calculator/default.nix
+++ b/pkgs/games/pro-office-calculator/default.nix
@@ -15,7 +15,7 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
-    description = "Just an ordinary calculator. Nothing to see here...";
+    description = "A completely normal office calculator";
     homepage = "https://proofficecalculator.com/";
     maintainers = [ maintainers.pmiddend ];
     platforms = platforms.linux;

--- a/pkgs/games/tes3cmd/default.nix
+++ b/pkgs/games/tes3cmd/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A command line tool for examining and modifying plugins for the Elder Scrolls game Morrowind by Bethesda Softworks.";
+    description = "A command line tool for examining and modifying plugins for the Elder Scrolls game Morrowind by Bethesda Softworks";
     homepage = "https://github.com/john-moonsugar/tes3cmd";
     license = licenses.mit;
     maintainers = [ maintainers.marius851000 ];

--- a/pkgs/tools/admin/chamber/default.nix
+++ b/pkgs/tools/admin/chamber/default.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   meta = with lib; {
     description =
-      "Chamber is a tool for managing secrets by storing them in AWS SSM Parameter Store.";
+      "A tool for managing secrets by storing them in AWS SSM Parameter Store";
     homepage = "https://github.com/segmentio/chamber";
     license = licenses.mit;
     maintainers = with maintainers; [ kalekseev ];

--- a/pkgs/tools/system/snooze/default.nix
+++ b/pkgs/tools/system/snooze/default.nix
@@ -11,8 +11,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "DESTDIR=$(out)" "PREFIX=/" ];
 
   meta = with stdenv.lib; {
-    description =
-      "Tool for waiting until a particular time and then running a command.";
+    description = "Tool for waiting until a particular time and then running a command";
     maintainers = with maintainers; [ kaction ];
     license = licenses.cc0;
     platforms = platforms.linux;

--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -35,7 +35,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A minimalist fan control program. Originally designed
+    description  = "A minimalist fan control program";
+    longDescription = "A minimalist fan control program. Originally designed
 specifically for IBM/Lenovo Thinkpads, it now supports any kind of system via
 the sysfs hwmon interface (/sys/class/hwmon).";
     license = licenses.gpl3;


### PR DESCRIPTION
###### Motivation for this change

Part of #97685 until we get automatic checks in ofborg/GitHub actions. The PR #97835 managed to fix this for 260+ packages however there were still some remaining ones that had multiline/unusual descriptions. This PR fixes that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
