### PR TITLE
pcb2gcode: init at 2.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4683,6 +4683,12 @@
     githubId = 4032;
     name = "Kristoffer Thømt Ravneberg";
   };
+  kritnich = {
+    email = "kritnich@kritni.ch";
+    github = "Kritnich";
+    githubId = 22116767;
+    name = "Kritnich";
+  };
   kroell = {
     email = "nixosmainter@makroell.de";
     github = "rokk4";

--- a/pkgs/tools/misc/pcb2gcode/default.nix
+++ b/pkgs/tools/misc/pcb2gcode/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, boost
+, glibmm
+, gtkmm2
+, gerbv
+, librsvg
+, bash
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pcb2gcode";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "pcb2gcode";
+    repo = "pcb2gcode";
+    rev = "v${version}";
+    sha256 = "0nzglcyh6ban27cc73j4l7w7r9k38qivq0jz8iwnci02pfalw4ry";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  buildInputs = [ boost glibmm gtkmm2 gerbv librsvg ];
+
+  postPatch = ''
+    substituteInPlace ./Makefile.am \
+    --replace '`git describe --dirty --always --tags`' '${version}'
+  '';
+
+  meta = with lib; {
+    description = "Command-line tool for isolation, routing and drilling of PCBs ";
+    longDescription = ''
+      pcb2gcode is a command-line software for the isolation, routing and drilling of PCBs.
+      It takes Gerber files as input and it outputs gcode files, suitable for the milling of PCBs.
+      It also includes an Autoleveller, useful for the automatic dynamic calibration of the milling depth.
+    '';
+    homepage = "https://github.com/pcb2gcode/pcb2gcode";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ kritnich ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2348,6 +2348,8 @@ in
 
   pbzx = callPackage ../tools/compression/pbzx { };
 
+  pcb2gcode = callPackage ../tools/misc/pcb2gcode { };
+
   persepolis = python3Packages.callPackage ../tools/networking/persepolis {
     wrapQtAppsHook = qt5.wrapQtAppsHook;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
pcb2gcode is a command-line software for the isolation, routing and drilling of PCBs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
