### PR TITLE
[20.09] goaccess: fix build on darwin

### DIFF
--- a/pkgs/tools/misc/goaccess/default.nix
+++ b/pkgs/tools/misc/goaccess/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, ncurses, glib, libmaxminddb }:
+{ stdenv, fetchurl, pkgconfig, ncurses, glib, libmaxminddb, fetchpatch }:
 
 stdenv.mkDerivation rec {
   version = "1.4";
@@ -8,6 +8,13 @@ stdenv.mkDerivation rec {
     url = "https://tar.goaccess.io/goaccess-${version}.tar.gz";
     sha256 = "1gkpjg39f3afdwm9128jqjsfap07p8s027czzlnxfmi5hpzvkyz8";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/allinurl/goaccess/commit/514618cdd69453497fbf67913ccb37a0a0b07391.patch";
+      sha256 = "11lp7mabfl6ibgzsd9nw10k2xvcm0hrimrwidl06r8dqn2jzjxf6";
+    })
+  ];
 
   configureFlags = [
     "--enable-geoip=mmdb"


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/101709
(cherry picked from commit d8b38de1e10f7a09480766da9d8f3b6d2e55f7ec)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF 20.09 https://github.com/NixOS/nixpkgs/issues/97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
