### PR TITLE
treewide: remove package names from prefix of descriptions

### DIFF
--- a/pkgs/applications/audio/ecasound/default.nix
+++ b/pkgs/applications/audio/ecasound/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ alsaLib audiofile libjack2 liblo liboil libsamplerate libsndfile lilv lv2 ];
 
   meta = {
-    description = "Ecasound is a software package designed for multitrack audio processing";
+    description = "Software package designed for multitrack audio processing";
     license = with stdenv.lib.licenses;  [ gpl2 lgpl21 ];
     homepage = "http://nosignal.fi/ecasound/";
   };

--- a/pkgs/applications/audio/eflite/default.nix
+++ b/pkgs/applications/audio/eflite/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://eflite.sourceforge.net";
-    description = "EFlite is a speech server for screen readers";
+    description = "Speech server for screen readers";
     longDescription = ''
       EFlite is a speech server for Emacspeak and other screen
       readers that allows them to interface with Festival Lite,

--- a/pkgs/applications/audio/picoloop/default.nix
+++ b/pkgs/applications/audio/picoloop/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Picoloop is a synth and a stepsequencer (a clone of the famous nanoloop)";
+    description = "A synth and a stepsequencer (a clone of the famous nanoloop)";
     homepage = "https://github.com/yoyz/picoloop";
     platforms = platforms.linux;
     license = licenses.bsd3;

--- a/pkgs/applications/blockchains/sumokoin.nix
+++ b/pkgs/applications/blockchains/sumokoin.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    description = "Sumokoin is a fork of Monero and a truely fungible cryptocurrency";
+    description = "A fork of Monero and a truely fungible cryptocurrency";
     homepage = "https://www.sumokoin.org/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ fpletz ];

