### PR TITLE
maxima: 5.42.2 -> 5.44.0

### DIFF
--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -27,6 +27,16 @@
 assert withSbcl != withEcl;
 
 let
+
+  # Fetch a patch from the SageMath Git repository.
+  fetchPatchFromSage = { name, rev, hash } @args : (
+    fetchpatch {
+      inherit name;
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/${name}?id=${rev}";
+      sha256 = hash;
+    }
+  );
+
   searchPath = stdenv.lib.makeBinPath ([
   ] ++ stdenv.lib.optionals withSbcl [
     sbcl
@@ -79,34 +89,40 @@ in stdenv.mkDerivation rec {
 
   patches = [
     # fix path to info dir (see https://trac.sagemath.org/ticket/11348)
-    (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/infodir.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-      sha256 = "09v64n60f7i6frzryrj0zd056lvdpms3ajky4f9p6kankhbiv21x";
+    (fetchPatchFromSage {
+      name = "infodir.patch";
+      rev  = "07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      hash = "09v64n60f7i6frzryrj0zd056lvdpms3ajky4f9p6kankhbiv21x";
     })
 
     # fix https://sourceforge.net/p/maxima/bugs/2596/
-    (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/matrixexp.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-      sha256 = "06961hn66rhjijfvyym21h39wk98sfxhp051da6gz0n9byhwc6zg";
+    (fetchPatchFromSage {
+      name = "matrixexp.patch";
+      rev  = "07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      hash = "06961hn66rhjijfvyym21h39wk98sfxhp051da6gz0n9byhwc6zg";
     })
 
-    # undo https://sourceforge.net/p/maxima/code/ci/f5e9b0f7eb122c4e48ea9df144dd57221e5ea0ca, see see https://trac.sagemath.org/ticket/13364#comment:93
-    (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/undoing_true_false_printing_patch.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-      sha256 = "0fvi3rcjv6743sqsbgdzazy9jb6r1p1yq63zyj9fx42wd1hgf7yx";
+    # undo https://sourceforge.net/p/maxima/code/ci/f5e9b0f7eb122c4e48ea9df144dd57221e5ea0ca
+    # see https://trac.sagemath.org/ticket/13364#comment:93
+    (fetchPatchFromSage {
+      name = "undoing_true_false_printing_patch.patch";
+      rev  = "07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      hash = "0fvi3rcjv6743sqsbgdzazy9jb6r1p1yq63zyj9fx42wd1hgf7yx";
     })
 
     # upstream bug https://sourceforge.net/p/maxima/bugs/2520/ (not fixed)
     # introduced in https://trac.sagemath.org/ticket/13364
-    (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/0001-taylor2-Avoid-blowing-the-stack-when-diff-expand-isn.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-      sha256 = "0xa0b6cr458zp7lc7qi0flv5ar0r3ivsqhjl0c3clv86di2y522d";
+    (fetchPatchFromSage {
+      name = "0001-taylor2-Avoid-blowing-the-stack-when-diff-expand-isn.patch";
+      rev  = "07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      hash = "0xa0b6cr458zp7lc7qi0flv5ar0r3ivsqhjl0c3clv86di2y522d";
     })
   ] ++ stdenv.lib.optionals withEcl [
     # build fasl, needed for ECL support
-    (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/maxima.system.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-      sha256 = "18zafig8vflhkr80jq2ivk46k92dkszqlyq8cfmj0b2vcfjwwbar";
+    (fetchPatchFromSage {
+      name = "maxima.system.patch";
+      rev  = "07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      hash = "18zafig8vflhkr80jq2ivk46k92dkszqlyq8cfmj0b2vcfjwwbar";
     })
   ];
 

--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -27,9 +27,6 @@
 assert withSbcl != withEcl;
 
 let
-  name    = "maxima";
-  version = "5.42.2";
-
   searchPath = stdenv.lib.makeBinPath ([
   ] ++ stdenv.lib.optionals withSbcl [
     sbcl
@@ -43,13 +40,14 @@ let
     gnuplot
   ]);
 
-in
-stdenv.mkDerivation ({
-  inherit version;
-  name = "${name}-${version}";
+in stdenv.mkDerivation rec {
+
+  pname   = "maxima";
+  version = "5.42.2";
+  name    = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${name}/${name}-${version}.tar.gz";
+    url = "mirror://sourceforge/${pname}/${name}.tar.gz";
     sha256 = "0kdncy6137sg3rradirxzj10mkcvafxd892zlclwhr9sa7b12zhn";
   };
 
@@ -131,4 +129,4 @@ stdenv.mkDerivation ({
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.peti ];
   };
-})
+}

--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -130,10 +130,10 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Computer algebra system";
     homepage = "http://maxima.sourceforge.net";
-    license = stdenv.lib.licenses.gpl2;
+    license = licenses.gpl2;
 
     longDescription = ''
       Maxima is a fairly complete computer algebra system written in
@@ -142,7 +142,7 @@ in stdenv.mkDerivation rec {
       symbolic integration, 3D plotting, and an ODE solver.
     '';
 
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.peti ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ peti ];
   };
 }

--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -14,9 +14,7 @@
   #
   #   Errors found in /build/maxima-5.42.2/share/linearalgebra/rtest_matrixexp.mac, problems:
   #   (20 21 22)
-  #   Error found in rtest_arag, problem:
-  #   (error break)
-  #   3 tests failed out of 3,881 total tests.
+  #   3 tests failed out of 3,988 total tests.
   #
   # These failures don't look serious. It would be nice to fix them, but I
   # don't know how and probably won't have the time to find out.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26729,7 +26729,6 @@ in
 
   maxima = callPackage ../applications/science/math/maxima { };
   maxima-ecl = maxima.override {
-    ecl = ecl_16_1_2;
     withEcl = true;
     withSbcl = false;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26727,13 +26727,11 @@ in
   geogebra = callPackage ../applications/science/math/geogebra { };
   geogebra6 = callPackage ../applications/science/math/geogebra/geogebra6.nix { };
 
-  maxima = callPackage ../applications/science/math/maxima {
-    ecl = null;
-  };
+  maxima = callPackage ../applications/science/math/maxima { };
   maxima-ecl = maxima.override {
     ecl = ecl_16_1_2;
-    ecl-fasl = true;
-    sbcl = null;
+    withEcl = true;
+    withSbcl = false;
   };
 
   mxnet = callPackage ../applications/science/math/mxnet {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->
###### Motivation for this change

This change updates `maxima` and `maxima-ecl` packages to the latest release. The [change log for Maxima 5.44](https://sourceforge.net/p/maxima/code/ci/master/tree/ChangeLog-5.44.md) and [change log for Maxima 5.43](https://sourceforge.net/p/maxima/code/ci/master/tree/ChangeLog-5.43.md) are available.

Note that `maxima-ecl` now compiles with the default `ecl` due to failures with Maxima 16.1.2. The `sage` package, the only remaining client of the `ecl_16_1_2` package, will also migrate to `ecl` in SageMath 9.2.

Depends on https://github.com/NixOS/nixpkgs/pull/101830.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
