### PR TITLE
ocamlPackages.curly: unstable-2019-11-14 → 0.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/curly/default.nix
+++ b/pkgs/development/ocaml-modules/curly/default.nix
@@ -1,25 +1,26 @@
-{ lib, buildDunePackage, fetchFromGitHub, ocaml
+{ stdenv, buildDunePackage, fetchurl, ocaml
 , result, alcotest, cohttp-lwt-unix, odoc, curl }:
 
 buildDunePackage rec {
   pname = "curly";
-  version = "unstable-2019-11-14";
+  version = "0.2.0";
 
   minimumOCamlVersion = "4.02";
 
   useDune2 = true;
 
-  src = fetchFromGitHub {
-    owner  = "rgrinberg";
-    repo   = pname;
-    rev    = "33a538c89ef8279d4591454a7f699a4183dde5d0";
-    sha256 = "10pxbvf5xrsajaxrccxh2lqhgp3yaf61z9w03rvb2mq44nc2dggz";
+  src = fetchurl {
+    url = "https://github.com/rgrinberg/curly/releases/download/${version}/curly-${version}.tbz";
+    sha256 = "07vqdrklar0d5i83ip7sjw2c1v18a9m3anw07vmi5ay29pxzal6k";
   };
 
   propagatedBuildInputs = [ result ];
   checkInputs = [ alcotest cohttp-lwt-unix ];
-  # test dependencies are only available for >= 4.05
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  # test dependencies are only available for >= 4.08
+  doCheck = stdenv.lib.versionAtLeast ocaml.version "4.08"
+    # Some test fails in macOS sandbox
+    # > Fatal error: exception Unix.Unix_error(Unix.EPERM, "bind", "")
+    && !stdenv.isDarwin;
 
   postPatch = ''
     substituteInPlace src/curly.ml \


### PR DESCRIPTION
###### Motivation for this change

Tests fail on macOS:
https://github.com/NixOS/nixpkgs/pull/101995#issuecomment-718592479

cc @sternenseemann @SuperSandro2000 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
