### PR TITLE
nxdomain: init at 1.0.1

### DIFF
--- a/pkgs/tools/networking/nxdomain/default.nix
+++ b/pkgs/tools/networking/nxdomain/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonApplication, fetchPypi, dnspython, pytestCheckHook }:
+
+buildPythonApplication rec {
+  pname = "nxdomain";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1z9iffggqq2kw6kpnj30shi98cg0bkvkwpglmhnkgwac6g55n2zn";
+  };
+
+  propagatedBuildInputs = [ dnspython ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  postCheck = ''
+    echo example.org > simple.list
+    python -m nxdomain --format dnsmasq --out dnsmasq.conf --simple ./simple.list
+    grep -q 'address=/example.org/' dnsmasq.conf
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/zopieux/nxdomain";
+    description = "A domain (ad) block list creator";
+    platforms = platforms.all;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ zopieux ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5902,6 +5902,8 @@ in
 
   nwdiag = with python3Packages; toPythonApplication nwdiag;
 
+  nxdomain = python3.pkgs.callPackage ../tools/networking/nxdomain { };
+
   nxpmicro-mfgtools = callPackage ../development/tools/misc/nxpmicro-mfgtools { };
 
   nyancat = callPackage ../tools/misc/nyancat { };


### PR DESCRIPTION
###### Motivation for this change

nxdomain is a small tool to generate DNS block lists, available on PyPi and GitHub under GPLv3+.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
