### PR TITLE
Add package wmderland

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8403,6 +8403,12 @@
     githubId = 321799;
     name = "Paul Colomiets";
   };
+  takagiy = {
+    email = "takagiy.4dev@gmail.com";
+    github = "takagiy";
+    githubId = 18656090;
+    name = "Yuki Takagi";
+  };
   taketwo = {
     email = "alexandrov88@gmail.com";
     github = "taketwo";

--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -36,6 +36,7 @@ in
     ./tinywm.nix
     ./twm.nix
     ./windowmaker.nix
+    ./wmderland.nix
     ./wmii.nix
     ./xmonad.nix
     ./yeahwm.nix

--- a/nixos/modules/services/x11/window-managers/wmderland.nix
+++ b/nixos/modules/services/x11/window-managers/wmderland.nix
@@ -1,0 +1,61 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.windowManager.wmderland;
+in
+
+{
+  options.services.xserver.windowManager.wmderland = {
+    enable = mkEnableOption "wmderland";
+
+    extraSessionCommands = mkOption {
+      default = "";
+      type = types.lines;
+      description = ''
+        Shell commands executed just before wmderland is started.
+      '';
+    };
+
+    extraPackages = mkOption {
+      type = with types; listOf package;
+      default = with pkgs; [
+        rofi
+        dunst
+        light
+        hsetroot
+        feh
+        rxvt-unicode
+      ];
+      example = literalExample ''
+        with pkgs; [
+          rofi
+          dunst
+          light
+          hsetroot
+          feh
+          rxvt-unicode
+        ]
+      '';
+      description = ''
+        Extra packages to be installed system wide.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.xserver.windowManager.session = singleton {
+      name = "wmderland";
+      start = ''
+        ${cfg.extraSessionCommands}
+
+        ${pkgs.wmderland}/bin/wmderland &
+        waitPID=$!
+      '';
+    };
+    environment.systemPackages = [
+      pkgs.wmderland pkgs.wmderlandc
+    ] ++ cfg.extraPackages;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -371,6 +371,7 @@ in
   virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix {};
   wasabibackend = handleTest ./wasabibackend.nix {};
   wireguard = handleTest ./wireguard {};
+  wmderland = handleTest ./wmderland.nix {};
   wordpress = handleTest ./wordpress.nix {};
   xandikos = handleTest ./xandikos.nix {};
   xautolock = handleTest ./xautolock.nix {};

--- a/nixos/tests/wmderland.nix
+++ b/nixos/tests/wmderland.nix
@@ -1,0 +1,54 @@
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "wmderland";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ takagiy ];
+  };
+
+  machine = { lib, ... }: {
+    imports = [ ./common/x11.nix ./common/user-account.nix ];
+    test-support.displayManager.auto.user = "alice";
+    services.xserver.displayManager.defaultSession = lib.mkForce "none+wmderland";
+    services.xserver.windowManager.wmderland.enable = true;
+
+    systemd.services.setupWmderlandConfig = {
+      wantedBy = [ "multi-user.target" ];
+      before = [ "multi-user.target" ];
+      environment = {
+        HOME = "/home/alice";
+      };
+      unitConfig = {
+        type = "oneshot";
+        RemainAfterExit = true;
+        user = "alice";
+      };
+      script = let
+        config = pkgs.writeText "config" ''
+             set $Mod = Mod1
+             bindsym $Mod+Return exec ${pkgs.xterm}/bin/xterm -cm -pc
+        '';
+      in ''
+        mkdir -p $HOME/.config/wmderland
+        cp ${config} $HOME/.config/wmderland/config
+      '';
+    };
+  };
+
+  testScript = { ... }: ''
+    with subtest("ensure x starts"):
+        machine.wait_for_x()
+        machine.wait_for_file("/home/alice/.Xauthority")
+        machine.succeed("xauth merge ~alice/.Xauthority")
+
+    with subtest("ensure we can open a new terminal"):
+        machine.send_key("alt-ret")
+        machine.wait_until_succeeds("pgrep xterm")
+        machine.wait_for_window(r"alice.*?machine")
+        machine.screenshot("terminal")
+
+    with subtest("ensure we can communicate through ipc with wmderlandc"):
+        # Kills the previously open xterm
+        machine.succeed("pgrep xterm")
+        machine.execute("DISPLAY=:0 wmderlandc kill")
+        machine.fail("pgrep xterm")
+  '';
+})

