### PR TITLE
ocamlPackages.gapi_ocaml: 0.3.19 → 0.4.1

### DIFF
--- a/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
+++ b/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
@@ -8,6 +8,8 @@ buildDunePackage rec {
 
   useDune2 = true;
 
+  minimumOCamlVersion = "4.06";
+
   src = fetchFromGitHub {
     owner = "astrada";
     repo = "google-drive-ocamlfuse";

--- a/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
@@ -1,10 +1,13 @@
-{ stdenv, fetchFromGitHub, buildDunePackage
-, ocurl, cryptokit, ocaml_extlib, yojson, ocamlnet, xmlm
+{ lib, fetchFromGitHub, buildDunePackage, ocaml
+, cryptokit, ocamlnet, ocurl, yojson
+, ounit
 }:
 
 buildDunePackage rec {
   pname = "gapi-ocaml";
-  version = "0.3.19";
+  version = "0.4.1";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.02";
 
@@ -12,16 +15,18 @@ buildDunePackage rec {
     owner = "astrada";
     repo = pname;
     rev = "v${version}";
-    sha256 = "04arif1p1vj5yr24cwicj70b7yx17hrgf4pl47vqg8ngcrdh71v9";
+    sha256 = "0riax23grjnq9pczmp1yv02ji0svvs2kbiqskj6f6yjviamnpa31";
   };
 
-  propagatedBuildInputs = [ ocurl cryptokit ocaml_extlib ocamlnet yojson ];
-  buildInputs = [ xmlm ];
+  propagatedBuildInputs = [ cryptokit ocamlnet ocurl yojson ];
+
+  doCheck = lib.versionAtLeast ocaml.version "4.04";
+  checkInputs = [ ounit ];
 
   meta = {
     description = "OCaml client for google services";
     homepage = "http://gapi-ocaml.forge.ocamlcore.org";
-    license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [ bennofs ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bennofs ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Use dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc/ maintainer @bennofs 