### PR TITLE
ns-3: 3.30 -> 3.32

### DIFF
--- a/pkgs/development/libraries/science/networking/ns-3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns-3/default.nix
@@ -26,7 +26,7 @@
 
 # All modules can be enabled by choosing 'all_modules'.
 # we include here the DCE mandatory ones
-, modules ? [ "core" "network" "internet" "point-to-point" "fd-net-device" "netanim"]
+, modules ? [ "core" "network" "internet" "point-to-point" "point-to-point-layout" "fd-net-device" "netanim" ]
 , lib
 }:
 
@@ -38,13 +38,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "ns-3";
-  version = "30";
+  version = "32";
 
   src = fetchFromGitLab {
     owner = "nsnam";
     repo   = "ns-3-dev";
     rev    = "ns-3.${version}";
-    sha256 = "0smdi3gglmafpc7a20hj2lbmwks3d5fpsicpn39lmm3svazw0bvp";
+    sha256 = "158yjhsrmslj1q4zcq5p16hv9i82qnxx714l7idicncn0wzrfx7k";
   };
 
   nativeBuildInputs = [ wafHook ];
@@ -60,6 +60,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs doc/ns3_html_theme/get_version.sh
+    # FIX/Remove when https://github.com/NixOS/nixpkgs/pull/69310 gets merged
+    sed -i 's/program.ns3_module_dependencies.copy()/program.ns3_module_dependencies[:]/g' wscript
   '';
 
   wafConfigureFlags = with stdenv.lib; [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Bugfixes and this - https://github.com/NixOS/nixpkgs/pull/100770

Keep in mind there is a cheap patch to bypass this issue mentioned here - https://github.com/NixOS/nixpkgs/pull/69310

I have added "point-to-point-layout", as netanim would not work without it.

All libs now has the name of `libns3.32-...-debug` instead of `libns3-dev-...-debug`, not sure if we should do anything about that?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
