### PR TITLE
piglit: init at unstable-2020-10-28

### DIFF
--- a/pkgs/development/libraries/waffle/default.nix
+++ b/pkgs/development/libraries/waffle/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, fetchFromGitLab
+, lib
+, cmake
+, libGL
+, libglvnd
+, makeWrapper
+, pkg-config
+, wayland
+, libxcb
+, libX11
+}:
+
+stdenv.mkDerivation rec {
+  pname = "waffle";
+  version = "1.6.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "mesa";
+    repo = "waffle";
+    rev = "v${version}";
+    sha256 = "0s8gislmhccfa04zsj1yqk97lscbbnmxirr2zm4q3p8ybmpfhpqr";
+  };
+
+  buildInputs = [
+    libGL
+    libglvnd
+    libX11
+    libxcb
+    wayland
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    pkg-config
+  ];
+
+  cmakeFlags = [ "-Dplatforms=x11,wayland" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/wflinfo \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ libGL libglvnd ]}
+  '';
+
+  meta = with lib; {
+    description = "A cross-platform C library that allows one to defer selection of an OpenGL API and window system until runtime";
+    homepage = "http://www.waffle-gl.org/";
+    license = licenses.bsd2;
+    platforms = platforms.mesaPlatforms;
+    maintainers = with maintainers; [ Flakebi ];
+  };
+}

--- a/pkgs/tools/graphics/piglit/default.nix
+++ b/pkgs/tools/graphics/piglit/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, fetchFromGitLab
+, lib
+, cmake
+, freeglut
+, libGL
+, libGLU
+, libglvnd
+, makeWrapper
+, ninja
+, pkg-config
+, python3
+, waffle
+, wayland
+, libX11
+, libXrender
+, libxcb
+, libxkbcommon
+}:
+
+stdenv.mkDerivation rec {
+  pname = "piglit";
+  version = "unstable-2020-10-23";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "mesa";
+    repo = "piglit";
+    rev = "59e695c16fdcdd4ea4f16365f0e397a93cef7b80";
+    sha256 = "kx0+2Sdvdc3SbpAIl2OuGCWCpaLJC/7cXG+ZLvf92g8=";
+  };
+
+  buildInputs = [
+    freeglut
+    libGL
+    libGLU
+    libglvnd
+    libX11
+    libXrender
+    libxcb
+    libxkbcommon
+    (python3.withPackages (ps: with ps; [
+      Mako
+      numpy
+    ]))
+    waffle
+    wayland
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    ninja
+    pkg-config
+  ];
+
+  # Find data dir: piglit searches for the data directory in some places, however as it is wrapped,
+  # it search in ../lib/.piglit-wrapped, we just replace the script name with "piglit" again.
+  prePatch = ''
+    substituteInPlace piglit \
+      --replace 'script_basename_noext = os.path.splitext(os.path.basename(__file__))[0]' 'script_basename_noext = "piglit"'
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/piglit \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ libGL libglvnd ]} \
+      --prefix PATH : "${waffle}/bin"
+  '';
+
+  meta = with lib; {
+    description = "An OpenGL test suite, and test-suite runner";
+    homepage = "https://gitlab.freedesktop.org/mesa/piglit";
+    license = licenses.free; # custom license. See COPYING in the source repo.
+    platforms = platforms.mesaPlatforms;
+    maintainers = with maintainers; [ Flakebi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16045,6 +16045,8 @@ in
     stdenv = gcc6Stdenv; # upstream code incompatible with gcc7
   };
 
+  waffle = callPackage ../development/libraries/waffle { };
+
   wally-cli = callPackage ../development/tools/wally-cli { };
 
   wavpack = callPackage ../development/libraries/wavpack { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2465,6 +2465,8 @@ in
 
   photon = callPackage ../tools/networking/photon { };
 
+  piglit = callPackage ../tools/graphics/piglit { };
+
   playerctl = callPackage ../tools/audio/playerctl { };
 
   ps_mem = callPackage ../tools/system/ps_mem { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
[Piglit](https://gitlab.freedesktop.org/mesa/piglit) is a test runner for mesa.
[waffle](http://www.waffle-gl.org) is a dependency for piglit.

To check if everything is working: `piglit run sanity results/sanity`

cc @danieldk 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
