### PR TITLE
Remove mildlyincompetent from the maintainers list

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5689,12 +5689,6 @@
     githubId = 1387206;
     name = "Mike Sperber";
   };
-  mildlyincompetent = {
-    email = "nix@kch.dev";
-    github = "mildlyincompetent";
-    githubId = 19479662;
-    name = "Kajetan Champlewski";
-  };
   millerjason = {
     email = "mailings-github@millerjason.com";
     github = "millerjason";

--- a/pkgs/development/python-modules/coordinates/default.nix
+++ b/pkgs/development/python-modules/coordinates/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     description = "Convenience class for doing maths with explicit coordinates";
     homepage = "https://github.com/clbarnes/coordinates";
     license = licenses.mit;
-    maintainers = [ maintainers.mildlyincompetent ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Kajetan was a personal friend, and he unfortunately passed away earlier this year. I didn't realise he was still in `maintainer-list.nix` but I think he should be removed and another maintainer found for `python-modules/coordinates`.

Article from the local Southampton newspaper about his death: https://www.dailyecho.co.uk/news/18461603.man-found-hanging-southampton-home/

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
