### PR TITLE
home-assistant: 0.116.4 -> 0.117.0 (+ additional package updates)

### DIFF
--- a/pkgs/development/python-modules/asgi-csrf/default.nix
+++ b/pkgs/development/python-modules/asgi-csrf/default.nix
@@ -2,7 +2,7 @@
 , pytestCheckHook, starlette, httpx, pytest-asyncio }:
 
 buildPythonPackage rec {
-  version = "0.7";
+  version = "0.7.1";
   pname = "asgi-csrf";
   disabled = isPy27;
 
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     owner = "simonw";
     repo = pname;
     rev = version;
-    sha256 = "1vf4lh007790836cp3hd6wf8wsgj045dcg0w1cm335p08zz6j4k7";
+    sha256 = "1hhqrb9r46y6i3d3w6hc9zm6yyikdyd2k5pcbyw0r9fl959yi4hf";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/asgi-csrf/default.nix
+++ b/pkgs/development/python-modules/asgi-csrf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, isPy27, fetchFromGitHub, itsdangerous, python-multipart
-, pytest, starlette, httpx, pytest-asyncio }:
+, pytestCheckHook, starlette, httpx, pytest-asyncio }:
 
 buildPythonPackage rec {
   version = "0.7";
@@ -14,12 +14,23 @@ buildPythonPackage rec {
     sha256 = "1vf4lh007790836cp3hd6wf8wsgj045dcg0w1cm335p08zz6j4k7";
   };
 
-  propagatedBuildInputs = [ itsdangerous python-multipart ];
+  propagatedBuildInputs = [
+    itsdangerous
+    python-multipart
+  ];
 
-  checkInputs = [ pytest starlette httpx pytest-asyncio ];
-  checkPhase = ''
-    pytest test_asgi_csrf.py
-  '';
+  checkInputs = [
+    httpx
+    pytest-asyncio
+    pytestCheckHook
+    starlette
+  ];
+
+  # tests fail while importing a private module from httpx
+  #  E   ModuleNotFoundError: No module named 'httpx._content_streams'
+  # https://github.com/simonw/asgi-csrf/issues/18
+  doCheck = false;
+
   pythonImportsCheck = [ "asgi_csrf" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/httpcore/default.nix
+++ b/pkgs/development/python-modules/httpcore/default.nix
@@ -1,34 +1,52 @@
-{ stdenv
+{ lib
 , buildPythonPackage
+, pythonOlder
 , fetchFromGitHub
-, isPy27
 , h11
+, h2
+, pproxy
+, pytestCheckHook
+, pytestcov
 , sniffio
+, uvicorn
 }:
 
 buildPythonPackage rec {
   pname = "httpcore";
-  version = "0.10.2";
-  disabled = isPy27;
+  version = "0.12.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "00gn8nfv814rg6fj7xv97mrra3fvx6fzjcgx9y051ihm6hxljdsi";
+    sha256 = "0bwxn7m7r7h6k41swxj0jqj3nzi76wqxwbnry6y7d4qfh4m26g2j";
   };
 
-  propagatedBuildInputs = [ h11 sniffio ];
+  propagatedBuildInputs = [
+    h11
+    h2
+    sniffio
+  ];
 
-  # tests require pythonic access to mitmproxy, which isn't (yet?) packaged as
-  # a pythonPackage.
-  doCheck = false;
+  checkInputs = [
+    pproxy
+    pytestCheckHook
+    pytestcov
+    uvicorn
+  ];
+
+  pytestFlagsArray = [
+    # these tests fail during dns lookups: httpcore.ConnectError: [Errno -2] Name or service not known
+    "--ignore=tests/sync_tests/test_interfaces.py"
+  ];
+
   pythonImportsCheck = [ "httpcore" ];
 
-  meta = with stdenv.lib; {
-    description = "A minimal HTTP client";
+  meta = with lib; {
+    description = "A minimal low-level HTTP client";
     homepage = "https://github.com/encode/httpcore";
     license = licenses.bsd3;
-    maintainers = [ maintainers.ris ];
+    maintainers = with maintainers; [ ris ];
   };
 }

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -1,70 +1,60 @@
 { lib
 , buildPythonPackage
+, pythonOlder
 , fetchFromGitHub
-, fetchpatch
+, brotli
 , certifi
-, chardet
-, h11
 , h2
 , httpcore
-, idna
 , rfc3986
 , sniffio
-, isPy27
-, pytest
+, pytestCheckHook
 , pytest-asyncio
 , pytest-trio
 , pytestcov
 , trustme
 , uvicorn
-, brotli
 }:
 
 buildPythonPackage rec {
   pname = "httpx";
-  version = "0.14.2";
-  disabled = isPy27;
+  version = "0.16.1";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "08b6k5g8car3bic90aw4ysb2zvsa5nm8qk3hk4dgamllnnxzl5br";
+    sha256 = "00gmq45fckcqkj910bvd7pyqz1mvgsdvz4s0k7dzbnc5czzq1f4a";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "fix-cookie-test-timestamp.patch";
-      url = "https://github.com/encode/httpx/pull/1270.patch";
-      sha256 = "1hgrynac6226sgnyzmsr1nr15rn49gbfmk4c2kx3dwkbh6vr7jpd";
-    })
-  ];
-
   propagatedBuildInputs = [
+    brotli
     certifi
-    chardet
-    h11
     h2
     httpcore
-    idna
     rfc3986
     sniffio
   ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
     pytest-asyncio
     pytest-trio
     pytestcov
     trustme
     uvicorn
-    brotli
   ];
 
-  checkPhase = ''
-    PYTHONPATH=.:$PYTHONPATH pytest -k 'not (test_connect_timeout or test_elapsed_timer)'
-  '';
   pythonImportsCheck = [ "httpx" ];
+
+  disabledTests = [
+    # httpcore.ConnectError: [Errno 101] Network is unreachable
+    "test_connect_timeout"
+    # httpcore.ConnectError: [Errno -2] Name or service not known
+    "test_async_proxy_close"
+    "test_sync_proxy_close"
+  ];
 
   meta = with lib; {
     description = "The next generation HTTP client";

--- a/pkgs/development/python-modules/spotipy/default.nix
+++ b/pkgs/development/python-modules/spotipy/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, buildPythonPackage, fetchPypi, requests, six, mock }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+, six }:
 
 buildPythonPackage rec {
   pname = "spotipy";
@@ -10,19 +14,19 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ requests six ];
-  checkInputs = [ mock ];
 
