### PR TITLE
[20.09] treewide: mark broken for 20.09

### DIFF
--- a/pkgs/applications/audio/faust/faustlive.nix
+++ b/pkgs/applications/audio/faust/faustlive.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A standalone just-in-time Faust compiler";
     longDescription = ''
       FaustLive is a standalone just-in-time Faust compiler. It tries to bring

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -56,6 +56,7 @@ python3.pkgs.buildPythonApplication rec {
   preFixup = stdenv.lib.optionalString (kakasi != null) "gappsWrapperArgs+=(--prefix PATH : ${kakasi}/bin)";
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "GTK-based audio player written in Python, using the Mutagen tagging library";
     license = licenses.gpl2Plus;
 

--- a/pkgs/applications/editors/jucipp/default.nix
+++ b/pkgs/applications/editors/jucipp/default.nix
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
   version = "1.2.3";
 
   meta = {
+    broken = true;
     homepage = "https://github.com/cppit/jucipp";
     description = "A lightweight, platform independent C++-IDE with support for C++11, C++14, and experimental C++17 features depending on libclang version";
     license = licenses.mit;

--- a/pkgs/applications/kde/akonadi/default.nix
+++ b/pkgs/applications/kde/akonadi/default.nix
@@ -10,6 +10,7 @@ mkDerivation {
   meta = {
     license = [ lib.licenses.lgpl21 ];
     maintainers = kdepimTeam;
+    broken = lib.versionOlder (lib.getVersion qttools.name) "5.13";
   };
   patches = [
     ./0001-akonadi-paths.patch

--- a/pkgs/applications/kde/grantleetheme/default.nix
+++ b/pkgs/applications/kde/grantleetheme/default.nix
@@ -9,6 +9,7 @@ mkDerivation {
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
+    broken = lib.versionOlder qtbase.version "5.13";
   };
   output = [ "out" "dev" ];
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];

--- a/pkgs/applications/kde/kmime.nix
+++ b/pkgs/applications/kde/kmime.nix
@@ -9,6 +9,7 @@ mkDerivation {
   meta = {
     license = [ lib.licenses.lgpl21 ];
     maintainers = kdepimTeam;
+    broken = lib.versionOlder qtbase.version "5.13";
   };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kcodecs ki18n qtbase ];

--- a/pkgs/applications/kde/kpimtextedit.nix
+++ b/pkgs/applications/kde/kpimtextedit.nix
@@ -2,7 +2,7 @@
   mkDerivation, lib, kdepimTeam,
   extra-cmake-modules, kdoctools,
   grantlee, kcodecs, kconfigwidgets, kemoticons, ki18n, kiconthemes, kio,
-  kdesignerplugin, ktextwidgets, sonnet, syntax-highlighting, qttools, 
+  kdesignerplugin, ktextwidgets, sonnet, syntax-highlighting, qttools,
   qtspeech
 }:
 
@@ -11,6 +11,7 @@ mkDerivation {
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
+    broken = lib.versionOlder (lib.getVersion qttools.name) "5.13";
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [

--- a/pkgs/applications/kde/kpkpass.nix
+++ b/pkgs/applications/kde/kpkpass.nix
@@ -8,6 +8,7 @@ mkDerivation {
   meta = {
     license = with lib.licenses; [ lgpl21 ];
     maintainers = [ lib.maintainers.bkchr ];
+    broken = lib.versionOlder qtbase.version "5.13";
   };
   nativeBuildInputs = [ extra-cmake-modules shared-mime-info ];
   buildInputs = [ qtbase karchive ];

--- a/pkgs/applications/kde/libkgapi.nix
+++ b/pkgs/applications/kde/libkgapi.nix
@@ -10,6 +10,7 @@ mkDerivation {
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
+    broken = lib.versionOlder (lib.getVersion qtwebengine.name) "5.13";
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ qtwebengine kio kcalendarcore kcontacts cyrus_sasl ];

--- a/pkgs/applications/misc/kupfer/default.nix
+++ b/pkgs/applications/misc/kupfer/default.nix
@@ -47,6 +47,7 @@ buildPythonApplication rec {
   doCheck = false; # no tests
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A smart, quick launcher";
     homepage    = "https://kupferlauncher.github.io/";
     license     = licenses.gpl3;

--- a/pkgs/applications/misc/navit/default.nix
+++ b/pkgs/applications/misc/navit/default.nix
@@ -81,6 +81,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    broken = true;
     homepage = "https://www.navit-project.org";
     description = "Car navigation system with routing engine using OSM maps";
     license = licenses.gpl2;

--- a/pkgs/applications/misc/toggldesktop/default.nix
+++ b/pkgs/applications/misc/toggldesktop/default.nix
@@ -139,6 +139,7 @@ buildEnv {
   paths = [ desktopItem toggldesktop-icons toggldesktop-wrapped ];
 
   meta = with lib; {
+    broken = true;
     description = "Client for Toggl time tracking service";
     homepage = "https://github.com/toggl/toggldesktop";
     license = licenses.bsd3;

--- a/pkgs/applications/misc/valentina/default.nix
+++ b/pkgs/applications/misc/valentina/default.nix
@@ -57,6 +57,7 @@ mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
+    broken = true;
     description = "An open source sewing pattern drafting software";
     homepage = "https://valentinaproject.bitbucket.io/";
     license = licenses.gpl3;

--- a/pkgs/applications/misc/xmr-stak/default.nix
+++ b/pkgs/applications/misc/xmr-stak/default.nix
@@ -37,6 +37,7 @@ stdenv'.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Unified All-in-one Monero miner";
     homepage = "https://github.com/fireice-uk/xmr-stak";
     license = licenses.gpl3Plus;

--- a/pkgs/applications/networking/browsers/arora/default.nix
+++ b/pkgs/applications/networking/browsers/arora/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
+    broken = true;
     platforms = qt4.meta.platforms;
     maintainers = [ maintainers.phreedom ];
     description = "A cross-platform Qt4 Webkit browser";

--- a/pkgs/applications/networking/instant-messengers/amsn/default.nix
+++ b/pkgs/applications/networking/instant-messengers/amsn/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
+    broken = true;
     description = "Instant messaging (MSN Messenger clone)";
     homepage = "http://amsn-project.net";
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
   inherit (ocamlPackages.topkg) installPhase;
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = "https://github.com/hannesm/jackline";
     description = "minimalistic secure XMPP client in OCaml";
     license = licenses.bsd2;

--- a/pkgs/applications/networking/mumble/overlay.nix
+++ b/pkgs/applications/networking/mumble/overlay.nix
@@ -24,5 +24,6 @@ in stdenv.mkDerivation {
 
   meta = {
     platforms = stdenv.lib.platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/networking/nym/default.nix
+++ b/pkgs/applications/networking/nym/default.nix
@@ -43,6 +43,7 @@ rustPlatform.buildRustPackage rec {
   passthru.updateScript = ./update.sh;
 
   meta = with lib; {
+    broken = true;
     description = "A mixnet providing IP-level privacy";
     longDescription = ''
       Nym routes IP packets through other participating nodes to hide their source and destination.

--- a/pkgs/applications/networking/ostinato/default.nix
+++ b/pkgs/applications/networking/ostinato/default.nix
@@ -59,6 +59,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = false;
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A packet traffic generator and analyzer";
     homepage    = "https://ostinato.org";
     license     = licenses.gpl3;

--- a/pkgs/applications/office/zanshin/default.nix
+++ b/pkgs/applications/office/zanshin/default.nix
@@ -27,6 +27,7 @@ mkDerivation rec {
   ];
 
   meta = with lib; {
+    broken = true;
     description = "A powerful yet simple application to manage your day to day actions, getting your mind like water";
     homepage = "https://zanshin.kde.org/";
     maintainers = with maintainers; [ zraexy ];

--- a/pkgs/applications/science/biology/tebreak/default.nix
+++ b/pkgs/applications/science/biology/tebreak/default.nix
@@ -33,6 +33,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Find and characterise transposable element insertions";
     homepage = "https://github.com/adamewing/tebreak";
     license = licenses.mit;

--- a/pkgs/applications/science/electronics/dsview/default.nix
+++ b/pkgs/applications/science/electronics/dsview/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A GUI program for supporting various instruments from DreamSourceLab, including logic analyzer, oscilloscope, etc";
     homepage = "https://www.dreamsourcelab.com/";
     license = licenses.gpl3Plus;

--- a/pkgs/applications/science/logic/cedille/default.nix
+++ b/pkgs/applications/science/logic/cedille/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "An interactive theorem-prover and dependently typed programming language, based on extrinsic (aka Curry-style) type theory";
     homepage = "https://cedille.github.io/";
     license = licenses.mit;

--- a/pkgs/applications/science/logic/leo2/default.nix
+++ b/pkgs/applications/science/logic/leo2/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A high-performance typed higher order prover";
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;

--- a/pkgs/applications/science/logic/petrinizer/default.nix
+++ b/pkgs/applications/science/logic/petrinizer/default.nix
@@ -28,4 +28,5 @@ mkDerivation rec {
   description = "Safety and Liveness Analysis of Petri Nets with SMT solvers";
   license = stdenv.lib.licenses.gpl3;
   maintainers = with stdenv.lib.maintainers; [ raskin ];
+  broken = true;
 }

--- a/pkgs/applications/science/math/cntk/default.nix
+++ b/pkgs/applications/science/math/cntk/default.nix
@@ -93,9 +93,9 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
+    broken = true;
     # Newer cub is included with cudatoolkit now and it breaks the build.
     # https://github.com/Microsoft/CNTK/issues/3191
-    broken = cudaSupport;
     homepage = "https://github.com/Microsoft/CNTK";
     description = "An open source deep-learning toolkit";
     license = if onebitSGDSupport then licenses.unfreeRedistributable else licenses.mit;

--- a/pkgs/applications/science/math/sage/sage.nix
+++ b/pkgs/applications/science/math/sage/sage.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Open Source Mathematics Software, free alternative to Magma, Maple, Mathematica, and Matlab";
     license = licenses.gpl2;
     maintainers = with maintainers; [ timokau ];

--- a/pkgs/applications/virtualization/virt-manager/qt.nix
+++ b/pkgs/applications/virtualization/virt-manager/qt.nix
@@ -29,6 +29,7 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig qttools ];
 
   meta = with lib; {
+    broken = true;
     homepage    = "https://f1ash.github.io/qt-virt-manager";
     description = "Desktop user interface for managing virtual machines (QT)";
     longDescription = ''

--- a/pkgs/desktops/gnome-3/games/iagno/default.nix
+++ b/pkgs/desktops/gnome-3/games/iagno/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = "https://wiki.gnome.org/Apps/Iagno";
     description = "Computer version of the game Reversi, more popularly called Othello";
     maintainers = teams.gnome.members;

--- a/pkgs/development/compilers/avian/default.nix
+++ b/pkgs/development/compilers/avian/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    broken = true;
     description = "Lightweight Java virtual machine";
     longDescription = ''
       Avian is a lightweight virtual machine and class library designed

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -174,6 +174,7 @@ let
     };
 
     meta = with lib; {
+      broken = true;
       description = "A compiled language with Ruby like syntax and type inference";
       homepage = "https://crystal-lang.org/";
       license = licenses.asl20;

--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -271,6 +271,7 @@ in rec {
         --set    FINDBUGS_HOME ${findbugs}
     '';
     meta = with stdenv.lib; {
+      broken = true;
       homepage = "https://github.com/graalvm/mx";
       description = "Command-line tool used for the development of Graal projects";
       license = licenses.gpl2;
@@ -528,6 +529,7 @@ in rec {
     passthru.home = graalvm8;
 
     meta = with stdenv.lib; {
+      broken = true;
       homepage = "https://github.com/oracle/graal";
       description = "High-Performance Polyglot VM";
       license = licenses.gpl2;

--- a/pkgs/development/compilers/julia/1.3.nix
+++ b/pkgs/development/compilers/julia/1.3.nix
@@ -150,11 +150,11 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
+    broken = true;
     description = "High-level performance-oriented dynamical language for technical computing";
     homepage = "https://julialang.org/";
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ raskin rob garrison ];
     platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
-    broken = stdenv.isi686;
   };
 }

--- a/pkgs/development/compilers/julia/shared.nix
+++ b/pkgs/development/compilers/julia/shared.nix
@@ -200,11 +200,11 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
+    broken = true;
     description = "High-level performance-oriented dynamical language for technical computing";
     homepage = "https://julialang.org/";
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ raskin rob garrison ];
     platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
-    broken = stdenv.isi686;
   };
 }

--- a/pkgs/development/compilers/julia/shared.nix
+++ b/pkgs/development/compilers/julia/shared.nix
@@ -200,7 +200,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    broken = true;
+    broken = true; # yes, all versions are currently broken
     description = "High-level performance-oriented dynamical language for technical computing";
     homepage = "https://julialang.org/";
     license = stdenv.lib.licenses.mit;

--- a/pkgs/development/compilers/seexpr/default.nix
+++ b/pkgs/development/compilers/seexpr/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ cmake libGLU libpng zlib qt4 pythonPackages.pyqt4 bison flex ];
   meta = with stdenv.lib; {
+    broken = true;
     description = "Embeddable expression evaluation engine from Disney Animation";
     homepage = "https://www.disneyanimation.com/technology/seexpr.html";
     maintainers = with maintainers; [ hodapp ];

--- a/pkgs/development/idris-modules/data.nix
+++ b/pkgs/development/idris-modules/data.nix
@@ -17,6 +17,7 @@ build-idris-package  {
   };
 
   meta = {
+    broken = true;
     description = "Functional data structures in Idris";
     homepage = "https://github.com/jdevuyst/idris-data";
     license = lib.licenses.bsd3;

--- a/pkgs/development/idris-modules/pacman.nix
+++ b/pkgs/development/idris-modules/pacman.nix
@@ -22,6 +22,7 @@ build-idris-package  {
   '';
 
   meta = {
+    broken = true;
     description = "Proof that Idris is pacman complete";
     homepage = "https://github.com/jdublu10/pacman";
     maintainers = [ lib.maintainers.brainrape ];

--- a/pkgs/development/idris-modules/sdl2.nix
+++ b/pkgs/development/idris-modules/sdl2.nix
@@ -28,6 +28,7 @@ build-idris-package rec {
   };
 
   meta = {
+    broken = true;
     description = "SDL2 binding for Idris";
     homepage = "https://github.com/steshaw/idris-sdl2";
     maintainers = with lib.maintainers; [

--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A Clojure babushka for the grey areas of Bash";
     longDescription = ''
       The main idea behind babashka is to leverage Clojure in places where you

--- a/pkgs/development/libraries/folly/default.nix
+++ b/pkgs/development/libraries/folly/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "An open-source C++ library developed and used at Facebook";
     homepage = "https://github.com/facebook/folly";
     license = licenses.asl20;

--- a/pkgs/development/libraries/google-cloud-cpp/default.nix
+++ b/pkgs/development/libraries/google-cloud-cpp/default.nix
@@ -54,6 +54,7 @@ in stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
+    broken = true;
     license = with licenses; [ asl20 ];
     homepage = "https://github.com/googleapis/google-cloud-cpp";
     description = "C++ Idiomatic Clients for Google Cloud Platform services";

--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -84,6 +84,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Tools for accessing and modifying virtual machine disk images";
     license = with licenses; [ gpl2 lgpl21 ];
     homepage = "http://libguestfs.org/";

--- a/pkgs/development/libraries/libjson-rpc-cpp/default.nix
+++ b/pkgs/development/libraries/libjson-rpc-cpp/default.nix
@@ -59,6 +59,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "C++ framework for json-rpc (json remote procedure call)";
     homepage = "https://github.com/cinemast/libjson-rpc-cpp";
     license = licenses.mit;

--- a/pkgs/development/libraries/qtscriptgenerator/default.nix
+++ b/pkgs/development/libraries/qtscriptgenerator/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation {
   hardeningDisable = [ "format" ];
 
   meta = {
+    broken = true;
     description = "QtScript bindings generator";
     homepage = "https://code.qt.io/cgit/qt-labs/qtscriptgenerator.git/";
     inherit (qt4.meta) platforms;

--- a/pkgs/development/libraries/science/math/tensorflow/bin.nix
+++ b/pkgs/development/libraries/science/math/tensorflow/bin.nix
@@ -10,7 +10,7 @@ let
 
   tfType = if cudaSupport then "gpu" else "cpu";
 
-  system = 
+  system =
     if      stdenv.isLinux  then "linux"
     else if stdenv.isDarwin then "darwin"
     else unavailable;
@@ -73,5 +73,6 @@ in stdenv.mkDerivation rec {
     license = licenses.asl20;
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ basvandijk ];
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/swiftshader/default.nix
+++ b/pkgs/development/libraries/swiftshader/default.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description =
       "A high-performance CPU-based implementation of the Vulkan, OpenGL ES, and Direct3D 9 graphics APIs";
     homepage = "https://opensource.google/projects/swiftshader";

--- a/pkgs/development/misc/qmk_firmware/default.nix
+++ b/pkgs/development/misc/qmk_firmware/default.nix
@@ -36,4 +36,5 @@ in stdenv.mkDerivation {
     dfu-programmer
     dfu-util
   ];
+  meta.broken = true;
 }

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -175,6 +175,7 @@ let
 
         self.node-pre-gyp
       ];
+      meta.broken = true;
     };
 
     thelounge = super.thelounge.override {

--- a/pkgs/development/python-modules/JPype1/default.nix
+++ b/pkgs/development/python-modules/JPype1/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/originell/jpype/";
     license = licenses.asl20;
     description = "A Python to Java bridge";
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/JayDeBeApi/default.nix
+++ b/pkgs/development/python-modules/JayDeBeApi/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/baztian/jaydebeapi";
     license = licenses.lgpl2;
     description = "Use JDBC database drivers from Python 2/3 or Jython with a DB-API";
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/Nikola/default.nix
+++ b/pkgs/development/python-modules/Nikola/default.nix
@@ -68,6 +68,7 @@ buildPythonPackage rec {
   '';
 
   meta = {
+    broken = true;
     homepage = "https://getnikola.com/";
     description = "A modular, fast, simple, static website and blog generator";
     license = lib.licenses.mit;

--- a/pkgs/development/python-modules/WSME/default.nix
+++ b/pkgs/development/python-modules/WSME/default.nix
@@ -42,6 +42,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
+    broken = true;
     description = "Simplify the writing of REST APIs, and extend them with additional protocols";
     homepage = "http://git.openstack.org/cgit/openstack/wsme";
     license = licenses.mit;

--- a/pkgs/development/python-modules/agate-sql/default.nix
+++ b/pkgs/development/python-modules/agate-sql/default.nix
@@ -12,6 +12,7 @@ buildPythonPackage rec {
     propagatedBuildInputs = [ agate sqlalchemy ];
 
     meta = with stdenv.lib; {
+      broken = true;
       description = "Adds SQL read/write support to agate.";
       homepage    = "https://github.com/wireservice/agate-sql";
       license     = with licenses; [ mit ];

--- a/pkgs/development/python-modules/avro-python3/default.nix
+++ b/pkgs/development/python-modules/avro-python3/default.nix
@@ -13,6 +13,7 @@ buildPythonPackage rec {
   doCheck = false;        # No such file or directory: './run_tests.py
 
   meta = with lib; {
+    broken = true;
     description = "A serialization and RPC framework";
     homepage = "https://pypi.python.org/pypi/avro-python3/";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/bayesian-optimization/default.nix
+++ b/pkgs/development/python-modules/bayesian-optimization/default.nix
@@ -29,6 +29,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "A Python implementation of global optimization with gaussian processes";
     homepage = "https://github.com/fmfn/BayesianOptimization";
     license = licenses.mit;

--- a/pkgs/development/python-modules/block-io/default.nix
+++ b/pkgs/development/python-modules/block-io/default.nix
@@ -28,6 +28,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Integrate Bitcoin, Dogecoin and Litecoin in your Python applications using block.io";
     homepage = "https://github.com/BlockIo/block_io-python";
     license = licenses.mit;

--- a/pkgs/development/python-modules/browser-cookie3/default.nix
+++ b/pkgs/development/python-modules/browser-cookie3/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
+    broken = true;
     description = "Loads cookies from your browser into a cookiejar object";
     maintainers = with maintainers; [ borisbabic ];
     homepage = "https://github.com/borisbabic/browser_cookie3";

--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -39,6 +39,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "A Python client driver for Apache Cassandra";
     homepage = "http://datastax.github.io/python-driver";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/cma/default.nix
+++ b/pkgs/development/python-modules/cma/default.nix
@@ -25,6 +25,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "CMA-ES, Covariance Matrix Adaptation Evolution Strategy for non-linear numerical optimization in Python";
     homepage = "https://github.com/CMA-ES/pycma";
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/cntk/default.nix
+++ b/pkgs/development/python-modules/cntk/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage {
 
   meta = {
     inherit (cntk.meta) homepage description license maintainers platforms;
-    # doesn't support Python 3.7
-    broken = lib.versionAtLeast python.version "3.7";
+    # doesn't support Python 3.7, 2.7
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/consonance/default.nix
+++ b/pkgs/development/python-modules/consonance/default.nix
@@ -1,10 +1,11 @@
 { buildPythonPackage, lib, fetchFromGitHub, pytest, dissononce, python-axolotl-curve25519
-, transitions, protobuf, nose
+, transitions, protobuf, nose, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "consonance";
   version = "0.1.3";
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "tgalal";

--- a/pkgs/development/python-modules/dependency-injector/default.nix
+++ b/pkgs/development/python-modules/dependency-injector/default.nix
@@ -24,6 +24,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Dependency injection microframework for Python";
     homepage = "https://github.com/ets-labs/python-dependency-injector";
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/django-sampledatahelper/default.nix
+++ b/pkgs/development/python-modules/django-sampledatahelper/default.nix
@@ -7,6 +7,7 @@ buildPythonPackage rec {
   version = "0.5";
 
   meta = {
+    broken = true;
     description = "Helper class for generate sample data for django apps development";
     homepage = "https://github.com/kaleidos/django-sampledatahelper";
     license = lib.licenses.bsd3;

--- a/pkgs/development/python-modules/ecpy/default.nix
+++ b/pkgs/development/python-modules/ecpy/default.nix
@@ -3,6 +3,7 @@
 buildPythonPackage rec {
   pname = "ECPy";
   version = "1.2.3";
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/flask-migrate/default.nix
+++ b/pkgs/development/python-modules/flask-migrate/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     description = "SQLAlchemy database migrations for Flask applications using Alembic";
     license = licenses.mit;
     homepage = "https://github.com/miguelgrinberg/Flask-Migrate";
+    broken = !isPy3k;
   };
 }

--- a/pkgs/development/python-modules/gipc/default.nix
+++ b/pkgs/development/python-modules/gipc/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ gevent ];
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "gevent-cooperative child processes and IPC";
     longDescription = ''
       Usage of Python's multiprocessing package in a gevent-powered

--- a/pkgs/development/python-modules/google_cloud_bigquery/default.nix
+++ b/pkgs/development/python-modules/google_cloud_bigquery/default.nix
@@ -35,6 +35,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Google BigQuery API client library";
     homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/google_cloud_container/default.nix
+++ b/pkgs/development/python-modules/google_cloud_container/default.nix
@@ -24,6 +24,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Google Container Engine API client library";
     homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/google_cloud_kms/default.nix
+++ b/pkgs/development/python-modules/google_cloud_kms/default.nix
@@ -25,6 +25,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Cloud Key Management Service (KMS) API API client library";
     homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/google_cloud_spanner/default.nix
+++ b/pkgs/development/python-modules/google_cloud_spanner/default.nix
@@ -28,6 +28,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Cloud Spanner API client library";
     homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/google_cloud_texttospeech/default.nix
+++ b/pkgs/development/python-modules/google_cloud_texttospeech/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Google Cloud Text-to-Speech API client library";
     homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/google_cloud_translate/default.nix
+++ b/pkgs/development/python-modules/google_cloud_translate/default.nix
@@ -27,6 +27,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Google Cloud Translation API client library";
     homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/google_cloud_websecurityscanner/default.nix
+++ b/pkgs/development/python-modules/google_cloud_websecurityscanner/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Google Cloud Web Security Scanner API client library";
     homepage = "https://github.com/GoogleCloudPlatform/google-cloud-python";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/graph_nets/default.nix
+++ b/pkgs/development/python-modules/graph_nets/default.nix
@@ -41,5 +41,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/deepmind/graph_nets";
     license = licenses.asl20;
     maintainers = with maintainers; [ timokau ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/h3/default.nix
+++ b/pkgs/development/python-modules/h3/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = "https://github.com/uber/h3-py";
     description = "This library provides Python bindings for the H3 Core Library.";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/hmmlearn/default.nix
+++ b/pkgs/development/python-modules/hmmlearn/default.nix
@@ -18,6 +18,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Hidden Markov Models in Python with scikit-learn like API";
     homepage    = "https://github.com/hmmlearn/hmmlearn";
     license     = licenses.bsd3;

--- a/pkgs/development/python-modules/hug/default.nix
+++ b/pkgs/development/python-modules/hug/default.nix
@@ -31,6 +31,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "A Python framework that makes developing APIs as simple as possible, but no simpler";
     homepage = "https://github.com/timothycrosley/hug";
     license = licenses.mit;

--- a/pkgs/development/python-modules/imbalanced-learn/default.nix
+++ b/pkgs/development/python-modules/imbalanced-learn/default.nix
@@ -29,6 +29,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Library offering a number of re-sampling techniques commonly used in datasets showing strong between-class imbalance";
     homepage = "https://github.com/scikit-learn-contrib/imbalanced-learn";
     license = licenses.mit;

--- a/pkgs/development/python-modules/impacket/default.nix
+++ b/pkgs/development/python-modules/impacket/default.nix
@@ -20,5 +20,6 @@ buildPythonPackage rec {
     # Modified Apache Software License, Version 1.1
     license = licenses.free;
     maintainers = with maintainers; [ peterhoeg ];
+    broken = !isPy3k;
   };
 }

--- a/pkgs/development/python-modules/iterm2/default.nix
+++ b/pkgs/development/python-modules/iterm2/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "iterm2" ];
 
   meta = with lib; {
+    broken = true;
     description = "Python interface to iTerm2's scripting API";
     homepage = "http://github.com/gnachman/iTerm2";
     license = licenses.gpl2;

--- a/pkgs/development/python-modules/jupytext/default.nix
+++ b/pkgs/development/python-modules/jupytext/default.nix
@@ -31,6 +31,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Jupyter notebooks as Markdown documents, Julia, Python or R scripts";
     homepage = "https://github.com/mwouts/jupytext";
     license = licenses.mit;

--- a/pkgs/development/python-modules/labelbox/default.nix
+++ b/pkgs/development/python-modules/labelbox/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
+    broken = true;
     homepage = "https://github.com/Labelbox/Labelbox";
     description = "Platform API for LabelBox";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/locustio/default.nix
+++ b/pkgs/development/python-modules/locustio/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, fetchFromGitHub, isPy38
+{ buildPythonPackage, fetchFromGitHub, isPy38, isPy3k
 , flask
 , gevent
 , mock
@@ -22,6 +22,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ msgpack requests flask gevent pyzmq ];
+  doCheck = isPy3k;
   checkInputs = [ mock unittest2 ];
   # remove file which attempts to do GET request
   preCheck = ''

--- a/pkgs/development/python-modules/macropy/default.nix
+++ b/pkgs/development/python-modules/macropy/default.nix
@@ -30,6 +30,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
+    broken = true;
     homepage = "https://github.com/lihaoyi/macropy";
     description = "Macros in Python: quasiquotes, case classes, LINQ and more";
     license = licenses.mit;

--- a/pkgs/development/python-modules/markdownsuperscript/default.nix
+++ b/pkgs/development/python-modules/markdownsuperscript/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   checkInputs = [ pytest pytestrunner pytestcov coverage ];
 
   meta = {
+    broken = true;
     description = "An extension to the Python Markdown package enabling superscript text";
     homepage = "https://github.com/jambonrose/markdown_superscript_extension";
     license = stdenv.lib.licenses.bsd2;

--- a/pkgs/development/python-modules/mlrose/default.nix
+++ b/pkgs/development/python-modules/mlrose/default.nix
@@ -17,6 +17,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Machine Learning, Randomized Optimization and SEarch";
     homepage    = "https://github.com/gkhayes/mlrose";
     license     = licenses.bsd3;

--- a/pkgs/development/python-modules/msal-extensions/default.nix
+++ b/pkgs/development/python-modules/msal-extensions/default.nix
@@ -1,10 +1,12 @@
 { buildPythonPackage
 , fetchPypi
 , lib
+, isPy27
 
 # pythonPackages
 , msal
 , portalocker
+, pathlib2
 }:
 
 buildPythonPackage rec {
@@ -19,6 +21,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     msal
     portalocker
+  ] ++ lib.optionals isPy27 [
+    pathlib2
   ];
 
   # No tests found

--- a/pkgs/development/python-modules/myfitnesspal/default.nix
+++ b/pkgs/development/python-modules/myfitnesspal/default.nix
@@ -21,6 +21,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ blessed keyring keyrings-alt lxml measurement python-dateutil requests six ];
 
   meta = with lib; {
+    broken = true;
     description = "Access your meal tracking data stored in MyFitnessPal programatically";
     homepage = "https://github.com/coddingtonbear/python-myfitnesspal";
     license = licenses.mit;

--- a/pkgs/development/python-modules/mysqlclient/default.nix
+++ b/pkgs/development/python-modules/mysqlclient/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, buildPythonPackage, fetchPypi, libmysqlclient }:
+{ stdenv, buildPythonPackage, isPy27, fetchPypi, libmysqlclient }:
 
 buildPythonPackage rec {
   pname = "mysqlclient";
   version = "2.0.1";
+  disabled = isPy27;
 
   nativeBuildInputs = [
     libmysqlclient

--- a/pkgs/development/python-modules/nbconflux/default.nix
+++ b/pkgs/development/python-modules/nbconflux/default.nix
@@ -1,8 +1,9 @@
-{ lib, buildPythonPackage, fetchFromGitHub, nbconvert, pytest, requests, responses }:
+{ lib, buildPythonPackage, isPy27, fetchFromGitHub, nbconvert, pytest, requests, responses }:
 
 buildPythonPackage rec {
   pname = "nbconflux";
   version = "0.7.0";
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "Valassis-Digital-Media";

--- a/pkgs/development/python-modules/nixpkgs/default.nix
+++ b/pkgs/development/python-modules/nixpkgs/default.nix
@@ -24,6 +24,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/t184256/nixpkgs-python-importer";
     license = licenses.mit;
     maintainers = with maintainers; [ t184256 ];
+    broken = true;
   };
 
 }

--- a/pkgs/development/python-modules/pg8000/default.nix
+++ b/pkgs/development/python-modules/pg8000/default.nix
@@ -19,6 +19,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ passlib ];
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = "https://github.com/tlocke/pg8000";
     description = "PostgreSQL interface library, for asyncio";
     maintainers = with maintainers; [ domenkozar ];

--- a/pkgs/development/python-modules/piep/default.nix
+++ b/pkgs/development/python-modules/piep/default.nix
@@ -18,6 +18,7 @@ buildPythonPackage rec {
   checkInputs = [ nose ];
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Bringing the power of python to stream editing";
     homepage = "https://github.com/timbertson/piep";
     maintainers = with maintainers; [ timbertson ];

--- a/pkgs/development/python-modules/piexif/default.nix
+++ b/pkgs/development/python-modules/piexif/default.nix
@@ -14,6 +14,7 @@ buildPythonPackage rec {
   };
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Simplify Exif manipulations with Python";
     homepage = "https://github.com/hMatoba/Piexif";
     license = licenses.mit;

--- a/pkgs/development/python-modules/plaster-pastedeploy/default.nix
+++ b/pkgs/development/python-modules/plaster-pastedeploy/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, fetchPypi, fetchpatch
+{ buildPythonPackage, fetchPypi, fetchpatch, isPy27
 , plaster, PasteDeploy
 , pytest, pytestcov
 }:
@@ -6,6 +6,7 @@
 buildPythonPackage rec {
   pname = "plaster_pastedeploy";
   version = "0.6";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/premailer/default.nix
+++ b/pkgs/development/python-modules/premailer/default.nix
@@ -1,10 +1,11 @@
-{ lib, buildPythonPackage, fetchPypi,
-  cssselect, cssutils, lxml, mock, nose, requests, cachetools
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, cssselect, cssutils, lxml, mock, nose, requests, cachetools
 }:
 
 buildPythonPackage rec {
   pname = "premailer";
   version = "3.7.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pushover-complete/default.nix
+++ b/pkgs/development/python-modules/pushover-complete/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , requests
 , six
 , tox
@@ -11,6 +12,7 @@
 buildPythonPackage rec {
   pname = "pushover-complete";
   version = "1.1.1";
+  disabled = isPy27;
 
   src = fetchPypi {
     pname = "pushover_complete";

--- a/pkgs/development/python-modules/py-multihash/default.nix
+++ b/pkgs/development/python-modules/py-multihash/default.nix
@@ -41,6 +41,7 @@ buildPythonPackage rec {
   disabled = isPy27;
 
   meta = with lib; {
+    broken = true;
     description = "Self describing hashes - for future proofing";
     homepage = "https://github.com/multiformats/py-multihash";
     license = licenses.mit;

--- a/pkgs/development/python-modules/pyatv/default.nix
+++ b/pkgs/development/python-modules/pyatv/default.nix
@@ -46,6 +46,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A python client library for the Apple TV";
     homepage = "https://github.com/postlund/pyatv";
     license = licenses.mit;

--- a/pkgs/development/python-modules/pyside/default.nix
+++ b/pkgs/development/python-modules/pyside/default.nix
@@ -20,6 +20,7 @@ buildPythonPackage rec {
   makeFlags = [ "QT_PLUGIN_PATH=${pysideShiboken}/lib/generatorrunner" ];
 
   meta = {
+    broken = true;
     description = "LGPL-licensed Python bindings for the Qt cross-platform application and UI framework";
     license = lib.licenses.lgpl21;
     homepage = "http://www.pyside.org";

--- a/pkgs/development/python-modules/pyside/shiboken.nix
+++ b/pkgs/development/python-modules/pyside/shiboken.nix
@@ -30,6 +30,7 @@ buildPythonPackage rec {
   cmakeFlags = lib.optional isPy3k "-DUSE_PYTHON3=TRUE";
 
   meta = {
+    broken = true;
     description = "Plugin (front-end) for pyside-generatorrunner, that generates bindings for C++ libraries using CPython source code";
     license = lib.licenses.gpl2;
     homepage = "http://www.pyside.org/docs/shiboken/";

--- a/pkgs/development/python-modules/pyside/tools.nix
+++ b/pkgs/development/python-modules/pyside/tools.nix
@@ -19,6 +19,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ pyside pysideShiboken ];
 
   meta = with lib; {
+    broken = true;
     description = "Development tools (pyside-uic/rcc/lupdate) for PySide, the LGPL-licensed Python bindings for the Qt framework";
     license = licenses.gpl2;
     homepage = "https://wiki.qt.io/PySide";

--- a/pkgs/development/python-modules/pytest-services/default.nix
+++ b/pkgs/development/python-modules/pytest-services/default.nix
@@ -12,6 +12,7 @@
 buildPythonPackage rec {
   pname = "pytest-services";
   version = "2.1.0";
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/python-axolotl/default.nix
+++ b/pkgs/development/python-modules/python-axolotl/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, cryptography, python-axolotl-curve25519, protobuf }:
+{ lib, buildPythonPackage, fetchPypi, isPy3k, cryptography, python-axolotl-curve25519, protobuf }:
 
 buildPythonPackage rec {
   pname = "python-axolotl";
@@ -10,6 +10,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ cryptography python-axolotl-curve25519 protobuf ];
+  doCheck = isPy3k;
 
   meta = with lib; {
     homepage = "https://github.com/tgalal/python-axolotl";

--- a/pkgs/development/python-modules/python-miio/default.nix
+++ b/pkgs/development/python-modules/python-miio/default.nix
@@ -30,6 +30,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Python library for interfacing with Xiaomi smart appliances";
     homepage = "https://github.com/rytilahti/python-miio";
     license = licenses.gpl3;

--- a/pkgs/development/python-modules/pythonmagick/default.nix
+++ b/pkgs/development/python-modules/pythonmagick/default.nix
@@ -33,11 +33,10 @@ buildPythonPackage rec {
     "PythonMagick"
   ];
 
-  disabled = isPy3k;
-
   meta = with lib; {
     homepage = "http://www.imagemagick.org/script/api.php";
     license = licenses.imagemagick;
     description = "PythonMagick provides object oriented bindings for the ImageMagick Library.";
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pywbem/default.nix
+++ b/pkgs/development/python-modules/pywbem/default.nix
@@ -49,6 +49,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Support for the WBEM standard for systems management";
     homepage = "https://pywbem.github.io";
     license = licenses.lgpl21Plus;

--- a/pkgs/development/python-modules/repoze_who/default.nix
+++ b/pkgs/development/python-modules/repoze_who/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , zope_interface
 , webob
 }:
@@ -8,6 +9,7 @@
 buildPythonPackage rec {
   pname = "repoze.who";
   version = "2.4";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/robotframework-tools/default.nix
+++ b/pkgs/development/python-modules/robotframework-tools/default.nix
@@ -42,6 +42,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Python Tools for Robot Framework and Test Libraries";
     homepage = "https://bitbucket.org/userzimmermann/robotframework-tools";
     license = licenses.gpl3;

--- a/pkgs/development/python-modules/rpy2/default.nix
+++ b/pkgs/development/python-modules/rpy2/default.nix
@@ -98,6 +98,7 @@ buildPythonPackage rec {
     ];
 
     meta = {
+      broken = true;
       homepage = "http://rpy.sourceforge.net/rpy2";
       description = "Python interface to R";
       license = lib.licenses.gpl2Plus;

--- a/pkgs/development/python-modules/rubymarshal/default.nix
+++ b/pkgs/development/python-modules/rubymarshal/default.nix
@@ -13,6 +13,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ hypothesis ];
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = "https://github.com/d9pouces/RubyMarshal/";
     description = "Read and write Ruby-marshalled data";
     license = licenses.wtfpl;

--- a/pkgs/development/python-modules/scikit-tda/default.nix
+++ b/pkgs/development/python-modules/scikit-tda/default.nix
@@ -56,6 +56,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
+    broken = true;
     description = "Topological Data Analysis for humans";
     homepage = "https://github.com/scikit-tda/scikit-tda";
     license = licenses.mit;

--- a/pkgs/development/python-modules/scikits-odes/default.nix
+++ b/pkgs/development/python-modules/scikits-odes/default.nix
@@ -17,6 +17,7 @@
 buildPythonPackage rec {
   pname = "scikits.odes";
   version = "2.6.1";
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/serpent/default.nix
+++ b/pkgs/development/python-modules/serpent/default.nix
@@ -12,13 +12,12 @@
 buildPythonPackage rec {
   pname = "serpent";
   version = "1.30.2";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "72753820246a7d8486e8b385353e3bbf769abfceec2e850fa527a288b084ff7a";
   };
-
-  propagatedBuildInputs = lib.optionals isPy27 [ enum34 ];
 
   checkInputs = [ attrs pytz ];
   checkPhase = ''

--- a/pkgs/development/python-modules/shortuuid/default.nix
+++ b/pkgs/development/python-modules/shortuuid/default.nix
@@ -1,12 +1,14 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , pep8
 }:
 
 buildPythonPackage rec {
   pname = "shortuuid";
   version = "1.0.1";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/shouldbe/default.nix
+++ b/pkgs/development/python-modules/shouldbe/default.nix
@@ -18,6 +18,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ forbiddenfruit ];
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Python Assertion Helpers inspired by Shouldly";
     homepage =  "https://pypi.python.org/pypi/shouldbe/";
     license = licenses.mit;

--- a/pkgs/development/python-modules/showit/default.nix
+++ b/pkgs/development/python-modules/showit/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, isPy27
 , numpy
 , matplotlib
 , pytest
@@ -9,6 +10,7 @@
 buildPythonPackage rec {
   pname = "showit";
   version = "1.1.4";
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "freeman-lab";

--- a/pkgs/development/python-modules/skein/default.nix
+++ b/pkgs/development/python-modules/skein/default.nix
@@ -30,6 +30,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = "https://jcristharif.com/skein";
     description = "A tool and library for easily deploying applications on Apache YARN";
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/slither-analyzer/default.nix
+++ b/pkgs/development/python-modules/slither-analyzer/default.nix
@@ -27,6 +27,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Static Analyzer for Solidity";
     longDescription = ''
       Slither is a Solidity static analysis framework written in Python 3. It

--- a/pkgs/development/python-modules/sphinxcontrib-devhelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-devhelp/default.nix
@@ -1,17 +1,18 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "sphinxcontrib-devhelp";
   version = "1.0.2";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4";
   };
-
 
   # Check is disabled due to circular dependency of sphinx
   doCheck = false;

--- a/pkgs/development/python-modules/sphinxcontrib-openapi/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-openapi/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , setuptools_scm
 , m2r
 , pyyaml
@@ -11,6 +12,7 @@
 buildPythonPackage rec {
   pname = "sphinxcontrib-openapi";
   version = "0.7.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/sphinxcontrib-spelling/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-spelling/default.nix
@@ -1,7 +1,10 @@
 { stdenv
+, lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , sphinx
+, importlib-metadata
 , pyenchant
 , pbr
 }:
@@ -15,7 +18,8 @@ buildPythonPackage rec {
     sha256 = "c8250ff02e6033c3aeabc41e91dc185168fecefb0c5722aaa3e2055a829e1e4c";
   };
 
-  propagatedBuildInputs = [ sphinx pyenchant pbr ];
+  propagatedBuildInputs = [ sphinx pyenchant pbr ]
+    ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   # No tests included
   doCheck = false;

--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -7,6 +7,7 @@
 buildPythonPackage rec {
   pname = "SQLAlchemy";
   version = "1.3.19";
+  #disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/sseclient/default.nix
+++ b/pkgs/development/python-modules/sseclient/default.nix
@@ -1,10 +1,11 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, isPy27
 , requests, six
 , backports_unittest-mock, pytestCheckHook, pytestrunner }:
 
 buildPythonPackage rec {
   pname = "sseclient";
   version = "0.0.26";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/tarman/default.nix
+++ b/pkgs/development/python-modules/tarman/default.nix
@@ -11,7 +11,6 @@
 buildPythonPackage rec {
   version = "0.1.3";
   pname = "tarman";
-
   disabled = isPy3k;
 
   src = fetchPypi {
@@ -29,6 +28,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/matejc/tarman";
     description = "Archive manager with curses interface";
     license = licenses.bsd0;
+    broken = true; # doesn't unpack correctly
   };
 
 }

--- a/pkgs/development/python-modules/tasklib/default.nix
+++ b/pkgs/development/python-modules/tasklib/default.nix
@@ -1,4 +1,4 @@
-{ lib, pythonPackages, taskwarrior, writeShellScriptBin }:
+{ lib, pythonPackages, taskwarrior, writeShellScriptBin, isPy27 }:
 
 with pythonPackages;
 
@@ -9,6 +9,7 @@ wsl_stub = writeShellScriptBin "wsl" "true";
 in buildPythonPackage rec {
   pname = "tasklib";
   version = "2.2.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/tensorboardx/default.nix
+++ b/pkgs/development/python-modules/tensorboardx/default.nix
@@ -22,6 +22,7 @@ buildPythonPackage rec {
   disabledTests = [ "test_TorchVis"  "test_onnx_graph" ];
 
   meta = with lib; {
+    broken = true;
     description = "Library for writing tensorboard-compatible logs";
     homepage = "https://github.com/lanpa/tensorboardX";
     license = licenses.mit;

--- a/pkgs/development/python-modules/tensorflow/1/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/1/bin.nix
@@ -114,8 +114,6 @@ in buildPythonPackage {
     license = licenses.asl20;
     maintainers = with maintainers; [ jyp abbradar ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
-    # Python 2.7 build uses different string encoding.
-    # See https://github.com/NixOS/nixpkgs/pull/37044#issuecomment-373452253
-    broken = stdenv.isDarwin && !isPy3k;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/tensorflow/2/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/2/bin.nix
@@ -180,8 +180,6 @@ in buildPythonPackage {
     license = licenses.asl20;
     maintainers = with maintainers; [ jyp abbradar cdepillabout ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
-    # Python 2.7 build uses different string encoding.
-    # See https://github.com/NixOS/nixpkgs/pull/37044#issuecomment-373452253
-    broken = stdenv.isDarwin && !isPy3k;
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/tifffile/default.nix
+++ b/pkgs/development/python-modules/tifffile/default.nix
@@ -14,6 +14,7 @@
 buildPythonPackage rec {
   pname = "tifffile";
   version = "2020.8.25";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/tiros/default.nix
+++ b/pkgs/development/python-modules/tiros/default.nix
@@ -17,4 +17,6 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [ semantic-version boto3 flask docutils requests ];
+
+  meta.broken = true;
 }

--- a/pkgs/development/python-modules/transaction/default.nix
+++ b/pkgs/development/python-modules/transaction/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchPypi
+, isPy27
 , buildPythonPackage
 , zope_interface
 , mock
@@ -9,6 +10,7 @@
 buildPythonPackage rec {
   pname = "transaction";
   version = "3.0.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/umap-learn/default.nix
+++ b/pkgs/development/python-modules/umap-learn/default.nix
@@ -41,6 +41,7 @@ def test_umap_transform_on_iris()"
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Uniform Manifold Approximation and Projection";
     homepage = "https://github.com/lmcinnes/umap";
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/update_checker/default.nix
+++ b/pkgs/development/python-modules/update_checker/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, buildPythonPackage, fetchPypi, requests}:
+{ stdenv, buildPythonPackage, fetchPypi, isPy27, requests}:
 
 buildPythonPackage rec {
   pname = "update_checker";
   version = "0.18.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/vmprof/default.nix
+++ b/pkgs/development/python-modules/vmprof/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , colorama
 , libunwind
 , pytz
@@ -28,5 +29,6 @@ buildPythonPackage rec {
     description = "A vmprof client";
     license = licenses.mit;
     homepage = "https://vmprof.readthedocs.org/";
+    broken = isPy27;
   };
 }

--- a/pkgs/development/python-modules/web/default.nix
+++ b/pkgs/development/python-modules/web/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
     homepage = "https://webpy.org/";
     license = licenses.publicDomain;
     maintainers = with maintainers; [ layus ];
+    broken = true;
   };
 
 }

--- a/pkgs/development/python-modules/yappi/default.nix
+++ b/pkgs/development/python-modules/yappi/default.nix
@@ -15,6 +15,7 @@ buildPythonPackage rec {
   checkInputs = [ nose ];
 
   meta = with lib; {
+    broken = true;
     homepage = "https://github.com/sumerc/yappi";
     description = "Python profiler that supports multithreading and measuring CPU time";
     license = licenses.mit;

--- a/pkgs/development/python-modules/yattag/default.nix
+++ b/pkgs/development/python-modules/yattag/default.nix
@@ -1,8 +1,9 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchPypi, isPy27 }:
 
 buildPythonPackage rec {
   pname = "yattag";
   version = "1.14.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/zc_lockfile/default.nix
+++ b/pkgs/development/python-modules/zc_lockfile/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage
 , fetchPypi
+, isPy27
 , mock
 , zope_testing
 , stdenv
@@ -22,5 +23,6 @@ buildPythonPackage rec {
     homepage =  "https://www.python.org/pypi/zc.lockfile";
     license = licenses.zpl20;
     maintainers = with maintainers; [ goibhniu ];
+    broken = isPy27;
   };
 }

--- a/pkgs/development/python-modules/zict/default.nix
+++ b/pkgs/development/python-modules/zict/default.nix
@@ -1,9 +1,10 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, isPy27
 , pytest, heapdict }:
 
 buildPythonPackage rec {
   pname = "zict";
   version = "2.0.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/zope_copy/default.nix
+++ b/pkgs/development/python-modules/zope_copy/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , zope_interface
 , zope_location
 , zope_schema
@@ -26,5 +27,6 @@ buildPythonPackage rec {
 
   meta = {
     maintainers = with lib.maintainers; [ domenkozar ];
+    broken = isPy27;
   };
 }

--- a/pkgs/development/tools/analysis/retdec/default.nix
+++ b/pkgs/development/tools/analysis/retdec/default.nix
@@ -227,6 +227,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "A retargetable machine-code decompiler based on LLVM";
     homepage = "https://retdec.com";
     license = licenses.mit;

--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "A linter for Clojure code that sparks joy.";
     homepage = "https://github.com/borkdude/clj-kondo";
     license = licenses.epl10;

--- a/pkgs/development/tools/kythe/default.nix
+++ b/pkgs/development/tools/kythe/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A pluggable, (mostly) language-agnostic ecosystem for building tools that work with code.";
     longDescription = ''
     The Kythe project was founded to provide and support tools and standards

--- a/pkgs/development/tools/literate-programming/Literate/default.nix
+++ b/pkgs/development/tools/literate-programming/Literate/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation {
   installPhase = "install -D bin/lit $out/bin/lit";
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A literate programming tool for any language";
     homepage    = "http://literate.zbyedidia.webfactional.com/";
     license = licenses.mit;

--- a/pkgs/development/tools/misc/remarkable/remarkable-toolchain/default.nix
+++ b/pkgs/development/tools/misc/remarkable/remarkable-toolchain/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A toolchain for cross-compiling to reMarkable tablets";
     homepage = "https://remarkable.engineering/";
     license = licenses.gpl2;

--- a/pkgs/development/tools/ocaml/dune-release/default.nix
+++ b/pkgs/development/tools/ocaml/dune-release/default.nix
@@ -46,6 +46,7 @@ in buildDunePackage rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Release dune packages in opam";
     homepage = "https://github.com/ocamllabs/dune-release";
     license = licenses.isc;

--- a/pkgs/development/tools/prospector/default.nix
+++ b/pkgs/development/tools/prospector/default.nix
@@ -64,6 +64,7 @@ buildPythonApplication rec {
   ];
 
   meta = with lib; {
+    broken = true;
     description = "Tool to analyse Python code and output information about errors, potential problems, convention violations and complexity";
     homepage = "https://github.com/PyCQA/prospector";
     license = licenses.gpl2;

--- a/pkgs/development/tools/scry/default.nix
+++ b/pkgs/development/tools/scry/default.nix
@@ -35,6 +35,7 @@ in crystal.buildCrystalPackage rec {
   doInstallCheck = false;
 
   meta = with lib; {
+    broken = true;
     description = "Code analysis server for the Crystal programming language";
     homepage = "https://github.com/crystal-lang-tools/scry";
     license = licenses.mit;

--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = "https://github.com/diasurgical/devilutionX";
     description = "Diablo build for modern operating systems";
     longDescription = "In order to play this game a copy of diabdat.mpq is required. Place a copy of diabdat.mpq in ~/.local/share/diasurgical/devilution before executing the game.";

--- a/pkgs/games/easyrpg-player/default.nix
+++ b/pkgs/games/easyrpg-player/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "RPG Maker 2000/2003 and EasyRPG games interpreter";
     homepage = "https://easyrpg.org/";
     license = licenses.gpl3;

--- a/pkgs/games/gambatte/default.nix
+++ b/pkgs/games/gambatte/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Portable, open-source Game Boy Color emulator";
     homepage = "https://github.com/sinamas/gambatte";
     license = licenses.gpl2;

--- a/pkgs/games/lincity/ng.nix
+++ b/pkgs/games/lincity/ng.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "City building game";
     license = licenses.gpl2;
     maintainers = with maintainers; [ raskin ];

--- a/pkgs/games/onscripter-en/default.nix
+++ b/pkgs/games/onscripter-en/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Japanese visual novel scripting engine";
     homepage = "http://unclemion.com/onscripter/";
     license = licenses.gpl2;

--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = "https://springlobby.info/";
     repositories.git = "git://github.com/springlobby/springlobby.git";
     description = "Cross-platform lobby client for the Spring RTS project";

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -49,8 +49,8 @@ let
     };
 
     meta = with stdenv.lib; {
+      broken = true;
       inherit (a) description license;
-      broken = a.broken or false;
       homepage = "https://www.libretro.com/";
       maintainers = with maintainers; [ edwtjo hrdinka MP2E ];
       platforms = platforms.unix;

--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -46,6 +46,7 @@ mkDerivation {
   enableParallelBuilding = true;
 
   meta = with lib; {
+    broken = true;
     description = "PS3 emulator/debugger";
     homepage = "https://rpcs3.net/";
     maintainers = with maintainers; [ abbradar nocent ];

--- a/pkgs/os-specific/darwin/libtapi/default.nix
+++ b/pkgs/os-specific/darwin/libtapi/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     license = licenses.apsl20;
     maintainers = with maintainers; [ matthewbauer ];
+    broken = stdenv.isLinux;
   };
 
 }

--- a/pkgs/os-specific/linux/anbox/kmod.nix
+++ b/pkgs/os-specific/linux/anbox/kmod.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/anbox/anbox-modules";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    broken = (versionOlder kernel.version "4.4") || (kernel.features.grsecurity);
+    broken = (versionOlder kernel.version "4.4") || (kernel.features.grsecurity) || versionAtLeast kernel.version "5.8";
     maintainers = with maintainers; [ edwtjo ];
   };
 

--- a/pkgs/os-specific/linux/cryptodev/default.nix
+++ b/pkgs/os-specific/linux/cryptodev/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     homepage = "http://cryptodev-linux.org/";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
-    broken = !stdenv.lib.versionOlder kernel.version "4.13";
+    broken = true;
   };
 }

--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = with licenses; [ lgpl21 gpl2 ];
     homepage = "https://www.displaylink.com/";
-    broken = versionOlder kernel.version "4.9" || stdenv.isAarch64;
+    broken = versionOlder kernel.version "5" || stdenv.isAarch64;
   };
 }

--- a/pkgs/os-specific/linux/mxu11x0/default.nix
+++ b/pkgs/os-specific/linux/mxu11x0/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation {
   hardeningDisable = [ "pic" ];
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "MOXA UPort 11x0 USB to Serial Hub driver";
     homepage = "https://www.moxa.com/en/products/industrial-edge-connectivity/usb-to-serial-converters-usb-hubs/usb-to-serial-converters/uport-1000-series";
     license = licenses.gpl2Plus;

--- a/pkgs/os-specific/linux/ndiswrapper/default.nix
+++ b/pkgs/os-specific/linux/ndiswrapper/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation {
   buildInputs = [ perl libelf ];
 
   meta = {
+    broken = true;
     description = "Ndis driver wrapper for the Linux kernel";
     homepage = "https://sourceforge.net/projects/ndiswrapper";
     license = "GPL";

--- a/pkgs/os-specific/linux/r8168/default.nix
+++ b/pkgs/os-specific/linux/r8168/default.nix
@@ -43,6 +43,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Realtek r8168 driver";
     longDescription = ''
       A kernel module for Realtek 8168 network cards.

--- a/pkgs/os-specific/linux/rtl8814au/default.nix
+++ b/pkgs/os-specific/linux/rtl8814au/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Realtek 8814AU USB WiFi driver";
     homepage = "https://github.com/zebulon2/rtl8814au";
     license = licenses.gpl2;

--- a/pkgs/os-specific/linux/rtl8821au/default.nix
+++ b/pkgs/os-specific/linux/rtl8821au/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "rtl8821AU, rtl8812AU and rtl8811AU chipset driver with firmware";
     homepage = "https://github.com/zebulon2/rtl8812au";
     license = licenses.gpl2;

--- a/pkgs/os-specific/linux/rtlwifi_new/default.nix
+++ b/pkgs/os-specific/linux/rtlwifi_new/default.nix
@@ -31,6 +31,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = {
+    broken = true;
     description = "The newest Realtek rtlwifi codes";
     inherit (src.meta) homepage;
     license = stdenv.lib.licenses.gpl2;

--- a/pkgs/os-specific/linux/tbs/default.nix
+++ b/pkgs/os-specific/linux/tbs/default.nix
@@ -58,6 +58,6 @@ in stdenv.mkDerivation {
     license = licenses.gpl2;
     maintainers = with maintainers; [ ck3d ];
     priority = -1;
-    broken = stdenv.lib.versionAtLeast kernel.version "4.18";
+    broken = true;
   };
 }

--- a/pkgs/os-specific/linux/usbip/default.nix
+++ b/pkgs/os-specific/linux/usbip/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation {
     description = "allows to pass USB device from server to client over the network";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    broken = lib.versionOlder kernel.version "4.14";
   };
 }

--- a/pkgs/os-specific/linux/v4l2loopback/default.nix
+++ b/pkgs/os-specific/linux/v4l2loopback/default.nix
@@ -33,5 +33,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = [ maintainers.domenkozar ];
     platforms = platforms.linux;
+    broken = stdenv.lib.versionOlder kernel.version "4.14";
   };
 }

--- a/pkgs/servers/foundationdb/python.nix
+++ b/pkgs/servers/foundationdb/python.nix
@@ -15,6 +15,7 @@ buildPythonPackage {
   doCheck = false;
 
   meta = with lib; {
+    broken = true;
     description = "Python bindings for FoundationDB";
     homepage    = "https://www.foundationdb.org";
     license     = with licenses; [ asl20 ];

--- a/pkgs/servers/foundationdb/vsmake.nix
+++ b/pkgs/servers/foundationdb/vsmake.nix
@@ -140,6 +140,7 @@ let
         outputs = [ "out" "lib" "dev" "pythonsrc" ];
 
         meta = with gcc6Stdenv.lib; {
+          broken = true;
           description = "Open source, distributed, transactional key-value store";
           homepage    = "https://www.foundationdb.org";
           license     = licenses.asl20;

--- a/pkgs/servers/isso/default.nix
+++ b/pkgs/servers/isso/default.nix
@@ -30,6 +30,7 @@ with python2.pkgs; buildPythonApplication rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A commenting server similar to Disqus";
     homepage = "https://posativ.org/isso/";
     license = licenses.mit;

--- a/pkgs/servers/mail/public-inbox/default.nix
+++ b/pkgs/servers/mail/public-inbox/default.nix
@@ -70,5 +70,6 @@ buildPerlPackage rec {
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ qyliss ];
     platforms = platforms.all;
+    broken = true;
   };
 }

--- a/pkgs/servers/monitoring/fusion-inventory/default.nix
+++ b/pkgs/servers/monitoring/fusion-inventory/default.nix
@@ -89,5 +89,6 @@ perlPackages.buildPerlPackage rec {
     description = "FusionInventory unified Agent for UNIX, Linux, Windows and MacOSX";
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ maintainers.phile314 ];
+    broken = true;
   };
 }

--- a/pkgs/servers/monitoring/plugins/esxi.nix
+++ b/pkgs/servers/monitoring/plugins/esxi.nix
@@ -33,5 +33,6 @@ in python2Packages.buildPythonApplication rec {
     homepage = "https://www.claudiokuenzler.com/nagios-plugins/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ peterhoeg ];
+    broken = true;
   };
 }

--- a/pkgs/servers/rippled/validator-keys-tool.nix
+++ b/pkgs/servers/rippled/validator-keys-tool.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = true;
     description = "Generate master and ephemeral rippled validator keys";
     homepage = "https://github.com/ripple/validator-keys-tool";
     maintainers = with maintainers; [ offline ];

--- a/pkgs/servers/rt/default.nix
+++ b/pkgs/servers/rt/default.nix
@@ -98,5 +98,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     platforms = stdenv.lib.platforms.unix;
+    broken = true;
   };
 }

--- a/pkgs/servers/sql/patroni/default.nix
+++ b/pkgs/servers/sql/patroni/default.nix
@@ -48,6 +48,7 @@ pythonPackages.buildPythonApplication rec {
   preCheck = "export HOME=$(mktemp -d)";
 
   meta = with lib; {
+    broken = true;
     homepage = "https://patroni.readthedocs.io/en/latest/";
     description = "A Template for PostgreSQL HA with ZooKeeper, etcd or Consul";
     license = licenses.mit;

--- a/pkgs/shells/dgsh/default.nix
+++ b/pkgs/shells/dgsh/default.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "The Directed Graph Shell";
     homepage = "http://www.dmst.aueb.gr/dds/sw/dgsh";
     license = with licenses; asl20;

--- a/pkgs/tools/backup/hpe-ltfs/default.nix
+++ b/pkgs/tools/backup/hpe-ltfs/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "HPE's implementation of the open-source tape filesystem standard ltfs";
     homepage = "https://support.hpe.com/hpesc/public/km/product/1009214665/Product";
     license = licenses.lgpl21;

--- a/pkgs/tools/backup/zfs-replicate/default.nix
+++ b/pkgs/tools/backup/zfs-replicate/default.nix
@@ -34,6 +34,7 @@ buildPythonApplication rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = "https://github.com/alunduil/zfs-replicate";
     description = "ZFS Snapshot Replication";
     license = licenses.bsd2;

--- a/pkgs/tools/filesystems/bcachefs-tools/default.nix
+++ b/pkgs/tools/filesystems/bcachefs-tools/default.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation {
   ];
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Tool for managing bcachefs filesystems";
     homepage = "https://bcachefs.org/";
     license = licenses.gpl2;

--- a/pkgs/tools/filesystems/mtdutils/default.nix
+++ b/pkgs/tools/filesystems/mtdutils/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 
   meta = {
+    broken = true;
     description = "Tools for MTD filesystems";
     license = stdenv.lib.licenses.gpl2Plus;
     homepage = "http://www.linux-mtd.infradead.org/";

--- a/pkgs/tools/graphics/appleseed/default.nix
+++ b/pkgs/tools/graphics/appleseed/default.nix
@@ -49,6 +49,7 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Open source, physically-based global illumination rendering engine";
     homepage = "https://appleseedhq.net/";
     maintainers = with maintainers; [ hodapp ];

--- a/pkgs/tools/graphics/lprof/default.nix
+++ b/pkgs/tools/graphics/lprof/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation {
   patches = [ ./lcms-1.17.patch  ./keep-environment.patch ];
 
   meta = {
+    broken = true;
     description = "Little CMS ICC profile construction set";
     homepage = "https://sourceforge.net/projects/lprof";
     license = stdenv.lib.licenses.gpl2;

--- a/pkgs/tools/graphics/luxcorerender/default.nix
+++ b/pkgs/tools/graphics/luxcorerender/default.nix
@@ -76,6 +76,7 @@ in stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Open source, physically based, unbiased rendering engine";
     homepage = "https://luxcorerender.org/";
     maintainers = with maintainers; [ hodapp ];

--- a/pkgs/tools/misc/grub/trusted.nix
+++ b/pkgs/tools/misc/grub/trusted.nix
@@ -92,6 +92,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "GRUB 2.0 extended with TCG (TPM) support for integrity measured boot process (trusted boot)";
     homepage = "https://github.com/Sirrix-AG/TrustedGRUB2";
     license = licenses.gpl3Plus;

--- a/pkgs/tools/misc/nagstamon/default.nix
+++ b/pkgs/tools/misc/nagstamon/default.nix
@@ -16,6 +16,7 @@ pythonPackages.buildPythonApplication rec {
      beautifulsoup4 keyring requests-kerberos kerberos lxml ];
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "A status monitor for the desktop";
     homepage = "https://nagstamon.ifw-dresden.de/";
     license = licenses.gpl2;

--- a/pkgs/tools/nix/rnix-hashes/default.nix
+++ b/pkgs/tools/nix/rnix-hashes/default.nix
@@ -13,6 +13,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "vaG+0t+XAckV9F4iIgcTkbIUurxdQsTCfOnRnrOKoRc=";
 
   meta = with lib; {
+    broken = true;
     description = "Nix Hash Converter";
     homepage = "https://github.com/numtide/rnix-hashes";
     license = licenses.asl20;

--- a/pkgs/tools/package-management/cargo-download/default.nix
+++ b/pkgs/tools/package-management/cargo-download/default.nix
@@ -9,6 +9,7 @@
     cargo-download = attrs: {
       buildInputs = lib.optional stdenv.isDarwin
         darwin.apple_sdk.frameworks.Security;
+      meta.broken = true;
     };
   };
 }

--- a/pkgs/tools/security/gencfsm/default.nix
+++ b/pkgs/tools/security/gencfsm/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
+    broken = true;
     homepage = "http://www.libertyzero.com/GEncfsM/";
     downloadPage = "https://launchpad.net/gencfsm/";
     description = "EncFS manager and mounter with GNOME3 integration";

--- a/pkgs/tools/typesetting/pdftk/legacy.nix
+++ b/pkgs/tools/typesetting/pdftk/legacy.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
 
 
   meta = {
+    broken = true;
     description = "Simple tool for doing everyday things with PDF documents";
     homepage = "https://www.pdflabs.com/tools/pdftk-server/";
     license = stdenv.lib.licenses.gpl2;

--- a/pkgs/tools/typesetting/ted/default.nix
+++ b/pkgs/tools/typesetting/ted/default.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig zlib pcre xorg.xlibsWrapper xorg.libXpm libjpeg libtiff libpng gtk2 libpaper makeWrapper ];
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "Ted, an easy rich text processor";
     longDescription = ''
       Ted is a text processor running under X Windows on Unix/Linux systems.
@@ -77,7 +78,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://nllgg.nl/Ted/";
     license     = licenses.gpl2;
     platforms   = platforms.all;
-    broken      = stdenv.isDarwin;
     maintainers = with maintainers; [ obadz ];
   };
 }

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -564,6 +564,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
       license = stdenv.lib.licenses.asl20;
       maintainers = with stdenv.lib.maintainers; [ obadz ];
       platforms = with stdenv.lib.platforms; linux;
+      broken = true;
     };
   };
 
@@ -591,6 +592,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
       license = stdenv.lib.licenses.asl20;
       maintainers = with stdenv.lib.maintainers; [ obadz ];
       platforms = with stdenv.lib.platforms; linux;
+      broken = true;
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11727,6 +11727,7 @@ let
 
      meta = {
        license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+       broken = stdenv.lib.versionOlder perl.version "5.32.0";
      };
   };
 
@@ -11851,6 +11852,9 @@ let
     };
     propagatedBuildInputs = [ MathLibm constant-defer ];
     buildInputs = [ DataFloat MathBigIntLite NumberFraction ];
+    meta = {
+      broken = stdenv.lib.versionOlder perl.version "5.32.0";
+    };
   };
 
   MathPrimeUtil = buildPerlPackage {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -324,7 +324,8 @@ in {
 
   appdirs = callPackage ../development/python-modules/appdirs { };
 
-  appleseed = disabledIf isPy3k (toPythonModule (pkgs.appleseed.override { inherit (self) python; }));
+  # currently fails in all python versions
+  appleseed = disabledIf true (toPythonModule (pkgs.appleseed.override { inherit (self) python; }));
 
   application = callPackage ../development/python-modules/application { };
 

--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -1132,6 +1132,7 @@
       type = "gem";
     };
     version = "3.4.1";
+    meta.broken = true;
   };
   hashie = {
     groups = ["default"];
@@ -1721,6 +1722,7 @@
       type = "gem";
     };
     version = "3.4.1";
+    meta.broken = true;
   };
   parallel = {
     groups = ["default"];


### PR DESCRIPTION
###### Motivation for this change
using git hub file changes to make sure the diff looks good

Fixes #100111

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
