### PR TITLE
fasmg: init at j27m

### DIFF
--- a/pkgs/development/compilers/fasmg/default.nix
+++ b/pkgs/development/compilers/fasmg/default.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, fetchzip
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fasmg";
+  version = "j27m";
+
+  src = fetchzip {
+    url = "https://flatassembler.net/fasmg.${version}.zip";
+    sha256 = "0qmklb24n3r0my2risid8r61pi88gqrvm1c0xvyd0bp1ans6d7zd";
+    stripRoot = false;
+  };
+
+  buildPhase = let
+    inherit (stdenv.hostPlatform) system;
+
+    path = {
+      x86_64-linux = {
+        bin = "fasmg.x64";
+        asm = "source/linux/x64/fasmg.asm";
+      };
+      x86_64-darwin = {
+        bin = "source/macos/x64/fasmg";
+        asm = "source/macos/x64/fasmg.asm";
+      };
+      x86-linux = {
+        bin = "fasmg";
+        asm = "source/linux/fasmg.asm";
+      };
+      x86-darwin = {
+        bin = "source/macos/fasmg";
+        asm = "source/macos/fasmg.asm";
+      };
+    }.${system} or (throw "Unsopported system: ${system}");
+
+  in ''
+    chmod +x ${path.bin}
+    ./${path.bin} ${path.asm} fasmg
+  '';
+
+  outputs = [ "out" "doc" ];
+
+  installPhase = ''
+    install -Dm755 fasmg $out/bin/fasmg
+
+    mkdir -p $doc/share/doc/fasmg
+    cp docs/*.txt $doc/share/doc/fasmg
+  '';
+
+  meta = with stdenv.lib; {
+    description = "x86(-64) macro assembler to binary, MZ, PE, COFF, and ELF";
+    homepage = "https://flatassembler.net";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ orivej luc65r ];
+    platforms = with platforms; intersectLists (linux ++ darwin) x86;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8770,6 +8770,8 @@ in
   };
   fasm-bin = callPackage ../development/compilers/fasm/bin.nix { };
 
+  fasmg = callPackage ../development/compilers/fasmg { };
+
   flyctl = callPackage ../development/web/flyctl { };
 
   flutterPackages =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Package fasmg to eventually package the CE C Toolchain

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
