### PR TITLE
pantheon.wingpanel-indicator-bluetooth: 2.1.5 -> 2020-10-01

### DIFF
--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/bluetooth/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/bluetooth/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "wingpanel-indicator-bluetooth";
-  version = "2.1.5";
+  version = "unstable-2020-10-01";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-txEjChutJCse/WjgQEfo+MSeeGWdpHUABGCsAqK6i3o=";
+    rev = "2b59d646ea0d66ae45dafc851374f24dcd98c064";
+    sha256 = "sha256-selp70P+7RhbdHF6iiNmcNbMf/c+B9zZ6nlxwRSZGn4=";
   };
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

* Fix device duplicates:
  https://github.com/elementary/wingpanel-indicator-bluetooth/pull/116
* Some other less important fixes.

I am not sure if it actually fixes the issue, since I don’t know how to reproduce it, it happens for me very randomly, but looking at the PR and the issue it all makes sense.

@worldofpeace 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
