### PR TITLE
nss: make reproducible

### DIFF
--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, nspr, perl, zlib, sqlite, darwin, fixDarwinDylibNames, buildPackages, ninja }:
+{ stdenv, fetchurl, nspr, perl, zlib, sqlite, darwin, fixDarwinDylibNames, buildPackages, ninja
+, # allow FIPS mode. Note that this makes the output non-reproducible.
+  # https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Tech_Notes/nss_tech_note6
+  enableFIPS ? false
+}:
 
 let
   nssPEM = fetchurl {
@@ -83,6 +87,7 @@ in stdenv.mkDerivation rec {
       -Dhost_arch=${host} \
       -Duse_system_zlib=1 \
       --enable-libpkix \
+      ${stdenv.lib.optionalString enableFIPS "--enable-fips"} \
       ${stdenv.lib.optionalString stdenv.isDarwin "--clang"} \
       ${stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "--disable-tests"}
 
@@ -128,7 +133,8 @@ in stdenv.mkDerivation rec {
   postFixup = let
     isCross = stdenv.hostPlatform != stdenv.buildPlatform;
     nss = if isCross then buildPackages.nss.tools else "$out";
-  in ''
+  in
+  (stdenv.lib.optionalString enableFIPS ''
     for libname in freebl3 nssdbm3 softokn3
     do '' +
     (if stdenv.isDarwin
@@ -141,7 +147,8 @@ in stdenv.mkDerivation rec {
      '') + ''
         ${nss}/bin/shlibsign -v -i "$libfile"
     done
-
+  '') +
+  ''
     moveToOutput bin "$tools"
     moveToOutput bin/nss-config "$dev"
     moveToOutput lib/libcrmf.a "$dev" # needed by firefox, for example


### PR DESCRIPTION
According to
https://hg.mozilla.org/projects/nss/file/c1fad130dce2081a5d6ce9f539c72d999f59afce/build.sh#l129
the FIPS mode is not enabled by default. Yet we generate the .chk files
that are only meant to be used for that mode. I have a sense that those
have been cargo-culted around.

Adding FIPS is still possible but you have to explictily build the lib
with `pkgs.nss.override { enableFIPS = true; }`

More info on what FIPS is:
https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Tech_Notes/nss_tech_note6

Other distros wrangling with the same issue:
https://bugzilla.opensuse.org/show_bug.cgi?id=1081723

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
