### PR TITLE
[20.09] add NixOS 20.09 AMIs

### DIFF
--- a/nixos/modules/virtualisation/ec2-amis.nix
+++ b/nixos/modules/virtualisation/ec2-amis.nix
@@ -329,5 +329,24 @@ let self = {
   "20.03".ap-east-1.hvm-ebs = "ami-0d18fdd309cdefa86";
   "20.03".sa-east-1.hvm-ebs = "ami-09859378158ae971d";
 
-  latest = self."20.03";
+  # 20.09beta1430.f5ad6d9f774
+  "20.09".eu-west-1.hvm-ebs = "ami-0e51504d15dabd99b";
+  "20.09".eu-west-2.hvm-ebs = "ami-0e27b16e926c09a4b";
+  "20.09".eu-west-3.hvm-ebs = "ami-05c0d6c903e7f7be5";
+  "20.09".eu-central-1.hvm-ebs = "ami-0aa77d86c202806d9";
+  "20.09".eu-north-1.hvm-ebs = "ami-084e3272fd1887087";
+  "20.09".us-east-1.hvm-ebs = "ami-049e90bd3fd249c4c";
+  "20.09".us-east-2.hvm-ebs = "ami-071b7665deabba0c8";
+  "20.09".us-west-1.hvm-ebs = "ami-087859a5da4c2b4b2";
+  "20.09".us-west-2.hvm-ebs = "ami-056bcd4ab33365c6f";
+  "20.09".ca-central-1.hvm-ebs = "ami-0ec14bf2ff2667e35";
+  "20.09".ap-southeast-1.hvm-ebs = "ami-01b5c4c07e40abd89";
+  "20.09".ap-southeast-2.hvm-ebs = "ami-0bc9b17a79a437b62";
+  "20.09".ap-northeast-1.hvm-ebs = "ami-0603d7581ae63e714";
+  "20.09".ap-northeast-2.hvm-ebs = "ami-0c88ca122764e71f3";
+  "20.09".ap-south-1.hvm-ebs = "ami-082ef1da872438bd8";
+  "20.09".ap-east-1.hvm-ebs = "ami-00fcf67b1d52c1ec4";
+  "20.09".sa-east-1.hvm-ebs = "ami-0f448178b49881f13";
+
+  latest = self."20.09";
 }; in self


### PR DESCRIPTION
Fixes #101694

(cherry picked from commit 2d79a21691ffcd6d8452608e3a43e8a4d9eb2caa)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
