### PR TITLE
Add python diagrams from GitHub

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -176,6 +176,12 @@
     githubId = 1773511;
     name = "Adrien Devresse";
   };
+  addict3d = {
+    email = "nickbathum@gmail.com";
+    github = "addict3d";
+    githubId = 49227;
+    name = "Nick Bathum";
+  };
   adisbladis = {
     email = "adis@blad.is";
     github = "adisbladis";

--- a/pkgs/applications/graphics/round/default.nix
+++ b/pkgs/applications/graphics/round/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "round";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "mingrammer";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "09brjr3h4qnhlidxlki1by5anahxy16ai078zm4k7ryl579amzdw";
+  };
+
+  vendorSha256 = null;
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Round image corners from CLI";
+    homepage    = "https://github.com/mingrammer/round";
+    license     = licenses.mit;
+    maintainers =  with maintainers; [ addict3d ];
+  };
+}

--- a/pkgs/development/python-modules/diagrams/build_poetry.patch
+++ b/pkgs/development/python-modules/diagrams/build_poetry.patch
@@ -1,0 +1,12 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 2c93a39..6c800e2 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -24,3 +24,7 @@ isort = "^4.3"
+ 
+ [tool.black]
+ line-length = 120
++
++[build-system]
++requires = ["poetry_core>=1.0.0"]
++build-backend = "poetry.core.masonry.api"

--- a/pkgs/development/python-modules/diagrams/default.nix
+++ b/pkgs/development/python-modules/diagrams/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, black
+, jinja2
+, poetry-core
+, round
+, graphviz
+, inkscape
+, imagemagick
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "diagrams";
+  version = "0.19.1";
+  format = "pyproject";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "mingrammer";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0qvk0cp3026n5jmwp9z7m70b6pws0h6a7slxr23glg18baxr44d4";
+  };
+
+  preConfigure = ''
+    patchShebangs autogen.sh
+    ./autogen.sh
+  '';
+
+  patches = [ ./build_poetry.patch ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  # Despite living in 'tool.poetry.dependencies',
+  # these are only used at build time to process the image resource files
+  nativeBuildInputs = [ black inkscape imagemagick jinja2 poetry-core round ];
+
+  propagatedBuildInputs = [ graphviz ];
+
+  meta = with lib; {
+    description = "Diagram as Code";
+    homepage    = "https://diagrams.mingrammer.com/";
+    license     = licenses.mit;
+    maintainers =  with maintainers; [ addict3d ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15333,6 +15333,8 @@ in
 
   rote = callPackage ../development/libraries/rote { };
 
+  round = callPackage ../applications/graphics/round { };
+
   ronn = callPackage ../development/tools/ronn { };
 
   rshell = python3.pkgs.callPackage ../development/tools/rshell { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1553,6 +1553,8 @@ in {
 
   dftfit = callPackage ../development/python-modules/dftfit { };
 
+  diagrams = callPackage ../development/python-modules/diagrams { };
+
   diceware = callPackage ../development/python-modules/diceware { };
 
   dicom2nifti = callPackage ../development/python-modules/dicom2nifti { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

_See original PR: https://github.com/NixOS/nixpkgs/pull/101533 -- Packaging from GH instead of PyPI to get tests running -- plus its more direct._

Add python diagrams library at version `0.19.1`. Generate nice architecture diagrams
with python code, allowing for rapid iteration.

The images are rendered using dot from graphviz. It outputs your choice of [png jpg svg pdf]

Closes #101532

Thank you @mweinelt 🚀 for all of the help getting this packaged.


###### Things done

I generated some diagrams using this library, with both of the following shell expressions. There are many examples on the project's website.

nix-shell --pure -I nixpkgs=./ -p python3 python3Packages.diagrams python3Packages.graphviz
nix-shell -I nixpkgs=./ -E 'with import <nixpkgs> {}; (python3.withPackages (ps: [ps.diagrams ps.graphviz])).env'

The closure size is ~218M.
The library itself has 22M in images.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
