### PR TITLE
remarkable-toolchain: use which instead of patching with sed

### DIFF
--- a/pkgs/development/tools/misc/remarkable/remarkable-toolchain/default.nix
+++ b/pkgs/development/tools/misc/remarkable/remarkable-toolchain/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libarchive, python3, file }:
+{ stdenv, fetchurl, libarchive, python, file, which }:
 
 stdenv.mkDerivation rec {
   pname = "remarkable-toolchain";
@@ -6,31 +6,30 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://remarkable.engineering/oecore-x86_64-cortexa9hf-neon-toolchain-zero-gravitas-${version}.sh";
-    sha256 = "6299955721bcd9bef92a87ad3cfe4d31df8e2da95b0c4b2cdded4431aa6748b0";
+    sha256 = "1rk1r80m5d18sw6hrybj6f78s8pna0wrsa40ax6j8jzfwahgzmfb";
+    executable = true;
   };
 
   nativeBuildInputs = [
     libarchive
-    python3
+    python
     file
+    which
   ];
 
-  unpackCmd = "mkdir src; install $curSrc src/install-toolchain.sh";
-
+  dontUnpack = true;
   dontBuild = true;
 
   installPhase = ''
-    patchShebangs install-toolchain.sh
-    sed -i -e '3,9d' install-toolchain.sh # breaks PATH
-    sed -i 's|PYTHON=.*$|PYTHON=${python3}/bin/python|' install-toolchain.sh
-    ./install-toolchain.sh -D -y -d $out
+    mkdir -p $out
+    ENVCLEANED=1 $src -y -d $out
   '';
 
   meta = with stdenv.lib; {
     description = "A toolchain for cross-compiling to reMarkable tablets";
     homepage = "https://remarkable.engineering/";
     license = licenses.gpl2;
-    maintainers = [ maintainers.nickhu ];
-    platforms = platforms.x86_64;
+    maintainers = with maintainers; [ nickhu siraben ];
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
