### PR TITLE
Revert #101058 coq: propagate and install ocaml and findlib

### DIFF
--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -109,7 +109,7 @@ self = stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ]
   ++ stdenv.lib.optional (!versionAtLeast "8.6") gnumake42
   ;
-  buildInputs = [ ncurses ]
+  buildInputs = [ ncurses ocamlPackages.ocaml ocamlPackages.findlib ]
   ++ stdenv.lib.optional (!versionAtLeast "8.10") ocamlPackages.camlp5
   ++ stdenv.lib.optional (!versionAtLeast "8.12") ocamlPackages.num
   ++ stdenv.lib.optionals buildIde
@@ -117,10 +117,7 @@ self = stdenv.mkDerivation {
      then [ ocamlPackages.lablgtk3-sourceview3 glib gnome3.defaultIconTheme wrapGAppsHook ]
      else [ ocamlPackages.lablgtk ]);
 
-  propagatedBuildInputs = [ ocamlPackages.ocaml ocamlPackages.findlib ]
-    ++ stdenv.lib.optional (versionAtLeast "8.12") ocamlPackages.num;
-
-  propagatedUserEnvPkgs = [ ocamlPackages.ocaml ocamlPackages.findlib ];
+  propagatedBuildInputs = stdenv.lib.optional (versionAtLeast "8.12") ocamlPackages.num;
 
   postPatch = ''
     UNAME=$(type -tp uname)


### PR DESCRIPTION
This reverts commit 5d0e2dedd5594cdf3ebbda8bc61310e227235a9c.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/101058#issuecomment-718045405

cc @Zimmi48 @palmskog

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
