### PR TITLE
versus: init at 1.0

### DIFF
--- a/pkgs/applications/networking/versus/default.nix
+++ b/pkgs/applications/networking/versus/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "versus";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "INFURA";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0j5mj9gwwvgx7r1svlg14dpcqlj8mhwlf7sampkkih6bv92qfzcd";
+  };
+
+  vendorSha256 = "1d12jcd8crxcgp5m8ga691wivim4cg8cbz4pzgxp0jhzg9jplpbv";
+
+  meta = with stdenv.lib; {
+    description = "Benchmark multiple API endpoints against each other";
+    homepage = "https://github.com/INFURA/versus";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mmahut ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7835,6 +7835,8 @@ in
 
   verilog = callPackage ../applications/science/electronics/verilog {};
 
+  versus = callPackage ../applications/networking/versus { };
+
   vgrep = callPackage ../tools/text/vgrep { };
 
   vhd2vl = callPackage ../applications/science/electronics/vhd2vl { };


### PR DESCRIPTION
###### Motivation for this change

`versus` is a handy tool for API benchmarking

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
