### PR TITLE
ssh-audit: 2.3.0 -> 2.3.1

### DIFF
--- a/pkgs/tools/security/ssh-audit/default.nix
+++ b/pkgs/tools/security/ssh-audit/default.nix
@@ -2,37 +2,17 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ssh-audit";
-  version = "2.3.0";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "jtesta";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1k5nv2cdnzd3j2p729vjw6ya0gwwkxhqijs2b7p68wvp0n3y3m77";
+    sha256 = "1h739r5nv5zkmjyyjwkw8r6d4avddjjxsamc5rffwfxi1kjavpxm";
   };
-
-  postPatch = ''
-    cp ./README.md packages/sshaudit/
-    cp ./ssh-audit.py packages/sshaudit/sshaudit.py
-    mv packages/* .
-    ls -lah
-  '';
 
   checkInputs = with python3Packages; [
     pytestCheckHook
-  ];
-
-  disabledTests = [
-    "test_resolve_error"
-    "test_resolve_hostname_without_records"
-    "test_resolve_ipv4"
-    "test_resolve_ipv6"
-    "test_resolve_ipv46_both"
-    "test_resolve_ipv46_order"
-    "test_invalid_host"
-    "test_invalid_port"
-    "test_not_connected_socket"
-    "test_ssh2_server_simple"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


https://github.com/jtesta/ssh-audit/releases/tag/v2.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
