### PR TITLE
steam: Do $PATH lookup in steam.desktop instead of hardcoding derivation

### DIFF
--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -223,7 +223,7 @@ in buildFHSUserEnv rec {
     mkdir -p $out/share/applications
     ln -s ${steam}/share/icons $out/share
     ln -s ${steam}/share/pixmaps $out/share
-    sed "s,/usr/bin/steam,$out/bin/steam,g" ${steam}/share/applications/steam.desktop > $out/share/applications/steam.desktop
+    sed "s,/usr/bin/steam,steam,g" ${steam}/share/applications/steam.desktop > $out/share/applications/steam.desktop
   '';
 
   profile = ''


### PR DESCRIPTION
Note: I received this patch via E-Mail. As I'm not using any of the
"fancy" DEs I can't really judge if this is how and what we want to do
here.

> steam: Do $PATH lookup in steam.desktop instead of hardcoding derivation
>
> The desktop application and the absoloute path work fine.
> But consider desktop environments such as KDE where, in the application
> menu, one can right click entries and pin them to widgets/panels, add
> them to the desktop, etc.
>
> Doing so effectively means copying
> /run/current-system/sw/share/applications/steam.desktop to
> ~/.local/share/plasma_icons/ or ~/Desktop/, i.e. managed stated gets
> duplicated outside the nix scope.
>
> The problem here is that steam.desktop hardcodes
>
> 	Exec=/nix/store/<derivation hash>-steam/bin/steam %U
>
> this means such copies will point at wrong/outdated derivations once
> the steam package changes, i.e. widgets/panels/desktop icons will no
> longer work and must be recreated.
>
> Therefore replace the absoloute path with a $PATH lookup to allow "safe"
> copying;  this isn't optimal but other applications such Firefox and
> Thunderbrid currently behave the same way ($PATH lookup in their
> .desktop file).




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS - `nix-build -A steam`