### PR TITLE
stdenv/check-meta: add hint to NIXPKGS_ALLOW_* for unfree/broken/…

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -88,13 +88,28 @@ let
     broken-outputs = remediateOutputsToInstall;
     unknown-meta = x: "";
   };
+  remediation_env_var = allow_attr: {
+    Unfree = "NIXPKGS_ALLOW_UNFREE";
+    Broken = "NIXPKGS_ALLOW_BROKEN";
+    UnsupportedSystem = "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM";
+  }.${allow_attr};
+  remediation_phrase = allow_attr: {
+    Unfree = "unfree packages";
+    Broken = "broken packages";
+    UnsupportedSystem = "packages that are unsupported for this system";
+  }.${allow_attr};
   remediate_whitelist = allow_attr: attrs:
     ''
-      a) For `nixos-rebuild` you can set
+      a) To temporarily allow ${remediation_phrase allow_attr}, you can use an environment variable
+         for a single invocation of the nix tools.
+
+           $ export ${remediation_env_var allow_attr}=1
+
+      b) For `nixos-rebuild` you can set
         { nixpkgs.config.allow${allow_attr} = true; }
       in configuration.nix to override this.
 
-      b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
+      c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allow${allow_attr} = true; }
       to ~/.config/nixpkgs/config.nix.
     '';


### PR DESCRIPTION
A (slightly) different approach to https://github.com/NixOS/nixpkgs/pull/81990/files and more in line with https://github.com/NixOS/nixpkgs/pull/90031

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/90031
Closes https://github.com/NixOS/nixpkgs/pull/81990

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (via building a marked package)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
