### PR TITLE
Update Haskell package set to LTS 16.20 (plus other fixes) 

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1467,7 +1467,7 @@ self: super: {
   skylighting-core = doDistribute super.skylighting-core_0_10_0_3;
   hslua = doDistribute self.hslua_1_1_2;
   jira-wiki-markup = doDistribute self.jira-wiki-markup_1_3_2;
-  pandoc = doDistribute self.pandoc_2_11_0_2;
+  pandoc = doDistribute self.pandoc_2_11_0_4;
   # jailbreaking pandoc-citeproc because it has not bumped upper bound on pandoc
   pandoc-citeproc = doJailbreak (doDistribute self.pandoc-citeproc_0_17_0_2);
   pandoc-types = doDistribute self.pandoc-types_1_22;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.2.x.nix
@@ -44,7 +44,7 @@ self: super: {
   text = self.text_1_2_4_0;
 
   # Needs Cabal 3.0.x.
-  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_3_2_0_0; };
+  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_3_2_1_0; };
 
   # https://github.com/bmillwood/applicative-quoters/issues/6
   applicative-quoters = appendPatch super.applicative-quoters (pkgs.fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -41,8 +41,8 @@ self: super: {
   xhtml = null;
 
   # Needs Cabal 3.2.x.
-  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
-  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_3_2_0_0; };
+  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_2_1_0; });
+  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_3_2_1_0; };
 
   # Restricts aeson to <1.4
   # https://github.com/purescript/purescript/pull/3537

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -42,8 +42,8 @@ self: super: {
   xhtml = null;
 
   # Needs Cabal 3.0.x.
-  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
-  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_3_2_0_0; };
+  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_2_1_0; });
+  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_3_2_1_0; };
 
   # https://github.com/tibbe/unordered-containers/issues/214
   unordered-containers = dontCheck super.unordered-containers;
@@ -77,10 +77,10 @@ self: super: {
 
   # cabal2nix needs the latest version of Cabal, and the one
   # hackage-db uses must match, so take the latest
-  cabal2nix = super.cabal2nix.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
+  cabal2nix = super.cabal2nix.overrideScope (self: super: { Cabal = self.Cabal_3_2_1_0; });
 
   # cabal2spec needs a recent version of Cabal
-  cabal2spec = super.cabal2spec.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
+  cabal2spec = super.cabal2spec.overrideScope (self: super: { Cabal = self.Cabal_3_2_1_0; });
 
   # Builds only with ghc-8.8.x and beyond.
   policeman = markBroken super.policeman;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -53,8 +53,8 @@ self: super: {
   haddock-api = self.haddock-api_2_23_1;
 
   # These builds need Cabal 3.2.x.
-  cabal2spec = super.cabal2spec.override { Cabal = self.Cabal_3_2_0_0; };
-  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
+  cabal2spec = super.cabal2spec.override { Cabal = self.Cabal_3_2_1_0; };
+  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_3_2_1_0; });
 
   # Ignore overly restrictive upper version bounds.
   aeson-diff = doJailbreak super.aeson-diff;
