### PR TITLE
tdlib: 1.6.0 -> 1.6.9

### DIFF
--- a/pkgs/development/libraries/tdlib/default.nix
+++ b/pkgs/development/libraries/tdlib/default.nix
@@ -8,11 +8,11 @@ stdenv.mkDerivation rec {
     owner = "tdlib";
     repo = "td";
 
-    # At version 1.6.0, this line was `rev = "v${version}". Version 1.6.9 uses an explicit revision hash because 1.6.9
-    # is not a tdlib GitHub release, and is therefore not hosted at `https://github.com/tdlib/td/releases/tag/v1.6.9`.
-    # Please return to the `rev = "v${version}"` style on the next version bump if you can, since that will allow
+    # At version 1.6.0, this line was `rev = "v${version}". Version 1.6.9 uses an explicit revision because 1.6.9 is not
+    # a tdlib GitHub release, and is therefore not hosted at `https://github.com/tdlib/td/releases/tag/v1.6.9`. Please
+    # return to the `rev = "v${version}"` style on the next version bump if you can, since that will allow
     # `nixpkgs-update` to update the package automatically.
-    rev = "32f2338bd199dd06a1b4b5f1ad14f2d4f2868f01";
+    rev = "unstable-2020-10-25";
 
     sha256 = "0wv03hlgzrsc04kcwnwz6dsmkdzvhb0i1wjs08gzivwxw06pkq4n";
   };

--- a/pkgs/development/libraries/tdlib/default.nix
+++ b/pkgs/development/libraries/tdlib/default.nix
@@ -1,14 +1,14 @@
 { fetchFromGitHub, gperf, openssl, readline, zlib, cmake, stdenv }:
 
 stdenv.mkDerivation rec {
-  version = "1.6.0";
+  version = "1.6.9";
   pname = "tdlib";
 
   src = fetchFromGitHub {
     owner = "tdlib";
     repo = "td";
-    rev = "v${version}";
-    sha256 = "0zlzpl6fgszg18kwycyyyrnkm255dvc6fkq0b0y32m5wvwwl36cv";
+    rev = "32f2338bd199dd06a1b4b5f1ad14f2d4f2868f01";
+    sha256 = "0wv03hlgzrsc04kcwnwz6dsmkdzvhb0i1wjs08gzivwxw06pkq4n";
   };
 
   buildInputs = [ gperf openssl readline zlib ];

--- a/pkgs/development/libraries/tdlib/default.nix
+++ b/pkgs/development/libraries/tdlib/default.nix
@@ -1,18 +1,18 @@
 { fetchFromGitHub, gperf, openssl, readline, zlib, cmake, stdenv }:
 
 stdenv.mkDerivation rec {
-  version = "1.6.9";
+  version = "unstable-2020-10-25";
   pname = "tdlib";
 
   src = fetchFromGitHub {
     owner = "tdlib";
     repo = "td";
 
-    # At version 1.6.0, this line was `rev = "v${version}". Version 1.6.9 uses an explicit revision because 1.6.9 is not
-    # a tdlib GitHub release, and is therefore not hosted at `https://github.com/tdlib/td/releases/tag/v1.6.9`. Please
-    # return to the `rev = "v${version}"` style on the next version bump if you can, since that will allow
-    # `nixpkgs-update` to update the package automatically.
-    rev = "unstable-2020-10-25";
+    # At version 1.6.0, this line was `rev = "v${version}". Version 1.6.9 (here called `unstable-2020-10-25`) uses an
+    # explicit revision because 1.6.9 is not a tdlib GitHub release, and is therefore not hosted at
+    # `https://github.com/tdlib/td/releases/tag/v1.6.9`. Please return to the `rev = "v${version}"` style on the next
+    # version bump if you can, since that will allow `nixpkgs-update` to update the package automatically.
+    rev = "32f2338bd199dd06a1b4b5f1ad14f2d4f2868f01";
 
     sha256 = "0wv03hlgzrsc04kcwnwz6dsmkdzvhb0i1wjs08gzivwxw06pkq4n";
   };

--- a/pkgs/development/libraries/tdlib/default.nix
+++ b/pkgs/development/libraries/tdlib/default.nix
@@ -7,7 +7,13 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "tdlib";
     repo = "td";
+
+    # At version 1.6.0, this line was `rev = "v${version}". Version 1.6.9 uses an explicit revision hash because 1.6.9
+    # is not a tdlib GitHub release, and is therefore not hosted at `https://github.com/tdlib/td/releases/tag/v1.6.9`.
+    # Please return to the `rev = "v${version}"` style on the next version bump if you can, since that will allow
+    # `nixpkgs-update` to update the package automatically.
     rev = "32f2338bd199dd06a1b4b5f1ad14f2d4f2868f01";
+
     sha256 = "0wv03hlgzrsc04kcwnwz6dsmkdzvhb0i1wjs08gzivwxw06pkq4n";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This dependency is required for the current version of the Emacs package `telega`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
