### PR TITLE
pythonPackages.py-multihash: 0.2.3 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/py-multihash/default.nix
+++ b/pkgs/development/python-modules/py-multihash/default.nix
@@ -1,6 +1,6 @@
 { base58
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , isPy27
 , lib
 , morphys
@@ -14,11 +14,13 @@
 
 buildPythonPackage rec {
   pname = "py-multihash";
-  version = "0.2.3";
+  version = "1.0.0";
 
-  src = fetchPypi {
-    inherit pname version ;
-    sha256 = "f0ade4de820afdc4b4aaa40464ec86c9da5cae3a4578cda2daab4b0eb7e5b18d";
+  src = fetchFromGitHub {
+    owner = "multiformats";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "07qglrbgcb8sr9msqw2v7dqj9s4rs6nyvhdnx02i5w6xx5ibzi3z";
   };
 
   nativeBuildInputs = [
@@ -37,6 +39,8 @@ buildPythonPackage rec {
     pytest
     pytestcov
   ];
+
+  pythonImportsCheck = [ "multihash" ];
 
   disabled = isPy27;
 


### PR DESCRIPTION

###### Motivation for this change
Saw this [failing on hydra](https://hydra.nixos.org/build/127633742/log), and decided to fix it.

the `postPatch` phase should be removed upon the next release, as explained in the comment.

ZHF: #97479 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