--- a/pkgs/applications/window-managers/wmderland/0001-remove-flto.patch
+++ b/pkgs/applications/window-managers/wmderland/0001-remove-flto.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 17a4944..33406f3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,7 +10,7 @@ include(BuildType)
+ # Request C++14 standard, using new CMake variables.
+ set(CMAKE_CXX_STANDARD 14)
+ set(CMAKE_CXX_STANDARD_REQUIRED True)
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto -Wall")
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+ 
+ # If the BuildType is Debug, then add -rdynamic.
+ # (used to print stacktrace with function names)

--- a/pkgs/applications/window-managers/wmderland/default.nix
+++ b/pkgs/applications/window-managers/wmderland/default.nix
@@ -1,0 +1,49 @@
+{ lib, stdenv, fetchFromGitHub, cmake, libnotify, libX11, xorgproto, nixosTests }:
+
+stdenv.mkDerivation {
+  pname = "wmderland";
+  version = "unstable-2020-07-17";
+
+  src = fetchFromGitHub {
+    owner = "aesophor";
+    repo = "wmderland";
+    rev = "a40a3505dd735b401d937203ab6d8d1978307d72";
+    sha256 = "0npmlnybblp82mfpinjbz7dhwqgpdqc1s63wc1zs8mlcs19pdh98";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeBuildType = "MinSizeRel";
+
+  patches = [ ./0001-remove-flto.patch ];
+
+  postPatch = ''
+    substituteInPlace src/util.cc \
+      --replace "notify-send" "${libnotify}/bin/notify-send"
+  '';
+
+  buildInputs = [
+    libX11
+    xorgproto
+  ];
+
+  postInstall = ''
+    install -Dm0644 -t $out/share/wmderland/contrib $src/example/config
+    install -Dm0644 -t $out/share/xsessions $src/example/wmderland.desktop
+  '';
+
+  passthru = {
+    tests.basic = nixosTests.wmderland;
+    providedSessions = [ "wmderland" ];
+  };
+
+  meta = with lib; {
+    description = "Modern and minimal X11 tiling window manager";
+    homepage = "https://github.com/aesophor/wmderland";
+    license = licenses.mit;
+    platforms = libX11.meta.platforms;
+    maintainers = with maintainers; [ takagiy ];
+  };
+}

--- a/pkgs/applications/window-managers/wmderlandc/default.nix
+++ b/pkgs/applications/window-managers/wmderlandc/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, cmake, libX11, xorgproto }:
+
+stdenv.mkDerivation {
+  pname = "wmderlandc";
+  version = "unstable-2020-07-17";
+
+  src = fetchFromGitHub {
+    owner = "aesophor";
+    repo = "wmderland";
+    rev = "a40a3505dd735b401d937203ab6d8d1978307d72";
+    sha256 = "0npmlnybblp82mfpinjbz7dhwqgpdqc1s63wc1zs8mlcs19pdh98";
+  };
+
+  sourceRoot = "source/ipc-client";
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    libX11
+    xorgproto
+  ];
+
+  meta = with lib; {
+    description = "A tiny program to interact with wmderland";
+    homepage = "https://github.com/aesophor/wmderland/tree/master/ipc-client";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ takagiy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24191,6 +24191,10 @@ in
 
   wmctrl = callPackage ../tools/X11/wmctrl { };
 
+  wmderland = callPackage ../applications/window-managers/wmderland { };
+
+  wmderlandc = callPackage ../applications/window-managers/wmderlandc { };
+
   wmii_hg = callPackage ../applications/window-managers/wmii-hg { };
 
   wofi = callPackage ../applications/misc/wofi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This request is going to add [wmderland](https://github.com/aesophor/wmderland), the X11 tiling window manager to nixpkgs and also some configuration of window managers for wmderland to nixos.

list of packages which will be available:
* `wmderland`: An X11 tiling window manager
* `wmderlandc`: An ipc-client to communicate with wmderland

list of configurations which will be available (in nixos):
* `services.xserver.windowManager.wmderland.enable`
        If `true`, wmderland is made available.
* `services.xserver.windowManager.wmderland.extraSessionCommands`
        Shell commands executed just before wmderland is started.
* `services.xserver.windowManager.wmderland.extraPackages`
        Extra packages to be installed system wide. (defaulted to `[ rofi dunst light hsetroot feh rxvt-unicode ]`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```console
$ nix path-info -S /run/current-system/sw/bin/wmderland
/nix/store/i956jcaqzlkwf4nfffxriw4gqlvvkzan-wmderland-2020-07-17	   43616424
$ nix path-info -S /run/current-system/sw/bin/wmderlandc
/nix/store/a9223wa17zsiakfmccyliwy1v8pb2rrb-wmderlandc-2020-07-17	   37202000
```
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
