### PR TITLE
python3Packages.pycmarkgfm: init at v1.0.1

### DIFF
--- a/pkgs/development/python-modules/pycmarkgfm/default.nix
+++ b/pkgs/development/python-modules/pycmarkgfm/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, cffi, pytest }:
+
+buildPythonPackage rec {
+  pname = "pycmarkgfm";
+  version = "1.0.1";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wkbbma214f927ikn3cijxsrzkmm5cqz1x4fimrwx9s2wfphj250";
+  };
+
+  propagatedBuildInputs = [ cffi ];
+
+  # I would gladly use pytestCheckHook, but pycmarkgfm relies on a native
+  # extension (cmark.so, built through setup.py), and pytestCheckHook runs
+  # pytest in an environment that does not contain this extension, which fails.
+  # cmarkgfm has virtually the same build setup as this package, and uses the
+  # same trick: pkgs/development/python-modules/cmarkgfm/default.nix
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/zopieux/pycmarkgfm";
+    description = "Bindings to GitHub's Flavored Markdown (cmark-gfm), with enhanced support for task lists";
+    platforms = platforms.linux ++ platforms.darwin;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ zopieux ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4864,6 +4864,8 @@ in {
 
   pycm = callPackage ../development/python-modules/pycm { };
 
+  pycmarkgfm = callPackage ../development/python-modules/pycmarkgfm { };
+
   pycodestyle = callPackage ../development/python-modules/pycodestyle { };
 
   pycognito = callPackage ../development/python-modules/pycognito { };


### PR DESCRIPTION
###### Motivation for this change

New Python 3 package for parsing GitHub Flavored Markdown (GFM) and managing GFM task lists.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
