### PR TITLE
openbgpd: 6.7p0 -> 6.8p0

### DIFF
--- a/pkgs/servers/openbgpd/default.nix
+++ b/pkgs/servers/openbgpd/default.nix
@@ -1,27 +1,27 @@
-{ stdenv, fetchFromGitHub, autoconf, automake
-, libtool, m4, yacc }:
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, m4, yacc }:
 
 let
-  openbsd_version = "OPENBSD_6_7"; # This has to be equal to ${src}/OPENBSD_BRANCH
+  openbsd_version =
+    "OPENBSD_6_8"; # This has to be equal to ${src}/OPENBSD_BRANCH
   openbsd = fetchFromGitHub {
+    name = "portable";
     owner = "openbgpd-portable";
     repo = "openbgpd-openbsd";
     rev = openbsd_version;
-    sha256 = "sha256-YJTHUsn6s4xLcLQuxCLmEkIE8ozxzooj71cJ5Wl+0lI=";
+    sha256 = "sha256-vCVK5k4g6aW2z2fg7Kv0uvkX7f34aRc8K2myb3jjl6w=";
   };
 in stdenv.mkDerivation rec {
   pname = "opengpd";
-  version = "6.7p0";
+  version = "6.8p0";
 
   src = fetchFromGitHub {
     owner = "openbgpd-portable";
     repo = "openbgpd-portable";
     rev = version;
-    sha256 = "sha256-10DfK45BsSHeyANB0OJLKog1mEj0mydXSDAT9G6u1gM";
+    sha256 = "sha256-TKs6tt/SCWes6kYAGIrSShZgOLf7xKh26xG3Zk7wCCw=";
   };
 
-  nativeBuildInputs =
-    [  autoconf automake libtool m4 yacc ];
+  nativeBuildInputs = [ autoconf automake libtool m4 yacc ];
 
   preConfigure = ''
     mkdir ./openbsd
@@ -36,7 +36,8 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A free implementation of the Border Gateway Protocol, Version 4. It allows ordinary machines to be used as routers exchanging routes with other systems speaking the BGP protocol";
+    description =
+      "A free implementation of the Border Gateway Protocol, Version 4. It allows ordinary machines to be used as routers exchanging routes with other systems speaking the BGP protocol";
     license = licenses.isc;
     homepage = "http://www.openbgpd.org/";
     maintainers = with maintainers; [ kloenk ];


### PR DESCRIPTION
###### Motivation for this change
update openbgdp

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
