### PR TITLE
nixos/plasma5: Install default KDE apps for music, images and documents

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -307,6 +307,10 @@ in
           qtvirtualkeyboard
 
           pkgs.xdg-user-dirs # Update user dirs as described in https://freedesktop.org/wiki/Software/xdg-user-dirs/
+
+          elisa
+          gwenview
+          okular
         ]
 
         # Phonon audio backend


### PR DESCRIPTION
###### Motivation for this change

I received this commit via Email and think this might require discussion with
those maintaining the KDE Plasma modules & packages.

> >From https://apps.kde.org/:
> Elisa is a simple KDE music player (with builtin internet radio support),
> Okular is a universal KDE document viewer (can fill PDF forms),
> Gwenview is a fast and easy to use KDE image viewer.
> 
> All three are missing in the default installation KDE installation, e.g.
> 
> 	services.xserver = {
> 	  displayManager.sddm.enable = true;
> 	  desktopManager.plasma5.enable = true;
> 	};
> 
> which provides no alternatives, hence requiring them whilst being
> offline is unfortunate, so install them by default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

-  [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [X] I did execute nixos/tests/plasma5.nix