@@ -109,10 +109,10 @@ self: super: {
   apply-refact = super.apply-refact_0_7_0_0;
 
   # The package needs the latest Cabal version.
-  cabal-install-parsers = super.cabal-install-parsers.overrideScope (self: super: { Cabal = self.Cabal_3_2_0_0; });
+  cabal-install-parsers = super.cabal-install-parsers.overrideScope (self: super: { Cabal = self.Cabal_3_2_1_0; });
 
   # cabal-fmt requires Cabal3
-  cabal-fmt = super.cabal-fmt.override { Cabal = self.Cabal_3_2_0_0; };
+  cabal-fmt = super.cabal-fmt.override { Cabal = self.Cabal_3_2_1_0; };
 
   # liquidhaskell does not support ghc version 8.8.x.
   liquid = markBroken super.liquid;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -75,7 +75,7 @@ default-package-overrides:
   # haskell-language-server 0.5.0.0 doesn't accept newer versions
   - fourmolu ==0.2.*
   - refinery ==0.2.*
-  # LTS Haskell 16.19
+  # LTS Haskell 16.20
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -91,7 +91,7 @@ default-package-overrides:
   - aeson-attoparsec ==0.0.0
   - aeson-better-errors ==0.9.1.0
   - aeson-casing ==0.2.0.0
-  - aeson-combinators ==0.0.3.0
+  - aeson-combinators ==0.0.4.0
   - aeson-compat ==0.3.9
   - aeson-default ==0.9.1.0
   - aeson-diff ==1.1.0.9
@@ -214,12 +214,12 @@ default-package-overrides:
   - annotated-wl-pprint ==0.7.0
   - ansi-terminal ==0.10.3
   - ansi-wl-pprint ==0.6.9
-  - antiope-core ==7.5.1
-  - antiope-dynamodb ==7.5.1
-  - antiope-messages ==7.5.1
-  - antiope-s3 ==7.5.1
-  - antiope-sns ==7.5.1
-  - antiope-sqs ==7.5.1
+  - antiope-core ==7.5.3
+  - antiope-dynamodb ==7.5.3
+  - antiope-messages ==7.5.3
+  - antiope-s3 ==7.5.3
+  - antiope-sns ==7.5.3
+  - antiope-sqs ==7.5.3
   - ANum ==0.2.0.2
   - apecs ==0.9.2
   - apecs-gloss ==0.2.4
@@ -814,7 +814,7 @@ default-package-overrides:
   - fmlist ==0.9.4
   - fmt ==0.6.1.2
   - fn ==0.3.0.2
-  - focus ==1.0.1.3
+  - focus ==1.0.1.4
   - focuslist ==0.1.0.2
   - foldable1 ==0.1.0.0
   - fold-debounce ==0.2.0.9
@@ -975,7 +975,7 @@ default-package-overrides:
   - hackage-db ==2.1.0
   - hackage-security ==0.6.0.1
   - haddock-library ==1.8.0
-  - hadolint ==1.18.0
+  - hadolint ==1.18.2
   - hadoop-streaming ==0.2.0.3
   - hakyll ==4.13.4.0
   - half ==0.3
@@ -1275,7 +1275,7 @@ default-package-overrides:
   - JuicyPixels-blurhash ==0.1.0.3
   - JuicyPixels-extra ==0.4.1
   - JuicyPixels-scale-dct ==0.1.2
-  - junit-xml ==0.1.0.1
+  - junit-xml ==0.1.0.2
   - justified-containers ==0.3.0.0
   - jwt ==0.10.0
   - kan-extensions ==5.2.1
@@ -1302,7 +1302,7 @@ default-package-overrides:
   - language-bash ==0.9.2
   - language-c ==0.8.3
   - language-c-quote ==0.12.2.1
-  - language-docker ==9.1.1
+  - language-docker ==9.1.2
   - language-haskell-extract ==0.2.4
   - language-java ==0.2.9
   - language-javascript ==0.7.1.0
@@ -1651,7 +1651,7 @@ default-package-overrides:
   - password-instances ==2.0.0.1
   - path ==0.7.0
   - path-extra ==0.2.0
-  - path-io ==1.6.1
+  - path-io ==1.6.2
   - path-pieces ==0.2.1
   - path-text-utf8 ==0.0.1.6
   - pathtype ==0.8.1.1
@@ -1818,7 +1818,7 @@ default-package-overrides:
   - range ==0.3.0.2
   - Ranged-sets ==0.4.0
   - range-set-list ==0.1.3.1
-  - rank1dynamic ==0.4.0
+  - rank1dynamic ==0.4.1
   - rank2classes ==1.3.2.1
   - Rasterific ==0.7.5.3
   - rasterific-svg ==0.3.3.2
@@ -2478,7 +2478,7 @@ default-package-overrides:
   - xdg-userdirs ==0.1.0.2
   - xeno ==0.4.2
   - xls ==0.1.3
-  - xlsx ==0.8.1
+  - xlsx ==0.8.2
   - xlsx-tabular ==0.2.2.1
   - xml ==1.3.14
   - xml-basic ==0.1.3.1
@@ -2507,7 +2507,7 @@ default-package-overrides:
   - yesod-auth-fb ==1.10.1
   - yesod-auth-hashdb ==1.7.1.2
   - yesod-bin ==1.6.0.6
-  - yesod-core ==1.6.18.4
+  - yesod-core ==1.6.18.5
   - yesod-fb ==0.6.1
   - yesod-form ==1.6.7
   - yesod-form-bootstrap4 ==3.0.0

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8746,7 +8746,11 @@ broken-packages:
   - polydata-core
   - polynomial
   - polysemy-chronos
+  - polysemy-extra
+  - polysemy-fskvstore
   - polysemy-http
+  - polysemy-kvstore-jsonfile
+  - polysemy-methodology
   - polysemy-optics
   - polysemy-RandomFu
   - polysemy-resume
@@ -11115,6 +11119,7 @@ broken-packages:
   - windns
   - windowslive
   - winerror
+  - winery
   - winio
   - Wired
   - wires

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5066,7 +5066,6 @@ broken-packages:
   - flamethrower
   - flamingra
   - flashblast
-  - flat
   - flat-maybe
   - flatbuffers
   - flay


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2020-10-30 20:00 +02:00. You can watch this live on Twitch at https://www.twitch.tv/peti343. In addition to the chat features offered by Twitch, there is also a voice conference at https://discord.gg/YTEa3XR that viewers can use to chat with me and with each other.