### PR TITLE
postgresqlPackages.periods: 1.1 -> 1.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/periods.nix
+++ b/pkgs/servers/sql/postgresql/ext/periods.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "periods";
-  version = "1.1";
+  version = "1.2";
 
   src = fetchFromGitHub {
     owner = "xocolatl";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0gdnlbh7kp7c0kvsrri2kxdbmm2qgib1qqpl37203z6c3fk45kfh";
+    sha256 = "13aix61qzlb7cs042dz4x0z4sc2xayg4nzi2cks46zibxm5i4gzm";
   };
 
   buildInputs = [ postgresql ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/xocolatl/periods/commits

periods 1.2 is required to `pg_upgrade` from PostgreSQL 12 to 13. periods must be upgraded in each database before `pg_upgrade` can succeed (otherwise you see [this error](https://gist.github.com/ivan/5dcc35ef895c93671e5ff7d9d112318c) - ref https://github.com/xocolatl/periods/commit/58e30e5b25d337c0fe4bf8eec193f989c3e42852)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested an upgrade of periods from 1.1 to 1.2 in PostgreSQL 12 and I tested that PostgreSQL 13 can load periods 1.2.