### PR TITLE
cloudcompare: 2.11.0 → 2.11.2

### DIFF
--- a/pkgs/applications/graphics/cloudcompare/default.nix
+++ b/pkgs/applications/graphics/cloudcompare/default.nix
@@ -18,17 +18,17 @@
 
 mkDerivation rec {
   pname = "cloudcompare";
-  version = "2.11.0";
+  version = "2.11.2";
 
   src = fetchFromGitHub {
     owner = "CloudCompare";
     repo = "CloudCompare";
     rev = "v${version}";
-    sha256 = "02ahhhivgb9k1aygw1m35wdvhaizag1r98mb0r6zzrs5p4y64wlb";
+    sha256 = "0sb2h08iaf6zrf54sg6ql6wm63q5vq0kpd3gffdm26z8w6j6wv3s";
     # As of writing includes (https://github.com/CloudCompare/CloudCompare/blob/a1c589c006fc325e8b560c77340809b9c7e7247a/.gitmodules):
     # * libE57Format
     # * PoissonRecon
-    # In > 2.11 it will also contain
+    # In a future version it will also contain
     # * CCCoreLib
     fetchSubmodules = true;
   };
@@ -53,7 +53,7 @@ mkDerivation rec {
   ];
 
   cmakeFlags = [
-    # TODO: This will become -DCCCORELIB_USE_TBB=ON in > 2.11.0, see
+    # TODO: This will become -DCCCORELIB_USE_TBB=ON in a future version, see
     #       https://github.com/CloudCompare/CloudCompare/commit/f5a0c9fd788da26450f3fa488b2cf0e4a08d255f
     "-DCOMPILE_CC_CORE_LIB_WITH_TBB=ON"
     "-DOPTION_USE_DXF_LIB=ON"


### PR DESCRIPTION
###### Motivation for this change
* [Changelog](https://github.com/CloudCompare/CloudCompare/blob/master/CHANGELOG.md)
* Replace `-DCOMPILE_CC_CORE_LIB_WITH_TBB=ON` with `-DCCCORELIB_USE_TBB=ON`
* Remove outdated comments

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
