### PR TITLE
Updated Freecad fixes AddonManager bug

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -9,13 +9,13 @@ let
   pythonPackages = python3Packages;
 in mkDerivation rec {
   pname = "freecad-unstable";
-  version = "2020-10-17";
+  version = "2020-10-28";
 
   src = fetchFromGitHub {
     owner = "FreeCAD";
     repo = "FreeCAD";
-    rev = "f3bdaaa55a6c03b297924c40819d23e4603fa55b";
-    sha256 = "1q1iy4i9k65v8z7h8a6r4bf5ycn124jp26xwp0xwbar4gnkx2jiq";
+    rev = "0f875168b67536fd859ed44e1fe50d9b0a11f223";
+    sha256 = "16aycnvs9p5590rhivbqympajfixfsy1sjljh3s8fq6kv9s64gaw";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
I'm seeing the bug mentioned in the FreeCad commit below that prevents the AddonManager working in the packaged version in 20.03 and in the packaged version on master. 

https://github.com/FreeCAD/FreeCAD/commit/72eb41b24f12b572d55081042160954b93f4614c

This PR updates the FreeCad package to the commit which was the most recently committed on FreeCad master when I built the  latest version, it includes the fix.

https://github.com/FreeCAD/FreeCAD/commit/0f875168b67536fd859ed44e1fe50d9b0a11f223

The hash I got running:

nix-prefetch-url --type sha256 https://github.com/FreeCad/FreeCad/archive/0f875168b67536fd859ed44e1fe50d9b0a11f223.tar.gz

Didn't work, so I just used the hast the build expected.

Not concerned if this PR doesn't get merged more an FYI that the current version seems to have an issue with the AddonManager.

Cheers

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [yes] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
