### PR TITLE
outguess: init at 0.2.2

### DIFF
--- a/pkgs/tools/security/outguess/default.nix
+++ b/pkgs/tools/security/outguess/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "outguess";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "resurrecting-open-source-projects";
+    repo = "outguess";
+    rev = version;
+    sha256 = "1wz0cpwg0r8sz46klhd78pmcbncmi2ih4r4ydb60l5vpjr1xf07j";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Universal steganographic tool";
+    homepage = "https://github.com/resurrecting-open-source-projects/outguess";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ siraben ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6101,6 +6101,8 @@ in
 
   otpw = callPackage ../os-specific/linux/otpw { };
 
+  outguess = callPackage ../tools/security/outguess { };
+
   overcommit = callPackage ../development/tools/overcommit { };
 
   overmind = callPackage ../applications/misc/overmind { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
