### PR TITLE
vscode: Fix "Save as Admin" #49643

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, makeDesktopItem
 , unzip, libsecret, libXScrnSaver, wrapGAppsHook
 , gtk2, atomEnv, at-spi2-atk, autoPatchelfHook
-, systemd, fontconfig, libdbusmenu
+, systemd, fontconfig, libdbusmenu, bash, nodePackages
 
 # Attributes inherit from specific versions
 , version, src, meta, sourceRoot
@@ -68,6 +68,16 @@ in
 
     dontBuild = true;
     dontConfigure = true;
+
+    patchPhase =
+      if system != "x86_64-darwin" then ''
+        ${nodePackages.asar}/bin/asar extract ./resources/app/node_modules.asar tmp
+        # use Nix(OS) paths
+        sed -i "s|/usr/bin/pkexec|/usr/bin/pkexec', '/run/wrappers/bin/pkexec|" tmp/sudo-prompt/index.js
+        sed -i 's|/bin/bash|${bash}/bin/bash|' tmp/sudo-prompt/index.js
+        ${nodePackages.asar}/bin/asar pack tmp ./resources/app/node_modules.asar
+        rm -rf tmp
+      '' else '''';
 
     installPhase =
       if system == "x86_64-darwin" then ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I decided to fix something that I found was broken, and saw in the relevant issue that a fix was already applied to another package in a similar fashion, but had not made its way to this package yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
