### PR TITLE
ssm-session-manager-plugin: 1.1.61.0 -> 1.2.7.0, add macos support

### DIFF
--- a/pkgs/applications/networking/cluster/ssm-session-manager-plugin/default.nix
+++ b/pkgs/applications/networking/cluster/ssm-session-manager-plugin/default.nix
@@ -1,28 +1,38 @@
-{ stdenv, lib, fetchurl, autoPatchelfHook, dpkg, awscli }:
+{ stdenv, lib, fetchurl, autoPatchelfHook, dpkg, awscli, unzip }:
+let
+  ver = "1.2.7.0";
+  source = if stdenv.isDarwin then {
+    url =
+      "https://s3.amazonaws.com/session-manager-downloads/plugin/${ver}/mac/sessionmanager-bundle.zip";
+    sha256 = "sha256-HP+opNjS53zR9eUxpNUHGD9rZN1z7lDc6+nONR8fa/s=";
+  } else {
+    url =
+      "https://s3.amazonaws.com/session-manager-downloads/plugin/${ver}/ubuntu_64bit/session-manager-plugin.deb";
+    sha256 = "sha256-EZ9ncj1YYlod1RLfXOpZFijnKjLYWYVBb+C6yd42l34=";
+  };
+  platformBuildInput = if stdenv.isDarwin then [ unzip ] else [ dpkg ];
+  unpackCmd = if stdenv.isDarwin then "unzip $src" else "dpkg-deb -x $src .";
+  archivePath = if stdenv.isDarwin then "sessionmanager-bundle" else "usr/local/sessionmanagerplugin";
+in
 stdenv.mkDerivation rec {
   pname = "ssm-session-manager-plugin";
-  version = "1.1.61.0";
+  version = ver;
 
-  src = fetchurl {
-    url =
-      "https://s3.amazonaws.com/session-manager-downloads/plugin/${version}/ubuntu_64bit/session-manager-plugin.deb";
-    sha256 = "0z59irrpwhjjhn379454xyraqs590hij2n6n6k25w5hh8ak7imfl";
-  };
+  src = fetchurl source;
 
-  nativeBuildInputs = [ autoPatchelfHook dpkg ];
+  nativeBuildInputs = [ autoPatchelfHook ] ++ platformBuildInput;
 
   buildInputs = [ awscli ];
 
-  unpackPhase = "dpkg-deb -x $src .";
+  unpackPhase = unpackCmd;
 
-  installPhase =
-    "install -m755 -D usr/local/sessionmanagerplugin/bin/session-manager-plugin $out/bin/session-manager-plugin";
+  installPhase = "install -m755 -D ${archivePath}/bin/session-manager-plugin $out/bin/session-manager-plugin";
 
   meta = with lib; {
     homepage =
       "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html";
     description = "Amazon SSM Session Manager Plugin";
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
     license = licenses.unfree;
     maintainers = with maintainers; [ mbaillie ];
   };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
