### PR TITLE
batman-adv: v2020.3 -> v2020.4

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/version.nix
+++ b/pkgs/os-specific/linux/batman-adv/version.nix
@@ -1,9 +1,9 @@
 {
-  version = "2020.3";
+  version = "2020.4";
 
   sha256 = {
-    batman-adv = "0wrzh0k44zzjx2s5zj65hjkh4jm9y38qpis1s5cbx9cyj756slb5";
-    alfred = "13bvccz90pkjl09jyw68gj23pbrw9b05w1vhds9sjggwf3jkj5w2";
-    batctl = "0r2w2v4sy6wgr7mp9lc7yj9k4ldsbsm3425rjil7p0b17zmzf4rm";
+    batman-adv = "1cxr0zmn9nzisawkrfk0gzd9fx0pg6261c889kz47hwp4f545v6d";
+    alfred = "1ay69nifzghpbvy11fdca5cllkn852h6rg045lci4vzgqf7b2bd2";
+    batctl = "05rrpfbpdhxn5zgdps849qls2ifis6a94cjryb60d4y1nc2n0d7w";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release of the batman-adv kmod and accompanying packages.

https://www.open-mesh.org/news/99

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
