### PR TITLE
springlobby: fix build failure

### DIFF
--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, wxGTK30, openal, pkgconfig, curl, libtorrentRasterbar
+{ stdenv, fetchurl, fetchpatch, cmake, wxGTK30, openal, pkgconfig, curl, libtorrentRasterbar
 , libpng, libX11, gettext, boost, libnotify, gtk2, doxygen, spring
 , makeWrapper, glib, minizip, alure, pcre, jsoncpp }:
 
@@ -17,7 +17,14 @@ stdenv.mkDerivation rec {
     boost libpng libX11 libnotify gtk2 doxygen makeWrapper glib minizip alure
   ];
 
-  patches = [ ./revert_58b423e.patch ./fix-certs.patch ]; # Allows springLobby to continue using system installed spring until #707 is fixed
+  patches = [
+    ./revert_58b423e.patch # Allows springLobby to continue using system installed spring until #707 is fixed
+    ./fix-certs.patch
+    (fetchpatch {
+      url = "https://github.com/springlobby/springlobby/commit/252c4cb156c1442ed9b4faec3f26265bc7c295ff.patch";
+      sha256 = "sha256-Nq1F5fRPnCkZwl9KgrfuUmpIMK3hUOyZQYIKElWpmzU=";
+    })
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -11,10 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "1r1g2hw9ipsmsmzbhsi7bxqra1za6x7j1kw12qzl5psqyq8rqbgs";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig gettext doxygen makeWrapper ];
   buildInputs = [
-    cmake wxGTK30 openal curl gettext libtorrentRasterbar pcre jsoncpp
-    boost libpng libX11 libnotify gtk2 doxygen makeWrapper glib minizip alure
+    wxGTK30 openal curl libtorrentRasterbar pcre jsoncpp
+    boost libpng libX11 libnotify gtk2 glib minizip alure
   ];
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

The build of springLobby was failing. This PR is intended to resolve a hydra failure of 20.09, part of https://github.com/NixOS/nixpkgs/issues/97479

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
