### PR TITLE
fetchzip: remove write permissions for unpacked files

### DIFF
--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -355,9 +355,6 @@ rec {
       url = "https://download.jboss.org/drools/release/${version}/droolsjbpm-tools-distribution-${version}.zip";
       sha512 = "2qzc1iszqfrfnw8xip78n3kp6hlwrvrr708vlmdk7nv525xhs0ssjaxriqdhcr0s6jripmmazxivv3763rnk2bfkh31hmbnckpx4r3m";
       extraPostFetch = ''
-        # work around https://github.com/NixOS/nixpkgs/issues/38649
-        chmod go-w $out;
-
         # update site is a couple levels deep, alongside some other irrelevant stuff
         cd $out;
         find . -type f -not -path ./binaries/org.drools.updatesite/\* -exec rm {} \;

--- a/pkgs/applications/misc/ipmicfg/default.nix
+++ b/pkgs/applications/misc/ipmicfg/default.nix
@@ -8,7 +8,6 @@ stdenv.mkDerivation rec {
   src = fetchzip {
     url = "https://www.supermicro.com/wftp/utility/IPMICFG/IPMICFG_${version}_build.${buildVersion}.zip";
     sha256 = "0srkzivxa4qlf3x9zdkri7xfq7kjj4fsmn978vzmzsvbxkqswd5a";
-    extraPostFetch = "chmod u+rwX,go-rwx+X $out/";
   };
 
   installPhase = ''

--- a/pkgs/applications/office/atlassian-cli/default.nix
+++ b/pkgs/applications/office/atlassian-cli/default.nix
@@ -7,7 +7,6 @@ stdenv.mkDerivation rec {
   src = fetchzip {
     url  = "https://bobswift.atlassian.net/wiki/download/attachments/16285777/${pname}-${version}-distribution.zip";
     sha256  = "091dhjkx7fdn23cj7c4071swncsbmknpvidmmjzhc0355l3p4k2g";
-    extraPostFetch = "chmod go-w $out";
   };
 
   tools = [

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -44,8 +44,13 @@
       mv "$unpackDir/$fn" "$out"
     '' else ''
       mv "$unpackDir" "$out"
-    '') #*/
-    + extraPostFetch;
+    '')
+    + extraPostFetch
+    # Remove write permissions for files unpacked with write bits set
+    # Fixes https://github.com/NixOS/nixpkgs/issues/38649
+    + ''
+      chmod -R a-w "$out"
+    '';
 } // removeAttrs args [ "stripRoot" "extraPostFetch" ])).overrideAttrs (x: {
   # Hackety-hack: we actually need unzip hooks, too
   nativeBuildInputs = x.nativeBuildInputs ++ [ unzip ];

--- a/pkgs/servers/web-apps/engelsystem/default.nix
+++ b/pkgs/servers/web-apps/engelsystem/default.nix
@@ -11,8 +11,6 @@ in stdenv.mkDerivation rec {
     url =
       "https://github.com/engelsystem/engelsystem/releases/download/v3.1.0/engelsystem-v3.1.0.zip";
     sha256 = "01wra7li7n5kn1l6xkrmw4vlvvyqh089zs43qzn98hj0mw8gw7ai";
-    # This is needed, because the zip contains a directory with world write access, which is not allowed in nix
-    extraPostFetch = "chmod -R a-w $out";
   };
 
   buildInputs = [ phpExt ];


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/38649

Some zip files contain [4.4.15 external file attributes](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) that may set the write bit of unpacked files. This change ensures that all files fetched & unpacked with `fetchzip` will have their write bits cleared as final step. This change should not affect the hash of any outputs built with `fetchzip`.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  I manually rebuilt all projects that used `extraPostFetch` as a workaround, and they all still resolve to the their original hashes. However, ipmicfg isn't exposed through an attribute, and when I tried to build it, it failed with:
  ```
  End-of-central-directory signature not found
  ```
  Should it just be removed?
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).