### PR TITLE
exifprobe: init at unstable-2018-06-19

### DIFF
--- a/pkgs/tools/graphics/exifprobe/default.nix
+++ b/pkgs/tools/graphics/exifprobe/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "exifprobe";
+  version = "unstable-2018-06-19";
+
+  src = fetchFromGitHub {
+    owner = "hfiguiere";
+    repo = "exifprobe";
+    rev = "ce1ea2bc3dbbe8092b26f41cd89831cafe633d69";
+    sha256 = "1c1fhc0v1m452lgnfcijnvrc0by06qfbhn3zkliqi60kv8l2isbp";
+  };
+
+  CFLAGS = [ "-O2" ];
+
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  postInstall = ''
+    mv $out/usr/bin $out/bin
+    mv $out/usr/share $out/share
+    rm -r $out/usr
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tool for reading EXIF data from image files produced by digital cameras";
+    homepage = "https://github.com/hfiguiere/exifprobe";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ siraben ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3586,6 +3586,8 @@ in
 
   exif = callPackage ../tools/graphics/exif { };
 
+  exifprobe = callPackage ../tools/graphics/exifprobe { };
+
   exiftags = callPackage ../tools/graphics/exiftags { };
 
   exiftool = perlPackages.ImageExifTool;


### PR DESCRIPTION
###### Motivation for this change
#81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
