### PR TITLE
ptouch-print: init at 1.4.3

### DIFF
--- a/pkgs/misc/ptouch-print/default.nix
+++ b/pkgs/misc/ptouch-print/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchgit
+, autoreconfHook
+, gd
+, libusb1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ptouch-print";
+  version = "1.4.3";
+
+  src = fetchgit {
+    url = "https://mockmoon-cybernetics.ch/cgi/cgit/linux/ptouch-print.git";
+    rev = "v${version}";
+    sha256 = "0i57asg2hj1nfwy5lcb0vhrpvb9dqfhf81vh4i929h1kiqhlw2hx";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    gd
+    libusb1
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Command line tool to print labels on Brother P-Touch printers on Linux";
+    license = licenses.gpl3Plus;
+    homepage = "https://mockmoon-cybernetics.ch/computer/p-touch2430pc/";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -212,6 +212,8 @@ in
 
   ptags = callPackage ../development/tools/misc/ptags { };
 
+  ptouch-print = callPackage ../misc/ptouch-print { };
+
   demoit = callPackage ../servers/demoit { };
 
   deviceTree = callPackage ../os-specific/linux/device-tree {};


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/101712

###### Things done
Packaged ptouch-print release 1.4.3

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
