### PR TITLE
[staging] hidapi: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/development/libraries/hidapi/default.nix
+++ b/pkgs/development/libraries/hidapi/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "hidapi";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "libusb";
     repo = "hidapi";
     rev = "${pname}-${version}";
-    sha256 = "1p4g8lgwj4rki6lbn5l6rvwj0xlbn1xfh4d255bg5pvgczmwmc4i";
+    sha256 = "1n3xn1zvxgyzb84cjpw3i5alw0gkbrps11r4ijxzyqxqym0khagr";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Library for communicating with USB and Bluetooth HID devices";
     homepage = "https://github.com/libusb/hidapi";
+    maintainers = with maintainers; [ prusnak ];
     # Actually, you can chose between GPLv3, BSD or HIDAPI license (more liberal)
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/development/python-modules/hidapi/default.nix
+++ b/pkgs/development/python-modules/hidapi/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "hidapi";
-  version = "0.9.0.post3";
+  version = "0.10.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5a2442928f17ba742d9c53073f48b152051c5747d758d2fefd937543da5ab2e5";
+    sha256 = "2560ad8db212f54cf40ea8d78715adad7df803011cfdce9dabbac0e76acf31ef";
   };
 
   propagatedBuildInputs =
@@ -26,11 +26,11 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "hid" ];
 
   meta = with stdenv.lib; {
-    description = "A Cython interface to the hidapi from https://github.com/signal11/hidapi";
+    description = "A Cython interface to the hidapi from https://github.com/libusb/hidapi";
     homepage = "https://github.com/trezor/cython-hidapi";
     # license can actually be either bsd3 or gpl3
     # see https://github.com/trezor/cython-hidapi/blob/master/LICENSE-orig.txt
     license = licenses.bsd3;
-    maintainers = with maintainers; [ np ];
+    maintainers = with maintainers; [ np prusnak ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Version update (+version update of Python binding)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
