### PR TITLE
maintainer scripts: init check-hydra-by-maintainer.nix

### DIFF
--- a/maintainers/scripts/check-hydra-by-maintainer.nix
+++ b/maintainers/scripts/check-hydra-by-maintainer.nix
@@ -1,0 +1,67 @@
+{ maintainer }:
+let
+  pkgs = import ./../../default.nix { };
+  maintainer_ = pkgs.lib.maintainers.${maintainer};
+  packagesWith = cond: return: prefix: set:
+    (pkgs.lib.flatten
+      (pkgs.lib.mapAttrsToList
+        (name: pkg:
+          let
+            result = builtins.tryEval
+              (
+                if pkgs.lib.isDerivation pkg && cond name pkg then
+                # Skip packages whose closure fails on evaluation.
+                # This happens for pkgs like `python27Packages.djangoql`
+                # that have disabled Python pkgs as dependencies.
+                  builtins.seq pkg.outPath
+                    [ (return "${prefix}${name}") ]
+                else if pkg.recurseForDerivations or false || pkg.recurseForRelease or false
+                # then packagesWith cond return pkg
+                then packagesWith cond return "${name}." pkg
+                else [ ]
+              );
+          in
+          if result.success then result.value
+          else [ ]
+        )
+        set
+      )
+    );
+
+  packages = packagesWith
+    (name: pkg:
+      (
+        if builtins.hasAttr "meta" pkg && builtins.hasAttr "maintainers" pkg.meta
+        then
+          (
+            if builtins.isList pkg.meta.maintainers
+            then builtins.elem maintainer_ pkg.meta.maintainers
+            else maintainer_ == pkg.meta.maintainers
+          )
+        else false
+      )
+    )
+    (name: name)
+    ("")
+    pkgs;
+
+in
+pkgs.stdenv.mkDerivation {
+  name = "nixpkgs-update-script";
+  buildCommand = ''
+    echo ""
+    echo "----------------------------------------------------------------"
+    echo ""
+    echo "nix-shell maintainers/scripts/check-hydra-by-maintainer.nix --argstr maintainer SuperSandro2000"
+    echo ""
+    echo "----------------------------------------------------------------"
+    exit 1
+  '';
+  shellHook = ''
+    unset shellHook # do not contaminate nested shells
+    echo "Please stand by"
+    echo nix-shell -p hydra-check --run "hydra-check ${builtins.concatStringsSep " " packages}"
+    nix-shell -p hydra-check --run "hydra-check ${builtins.concatStringsSep " " packages}"
+    exit $?
+  '';
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

There was no easy way to do this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
