### PR TITLE
python3.pkgs.pyosmium: 2.15.3 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/pyosmium/default.nix
+++ b/pkgs/development/python-modules/pyosmium/default.nix
@@ -1,16 +1,18 @@
 { lib, buildPythonPackage, fetchFromGitHub, cmake, python
 , libosmium, protozero, boost, expat, bzip2, zlib, pybind11
-, nose, shapely, mock, isPy3k }:
+, nose, shapely, pythonOlder, isPyPy }:
 
 buildPythonPackage rec {
   pname = "pyosmium";
-  version = "2.15.3";
+  version = "3.0.1";
+
+  disabled = pythonOlder "3.4" || isPyPy;
 
   src = fetchFromGitHub {
     owner = "osmcode";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1523ym9i4rnwi5kcp7n2lm67kxlhar8xlv91s394ixzwax9bgg7w";
+    sha256 = "06jngbmmmswhyi5q5bjph6gwss28d2azn5414zf0arik5bcvz128";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -18,7 +20,7 @@ buildPythonPackage rec {
 
   preBuild = "cd ..";
 
-  checkInputs = [ nose shapely ] ++ lib.optionals (!isPy3k) [ mock ];
+  checkInputs = [ nose shapely ];
 
   checkPhase = "(cd test && ${python.interpreter} run_tests.py)";
 


### PR DESCRIPTION
###### Motivation for this change

upstream releases:
- [2.15.4](https://github.com/osmcode/pyosmium/releases/tag/v2.15.4)
- [3.0.0](https://github.com/osmcode/pyosmium/releases/tag/v3.0.0)
- [3.0.1](https://github.com/osmcode/pyosmium/releases/tag/v3.0.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix run nixpkgs.nixpkgs-review -c nixpkgs-review pr 101882 --post-result`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
