### PR TITLE
linux: add flavor metadata

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -45,6 +45,11 @@
                        stdenv.hostPlatform != stdenv.buildPlatform
 , extraMeta ? {}
 
+, isXen      ? features.xen_dom0 or false
+, isZen      ? false
+, isLibre    ? false
+, isHardened ? false
+
 # easy overrides to stdenv.hostPlatform.platform members
 , autoModules ? stdenv.hostPlatform.platform.kernelAutoModules
 , preferBuiltin ? stdenv.hostPlatform.platform.kernelPreferBuiltin or false
@@ -175,7 +180,9 @@ let
 
   passthru = {
     features = kernelFeatures;
-    inherit commonStructuredConfig;
+    inherit commonStructuredConfig isXen isZen isHardened isLibre;
+    kernelOlder = lib.versionOlder version;
+    kernelAtLeast = lib.versionAtLeast version;
     passthru = kernel.passthru // (removeAttrs passthru [ "passthru" ]);
   };
 

--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -17,6 +17,7 @@ let
 in linux.override {
   argsOverride = {
     modDirVersion = "${linux.modDirVersion}-gnu";
+    isLibre = true;
 
     src = stdenv.mkDerivation {
       name = "${linux.name}-libre-src";

--- a/pkgs/os-specific/linux/kernel/linux-zen.nix
+++ b/pkgs/os-specific/linux/kernel/linux-zen.nix
@@ -7,6 +7,7 @@ in
 buildLinux (args // {
   modDirVersion = "${version}-zen1";
   inherit version;
+  isZen = true;
 
   src = fetchFromGitHub {
     owner = "zen-kernel";

--- a/pkgs/os-specific/linux/usbip/default.nix
+++ b/pkgs/os-specific/linux/usbip/default.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv, kernel, udev, autoconf, automake, libtool }:
+{ lib, stdenv, kernel, udev, autoconf, automake, libtool, kernelOlder }:
 
 stdenv.mkDerivation {
   name = "usbip-${kernel.name}";
 
   src = kernel.src;
 
-  patches = lib.optionals (lib.versionAtLeast "5.4" kernel.version) [
+  patches = lib.optionals (kernelOlder "5.4") [
     # fixes build with gcc8
     ./fix-snprintf-truncation.patch
     # fixes build with gcc9
@@ -27,5 +27,6 @@ stdenv.mkDerivation {
     description = "allows to pass USB device from server to client over the network";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    broken = kernelOlder "4.10";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18008,6 +18008,10 @@ in
     inherit kernel;
     inherit (kernel) stdenv; # in particular, use the same compiler by default
 
+    # to help determine module compatibility
+    inherit (kernel) isXen isZen isHardened isLibre;
+    inherit (kernel) kernelOlder kernelAtLeast;
+
     # Obsolete aliases (these packages do not depend on the kernel).
     inherit (pkgs) odp-dpdk pktgen; # added 2018-05
 
@@ -18271,6 +18275,7 @@ in
         kernelPatches.hardened.${kernel.meta.branch}
       ];
       modDirVersionArg = kernel.modDirVersion + "-hardened";
+      isHardened = true;
   });
 
   linuxPackages_hardened = recurseIntoAttrs (hardenedLinuxPackagesFor pkgs.linux { });


### PR DESCRIPTION
###### Motivation for this change
part of #101863 

This is what I had in mind @NeQuissimus 

I chose usbip because of https://hydra.nixos.org/eval/1622654?filter=linuxPackages&compare=1622624&full=#tabs-still-fail . Just being used as an example.

Ideally i would backport the metadata commit to 20.09 and disable the remaining failing kernel modules

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
