### PR TITLE
libtensorflow-bin: unmark as broken

### DIFF
--- a/pkgs/development/libraries/science/math/tensorflow/bin.nix
+++ b/pkgs/development/libraries/science/math/tensorflow/bin.nix
@@ -73,6 +73,5 @@ in stdenv.mkDerivation rec {
     license = licenses.asl20;
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ basvandijk ];
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Accidentally marked it broken when marking the tensorflow python packages as broken

context: https://github.com/NixOS/nixpkgs/issues/101863#issuecomment-718031291

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
