### PR TITLE
nixos/acme: Make challenges world readable

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -19,7 +19,6 @@ let
       Type = "oneshot";
       User = "acme";
       Group = mkDefault "acme";
-      UMask = 0027;
       StateDirectoryMode = 750;
       ProtectSystem = "full";
       PrivateTmp = true;
@@ -669,7 +668,7 @@ in {
         "d /var/lib/acme/.lego/accounts - acme acme"
       ] ++ (unique (concatMap (conf: [
           "d ${conf.accountDir} - acme acme"
-        ] ++ (optional (conf.webroot != null) "d ${conf.webroot}/.well-known/acme-challenge - acme ${conf.group}")
+        ] ++ (optional (conf.webroot != null) "d ${conf.webroot}/.well-known/acme-challenge - acme acme")
       ) (attrValues certConfigs)));
 
       # Create some targets which can be depended on to be "active" after cert renewals


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

By making it world-readable,
this enables setting a `group` for a given cert
that does not include the webserver used for an http-01 challenge.
For example, this allows setting the group to `postgres`
while using `nginx` to serve the challenge,
without having to create a group containing both `postgres` and `nginx`.

Additionally, change the tmpfiles rule
to always create the directory as owned by acme
to avoid duplicate tmpfiles for the same webroot
trying to make it be owned by different groups
(e.g. both `nginx` and `postgres`),
which causes:
```
setting up tmpfiles
/etc/tmpfiles.d/00-nixos.conf:23: Duplicate line for path "/var/lib/acme/acme-challenge/.well-known/acme-challenge", ignoring.
```

The challenge data does not need to be kept private
(as it is world-accessible over HTTP to fulfill the challenge!)
so this is safe to do.

Note that lego already writes any challenge files out as 644,
but the UMask was impeding this by preventing world-readability.
Omitting it will cause us to use systemd's default of 022.

No units should not leak any sensitive data from this:
- minica creates self-signed certs which are not sensitive
  since they won't be trusted
- lego creates account and cert files with 600 permissions.

Note that all units also use PrivateTmp so we only need to consider
files which are directly output into a directory in BindPaths;
they all also chmod their outputs to appropriate permissions,
but that is not sufficient as we don't want any window (i.e. before chmod)
with insecure permissions on relevant files.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
