### PR TITLE
nmapsi4: 0.4.80-20180430 -> 0.5-alpha2

### DIFF
--- a/pkgs/tools/security/nmap/qt.nix
+++ b/pkgs/tools/security/nmap/qt.nix
@@ -1,16 +1,24 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, wrapQtAppsHook
-, dnsutils, nmap
-, qtbase, qtscript, qtwebengine }:
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkgconfig
+, wrapQtAppsHook
+, dnsutils
+, nmap
+, qtbase
+, qtscript
+, qtwebengine
+}:
 
 stdenv.mkDerivation rec {
   pname = "nmapsi4";
-  version = "0.4.80-20180430";
+  version = "0.5-alpha2";
 
   src = fetchFromGitHub {
     owner = "nmapsi4";
     repo = "nmapsi4";
-    rev = "d7f18e4c1e38dcf9c29cb4496fe14f9ff172861a";
-    sha256 = "10wqyrjzmad1g7lqa65rymbkna028xbp4xcpj442skw8gyrs3994";
+    rev = "v${version}";
+    sha256 = "sha256-q3XfwJ4TGK4E58haN0Q0xRH4GDpKD8VZzyxHe/VwBqY=";
   };
 
   nativeBuildInputs = [ cmake pkgconfig wrapQtAppsHook ];
@@ -47,7 +55,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Qt frontend for nmap";
-    license     = licenses.gpl2;
+    license = licenses.gpl2;
     maintainers = with maintainers; [ peterhoeg ];
     inherit (src.meta) homepage;
   };


### PR DESCRIPTION
###### Motivation for this change

The qt frontend to nmap is moving closer to proper qt5 support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).