### PR TITLE
systemd: introduce more options for a more minimal build

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1,28 +1,59 @@
-{ stdenv, lib, fetchFromGitHub
+{ stdenv
+, lib
+, fetchFromGitHub
 , buildPackages
-, ninja, meson, m4, pkgconfig, coreutils, gperf, getent
-, patchelf, perl, glibcLocales, glib, substituteAll
-, gettext, python3Packages
+, ninja
+, meson
+, m4
+, pkgconfig
+, coreutils
+, gperf
+, getent
+, patchelf
+, perl
+, glibcLocales
+, glib
+, substituteAll
+, gettext
+, python3Packages
 
-# Mandatory dependencies
+  # Mandatory dependencies
 , libcap
 , utillinux
 , kbd
 , kmod
 
-# Optional dependencies
-, pam, cryptsetup, lvm2, audit, acl
-, lz4, libgcrypt, libgpgerror, libidn2
-, curl, gnutar, gnupg, zlib
-, xz, libuuid, libffi
-, libapparmor, intltool
-, bzip2, pcre2, e2fsprogs
+  # Optional dependencies
+, pam
+, cryptsetup
+, lvm2
+, audit
+, acl
+, lz4
+, libgcrypt
+, libgpgerror
+, libidn2
+, curl
+, gnutar
+, gnupg
+, zlib
+, xz
+, libuuid
+, libffi
+, libapparmor
+, intltool
+, bzip2
+, pcre2
+, e2fsprogs
 , linuxHeaders ? stdenv.cc.libc.linuxHeaders
 , gnu-efi
 , iptables
-, withSelinux ? false, libselinux
-, withLibseccomp ? lib.any (lib.meta.platformMatch stdenv.hostPlatform) libseccomp.meta.platforms, libseccomp
-, withKexectools ? lib.any (lib.meta.platformMatch stdenv.hostPlatform) kexectools.meta.platforms, kexectools
+, withSelinux ? false
+, libselinux
+, withLibseccomp ? lib.any (lib.meta.platformMatch stdenv.hostPlatform) libseccomp.meta.platforms
+, libseccomp
+, withKexectools ? lib.any (lib.meta.platformMatch stdenv.hostPlatform) kexectools.meta.platforms
+, kexectools
 , bashInteractive
 
 , withResolved ? true
@@ -37,24 +68,27 @@
 , withImportd ? true
 , withCryptsetup ? true
 
-# name argument
+  # name argument
 , pname ? "systemd"
 
 
-, libxslt, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_45
+, libxslt
+, docbook_xsl
+, docbook_xml_dtd_42
+, docbook_xml_dtd_45
 }:
 
 assert withResolved -> (libgcrypt != null && libgpgerror != null);
 assert withImportd ->
-  ( curl.dev != null && zlib != null && xz != null && libgcrypt != null
+(curl.dev != null && zlib != null && xz != null && libgcrypt != null
   && gnutar != null && gnupg != null);
 
 assert withCryptsetup ->
-  ( cryptsetup != null );
-
+(cryptsetup != null);
 let
   version = "246.6";
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   inherit version pname;
 
   # We use systemd/systemd-stable for src, and ship NixOS-specific patches inside nixpkgs directly
@@ -105,28 +139,56 @@ in stdenv.mkDerivation {
   outputs = [ "out" "man" "dev" ];
 
   nativeBuildInputs =
-    [ pkgconfig gperf
-      ninja meson
+    [
+      pkgconfig
+      gperf
+      ninja
+      meson
       coreutils # meson calls date, stat etc.
       glibcLocales
-      patchelf getent m4
+      patchelf
+      getent
+      m4
       perl # to patch the libsystemd.so and remove dependencies on aarch64
 
       intltool
       gettext
 
-      libxslt docbook_xsl docbook_xml_dtd_42 docbook_xml_dtd_45
-      (buildPackages.python3Packages.python.withPackages ( ps: with ps; [ python3Packages.lxml ]))
+      libxslt
+      docbook_xsl
+      docbook_xml_dtd_42
+      docbook_xml_dtd_45
+      (buildPackages.python3Packages.python.withPackages (ps: with ps; [ python3Packages.lxml ]))
     ];
+
   buildInputs =
-    [ linuxHeaders libcap curl.dev kmod xz pam acl
-      cryptsetup libuuid glib libgcrypt libgpgerror libidn2
-      pcre2 libffi audit lz4 bzip2 libapparmor iptables ] ++
-      lib.optional withKexectools kexectools ++
-      lib.optional withLibseccomp libseccomp ++
-      lib.optional withEfi gnu-efi ++
-      lib.optional withSelinux libselinux ++
-      lib.optional withCryptsetup cryptsetup.dev;
+    [
+      acl
+      audit
+      bzip2
+      cryptsetup
+      curl.dev
+      glib
+      iptables
+      kmod
+      libapparmor
+      libcap
+      libffi
+      libgcrypt
+      libgpgerror
+      libidn2
+      libuuid
+      linuxHeaders
+      lz4
+      pam
+      pcre2
+      xz
+    ] ++ lib.optional withKexectools kexectools
+    ++ lib.optional withLibseccomp libseccomp
+    ++ lib.optional withEfi gnu-efi
+    ++ lib.optional withSelinux libselinux
+    ++ lib.optional withCryptsetup cryptsetup.dev
+  ;
 
   #dontAddPrefix = true;
 
@@ -271,14 +333,17 @@ in stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = toString [
     # Can't say ${polkit.bin}/bin/pkttyagent here because that would
     # lead to a cyclic dependency.
-    "-UPOLKIT_AGENT_BINARY_PATH" "-DPOLKIT_AGENT_BINARY_PATH=\"/run/current-system/sw/bin/pkttyagent\""
+    "-UPOLKIT_AGENT_BINARY_PATH"
+    "-DPOLKIT_AGENT_BINARY_PATH=\"/run/current-system/sw/bin/pkttyagent\""
 
     # Set the release_agent on /sys/fs/cgroup/systemd to the
     # currently running systemd (/run/current-system/systemd) so
     # that we don't use an obsolete/garbage-collected release agent.
-    "-USYSTEMD_CGROUP_AGENT_PATH" "-DSYSTEMD_CGROUP_AGENT_PATH=\"/run/current-system/systemd/lib/systemd/systemd-cgroups-agent\""
+    "-USYSTEMD_CGROUP_AGENT_PATH"
+    "-DSYSTEMD_CGROUP_AGENT_PATH=\"/run/current-system/systemd/lib/systemd/systemd-cgroups-agent\""
 
-    "-USYSTEMD_BINARY_PATH" "-DSYSTEMD_BINARY_PATH=\"/run/current-system/systemd/lib/systemd/systemd\""
+    "-USYSTEMD_BINARY_PATH"
+    "-DSYSTEMD_BINARY_PATH=\"/run/current-system/systemd/lib/systemd/systemd\""
   ];
 
   doCheck = false; # fails a bunch of tests

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -213,6 +213,7 @@ stdenv.mkDerivation {
     # while we do not run tests we should also not build them. Removes about 600 targets
     "-Dtests=false"
     "-Danalyze=${lib.boolToString withAnalyze}"
+    "-Dgcrypt=${lib.boolToString (libgcrypt != null)}"
     "-Dimportd=${lib.boolToString withImportd}"
     "-Dlz4=${lib.boolToString withCompression}"
     "-Dhomed=false"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -73,6 +73,7 @@
 , withShellCompletions ? true
 , withTimedated ? true
 , withTimesyncd ? true
+, withUserDb ? true
 
   # name argument
 , pname ? "systemd"
@@ -233,6 +234,7 @@ stdenv.mkDerivation {
     "-Dsysusers=false"
     "-Dtimedated=${lib.boolToString withTimedated}"
     "-Dtimesyncd=${lib.boolToString withTimesyncd}"
+    "-Duserdb=${lib.boolToString withUserDb}"
     "-Dcoredump=${lib.boolToString withCoredump}"
     "-Dfirstboot=false"
     "-Dresolve=${lib.boolToString withResolved}"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -224,7 +224,6 @@ stdenv.mkDerivation {
     "-Dtimedated=${lib.boolToString withTimedated}"
     "-Dtimesyncd=${lib.boolToString withTimesyncd}"
     "-Dfirstboot=false"
-    "-Dlocaled=true"
     "-Dresolve=${lib.boolToString withResolved}"
     "-Dsplit-usr=false"
     "-Dlibcurl=${lib.boolToString wantCurl}"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -69,6 +69,7 @@
 , withMachined ? true
 , withNetworkd ? true
 , withNss ? true
+, withPCRE2 ? true
 , withPolkit ? true
 , withRemote ? false  # has always been disabled on NixOS, upstream version appears broken anyway
 , withResolved ? true
@@ -187,8 +188,8 @@ stdenv.mkDerivation {
       libuuid
       linuxHeaders
       pam
-      pcre2
     ]
+
     ++ lib.optional withApparmor libapparmor
     ++ lib.optional wantCurl (lib.getDev curl)
     ++ lib.optionals withCompression [ bzip2 lz4 xz ]
@@ -197,6 +198,7 @@ stdenv.mkDerivation {
     ++ lib.optional withKexectools kexectools
     ++ lib.optional withLibseccomp libseccomp
     ++ lib.optional withNetworkd iptables
+    ++ lib.optional withPCRE2 pcre2
     ++ lib.optional withResolved libgpgerror
     ++ lib.optional withSelinux libselinux
     ;

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -183,7 +183,6 @@ stdenv.mkDerivation {
       libapparmor
       libcap
       libgcrypt
-      libgpgerror
       libidn2
       libuuid
       linuxHeaders
@@ -192,13 +191,14 @@ stdenv.mkDerivation {
     ]
     ++ lib.optional wantCurl (lib.getDev curl)
     ++ lib.optionals withCompression [ bzip2 lz4 xz ]
-    ++ lib.optional withNetworkd iptables
+    ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)
+    ++ lib.optional withEfi gnu-efi
     ++ lib.optional withKexectools kexectools
     ++ lib.optional withLibseccomp libseccomp
-    ++ lib.optional withEfi gnu-efi
+    ++ lib.optional withNetworkd iptables
+    ++ lib.optional withResolved libgpgerror
     ++ lib.optional withSelinux libselinux
-    ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)
-  ;
+    ;
 
   #dontAddPrefix = true;
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -167,7 +167,6 @@ stdenv.mkDerivation {
       cryptsetup
       curl.dev
       glib
-      iptables
       kmod
       libapparmor
       libcap
@@ -181,7 +180,9 @@ stdenv.mkDerivation {
       pam
       pcre2
       xz
-    ] ++ lib.optional withKexectools kexectools
+    ]
+    ++ lib.optional withNetworkd iptables
+    ++ lib.optional withKexectools kexectools
     ++ lib.optional withLibseccomp libseccomp
     ++ lib.optional withEfi gnu-efi
     ++ lib.optional withSelinux libselinux

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -67,6 +67,7 @@
 , withLocaled ? true
 , withLogind ? true
 , withNetworkd ? true
+, withNss ? true
 , withPolkit ? true
 , withRemote ? false  # has always been disabled on NixOS, upstream version appears broken anyway
 , withResolved ? true
@@ -285,6 +286,11 @@ stdenv.mkDerivation {
   ] ++ lib.optionals (withShellCompletions == false) [
     "-Dbashcompletiondir=no"
     "-Dzshcompletiondir=no"
+  ] ++ lib.optionals (!withNss) [
+    "-Dnss-myhostname=false"
+    "-Dnss-mymachines=false"
+    "-Dnss-resolve=false"
+    "-Dnss-systemd=false"
   ];
 
   preConfigure = ''

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -69,6 +69,7 @@
 , withPolkit ? true
 , withRemote ? false  # has always been disabled on NixOS, upstream version appears broken anyway
 , withResolved ? true
+, withShellCompletions ? true
 , withTimedated ? true
 , withTimesyncd ? true
 
@@ -278,6 +279,9 @@ stdenv.mkDerivation {
     "-Defi-libdir=${toString gnu-efi}/lib"
     "-Defi-includedir=${toString gnu-efi}/include/efi"
     "-Defi-ldsdir=${toString gnu-efi}/lib"
+  ] ++ lib.optionals (withShellCompletions == false) [
+    "-Dbashcompletiondir=no"
+    "-Dzshcompletiondir=no"
   ];
 
   preConfigure = ''

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -59,6 +59,7 @@
 , withCoredump ? true
 , withCompression ? true  # adds bzip2, lz4 and xz
 , withCryptsetup ? true
+, withDocumentation ? true
 , withEfi ? stdenv.hostPlatform.isEfi
 , withHostnamed ? true
 , withHwdb ? true
@@ -390,7 +391,9 @@ stdenv.mkDerivation {
 
     # "kernel-install" shouldn't be used on NixOS.
     find $out -name "*kernel-install*" -exec rm {} \;
-  ''; # */
+  '' + lib.optionalString (!withDocumentation) ''
+    rm -rf $out/share/doc
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -55,6 +55,7 @@
 , bashInteractive
 
 , withAnalyze ? true
+, withApparmor ? true
 , withCoredump ? true
 , withCompression ? true  # adds bzip2, lz4 and xz
 , withCryptsetup ? true
@@ -180,7 +181,6 @@ stdenv.mkDerivation {
       audit
       glib
       kmod
-      libapparmor
       libcap
       libgcrypt
       libidn2
@@ -189,6 +189,7 @@ stdenv.mkDerivation {
       pam
       pcre2
     ]
+    ++ lib.optional withApparmor libapparmor
     ++ lib.optional wantCurl (lib.getDev curl)
     ++ lib.optionals withCompression [ bzip2 lz4 xz ]
     ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -38,7 +38,6 @@
 , zlib
 , xz
 , libuuid
-, libffi
 , libapparmor
 , intltool
 , bzip2
@@ -183,7 +182,6 @@ stdenv.mkDerivation {
       kmod
       libapparmor
       libcap
-      libffi
       libgcrypt
       libgpgerror
       libidn2

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -270,6 +270,7 @@ stdenv.mkDerivation {
     # more frequent development builds
     "-Dman=true"
 
+    "-Defi=${lib.boolToString withEfi}"
     "-Dgnu-efi=${lib.boolToString withEfi}"
   ] ++ lib.optionals withEfi [
     "-Defi-libdir=${toString gnu-efi}/lib"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -55,6 +55,7 @@
 , kexectools
 , bashInteractive
 
+, withCompression ? true  # adds bzip2, lz4 and xz
 , withCryptsetup ? true
 , withEfi ? stdenv.hostPlatform.isEfi
 , withHostnamed ? true
@@ -81,7 +82,7 @@
 assert withResolved -> (libgcrypt != null && libgpgerror != null);
 assert withImportd ->
 (curl.dev != null && zlib != null && xz != null && libgcrypt != null
-  && gnutar != null && gnupg != null);
+  && gnutar != null && gnupg != null && withCompression );
 
 assert withRemote -> lib.getDev curl != null;
 
@@ -168,7 +169,6 @@ stdenv.mkDerivation {
     [
       acl
       audit
-      bzip2
       glib
       kmod
       libapparmor
@@ -179,12 +179,11 @@ stdenv.mkDerivation {
       libidn2
       libuuid
       linuxHeaders
-      lz4
       pam
       pcre2
-      xz
     ]
     ++ lib.optional wantCurl (lib.getDev curl)
+    ++ lib.optionals withCompression [ bzip2 lz4 xz ]
     ++ lib.optional withNetworkd iptables
     ++ lib.optional withKexectools kexectools
     ++ lib.optional withLibseccomp libseccomp
@@ -211,7 +210,7 @@ stdenv.mkDerivation {
     # while we do not run tests we should also not build them. Removes about 600 targets
     "-Dtests=false"
     "-Dimportd=${lib.boolToString withImportd}"
-    "-Dlz4=true"
+    "-Dlz4=${lib.boolToString withCompression}"
     "-Dhomed=false"
     "-Dlogind=${lib.boolToString withLogind}"
     "-Dlocaled=${lib.boolToString withLocaled}"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -169,7 +169,6 @@ stdenv.mkDerivation {
       acl
       audit
       bzip2
-      cryptsetup
       glib
       kmod
       libapparmor
@@ -191,7 +190,7 @@ stdenv.mkDerivation {
     ++ lib.optional withLibseccomp libseccomp
     ++ lib.optional withEfi gnu-efi
     ++ lib.optional withSelinux libselinux
-    ++ lib.optional withCryptsetup cryptsetup.dev
+    ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)
   ;
 
   #dontAddPrefix = true;

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -122,12 +122,12 @@ in stdenv.mkDerivation {
     [ linuxHeaders libcap curl.dev kmod xz pam acl
       cryptsetup libuuid glib libgcrypt libgpgerror libidn2
       pcre2 ] ++
-      stdenv.lib.optional withKexectools kexectools ++
-      stdenv.lib.optional withLibseccomp libseccomp ++
+      lib.optional withKexectools kexectools ++
+      lib.optional withLibseccomp libseccomp ++
       [ libffi audit lz4 bzip2 libapparmor iptables ] ++
-      stdenv.lib.optional withEfi gnu-efi ++
-      stdenv.lib.optional withSelinux libselinux ++
-      stdenv.lib.optional withCryptsetup cryptsetup.dev;
+      lib.optional withEfi gnu-efi ++
+      lib.optional withSelinux libselinux ++
+      lib.optional withCryptsetup cryptsetup.dev;
 
   #dontAddPrefix = true;
 
@@ -143,26 +143,26 @@ in stdenv.mkDerivation {
     "-Dsetfont-path=${kbd}/bin/setfont"
     "-Dtty-gid=3" # tty in NixOS has gid 3
     "-Ddebug-shell=${bashInteractive}/bin/bash"
-    "-Dglib=${stdenv.lib.boolToString (glib != null)}"
+    "-Dglib=${lib.boolToString (glib != null)}"
     # while we do not run tests we should also not build them. Removes about 600 targets
     "-Dtests=false"
-    "-Dimportd=${stdenv.lib.boolToString withImportd}"
+    "-Dimportd=${lib.boolToString withImportd}"
     "-Dlz4=true"
     "-Dhomed=false"
-    "-Dlogind=${stdenv.lib.boolToString withLogind}"
-    "-Dlocaled=${stdenv.lib.boolToString withLocaled}"
-    "-Dhostnamed=${stdenv.lib.boolToString withHostnamed}"
-    "-Dnetworkd=${stdenv.lib.boolToString withNetworkd}"
-    "-Dcryptsetup=${stdenv.lib.boolToString withCryptsetup}"
+    "-Dlogind=${lib.boolToString withLogind}"
+    "-Dlocaled=${lib.boolToString withLocaled}"
+    "-Dhostnamed=${lib.boolToString withHostnamed}"
+    "-Dnetworkd=${lib.boolToString withNetworkd}"
+    "-Dcryptsetup=${lib.boolToString withCryptsetup}"
     "-Dportabled=false"
-    "-Dhwdb=${stdenv.lib.boolToString withHwdb}"
+    "-Dhwdb=${lib.boolToString withHwdb}"
     "-Dremote=false"
     "-Dsysusers=false"
-    "-Dtimedated=${stdenv.lib.boolToString withTimedated}"
-    "-Dtimesyncd=${stdenv.lib.boolToString withTimesyncd}"
+    "-Dtimedated=${lib.boolToString withTimedated}"
+    "-Dtimesyncd=${lib.boolToString withTimesyncd}"
     "-Dfirstboot=false"
     "-Dlocaled=true"
-    "-Dresolve=${stdenv.lib.boolToString withResolved}"
+    "-Dresolve=${lib.boolToString withResolved}"
     "-Dsplit-usr=false"
     "-Dlibcurl=true"
     "-Dlibidn=false"
@@ -201,8 +201,8 @@ in stdenv.mkDerivation {
     # more frequent development builds
     "-Dman=true"
 
-    "-Dgnu-efi=${stdenv.lib.boolToString (withEfi && gnu-efi != null)}"
-  ] ++ stdenv.lib.optionals (withEfi && gnu-efi != null) [
+    "-Dgnu-efi=${lib.boolToString (withEfi && gnu-efi != null)}"
+  ] ++ lib.optionals (withEfi && gnu-efi != null) [
     "-Defi-libdir=${toString gnu-efi}/lib"
     "-Defi-includedir=${toString gnu-efi}/include/efi"
     "-Defi-ldsdir=${toString gnu-efi}/lib"
@@ -323,7 +323,7 @@ in stdenv.mkDerivation {
   # runtime; otherwise we can't and we need to reboot.
   passthru.interfaceVersion = 2;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://www.freedesktop.org/wiki/Software/systemd/";
     description = "A system and service manager for Linux";
     license = licenses.lgpl21Plus;

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -86,6 +86,7 @@ assert withImportd ->
 (curl.dev != null && zlib != null && xz != null && libgcrypt != null
   && gnutar != null && gnupg != null && withCompression );
 
+assert withEfi -> (gnu-efi != null);
 assert withRemote -> lib.getDev curl != null;
 assert withCoredump -> withCompression;
 
@@ -269,8 +270,8 @@ stdenv.mkDerivation {
     # more frequent development builds
     "-Dman=true"
 
-    "-Dgnu-efi=${lib.boolToString (withEfi && gnu-efi != null)}"
-  ] ++ lib.optionals (withEfi && gnu-efi != null) [
+    "-Dgnu-efi=${lib.boolToString withEfi}"
+  ] ++ lib.optionals withEfi [
     "-Defi-libdir=${toString gnu-efi}/lib"
     "-Defi-includedir=${toString gnu-efi}/include/efi"
     "-Defi-ldsdir=${toString gnu-efi}/lib"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -66,6 +66,7 @@
 , withImportd ? true
 , withLocaled ? true
 , withLogind ? true
+, withMachined ? true
 , withNetworkd ? true
 , withNss ? true
 , withPolkit ? true
@@ -226,6 +227,7 @@ stdenv.mkDerivation {
     "-Dlogind=${lib.boolToString withLogind}"
     "-Dlocaled=${lib.boolToString withLocaled}"
     "-Dhostnamed=${lib.boolToString withHostnamed}"
+    "-Dmachined=${lib.boolToString withMachined}"
     "-Dnetworkd=${lib.boolToString withNetworkd}"
     "-Dpolkit=${lib.boolToString withPolkit}"
     "-Dcryptsetup=${lib.boolToString withCryptsetup}"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -66,6 +66,7 @@
 , withLocaled ? true
 , withLogind ? true
 , withNetworkd ? true
+, withPolkit ? true
 , withRemote ? false  # has always been disabled on NixOS, upstream version appears broken anyway
 , withResolved ? true
 , withTimedated ? true
@@ -222,6 +223,7 @@ stdenv.mkDerivation {
     "-Dlocaled=${lib.boolToString withLocaled}"
     "-Dhostnamed=${lib.boolToString withHostnamed}"
     "-Dnetworkd=${lib.boolToString withNetworkd}"
+    "-Dpolkit=${lib.boolToString withPolkit}"
     "-Dcryptsetup=${lib.boolToString withCryptsetup}"
     "-Dportabled=false"
     "-Dhwdb=${lib.boolToString withHwdb}"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -305,7 +305,6 @@ stdenv.mkDerivation {
       src/core/mount.c \
       src/core/swap.c \
       src/cryptsetup/cryptsetup-generator.c \
-      src/fsck/fsck.c \
       src/journal/cat.c \
       src/nspawn/nspawn.c \
       src/remount-fs/remount-fs.c \
@@ -322,8 +321,6 @@ stdenv.mkDerivation {
         --replace /sbin/mkswap ${lib.getBin utillinux}/sbin/mkswap \
         --replace /sbin/swapon ${lib.getBin utillinux}/sbin/swapon \
         --replace /sbin/swapoff ${lib.getBin utillinux}/sbin/swapoff \
-        --replace /sbin/mke2fs ${lib.getBin e2fsprogs}/sbin/mke2fs \
-        --replace /sbin/fsck ${lib.getBin utillinux}/sbin/fsck \
         --replace /bin/echo ${coreutils}/bin/echo \
         --replace /bin/cat ${coreutils}/bin/cat \
         --replace /sbin/sulogin ${lib.getBin utillinux}/sbin/sulogin \

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -10,7 +10,6 @@
 , gperf
 , getent
 , patchelf
-, perl
 , glibcLocales
 , glib
 , substituteAll
@@ -149,7 +148,6 @@ stdenv.mkDerivation {
       patchelf
       getent
       m4
-      perl # to patch the libsystemd.so and remove dependencies on aarch64
 
       intltool
       gettext

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -55,6 +55,7 @@
 , kexectools
 , bashInteractive
 
+, withCoredump ? true
 , withCompression ? true  # adds bzip2, lz4 and xz
 , withCryptsetup ? true
 , withEfi ? stdenv.hostPlatform.isEfi
@@ -85,6 +86,7 @@ assert withImportd ->
   && gnutar != null && gnupg != null && withCompression );
 
 assert withRemote -> lib.getDev curl != null;
+assert withCoredump -> withCompression;
 
 assert withCryptsetup ->
 (cryptsetup != null);
@@ -223,6 +225,7 @@ stdenv.mkDerivation {
     "-Dsysusers=false"
     "-Dtimedated=${lib.boolToString withTimedated}"
     "-Dtimesyncd=${lib.boolToString withTimesyncd}"
+    "-Dcoredump=${lib.boolToString withCoredump}"
     "-Dfirstboot=false"
     "-Dresolve=${lib.boolToString withResolved}"
     "-Dsplit-usr=false"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -121,10 +121,9 @@ in stdenv.mkDerivation {
   buildInputs =
     [ linuxHeaders libcap curl.dev kmod xz pam acl
       cryptsetup libuuid glib libgcrypt libgpgerror libidn2
-      pcre2 ] ++
+      pcre2 libffi audit lz4 bzip2 libapparmor iptables ] ++
       lib.optional withKexectools kexectools ++
       lib.optional withLibseccomp libseccomp ++
-      [ libffi audit lz4 bzip2 libapparmor iptables ] ++
       lib.optional withEfi gnu-efi ++
       lib.optional withSelinux libselinux ++
       lib.optional withCryptsetup cryptsetup.dev;

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -55,6 +55,7 @@
 , kexectools
 , bashInteractive
 
+, withAnalyze ? true
 , withCoredump ? true
 , withCompression ? true  # adds bzip2, lz4 and xz
 , withCryptsetup ? true
@@ -211,6 +212,7 @@ stdenv.mkDerivation {
     "-Dglib=${lib.boolToString (glib != null)}"
     # while we do not run tests we should also not build them. Removes about 600 targets
     "-Dtests=false"
+    "-Danalyze=${lib.boolToString withAnalyze}"
     "-Dimportd=${lib.boolToString withImportd}"
     "-Dlz4=${lib.boolToString withCompression}"
     "-Dhomed=false"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18676,6 +18676,7 @@ in
     withResolved = false;
     withTimedated = false;
     glib = null;
+    libgcrypt = null;
     lvm2 = null;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18663,6 +18663,7 @@ in
   systemdMinimal = systemd.override {
     pname = "systemd-minimal";
     withCompression = false;
+    withCoredump = false;
     withCryptsetup = false;
     withEfi = false;
     withHostnamed = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18673,6 +18673,7 @@ in
     withLocaled = false;
     withLogind = false;
     withNetworkd = false;
+    withPolkit = false;
     withResolved = false;
     withTimedated = false;
     glib = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18670,6 +18670,7 @@ in
     withHwdb = false;
     withEfi = false;
     withImportd = false;
+    withCompression = false;
     withCryptsetup = false;
     glib = null;
     lvm2 = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18680,6 +18680,7 @@ in
     withResolved = false;
     withShellCompletions = false;
     withTimedated = false;
+    withTimesyncd = false;
     withUserDb = false;
     glib = null;
     libgcrypt = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18671,7 +18671,6 @@ in
     withEfi = false;
     withImportd = false;
     withCryptsetup = false;
-    cryptsetup = null;
     glib = null;
     lvm2 = null;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18662,6 +18662,7 @@ in
   };
   systemdMinimal = systemd.override {
     pname = "systemd-minimal";
+    withAnalyze = false;
     withCompression = false;
     withCoredump = false;
     withCryptsetup = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18674,6 +18674,7 @@ in
     withLocaled = false;
     withLogind = false;
     withNetworkd = false;
+    withNss = false;
     withPolkit = false;
     withResolved = false;
     withShellCompletions = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18663,6 +18663,7 @@ in
   systemdMinimal = systemd.override {
     pname = "systemd-minimal";
     withAnalyze = false;
+    withApparmor = false;
     withCompression = false;
     withCoredump = false;
     withCryptsetup = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18670,6 +18670,7 @@ in
     withImportd = false;
     withLocaled = false;
     withLogind = false;
+    withNetworkd = false;
     withResolved = false;
     withTimedated = false;
     glib = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18662,16 +18662,16 @@ in
   };
   systemdMinimal = systemd.override {
     pname = "systemd-minimal";
-    withResolved = false;
-    withLogind = false;
-    withHostnamed = false;
-    withLocaled = false;
-    withTimedated = false;
-    withHwdb = false;
-    withEfi = false;
-    withImportd = false;
     withCompression = false;
     withCryptsetup = false;
+    withEfi = false;
+    withHostnamed = false;
+    withHwdb = false;
+    withImportd = false;
+    withLocaled = false;
+    withLogind = false;
+    withResolved = false;
+    withTimedated = false;
     glib = null;
     lvm2 = null;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18678,6 +18678,7 @@ in
     withResolved = false;
     withShellCompletions = false;
     withTimedated = false;
+    withUserDb = false;
     glib = null;
     libgcrypt = null;
     lvm2 = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18673,6 +18673,7 @@ in
     withImportd = false;
     withLocaled = false;
     withLogind = false;
+    withMachined = false;
     withNetworkd = false;
     withNss = false;
     withPolkit = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18666,6 +18666,7 @@ in
     withCompression = false;
     withCoredump = false;
     withCryptsetup = false;
+    withDocumentation = false;
     withEfi = false;
     withHostnamed = false;
     withHwdb = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18677,6 +18677,7 @@ in
     withMachined = false;
     withNetworkd = false;
     withNss = false;
+    withPCRE2 = false;
     withPolkit = false;
     withResolved = false;
     withShellCompletions = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18675,6 +18675,7 @@ in
     withNetworkd = false;
     withPolkit = false;
     withResolved = false;
+    withShellCompletions = false;
     withTimedated = false;
     glib = null;
     libgcrypt = null;


### PR DESCRIPTION
###### Motivation for this change
Paired with @andir on this. Apart from some cleanups, this adds some more flags to the systemd derivation, both cutting down the runtime and build closure size of `systemdMinimal`.

Sizes:
```
Before:
/nix/store/mckmzpwswm0zhq1i7xhbzn6jbhf9j2zk-systemd-minimal-246.6                 16.1M
After:
/nix/store/xgabn4cyxy68cg17m18f6zq93xin06x2-systemd-minimal-246.6         10.0M
```



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
