### PR TITLE
bug: fix libnvidia-container build

### DIFF
--- a/pkgs/applications/virtualization/nvidia-docker/avoid-static-libtirpc-build.patch
+++ b/pkgs/applications/virtualization/nvidia-docker/avoid-static-libtirpc-build.patch
@@ -1,0 +1,21 @@
+diff --git a/Makefile b/Makefile
+index 0070ada..802cef0 100644
+--- a/Makefile
++++ b/Makefile
+@@ -202,7 +202,7 @@ $(BIN_NAME): $(BIN_OBJS)
+ ##### Public rules #####
+ 
+ all: CPPFLAGS += -DNDEBUG
+-all: shared static tools
++all: shared tools
+ 
+ # Run with ASAN_OPTIONS="protect_shadow_gap=0" to avoid CUDA OOM errors
+ debug: CFLAGS += -pedantic -fsanitize=undefined -fno-omit-frame-pointer -fno-common -fsanitize=address
+@@ -232,7 +232,6 @@ install: all
+ 	# Install header files
+ 	$(INSTALL) -m 644 $(LIB_INCS) $(DESTDIR)$(includedir)
+ 	# Install library files
+-	$(INSTALL) -m 644 $(LIB_STATIC) $(DESTDIR)$(libdir)
+ 	$(INSTALL) -m 755 $(LIB_SHARED) $(DESTDIR)$(libdir)
+ 	$(LN) -sf $(LIB_SONAME) $(DESTDIR)$(libdir)/$(LIB_SYMLINK)
+ 	$(LDCONFIG) -n $(DESTDIR)$(libdir)

--- a/pkgs/applications/virtualization/nvidia-docker/libnvc.nix
+++ b/pkgs/applications/virtualization/nvidia-docker/libnvc.nix
@@ -1,17 +1,23 @@
-{ stdenv, lib, fetchFromGitHub, pkgconfig, libelf, libcap, libseccomp }:
-
-with lib; let
-
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkgconfig
+, libelf
+, libcap
+, libseccomp
+, rpcsvc-proto
+, libtirpc
+}:
+let
   modp-ver = "396.51";
-
   nvidia-modprobe = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "nvidia-modprobe";
     rev = modp-ver;
     sha256 = "1fw2qwc84k64agw6fx2v0mjf88aggph9c6qhs4cv7l3gmflv8qbk";
   };
-
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "libnvidia-container";
   version = "1.0.6";
 
@@ -22,19 +28,32 @@ in stdenv.mkDerivation rec {
     sha256 = "1pnpc9knwh8d1zqb28zc3spkjc00w0z10vd3jna8ksvpl35jl7w3";
   };
 
-  # locations of nvidia-driver libraries are not resolved via ldconfig which
-  # doesn't get used on NixOS. Additional support binaries like nvidia-smi are
-  # not resolved via the environment PATH but via the derivation output path.
-  patches = [ ./libnvc-ldconfig-and-path-fixes.patch ];
+  patches = [
+    # locations of nvidia-driver libraries are not resolved via ldconfig which
+    # doesn't get used on NixOS. Additional support binaries like nvidia-smi
+    # are not resolved via the environment PATH but via the derivation output
+    # path.
+    ./libnvc-ldconfig-and-path-fixes.patch
+
+    # the libnvidia-container Makefile wants to build and install static
+    # libtirpc libraries; this patch prevents that from happening
+    ./avoid-static-libtirpc-build.patch
+  ];
 
   makeFlags = [
     "WITH_LIBELF=yes"
     "prefix=$(out)"
+    # we can't use the WITH_TIRPC=yes flag that exists in the Makefile for the
+    # same reason we patch out the static library use of libtirpc so we set the
+    # define in CFLAGS
+    "CFLAGS=-DWITH_TIRPC"
   ];
 
   postPatch = ''
-    sed -i 's/^REVISION :=.*/REVISION = ${src.rev}/' mk/common.mk
-    sed -i 's/^COMPILER :=.*/COMPILER = $(CC)/' mk/common.mk
+    sed -i \
+      -e 's/^REVISION :=.*/REVISION = ${src.rev}/' \
+      -e 's/^COMPILER :=.*/COMPILER = $(CC)/' \
+      mk/common.mk
 
     mkdir -p deps/src/nvidia-modprobe-${modp-ver}
     cp -r ${nvidia-modprobe}/* deps/src/nvidia-modprobe-${modp-ver}
@@ -42,11 +61,14 @@ in stdenv.mkDerivation rec {
     touch deps/src/nvidia-modprobe-${modp-ver}/.download_stamp
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
+  NIX_CFLAGS_COMPILE = [ "-I${libtirpc.dev}/include/tirpc" ];
+  NIX_LDFLAGS = [ "-L${libtirpc.dev}/lib" "-ltirpc" ];
 
-  buildInputs = [ libelf libcap libseccomp ];
+  nativeBuildInputs = [ pkgconfig rpcsvc-proto ];
 
-  meta = {
+  buildInputs = [ libelf libcap libseccomp libtirpc ];
+
+  meta = with lib; {
     homepage = "https://github.com/NVIDIA/libnvidia-container";
     description = "NVIDIA container runtime library";
     license = licenses.bsd3;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This change fixes the build of `libnvidia-container`.

Closes #101517.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
