### PR TITLE
systemd: fix 0019-*.patch

### DIFF
--- a/pkgs/os-specific/linux/systemd/0019-logind-seat-debus-show-CanMultiSession-again.patch
+++ b/pkgs/os-specific/linux/systemd/0019-logind-seat-debus-show-CanMultiSession-again.patch
@@ -1,3 +1,13 @@
+From 3999d8949ddaf9296928f603661abcea13576d83 Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@mailbox.org>
+Date: Mon, 26 Oct 2020 21:21:38 +0100
+Subject: [PATCH 19/19] logind-seat-debus: show CanMultiSession again
+
+Fixes the "switch user" function in Plasma < 5.20.
+---
+ src/login/logind-seat-dbus.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/src/login/logind-seat-dbus.c b/src/login/logind-seat-dbus.c
 index a91765205c..742aeb1064 100644
 --- a/src/login/logind-seat-dbus.c
@@ -11,3 +21,6 @@ index a91765205c..742aeb1064 100644
          SD_BUS_PROPERTY("CanTTY", "b", property_get_can_tty, 0, SD_BUS_VTABLE_PROPERTY_CONST),
          SD_BUS_PROPERTY("CanGraphical", "b", property_get_can_graphical, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
          SD_BUS_PROPERTY("Sessions", "a(so)", property_get_sessions, 0, 0),
+-- 
+2.28.0
+

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -88,7 +88,7 @@ in stdenv.mkDerivation {
     ./0016-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
     ./0017-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
     ./0018-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
-    ./0019-revert-get-rid-of-seat_can_multi_session.patch
+    ./0019-logind-seat-debus-show-CanMultiSession-again.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
This should be zero functionality change, just make tooling better.
I'm currently preparing a local `247-rc1` and realized the patches
don't apply properly.

This was introduced in https://github.com/NixOS/nixpkgs/pull/99621, but
didn't follow the process documented in
pkgs/os-specific/linux/systemd/default.nix, namely, the `git am` and
`git format-patch` workflow, which caused
`0019-revert-get-rid-of-seat_can_multi_session.patch` to not apply with
`git am` due to missing authorship information.

I did apply this patch manually, and copied authorship information from
4e384ddc113f25aa00f96c96368cb8382981ddc7.

###### Motivation for this change
Make these lines be accurate again:

```
# If these need to be regenerated, `git am path/to/00*.patch` them into a
# systemd worktree, rebase to the more recent systemd version, and export the
# patches again via `git format-patch v${version}`.
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
