### PR TITLE
gogs: 0.11.91 -> 0.12.3

### DIFF
--- a/pkgs/applications/version-management/gogs/default.nix
+++ b/pkgs/applications/version-management/gogs/default.nix
@@ -8,7 +8,7 @@ with stdenv.lib;
 
 buildGoPackage rec {
   pname = "gogs";
-  version = "0.11.91";
+  version = "0.12.3";
 
   src = fetchFromGitHub {
     owner = "gogs";

--- a/pkgs/applications/version-management/gogs/static-root-path.patch
+++ b/pkgs/applications/version-management/gogs/static-root-path.patch
@@ -1,8 +1,8 @@
-diff --git a/pkg/setting/setting.go b/pkg/setting/setting.go
-index f206592d..796da6ef 100644
---- a/pkg/setting/setting.go
-+++ b/pkg/setting/setting.go
-@@ -474,7 +474,7 @@ func NewContext() {
+Index: source/pkg/setting/setting.go
+===================================================================
+--- source.orig/pkg/setting/setting.go
++++ source/pkg/setting/setting.go
+@@ -489,7 +489,7 @@ func NewContext() {
  	LocalURL = sec.Key("LOCAL_ROOT_URL").MustString(string(Protocol) + "://localhost:" + HTTPPort + "/")
  	OfflineMode = sec.Key("OFFLINE_MODE").MustBool()
  	DisableRouterLog = sec.Key("DISABLE_ROUTER_LOG").MustBool()


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Should solve [https://nvd.nist.gov/vuln/detail/CVE-2020-15867](CVE-2020-15867)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
