### PR TITLE
nixos/searx: declarative configuration

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -402,6 +402,18 @@ http://some.json-exporter.host:7979/probe?target=https://example.com/some/json/e
        SDK licenses if your project requires it. See the androidenv documentation for more details.
      </para>
    </listitem>
+   <listitem>
+     <para>
+      The Searx module has been updated with the ability to configure the
+      service declaratively and uWSGI integration.
+      The option <literal>services.searx.configFile</literal> has been renamed
+      to <xref linkend="opt-services.searx.settingsFile"/> for consistency with
+      the new <xref linkend="opt-services.searx.settings"/>. In addition, the
+      <literal>searx</literal> uid and gid reservations have been removed
+      since they were not necessary: the service is now running with a
+      dynamically allocated uid.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -143,7 +143,7 @@ in
       nix-ssh = 104;
       dictd = 105;
       couchdb = 106;
-      searx = 107;
+      #searx = 107; # dynamically allocated as of 2020-10-27
       kippo = 108;
       jenkins = 109;
       systemd-journal-gateway = 110;
@@ -457,7 +457,7 @@ in
       #nix-ssh = 104; # unused
       dictd = 105;
       couchdb = 106;
-      searx = 107;
+      #searx = 107; # dynamically allocated as of 2020-10-27
       kippo = 108;
       jenkins = 109;
       systemd-journal-gateway = 110;

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -3,14 +3,60 @@
 with lib;
 
 let
-
+  dataDir = "/var/lib/searx";
   cfg = config.services.searx;
 
