### PR TITLE
conv{bin,img,font}: init at {3.0,8.3,1.0}

### DIFF
--- a/pkgs/tools/misc/convbin/default.nix
+++ b/pkgs/tools/misc/convbin/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "convbin";
+  version = "3.0";
+
+  src = fetchFromGitHub {
+    owner = "mateoconlechuga";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0n502zj8igm583kbfvyv7zhd97vb71jac41ncb9jr2yz2v5ir8j9";
+  };
+
+  makeFlags = [ "CC=cc" ];
+
+  checkPhase = ''
+    pushd test
+    patchShebangs test.sh
+    ./test.sh
+    popd
+  '';
+
+  doCheck = true;
+
+  installPhase = ''
+    install -Dm755 bin/convbin $out/bin/convbin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Converts files to other formats";
+    longDescription = ''
+      This program is used to convert files to other formats,
+      specifically for the TI84+CE and related calculators.
+    '';
+    homepage = "https://github.com/mateoconlechuga/convbin";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ luc65r ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/convfont/default.nix
+++ b/pkgs/tools/misc/convfont/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "convfont";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "drdnar";
+    repo = pname;
+    rev = "v20190438";
+    sha256 = "1lj24yq5gj9hxhy1srk73521q95zyqzkws0q4v271hf5wmqaxa2f";
+  };
+
+  makeFlags = [ "CC=cc" ];
+
+  installPhase = ''
+    install -Dm755 convfont $out/bin/convfont
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Converts font for use with FontLibC";
+    homepage = "https://github.com/drdnar/convfont";
+    license = licenses.wtfpl;
+    maintainers = with maintainers; [ luc65r ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/convimg/default.nix
+++ b/pkgs/tools/misc/convimg/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "convimg";
+  version = "8.3";
+
+  src = fetchFromGitHub {
+    owner = "mateoconlechuga";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1k2fkzfg08y2gcm8jabmb2plgqmgw6y30m73ys4mmbskxgy7hc3s";
+    fetchSubmodules = true;
+  };
+
+  makeFlags = [ "CC=cc" ];
+
+  checkPhase = ''
+    pushd test
+    patchShebangs test.sh
+    ./test.sh
+    popd
+  '';
+
+  doCheck = true;
+
+  installPhase = ''
+    install -Dm755 bin/convimg $out/bin/convimg
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Image palette quantization";
+    longDescription = ''
+      This program is used to convert images to other formats,
+      specifically for the TI84+CE and related calculators.
+    '';
+    homepage = "https://github.com/mateoconlechuga/convimg";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ luc65r ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3072,6 +3072,8 @@ in
 
   console-bridge = callPackage ../development/libraries/console-bridge { };
 
+  convbin = callPackage ../tools/misc/convbin { };
+
   convmv = callPackage ../tools/misc/convmv { };
 
   convoy = callPackage ../tools/filesystems/convoy { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3076,6 +3076,8 @@ in
 
   convimg = callPackage ../tools/misc/convimg { };
 
+  convfont = callPackage ../tools/misc/convfont { };
+
   convmv = callPackage ../tools/misc/convmv { };
 
   convoy = callPackage ../tools/filesystems/convoy { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3074,6 +3074,8 @@ in
 
   convbin = callPackage ../tools/misc/convbin { };
 
+  convimg = callPackage ../tools/misc/convimg { };
+
   convmv = callPackage ../tools/misc/convmv { };
 
   convoy = callPackage ../tools/filesystems/convoy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Package conv* utilities to eventually package the CE C Toolchain

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