-  preConfigure = ''
-    substituteInPlace setup.py \
-      --replace "mock==2.0.0" "mock"
-  '';
+  # tests want to access the spotify API
+  doCheck = false;
+  pythonImportsCheck = [
+    "spotipy"
+    "spotipy.oauth2"
+  ];
 
-  pythonImportsCheck = [ "spotipy" ];
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://spotipy.readthedocs.org/";
+    changelog = "https://github.com/plamere/spotipy/blob/${version}/CHANGELOG.md";
     description = "A light weight Python library for the Spotify Web API";
     license = licenses.mit;
-    maintainers = [ maintainers.rvolosatovs ];
+    maintainers = with maintainers; [ rvolosatovs ];
   };
 }

--- a/pkgs/development/python-modules/spotipy/default.nix
+++ b/pkgs/development/python-modules/spotipy/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "spotipy";
-  version = "2.16.0";
+  version = "2.16.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "315eadd1248053ed336b4d3adbf2e3c32895fdbb0cfcd170542c848c8fd45649";
+    sha256 = "1f50xczv8kgly6wz6zrvqzwdj6nvhdlgx8wnrhmbipjrb6qacr25";
   };
 
   propagatedBuildInputs = [ requests six ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.116.4";
+  version = "0.117.0";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];
@@ -11,6 +11,7 @@
     "actiontec" = ps: with ps; [ ];
     "adguard" = ps: with ps; [ adguardhome ];
     "ads" = ps: with ps; [ pyads ];
+    "advantage_air" = ps: with ps; [ ]; # missing inputs: advantage_air
     "aftership" = ps: with ps; [ pyaftership ];
     "agent_dvr" = ps: with ps; [ ]; # missing inputs: agent-py
     "air_quality" = ps: with ps; [ ];
@@ -91,7 +92,6 @@
     "bme680" = ps: with ps; [ ]; # missing inputs: bme680 smbus-cffi
     "bmp280" = ps: with ps; [ ]; # missing inputs: RPi.GPIO adafruit-circuitpython-bmp280
     "bmw_connected_drive" = ps: with ps; [ ]; # missing inputs: bimmer_connected
-    "bom" = ps: with ps; [ ]; # missing inputs: bomradarloop
     "bond" = ps: with ps; [ ]; # missing inputs: bond-api
     "braviatv" = ps: with ps; [ bravia-tv ];
     "broadlink" = ps: with ps; [ broadlink ];
@@ -107,7 +107,7 @@
     "calendar" = ps: with ps; [ aiohttp-cors ];
     "camera" = ps: with ps; [ aiohttp-cors ];
     "canary" = ps: with ps; [ ha-ffmpeg ]; # missing inputs: py-canary
-    "cast" = ps: with ps; [ aiohttp-cors hass-nabucasa mutagen PyChromecast zeroconf ];
+    "cast" = ps: with ps; [ aiohttp-cors hass-nabucasa mutagen plexapi plexauth plexwebsocket PyChromecast pysonos zeroconf ];
     "cert_expiry" = ps: with ps; [ ];
     "channels" = ps: with ps; [ ]; # missing inputs: pychannels
     "circuit" = ps: with ps; [ ]; # missing inputs: circuit-webhook
@@ -163,7 +163,7 @@
     "device_automation" = ps: with ps; [ ];
     "device_sun_light_trigger" = ps: with ps; [ aiohttp-cors pillow ];
     "device_tracker" = ps: with ps; [ ];
-    "devolo_home_control" = ps: with ps; [ ]; # missing inputs: devolo-home-control-api
+    "devolo_home_control" = ps: with ps; [ aiohttp-cors zeroconf ]; # missing inputs: devolo-home-control-api
     "dexcom" = ps: with ps; [ ]; # missing inputs: pydexcom
     "dht" = ps: with ps; [ ]; # missing inputs: Adafruit-DHT
     "dialogflow" = ps: with ps; [ aiohttp-cors ];
@@ -301,7 +301,7 @@
     "gitlab_ci" = ps: with ps; [ python-gitlab ];
     "gitter" = ps: with ps; [ ]; # missing inputs: gitterpy
     "glances" = ps: with ps; [ ]; # missing inputs: glances_api
-    "gntp" = ps: with ps; [ ]; # missing inputs: gntp
+    "gntp" = ps: with ps; [ gntp ];
     "goalfeed" = ps: with ps; [ ]; # missing inputs: pysher
     "goalzero" = ps: with ps; [ ]; # missing inputs: goalzero
     "gogogate2" = ps: with ps; [ ]; # missing inputs: gogogate2-api
@@ -318,6 +318,7 @@
     "gpsd" = ps: with ps; [ ]; # missing inputs: gps3
     "gpslogger" = ps: with ps; [ aiohttp-cors ];
     "graphite" = ps: with ps; [ ];
+    "gree" = ps: with ps; [ ]; # missing inputs: greeclimate
     "greeneye_monitor" = ps: with ps; [ ]; # missing inputs: greeneye_monitor
     "greenwave" = ps: with ps; [ ]; # missing inputs: greenwavereality
     "griddy" = ps: with ps; [ ]; # missing inputs: griddypower
@@ -470,7 +471,7 @@
     "mastodon" = ps: with ps; [ ]; # missing inputs: Mastodon.py
     "matrix" = ps: with ps; [ matrix-client ];
     "maxcube" = ps: with ps; [ ]; # missing inputs: maxcube-api
-    "mcp23017" = ps: with ps; [ ]; # missing inputs: RPi.GPIO adafruit-blinka adafruit-circuitpython-mcp230xx
+    "mcp23017" = ps: with ps; [ ]; # missing inputs: RPi.GPIO adafruit-circuitpython-mcp230xx
     "media_extractor" = ps: with ps; [ aiohttp-cors youtube-dl-light ];
     "media_player" = ps: with ps; [ aiohttp-cors ];
     "media_source" = ps: with ps; [ aiohttp-cors ];
@@ -527,7 +528,7 @@
     "nederlandse_spoorwegen" = ps: with ps; [ ]; # missing inputs: nsapi
     "nello" = ps: with ps; [ ]; # missing inputs: pynello
     "ness_alarm" = ps: with ps; [ ]; # missing inputs: nessclient
-    "nest" = ps: with ps; [ python-nest ];
+    "nest" = ps: with ps; [ aiohttp-cors python-nest ]; # missing inputs: google-nest-sdm
     "netatmo" = ps: with ps; [ aiohttp-cors hass-nabucasa pyatmo ];
     "netdata" = ps: with ps; [ ]; # missing inputs: netdata
     "netgear" = ps: with ps; [ ]; # missing inputs: pynetgear
@@ -568,7 +569,7 @@
     "ombi" = ps: with ps; [ ]; # missing inputs: pyombi
     "omnilogic" = ps: with ps; [ ]; # missing inputs: omnilogic
     "onboarding" = ps: with ps; [ aiohttp-cors pillow ]; # missing inputs: home-assistant-frontend
-    "onewire" = ps: with ps; [ ]; # missing inputs: pyownet
+    "onewire" = ps: with ps; [ ]; # missing inputs: pi1wire pyownet
     "onkyo" = ps: with ps; [ onkyo-eiscp ];
     "onvif" = ps: with ps; [ ha-ffmpeg zeep ]; # missing inputs: WSDiscovery onvif-zeep-async
     "openalpr_cloud" = ps: with ps; [ ];
@@ -622,6 +623,7 @@
     "point" = ps: with ps; [ aiohttp-cors ]; # missing inputs: pypoint
     "poolsense" = ps: with ps; [ ]; # missing inputs: poolsense
     "powerwall" = ps: with ps; [ ]; # missing inputs: tesla-powerwall
