### PR TITLE
tvm: init at 0.7.0

### DIFF
--- a/pkgs/development/compilers/tvm/default.nix
+++ b/pkgs/development/compilers/tvm/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "tvm";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "incubator-tvm";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "0qflpd3lw0jslyk5lqpv2v42lkqs8mkvnn6i3fdms32iskdfk6p5";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  # TVM CMake build uses some sources in the project's ./src/target/opt/
+  # directory which errneously gets mangled by the eager `fixCmakeFiles`
+  # function in Nix's CMake setup-hook.sh to ./src/target/var/empty/,
+  # which then breaks the build. Toggling this flag instructs Nix to
+  # not mangle the legitimate use of the opt/ folder.
+  dontFixCmake = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://tvm.apache.org/";
+    description = "An End to End Deep Learning Compiler Stack for CPUs, GPUs and accelerators";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ adelbertc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7601,6 +7601,8 @@ in
 
   turses = callPackage ../applications/networking/instant-messengers/turses { };
 
+  tvm = callPackage ../development/compilers/tvm { };
+
   oysttyer = callPackage ../applications/networking/instant-messengers/oysttyer { };
 
   twilight = callPackage ../tools/graphics/twilight {


### PR DESCRIPTION
###### Motivation for this change
New package: [TVM](https://tvm.apache.org/), An End to End Deep Learning Compiler Stack for CPUs, GPUs and accelerators.

cc @imalsogreg @tkonolige 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux) <-- does this work on Darwin ATM? It didn't last time I checked.
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`) <-- None, shared headers and library only
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Result of a Nix build

```shell
$ ls -R result
result:
include  lib

result/include:
tvm

result/include/tvm:
runtime

result/include/tvm/runtime:
c_backend_api.h  container.h  data_type.h   memory.h  module.h	 object.h	registry.h    threading_backend.h
c_runtime_api.h  crt	      device_api.h  micro     ndarray.h  packed_func.h	serializer.h  vm

result/include/tvm/runtime/crt:
crt.h  error_codes.h  func_registry.h  graph_runtime.h	logging.h  memory.h  module.h  packed_func.h  platform.h  rpc_common  utvm_rpc_server.h

result/include/tvm/runtime/crt/rpc_common:
frame_buffer.h	framing.h  session.h  write_stream.h

result/include/tvm/runtime/micro:
standalone

result/include/tvm/runtime/micro/standalone:
utvm_runtime.h

result/include/tvm/runtime/vm:
bytecode.h  executable.h  memory_manager.h  vm.h

result/lib:
libtvm.dylib  libtvm_runtime.dylib
```