### PR TITLE
Hass nabucasa.0.37.1

### DIFF
--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -4,13 +4,13 @@
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
-  version = "0.34.6";
+  version = "0.37.1";
 
   src = fetchFromGitHub {
     owner = "nabucasa";
     repo = pname;
     rev = version;
-    sha256 = "1lkqwj58qr0vn7zf5mhrhaz973ahj9wjp4mgzvyja1gcdh6amv34";
+    sha256 = "/GFNrLi1I69gUDIwnHa2q/pxkiRl9PKxpKtb56JrmuA=";
   };
 
   postPatch = ''
@@ -18,23 +18,11 @@ buildPythonPackage rec {
     sed -i 's/"cryptography.*"/"cryptography"/' setup.py
   '';
 
-  patches = [
-    # relax pytz dependency
-    (fetchpatch {
-      url = "https://github.com/NabuCasa/hass-nabucasa/commit/419e80feddc36c68384c032feda0057515b53eaa.patch";
-      sha256 = "14dgwci8615cwcf27hg7b42s7da50xhyjys3yx446q7ipk8zw4x6";
-    })
-  ];
-
   propagatedBuildInputs = [
     acme aiohttp atomicwrites snitun attrs warrant pycognito
   ];
 
   checkInputs = [ pytest pytest-aiohttp asynctest ];
-
-  # Asynctest's mocking is broken with python3.8
-  # https://github.com/Martiusweb/asynctest/issues/132
-  doCheck = pythonOlder "3.8";
 
   checkPhase = ''
     pytest tests/

--- a/pkgs/development/python-modules/pycognito/default.nix
+++ b/pkgs/development/python-modules/pycognito/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "pycognito";
-  version = "0.1.3";
+  version = "0.1.4";
 
   src = fetchFromGitHub {
     owner = "pvizeli";
     repo = "pycognito";
     rev = version;
-    sha256 = "0wy6d274xda7v6dazv10h2vwig2avfyz8mh2lpd1a5k7i06r335r";
+    sha256 = "HLzPrRon+ipcUZlD1l4nYSwSbdDLwOALy4ejGunjK0w=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/python-jose/default.nix
+++ b/pkgs/development/python-modules/python-jose/default.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "python-jose";
-  version = "3.1.0";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "mpdavis";
     repo = "python-jose";
     rev = version;
-    sha256 = "1gnn0zy03pywj65ammy3sd07knzhjv8n5jhx1ir9bikgra9v0iqh";
+    sha256 = "cSPIZrps0xFd4pPcQ4w/jFWOk2XYgd3mtE/sDzlytvY=";
   };
 
   checkInputs = [
@@ -22,6 +22,13 @@ buildPythonPackage rec {
     pytestrunner
     cryptography # optional dependency, but needed in tests
   ];
+
+  # relax ecdsa deps
+  patchPhase = ''
+    substituteInPlace setup.py \
+      --replace 'ecdsa<0.15' 'ecdsa' \
+      --replace 'ecdsa <0.15' 'ecdsa'
+  '';
 
   disabledTests = [
     # https://github.com/mpdavis/python-jose/issues/176


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
upgrade hass-nabucasa and deps

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
