### PR TITLE
buildFHSUserEnvBubblewrap: fix whitespace with root directories

### DIFF
--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -77,13 +77,13 @@ let
       done
     fi
 
-    auto_mounts=""
+    declare -a auto_mounts
     # loop through all directories in the root
     for dir in /*; do
       # if it is a directory and it is not in the blacklist
       if [[ -d "$dir" ]] && grep -v "$dir" <<< "$blacklist" >/dev/null; then
         # add it to the mount list
-        auto_mounts="$auto_mounts --bind $dir $dir"
+        auto_mounts+=(--bind "$dir" "$dir")
       fi
     done
 
@@ -97,7 +97,7 @@ let
       --ro-bind /nix /nix \
       ${etcBindFlags} \
       $ro_mounts \
-      $auto_mounts \
+      "''${auto_mounts[@]}" \
       ${init runScript}/bin/${name}-init ${initArgs}
   '';
 


### PR DESCRIPTION
###### Motivation for this change
closes https://github.com/NixOS/nixpkgs/issues/101942

I tried doing the same to the ro_mounts, but for some reason the entire array was getting escaped in a `' .. '`, which was causing issues.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
