### PR TITLE
[20.09] p4: 2020.1.1991450 -> 2020.1.2007551

### DIFF
--- a/pkgs/applications/version-management/p4/default.nix
+++ b/pkgs/applications/version-management/p4/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "p4";
-  version = "2020.1.1991450";
+  version = "2020.1.2007551";
 
   src = fetchurl {
     url = "https://cdist2.perforce.com/perforce/r20.1/bin.linux26x86_64/helix-core-server.tgz";
-    sha256 = "0nhcxhwx3scx6vf7i2bc8j0b1l57lmq9bfy1cfbfbqasd3an721k";
+    sha256 = "0ly9b838zrpp6841fzapizdd3xmria55bwfrh2j29qwxiwzqj80y";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
###### Motivation for this change
closes #101955
backport #101470 

The download URL hasn't changed, but the sha256 and user facing download
version has. See [perforce downloads][p4-download].

[p4-download]: https://www.perforce.com/downloads/helix-command-line-client-p4

(cherry picked from commit b197c7fb487b12bb8ff6c1e014b5f10ba9ed6edf)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
