### PR TITLE
wine{Unstable,Staging}: 5.18 -> 5.20

### DIFF
--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -39,16 +39,16 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "5.18";
+    version = "5.19";
     url = "https://dl.winehq.org/wine/source/5.x/wine-${version}.tar.xz";
-    sha256 = "0hpkcpi6j162bkgcgzzj8y471777q06j7pydl61yp6qscn4g80ch";
+    sha256 = "sha256-ACBIK57q6E6hoSgTI6S80bF9vUXqLovrOhAHN4fml8c=";
     inherit (stable) mono gecko32 gecko64;
   };
 
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "0bwcvkf1g1dsq1qmric3jfl85rfjzhq6x4h839hfqc536lkfbrpy";
+    sha256 = "sha256-Wfh0tAjQurJ/ZuiaSfP922H8KaQuTdHmVExZ23vrcfI=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";

--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -39,16 +39,16 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "5.19";
+    version = "5.20";
     url = "https://dl.winehq.org/wine/source/5.x/wine-${version}.tar.xz";
-    sha256 = "sha256-ACBIK57q6E6hoSgTI6S80bF9vUXqLovrOhAHN4fml8c=";
+    sha256 = "sha256-j1Ui+M6+vbqhL1jhumcaEfZjcuCu33T7kyz1qJOQhhw=";
     inherit (stable) mono gecko32 gecko64;
   };
 
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-Wfh0tAjQurJ/ZuiaSfP922H8KaQuTdHmVExZ23vrcfI=";
+    sha256 = "sha256-1oWoLb5w9g3wDghpvHpNsJCws7QoZ/E2dqxLuaIgi6o=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";


### PR DESCRIPTION
###### Motivation for this change

Upstream updates, seems to include some nice esync related stuff again.

```
$ nix-shell -p nixpkgs-review --run "nixpkgs-review rev wine-5.20"
[...]
9 package built:
lutris lutris-free lutris-unwrapped pipelight wineStaging winePackages.staging wineUnstable wineWowPackages.staging wineWowPackages.unstable
```

The intermediate 5.19 has been `nixpkgs-review`ed as well without issues.

The programs I run under wine seem to work fine with this new version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
