### PR TITLE
pythonPackages.rich: 8.0.0 -> 9.1.0

### DIFF
--- a/pkgs/development/python-modules/rich/default.nix
+++ b/pkgs/development/python-modules/rich/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "rich";
-  version = "8.0.0";
+  version = "9.1.0";
 
   # tests not included in pypi tarball
   src = fetchFromGitHub {
     owner = "willmcgugan";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0hv27b22x7dbx1i7nzsd8y8fymmvdak2hcx9242jwk4c1a7jr151";
+    sha256 = "18iha0fs8vm0j11k39yxj26h8qxrp27ijhx6h1yyizbygmr5b5nk";
   };
   format = "pyproject";
 


### PR DESCRIPTION
###### Things done

Result of `nixpkgs-review pr 101759` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>6 packages built:</summary>
  <ul>
    <li>ansible-lint (python38Packages.ansible-lint)</li>
    <li>python37Packages.ansible-lint</li>
    <li>python37Packages.perfplot</li>
    <li>python37Packages.rich</li>
    <li>python38Packages.perfplot</li>
    <li>python38Packages.rich</li>
  </ul>
</details>

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
