### PR TITLE
nixos/cabal-install: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -106,6 +106,7 @@
   ./programs/bash-my-aws.nix
   ./programs/bcc.nix
   ./programs/browserpass.nix
+  ./programs/cabal-install.nix
   ./programs/captive-browser.nix
   ./programs/ccache.nix
   ./programs/cdemu.nix

--- a/nixos/modules/programs/cabal-install.nix
+++ b/nixos/modules/programs/cabal-install.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.cabal-install;
+
+  cabal-exec-deps = [
+    pkgs.binutils-unwrapped
+    pkgs.gnutar
+  ];
+  cabal-install-wrapper = pkgs.stdenv.mkDerivation {
+      inherit (pkgs.cabal-install) pname version;
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      buildCommand = ''
+        makeWrapper ${pkgs.cabal-install}/bin/cabal $out/bin/cabal \
+          --prefix PATH : ${lib.makeBinPath cabal-exec-deps}
+      '';
+    };
+in {
+
+  meta.maintainers = [ maintainers.xaverdh ];
+
+  options = {
+    programs.cabal-install = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Put a cabal-install wrapper binary into PATH, with
+          its runtime dependencies in place.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cabal-install-wrapper ];
+  };
+
+}
+


### PR DESCRIPTION
#### Motivation for this change

cf. https://github.com/NixOS/nixpkgs/pull/85136

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Will add some docs if / when people agree, that this is a good approach. 
