### PR TITLE
palemoon: 28.14.2 -> 28.15.0

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -16,13 +16,14 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "28.14.2";
+  version = "28.15.0";
 
   src = fetchFromGitHub {
+    githubBase = "repo.palemoon.org";
     owner = "MoonchildProductions";
     repo = "Pale-Moon";
     rev = "${version}_Release";
-    sha256 = "1qz2sqc8rcg5z5kncabgmpl6v4i6wrs9dlgmna69255qrmsshwgm";
+    sha256 = "1sbs3gcwfx58mxc0x1g6jklmvpa9dw2bq3i8y9645gfa1s12p8wy";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Simple version bump. Project changed its repo page to https://repo.palemoon.org/MoonchildProductions/Pale-Moon/releases, overriding `fetchFromGitHub`'s `githubBase` seemed to work well enough, though it may not be the ideal/intended way of doing this.

> · Security issues fixed: CVE-2020-15680 (VG-VD-20-115) and several memory safety hazards.
> · Unified XUL Platform Mozilla Security Patch Summary: 1 fixed, 2 defense-in-depth, 12 not applicable.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
