### PR TITLE
[20.09] wire-desktop: linux 3.20.2934 -> 3.21.2936, mac 3.20.3912 -> 3.21.3959

### DIFF
--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -21,12 +21,12 @@ let
   pname = "wire-desktop";
 
   version = {
-    x86_64-darwin = "3.20.3912";
+    x86_64-darwin = "3.21.3959";
     x86_64-linux = "3.21.2936";
   }.${system} or throwSystem;
 
   sha256 = {
-    x86_64-darwin = "1crkdqzq3iccxbrqlrar4ai43qzjsgd4hvcajgzmz2y33f30xgqr";
+    x86_64-darwin = "0fgzzqf1wnkjbcr0j0vjn6sggkz0z1kx6w4gi7gk4c4markdicm1";
     x86_64-linux = "033804nkz1fdmq3p8iplrlx708x1fjlr09bmrpy36lqg5h7m3yd6";
   }.${system} or throwSystem;
 

--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -22,12 +22,12 @@ let
 
   version = {
     x86_64-darwin = "3.20.3912";
-    x86_64-linux = "3.20.2934";
+    x86_64-linux = "3.21.2936";
   }.${system} or throwSystem;
 
   sha256 = {
     x86_64-darwin = "1crkdqzq3iccxbrqlrar4ai43qzjsgd4hvcajgzmz2y33f30xgqr";
-    x86_64-linux = "0z6vrhzrhrrnl3swjbxrbl1dhk2fx86s45n2z2in2shdlv08dcx7";
+    x86_64-linux = "033804nkz1fdmq3p8iplrlx708x1fjlr09bmrpy36lqg5h7m3yd6";
   }.${system} or throwSystem;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backport for #102157

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
