### PR TITLE
whalebird: init at 4.3.1

### DIFF
--- a/pkgs/applications/networking/whalebird/default.nix
+++ b/pkgs/applications/networking/whalebird/default.nix
@@ -1,0 +1,53 @@
+{ appimageTools, fetchurl, lib, gsettings-desktop-schemas, gtk3
+, makeDesktopItem
+}:
+
+let
+  pname = "whalebird";
+  version = "4.4.1";
+
+  icon = fetchurl {
+    url = "https://raw.githubusercontent.com/h3poteto/whalebird-desktop/master/static/images/icon.png";
+    sha256 = "15i5jp1i0134acvh78f8x4dfdfm22sfr1j26cmih3haqlk0y694x";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = pname;
+    icon = icon;
+    desktopName = pname;
+    genericName = "Whalebird fediverse client";
+    categories = "Application";
+  };
+
+in appimageTools.wrapType2 rec {
+  name = "${pname}";
+  src = fetchurl {
+    url = "https://github.com/h3poteto/whalebird-desktop/releases/download/${version}/Whalebird-${version}-linux-x64.AppImage";
+    sha256 = "158nisk69yzkp5f681zrm2nj9zv1f6vrw93b8r9ry7dah34c94py";
+  };
+
+  profile = ''
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+  '';
+
+  multiPkgs = null; # no 32bit needed
+  extraPkgs = pkgs:
+    appimageTools.defaultFhsEnvArgs.multiPkgs pkgs ++ (with pkgs; [ libdbusmenu ]);
+
+  extraInstallCommands = ''
+    mkdir "$out/share"
+    ln -s "${desktopItem}/share/applications" "$out/share/"
+  '';
+
+  meta = with lib; {
+    description = "Fediverse client application";
+    longDescription = ''
+      Whalebird is a client app for Mastodon, Pleroma, and Misskey, implemented in Typescript and Electron.
+    '';
+    homepage = "https://whalebird.social/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ greydot ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31945,6 +31945,8 @@ in
 
   websocketd = callPackage ../applications/networking/websocketd { };
 
+  whalebird = callPackage ../applications/networking/whalebird { };
+
   wikicurses = callPackage ../applications/misc/wikicurses {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Introduce Whalebird.

###### Things done
Added whalebird derivation for Linux x64.

Note that while it is an open source app, building it from source is nigh impossible due to Electron being weird :(

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
