### PR TITLE
asterisk_18: Init at 18.0.0

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -91,17 +91,18 @@ let
   };
 
 in rec {
-  # Supported releases (as of 2020-10-07).
+  # Supported releases (as of 2020-10-26).
   # Source: https://wiki.asterisk.org/wiki/display/AST/Asterisk+Versions
   # Exact version can be found at https://www.asterisk.org/downloads/asterisk/all-asterisk-versions/
   #
   # Series  Type       Rel. Date   Sec. Fixes  EOL
   # 13.x    LTS        2014-10-24  2020-10-24  2021-10-24
   # 16.x    LTS        2018-10-09  2022-10-09  2023-10-09
-  asterisk-lts = asterisk_16;
+  # 18.x    LTS        2020-10-20  2024-10-20  2025-10-20
+  asterisk-lts = asterisk_18;
   # 17.x    Standard   2019-10-28  2020-10-28  2021-10-28
-  asterisk-stable = asterisk_17;
-  asterisk = asterisk_17;
+  asterisk-stable = asterisk_18;
+  asterisk = asterisk_18;
 
   asterisk_13 = common {
     version = "13.36.0";
@@ -124,6 +125,15 @@ in rec {
   asterisk_17 = common {
     version = "17.7.0";
     sha256 = "0lsglrh3l823200rmkay3pgy42k0fsij610s3s4vd3zv4jjb1g0s";
+    externals = {
+      "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
+      "addons/mp3" = mp3-202;
+    };
+  };
+
+  asterisk_18 = common {
+    version = "18.0.0";
+    sha256 = "174zasx8d7ragy2fz4vwc4pbra9wl471mnisz1z0a3b2qsbh4y4v";
     externals = {
       "externals_cache/pjproject-2.10.tar.bz2" = pjproject_2_10;
       "addons/mp3" = mp3-202;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16409,7 +16409,7 @@ in
 
   inherit (callPackages ../servers/asterisk { })
     asterisk asterisk-stable asterisk-lts
-    asterisk_13 asterisk_16 asterisk_17;
+    asterisk_13 asterisk_16 asterisk_17 asterisk_18;
 
   asterisk-module-sccp = callPackage ../servers/asterisk/sccp { };
 


### PR DESCRIPTION
I hope I bumped all attributes correctly.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
