### PR TITLE
WIP: z80: add cross-compile support

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -35,6 +35,7 @@ let
     "msp430-none"
     "riscv64-none" "riscv32-none"
     "vc4-none"
+    "z80-none"
 
     "js-ghcjs"
 
@@ -58,6 +59,7 @@ in {
   mips          = filterDoubles predicates.isMips;
   riscv         = filterDoubles predicates.isRiscV;
   vc4           = filterDoubles predicates.isVc4;
+  z80           = filterDoubles predicates.isZ80;
   js            = filterDoubles predicates.isJavaScript;
 
   bigEndian     = filterDoubles predicates.isBigEndian;

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -120,6 +120,7 @@ rec {
 
   z80 = {
     config = "z80";
+    libc = "newlib";
   };
 
   vc4 = {

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -118,6 +118,10 @@ rec {
     config = "avr";
   };
 
+  z80 = {
+    config = "z80";
+  };
+
   vc4 = {
     config = "vc4-elf";
     libc = "newlib";

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -23,6 +23,7 @@ rec {
     isMsp430       = { cpu = { family = "msp430"; }; };
     isVc4          = { cpu = { family = "vc4"; }; };
     isAvr          = { cpu = { family = "avr"; }; };
+    isZ80          = { cpu = { family = "z80"; bits = 8; }; };
     isAlpha        = { cpu = { family = "alpha"; }; };
     isJavaScript   = { cpu = cpuTypes.js; };
 

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -112,6 +112,8 @@ rec {
     msp430   = { bits = 16; significantByte = littleEndian; family = "msp430"; };
     avr      = { bits = 8; family = "avr"; };
 
+    z80      = { bits = 8; family = "z80"; };
+
     vc4      = { bits = 32; significantByte = littleEndian; family = "vc4"; };
 
     js       = { bits = 32; significantByte = littleEndian; family = "js"; };
@@ -367,7 +369,7 @@ rec {
     setType "system" components;
 
   mkSkeletonFromList = l: {
-    "1" = if elemAt l 0 == "avr"
+    "1" = if elemAt l 0 == "avr" || elemAt l 0 == "z80"
       then { cpu = elemAt l 0; kernel = "none"; abi = "unknown"; }
       else throw "Target specification with 1 components is ambiguous";
     "2" = # We only do 2-part hacks for things Nix already supports

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -305,6 +305,12 @@ stdenv.mkDerivation {
       done
     ''
 
+    + optionalString (libc != null && targetPlatform.isZ80) ''
+      for isa in z80; do
+        echo "-L${getLib libc}/z80/lib/$isa" >> $out/nix-support/libc-cflags
+      done
+    ''
+
     + ''
       for flags in "$out/nix-support"/*flags*; do
         substituteInPlace "$flags" --replace $'\n' ' '

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -183,6 +183,7 @@ stdenv.mkDerivation {
       else if targetPlatform.isSparc then "sparc"
       else if targetPlatform.isMsp430 then "msp430"
       else if targetPlatform.isAvr then "avr"
+      else if targetPlatform.isZ80 then "z80"
       else if targetPlatform.isAlpha then "alpha"
       else if targetPlatform.isVc4 then "vc4"
       else throw "unknown emulation for platform: ${targetPlatform.config}";

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -306,9 +306,7 @@ stdenv.mkDerivation {
     ''
 
     + optionalString (libc != null && targetPlatform.isZ80) ''
-      for isa in z80; do
-        echo "-L${getLib libc}/z80/lib/$isa" >> $out/nix-support/libc-cflags
-      done
+      echo "-L${getLib libc}/z80/lib/z80" >> $out/nix-support/libc-cflags
     ''
 
     + ''

--- a/pkgs/development/misc/z80/newlib/newlib.nix
+++ b/pkgs/development/misc/z80/newlib/newlib.nix
@@ -1,6 +1,6 @@
-{ fetchFromGitHub, stdenv, makeWrapper, unzip, libxml2, m4, uthash, which }:
+{ fetchFromGitHub, stdenv, makeWrapper, unzip, libxml2, m4, uthash, which, crossLibcStdenv }:
 
-stdenv.mkDerivation rec {
+crossLibcStdenv.mkDerivation rec {
   pname = "z88dk-unstable";
   version = "2020-01-27";
 
@@ -42,10 +42,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ which makeWrapper unzip ];
   buildInputs = [ libxml2 m4 uthash ];
-
-  postInstall = ''
-    wrapProgram $out/bin/zcc --set CC ${placeholder "out"}/bin/zcc
-  '';
 
   preInstall = ''
     mkdir -p $out/{bin,share}

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -33,6 +33,13 @@ let
     rev = "708acc851880dbeda1dd18aca4fd0a95b2573b36";
     sha256 = "1kdrz6fki55lm15rwwamn74fnqpy0zlafsida2zymk76n3656c63";
   };
+
+  z80-binutils-src = fetchFromGitHub {
+    owner = "atsidaev";
+    repo = "binutils-z80";
+    rev = "2f1482029bbf8793b9d1341509557d00ad4070c6";
+    sha256 = "1kdrz6fki55l005rwwamn74fnqpy0zlafsida2zymk76n3656c63";
+  };
   # HACK to ensure that we preserve source from bootstrap binutils to not rebuild LLVM
   normal-src = stdenv.__bootPackages.binutils-unwrapped.src or (fetchurl {
     url = "mirror://gnu/binutils/${basename}-${version}.tar.bz2";
@@ -44,7 +51,8 @@ stdenv.mkDerivation {
   pname = targetPrefix + basename;
   inherit version;
 
-  src = if stdenv.targetPlatform.isVc4 then vc4-binutils-src else normal-src;
+  src = if stdenv.targetPlatform.isVc4 then vc4-binutils-src else
+        if stdenv.targetPlatform.isZ80 then z80-binutils-src else normal-src;
 
   patches = [
     # Make binutils output deterministic by default.

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -67,6 +67,8 @@ in lib.init bootStages ++ [
              then buildPackages.llvmPackages.clang
            else if crossSystem.useLLVM or false
              then buildPackages.llvmPackages_8.lldClang
+           else if crossSystem.isZ80
+             then buildPackages.z88dk
            else buildPackages.gcc;
 
       extraNativeBuildInputs = old.extraNativeBuildInputs

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -68,7 +68,7 @@ in lib.init bootStages ++ [
            else if crossSystem.useLLVM or false
              then buildPackages.llvmPackages_8.lldClang
            else if crossSystem.isZ80
-             then buildPackages.z88dk-unwrapped
+             then buildPackages.z88dk
            else buildPackages.gcc;
 
       extraNativeBuildInputs = old.extraNativeBuildInputs

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -68,7 +68,7 @@ in lib.init bootStages ++ [
            else if crossSystem.useLLVM or false
              then buildPackages.llvmPackages_8.lldClang
            else if crossSystem.isZ80
-             then buildPackages.z88dk
+             then buildPackages.z88dk-unwrapped
            else buildPackages.gcc;
 
       extraNativeBuildInputs = old.extraNativeBuildInputs

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9979,7 +9979,8 @@ in
     cc = z88dk-unwrapped;
     extraBuildCommands = ''
       wrap zcc $wrapper $ccPath/zcc
-      export named_cc=zcc
+      export named_cc=$out/cc
+      wrapProgram '${cc}/bin/zcc' $out/bin/cc
     '';
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8694,11 +8694,12 @@ in
   gerbil-support = callPackage ../development/compilers/gerbil/gerbil-support.nix { };
   gerbilPackages-unstable = gerbil-support.gerbilPackages-unstable; # NB: don't recurseIntoAttrs for (unstable!) libraries
 
-  gccFun = callPackage (if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
-    then ../development/compilers/gcc/6
-    else ../development/compilers/gcc/9);
-  gcc = if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
-    then gcc6 else gcc9;
+  gccFun = callPackage (if stdenv.targetPlatform.isZ80
+                        then ../development/compilers/z88dk
+                        else (if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
+                              then ../development/compilers/gcc/6
+                              else ../development/compilers/gcc/9));
+  gcc = if stdenv.targetPlatform.isZ80 then z88dk else if (with stdenv.targetPlatform; isVc4 || libc == "relibc") then gcc6 else gcc9;
 
   gcc-unwrapped = gcc.cc;
 
@@ -12685,6 +12686,7 @@ in
     else if name == "bionic" then targetPackages.bionic or bionic
     else if name == "uclibc" then targetPackages.uclibcCross or uclibcCross
     else if name == "avrlibc" then targetPackages.avrlibcCross or avrlibcCross
+    else if name == "newlib" && stdenv.targetPlatform.isZ80 then targetPackages.z88dk or z88dk
     else if name == "newlib" && stdenv.targetPlatform.isMsp430 then targetPackages.msp430NewlibCross or msp430NewlibCross
     else if name == "newlib" && stdenv.targetPlatform.isVc4 then targetPackages.vc4-newlib or vc4-newlib
     else if name == "newlib" then targetPackages.newlibCross or newlibCross

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10539,6 +10539,7 @@ in
 
   xidel = callPackage ../tools/text/xidel { };
 
+  z80-newlib = callPackage ../development/misc/z80/newlib { };
 
   ### DEVELOPMENT / TOOLS
 
@@ -12686,7 +12687,7 @@ in
     else if name == "bionic" then targetPackages.bionic or bionic
     else if name == "uclibc" then targetPackages.uclibcCross or uclibcCross
     else if name == "avrlibc" then targetPackages.avrlibcCross or avrlibcCross
-    else if name == "newlib" && stdenv.targetPlatform.isZ80 then targetPackages.z88dk or z88dk
+    else if name == "newlib" && stdenv.targetPlatform.isZ80 then targetPackages.z80-newlib or z80-newlib
     else if name == "newlib" && stdenv.targetPlatform.isMsp430 then targetPackages.msp430NewlibCross or msp430NewlibCross
     else if name == "newlib" && stdenv.targetPlatform.isVc4 then targetPackages.vc4-newlib or vc4-newlib
     else if name == "newlib" then targetPackages.newlibCross or newlibCross

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8694,12 +8694,11 @@ in
   gerbil-support = callPackage ../development/compilers/gerbil/gerbil-support.nix { };
   gerbilPackages-unstable = gerbil-support.gerbilPackages-unstable; # NB: don't recurseIntoAttrs for (unstable!) libraries
 
-  gccFun = callPackage (if stdenv.targetPlatform.isZ80
-                        then ../development/compilers/z88dk
-                        else (if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
-                              then ../development/compilers/gcc/6
-                              else ../development/compilers/gcc/9));
-  gcc = if stdenv.targetPlatform.isZ80 then z88dk else if (with stdenv.targetPlatform; isVc4 || libc == "relibc") then gcc6 else gcc9;
+  gccFun = callPackage (if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
+    then ../development/compilers/gcc/6
+    else ../development/compilers/gcc/9);
+  gcc = if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
+    then gcc6 else gcc9;
 
   gcc-unwrapped = gcc.cc;
 
@@ -9976,7 +9975,15 @@ in
 
   yosys = callPackage ../development/compilers/yosys { };
 
-  z88dk = callPackage ../development/compilers/z88dk { };
+  z88dk = wrapCC {
+    cc = z88dk-unwrapped;
+    extraBuildCommands = ''
+      wrap zcc $wrapper $ccPath/zcc
+      export named_cc=zcc
+    '';
+  };
+
+  z88dk-unwrapped = callPackage ../development/compilers/z88dk { };
 
   zulip = callPackage ../applications/networking/instant-messengers/zulip {
     # Bubblewrap breaks zulip, see https://github.com/NixOS/nixpkgs/pull/97264#issuecomment-704454645


### PR DESCRIPTION
# Closed due to infeasibility.
###### Motivation for this change

#101990

Current difficulty seems to be two things;

- [ ] Get `z88dk` to work in place of `gcc`
- [ ] Use the `newlib` C library which is in `z88dk`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
