### PR TITLE
rss-bridge-cli: init

### DIFF
--- a/pkgs/applications/misc/rss-bridge-cli/default.nix
+++ b/pkgs/applications/misc/rss-bridge-cli/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, writeShellScriptBin, rss-bridge, php }:
+
+let
+  phpWithExts = (php.withExtensions
+    ({ all, ... }: with all; [
+      curl
+      filter
+      iconv
+      json
+      mbstring
+      openssl
+      simplexml
+      sqlite3
+    ])
+  );
+  phpBin = "${phpWithExts}/bin/php";
+in (writeShellScriptBin "rss-bridge-cli" ''
+  ${phpBin} ${rss-bridge}/index.php "$@"
+'').overrideAttrs (oldAttrs: rec {
+  version = rss-bridge.version;
+
+  meta = with stdenv.lib; {
+    description = "Command-line interface for RSS-Bridge";
+    homepage = "https://github.com/RSS-Bridge/rss-bridge";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ ymeister ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6879,6 +6879,8 @@ in
 
   rsibreak = libsForQt514.callPackage ../applications/misc/rsibreak { };
 
+  rss-bridge-cli = callPackage ../applications/misc/rss-bridge-cli { };
+
   rss2email = callPackage ../applications/networking/feedreaders/rss2email {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adds command-line interface to RSS-Bridge, so that it can be used without running it as a server.
It can be very useful for RSS feed applications such as newsboat (see "exec:" option).

It is made as a separate package because its CLI requires a php interpreter.
You can find official RSS-Bridge CLI documentation at https://github.com/RSS-Bridge/rss-bridge/wiki/Command-Line-Interface-(CLI)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
