### PR TITLE
linux: Allow extraMeta from top level

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -9,7 +9,7 @@ buildLinux (args // rec {
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+  extraMeta = { branch = versions.majorMinor version; } // (args.extraMeta or {});
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.19.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.19.nix
@@ -9,7 +9,7 @@ buildLinux (args // rec {
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+  extraMeta = { branch = versions.majorMinor version; } // (args.extraMeta or {});
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4.nix
@@ -1,8 +1,11 @@
 { stdenv, buildPackages, fetchurl, perl, buildLinux, ... } @ args:
 
+with stdenv.lib;
+
 buildLinux (args // rec {
+
   version = "4.4.240";
-  extraMeta.branch = "4.4";
+  extraMeta = { branch = versions.majorMinor version; } // (args.extraMeta or {});
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9.nix
@@ -1,8 +1,10 @@
 { stdenv, buildPackages, fetchurl, perl, buildLinux, ... } @ args:
 
+with stdenv.lib;
+
 buildLinux (args // rec {
   version = "4.9.240";
-  extraMeta.branch = "4.9";
+  extraMeta = { branch = versions.majorMinor version; } // (args.extraMeta or {});
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-5.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.4.nix
@@ -9,7 +9,7 @@ buildLinux (args // rec {
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+  extraMeta = { branch = versions.majorMinor version; } // (args.extraMeta or {});
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-5.8.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.8.nix
@@ -9,7 +9,7 @@ buildLinux (args // rec {
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+  extraMeta = { branch = versions.majorMinor version; } // (args.extraMeta or {});
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-5.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.9.nix
@@ -9,7 +9,7 @@ buildLinux (args // rec {
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+  extraMeta = { branch = versions.majorMinor version; } // (args.extraMeta or {});
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
@@ -1,5 +1,7 @@
 { stdenv, buildPackages, fetchFromGitHub, perl, buildLinux, libelf, utillinux, ... } @ args:
 
+with stdenv.lib;
+
 buildLinux (args // rec {
   version = "4.14.165-172";
 
@@ -7,7 +9,10 @@ buildLinux (args // rec {
   modDirVersion = "4.14.165";
 
   # branchVersion needs to be x.y.
-  extraMeta.branch = "4.14";
+  extraMeta = {
+    branch = versions.majorMinor version;
+    platforms = [ "armv7l-linux" ];
+  } // (args.extraMeta or {});
 
   src = fetchFromGitHub {
     owner = "hardkernel";
@@ -27,7 +32,5 @@ buildLinux (args // rec {
     #GATOR_MALI_MIDGARD_PATH ${src}/drivers/gpu/arm/midgard
 
   '' + (args.extraConfig or "");
-
-  extraMeta.platforms = [ "armv7l-linux" ];
 
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-mptcp-94.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp-94.nix
@@ -1,4 +1,7 @@
 { stdenv, buildPackages, fetchFromGitHub, perl, buildLinux, structuredExtraConfig ? {}, ... } @ args:
+
+with stdenv.lib;
+
 let
   mptcpVersion = "0.94.6";
   modDirVersion = "4.14.127";
@@ -8,9 +11,9 @@ buildLinux ({
   inherit modDirVersion;
 
   extraMeta = {
-    branch = "4.4";
+    branch = versions.majorMinor version;
     maintainers = with stdenv.lib.maintainers; [ teto layus ];
-  };
+  } // (args.extraMeta or {});
 
   src = fetchFromGitHub {
     owner = "multipath-tcp";

--- a/pkgs/os-specific/linux/kernel/linux-mptcp-95.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp-95.nix
@@ -1,4 +1,7 @@
 { stdenv, buildPackages, fetchFromGitHub, perl, buildLinux, structuredExtraConfig ? {}, ... } @ args:
+
+with stdenv.lib;
+
 let
   mptcpVersion = "0.95";
   modDirVersion = "4.19.55";
@@ -8,9 +11,9 @@ buildLinux ({
   inherit modDirVersion;
 
   extraMeta = {
-    branch = "4.19";
+    branch = versions.majorMinor version;
     maintainers = with stdenv.lib.maintainers; [ teto layus ];
-  };
+  } // (args.extraMeta or {});
 
   src = fetchFromGitHub {
     owner = "multipath-tcp";

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -26,13 +26,13 @@ lib.overrideDerivation (buildLinux (args // {
     efiBootStub = false;
   } // (args.features or {});
 
-  extraMeta = if (rpiVersion < 3) then {
+  extraMeta = (if (rpiVersion < 3) then {
     platforms = with lib.platforms; [ arm ];
     hydraPlatforms = [];
   } else {
     platforms = with lib.platforms; [ arm aarch64 ];
     hydraPlatforms = [ "aarch64-linux" ];
-  };
+  }) // (args.extraMeta or {});
 } // (args.argsOverride or {}))) (oldAttrs: {
   postConfigure = ''
     # The v7 defconfig has this set to '-v7' which screws up our modDirVersion.

--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -18,6 +18,6 @@ buildLinux (args // {
     hydraPlatforms = []; # Should the testing kernels ever be built on Hydra?
     maintainers = with stdenv.lib.maintainers; [ davidak chiiruno ];
     platforms = [ "x86_64-linux" ];
-  };
+  } // (args.extraMeta or {});
 
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -4,7 +4,11 @@ with stdenv.lib;
 
 buildLinux (args // rec {
   version = "5.10-rc1";
-  extraMeta.branch = "5.10";
+
+  extraMeta = {
+    branch = versions.majorMinor version;
+    hydraPlatforms = [];
+  } // (args.extraMeta or {});
 
   # modDirVersion needs to be x.y.z, will always add .0
   modDirVersion = if (modDirVersionArg == null) then builtins.replaceStrings ["-"] [".0-"] version else modDirVersionArg;
@@ -13,8 +17,5 @@ buildLinux (args // rec {
     url = "https://git.kernel.org/torvalds/t/linux-${version}.tar.gz";
     sha256 = "1s4ywf93xrlkjjq3c4142qhmsvx3kl0xwkbc09ss6gln8lwqnga8";
   };
-
-  # Should the testing kernels ever be built on Hydra?
-  extraMeta.hydraPlatforms = [];
 
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-zen.nix
+++ b/pkgs/os-specific/linux/kernel/linux-zen.nix
@@ -18,6 +18,6 @@ buildLinux (args // {
   extraMeta = {
     branch = "5.8/master";
     maintainers = with stdenv.lib.maintainers; [ atemu ];
-  };
+  } // (args.extraMeta or {});
 
 } // (args.argsOverride or {}))


### PR DESCRIPTION
This way it will be possible to add `extraMeta.broken = true` to any
top level kernel definition.
Other metadata can be added this way as well.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
#101863

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
