### PR TITLE
rakudo: 2020.09 -> 2020.10

### DIFF
--- a/pkgs/development/interpreters/rakudo/default.nix
+++ b/pkgs/development/interpreters/rakudo/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "rakudo";
-  version = "2020.09";
+  version = "2020.10";
 
   src = fetchurl {
     url    = "https://www.rakudo.org/dl/rakudo/rakudo-${version}.tar.gz";
-    sha256 = "1izfwns7viwy0x9hnhx13j9w5qa97qpyxqk9cd8iax7i68z057m7";
+    sha256 = "0wvsinmpz8icd0409f8rg93mqdb5ml76m0vb4r26ngz237ph69dn";
   };
 
   buildInputs = [ icu zlib gmp perl ];

--- a/pkgs/development/interpreters/rakudo/moarvm.nix
+++ b/pkgs/development/interpreters/rakudo/moarvm.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "moarvm";
-  version = "2020.09";
+  version = "2020.10";
 
   src = fetchurl {
     url = "https://www.moarvm.org/releases/MoarVM-${version}.tar.gz";
-    sha256 = "08prlvnyqwnzb7mwaqvgv662v78xgwsyy12cpyim6gc4z0i1kcj8";
+    sha256 = "1i7jjjwv4av3rsfgbqb213fhb9ns25jfm19nzn7kki0n7w486y33";
    };
 
   buildInputs = [ perl ] ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices ApplicationServices ];

--- a/pkgs/development/interpreters/rakudo/nqp.nix
+++ b/pkgs/development/interpreters/rakudo/nqp.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nqp";
-  version = "2020.09";
+  version = "2020.10";
 
   src = fetchurl {
     url    = "https://github.com/raku/nqp/releases/download/${version}/nqp-${version}.tar.gz";
-    sha256 = "09kiy7r732yrh3nzdzdq9yki0jx2hamyqvrbahk4mlxmb6cl9qmh";
+    sha256 = "0nb0vdycz2wrd5yspvps2wy7a21066csr18v786085qim347830h";
   };
 
   buildInputs = [ perl ];


### PR DESCRIPTION
https://github.com/rakudo/rakudo/blob/2020.10/docs/ChangeLog

dependencies:
nqp: 2020.09 -> 2020.10
moarvm: 2020.09 -> 2020.10


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
