### PR TITLE
gtypist, xcowsay: Patch shebangs in configure script

### DIFF
--- a/pkgs/games/gtypist/default.nix
+++ b/pkgs/games/gtypist/default.nix
@@ -12,6 +12,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ makeWrapper ncurses perl fortune ]
    ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
+  preConfigure = "
+    patchShebangs ./configure
+  ";
+
   preFixup = ''
      wrapProgram "$out/bin/typefortune" \
        --prefix PATH : "${fortune}/bin" \

--- a/pkgs/games/xcowsay/default.nix
+++ b/pkgs/games/xcowsay/default.nix
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
     gdk-pixbuf # loading cow images
     librsvg # dreaming SVG images
   ];
+
+  preConfigure = "
+    patchShebangs ./configure
+  ";
+
   nativeBuildInputs = [ makeWrapper pkg-config ];
 
   configureFlags = [ "--enable-dbus" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/102027#issuecomment-718751068

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
