### PR TITLE
rubber: put man and info pages in the right directory

### DIFF
--- a/pkgs/tools/typesetting/rubber/default.nix
+++ b/pkgs/tools/typesetting/rubber/default.nix
@@ -9,18 +9,18 @@ python3Packages.buildPythonApplication rec {
     sha256 = "178dmrp0mza5gqjiqgk6dqs0c10s0c517pk6k9pjbam86vf47a1p";
   };
 
-  nativeBuildInputs = [ texinfo ];
-
-  # I couldn't figure out how to pass the proper parameter to disable pdf generation, so we
-  # use sed to change the default
-  preBuild = ''
-    sed -i -r 's/pdf\s+= True/pdf = False/g' setup.py
+  # I'm sure there is a better way to pass these parameters to the build script...
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'pdf  = True' 'pdf = False' \
+      --replace '$base/man'   'share/man' \
+      --replace '$base/info'  'share/info' \
+      --replace '$base/share' 'share'
   '';
 
-  # the check scripts forces python2. If we need to use python3 at some point, we should use
-  # the correct python
+  nativeBuildInputs = [ texinfo ];
+
   checkPhase = ''
-    sed -i 's|python=python3|python=${python3Packages.python.interpreter}|' tests/run.sh
     cd tests && ${stdenv.shell} run.sh
   '';
 


### PR DESCRIPTION
###### Motivation for this change

We used to put man pages in $out/$out/man.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).