### PR TITLE
php: fix on darwin

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -29,7 +29,7 @@ let
     , embedSupport ? false
     , ipv6Support ? true
     , systemdSupport ? stdenv.isLinux
-    , valgrindSupport ? true
+    , valgrindSupport ? !stdenv.isDarwin
     , ztsSupport ? apxs2Support
     }@args:
       let


### PR DESCRIPTION
###### Motivation for this change
Fix build on darwin by disabling valgrind support, since valgrind is broken on darwin:
https://github.com/NixOS/nixpkgs/blob/791b40e320a559ef9395cdbd9e6b84bdc69b137f/pkgs/development/tools/analysis/valgrind/default.nix#L89

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
