### PR TITLE
numix-cursor-theme: patch inkscape command

### DIFF
--- a/pkgs/data/icons/numix-cursor-theme/default.nix
+++ b/pkgs/data/icons/numix-cursor-theme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, inkscape, xcursorgen }:
+{ stdenv, fetchFromGitHub, fetchpatch, inkscape, xcursorgen }:
 
 stdenv.mkDerivation rec {
   version = "1.1";
@@ -13,6 +13,15 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ inkscape xcursorgen ];
+
+  patches = [
+    # Remove when https://github.com/numixproject/numix-cursor-theme/pull/7 is merged
+    (fetchpatch {
+      url = "https://github.com/stephaneyfx/numix-cursor-theme/commit/3b647bf768cebb8f127b88e3786f6a9640460197.patch";
+      sha256 = "174kmhlvv76wwvndkys78aqc32051sqg3wzc0xg6b7by4agrbg76";
+      name = "support-inkscape-1-in-numix-cursor-theme.patch";
+    })
+  ];
 
   buildPhase = ''
     patchShebangs .


### PR DESCRIPTION
###### Motivation for this change
The generated cursor files were previously empty due to inkscape rejecting the command line argument. See #98481.

###### Things done
The theme is patched with a pending [PR to upstream](https://github.com/numixproject/numix-cursor-theme/pull/7) to use the long flags that are supported by both inkscape 0.x and 1.x.

Before this change, the generated cursor files have a size of zero. After this change, the cursors are valid and appear when selecting the theme.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
