### PR TITLE
aws-google-auth: 0.0.34 -> 0.0.36

### DIFF
--- a/pkgs/tools/admin/aws-google-auth/default.nix
+++ b/pkgs/tools/admin/aws-google-auth/default.nix
@@ -4,6 +4,7 @@
 , beautifulsoup4
 , boto3
 , configparser
+, filelock
 , keyring
 , keyrings-alt
 , lxml
@@ -19,7 +20,7 @@
 
 buildPythonApplication rec {
   pname = "aws-google-auth";
-  version = "0.0.34";
+  version = "0.0.36";
 
   # Pypi doesn't ship the tests, so we fetch directly from GitHub
   # https://github.com/cevoaustralia/aws-google-auth/issues/120
@@ -27,13 +28,14 @@ buildPythonApplication rec {
     owner = "cevoaustralia";
     repo = "aws-google-auth";
     rev = version;
-    sha256 = "12c5ssdy870szrizhs4d7dzcpq3hvszjvl8ba60qf1ak5jsr1ay4";
+    sha256 = "099r020v33sij2b3816cjp4fpy35c886l559szfxqx6kgy19y9z7";
   };
 
-  propagatedBuildInputs = [ 
+  propagatedBuildInputs = [
     beautifulsoup4
     boto3
     configparser
+    filelock
     keyring
     keyrings-alt
     lxml
@@ -43,10 +45,10 @@ buildPythonApplication rec {
     tabulate
     tzlocal
   ] ++ lib.optional withU2F python-u2flib-host;
-  
-  checkInputs = [ 
+
+  checkInputs = [
     mock
-    nose 
+    nose
   ];
 
   preCheck = ''


### PR DESCRIPTION
###### Motivation for this change
New upstream version.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
