### PR TITLE
kakounePlugins.rep: inherit from rep

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/default.nix
+++ b/pkgs/applications/editors/kakoune/plugins/default.nix
@@ -1,7 +1,7 @@
-{ pkgs, parinfer-rust }:
+{ pkgs, parinfer-rust, rep }:
 
 {
-  inherit parinfer-rust;
+  inherit parinfer-rust rep;
 
   case-kak = pkgs.callPackage ./case.kak.nix { };
   kak-ansi = pkgs.callPackage ./kak-ansi.nix { };


### PR DESCRIPTION
###### Motivation for this change

`rep` is usable as a Kakoune plugin without changes, so inherit the attribute here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).