### PR TITLE
mrsh: 2020-01-08 -> 2020-07-27 etc.

### DIFF
--- a/pkgs/shells/mrsh/default.nix
+++ b/pkgs/shells/mrsh/default.nix
@@ -2,17 +2,19 @@
 
 stdenv.mkDerivation rec {
   pname   = "mrsh";
-  version = "2020-01-08";
+  version = "2020-07-27";
 
   src = fetchFromGitHub {
     owner = "emersion";
     repo = "mrsh";
-    rev = "ef21854fc9ce172fb1f7f580b19a89d030d67c65";
-    sha256 = "1iyxmwl61p2x9v9b22416n4lnrlwjqyxybq35x8bcbjxkwypp943";
+    rev = "0da902c0ee6f443fe703498e60f266af7f12537e";
+    sha256 = "1yr09ln5p1s48aj8xv2d6dy0pahqvd86fkiwyc6zrjfq80igxf05";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig ];
   buildInputs = [ readline ];
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "A minimal POSIX shell";
@@ -20,5 +22,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ matthiasbeyer ];
     platforms = platforms.unix;
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This change updates `mrsh` to a newer revision. The [changes between them](https://github.com/emersion/mrsh/compare/ef21854fc9..0da902c0ee
) are available.

Moreover, it enables `doCheck` as executing the whole test suites takes just few seconds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
