### PR TITLE
go_bootstrap: disable failing timezone tests

### DIFF
--- a/pkgs/development/compilers/go/1.4.nix
+++ b/pkgs/development/compilers/go/1.4.nix
@@ -43,6 +43,8 @@ stdenv.mkDerivation rec {
     cd go
     patchShebangs ./ # replace /bin/bash
 
+    # Disable timezone tests (these fail when `tzdata` is updated)
+    rm src/time/{example,format}_test.go
     # Disabling the 'os/http/net' tests (they want files not available in
     # chroot builds)
     rm src/net/{multicast_test.go,parse_test.go,port_test.go}
@@ -56,8 +58,6 @@ stdenv.mkDerivation rec {
     sed -i '/TestDialTimeout/areturn' src/net/dial_test.go
     # Disable the hostname test
     sed -i '/TestHostname/areturn' src/os/os_test.go
-    # ParseInLocation fails the test
-    sed -i '/TestParseInSydney/areturn' src/time/format_test.go
 
     sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
   '' + lib.optionalString stdenv.isLinux ''
@@ -119,13 +119,6 @@ stdenv.mkDerivation rec {
   patches = [
     ./remove-tools-1.4.patch
     ./creds-test-1.4.patch
-
-    # This test checks for the wrong thing with recent tzdata. It's been fixed in master but the patch
-    # actually works on old versions too.
-    (fetchpatch {
-      url    = "https://github.com/golang/go/commit/91563ced5897faf729a34be7081568efcfedda31.patch";
-      sha256 = "1ny5l3f8a9dpjjrnjnsplb66308a0x13sa0wwr4j6yrkc8j4qxqi";
-    })
   ];
 
   GOOS = if stdenv.isDarwin then "darwin" else "linux";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes https://hydra.nixos.org/build/129275183/nixlog/1


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
