### PR TITLE
ncrack: init at 0.7

### DIFF
--- a/pkgs/tools/security/ncrack/default.nix
+++ b/pkgs/tools/security/ncrack/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, openssl, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "ncrack";
+  version = "0.7";
+
+  src = fetchFromGitHub {
+    owner = "nmap";
+    repo = "ncrack";
+    rev = version;
+    sha256 = "1gnv5xdd7n04glcpy7q1mkb6f8gdhdrhlrh8z6k4g2pjdhxlz26g";
+  };
+
+  buildInputs = [ openssl zlib ];
+
+  meta = with stdenv.lib; {
+    description = "Network authentication tool";
+    homepage = "https://nmap.org/ncrack/";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ siraben ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5072,6 +5072,8 @@ in
 
   nbench = callPackage ../tools/misc/nbench { };
 
+  ncrack = callPackage ../tools/security/ncrack { };
+
   netdata = callPackage ../tools/system/netdata {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation IOKit;
   };


### PR DESCRIPTION
###### Motivation for this change
#81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
