### PR TITLE
docs: Add 'how to request merging rights'

### DIFF
--- a/doc/contributing/reviewing-contributions.xml
+++ b/doc/contributing/reviewing-contributions.xml
@@ -515,18 +515,18 @@
    It is possible for community members that have enough knowledge and experience on a special topic to contribute by merging pull requests.
   </para>
 
-  <para>
-   TODO: add the procedure to request merging rights.
-  </para>
-
 <!--
-The following paragraph about how to deal with unactive contributors is just a
+The following paragraphs about how to deal with unactive contributors is just a
 proposition and should be modified to what the community agrees to be the right
 policy.
 
 <para>Please note that contributors with commit rights unactive for more than
   three months will have their commit rights revoked.</para>
 -->
+
+  <para>
+   Please see the discussion in <link xlink:href="https://github.com/NixOS/nixpkgs/issues/50105">GitHub nixpkgs issue #50105</link> for information on how to proceed to be granted this level of access.
+  </para>
 
   <para>
    In a case a contributor definitively leaves the Nix community, they should create an issue or post on <link


### PR DESCRIPTION
Linked also to the GitHub issue on how to become a committer

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

While looking for this information myself, I bumped into the TODO in the manual.
@cole-h provided the missing answer and the link to NixOS/nixpkgs-committers#60

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
