### PR TITLE
cinnamon.cjs: don't use fork, 4.6.0 -> 2020-10-19

### DIFF
--- a/pkgs/desktops/cinnamon/cjs/default.nix
+++ b/pkgs/desktops/cinnamon/cjs/default.nix
@@ -27,14 +27,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "cjs";
-  version = "4.6.0-gjs-1.66.0";
+  pname = "cjs-unstable";
+  version = "2020-10-19";
 
   src = fetchFromGitHub {
-    owner = "leigh123linux";
-    repo = pname;
-    rev = "gjs-1.66.0";
-    sha256 = "1pccz7h8mwljziflhn04gmfnbl99pvcj1byz1c6zn947v5gqskj1";
+    owner = "linuxmint";
+    repo = "cjs";
+    rev = "befc11adb5ba10681464e6fa81b1a79f108ce61c";
+    hash = "sha256-F2t8uKV2r29NxX2+3mYp5x1bug2lwihJZTK1dSS8rPg=";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
The code in that fork was been integrated into cjs master https://github.com/linuxmint/cjs/pull/84

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/101767

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
