### PR TITLE
Generate autocompletion database for awscli2

### DIFF
--- a/pkgs/tools/admin/awscli2/default.nix
+++ b/pkgs/tools/admin/awscli2/default.nix
@@ -72,6 +72,9 @@ with py.pkgs; buildPythonApplication rec {
     mkdir -p $out/share/zsh/site-functions
     mv $out/bin/aws_zsh_completer.sh $out/share/zsh/site-functions
     rm $out/bin/aws.cmd
+    # Generate completions
+    patchShebangs scripts/gen-ac-index
+    ./scripts/gen-ac-index --index-location $out/${python3.sitePackages}/awscli/data/ac.index
   '';
 
   passthru.python = py; # for aws_shell


### PR DESCRIPTION
#### Motivation for this change

Installing awscli2 and trying to use tab-completion fails and prints an error:

```
  File "/nix/store/dyvz5p30dl0jv2g6wlb7i0l0pnsa9hpy-awscli2-2.0.54/bin/.aws_completer-wrapped", line 37, in <module>
    main()
  File "/nix/store/dyvz5p30dl0jv2g6wlb7i0l0pnsa9hpy-awscli2-2.0.54/bin/.aws_completer-wrapped", line 29, in main
    autocomplete(command_line, command_index)
  File "/nix/store/dyvz5p30dl0jv2g6wlb7i0l0pnsa9hpy-awscli2-2.0.54/lib/python3.8/site-packages/awscli/autocomplete/main.py", line 61, in autocomplete
    results = completer.autocomplete(command_line, position)
  File "/nix/store/dyvz5p30dl0jv2g6wlb7i0l0pnsa9hpy-awscli2-2.0.54/lib/python3.8/site-packages/awscli/autocomplete/completer.py", line 42, in autocomplete
    parsed = self._parser.parse(command_line, index)
  File "/nix/store/dyvz5p30dl0jv2g6wlb7i0l0pnsa9hpy-awscli2-2.0.54/lib/python3.8/site-packages/awscli/autocomplete/parser.py", line 145, in parse
    global_args = self._index.arg_names(lineage=[], command_name='aws')
  File "/nix/store/dyvz5p30dl0jv2g6wlb7i0l0pnsa9hpy-awscli2-2.0.54/lib/python3.8/site-packages/awscli/autocomplete/local/model.py", line 104, in arg_names
    results = db.execute(self._ARG_NAME_QUERY,
  File "/nix/store/dyvz5p30dl0jv2g6wlb7i0l0pnsa9hpy-awscli2-2.0.54/lib/python3.8/site-packages/awscli/autocomplete/db.py", line 33, in execute
    return self._connection.execute(query, kwargs)
  File "/nix/store/dyvz5p30dl0jv2g6wlb7i0l0pnsa9hpy-awscli2-2.0.54/lib/python3.8/site-packages/awscli/autocomplete/db.py", line 23, in _connection
    self._db_conn = sqlite3.connect(
sqlite3.OperationalError: unable to open database file
```

As far as I can tell, awscli's official packages come pre-populated with their completion database (`awscli/data/ac.index`) pre-populated. In this PR, I've run it in postBuild.
You can test the results from the build-directory with `env COMP_LINE='aws athena get' result/bin/aws_completer`

I'm not a python developer / nix developer / aws developer, so it's entirely possible I've missed something silly, let me know if so.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
