### PR TITLE
gojsontoyaml: init at unstable-2020-06-02

### DIFF
--- a/pkgs/development/tools/gojsontoyaml/default.nix
+++ b/pkgs/development/tools/gojsontoyaml/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "gojsontoyaml";
+  version = "unstable-2020-06-02";
+
+  src = fetchFromGitHub {
+    owner = "brancz";
+    repo = "gojsontoyaml";
+    rev = "3697ded27e8cfea8e547eb082ebfbde36f1b5ee6";
+    sha256 = "07sisadpfnzbylzirs5ski8wl9fl18dm7xhbv8imw6ksxq4v467a";
+  };
+
+  vendorSha256 = null;
+
+  meta = with stdenv.lib; {
+    description = "Simply tool to convert json to yaml written in Go";
+    homepage = "https://github.com/brancz/gojsontoyaml";
+    license = licenses.mit;
+    maintainers = [ maintainers.bryanasdev000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1186,6 +1186,8 @@ in
 
   goimapnotify = callPackage ../tools/networking/goimapnotify { };
 
+  gojsontoyaml = callPackage ../development/tools/gojsontoyaml { };
+
   gomatrix = callPackage ../applications/misc/gomatrix { };
 
   gopacked = callPackage ../applications/misc/gopacked { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add gojsontoyaml, a simply tool to convert json to yaml and vice-versa written in Go.

NOTE: In the project's Github there is no tag (release) so I'm using the last commit from the master.

###### Things done

Added package definition at `pkgs/development/tools/gojsontoyaml/default.nix` and added a reference line to `pkgs/top-level/all-packages.nix` below gjo.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
