### PR TITLE
z88dk: 2020-01-27 -> 2.0

### DIFF
--- a/pkgs/development/compilers/z88dk/default.nix
+++ b/pkgs/development/compilers/z88dk/default.nix
@@ -1,14 +1,14 @@
 { fetchFromGitHub, stdenv, makeWrapper, unzip, libxml2, m4, uthash, which }:
 
 stdenv.mkDerivation rec {
-  pname = "z88dk-unstable";
-  version = "2020-01-27";
+  pname = "z88dk";
+  version = "2.0";
 
   src = fetchFromGitHub {
     owner = "z88dk";
-    repo  = "z88dk";
-    rev = "efdd07c2e2229cac7cfef97ec01f478004846e39";
-    sha256 = "0jcks5ygp256lmzmllffp4yb38cxjgdyqnnimkj4s65095cfasyb";
+    repo = "z88dk";
+    rev = "v${version}";
+    sha256 = "14r9bjw6lgz85a59a4ajspvg12swiqxi17zicl8r7p29pi9lsibp";
     fetchSubmodules = true;
   };
 
@@ -50,10 +50,10 @@ stdenv.mkDerivation rec {
   installTargets = [ "libs" "install" ];
 
   meta = with stdenv.lib; {
-    homepage    = "https://www.z88dk.org";
+    homepage = "https://www.z88dk.org";
     description = "z80 Development Kit";
-    license     = licenses.clArtistic;
-    maintainers = [ ];
-    platforms = platforms.linux;
+    license = licenses.clArtistic;
+    maintainers = [ maintainers.siraben ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Also enable build on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