--- a/pkgs/applications/editors/kile/default.nix
+++ b/pkgs/applications/editors/kile/default.nix
@@ -52,7 +52,7 @@ mkDerivation rec {
   propagatedUserEnvPkgs = [ konsole ];
 
   meta = {
-    description = "Kile is a user friendly TeX/LaTeX authoring tool for the KDE desktop environment";
+    description = "User-friendly TeX/LaTeX authoring tool for the KDE desktop environment";
     homepage = "https://www.kde.org/applications/office/kile/";
     maintainers = with lib.maintainers; [ fridh ];
     license = lib.licenses.gpl2Plus;

--- a/pkgs/applications/graphics/gnuclad/default.nix
+++ b/pkgs/applications/graphics/gnuclad/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://launchpad.net/gnuclad";
-    description = "gnuclad tries to help the environment by creating trees.  It's primary use will be generating cladogram trees for the GNU/Linux distro timeline project";
+    description = "gnuclad tries to help the environment by creating trees.  Its primary use will be generating cladogram trees for the GNU/Linux distro timeline project";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ mog ];
     platforms = platforms.linux;

--- a/pkgs/applications/graphics/lightburn/default.nix
+++ b/pkgs/applications/graphics/lightburn/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "LightBurn is layout, editing, and control software for your laser cutter";
+    description = "Layout, editing, and control software for your laser cutter";
     homepage = "https://lightburnsoftware.com/";
     license = stdenv.lib.licenses.unfree;
     maintainers = with stdenv.lib.maintainers; [ q3k ];

--- a/pkgs/applications/kde/bomber.nix
+++ b/pkgs/applications/kde/bomber.nix
@@ -7,7 +7,7 @@ mkDerivation {
   name = "bomber";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.bomber";
-    description = "Bomber is a single player arcade game";
+    description = "A single player arcade game";
     longDescription = ''
       Bomber is a single player arcade game. The player is invading various
       cities in a plane that is decreasing in height.

--- a/pkgs/applications/kde/granatier.nix
+++ b/pkgs/applications/kde/granatier.nix
@@ -7,7 +7,7 @@ mkDerivation {
   name = "granatier";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.granatier";
-    description = "Granatier is a clone of the classic Bomberman game";
+    description = "Clone of the classic Bomberman game";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kalzium.nix
+++ b/pkgs/applications/kde/kalzium.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kalzium";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.kalzium";
-    description = "Kalzium is a program that shows you the Periodic Table of Elements";
+    description = "Program that shows you the Periodic Table of Elements";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kapman.nix
+++ b/pkgs/applications/kde/kapman.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kapman";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kapman";
-    description = "Kapman is a clone of the well known game Pac-Man";
+    description = "Clone of the well known game Pac-Man";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/katomic.nix
+++ b/pkgs/applications/kde/katomic.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "katomic";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.katomic";
-    description = "KAtomic is a fun educational game built around molecular geometry";
+    description = "Fun educational game built around molecular geometry";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kblackbox.nix
+++ b/pkgs/applications/kde/kblackbox.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kblackbox";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kblackbox";
-    description = "KBlackbox is a game of hide and seek played on a grid of boxes";
+    description = "Game of hide and seek played on a grid of boxes";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kblocks.nix
+++ b/pkgs/applications/kde/kblocks.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kblocks";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kblocks";
-    description = "KBlocks is the classic falling blocks game";
+    description = "Classic falling blocks game";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kbounce.nix
+++ b/pkgs/applications/kde/kbounce.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kbounce";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kbounce";
-    description = "KBounce is a single player arcade game with the elements of puzzle";
+    description = "Single player arcade game with the elements of puzzle";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kdiamond.nix
+++ b/pkgs/applications/kde/kdiamond.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kdiamond";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kdiamond";
-    description = "KDiamond is a single player puzzle game";
+    description = "A single player puzzle game";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kfloppy.nix
+++ b/pkgs/applications/kde/kfloppy.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kfloppy";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.kfloppy";
-    description = "KFloppy is a utility to format 3.5\" and 5.25\" floppy disks";
+    description = "Utility to format 3.5\" and 5.25\" floppy disks";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/klettres.nix
+++ b/pkgs/applications/kde/klettres.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "klettres";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.klettres";
-    description = "KLettres is an application specially designed to help the user to learn an alphabet";
+    description = "An application specially designed to help the user to learn an alphabet";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/klines.nix
+++ b/pkgs/applications/kde/klines.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "klines";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.klines";
-    description = "KLines is a simple but highly addictive one player game";
+    description = "A simple but highly addictive one player game";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kmag.nix
+++ b/pkgs/applications/kde/kmag.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kmag";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.kmag";
-    description = "KMag is a small utility for Linux to magnify a part of the screen";
+    description = "A small Linux utility to magnify a part of the screen";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kmines.nix
+++ b/pkgs/applications/kde/kmines.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kmines";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kmines";
-    description = "KMines is a classic Minesweeper game";
+    description = "A classic Minesweeper game";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/knetwalk.nix
+++ b/pkgs/applications/kde/knetwalk.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "knetwalk";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.knetwalk";
-    description = "KNetWalk is a single player logic game";
+    description = "A single player logic game";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/knights.nix
+++ b/pkgs/applications/kde/knights.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "knights";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.knights";
-    description = "KNights is a chess game";
+    description = "A chess game";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kollision.nix
+++ b/pkgs/applications/kde/kollision.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kollision";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kollision";
-    description = "Kollision is a casual game";
+    description = "A casual game";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kreversi.nix
+++ b/pkgs/applications/kde/kreversi.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kreversi";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kreversi";
-    description = "KReversi is a simple one player strategy game played against the computer";
+    description = "A simple one player strategy game played against the computer";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kshisen.nix
+++ b/pkgs/applications/kde/kshisen.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kshisen";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kshisen";
-    description = "KShisen is a solitaire-like game played using the standard set of Mahjong tiles";
+    description = "A solitaire-like game played using the standard set of Mahjong tiles";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/ksquares.nix
+++ b/pkgs/applications/kde/ksquares.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "ksquares";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.ksquares";
-    description = "KSquares is a game of Dots and Boxes";
+    description = "A game of Dots and Boxes";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kteatime.nix
+++ b/pkgs/applications/kde/kteatime.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kteatime";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.kteatime";
-    description = "KTeaTime is a handy timer for steeping tea";
+    description = "A handy timer for steeping tea";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/ktimer.nix
+++ b/pkgs/applications/kde/ktimer.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "ktimer";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.ktimer";
-    description = "KTimer is a little tool to execute programs after some time";
+    description = "A little tool to execute programs after some time";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kturtle.nix
+++ b/pkgs/applications/kde/kturtle.nix
@@ -4,7 +4,7 @@ mkDerivation {
   name = "kturtle";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.kturtle";
-    description = "KTurtle is an educational programming environment for learning how to program";
+    description = "An educational programming environment for learning how to program";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kwave.nix
+++ b/pkgs/applications/kde/kwave.nix
@@ -5,7 +5,7 @@ mkDerivation {
   name = "kwave";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/multimedia/org.kde.kwave";
-    description = "KWave is a simple media player";
+    description = "A simple media player";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/misc/dockbarx/default.nix
+++ b/pkgs/applications/misc/dockbarx/default.nix
@@ -30,7 +30,7 @@ pythonPackages.buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     homepage = "https://launchpad.net/dockbar/";
-    description = "DockBarX is a lightweight taskbar / panel replacement for Linux which works as a stand-alone dock";
+    description = "Lightweight taskbar / panel replacement for Linux which works as a stand-alone dock";
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = [ maintainers.volth ];

--- a/pkgs/applications/misc/fsv/default.nix
+++ b/pkgs/applications/misc/fsv/default.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
   version = "0.9-1";
 
   src = fetchFromGitHub {
-    owner  = "mcuelenaere"; 
+    owner  = "mcuelenaere";
     repo   = "fsv";
     rev    = "${pname}-${version}";
     sha256 = "0n09jd7yqj18mx6zqbg7kab4idg5llr15g6avafj74fpg1h7iimj";
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
   buildInputs       = [ file gtk2 libGLU gtkglarea ];
 
   meta = with stdenv.lib; {
-    description     = "fsv is a file system visualizer in cyberspace";
+    description     = "File system visualizer in cyberspace";
     longDescription = ''
       fsv (pronounced eff-ess-vee) is a file system visualizer in cyberspace.
       It lays out files and directories in three dimensions, geometrically

--- a/pkgs/applications/misc/grsync/default.nix
+++ b/pkgs/applications/misc/grsync/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    description = "Grsync is used to synchronize folders, files and make backups";
+    description = "Synchronize folders, files and make backups";
     homepage = "http://www.opbyte.it/grsync/";
     license = licenses.gpl1;
     platforms = platforms.linux;

--- a/pkgs/applications/misc/icesl/default.nix
+++ b/pkgs/applications/misc/icesl/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "IceSL is a GPU-accelerated procedural modeler and slicer for 3D printing";
+    description = "GPU-accelerated procedural modeler and slicer for 3D printing";
     homepage = "http://shapeforge.loria.fr/icesl/index.html";
     license = licenses.inria-icesl;
     platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/applications/misc/libosmocore/default.nix
+++ b/pkgs/applications/misc/libosmocore/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    description = "libosmocore";
+    description = "Set of Osmocom core libraries";
     homepage = "https://github.com/osmocom/libosmocore";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/misc/mapproxy/default.nix
+++ b/pkgs/applications/misc/mapproxy/default.nix
@@ -56,7 +56,7 @@ buildPythonApplication rec {
   #    https://github.com/NixOS/nixpkgs/pull/56480
   doCheck = false;
   meta = with lib; {
-  description = "MapProxy is an open source proxy for geospatial data";
+  description = "Open source proxy for geospatial data";
   homepage = "https://mapproxy.org/";
   license = licenses.asl20;
   maintainers = with maintainers; [ rakesh4g ];

--- a/pkgs/applications/misc/obsidian/default.nix
+++ b/pkgs/applications/misc/obsidian/default.nix
@@ -65,7 +65,7 @@ in stdenv.mkDerivation rec {
 
   meta = with lib; {
     description =
-      "Obsidian is a powerful knowledge base that works on top of a local folder of plain text Markdown files";
+      "A powerful knowledge base that works on top of a local folder of plain text Markdown files";
     homepage = "https://obsidian.md";
     license = licenses.obsidian;
     maintainers = with maintainers; [ conradmearns zaninime ];

--- a/pkgs/applications/misc/rsibreak/default.nix
+++ b/pkgs/applications/misc/rsibreak/default.nix
@@ -20,7 +20,7 @@ in mkDerivation rec {
   propagatedBuildInputs = [ knotifyconfig kidletime kwindowsystem ktextwidgets kcrash ];
 
   meta = with lib; {
-    description = "RSIBreak takes care of your health and regularly breaks your work to avoid repetitive strain injury (RSI)";
+    description = "Takes care of your health and regularly breaks your work to avoid repetitive strain injury (RSI)";
     license = licenses.gpl2;
     homepage = "https://www.kde.org/applications/utilities/rsibreak/";
     maintainers = with maintainers; [ vandenoever ];

--- a/pkgs/applications/misc/xmenu/default.nix
+++ b/pkgs/applications/misc/xmenu/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   postPatch = "sed -i \"s:/usr/local:$out:\" config.mk";
 
   meta = with stdenv.lib; {
-    description = "XMenu is a menu utility for X";
+    description = "A menu utility for X";
     homepage = "https://github.com/phillbush/xmenu";
     license = licenses.publicDomain;
     maintainers = with maintainers; [ neonfuz ];

--- a/pkgs/applications/networking/cluster/jx/default.nix
+++ b/pkgs/applications/networking/cluster/jx/default.nix
@@ -35,7 +35,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "JX is a command line tool for installing and using Jenkins X";
+    description = "Command line tool for installing and using Jenkins X";
     homepage = "https://jenkins-x.io";
     longDescription = ''
       Jenkins X provides automated CI+CD for Kubernetes with Preview

--- a/pkgs/applications/networking/cluster/prow/default.nix
+++ b/pkgs/applications/networking/cluster/prow/default.nix
@@ -52,7 +52,7 @@ buildGoModule rec {
   ];
 
   meta = with lib; {
-    description = "Prow is a Kubernetes based CI/CD system";
+    description = "A Kubernetes based CI/CD system";
     longDescription = ''
       Prow is a Kubernetes based CI/CD system. Jobs can be triggered by various
       types of events and report their status to many different services. In

--- a/pkgs/applications/networking/instant-messengers/ferdi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ferdi/default.nix
@@ -9,7 +9,7 @@ mkFranzDerivation rec {
     sha256 = "0i24vcnq4iz5amqmn2fgk92ff9x9y7fg8jhc3g6ksvmcfly7af3k";
   };
   meta = with stdenv.lib; {
-    description = "Ferdi allows you to combine your favorite messaging services into one application";
+    description = "Combine your favorite messaging services into one application";
     homepage = "https://getferdi.com/";
     license = licenses.free;
     maintainers = [ maintainers.davidtwco ];

--- a/pkgs/applications/networking/instant-messengers/psi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   ];
   enableParallelBuilding = true;
   meta = with stdenv.lib; {
-    description = "Psi, an XMPP (Jabber) client";
+    description = "An XMPP (Jabber) client";
     maintainers = [ maintainers.raskin ];
     license = licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -54,7 +54,7 @@ buildGoModule rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "aerc is an email client for your terminal";
+    description = "An email client for your terminal";
     homepage = "https://aerc-mail.org/";
     maintainers = with maintainers; [ tadeokondrak ];
     license = licenses.mit;

--- a/pkgs/applications/science/biology/dcm2niix/default.nix
+++ b/pkgs/applications/science/biology/dcm2niix/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libyamlcpp ];
 
   meta = with stdenv.lib; {
-    description = "dcm2niix DICOM to NIfTI converter";
+    description = "DICOM to NIfTI converter";
     longDescription = ''
       dcm2niix is a designed to convert neuroimaging data from the
       DICOM format to the NIfTI format.

--- a/pkgs/applications/science/biology/kallisto/default.nix
+++ b/pkgs/applications/science/biology/kallisto/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = false;
 
   meta = with stdenv.lib; {
-    description = "Kallisto is a program for quantifying abundances of transcripts from RNA-Seq data";
+    description = "Program for quantifying abundances of transcripts from RNA-Seq data";
     homepage = "https://pachterlab.github.io/kallisto";
     license = licenses.bsd2;
     platforms = platforms.linux;

--- a/pkgs/applications/science/logic/coq2html/default.nix
+++ b/pkgs/applications/science/logic/coq2html/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, ocaml }:
 
-let 
+let
   version = "20170720";
 in
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    description = "coq2html is an HTML documentation generator for Coq source files";
+    description = "HTML documentation generator for Coq source files";
     longDescription = ''
       coq2html is an HTML documentation generator for Coq source files. It is
       an alternative to the standard coqdoc documentation generator

--- a/pkgs/applications/science/logic/ott/default.nix
+++ b/pkgs/applications/science/logic/ott/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   postInstall = "opaline -prefix $out";
 
   meta = {
-    description = "Ott: tool for the working semanticist";
+    description = "A tool for the working semanticist";
     longDescription = ''
       Ott is a tool for writing definitions of programming languages and
       calculi. It takes as input a definition of a language syntax and

--- a/pkgs/applications/science/machine-learning/labelimg/default.nix
+++ b/pkgs/applications/science/machine-learning/labelimg/default.nix
@@ -28,7 +28,7 @@
       makeWrapperArgs+=("''${qtWrapperArgs[@]}")
     '';
     meta = with stdenv.lib; {
-      description = "LabelImg is a graphical image annotation tool and label object bounding boxes in images";
+      description = "A graphical image annotation tool and label object bounding boxes in images";
       homepage = "https://github.com/tzutalin/labelImg";
       license = licenses.mit;
       platforms = platforms.linux;

--- a/pkgs/applications/science/math/bliss/default.nix
+++ b/pkgs/applications/science/math/bliss/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "bliss is an open source tool for computing automorphism groups and canonical forms of graphs. It has both a command line user interface as well as C++ and C programming language APIs";
+    description = "An open source tool for computing automorphism groups and canonical forms of graphs. It has both a command line user interface as well as C++ and C programming language APIs";
     homepage = "http://www.tcs.hut.fi/Software/bliss/";
     license = licenses.lgpl3;
     platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/applications/science/misc/openmodelica/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    description = "OpenModelica is an open-source Modelica-based modeling and simulation environment";
+    description = "An open-source Modelica-based modeling and simulation environment";
     homepage    = "https://openmodelica.org";
     license     = licenses.gpl3;
     maintainers = with maintainers; [ smironov ];

--- a/pkgs/applications/science/programming/scyther/default.nix
+++ b/pkgs/applications/science/programming/scyther/default.nix
@@ -13,7 +13,7 @@ let
   };
 
   meta = with lib; {
-    description = "Scyther is a tool for the automatic verification of security protocols";
+    description = "A tool for the automatic verification of security protocols";
     homepage = "https://www.cs.ox.ac.uk/people/cas.cremers/scyther/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ infinisil ];

--- a/pkgs/applications/video/mjpg-streamer/default.nix
+++ b/pkgs/applications/video/mjpg-streamer/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/jacksonliam/mjpg-streamer";
-    description = "MJPG-streamer takes JPGs from Linux-UVC compatible webcams, filesystem or other input plugins and streams them as M-JPEG via HTTP to webbrowsers, VLC and other software";
+    description = "Takes JPGs from Linux-UVC compatible webcams, filesystem or other input plugins and streams them as M-JPEG via HTTP to webbrowsers, VLC and other software";
     platforms = platforms.linux;
     license = licenses.gpl2;
     maintainers = with maintainers; [ gebner ];

--- a/pkgs/applications/video/mkclean/default.nix
+++ b/pkgs/applications/video/mkclean/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "mkclean is a command line tool to clean and optimize Matroska (.mkv / .mka / .mks / .mk3d) and WebM (.webm / .weba) files that have already been muxed";
+    description = "Command line tool to clean and optimize Matroska (.mkv / .mka / .mks / .mk3d) and WebM (.webm / .weba) files that have already been muxed";
     homepage = "https://www.matroska.org";
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ chrisaw ];

--- a/pkgs/applications/window-managers/leftwm/default.nix
+++ b/pkgs/applications/window-managers/leftwm/default.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Leftwm - A tiling window manager for the adventurer";
+    description = "A tiling window manager for the adventurer";
     homepage = "https://github.com/leftwm/leftwm";
     license = licenses.mit;
     platforms = platforms.linux;

--- a/pkgs/data/fonts/merriweather/default.nix
+++ b/pkgs/data/fonts/merriweather/default.nix
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/SorkinType/Merriweather";
-    description = "Merriweather was designed to be a text face that is pleasant to read on screens";
+    description = "A text face designed to be pleasant to read on screens";
     license = licenses.ofl;
     platforms = platforms.all;
     maintainers = with maintainers; [ emily ];

--- a/pkgs/desktops/lxde/core/lxrandr/default.nix
+++ b/pkgs/desktops/lxde/core/lxrandr/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libX11 (if withGtk3 then gtk3 else gtk2) xrandr ];
 
   meta = with stdenv.lib; {
-    description = "LXRandR is the standard screen manager of LXDE";
+    description = "Standard screen manager of LXDE";
     homepage = "https://lxde.org/";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with maintainers; [ rawkode ];

--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Lazarus graphical IDE for the FreePascal language";
+    description = "Graphical IDE for the FreePascal language";
     homepage = "https://www.lazarus.freepascal.org";
     license = licenses.gpl2Plus ;
     maintainers = with maintainers; [ raskin ];

--- a/pkgs/development/compilers/stalin/default.nix
+++ b/pkgs/development/compilers/stalin/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://www.ece.purdue.edu/~qobi/software.html";
     license = stdenv.lib.licenses.gpl2Plus;
-    description = "Stalin, an optimizing Scheme compiler";
+    description = "An optimizing Scheme compiler";
 
     maintainers = [ ];
     platforms = ["i686-linux"];  # doesn't want to work on 64-bit platforms

--- a/pkgs/development/libraries/belr/default.nix
+++ b/pkgs/development/libraries/belr/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DENABLE_STATIC=NO" ];
 
   meta = with stdenv.lib; {
-    description = "Belr is Belledonne Communications' language recognition library";
+    description = "Belledonne Communications' language recognition library";
     homepage = "https://gitlab.linphone.org/BC/public/belr";
     license = licenses.gpl3;
     platforms = platforms.all;

--- a/pkgs/development/libraries/bzrtp/default.nix
+++ b/pkgs/development/libraries/bzrtp/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-Wno-error=cast-function-type";
 
   meta = with stdenv.lib; {
-    description = "BZRTP is an opensource implementation of ZRTP keys exchange protocol";
+    description = "An opensource implementation of ZRTP keys exchange protocol";
     homepage = "https://gitlab.linphone.org/BC/public/bzrtp";
     # They have switched to GPLv3 on git HEAD so probably the next release will
     # be GPL3.

--- a/pkgs/development/libraries/duckdb/default.nix
+++ b/pkgs/development/libraries/duckdb/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/cwida/duckdb";
-    description = "DuckDB is an embeddable SQL OLAP Database Management System";
+    description = "Embeddable SQL OLAP Database Management System";
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = with maintainers; [ costrouc ];

--- a/pkgs/development/libraries/libstroke/default.nix
+++ b/pkgs/development/libraries/libstroke/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     '';
 
   meta = {
-    description = "Libstroke, a library for simple gesture recognition";
+    description = "A library for simple gesture recognition";
     homepage = "https://web.archive.org/web/20161204100704/http://etla.net/libstroke/";
     license = stdenv.lib.licenses.gpl2;
 

--- a/pkgs/development/libraries/libthreadar/default.nix
+++ b/pkgs/development/libraries/libthreadar/default.nix
@@ -24,7 +24,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://libthreadar.sourceforge.net/";
-    description = ''
+    description = "A C++ library that provides several classes to manipulate threads";
+    longDescription = ''
       Libthreadar is a C++ library providing a small set of C++ classes to manipulate
       threads in a very simple and efficient way from your C++ code.
     '';

--- a/pkgs/development/libraries/martyr/default.nix
+++ b/pkgs/development/libraries/martyr/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Martyr is a Java framework around the IRC protocol to allow application writers easy manipulation of the protocol and client state";
+    description = "Java framework around the IRC protocol to allow application writers easy manipulation of the protocol and client state";
     homepage = "http://martyr.sourceforge.net/";
     license = stdenv.lib.licenses.lgpl21;
   };

--- a/pkgs/development/libraries/physics/qcdnum/default.nix
+++ b/pkgs/development/libraries/physics/qcdnum/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    description = "QCDNUM is a very fast QCD evolution program written in FORTRAN77";
+    description = "A very fast QCD evolution program written in FORTRAN77";
     license     = stdenv.lib.licenses.gpl3;
     homepage    = "https://www.nikhef.nl/~h24/qcdnum/index.html";
     platforms   = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/pupnp/default.nix
+++ b/pkgs/development/libraries/pupnp/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "fortify" ];
 
   meta = {
-    description = "libupnp, an open source UPnP development kit for Linux";
+    description = "An open source UPnP development kit for Linux";
 
     longDescription = ''
       The Linux SDK for UPnP Devices (libupnp) provides developers

--- a/pkgs/development/libraries/science/math/parmetis/default.nix
+++ b/pkgs/development/libraries/science/math/parmetis/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning unstructured graphs, meshes, and for computing fill-reducing orderings of sparse matrices";
+    description = "An MPI-based parallel library that implements a variety of algorithms for partitioning unstructured graphs, meshes, and for computing fill-reducing orderings of sparse matrices";
     homepage = "http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview";
     platforms = platforms.all;
     license = licenses.unfree;

--- a/pkgs/development/libraries/sope/default.nix
+++ b/pkgs/development/libraries/sope/default.nix
@@ -41,7 +41,7 @@ gnustep.stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "SOPE is an extensive set of frameworks which form a complete Web application server environment";
+    description = "An extensive set of frameworks which form a complete Web application server environment";
     license = licenses.publicDomain;
     homepage = "https://github.com/inverse-inc/sope";
     platforms = platforms.linux;

--- a/pkgs/development/libraries/symengine/default.nix
+++ b/pkgs/development/libraries/symengine/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "SymEngine is a fast symbolic manipulation library";
+    description = "A fast symbolic manipulation library";
     homepage = "https://github.com/symengine/symengine";
     platforms = platforms.unix ++ platforms.windows;
     license = licenses.bsd3;

--- a/pkgs/development/mobile/cocoapods/default.nix
+++ b/pkgs/development/mobile/cocoapods/default.nix
@@ -13,7 +13,7 @@ bundlerApp {
   passthru.updateScript = toString ./update;
 
   meta = with lib; {
-    description     = "CocoaPods manages dependencies for your Xcode projects";
+    description     = "Manages dependencies for your Xcode projects";
     homepage        = "https://github.com/CocoaPods/CocoaPods";
     license         = licenses.mit;
     platforms       = platforms.darwin;

--- a/pkgs/development/python-modules/buildbot/default.nix
+++ b/pkgs/development/python-modules/buildbot/default.nix
@@ -103,7 +103,7 @@ let
 
     meta = with lib; {
       homepage = "https://buildbot.net/";
-      description = "Buildbot is an open-source continuous integration framework for automating software build, test, and release processes";
+      description = "An open-source continuous integration framework for automating software build, test, and release processes";
       maintainers = with maintainers; [ nand0p ryansydnor lopsided98 ];
       license = licenses.gpl2;
     };

--- a/pkgs/development/python-modules/docutils/default.nix
+++ b/pkgs/development/python-modules/docutils/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    description = "Docutils -- Python Documentation Utilities";
+    description = "Python Documentation Utilities";
     homepage = "http://docutils.sourceforge.net/";
     maintainers = with lib.maintainers; [ AndersonTorres ];
   };

--- a/pkgs/development/python-modules/xdot/default.nix
+++ b/pkgs/development/python-modules/xdot/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ gobject-introspection pygobject3 graphviz gtk3 ];
 
   meta = with lib; {
-    description = "xdot.py is an interactive viewer for graphs written in Graphviz's dot";
+    description = "An interactive viewer for graphs written in Graphviz's dot";
     homepage = "https://github.com/jrfonseca/xdot.py";
     license = licenses.lgpl3Plus;
   };

--- a/pkgs/development/tools/analysis/coz/default.nix
+++ b/pkgs/development/tools/analysis/coz/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://github.com/plasma-umass/coz";
-    description = "Coz: Causal Profiling";
+    description = "Profiler based on casual profiling";
     license = stdenv.lib.licenses.bsd2;
     maintainers = with stdenv.lib.maintainers; [ zimbatm ];
   };

--- a/pkgs/development/tools/analysis/pev/default.nix
+++ b/pkgs/development/tools/analysis/pev/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   installFlags = [ "prefix=$(out)" ];
 
   meta = with stdenv.lib; {
-    description = "pev is a full-featured, open source, multiplatform command line toolkit to work with PE (Portable Executables) binaries";
+    description = "A full-featured, open source, multiplatform command line toolkit to work with PE (Portable Executables) binaries";
     homepage = "http://pev.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/development/tools/build-managers/bloop/default.nix
+++ b/pkgs/development/tools/build-managers/bloop/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://scalacenter.github.io/bloop/";
     license = licenses.asl20;
-    description = "Bloop is a Scala build server and command-line tool to make the compile and test developer workflows fast and productive in a build-tool-agnostic way";
+    description = "A Scala build server and command-line tool to make the compile and test developer workflows fast and productive in a build-tool-agnostic way";
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ tomahna ];
   };

--- a/pkgs/development/tools/deadcode/default.nix
+++ b/pkgs/development/tools/deadcode/default.nix
@@ -22,7 +22,7 @@ buildGoPackage rec {
   };
 
   meta = with lib; {
-    description = "deadcode is a very simple utility which detects unused declarations in a Go package";
+    description = "Very simple utility which detects unused declarations in a Go package";
     homepage = "https://github.com/remyoudompheng/go-misc/tree/master/deadcode";
     license = licenses.bsd3;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/tools/errcheck/default.nix
+++ b/pkgs/development/tools/errcheck/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   meta = with lib; {
-    description = "errcheck is a program for checking for unchecked errors in go programs";
+    description = "Program for checking for unchecked errors in go programs";
     homepage = "https://github.com/kisielk/errcheck";
     license = licenses.mit;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/tools/impl/default.nix
+++ b/pkgs/development/tools/impl/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   meta = with lib; {
-    description = "impl generates method stubs for implementing an interface";
+    description = "Generate method stubs for implementing an interface";
     homepage = "https://github.com/josharian/impl";
     license = licenses.mit;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/tools/jbake/default.nix
+++ b/pkgs/development/tools/jbake/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with stdenv.lib; {
-    description = "JBake is a Java based, open source, static site/blog generator for developers & designers";
+    description = "Java based, open source, static site/blog generator for developers & designers";
     homepage = "https://jbake.org/";
     license = licenses.mit;
     maintainers = with maintainers; [ moaxcp ];

--- a/pkgs/development/tools/minizinc/default.nix
+++ b/pkgs/development/tools/minizinc/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = "https://www.minizinc.org/";
-    description = "MiniZinc is a medium-level constraint modelling language";
+    description = "A medium-level constraint modelling language";
 
     longDescription = ''
       MiniZinc is a medium-level constraint modelling

--- a/pkgs/development/tools/misc/cli11/default.nix
+++ b/pkgs/development/tools/misc/cli11/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    description = "CLI11 is a command line parser for C++11";
+    description = "Command line parser for C++11";
     homepage = "https://github.com/CLIUtils/CLI11";
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ nand0p ];

--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";
+    description = "An interface compiler that connects C/C++ code to higher-level languages";
     homepage = "http://swig.org/";
     # Different types of licenses available: http://www.swig.org/Release/LICENSE .
     license = licenses.gpl3Plus;

--- a/pkgs/development/tools/nsis/default.nix
+++ b/pkgs/development/tools/nsis/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   installTargets = [ "install-compiler" ];
 
   meta = with stdenv.lib; {
-    description = "NSIS is a free scriptable win32 installer/uninstaller system that doesn't suck and isn't huge";
+    description = "A free scriptable win32 installer/uninstaller system that doesn't suck and isn't huge";
     homepage = "https://nsis.sourceforge.io/";
     license = licenses.zlib;
     platforms = platforms.linux;

--- a/pkgs/development/tools/omniorb/default.nix
+++ b/pkgs/development/tools/omniorb/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   meta = with stdenv.lib; {
-    description = "omniORB is a robust high performance CORBA ORB for C++ and Python. It is freely available under the terms of the GNU Lesser General Public License (for the libraries), and GNU General Public License (for the tools). omniORB is largely CORBA 2.6 compliant";
+    description = "A robust high performance CORBA ORB for C++ and Python. It is freely available under the terms of the GNU Lesser General Public License (for the libraries), and GNU General Public License (for the tools). omniORB is largely CORBA 2.6 compliant";
     homepage    = "http://omniorb.sourceforge.net/";
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ smironov ];

--- a/pkgs/development/tools/pgloader/default.nix
+++ b/pkgs/development/tools/pgloader/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://pgloader.io/";
-    description = "pgloader loads data into PostgreSQL and allows you to implement Continuous Migration from your current database to PostgreSQL";
+    description = "Loads data into PostgreSQL and allows you to implement Continuous Migration from your current database to PostgreSQL";
     maintainers = with maintainers; [ mguentner ];
     license = licenses.postgresql;
     platforms = platforms.all;

--- a/pkgs/development/tools/reftools/default.nix
+++ b/pkgs/development/tools/reftools/default.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    description = "reftools - refactoring tools for Go";
+    description = "Refactoring tools for Go";
     homepage = "https://github.com/davidrjenni/reftools";
     license = licenses.bsd2;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/tools/xqilla/default.nix
+++ b/pkgs/development/tools/xqilla/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-xerces=${xercesc}" ];
 
   meta = with stdenv.lib; {
-    description = "XQilla is an XQuery and XPath 2 library and command line utility written in C++, implemented on top of the Xerces-C library";
+    description = "An XQuery and XPath 2 library and command line utility written in C++, implemented on top of the Xerces-C library";
     license     = licenses.asl20 ;
     maintainers = with maintainers; [ obadz ];
     platforms   = platforms.all;

--- a/pkgs/development/web/newman/default.nix
+++ b/pkgs/development/web/newman/default.nix
@@ -12,7 +12,7 @@ in
 nodePackages.newman.override {
   meta = with lib; {
     homepage = "https://www.getpostman.com";
-    description = "Newman is a command-line collection runner for Postman";
+    description = "A command-line collection runner for Postman";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.asl20;
   };

--- a/pkgs/games/chessx/default.nix
+++ b/pkgs/games/chessx/default.nix
@@ -48,7 +48,7 @@ mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "http://chessx.sourceforge.net/";
-    description = "ChessX allows you to browse and analyse chess games";
+    description = "Browse and analyse chess games";
     license = licenses.gpl2;
     maintainers = [ maintainers.luispedro ];
     platforms = platforms.linux;

--- a/pkgs/games/lugaru/default.nix
+++ b/pkgs/games/lugaru/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DSYSTEM_INSTALL=ON" ];
 
   meta = {
-    description = "Lugaru HD: Third person ninja rabbit fighting game";
+    description = "Third person ninja rabbit fighting game";
     homepage = "https://osslugaru.gitlab.io";
     maintainers = [ maintainers.genesis ];
     platforms = platforms.linux;

--- a/pkgs/games/megaglest/default.nix
+++ b/pkgs/games/megaglest/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "MegaGlest is an entertaining free (freeware and free software) and open source cross-platform 3D real-time strategy (RTS) game";
+    description = "An entertaining free (freeware and free software) and open source cross-platform 3D real-time strategy (RTS) game";
     license = stdenv.lib.licenses.gpl3;
     homepage = "http://megaglest.org/";
     maintainers = [ stdenv.lib.maintainers.matejc ];

--- a/pkgs/games/pacvim/default.nix
+++ b/pkgs/games/pacvim/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/jmoon018/PacVim";
-    description = "PacVim is a game that teaches you vim commands";
+    description = "A game that teaches you vim commands";
     maintainers = with maintainers; [ infinisil ];
     license = licenses.lgpl3;
     platforms = platforms.unix;

--- a/pkgs/misc/frescobaldi/default.nix
+++ b/pkgs/misc/frescobaldi/default.nix
@@ -29,9 +29,9 @@ buildPythonApplication rec {
 
   meta = with lib; {
     homepage = "https://frescobaldi.org/";
-    description = ''Frescobaldi is a LilyPond sheet music text editor'';
+    description = "A LilyPond sheet music text editor";
     longDescription = ''
-      Powerful text editor with syntax highlighting and automatic completion, 
+      Powerful text editor with syntax highlighting and automatic completion,
       Music view with advanced Point & Click, Midi player to proof-listen
       LilyPond-generated MIDI files, Midi capturing to enter music,
       Powerful Score Wizard to quickly setup a music score, Snippet Manager

--- a/pkgs/misc/screensavers/betterlockscreen/default.nix
+++ b/pkgs/misc/screensavers/betterlockscreen/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with stdenv.lib; {
-    description = "Betterlockscreen is a simple minimal lock screen which allows you to cache images with different filters and lockscreen with blazing speed";
+    description = "A simple minimal lock screen which allows you to cache images with different filters and lockscreen with blazing speed";
     homepage = "https://github.com/pavanjadhaw/betterlockscreen";
     license = licenses.mit;
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/cpuset/default.nix
+++ b/pkgs/os-specific/linux/cpuset/default.nix
@@ -19,7 +19,7 @@ python2Packages.buildPythonApplication rec {
   };
 
   meta = with stdenv.lib; {
-    description = "Cpuset is a Python application that forms a wrapper around the standard Linux filesystem calls to make using the cpusets facilities in the Linux kernel easier";
+    description = "Python application that forms a wrapper around the standard Linux filesystem calls to make using the cpusets facilities in the Linux kernel easier";
     homepage    = "https://github.com/wykurz/cpuset";
     license     = licenses.gpl2;
     maintainers = with maintainers; [ wykurz ];

--- a/pkgs/servers/hitch/default.nix
+++ b/pkgs/servers/hitch/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   passthru.tests.hitch = nixosTests.hitch;
 
   meta = with stdenv.lib; {
-    description = "Hitch is a libev-based high performance SSL/TLS proxy by Varnish Software";
+    description = "Libev-based high performance SSL/TLS proxy by Varnish Software";
     homepage = "https://hitch-tls.org/";
     license = licenses.bsd2;
     maintainers = [ maintainers.jflanglois ];

--- a/pkgs/servers/monitoring/longview/default.nix
+++ b/pkgs/servers/monitoring/longview/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://www.linode.com/longview";
-    description = "Longview collects all of your system-level metrics and sends them to Linode";
+    description = "Collects all of your system-level metrics and sends them to Linode";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.rvl ];
     inherit version;

--- a/pkgs/servers/news/leafnode/default.nix
+++ b/pkgs/servers/news/leafnode/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = "http://leafnode.sourceforge.net/";
-    description = "Leafnode implements a store & forward NNTP proxy";
+    description = "Implementation of a store & forward NNTP proxy";
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/servers/openbgpd/default.nix
+++ b/pkgs/servers/openbgpd/default.nix
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "OpenBGPD is a FREE implementation of the Border Gateway Protocol, Version 4. It allows ordinary machines to be used as routers exchanging routes with other systems speaking the BGP protocol";
+    description = "A free implementation of the Border Gateway Protocol, Version 4. It allows ordinary machines to be used as routers exchanging routes with other systems speaking the BGP protocol";
     license = licenses.isc;
     homepage = "http://www.openbgpd.org/";
     maintainers = with maintainers; [ kloenk ];

--- a/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = ''
+    description = "An extension to support similarity queries on PostgreSQL";
+    longDescription = ''
        pg_similarity is an extension to support similarity queries on PostgreSQL. The implementation
        is tightly integrated in the RDBMS in the sense that it defines operators so instead of the traditional
        operators (= and <>) you can use ~~~ and ~!~ (any of these operators represents a similarity function).

--- a/pkgs/servers/sql/postgresql/ext/pgtap.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgtap.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "pgTAP is a unit testing framework for PostgreSQL";
+    description = "A unit testing framework for PostgreSQL";
     longDescription = ''
       pgTAP is a unit testing framework for PostgreSQL written in PL/pgSQL and PL/SQL.
       It includes a comprehensive collection of TAP-emitting assertion functions,

--- a/pkgs/servers/web-apps/jirafeau/default.nix
+++ b/pkgs/servers/web-apps/jirafeau/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Jirafeau is a web site permitting to upload a file in a simple way and give an unique link to it";
+    description = "Website permitting upload of a file in a simple way and giving a unique link to it";
     license = licenses.agpl3;
     homepage = "https://gitlab.com/mojo42/Jirafeau";
     platforms = platforms.all;

--- a/pkgs/servers/web-apps/sogo/default.nix
+++ b/pkgs/servers/web-apps/sogo/default.nix
@@ -67,7 +67,7 @@ with lib; gnustep.stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "SOGo is a very fast and scalable modern collaboration suite (groupware)";
+    description = "A very fast and scalable modern collaboration suite (groupware)";
     license = with licenses; [ gpl2 lgpl21 ];
     homepage = "https://sogo.nu/";
     platforms = platforms.linux;

--- a/pkgs/shells/es/default.nix
+++ b/pkgs/shells/es/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   configureFlags = [ "--with-readline" ];
 
   meta = with stdenv.lib; {
-    description = "Es is an extensible shell";
+    description = "An extensible shell with higher order functions";
     longDescription =
       ''
         Es is an extensible shell. The language was derived

--- a/pkgs/tools/X11/x11spice/default.nix
+++ b/pkgs/tools/X11/x11spice/default.nix
@@ -24,10 +24,7 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = "-lpthread";
 
   meta = with stdenv.lib; {
-    description = ''
-      x11spice will enable a running X11 desktop to be available
-      via a Spice server
-    '';
+    description = "Enable a running X11 desktop to be available via a Spice server";
     homepage = "https://gitlab.freedesktop.org/spice/x11spice";
     platforms = platforms.linux;
     license = licenses.gpl3;

--- a/pkgs/tools/admin/oxidized/default.nix
+++ b/pkgs/tools/admin/oxidized/default.nix
@@ -11,7 +11,7 @@ bundlerApp {
   passthru.updateScript = bundlerUpdateScript "oxidized";
 
   meta = with lib; {
-    description = "Oxidized is a network device configuration backup tool. It's a RANCID replacement!";
+    description = "A network device configuration backup tool. It's a RANCID replacement!";
     homepage    = "https://github.com/ytti/oxidized";
     license     = licenses.asl20;
     maintainers = with maintainers; [ willibutz nicknovitski ];

--- a/pkgs/tools/backup/dirvish/default.nix
+++ b/pkgs/tools/backup/dirvish/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Dirvish is a fast, disk based, rotating network backup system";
+    description = "Fast, disk based, rotating network backup system";
     homepage = "http://dirvish.org/";
     license = stdenv.lib.licenses.osl2;
     platforms = platforms.linux;

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = "https://tukaani.org/xz/";
-    description = "XZ, general-purpose data compression software, successor of LZMA";
+    description = "A general-purpose data compression software, successor of LZMA";
 
     longDescription =
       '' XZ Utils is free general-purpose data compression software with high

--- a/pkgs/tools/filesystems/httpfs/default.nix
+++ b/pkgs/tools/filesystems/httpfs/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = {
-    description = "HTTPFS2, a FUSE-based HTTP file system for Linux";
+    description = "FUSE-based HTTP filesystem for Linux";
 
     homepage = "http://httpfs.sourceforge.net/";
 

--- a/pkgs/tools/graphics/optar/default.nix
+++ b/pkgs/tools/graphics/optar/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    description = "Optar stands for OPTical ARchiver - it's a codec for encoding data on paper";
+    description = "OPTical ARchiver - it's a codec for encoding data on paper";
     homepage = "http://ronja.twibright.com/optar/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/tools/misc/logstash/6.x.nix
+++ b/pkgs/tools/misc/logstash/6.x.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Logstash is a data pipeline that helps you process logs and other event data from a variety of systems";
+    description = "A data pipeline that helps you process logs and other event data from a variety of systems";
     homepage    = "https://www.elastic.co/products/logstash";
     license     = if enableUnfree then licenses.elastic else licenses.asl20;
     platforms   = platforms.unix;

--- a/pkgs/tools/misc/shallot/default.nix
+++ b/pkgs/tools/misc/shallot/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Shallot allows you to create customized .onion addresses for your hidden service";
+    description = "Allows you to create customized .onion addresses for your hidden service";
 
     license = stdenv.lib.licenses.mit;
     homepage = "https://github.com/katmagic/Shallot";

--- a/pkgs/tools/misc/wootility/default.nix
+++ b/pkgs/tools/misc/wootility/default.nix
@@ -35,7 +35,7 @@ appimageTools.wrapType2 rec {
 
   meta = with lib; {
     homepage = "https://wooting.io/wootility";
-    description = "Wootility is customization and management software for Wooting keyboards";
+    description = "A customization and management software for Wooting keyboards";
     platforms = [ "x86_64-linux" ];
     license = "unknown";
     maintainers = with maintainers; [ davidtwco ];

--- a/pkgs/tools/networking/bukubrow/default.nix
+++ b/pkgs/tools/networking/bukubrow/default.nix
@@ -39,7 +39,7 @@ in rustPlatform.buildRustPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Bukubrow is a WebExtension for Buku, a command-line bookmark manager";
+    description = "A WebExtension for Buku, a command-line bookmark manager";
     homepage = "https://github.com/SamHH/bukubrow-host";
     license = licenses.gpl3;
     maintainers = with maintainers; [ infinisil ];

--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mdlayher/corerad";
-    description = "CoreRAD extensible and observable IPv6 NDP RA daemon";
+    description = "Extensible and observable IPv6 NDP RA daemon";
     license = licenses.asl20;
     maintainers = with maintainers; [ mdlayher ];
   };

--- a/pkgs/tools/networking/curlie/default.nix
+++ b/pkgs/tools/networking/curlie/default.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Curlie is a frontend to curl that adds the ease of use of httpie, without compromising on features and performance";
+    description = "Frontend to curl that adds the ease of use of httpie, without compromising on features and performance";
     homepage = "https://curlie.io/";
     maintainers = with maintainers; [ ma27 ];
     license = licenses.mit;

--- a/pkgs/tools/networking/dnstracer/default.nix
+++ b/pkgs/tools/networking/dnstracer/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lresolv";
 
   meta = with stdenv.lib; {
-    description = "Dnstracer determines where a given Domain Name Server (DNS) gets its information from, and follows the chain of DNS servers back to the servers which know the data";
+    description = "Determines where a given Domain Name Server (DNS) gets its information from, and follows the chain of DNS servers back to the servers which know the data";
     homepage = "http://www.mavetju.org/unix/general.php";
     license = licenses.bsd2;
     maintainers = with maintainers; [ andir ];

--- a/pkgs/tools/networking/driftnet/default.nix
+++ b/pkgs/tools/networking/driftnet/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   };
 
   meta = {
-    description = "Driftnet watches network traffic, and picks out and displays JPEG and GIF images for display";
+    description = "Watches network traffic, and picks out and displays JPEG and GIF images for display";
     homepage = "https://github.com/deiv/driftnet";
     maintainers = with maintainers; [ offline ];
     platforms = platforms.linux;

--- a/pkgs/tools/networking/goreplay/default.nix
+++ b/pkgs/tools/networking/goreplay/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
   meta = {
     homepage = "https://github.com/buger/goreplay";
     license = stdenv.lib.licenses.lgpl3Only;
-    description = "GoReplay is an open-source tool for capturing and replaying live HTTP traffic";
+    description = "Open-source tool for capturing and replaying live HTTP traffic";
     platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ lovek323 ];
   };

--- a/pkgs/tools/networking/maxscale/default.nix
+++ b/pkgs/tools/networking/maxscale/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-     description = ''MaxScale database proxy extends MariaDB Server's high availability'';
+     description = "MaxScale database proxy extends MariaDB Server's high availability";
      homepage = "https://mariadb.com/products/technology/maxscale";
      license = licenses.bsl11;
      platforms = platforms.linux;

--- a/pkgs/tools/networking/ngrok-2/default.nix
+++ b/pkgs/tools/networking/ngrok-2/default.nix
@@ -35,10 +35,7 @@ stdenv.mkDerivation {
   passthru.updateScript = ./update.sh;
 
   meta = {
-    description = "ngrok";
-    longDescription = ''
-      Allows you to expose a web server running on your local machine to the internet.
-    '';
+    description = "Allows you to expose a web server running on your local machine to the internet";
     homepage = "https://ngrok.com/";
     license = licenses.unfree;
     platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];

--- a/pkgs/tools/networking/pmacct/default.nix
+++ b/pkgs/tools/networking/pmacct/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     ++ optional withMysql "--enable-mysql";
 
   meta = with stdenv.lib; {
-    description = "pmacct is a small set of multi-purpose passive network monitoring tools";
+    description = "A small set of multi-purpose passive network monitoring tools";
     longDescription = ''
       pmacct is a small set of multi-purpose passive network monitoring tools
       [NetFlow IPFIX sFlow libpcap BGP BMP RPKI IGP Streaming Telemetry]

--- a/pkgs/tools/networking/ssldump/default.nix
+++ b/pkgs/tools/networking/ssldump/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
                      "--with-openssl-lib=${openssl}/lib"
                      "--with-openssl-inc=${openssl}/include" ];
   meta = {
-    description = "ssldump is an SSLv3/TLS network protocol analyzer";
+    description = "An SSLv3/TLS network protocol analyzer";
     homepage = "http://ssldump.sourceforge.net";
     license = "BSD-style";
     maintainers = with stdenv.lib.maintainers; [ aycanirican ];

--- a/pkgs/tools/package-management/morph/default.nix
+++ b/pkgs/tools/package-management/morph/default.nix
@@ -35,7 +35,7 @@ buildGoPackage rec {
   outputs = [ "out" "lib" ];
 
   meta = with lib; {
-    description = "Morph is a NixOS host manager written in Golang";
+    description = "A NixOS host manager written in Golang";
     license = licenses.mit;
     homepage = "https://github.com/dbcdk/morph";
     maintainers = with maintainers; [adamt johanot];

--- a/pkgs/tools/security/acsccid/default.nix
+++ b/pkgs/tools/security/acsccid/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "acsccid is a PC/SC driver for Linux/Mac OS X and it supports ACS CCID smart card readers";
+    description = "A PC/SC driver for Linux/Mac OS X and it supports ACS CCID smart card readers";
     longDescription = ''
       acsccid is a PC/SC driver for Linux/Mac OS X and it supports ACS CCID smart card
       readers. This library provides a PC/SC IFD handler implementation and

--- a/pkgs/tools/security/fpm2/default.nix
+++ b/pkgs/tools/security/fpm2/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gnupg gtk2 libxml2 intltool ];
 
   meta = {
-    description = "FPM2 is GTK2 port from Figaro's Password Manager originally developed by John Conneely, with some new enhancements";
+    description = "GTK2 port from Figaro's Password Manager originally developed by John Conneely, with some new enhancements";
     homepage    = "https://als.regnet.cz/fpm2/";
     license     = licenses.gpl2;
     platforms   = platforms.linux;

--- a/pkgs/tools/security/notary/default.nix
+++ b/pkgs/tools/security/notary/default.nix
@@ -36,7 +36,7 @@ buildGoPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Notary is a project that allows anyone to have trust over arbitrary collections of data";
+    description = "A project that allows anyone to have trust over arbitrary collections of data";
     longDescription = ''
       The Notary project comprises a server and a client for running and
       interacting with trusted collections. See the service architecture

--- a/pkgs/tools/security/sshguard/default.nix
+++ b/pkgs/tools/security/sshguard/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--sysconfdir=/etc" ];
 
   meta = with stdenv.lib; {
-    description = "SSHGuard protects hosts from brute-force attacks";
+    description = "Protects hosts from brute-force attacks";
     longDescription = ''
       SSHGuard can read log messages from various input sources. Log messages are parsed, line-by-line, for recognized patterns.
       If an attack, such as several login failures within a few seconds, is detected, the offending IP is blocked.

--- a/pkgs/tools/system/daemon/default.nix
+++ b/pkgs/tools/system/daemon/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   buildInputs = [ perl ];
 
   meta = {
-    description = "Daemon turns other process into daemons";
+    description = "Turns other processes into daemons";
     longDescription = ''
       Daemon turns other process into daemons. There are many tasks that need
       to be performed to correctly set up a daemon process. This can be tedious.

--- a/pkgs/tools/system/jump/default.nix
+++ b/pkgs/tools/system/jump/default.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "Jump helps you navigate faster by learning your habits";
+    description = "Navigate directories faster by learning your habits";
     longDescription = ''
       Jump integrates with the shell and learns about your
       navigational habits by keeping track of the directories you visit. It

--- a/pkgs/tools/system/testdisk/default.nix
+++ b/pkgs/tools/system/testdisk/default.nix
@@ -46,7 +46,7 @@ assert enableQt -> qwt != null;
   meta = with stdenv.lib; {
     homepage = "https://www.cgsecurity.org/wiki/Main_Page";
     downloadPage = "https://www.cgsecurity.org/wiki/TestDisk_Download";
-    description = "Testdisk / Photorec - Data recovery utilities";
+    description = "Data recovery utilities";
     longDescription = ''
       TestDisk is a powerful free data recovery software. It was primarily
       designed to help recover lost partitions and/or make non-booting disks

--- a/pkgs/tools/text/jsawk/default.nix
+++ b/pkgs/tools/text/jsawk/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "Jsawk is like awk, but for JSON";
+    description = "Like awk, but for JSON";
     homepage = "https://github.com/micha/jsawk";
     license = stdenv.lib.licenses.publicDomain;
     maintainers = with stdenv.lib.maintainers; [ puffnfresh ];

--- a/pkgs/tools/text/miller/default.nix
+++ b/pkgs/tools/text/miller/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook flex libtool ];
 
   meta = with stdenv.lib; {
-    description = "Miller is like awk, sed, cut, join, and sort for name-indexed data such as CSV, TSV, and tabular JSON";
+    description = "Like awk, sed, cut, join, and sort for name-indexed data such as CSV, TSV, and tabular JSON";
     homepage    = "http://johnkerl.org/miller/";
     license     = licenses.bsd2;
     maintainers = with maintainers; [ mstarzyk ];

--- a/pkgs/tools/text/sift/default.nix
+++ b/pkgs/tools/text/sift/default.nix
@@ -17,7 +17,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   meta = with lib; {
-    description = "sift is a fast and powerful alternative to grep";
+    description = "A fast and powerful alternative to grep";
     homepage = "https://sift-tool.org";
     maintainers = [ maintainers.carlsverre ];
     license = licenses.gpl3;

--- a/pkgs/tools/typesetting/asciidoctorj/default.nix
+++ b/pkgs/tools/typesetting/asciidoctorj/default.nix
@@ -19,9 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = ''
-      AsciidoctorJ is the official library for running Asciidoctor on the JVM.
-    '';
+    description = "Official library for running Asciidoctor on the JVM";
     longDescription = ''
       AsciidoctorJ is the official library for running Asciidoctor on the JVM.
       Using AsciidoctorJ, you can convert AsciiDoc content or analyze the

--- a/pkgs/tools/typesetting/ted/default.nix
+++ b/pkgs/tools/typesetting/ted/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig zlib pcre xorg.xlibsWrapper xorg.libXpm libjpeg libtiff libpng gtk2 libpaper makeWrapper ];
 
   meta = with stdenv.lib; {
-    description = "Ted, an easy rich text processor";
+    description = "An easy rich text processor";
     longDescription = ''
       Ted is a text processor running under X Windows on Unix/Linux systems.
       Ted was developed as a standard easy light weight word processor, having


### PR DESCRIPTION
###### Motivation for this change
Part of #97685.

I edited the files by hand (!), roughly according to these rules

- "X is a(n) ..." -> "A(n) ..."
- "X, a(n) ..." -> "A(n) ..."
- fixed grammatical errors/minor rephrasing
- if the first word referred to a protocol/trademark, did not remove

I had to cleanup whitespace in three files, due to ofborg complaining.
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
