### PR TITLE
snow: init at 20130616

### DIFF
--- a/pkgs/tools/security/snow/default.nix
+++ b/pkgs/tools/security/snow/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "snow";
+  version = "20130616";
+
+  src = fetchurl {
+    url = "https://web.archive.org/web/20200304125913if_/http://darkside.com.au/snow/snow-${version}.tar.gz";
+    sha256 = "0r9q45y55z4i0askkxmxrx0jr1620ypd870vz0hx2a6n9skimdy0";
+  };
+
+  makeFlags = [ "CFLAGS=-O2" ];
+
+  installPhase = ''
+    install -Dm755 snow -t $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Conceal messages in ASCII text by appending whitespace to the end of lines";
+    homepage = "http://www.darkside.com.au/snow/";
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ siraben ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15487,6 +15487,8 @@ in
 
   snappy = callPackage ../development/libraries/snappy { };
 
+  snow = callPackage ../tools/security/snow { };
+
   soapyairspy = callPackage ../applications/radio/soapyairspy { };
 
   soapybladerf = callPackage ../applications/radio/soapybladerf { };


### PR DESCRIPTION
###### Motivation for this change
#81418

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
