### PR TITLE
fwupd: 1.4.6 → 1.5.1

### DIFF
--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -11,8 +11,8 @@ let
     "fwupd/daemon.conf" = {
       source = pkgs.writeText "daemon.conf" ''
         [fwupd]
-        BlacklistDevices=${lib.concatStringsSep ";" cfg.blacklistDevices}
-        BlacklistPlugins=${lib.concatStringsSep ";" cfg.blacklistPlugins}
+        DisabledDevices=${lib.concatStringsSep ";" cfg.disabledDevices}
+        DisabledPlugins=${lib.concatStringsSep ";" cfg.disabledPlugins}
       '';
     };
     "fwupd/uefi.conf" = {
@@ -59,21 +59,21 @@ in {
         '';
       };
 
-      blacklistDevices = mkOption {
+      disabledDevices = mkOption {
         type = types.listOf types.str;
         default = [];
         example = [ "2082b5e0-7a64-478a-b1b2-e3404fab6dad" ];
         description = ''
-          Allow blacklisting specific devices by their GUID
+          Allow disabling specific devices by their GUID
         '';
       };
 
-      blacklistPlugins = mkOption {
+      disabledPlugins = mkOption {
         type = types.listOf types.str;
         default = [];
         example = [ "udev" ];
         description = ''
-          Allow blacklisting specific plugins
+          Allow disabling specific plugins
         '';
       };
 
@@ -105,11 +105,15 @@ in {
     };
   };
 
+  imports = [
+    (mkRenamedOptionModule [ "services" "fwupd" "blacklistDevices"] [ "services" "fwupd" "disabledDevices" ])
+    (mkRenamedOptionModule [ "services" "fwupd" "blacklistPlugins"] [ "services" "fwupd" "disabledPlugins" ])
+  ];
 
   ###### implementation
   config = mkIf cfg.enable {
     # Disable test related plug-ins implicitly so that users do not have to care about them.
-    services.fwupd.blacklistPlugins = cfg.package.defaultBlacklistedPlugins;
+    services.fwupd.disabledPlugins = cfg.package.defaultDisabledPlugins;
 
     environment.systemPackages = [ cfg.package ];
 

--- a/nixos/tests/installed-tests/fwupd.nix
+++ b/nixos/tests/installed-tests/fwupd.nix
@@ -5,7 +5,7 @@ makeInstalledTest {
 
   testConfig = {
     services.fwupd.enable = true;
-    services.fwupd.blacklistPlugins = lib.mkForce []; # don't blacklist test plugin
+    services.fwupd.disabledPlugins = lib.mkForce []; # don't disable test plugin
     services.fwupd.enableTestRemote = true;
     virtualisation.memorySize = 768;
   };

--- a/pkgs/development/libraries/gusb/default.nix
+++ b/pkgs/development/libraries/gusb/default.nix
@@ -1,20 +1,26 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, gobject-introspection
-, gtk-doc, docbook_xsl, docbook_xml_dtd_412, docbook_xml_dtd_44
+, gtk-doc, docbook_xsl, docbook_xml_dtd_412, docbook_xml_dtd_44, python3
 , glib, systemd, libusb1, vala, hwdata
 }:
+
+let
+  pythonEnv = python3.withPackages(ps: with ps; [
+    setuptools
+  ]);
+in
 stdenv.mkDerivation rec {
   pname = "gusb";
-  version = "0.3.3";
+  version = "0.3.5";
 
   outputs = [ "bin" "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "https://people.freedesktop.org/~hughsient/releases/libgusb-${version}.tar.xz";
-    sha256 = "14pbd0812151ga7jrpzi88fcrwkckx6m07ay84l7dzkxbdc44fgr";
+    sha256 = "1pv5ivbwxb9anq2j34i68r8fgs8nwsi4hmss7h9v1i3wk7300ajv";
   };
 
   nativeBuildInputs = [
-    meson ninja pkgconfig gettext
+    meson ninja pkgconfig gettext pythonEnv
     gtk-doc docbook_xsl docbook_xml_dtd_412 docbook_xml_dtd_44
     gobject-introspection vala
   ];

--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -93,14 +93,11 @@ diff --git a/meson_options.txt b/meson_options.txt
 index 3da9b6c4..6c80275b 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -24,6 +24,7 @@ option('plugin_coreboot', type : 'boolean', value : true, description : 'enable
- option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
- option('systemdunitdir', type: 'string', value: '', description: 'Directory for systemd units')
- option('elogind', type : 'boolean', value : false, description : 'enable elogind support')
+@@ -1,3 +1,4 @@
 +option('sysconfdir_install', type: 'string', value: '', description: 'sysconfdir to use during installation')
- option('tests', type : 'boolean', value : true, description : 'enable tests')
- option('udevdir', type: 'string', value: '', description: 'Directory for udev rules')
- option('efi-cc', type : 'string', value : 'gcc', description : 'the compiler to use for EFI modules')
+ option('build', type : 'combo', choices : ['all', 'standalone', 'library'], value : 'all', description : 'build type')
+ option('agent', type : 'boolean', value : true, description : 'enable the fwupd agent')
+ option('consolekit', type : 'boolean', value : true, description : 'enable ConsoleKit support')
 diff --git a/plugins/ata/meson.build b/plugins/ata/meson.build
 index 8444bb8a..fa4a8ad1 100644
 --- a/plugins/ata/meson.build

--- a/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
@@ -1,3 +1,5 @@
+diff --git a/data/device-tests/hardware.py b/data/device-tests/hardware.py
+index 7f1e1907..10fee1b8 100755
 --- a/data/device-tests/hardware.py
 +++ b/data/device-tests/hardware.py
 @@ -1,4 +1,4 @@
@@ -6,25 +8,41 @@
  # pylint: disable=wrong-import-position,too-many-locals,unused-argument,wrong-import-order
  #
  # Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+diff --git a/data/installed-tests/meson.build b/data/installed-tests/meson.build
+index adadbcdd..1b51bb9c 100644
 --- a/data/installed-tests/meson.build
 +++ b/data/installed-tests/meson.build
-@@ -1,4 +1,4 @@
--installed_test_datadir = join_paths(datadir, 'installed-tests', 'fwupd')
-+installed_test_datadir = join_paths(get_option('installed_test_prefix'), 'share', 'installed-tests', 'fwupd')
- 
- con2 = configuration_data()
- con2.set('installedtestsdir', installed_test_datadir)
-@@ -52,5 +52,5 @@ configure_file(
+@@ -65,5 +65,5 @@ configure_file(
    output : 'fwupd-tests.conf',
    configuration : con2,
    install: true,
 -  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 +  install_dir: join_paths(get_option('installed_test_prefix'), 'etc', 'fwupd', 'remotes.d'),
  )
+diff --git a/meson.build b/meson.build
+index 772b7bbe..f59302cd 100644
+--- a/meson.build
++++ b/meson.build
+@@ -177,8 +177,8 @@ else
+   datadir = join_paths(prefix, get_option('datadir'))
+   sysconfdir = join_paths(prefix, get_option('sysconfdir'))
+   localstatedir = join_paths(prefix, get_option('localstatedir'))
+-  installed_test_bindir = join_paths(libexecdir, 'installed-tests', meson.project_name())
+-  installed_test_datadir = join_paths(datadir, 'installed-tests', meson.project_name())
++  installed_test_bindir = join_paths(get_option('installed_test_prefix'), 'libexec', 'installed-tests', meson.project_name())
++  installed_test_datadir = join_paths(get_option('installed_test_prefix'), 'share', 'installed-tests', meson.project_name())
+ endif
+ mandir = join_paths(prefix, get_option('mandir'))
+ localedir = join_paths(prefix, get_option('localedir'))
+diff --git a/meson_options.txt b/meson_options.txt
+index 0a0e2853..5f68d78b 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -1,3 +1,4 @@
-+option('installed_test_prefix', type: 'string', value: '', description: 'Prefix for installed tests')
- option('build', type : 'combo', choices : ['all', 'standalone', 'library'], value : 'all', description : 'build type')
- option('agent', type : 'boolean', value : true, description : 'enable the fwupd agent')
- option('consolekit', type : 'boolean', value : true, description : 'enable ConsoleKit support')
+@@ -25,6 +26,7 @@ option('plugin_coreboot', type : 'boolean', value : true, description : 'enable
+ option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
+ option('systemd_root_prefix', type: 'string', value: '', description: 'Directory to base systemd’s installation directories on')
+ option('elogind', type : 'boolean', value : false, description : 'enable elogind support')
++option('installed_test_prefix', type: 'string', description: 'Prefix for installed tests')
+ option('tests', type : 'boolean', value : true, description : 'enable tests')
+ option('tpm', type : 'boolean', value : true, description : 'enable TPM support')
+ option('udevdir', type: 'string', value: '', description: 'Directory for udev rules')


### PR DESCRIPTION
###### Motivation for this change

https://blogs.gnome.org/hughsie/2020/10/26/new-fwupd-1-5-0-release/
https://github.com/fwupd/fwupd/releases/tag/1.5.0

* [x] The changelog mentions removed dependency on efivar but we still need the package because it also contains efiboot required dependency. https://github.com/fwupd/fwupd/pull/2485
* [x] Blacklist options were renamed.
* [x] Test firmware was moved to a separate repo. We need to install it or some tests will be skipped. https://github.com/fwupd/fwupd/pull/2330
* [x] Initially, there was an option to configure dbx but in the end, it was removed in favour of bespoke dbxtool. https://github.com/fwupd/fwupd/pull/2061, https://github.com/fwupd/fwupd/pull/2318, https://github.com/fwupd/fwupd/pull/2329
* [x] Fwupd now checks hashes of plug-ins and will complain loudly that it is tainted. – This is caused by loading the `invalid` plug-in since we remove it from blacklist in installed tests.
* [x] Installed tests complain about not being able to access cdn, even though we are not setting CI_NETWORK env var. [Reported](https://github.com/fwupd/fwupd/issues/2566).
* [x] g_strcontains assertion, opened [issue](https://github.com/fwupd/fwupd/issues/2564) and [pr](https://github.com/fwupd/fwupd/pull/2565)
* [ ] `cc1: warning: /nix/store/jk52cw6djmyc4k1dqz38hagpkn75d6fx-tpm2-tss-3.0.1/include/tss: No such file or directory [-Wmissing-include-dirs]`
     seems to not matter, will be fixed by next release https://github.com/tpm2-software/tpm2-tss/commit/26663f03ee64cf3108db5f87f8c4defe8a792c42

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
