### PR TITLE
deeptools,tebreak,python3Packages.cnvkit,python3Packages.HTSeq: Fix test

### DIFF
--- a/pkgs/applications/science/biology/deeptools/default.nix
+++ b/pkgs/applications/science/biology/deeptools/default.nix
@@ -1,14 +1,14 @@
-{ lib
-, python
-}:
+{ lib, python, fetchFromGitHub }:
 with python.pkgs;
 buildPythonApplication rec {
   pname = "deepTools";
   version = "3.5.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1a14a29e60be13eac11bd204dab9aef73cd72fe56a94c587333f21087584c0d8";
+  src = fetchFromGitHub {
+    owner = "deeptools";
+    repo = "deepTools";
+    rev = version;
+    sha256 = "1bz8ln32mfc9k8l9wgp034vw80dxh6f92dfqxhcrpggk4akwj6ml";
   };
 
   propagatedBuildInputs = [
@@ -23,7 +23,7 @@ buildPythonApplication rec {
     deeptoolsintervals
   ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ nose ];
 
   meta = with lib; {
     homepage = "https://deeptools.readthedocs.io/en/develop";

--- a/pkgs/applications/science/biology/tebreak/default.nix
+++ b/pkgs/applications/science/biology/tebreak/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, last, exonerate, minia, python3Packages, bwa
-, samtools, findutils }:
+, samtools, findutils, python }:
 
 python3Packages.buildPythonApplication rec {
   pname = "tebreak";
@@ -30,6 +30,12 @@ python3Packages.buildPythonApplication rec {
       sed -i "s|'lastal'|'${last}/bin/lastal'|" $f
       sed -i "s|'lastdb'|'${last}/bin/lastdb'|" $f
     done
+  '';
+
+  checkPhase = ''
+    $out/bin/tebreak -b test/data/example.ins.bam  -r test/data/Homo_sapiens_chr4_50000000-60000000_assembly19.fasta -p 4 --pickle test/example.pickle --detail_out test/example.tebreak.detail.out -i lib/teref.human.fa
+    pushd test
+    ${python.interpreter} checktest.py
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/xmlsec/default.nix
+++ b/pkgs/development/libraries/xmlsec/default.nix
@@ -32,6 +32,11 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
   doCheck = true;
   checkInputs = [ nss_3_53.tools ];
+  preCheck = ''
+  substituteInPlace tests/testrun.sh \
+    --replace 'timestamp=`date +%Y%m%d_%H%M%S`' 'timestamp=19700101_000000' \
+    --replace 'TMPFOLDER=/tmp' '$(mktemp -d)'
+  '';
 
   # enable deprecated soap headers required by lasso
   # https://dev.entrouvert.org/issues/18771

--- a/pkgs/development/python-modules/HTSeq/default.nix
+++ b/pkgs/development/python-modules/HTSeq/default.nix
@@ -1,18 +1,26 @@
-{ stdenv, buildPythonPackage, fetchPypi, cython, numpy, pysam, matplotlib
-}:
+{ stdenv, buildPythonPackage, fetchFromGitHub, cython, numpy, pysam, matplotlib, python, isPy27, isPy3k }:
 buildPythonPackage rec {
   version = "0.12.4";
   pname = "HTSeq";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "e3980bb4f12899442b4fa6f24f0ba149090f71cedb1eaf7128249afe4eb921ff";
+  src = fetchFromGitHub {
+    owner = "htseq";
+    repo = "htseq";
+    rev = "release_${version}";
+    sha256 = "0y7vh249sljqjnv81060w4xkdx6f1y5zdqkh38yk926x6v9riijm";
   };
 
-  buildInputs = [ cython numpy pysam ];
+  nativeBuildInputs = [ cython ];
   propagatedBuildInputs = [ numpy pysam matplotlib ];
 
+  checkPhase = stdenv.lib.optionalString isPy27 ''
+    ${python.interpreter} python2/test/test_general.py
+  '' + stdenv.lib.optionalString isPy3k ''
+    ${python.interpreter} python3/test/test_general.py
+  '';
+
   meta = with stdenv.lib; {
+    homepage = "https://htseq.readthedocs.io/";
     description = "A framework to work with high-throughput sequencing data";
     maintainers = with maintainers; [ unode ];
     platforms = platforms.unix;

--- a/pkgs/development/python-modules/cnvkit/default.nix
+++ b/pkgs/development/python-modules/cnvkit/default.nix
@@ -1,5 +1,6 @@
 { lib
-, fetchPypi
+, fetchFromGitHub
+, fetchpatch
 , rPackages
 , rWrapper
 , buildPythonPackage
@@ -15,16 +16,28 @@
 , pillow
 , pomegranate
 , pyfaidx
+, python
+, R
 }:
 
 buildPythonPackage rec {
   pname = "CNVkit";
   version = "0.9.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "d68adc0121e17c61a3aa28c0a9ba6526510a5a0df0f0a6eb1818bab71b7e927a";
+  src = fetchFromGitHub {
+    owner = "etal";
+    repo = "cnvkit";
+    rev = "v${version}";
+    sha256 = "022zplgqil5l76vri647cyjx427vnbg5r2gw6lw712d2janvdjm7";
   };
+
+  patches = [
+    # Fix: AttributeError: module 'pandas.io.common' has no attribute 'EmptyDataError'
+    (fetchpatch {
+      url = "https://github.com/etal/cnvkit/commit/392adfffedfa0415e635b72c5027835b0a8d7ab5.patch";
+      sha256 = "0s0gwyy0hybmhc3jij2v9l44b6lkcmclii8bkwsazzj2kc24m2rh";
+    })
+  ];
 
   propagatedBuildInputs = [
     biopython
@@ -39,6 +52,7 @@ buildPythonPackage rec {
     future
     pillow
     pomegranate
+    rPackages.DNAcopy
   ];
 
   postPatch = ''
@@ -46,7 +60,16 @@ buildPythonPackage rec {
       --replace "pandas >= 0.20.1, < 0.25.0" "pandas"
   '';
 
-  pythonImportsCheck = [ "cnvlib" ];
+  checkInputs = [ R ];
+
+  checkPhase = ''
+    pushd test/
+    ${python.interpreter} test_io.py
+    ${python.interpreter} test_genome.py
+    ${python.interpreter} test_cnvlib.py
+    ${python.interpreter} test_commands.py
+    ${python.interpreter} test_r.py
+  '';
 
   meta = with lib; {
     homepage = "https://cnvkit.readthedocs.io";

--- a/pkgs/development/python-modules/pysaml2/default.nix
+++ b/pkgs/development/python-modules/pysaml2/default.nix
@@ -49,7 +49,8 @@ buildPythonPackage rec {
   checkPhase = ''
     py.test -k "not test_load_extern_incommon \
             and not test_load_remote_encoding \
-            and not test_load_external"
+            and not test_load_external \
+            and not test_conf_syslog"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

#100814

```
writing manifest file 'deepTools.egg-info/SOURCES.txt'
running build_ext
Matplotlib created a temporary config/cache directory at /build/matplotlib-qzbkbnui because the default path (/homeless-shelter/.config/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
Finished executing setuptoolsCheckPhase
pytestcachePhase
copying 1 paths...
copying path '/nix/store/n60jc9dap8acc3f28j154779am5rpsnd-deepTools-3.5.0'
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
