### PR TITLE
groff: fix PDF manpage building with -Tpdf/gropdf

### DIFF
--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -82,10 +82,6 @@ stdenv.mkDerivation rec {
     moveToOutput bin/afmtodit $perl
     moveToOutput bin/gperl $perl
     moveToOutput bin/chem $perl
-    moveToOutput share/groff/${version}/font/devpdf $perl
-
-    # idk if this is needed, but Fedora does it
-    moveToOutput share/groff/${version}/tmac/pdf.tmac $perl
 
     moveToOutput bin/gpinyin $perl
     moveToOutput lib/groff/gpinyin $perl


### PR DESCRIPTION
These files are pure data, just fonts; they shouldn't have been moved
to the "perl" output, because the Perl programs (namely, gropdf) use
them from the main "out" output.

These files don't contain any references to more dependencies (Perl or
otherwise), so they don't bloat the closure. And the files themselves
are small; 276K total as of this commit.