### PR TITLE
pythonPackages.myfitnesspal: fix build

### DIFF
--- a/pkgs/development/python-modules/myfitnesspal/default.nix
+++ b/pkgs/development/python-modules/myfitnesspal/default.nix
@@ -1,6 +1,9 @@
 { lib, fetchPypi, buildPythonPackage
-, blessed, keyring, keyrings-alt, lxml, measurement, python-dateutil, requests, six
-, mock, nose }:
+, blessed, keyring, keyrings-alt, lxml, measurement, python-dateutil, requests, six, rich
+, pytestCheckHook, mock, nose }:
+
+# TODO: Define this package in "all-packages.nix" using "toPythonApplication".
+# This currently errors out, complaining about not being able to find "etree" from "lxml" even though "lxml" is defined in "propagatedBuildInputs".
 
 buildPythonPackage rec {
   pname = "myfitnesspal";
@@ -11,14 +14,18 @@ buildPythonPackage rec {
     sha256 = "c2275e91c794a3569a76c47c78cf2ff04d7f569a98558227e899ead7b30af0d6";
   };
 
-  # Remove overly restrictive version constraints on keyring and keyrings.alt
+  # Remove overly restrictive version constraints
   postPatch = ''
     sed -i 's/keyring>=.*/keyring/' requirements.txt
     sed -i 's/keyrings.alt>=.*/keyrings.alt/' requirements.txt
+    sed -i 's/rich>=.*/rich/' requirements.txt
   '';
 
-  checkInputs = [ mock nose ];
-  propagatedBuildInputs = [ blessed keyring keyrings-alt lxml measurement python-dateutil requests six ];
+  propagatedBuildInputs = [ blessed keyring keyrings-alt lxml measurement python-dateutil requests six rich ];
+
+  # Integration tests require an account to be set
+  disabledTests = [ "test_integration" ];
+  checkInputs = [ pytestCheckHook mock nose ];
 
   meta = with lib; {
     description = "Access your meal tracking data stored in MyFitnessPal programatically";


### PR DESCRIPTION

###### Motivation for this change
Noticed this was [broken on hydra](https://hydra.nixos.org/build/128921743/log), decided to fix.

ZHF: #97479 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
