### PR TITLE
gif-for-cli: unstable-2018-08-14 -> 1.1.2

### DIFF
--- a/pkgs/tools/misc/gif-for-cli/default.nix
+++ b/pkgs/tools/misc/gif-for-cli/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchFromGitHub, python3Packages, ffmpeg_3, zlib, libjpeg }:
+{ stdenv, fetchFromGitHub, python3Packages, ffmpeg, zlib, libjpeg }:
 
 python3Packages.buildPythonApplication {
   pname = "gif-for-cli";
-  version = "unstable-2018-08-14";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "gif-for-cli";
-    rev = "9696f25fea2e38499b7c248a3151030c3c68bb00";
-    sha256 = "1rj8wjfsabn27k1ds7a5fdqgf2r28zpz4lvhbzssjfj1yf0mfh7s";
+    rev = "31f8aa2d617d6d6e941154f60e287c38dd9a74d5";
+    sha256 = "Bl5o492BUAn1KsscnlMIXCzJuy7xWUsdnxIKZKaRM3M=";
   };
 
   checkInputs = [ python3Packages.coverage ];
-  buildInputs = [ ffmpeg_3 zlib libjpeg ];
-  propagatedBuildInputs = with python3Packages; [ pillow requests x256 ];
+  buildInputs = [ zlib libjpeg ];
+  propagatedBuildInputs = with python3Packages; [ ffmpeg pillow requests x256 ];
 
   meta = with stdenv.lib; {
     description = "Render gifs as ASCII art in your cli";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