+    "profiler" = ps: with ps; [ pyprof2calltree ];
     "progettihwsw" = ps: with ps; [ ]; # missing inputs: progettihwsw
     "proliphix" = ps: with ps; [ ]; # missing inputs: proliphix
     "prometheus" = ps: with ps; [ aiohttp-cors prometheus_client ];
@@ -688,6 +690,7 @@
     "rpi_rf" = ps: with ps; [ ]; # missing inputs: rpi-rf
     "rss_feed_template" = ps: with ps; [ aiohttp-cors ];
     "rtorrent" = ps: with ps; [ ];
+    "ruckus_unleashed" = ps: with ps; [ ]; # missing inputs: pyruckus
     "russound_rio" = ps: with ps; [ ]; # missing inputs: russound_rio
     "russound_rnet" = ps: with ps; [ ]; # missing inputs: russound
     "sabnzbd" = ps: with ps; [ aiohttp-cors netdisco zeroconf ]; # missing inputs: pysabnzbd
@@ -809,6 +812,7 @@
     "tank_utility" = ps: with ps; [ ]; # missing inputs: tank_utility
     "tankerkoenig" = ps: with ps; [ ]; # missing inputs: pytankerkoenig
     "tapsaff" = ps: with ps; [ ]; # missing inputs: tapsaff
+    "tasmota" = ps: with ps; [ aiohttp-cors paho-mqtt ]; # missing inputs: hatasmota
     "tautulli" = ps: with ps; [ ]; # missing inputs: pytautulli
     "tcp" = ps: with ps; [ ];
     "ted5000" = ps: with ps; [ xmltodict ];
@@ -932,6 +936,7 @@
     "wunderground" = ps: with ps; [ ];
     "x10" = ps: with ps; [ ];
     "xbee" = ps: with ps; [ ]; # missing inputs: xbee-helper
+    "xbox" = ps: with ps; [ aiohttp-cors ]; # missing inputs: xbox-webapi
     "xbox_live" = ps: with ps; [ ]; # missing inputs: xboxapi
     "xeoma" = ps: with ps; [ ]; # missing inputs: pyxeoma
     "xfinity" = ps: with ps; [ ]; # missing inputs: xfinity-gateway
@@ -950,7 +955,7 @@
     "yeelightsunflower" = ps: with ps; [ ]; # missing inputs: yeelightsunflower
     "yessssms" = ps: with ps; [ ]; # missing inputs: YesssSMS
     "yi" = ps: with ps; [ aioftp ha-ffmpeg ];
-    "zabbix" = ps: with ps; [ ]; # missing inputs: pyzabbix
+    "zabbix" = ps: with ps; [ ]; # missing inputs: py-zabbix
     "zamg" = ps: with ps; [ ];
     "zengge" = ps: with ps; [ ]; # missing inputs: zengge
     "zeroconf" = ps: with ps; [ aiohttp-cors zeroconf ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -67,7 +67,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.116.4";
+  hassVersion = "0.117.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -83,28 +83,20 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "1wcr2afvq1l6xlws3jgzfyh4kx61i0x9n985fiq3ls29w9lpshk4";
+    sha256 = "1f5axspj5hffmaqhpmrrflyd0c62lww36yvd2wr999yix7jhsfnc";
   };
-
-  patches = [
-    (fetchpatch {
-      #  Fix group tests when run in parallel, remove >= 0.117.0
-      url = "https://github.com/home-assistant/core/pull/41446/commits/c79dc478b7136b6df43707bf0ad6b53419c8a909.patch";
-      sha256 = "1cl81swq960vd2f733dcqq60c0jjzrkm0l2sibcblhmyw597b4vj";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace setup.py \
       --replace "bcrypt==3.1.7" "bcrypt>=3.1.7" \
-      --replace "cryptography==2.9.2" "cryptography" \
+      --replace "cryptography==3.2.0" "cryptography" \
       --replace "ruamel.yaml==0.15.100" "ruamel.yaml>=0.15.100"
     substituteInPlace tests/test_config.py --replace '"/usr"' '"/build/media"'
   '';
 
   propagatedBuildInputs = [
     # From setup.py
-    aiohttp astral async-timeout attrs bcrypt certifi ciso8601 jinja2
+    aiohttp astral async-timeout attrs bcrypt certifi ciso8601 httpx jinja2
     pyjwt cryptography pip python-slugify pytz pyyaml requests ruamel_yaml
     setuptools voluptuous voluptuous-serialize yarl
     # From default_config. frontend, http, image, mobile_app and recorder components as well as

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20201001.2";
+  version = "20201021.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1wyac980d8j8bk4bzh9y3a5c4xqfn3062wj5m45kwsx1f5rfx26j";
+    sha256 = "04z8rvmnpmy7xx90pvqcr58hsxjsc10mrrjcx7ppspglb91b9cpb";
   };
 
   # no Python tests implemented


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release. Also update and clean up dependencies.

https://github.com/home-assistant/core/releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