-  configFile = cfg.configFile;
+  hasEngines =
+    builtins.hasAttr "engines" cfg.settings &&
+    cfg.settings.engines != { };
+
+  # Script to merge NixOS settings with
+  # the default settings.yml bundled in searx.
+  mergeConfig = ''
+    cd ${dataDir}
+    # find the default settings.yml
+    default=$(find '${cfg.package}/' -name settings.yml)
+
+    # write NixOS settings as JSON
+    cat <<'EOF' > settings.json
+      ${builtins.toJSON cfg.settings}
+    EOF
+
+    ${optionalString hasEngines ''
+      # extract and convert the default engines array to an object
+      ${pkgs.yq-go}/bin/yq r "$default" engines -j | \
+      ${pkgs.jq}/bin/jq 'reduce .[] as $e ({}; .[$e.name] = $e)' \
+        > engines.json
+
+      # merge and update the NixOS engines with the newly created object
+      cp settings.json temp.json
+      ${pkgs.jq}/bin/jq -s '. as [$s, $e] | $s | .engines |=
+        ($e * . | to_entries | map (.value))' \
+        temp.json engines.json > settings.json
+
+      # clean up temporary files
+      rm {engines,temp}.json
+    ''}
+
+    # merge the default and NixOS settings
+    ${pkgs.yq-go}/bin/yq m -P settings.json "$default" > settings.yml
+    rm settings.json
+
+    # substitute environment variables
+    env -0 | while IFS='=' read -r -d ''' n v; do
+      sed "s#@$n@#$v#g" -i settings.yml
+    done
+  '';
 
 in
 
 {
+
+  imports = [
+    (mkRenamedOptionModule
+      [ "services" "searx" "configFile" ]
+      [ "services" "searx" "settingsFile" ])
+  ];
 
   ###### interface
 
@@ -18,17 +64,69 @@ in
 
     services.searx = {
 
-      enable = mkEnableOption
-        "the searx server. See https://github.com/asciimoo/searx";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        relatedPackages = [ "searx" ];
+        description = "Whether to enable Searx, the meta search engine.";
+      };
 
-      configFile = mkOption {
+      environmentFile = mkOption {
         type = types.nullOr types.path;
         default = null;
-        description = "
-          The path of the Searx server configuration file. If no file
-          is specified, a default file is used (default config file has
-          debug mode enabled).
-        ";
+        description = ''
+          Environment file (see <literal>systemd.exec(5)</literal>
+          "EnvironmentFile=" section for the syntax) to define variables for
+          Searx. This option can be used to safely include secret keys into the
+          Searx configuration.
+        '';
+      };
+
+      settings = mkOption {
+        type = types.attrs;
+        default = { };
+        example = literalExample ''
+          { server.port = 8080;
+            server.bind_address = "0.0.0.0";
+            server.secret_key = "@SEARX_SECRET_KEY@";
+
+            engines.wolframalpha =
+              { shortcut = "wa";
+                api_key = "@WOLFRAM_API_KEY@";
+                engine = "wolframalpha_api";
+              };
+          }
+        '';
+        description = ''
+          Searx settings. These will be merged with (taking precedence over)
+          the default configuration. It's also possible to refer to
+          environment variables
+          (defined in <xref linkend="opt-services.searx.environmentFile"/>)
+          using the syntax <literal>@VARIABLE_NAME@</literal>.
+          <note>
+            <para>
+              For available settings, see the Searx
+              <link xlink:href="https://searx.github.io/searx/admin/settings.html">docs</link>.
+            </para>
+          </note>
+        '';
+      };
+
+      settingsFile = mkOption {
+        type = types.path;
+        default = "${dataDir}/settings.yml";
+        description = ''
+          The path of the Searx server settings.yml file. If no file is
+          specified, a default file is used (default config file has debug mode
+          enabled). Note: setting this options overrides
+          <xref linkend="opt-services.searx.settings"/>.
+          <warning>
+            <para>
+              This file, along with any secret key it contains, will be copied
+              into the world-readable Nix store.
+            </para>
+          </warning>
+        '';
       };
 
       package = mkOption {
@@ -46,30 +144,20 @@ in
   ###### implementation
 
   config = mkIf config.services.searx.enable {
-
-    users.users.searx =
-      { uid = config.ids.uids.searx;
-        description = "Searx user";
-        createHome = true;
-        home = "/var/lib/searx";
-      };
-
-    users.groups.searx =
-      { gid = config.ids.gids.searx;
-      };
-
-    systemd.services.searx =
-      {
-        description = "Searx server, the meta search engine.";
-        after = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          User = "searx";
-          ExecStart = "${cfg.package}/bin/searx-run";
-        };
-      } // (optionalAttrs (configFile != null) {
-        environment.SEARX_SETTINGS_PATH = configFile;
-      });
+    systemd.services.searx = {
+      description = "Searx server, the meta search engine.";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        User = "searx";
+        DynamicUser = true;
+        ExecStart = "${cfg.package}/bin/searx-run";
+        StateDirectory = "searx";
+      } // optionalAttrs (cfg.environmentFile != null)
+        { EnvironmentFile = builtins.toPath cfg.environmentFile; };
+      environment.SEARX_SETTINGS_PATH = cfg.settingsFile;
+      preStart = mergeConfig;
+    };
 
     environment.systemPackages = [ cfg.package ];
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -342,6 +342,7 @@ in
   sbt-extras = handleTest ./sbt-extras.nix {};
   scala = handleTest ./scala.nix {};
   sddm = handleTest ./sddm.nix {};
+  searx = handleTest ./searx.nix {};
   service-runner = handleTest ./service-runner.nix {};
   shadow = handleTest ./shadow.nix {};
   shadowsocks = handleTest ./shadowsocks {};

--- a/nixos/tests/searx.nix
+++ b/nixos/tests/searx.nix
@@ -1,0 +1,62 @@
+import ./make-test-python.nix ({ pkgs, ...} :
+
+{
+  name = "searx";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ rnhmjoj ];
+  };
+
+  machine = { ... }: {
+    imports = [ ../modules/profiles/minimal.nix ];
+
+    services.searx = {
+      enable = true;
+      environmentFile = pkgs.writeText "secrets" ''
+        WOLFRAM_API_KEY  = sometoken
+        SEARX_SECRET_KEY = somesecret
+      '';
+
+      settings.server =
+        { port = 8080;
+          bind_address = "0.0.0.0";
+          secret_key = "@SEARX_SECRET_KEY@";
+        };
+
+      settings.engines = {
+        wolframalpha =
+          { api_key = "@WOLFRAM_API_KEY@";
+            engine = "wolframalpha_api";
+          };
+        startpage.shortcut = "start";
+      };
+
+    };
+  };
+
+  testScript =
+    ''
+      start_all()
+
+      with subtest("Settings have been merged"):
+          machine.wait_for_unit("searx")
+          output = machine.succeed(
+              "${pkgs.yq-go}/bin/yq r /var/lib/searx/settings.yml"
+              " 'engines.(name==startpage).shortcut'"
+          ).strip()
+          assert output == "start", "Settings not merged"
+
+      with subtest("Environment variables have been substituted"):
+          machine.succeed("grep -q somesecret /var/lib/searx/settings.yml")
+          machine.succeed("grep -q sometoken /var/lib/searx/settings.yml")
+
+      with subtest("Searx service is running"):
+          machine.wait_for_open_port(8080)
+          machine.succeed(
+              "${pkgs.curl}/bin/curl --fail http://localhost:8080"
+          )
+
+      machine.copy_from_vm("/var/lib/searx/settings.yml")
+      machine.shutdown()
+    '';
+})
+

--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3, python3Packages, fetchFromGitHub, fetchpatch }:
+{ lib, nixosTests, python3, python3Packages, fetchFromGitHub, fetchpatch }:
 
 with python3Packages;
 
@@ -39,6 +39,8 @@ toPythonModule (buildPythonApplication rec {
     mkdir -p $out/share
     ln -s ../${python3.sitePackages}/searx/static $out/share/
   '';
+
+  passthru.tests = { inherit (nixosTests) searx; };
 
   meta = with lib; {
     homepage = "https://github.com/asciimoo/searx";

--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -1,8 +1,8 @@
-{ lib, python3Packages, fetchFromGitHub, fetchpatch }:
+{ lib, python3, python3Packages, fetchFromGitHub, fetchpatch }:
 
 with python3Packages;
 
-buildPythonApplication rec {
+toPythonModule (buildPythonApplication rec {
   pname = "searx";
   version = "0.17.0";
 
@@ -34,10 +34,16 @@ buildPythonApplication rec {
     rm tests/test_robot.py # A variable that is imported is commented out
   '';
 
+  postInstall = ''
+    # Create a symlink for easier access to static data
+    mkdir -p $out/share
+    ln -s ../${python3.sitePackages}/searx/static $out/share/
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/asciimoo/searx";
     description = "A privacy-respecting, hackable metasearch engine";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ matejc fpletz globin danielfullmer ];
   };
-}
+})


### PR DESCRIPTION
###### Motivation for this change
The pain of having to manually diff the settings.yml on every update,
like if NixOS were some kind of Arch Linux.

###### Things done

- [x] Tested environment substitution
- [x] Tested configuration merging
- [x] Tested service runs
- [x] Remove searx uid,gids
- [x] Document changes in the release notes
- [x] Run more tests for uWSGI
- [x] Figure out why immediate-uid is necessary
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
