### PR TITLE
audiowaveform: init at 1.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2407,6 +2407,12 @@
     githubId = 984691;
     name = "Evan Danaher";
   };
+  edbentley = {
+    email = "hello@edbentley.dev";
+    github = "edbentley";
+    githubId = 15923595;
+    name = "Ed Bentley";
+  };
   edcragg = {
     email = "ed.cragg@eipi.xyz";
     github = "nuxeh";

--- a/pkgs/tools/audio/audiowaveform/default.nix
+++ b/pkgs/tools/audio/audiowaveform/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, cmake, gtest, boost, gd, libsndfile, libmad, libid3tag }:
+
+stdenv.mkDerivation rec {
+  pname = "audiowaveform";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "bbc";
+    repo = "audiowaveform";
+    rev = version;
+    sha256 = "0k2s2f2hgq4pnjzfkgvjwgsflihmzdq7shicfjn0z2mzw4d1bvp2";
+  };
+
+  nativeBuildInputs = [ cmake gtest ];
+
+  buildInputs = [ boost gd libsndfile libmad libid3tag ];
+
+  preConfigure = ''
+    ln -s ${gtest.src}/googletest googletest
+    ln -s ${gtest.src}/googlemock googlemock
+  '';
+
+  # One test is failing, see PR #101947
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "C++ program to generate waveform data and render waveform images from audio files";
+    longDescription = ''
+      audiowaveform is a C++ command-line application that generates waveform data from either MP3, WAV, FLAC, or Ogg Vorbis format audio files.
+      Waveform data can be used to produce a visual rendering of the audio, similar in appearance to audio editing applications.
+    '';
+    homepage = "https://github.com/bbc/audiowaveform";
+    changelog = "https://github.com/bbc/audiowaveform/blob/${version}/ChangeLog";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ edbentley ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -794,6 +794,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
+  audiowaveform = callPackage ../tools/audio/audiowaveform { };
+
   autoflake = callPackage ../development/tools/analysis/autoflake { };
 
   autospotting = callPackage ../applications/misc/autospotting { };


### PR DESCRIPTION
###### Motivation for this change

Adding the [audiowaveform](https://github.com/bbc/audiowaveform) CLI program. Used their [homebrew file](https://github.com/bbc/homebrew-audiowaveform/blob/master/audiowaveform.rb) as a reference.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
