### PR TITLE
pythonPackages.tmdb3: disable on python3

### DIFF
--- a/pkgs/development/python-modules/tmdb3/default.nix
+++ b/pkgs/development/python-modules/tmdb3/default.nix
@@ -1,8 +1,9 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchPypi, isPy3k }:
 
 buildPythonPackage rec {
   pname = "tmdb3";
   version = "0.7.2";
+  disabled = isPy3k; # Upstream has not received any updates since 2015, and importing from python3 does not work.
 
   src = fetchPypi {
     inherit pname version;
@@ -11,6 +12,8 @@ buildPythonPackage rec {
 
   # no tests implemented
   doCheck = false;
+
+  pythonImportsCheck = [ "tmdb3" ];
 
   meta = with lib; {
     description = "Python implementation of the v3 API for TheMovieDB.org, allowing access to movie and cast information";


### PR DESCRIPTION
###### Motivation for this change
Wanted to use this library, and noticed it didn't work on python3. 

Not sure if we should keep the library around at all, as python2 has been deprecated for a while now. For now I've simply disabled it on python3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
