### PR TITLE
eyewitness: init at v20201021.1

### DIFF
--- a/pkgs/tools/security/eyewitness/default.nix
+++ b/pkgs/tools/security/eyewitness/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, fetchFromGitHub
+, firefox
+, geckodriver
+, xorg
+, python37
+, python37Packages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "eyewitness";
+  version = "v20201021.1";
+
+  src = fetchFromGitHub {
+    owner = "FortyNorthSecurity";
+    repo = "EyeWitness";
+    rev = version;
+    sha256 = "16ayiklgf9d1sq8phsfpg1kjs40y4dpwzgwgx8vy2n32ckqv8f6i";
+  };
+
+  # These _are_ runtime, not buildtime dependencies. EyeWitness functions by
+  # executing firefox in Xvfb so have a somewhat 'heavy' dependency tree.
+  #
+  # After EyeWitness finishes processing, firefox and Xvfb are terminated.
+  propagatedBuildInputs = [
+    firefox
+    geckodriver
+    xorg.xorgserver
+    python37
+    python37Packages.pip
+    python37Packages.netaddr
+    python37Packages.selenium
+    python37Packages.fuzzywuzzy
+    python37Packages.virtual-display
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/
+    mv Python bin
+    cp -r bin $out/bin
+
+    runHook postInstall
+  '';
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Headless process to take screenshots of websites, capture header info, identify default credentials if known";
+    homepage = "https://github.com/FortyNorthSecurity/EyeWitness";
+    maintainers = with maintainers; [ redvers ];
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3496,6 +3496,8 @@ in
 
   epubcheck = callPackage ../tools/text/epubcheck { };
 
+  eyewitness = callPackage ../tools/security/eyewitness { };
+
   luckybackup = libsForQt5.callPackage ../tools/backup/luckybackup {
     ssh = openssh;
   };


### PR DESCRIPTION
###### Motivation for this change

EyeWitness is a tool that I use on a daily basis to evaluate large swathes of network services that I am responsible for.  It is a headless application which takes as input a list of URLs and outputs screenshots and source-code for each item in the list.

To test:
```
nix-shell -p eyewitness
EyeWitness.py --single https://nixos.org/
```

(You can see example output of the above here: https://evil.red/2020-10-28_032409/report.html)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
