### PR TITLE
promscale: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/servers/monitoring/prometheus/promscale.nix
+++ b/pkgs/servers/monitoring/prometheus/promscale.nix
@@ -5,20 +5,20 @@
 
 buildGoModule rec {
   pname = "promscale";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "timescale";
     repo = pname;
     rev = "${version}";
-    sha256 = "sha256:0535sq640b9x9vi2sfazi9qs6arwjdn7nff16km2agncvs449dn4";
+    sha256 = "sha256:00mhkp3nf6h2zsvmmwyza1lahvmm05isfi7rqkx24c0dmkmif3x9";
   };
 
   vendorSha256 = "sha256:1ilciwf08678sciwwrjalwvcs5bp7x254nxc3nhdf88cf0bp2nxi";
 
   buildFlagsArray = [ "-ldflags=-s -w -X github.com/timescale/promscale/pkg/version.Version=${version} -X github.com/timescale/promscale/pkg/version.CommitHash=${src.rev}" ];
 
-  doCheck = false;
+  doCheck = false; # Requires access to a docker daemon
 
   meta = with stdenv.lib; {
     description = "An open-source analytical platform for Prometheus metrics";


### PR DESCRIPTION
###### Motivation for this change

Changelog:
 - Add QueryRow to our connection interface
 - Add SQL API for managing metric compression setting
 - Add code documentation for query/read path of the connector
 - Adds support for checking pg version on startup
 - BUGFIX reset pendingBuffer epoch when we're done
 - Epoch-Based cache validation
 - First pass documenting the write path
 - Fix bug with deletion of metric name labels.
 - Fix erroneous PromQL query in end-to-end tests
 - Fix error reporting to prevent panic
 - Fix golden file tests
 - Fix logging output to match rest of the project
 - Fix views on Vanilla PG and add tests
 - Make example docker-compose clearer (#305)
 - Mask password while printing config
 - Prepare for the 0.1.1 release
 - Prepare for the next development cycle
 - REFACTOR rearrange mocks
 - REFACTOR switch TestPGXInserterInsertData to the new mock
 - REFACTOR switch TestPGXInserterInsertSeries to the new mock
 - Start a pgmodel Readme

Source: https://github.com/timescale/promscale/releases/tag/0.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS