### PR TITLE
miranda: remove gcc as buildInput

### DIFF
--- a/pkgs/development/compilers/miranda/default.nix
+++ b/pkgs/development/compilers/miranda/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchzip, fetchpatch, gcc }:
+{ stdenv, lib, fetchzip, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "miranda";


### PR DESCRIPTION
###### Motivation for this change
`gcc` was an unused dependency

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
