### PR TITLE
ocamlPackages.base64: 3.2.0 → 3.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/base64/default.nix
+++ b/pkgs/development/ocaml-modules/base64/default.nix
@@ -1,25 +1,17 @@
-{ lib, fetchpatch, fetchzip, buildDunePackage, alcotest, bos }:
-
-let version = "3.2.0"; in
+{ lib, fetchurl, buildDunePackage, alcotest, bos, dune-configurator }:
 
 buildDunePackage rec {
   pname = "base64";
-  inherit version;
+  version = "3.4.0";
 
-  src = fetchzip {
-    url = "https://github.com/mirage/ocaml-base64/archive/v${version}.tar.gz";
-    sha256 = "1ilw3zj0w6cq7i4pvr8m2kv5l5f2y9aldmv72drlwwns013b1gwy";
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-base64/releases/download/v${version}/base64-v${version}.tbz";
+    sha256 = "0d0n5gd4nkdsz14jnxq13f1f7rzxmndg5xql039a8wfppmazd70w";
   };
 
-  minimumOCamlVersion = "4.03";
-
-  buildInputs = [ bos ];
-
-  # Fix test-suite for alcotest ≥ 1.0
-  patches = [(fetchpatch {
-    url = "https://github.com/mirage/ocaml-base64/commit/8d334d02aa52875158fae3e2fb8fe0a5596598d0.patch";
-    sha256 = "0lvqdp98qavpzis1wgwh3ijajq79hq47898gsrk37fpyjbrdzf5q";
-  })];
+  buildInputs = [ bos dune-configurator ];
 
   doCheck = true;
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/biocaml/default.nix
+++ b/pkgs/development/ocaml-modules/biocaml/default.nix
@@ -6,12 +6,12 @@ buildDunePackage rec {
   pname = "biocaml";
   version = "0.10.1";
 
-  owner = "biocaml";
+  useDune2 = true;
 
   minimumOCamlVersion = "4.07";
 
   src = fetchFromGitHub {
-    inherit owner;
+    owner = "biocaml";
     repo   = pname;
     rev    = "v${version}";
     sha256 = "1f19nc8ld0iv45jjnsvaah3ddj88s2n9wj8mrz726kzg85cfr8xj";

--- a/pkgs/development/ocaml-modules/bistro/default.nix
+++ b/pkgs/development/ocaml-modules/bistro/default.nix
@@ -5,6 +5,9 @@
 buildDunePackage rec {
   pname = "bistro";
   version = "0.5.0";
+
+  useDune2 = true;
+
   src = fetchFromGitHub {
     owner = "pveber";
     repo = pname;

--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -7,6 +7,8 @@ buildDunePackage rec {
 	pname = "cohttp";
 	version = "2.5.4";
 
+	useDune2 = true;
+
 	minimumOCamlVersion = "4.04.1";
 
 	src = fetchurl {

--- a/pkgs/development/ocaml-modules/cohttp/lwt.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt.nix
@@ -8,7 +8,7 @@ else
 
 buildDunePackage {
 	pname = "cohttp-lwt";
-	inherit (cohttp) version src meta;
+	inherit (cohttp) version src useDune2 meta;
 
 	buildInputs = [ uri ppx_sexp_conv ];
 

--- a/pkgs/development/ocaml-modules/jwto/default.nix
+++ b/pkgs/development/ocaml-modules/jwto/default.nix
@@ -5,6 +5,8 @@ buildDunePackage rec {
   pname = "jwto";
   version = "0.3.0";
 
+  useDune2 = true;
+
   minimumOCamlVersion = "4.05";
 
   src = fetchFromGitHub {

--- a/pkgs/development/ocaml-modules/webmachine/default.nix
+++ b/pkgs/development/ocaml-modules/webmachine/default.nix
@@ -6,6 +6,7 @@
 buildDunePackage rec {
   pname = "webmachine";
   version = "0.6.2";
+  useDune2 = true;
 
   minimumOCamlVersion = "4.04";
 


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
