### PR TITLE
ocamlPackages.mirage-block: init at 2.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-block/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-block/default.nix
@@ -15,10 +15,10 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ cstruct lwt mirage-device ];
 
-  meta = {
+  meta = with lib; {
     description = "Block signatures and implementations for MirageOS";
     homepage = "https://github.com/mirage/mirage-block";
-    license = lib.licenses.isc;
-    maintainers = [ lib.maintainers.vbgl ];
+    license = licenses.isc;
+    maintainers = with maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/mirage-block/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-block/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchurl, buildDunePackage
+, cstruct, lwt, mirage-device
+}:
+
+buildDunePackage rec {
+  pname = "mirage-block";
+  version = "2.0.1";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-block/releases/download/v${version}/mirage-block-v${version}.tbz";
+    sha256 = "1wp8wmixaz9i2sbvq6nkx903lbnpdgb2w404pz1wk8kcg9p3ilcc";
+  };
+
+  propagatedBuildInputs = [ cstruct lwt mirage-device ];
+
+  meta = {
+    description = "Block signatures and implementations for MirageOS";
+    homepage = "https://github.com/mirage/mirage-block";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -539,6 +539,8 @@ let
 
     minisat = callPackage ../development/ocaml-modules/minisat { };
 
+    mirage-block = callPackage ../development/ocaml-modules/mirage-block { };
+
     mirage-bootvar-unix = callPackage ../development/ocaml-modules/mirage-bootvar-unix { };
 
     mirage-clock = callPackage ../development/ocaml-modules/mirage-clock { };


### PR DESCRIPTION
###### Motivation for this change

#23955

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
