### PR TITLE
libpaper: 1.1.24 -> 1.1.28

### DIFF
--- a/pkgs/development/libraries/libpaper/default.nix
+++ b/pkgs/development/libraries/libpaper/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.24";
+  version = "1.1.28";
   pname = "libpaper";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/libp/libpaper/libpaper_${version}.tar.gz";
-    sha256 = "0zhcx67afb6b5r936w5jmaydj3ks8zh83n9rm5sv3m3k8q8jib1q";
+    sha256 = "sha256-yLuUbsk9PCxyu7HXJX6QFyoipEoHoH+2uAKluyyV/dw=";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   # The configure script of libpaper is buggy: it uses AC_SUBST on a headerfile
   # to compile sysconfdir into the library. Autoconf however defines sysconfdir


### PR DESCRIPTION
###### Motivation for this change

debian testing is on 1.1.28.

~It seems pkgs.ted is failing to compile. I thought this might have something to do with it. My laptop isn't that fast, so ted is still building locally, but it seems to be further along than it did before this change. If ted builds successfully, this change needs to be part of 20.09: https://github.com/NixOS/nixpkgs/issues/97479~

Build of ted is still failing.

~I tested this PR by building ted:~

```
nix-build -A pkgs.ted
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
