### PR TITLE
pythonPackages.pyqtgraph: use PyQt5 and enable tests

### DIFF
--- a/pkgs/development/python-modules/pyqtgraph/default.nix
+++ b/pkgs/development/python-modules/pyqtgraph/default.nix
@@ -1,24 +1,49 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , scipy
 , numpy
-, pyqt4
+, pyqt5
 , pyopengl
+, h5py
+, qt5
+, python
+, pytest
+, freefont_ttf
+, makeFontsConf
 }:
 
-buildPythonPackage rec {
+let
+  fontsConf = makeFontsConf {
+    fontDirectories = [ freefont_ttf ];
+  };
+in buildPythonPackage rec {
   pname = "pyqtgraph";
   version = "0.11.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0p5k73wjfh0zzjvby8b5107cx7x0c2rdj66zh1nc8y95i0anf2na";
+  src = fetchFromGitHub {
+    owner = "pyqtgraph";
+    repo = "pyqtgraph";
+    rev = "pyqtgraph-${version}";
+    sha256 = "03fvpkqdn80ni51msvyivmghw41qk4vplwdqndkvzzzlppimdjbn";
   };
 
-  propagatedBuildInputs = [ scipy numpy pyqt4 pyopengl ];
+  propagatedBuildInputs = [ numpy pyqt5 scipy pyopengl h5py ];
 
-  doCheck = false;  # "PyQtGraph requires either PyQt4 or PySide; neither package could be imported."
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    export QT_PLUGIN_PATH="${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}"
+    export QT_QPA_PLATFORM=offscreen
+
+    export FONTCONFIG_FILE=${fontsConf}
+
+    # disable 6 tests which try to clone https://github.com/pyqtgraph/test-data
+    ${python.interpreter} test.py --pyqt5 \
+      -k "not test_ImageItem and not test_ImageItem_axisorder \
+      and not test_PlotCurveItem and not test_getArrayRegion \
+      and not test_getArrayRegion_axisorder and not test_PolyLineROI"
+  '';
 
   meta = with stdenv.lib; {
     description = "Scientific Graphics and GUI Library for Python";

--- a/pkgs/development/python-modules/pyqtgraph/default.nix
+++ b/pkgs/development/python-modules/pyqtgraph/default.nix
@@ -35,7 +35,7 @@ in buildPythonPackage rec {
   checkPhase = ''
     export QT_PLUGIN_PATH="${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}"
     export QT_QPA_PLATFORM=offscreen
-
+    export DYLD_FRAMEWORK_PATH=/System/Library/Frameworks
     export FONTCONFIG_FILE=${fontsConf}
 
     # disable 6 tests which try to clone https://github.com/pyqtgraph/test-data


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Use `fetchFromGitHub` because the tests aren't included in the PyPi package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
