### PR TITLE
Init libdatrie, libthai, ibus-engines.libthai; build pango with libthai

### DIFF
--- a/pkgs/development/libraries/libdatrie/default.nix
+++ b/pkgs/development/libraries/libdatrie/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, makeWrapper, installShellFiles, pkg-config, libiconv }:
+
+stdenv.mkDerivation rec {
+  pname = "libdatrie";
+  version = "0.2.12";
+
+  src = fetchurl {
+    url = "https://github.com/tlwg/libdatrie/releases/download/v${version}/libdatrie-${version}.tar.xz";
+    sha256 = "0jdi01pcxv0b24zbjy7zahawsqqqw4mv94f2yy01zh4n796wqba5";
+  };
+
+  nativeBuildInputs = [ installShellFiles pkg-config ];
+
+  buildInputs = stdenv.lib.optional stdenv.isDarwin libiconv;
+
+  postInstall = ''
+    installManPage man/trietool.1
+  '';
+
+  meta = with stdenv.lib;{
+    homepage = "https://linux.thai.net/~thep/datrie/datrie.html";
+    description = "This is an implementation of double-array structure for representing trie";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/development/libraries/libthai/default.nix
+++ b/pkgs/development/libraries/libthai/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, makeWrapper, installShellFiles, pkg-config, libdatrie }:
+
+stdenv.mkDerivation rec {
+  pname = "libthai";
+  version = "0.1.28";
+
+  src = fetchurl {
+    url = "https://github.com/tlwg/libthai/releases/download/v${version}/libthai-${version}.tar.xz";
+    sha256 = "04g93bgxrcnay9fglpq2lj9nr7x1xh06i60m7haip8as9dxs3q7z";
+  };
+
+  nativeBuildInputs = [ installShellFiles pkg-config ];
+
+  buildInputs = [ libdatrie ];
+
+  postInstall = ''
+    installManPage man/man3/*.3
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://linux.thai.net/projects/libthai/";
+    description = "Set of Thai language support routines";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, cairo, harfbuzz
-, libintl, gobject-introspection, darwin, fribidi, gnome3
+, libintl, libthai, gobject-introspection, darwin, fribidi, gnome3
 , gtk-doc, docbook_xsl, docbook_xml_dtd_43, makeFontsConf, freefont_ttf
 , meson, ninja, glib
 , x11Support? !stdenv.isDarwin, libXft
@@ -28,6 +28,7 @@ in stdenv.mkDerivation rec {
   ];
   buildInputs = [
     fribidi
+    libthai
   ] ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     ApplicationServices
     Carbon
@@ -39,7 +40,6 @@ in stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dgtk_doc=${if stdenv.isDarwin then "false" else "true"}"
-    "-Dlibthai=disabled" # Not packaged in Nixpkgs
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     "-Dxft=disabled"  # only works with x11
   ];

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-libthai/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-libthai/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, makeWrapper, pkg-config, ibus, gtk3, libthai }:
+
+stdenv.mkDerivation rec {
+  pname = "ibus-libthai";
+  version = "0.1.4";
+
+  src = fetchurl {
+    url = "https://linux.thai.net/pub/ThaiLinux/software/libthai/ibus-libthai-${version}.tar.xz";
+    sha256 = "0iam7308rxkx2xwaabc5wyj7vrxgd4cr95pvwrkm8fr9gh2xnwgv";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gtk3 ibus libthai ];
+
+  meta = with stdenv.lib; {
+    isIbusEngine = true;
+    homepage = "https://linux.thai.net/projects/ibus-libthai";
+    description = "Thai input method engine for IBus";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14218,6 +14218,8 @@ in
 
   libtcod = callPackage ../development/libraries/libtcod { };
 
+  libthai = callPackage ../development/libraries/libthai { };
+
   libtheora = callPackage ../development/libraries/libtheora { };
 
   libthreadar = callPackage ../development/libraries/libthreadar { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13500,6 +13500,8 @@ in
 
   libdap = callPackage ../development/libraries/libdap { };
 
+  libdatrie = callPackage ../development/libraries/libdatrie { };
+
   libdazzle = callPackage ../development/libraries/libdazzle { };
 
   libdbi = callPackage ../development/libraries/libdbi { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2876,6 +2876,8 @@ in
 
     libpinyin = callPackage ../tools/inputmethods/ibus-engines/ibus-libpinyin { };
 
+    libthai = callPackage ../tools/inputmethods/ibus-engines/ibus-libthai { };
+
     m17n = callPackage ../tools/inputmethods/ibus-engines/ibus-m17n { };
 
     mozc = callPackage ../tools/inputmethods/ibus-engines/ibus-mozc {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #68975

Build pango with libthai support.

###### Things done

This PR includes #102059 to be able to test pango on darwin.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
