### PR TITLE
WIP: python3.pkgs.maturin: PEP 517 build backend

### DIFF
--- a/pkgs/development/python-modules/maturin/0001-Don-t-build-maturin-executable.patch
+++ b/pkgs/development/python-modules/maturin/0001-Don-t-build-maturin-executable.patch
@@ -1,0 +1,53 @@
+From 9155e15034a1dcf7bfe1424f29bd596eb8cea074 Mon Sep 17 00:00:00 2001
+From: Frederik Rietdijk <fridh@fridh.nl>
+Date: Mon, 26 Oct 2020 15:26:41 +0100
+Subject: [PATCH 1/3] Don't build maturin executable
+
+---
+ setup.py | 30 ------------------------------
+ 1 file changed, 30 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index e3590d2..d4d0c8e 100644
+--- a/setup.py
++++ b/setup.py
+@@ -41,36 +41,6 @@ except ImportError:
+ class PostInstallCommand(install):
+     """Post-installation for installation mode."""
+ 
+-    def run(self):
+-        source_dir = os.path.dirname(os.path.abspath(__file__))
+-        executable_name = "maturin.exe" if sys.platform.startswith("win") else "maturin"
+-
+-        # Shortcut for development
+-        existing_binary = os.path.join(source_dir, "target", "debug", executable_name)
+-        if os.path.isfile(existing_binary):
+-            source = existing_binary
+-        else:
+-            if not shutil.which("cargo"):
+-                raise RuntimeError(
+-                    "cargo not found in PATH. Please install rust "
+-                    "(https://www.rust-lang.org/tools/install) and try again"
+-                )
+-            subprocess.check_call(
+-                ["cargo", "rustc", "--bin", "maturin", "--", "-C", "link-arg=-s"]
+-            )
+-            source = os.path.join(source_dir, "target", "debug", executable_name)
+-        # run this after trying to build with cargo (as otherwise this leaves
+-        # venv in a bad state: https://github.com/benfred/py-spy/issues/69)
+-        install.run(self)
+-
+-        target = os.path.join(self.install_scripts, executable_name)
+-        os.makedirs(self.install_scripts, exist_ok=True)
+-        self.copy_file(source, target)
+-        self.copy_tree(
+-            os.path.join(source_dir, "maturin"),
+-            os.path.join(self.root or self.install_lib, "maturin"),
+-        )
+-
+ 
+ with open("Readme.md", encoding="utf-8", errors="ignore") as fp:
+     long_description = fp.read()
+-- 
+2.28.0
+

