### PR TITLE
flasm: init at 1.64

### DIFF
--- a/pkgs/development/compilers/flasm/default.nix
+++ b/pkgs/development/compilers/flasm/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchzip, unzip, bison, flex, gperf, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "flasm";
+  version = "1.64";
+
+  src = fetchzip {
+    url = "https://www.nowrap.de/download/flasm16src.zip";
+    sha256 = "03hvxm66rb6rjwbr07hc3k7ia5rim2xlhxbd9qmcai9xwmyiqafg";
+    stripRoot = false;
+  };
+
+  makeFlags = [ "CC=cc" ];
+
+  nativeBuildInputs = [ unzip bison flex gperf ];
+
+  buildInputs = [ zlib ];
+
+  installPhase = ''
+    install -Dm755 flasm -t $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Assembler and disassembler for Flash (SWF) bytecode";
+    homepage = "http://flasm.sourceforge.net/";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ siraben ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9033,6 +9033,8 @@ in
 
   fasmg = callPackage ../development/compilers/fasmg { };
 
+  flasm = callPackage ../development/compilers/flasm { };
+
   flyctl = callPackage ../development/web/flyctl { };
 
   flutterPackages =


### PR DESCRIPTION
###### Motivation for this change
#81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
