### PR TITLE
[20.09] csvkit: unbreak agate-sql

### DIFF
--- a/pkgs/tools/text/csvkit/default.nix
+++ b/pkgs/tools/text/csvkit/default.nix
@@ -27,7 +27,9 @@ python3.pkgs.buildPythonApplication rec {
         inherit (old) pname;
         inherit version;
         sha256 = "1d6rbahmdix7xi7ma2v86fpk5yi32q5dba5vama35w5mmn2pnyw7";
-      };}))
+      };
+      meta = old.meta // { broken = false; };
+    }))
     six
   ];
 


### PR DESCRIPTION
###### Motivation for this change
ideally agate-sql would be compatible with the latest sqlalchemy, but doesn't seem likely.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
