### PR TITLE
asterisk: Bump all packages

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -104,8 +104,8 @@ in rec {
   asterisk = asterisk_17;
 
   asterisk_13 = common {
-    version = "13.36.0";
-    sha256 = "1p41xrxmzpqmjgvrl7f4vbigiqpmg60fd8bqg5rxbf4lxzpvknnp";
+    version = "13.37.0";
+    sha256 = "09wc6cqh4f15wm62drzdppwvh7nwgnbwapvz1kgb0qdgixsshn3v";
     externals = {
       "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
       "addons/mp3" = mp3-202;
@@ -113,8 +113,8 @@ in rec {
   };
 
   asterisk_16 = common {
-    version = "16.13.0";
-    sha256 = "01nja8hd6jk1966awc2vcz3hl46pvhi797k515q87vzmap1khlp9";
+    version = "16.14.0";
+    sha256 = "1y120p4jlhg4iwihdxlk64y3y3n8w7y785lwqxsyqg6zviz0ghx6";
     externals = {
       "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
       "addons/mp3" = mp3-202;
@@ -122,8 +122,8 @@ in rec {
   };
 
   asterisk_17 = common {
-    version = "17.7.0";
-    sha256 = "0lsglrh3l823200rmkay3pgy42k0fsij610s3s4vd3zv4jjb1g0s";
+    version = "17.8.0";
+    sha256 = "0xhwh8s8n8xg43gcdkqjj484assva7lm5ah1b306a5nf6j8p9bjy";
     externals = {
       "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
       "addons/mp3" = mp3-202;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Asterisk is out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
