### PR TITLE
[20.09] ec2-amis: add stable NixOS 20.09 AMIs

### DIFF
--- a/nixos/modules/virtualisation/ec2-amis.nix
+++ b/nixos/modules/virtualisation/ec2-amis.nix
@@ -329,5 +329,24 @@ let self = {
   "20.03".ap-east-1.hvm-ebs = "ami-0d18fdd309cdefa86";
   "20.03".sa-east-1.hvm-ebs = "ami-09859378158ae971d";
 
-  latest = self."20.03";
+  # 20.09.1465.9a0b14b097d
+  "20.09".eu-west-1.hvm-ebs = "ami-0d90f16418e3c364c";
+  "20.09".eu-west-2.hvm-ebs = "ami-0635ec0780ea57cfe";
+  "20.09".eu-west-3.hvm-ebs = "ami-0714e94352f2eabb9";
+  "20.09".eu-central-1.hvm-ebs = "ami-0979d39762a4d2a02";
+  "20.09".eu-north-1.hvm-ebs = "ami-0b14e273185c66e9b";
+  "20.09".us-east-1.hvm-ebs = "ami-0f8b063ac3f2d9645";
+  "20.09".us-east-2.hvm-ebs = "ami-0959202a0393fdd0c";
+  "20.09".us-west-1.hvm-ebs = "ami-096d50833b785478b";
+  "20.09".us-west-2.hvm-ebs = "ami-0fc31031df0df6104";
+  "20.09".ca-central-1.hvm-ebs = "ami-0787786a38cde3905";
+  "20.09".ap-southeast-1.hvm-ebs = "ami-0b3f693d3a2a0b9ae";
+  "20.09".ap-southeast-2.hvm-ebs = "ami-02471872bc876b610";
+  "20.09".ap-northeast-1.hvm-ebs = "ami-06505fd2bf44a59a7";
+  "20.09".ap-northeast-2.hvm-ebs = "ami-0754b4c014eea1e8a";
+  "20.09".ap-south-1.hvm-ebs = "ami-05100e32242ae65a6";
+  "20.09".ap-east-1.hvm-ebs = "ami-045288859a39de009";
+  "20.09".sa-east-1.hvm-ebs = "ami-0a937748db48fb00d";
+
+  latest = self."20.09";
 }; in self


### PR DESCRIPTION
Fixes #101694

(cherry picked from commit 8cae6703efdf7ddd8b999209de99bfd141abf7b0)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
