### PR TITLE
gstreamer: needs Xext build input when x11 is enabled

### DIFF
--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -21,6 +21,7 @@
 , libGL
 , enableX11 ? stdenv.isLinux
 , libXv
+, libXext
 , enableWayland ? stdenv.isLinux
 , wayland
 , wayland-protocols
@@ -84,6 +85,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals enableAlsa [
     alsaLib
   ] ++ lib.optionals enableX11 [
+    libXext
     libXv
     pango
   ] ++ lib.optionals enableWayland [


### PR DESCRIPTION
###### Motivation for this change

Fixes #102023

When x11 is enabled, gstreamer-plugins-base requires libXext as a build input.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
