### PR TITLE
vimPlugins.vim-easyclip: init at 2019-02-18

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -4440,6 +4440,18 @@ let
     meta.homepage = "https://github.com/junegunn/vim-easy-align/";
   };
 
+  vim-easyclip = buildVimPluginFrom2Nix {
+    pname = "vim-easyclip";
+    version = "2019-02-18";
+    src = fetchFromGitHub {
+      owner = "svermeulen";
+      repo = "vim-easyclip";
+      rev = "f1a3b95463402b30dd1e22dae7d0b6ea858db2df";
+      sha256 = "1y308y4czdzj9ppb0pnc8mkdd393wpwpncvki88aphicjzvw4498";
+    };
+    meta.homepage = "https://github.com/svermeulen/vim-easyclip";
+  };
+
   vim-easygit = buildVimPluginFrom2Nix {
     pname = "vim-easygit";
     version = "2018-07-08";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -475,6 +475,7 @@ sonph/onehalf
 stefandtw/quickfix-reflector.vim
 stephpy/vim-yaml
 sunaku/vim-dasht
+svermeulen/vim-easyclip
 svermeulen/vim-subversive
 t9md/vim-choosewin
 t9md/vim-smalls


### PR DESCRIPTION
> ###### Motivation for this change
> ###### Things done
> * [ ]  Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
> * Built on platform(s)
>   
>   * [x]  NixOS
>   * [ ]   macOS
>   * [ ]   other Linux distributions
> * [ ]  Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
> * [ ]  Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
> * [ ]  Tested execution of all binary files (usually in `./result/bin/`)
> * [ ]  Determined the impact on package closure size (by running `nix path-info -S` before and after)
> * [ ]  Ensured that relevant documentation is up to date
> * [ ]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).