### PR TITLE
ocamlPackages.hex: 1.3.0 → 1.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/fiat-p256/default.nix
+++ b/pkgs/development/ocaml-modules/fiat-p256/default.nix
@@ -5,6 +5,7 @@
 buildDunePackage rec {
   pname = "fiat-p256";
   version = "0.2.1";
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/fiat/releases/download/v${version}/${pname}-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/hex/default.nix
+++ b/pkgs/development/ocaml-modules/hex/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchurl, buildDunePackage, cstruct }:
+{ stdenv, fetchurl, buildDunePackage, bigarray-compat, cstruct }:
 
 buildDunePackage rec {
   pname = "hex";
-  version = "1.3.0";
+  version = "1.4.0";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.02";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-${pname}/releases/download/v${version}/hex-v${version}.tbz";
-    sha256 = "193567pn58df3b824vmfanncdfgf9cxzl7q3rq39zl9szvzhvkja";
+    sha256 = "07b9y0lmnflsslkrm6xilkj40n8sf2hjqkyqghnk7sw5l0plkqsp";
   };
 
-  propagatedBuildInputs = [ cstruct ];
+  propagatedBuildInputs = [ bigarray-compat cstruct ];
   doCheck = true;
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