--- a/pkgs/development/python-modules/maturin/0002-declare-maturin-executable.patch
+++ b/pkgs/development/python-modules/maturin/0002-declare-maturin-executable.patch
@@ -1,0 +1,54 @@
+From a03cfb00ce00ab2f9352c69d55baf2a9c5b44399 Mon Sep 17 00:00:00 2001
+From: Frederik Rietdijk <fridh@fridh.nl>
+Date: Mon, 26 Oct 2020 15:28:57 +0100
+Subject: [PATCH 2/3] declare maturin executable
+
+---
+ maturin/__init__.py | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/maturin/__init__.py b/maturin/__init__.py
+index b16b55b..d3c40a3 100644
+--- a/maturin/__init__.py
++++ b/maturin/__init__.py
+@@ -18,6 +18,10 @@ from typing import List, Dict
+ 
+ import toml
+ 
++
++MATURIN_EXECUTABLE = "@maturin@"
++
++
+ # these are only used when creating the sdist, not when building it
+ create_only_options = [
+     "sdist-include",
+@@ -55,7 +59,7 @@ def get_config_options() -> List[str]:
+ # noinspection PyUnusedLocal
+ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+     # The PEP 517 build environment guarantees that `python` is the correct python
+-    command = ["maturin", "pep517", "build-wheel", "-i", "python"]
++    command = [MATURIN_EXECUTABLE, "pep517", "build-wheel", "-i", "python"]
+     command.extend(get_config_options())
+ 
+     print("Running `{}`".format(" ".join(command)))
+@@ -74,7 +78,7 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+ 
+ # noinspection PyUnusedLocal
+ def build_sdist(sdist_directory, config_settings=None):
+-    command = ["maturin", "pep517", "write-sdist", "--sdist-directory", sdist_directory]
++    command = [MATURIN_EXECUTABLE, "pep517", "write-sdist", "--sdist-directory", sdist_directory]
+ 
+     print("Running `{}`".format(" ".join(command)))
+     try:
+@@ -123,7 +127,7 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+         sys.exit(1)
+ 
+     command = [
+-        "maturin",
++        MATURIN_EXECUTABLE,
+         "pep517",
+         "write-dist-info",
+         "--metadata-directory",
+-- 
+2.28.0
+

--- a/pkgs/development/python-modules/maturin/0003-install-python-module.patch
+++ b/pkgs/development/python-modules/maturin/0003-install-python-module.patch
@@ -1,0 +1,22 @@
+From 4152bcb5c3d9a57eaf475f343179b387d6418bbd Mon Sep 17 00:00:00 2001
+From: Frederik Rietdijk <fridh@fridh.nl>
+Date: Mon, 26 Oct 2020 15:38:59 +0100
+Subject: [PATCH 3/3] install python module
+
+---
+ setup.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/setup.py b/setup.py
+index d4d0c8e..1a088e1 100644
+--- a/setup.py
++++ b/setup.py
+@@ -69,4 +69,5 @@ setup(
+     ],
+     install_requires=["toml~=0.10.0"],
+     zip_safe=False,
++    packages=["maturin"],
+ )
+-- 
+2.28.0
+

--- a/pkgs/development/python-modules/maturin/default.nix
+++ b/pkgs/development/python-modules/maturin/default.nix
@@ -1,0 +1,41 @@
+{ buildPythonPackage
+, maturin
+, setuptools
+, toml
+, wheel
+, isPy3k
+}:
+
+buildPythonPackage {
+  inherit (maturin) pname version src meta;
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    setuptools
+    toml
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    maturin.rustPlatform.rust.cargo
+    maturin.rustPlatform.rust.rustc
+  ];
+
+  disabled = !isPy3k;
+
+  patches = [
+    ./0001-Don-t-build-maturin-executable.patch
+    ./0002-declare-maturin-executable.patch
+    ./0003-install-python-module.patch
+  ];
+
+  maturin = "${maturin}/bin/maturin";
+
+  postPatch = ''
+    substituteAllInPlace maturin/__init__.py
+  '';
+
+  # No tests
+  doCheck = false;
+}

--- a/pkgs/development/python-modules/orjson/default.nix
+++ b/pkgs/development/python-modules/orjson/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, maturin
+, fetchFromGitHub
+, wheel
+, toml
+}:
+
+buildPythonPackage rec {
+  pname = "orjson";
+  version = "3.4.1";
+
+  src = fetchFromGitHub {
+    owner = "ijl";
+    repo = pname;
+    rev = version;
+    sha256 = "2+CZ4K4Sijt3ksjD6pVteRNNf+4z0iwZQon11b0+nyk=";
+  };
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    maturin
+    wheel
+    toml
+  ];
+
+  meta = {
+    description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy";
+    license = with lib.licenses; [ 
+      asl20
+      mit
+    ];
+    homepage = "https://github.com/ijl/orjson";
+    broken = true; # Requires rust nightly
+  };
+
+}

--- a/pkgs/development/tools/rust/maturin/default.nix
+++ b/pkgs/development/tools/rust/maturin/default.nix
@@ -4,7 +4,7 @@
 let
   inherit (darwin.apple_sdk.frameworks) Security;
 in rustPlatform.buildRustPackage rec {
-  name = "maturin-${version}";
+  pname = "maturin";
   version = "0.8.3";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/rust/maturin/default.nix
+++ b/pkgs/development/tools/rust/maturin/default.nix
@@ -25,6 +25,10 @@ in rustPlatform.buildRustPackage rec {
   # Requires network access, fails in sandbox.
   doCheck = false;
 
+  passthru = {
+    inherit rustPlatform;
+  };
+
   meta = with stdenv.lib; {
     description = "Build and publish crates with pyo3 bindings as python packages";
     homepage = "https://github.com/PyO3/maturin";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3652,6 +3652,10 @@ in {
 
   matrix-nio = callPackage ../development/python-modules/matrix-nio { };
 
+  maturin = callPackage ../development/python-modules/maturin {
+    inherit (pkgs) maturin;
+  };
+
   mautrix = callPackage ../development/python-modules/mautrix { };
 
   mautrix-appservice = self.mautrix; # alias 2019-12-28

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4244,6 +4244,8 @@ in {
 
   orderedset = callPackage ../development/python-modules/orderedset { };
 
+  orjson = callPackage ../development/python-modules/orjson { };
+
   orm = callPackage ../development/python-modules/orm { };
 
   ortools = (toPythonModule (pkgs.or-tools.override { inherit (self) python; })).python;


### PR DESCRIPTION
##### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/83614


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
