### PR TITLE
jackmix: 0.5.2 -> 0.6.0

### DIFF
--- a/pkgs/applications/audio/jackmix/default.nix
+++ b/pkgs/applications/audio/jackmix/default.nix
@@ -1,17 +1,21 @@
-{ stdenv, fetchurl, pkgconfig, sconsPackages, qt4, lash, libjack2, jack ? libjack2, alsaLib }:
+{ mkDerivation, lib, fetchFromGitHub, pkgconfig, sconsPackages, qtbase, lash, libjack2, jack ? libjack2, alsaLib }:
 
-stdenv.mkDerivation {
-  name = "jackmix-0.5.2";
-  src = fetchurl {
-    url = "https://github.com/kampfschlaefer/jackmix/archive/v0.5.2.tar.gz";
-    sha256 = "18f5v7g66mgarhs476frvayhch7fy4nyjf2xivixc061ipn0m82j";
+mkDerivation rec {
+  pname = "jackmix";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "kampfschlaefer";
+    repo = "jackmix";
+    rev = version;
+    sha256 = "0p59411vk38lccn24r7nih10jpgg9i46yc26zpc3x13amxwwpd4h";
   };
 
   patches = [ ./no_error.patch ];
 
   nativeBuildInputs = [ sconsPackages.scons_3_1_2 pkgconfig ];
   buildInputs = [
-    qt4
+    qtbase
     lash
     jack
     alsaLib
@@ -21,11 +25,11 @@ stdenv.mkDerivation {
     install -D jackmix/jackmix $out/bin/jackmix
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Matrix-Mixer for the Jack-Audio-connection-Kit";
-    homepage = "http://www.arnoldarts.de/jackmix/";
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.kampfschlaefer ];
-    platforms = stdenv.lib.platforms.linux;
+    homepage = "https://github.com/kampfschlaefer/jackmix";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ kampfschlaefer ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/jackmix/no_error.patch
+++ b/pkgs/applications/audio/jackmix/no_error.patch
@@ -1,13 +1,13 @@
 diff --git a/SConstruct b/SConstruct
-index 4290fa5..0a7a679 100644
+index 8bf6517..a432aa9 100644
 --- a/SConstruct
 +++ b/SConstruct
 @@ -16,7 +16,7 @@ env = Environment(
- env.Replace( LIBS="" )
- env.Replace( LIBPATH="" )
-
--env.MergeFlags( ['-Wall', '-Werror', '-g', '-fpic'] )
-+env.MergeFlags( ['-g', '-fpic'] )
-
- tests = { }
- tests.update( env['PKGCONFIG_TESTS'] )
+ env.Replace(LIBS="")
+ env.Replace(LIBPATH="")
+ 
+-env.MergeFlags(['-Wall', '-Werror', '-g', '-fpic', '-std=c++11'])
++env.MergeFlags(['-g', '-fpic', '-std=c++11'])
+ 
+ tests = {}
+ tests.update(env['PKGCONFIG_TESTS'])

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21625,7 +21625,7 @@ in
 
   jackmeter = callPackage ../applications/audio/jackmeter { };
 
-  jackmix = callPackage ../applications/audio/jackmix { };
+  jackmix = libsForQt5.callPackage ../applications/audio/jackmix { };
   jackmix_jack1 = jackmix.override { jack = jack1; };
 
   jalv = callPackage ../applications/audio/jalv { };


### PR DESCRIPTION
###### Motivation for this change
#33248

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @kampfschlaefer 