### PR TITLE
odafileconverter: 21.7.0.0 -> 21.11.0.0

### DIFF
--- a/pkgs/applications/graphics/odafileconverter/default.nix
+++ b/pkgs/applications/graphics/odafileconverter/default.nix
@@ -4,7 +4,7 @@ let
   # To obtain the version you will need to run the following command:
   #
   # dpkg-deb -I ${odafileconverter.src} | grep Version
-  version = "21.7.0.0";
+  version = "21.9.0.0";
   rpath = "$ORIGIN:${lib.makeLibraryPath [ stdenv.cc.cc qtbase ]}";
 
 in mkDerivation {
@@ -14,8 +14,8 @@ in mkDerivation {
 
   src = fetchurl {
     # NB: this URL is not stable (i.e. the underlying file and the corresponding version will change over time)
-    url = "https://download.opendesign.com/guestfiles/ODAFileConverter/ODAFileConverter_QT5_lnxX64_7.2dll.deb";
-    sha256 = "0sa21nnwzqb6g7gl0z43smqgcd9h3xipj3cq2cl7ybfh3cvcxfi9";
+    url = "https://download.opendesign.com/guestfiles/Demo/ODAFileConverter_QT5_lnxX64_7.2dll_21.9.deb";
+    sha256 = "571f59bb1c340025df4742eaf9bd80d277e631fdfe622f81a44ae0c61b59672d";
   };
 
   unpackPhase = ''

--- a/pkgs/applications/graphics/odafileconverter/default.nix
+++ b/pkgs/applications/graphics/odafileconverter/default.nix
@@ -4,7 +4,7 @@ let
   # To obtain the version you will need to run the following command:
   #
   # dpkg-deb -I ${odafileconverter.src} | grep Version
-  version = "21.9.0.0";
+  version = "21.11.0.0";
   rpath = "$ORIGIN:${lib.makeLibraryPath [ stdenv.cc.cc qtbase ]}";
 
 in mkDerivation {
@@ -14,8 +14,8 @@ in mkDerivation {
 
   src = fetchurl {
     # NB: this URL is not stable (i.e. the underlying file and the corresponding version will change over time)
-    url = "https://download.opendesign.com/guestfiles/Demo/ODAFileConverter_QT5_lnxX64_7.2dll_21.9.deb";
-    sha256 = "571f59bb1c340025df4742eaf9bd80d277e631fdfe622f81a44ae0c61b59672d";
+    url = "http://web.archive.org/web/20201206221727if_/https://download.opendesign.com/guestfiles/Demo/ODAFileConverter_QT5_lnxX64_7.2dll_21.11.deb";
+    sha256 = "10027a3ab18efd04ca75aa699ff550eca3bdfe6f7084460d3c00001bffb50070";
   };
 
   unpackPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The current url is broken. Found the new url from https://www.opendesign.com/guestfiles/oda_file_converter. I built the new version successfully and converted some `dwg` files to `dxf` format.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
