### PR TITLE
groff: set "operating system" for mdoc pages

### DIFF
--- a/pkgs/tools/text/groff/site.tmac
+++ b/pkgs/tools/text/groff/site.tmac
@@ -14,3 +14,6 @@
 .  if '\V[GROFF_SGR]'' \
 .    output x X tty: sgr 0
 .\}
+.
+.ds doc-default-operating-system Nixpkgs
+.ds doc-volume-operating-system Nixpkgs


### PR DESCRIPTION
Prior to this change, man pages from Nixpkgs written using the mdoc(7)
macros would start like this:

    NC(1)                   BSD General Commands Manual                   NC(1)

and end like this:

    BSD                          December 27, 2018                          BSD

No matter what operating system they were run on.

It's far more accurate to say "Nixpkgs General Commands Manual", so
with this patch we configure groff to do just that.  The variable is
called "operating-system", but I think it makes more sense to say
"Nixpkgs" than "NixOS" or something, because packages from Nixpkgs can
run on lots of operating systems, and the important thing is that the
package is from Nixpkgs.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
