### PR TITLE
qt5-packages.nix: consistently make all libraries with same qt5 version

### DIFF
--- a/doc/languages-frameworks/qt.section.md
+++ b/doc/languages-frameworks/qt.section.md
@@ -92,32 +92,43 @@ mkDerivation {
 }
 ```
 ## Adding a library to Nixpkgs
-   Add a Qt library to all-packages.nix by adding it to the collection inside `mkLibsForQt5`. This ensures that the library is built with every available version of Qt as needed.
+Qt libraries are added to `qt5-packages.nix` and are made available for every Qt
+version supported.
+### Example adding a Qt library {#qt-library-all-packages-nix}
 
-### Example Adding a Qt library to all-packages.nix {#qt-library-all-packages-nix}
-
+The following represents the contents of `qt5-packages.nix`.
 ```
 {
   # ...
 
-  mkLibsForQt5 = self: with self; {
-    # ...
-
-    mylib = callPackage ../path/to/mylib {};
-  };
+  mylib = callPackage ../path/to/mylib {};
 
   # ...
 }
 ```
 ## Adding an application to Nixpkgs
-Add a Qt application to *all-packages.nix* using `libsForQt5.callPackage` instead of the usual `callPackage`. The former ensures that all dependencies are built with the same version of Qt.
+Applications that use Qt are also added to `qt5-packages.nix`. An alias is added
+in the top-level `all-packages.nix` pointing to the package with the desired Qt5 version.
 
-### Example Adding a QT application to all-packages.nix {#qt-application-all-packages-nix}
-```nix
+### Example adding a Qt application {#qt-application-all-packages-nix}
+
+The following represents the contents of `qt5-packages.nix`.
+```
 {
   # ...
 
-  myapp = libsForQt5.callPackage ../path/to/myapp/ {};
+  myapp = callPackage ../path/to/myapp {};
+
+  # ...
+}
+```
+
+The following represents the contents of `all-packages.nix`.
+```
+{
+  # ...
+
+  myapp = libsForQt5.myapp;
 
   # ...
 }

--- a/nixos/modules/i18n/input-method/ibus.nix
+++ b/nixos/modules/i18n/input-method/ibus.nix
@@ -48,7 +48,7 @@ in
       panel = mkOption {
         type = with types; nullOr path;
         default = null;
-        example = literalExample "''${pkgs.plasma5.plasma-desktop}/lib/libexec/kimpanel-ibus-panel";
+        example = literalExample "''${pkgs.plasma5Packages.plasma-desktop}/lib/libexec/kimpanel-ibus-panel";
         description = "Replace the IBus panel with another panel.";
       };
     };

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -430,8 +430,8 @@ let
               ${optionalString cfg.pamMount
                 "auth optional ${pkgs.pam_mount}/lib/security/pam_mount.so"}
               ${optionalString cfg.enableKwallet
-                ("auth optional ${pkgs.plasma5.kwallet-pam}/lib/security/pam_kwallet5.so" +
-                 " kwalletd=${pkgs.kdeFrameworks.kwallet.bin}/bin/kwalletd5")}
+                ("auth optional ${pkgs.plasma5Packages.kwallet-pam}/lib/security/pam_kwallet5.so" +
+                 " kwalletd=${pkgs.plasma5Packages.kwallet.bin}/bin/kwalletd5")}
               ${optionalString cfg.enableGnomeKeyring
                 "auth optional ${pkgs.gnome3.gnome-keyring}/lib/security/pam_gnome_keyring.so"}
               ${optionalString cfg.gnupg.enable
@@ -509,8 +509,8 @@ let
           ${optionalString (cfg.enableAppArmor && config.security.apparmor.enable)
               "session optional ${pkgs.apparmor-pam}/lib/security/pam_apparmor.so order=user,group,default debug"}
           ${optionalString (cfg.enableKwallet)
-              ("session optional ${pkgs.plasma5.kwallet-pam}/lib/security/pam_kwallet5.so" +
-               " kwalletd=${pkgs.kdeFrameworks.kwallet.bin}/bin/kwalletd5")}
+              ("session optional ${pkgs.plasma5Packages.kwallet-pam}/lib/security/pam_kwallet5.so" +
+               " kwalletd=${pkgs.plasma5Packages.kwallet.bin}/bin/kwalletd5")}
           ${optionalString (cfg.enableGnomeKeyring)
               "session optional ${pkgs.gnome3.gnome-keyring}/lib/security/pam_gnome_keyring.so auto_start"}
           ${optionalString cfg.gnupg.enable

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -7,8 +7,8 @@ let
   xcfg = config.services.xserver;
   cfg = xcfg.desktopManager.plasma5;
 
-  inherit (pkgs) kdeApplications kdeFrameworks plasma5;
-  inherit (pkgs) qt5 libsForQt5;
+  libsForQt5 = pkgs.plasma5Packages;
+  inherit (libsForQt5) kdeApplications kdeFrameworks plasma5;
   inherit (pkgs) writeText;
 
   pulseaudio = config.hardware.pulseaudio;
@@ -198,8 +198,8 @@ in
       };
 
       security.wrappers = {
-        kcheckpass.source = "${lib.getBin plasma5.kscreenlocker}/libexec/kcheckpass";
-        start_kdeinit.source = "${lib.getBin pkgs.kdeFrameworks.kinit}/libexec/kf5/start_kdeinit";
+        kcheckpass.source = "${lib.getBin libsForQt5.kscreenlocker}/libexec/kcheckpass";
+        start_kdeinit.source = "${lib.getBin libsForQt5.kinit}/libexec/kf5/start_kdeinit";
         kwin_wayland = {
           source = "${lib.getBin plasma5.kwin}/bin/kwin_wayland";
           capabilities = "cap_sys_nice+ep";
@@ -213,7 +213,7 @@ in
       '';
 
       environment.systemPackages =
-        with qt5; with libsForQt5;
+        with libsForQt5;
         with plasma5; with kdeApplications; with kdeFrameworks;
         [
           frameworkintegration

--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -9,7 +9,7 @@ let
 
   cfg = config.boot.plymouth;
 
-  nixosBreezePlymouth = pkgs.plasma5.breeze-plymouth.override {
+  nixosBreezePlymouth = pkgs.plasma5Packages.breeze-plymouth.override {
     logoFile = cfg.logo;
     logoName = "nixos";
     osName = "NixOS";

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -5,7 +5,7 @@
 , flashplayer, hal-flash
 , ffmpeg, xorg, alsaLib, libpulseaudio, libcanberra-gtk2, libglvnd
 , gnome3/*.gnome-shell*/
-, browserpass, chrome-gnome-shell, uget-integrator, plasma5, bukubrow
+, browserpass, chrome-gnome-shell, uget-integrator, plasma5Packages, bukubrow
 , tridactyl-native
 , fx_cast_bridge
 , udev
@@ -76,7 +76,7 @@ let
           ++ lib.optional (cfg.enableTridactylNative or false) tridactyl-native
           ++ lib.optional (cfg.enableGnomeExtensions or false) chrome-gnome-shell
           ++ lib.optional (cfg.enableUgetIntegrator or false) uget-integrator
-          ++ lib.optional (cfg.enablePlasmaBrowserIntegration or false) plasma5.plasma-browser-integration
+          ++ lib.optional (cfg.enablePlasmaBrowserIntegration or false) plasma5Packages.plasma-browser-integration
           ++ lib.optional (cfg.enableFXCastBridge or false) fx_cast_bridge
           ++ extraNativeMessagingHosts
         );

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -251,7 +251,7 @@ mapAliases ({
   k9copy = throw "k9copy has been removed from nixpkgs, as there is no upstream activity"; # 2020-11-06
   julia_07 = throw "julia_07 is deprecated in favor of julia_10 LTS"; # added 2020-09-15
   julia_11 = throw "julia_11 is deprecated in favor of latest Julia version"; # added 2020-09-15
-  kdeconnect = kdeApplications.kdeconnect-kde; # added 2020-10-28
+  kdeconnect = plasma5Packages.kdeconnect-kde; # added 2020-10-28
   kdiff3-qt5 = kdiff3; # added 2017-02-18
   keepass-keefox = keepass-keepassrpc; # backwards compatibility alias, added 2018-02
   keepassx-community = keepassxc; # added 2017-11
@@ -808,8 +808,8 @@ mapAliases ({
   between mixed versions of qt. See:
   https://github.com/NixOS/nixpkgs/pull/101369 */
 
-  inherit (kdeFrameworks) breeze-icons oxygen-icons5;
-  inherit (kdeApplications)
+  inherit (plasma5Packages) breeze-icons oxygen-icons5;
+  inherit (plasma5Packages)
     akonadi akregator ark
     bomber bovo
     dolphin dragon
@@ -841,7 +841,7 @@ mapAliases ({
     spectacle
     yakuake
   ;
-  inherit (plasma5)
+  inherit (plasma5Packages)
     bluedevil breeze-gtk breeze-qt5 breeze-grub breeze-plymouth discover
     kactivitymanagerd kde-cli-tools kde-gtk-config kdeplasma-addons kgamma5
     kinfocenter kmenuedit kscreen kscreenlocker ksshaskpass ksysguard
@@ -850,7 +850,7 @@ mapAliases ({
     plasma-workspace-wallpapers polkit-kde-agent powerdevil sddm-kcm
     systemsettings xdg-desktop-portal-kde
   ;
-  inherit (plasma5.thirdParty)
+  inherit (plasma5Packages.thirdParty)
     plasma-applet-caffeine-plus
     kwin-dynamic-workspaces
     kwin-tiling

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19770,7 +19770,7 @@ in
   fira-mono = callPackage ../data/fonts/fira-mono { };
 
   flat-remix-icon-theme = callPackage ../data/icons/flat-remix-icon-theme {
-    inherit (kdeFrameworks) breeze-icons;
+    inherit (plasma5Packages) breeze-icons;
   };
 
   font-awesome_4 = (callPackage ../data/fonts/font-awesome-5 { }).v4;
@@ -19935,7 +19935,7 @@ in
   luculent = callPackage ../data/fonts/luculent { };
 
   luna-icons = callPackage ../data/icons/luna-icons {
-    inherit (kdeFrameworks) breeze-icons;
+    inherit (plasma5Packages) breeze-icons;
   };
 
   maia-icon-theme = libsForQt5.callPackage ../data/icons/maia-icon-theme { };
@@ -20070,11 +20070,11 @@ in
   paper-icon-theme = callPackage ../data/icons/paper-icon-theme { };
 
   papirus-icon-theme = callPackage ../data/icons/papirus-icon-theme {
-    inherit (kdeFrameworks) breeze-icons;
+    inherit (plasma5Packages) breeze-icons;
   };
 
   papirus-maia-icon-theme = callPackage ../data/icons/papirus-maia-icon-theme {
-    inherit (kdeFrameworks) breeze-icons;
+    inherit (plasma5Packages) breeze-icons;
   };
 
   papis = with python3Packages; toPythonApplication papis;
@@ -20106,7 +20106,7 @@ in
   pop-gtk-theme = callPackage ../data/themes/pop-gtk { };
 
   pop-icon-theme = callPackage ../data/icons/pop-icon-theme {
-    inherit (kdeFrameworks) breeze-icons;
+    inherit (plasma5Packages) breeze-icons;
   };
 
   posix_man_pages = callPackage ../data/documentation/man-pages-posix { };
@@ -20390,7 +20390,7 @@ in
   yaru-theme = callPackage ../data/themes/yaru {};
 
   zafiro-icons = callPackage ../data/icons/zafiro-icons {
-    inherit (kdeFrameworks) breeze-icons;
+    inherit (plasma5Packages) breeze-icons;
   };
 
   zeal = libsForQt514.callPackage ../data/documentation/zeal { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7594,7 +7594,7 @@ in
 
   sonata = callPackage ../applications/audio/sonata { };
 
-  soundkonverter = kdeApplications.callPackage ../applications/audio/soundkonverter {};
+  soundkonverter = libsForQt5.soundkonverter;
 
   sozu = callPackage ../servers/sozu { };
 
@@ -13920,15 +13920,7 @@ in
 
   judy = callPackage ../development/libraries/judy { };
 
-  kdeFrameworks =
-    let
-      mkFrameworks = import ../development/libraries/kde-frameworks;
-      attrs = {
-        inherit libsForQt5;
-        inherit lib fetchurl;
-      };
-    in
-      recurseIntoAttrs (makeOverridable mkFrameworks attrs);
+  inherit (libsForQt5) kdeFrameworks;
 
   keybinder = callPackage ../development/libraries/keybinder {
     automake = automake111x;
@@ -15825,214 +15817,26 @@ in
       inherit llvmPackages_5;
     });
 
-  libsForQt512 = recurseIntoAttrs (lib.makeScope qt512.newScope mkLibsForQt5);
+  libsForQt512 = recurseIntoAttrs (import ./qt5-packages.nix {
+    inherit lib pkgs;
+    qt5 = qt512;
+  });
 
-  libsForQt514 = recurseIntoAttrs (lib.makeScope qt514.newScope mkLibsForQt5);
+  libsForQt514 = recurseIntoAttrs (import ./qt5-packages.nix {
+    inherit lib pkgs;
+    qt5 = qt514;
+  });
 
-  libsForQt515 = recurseIntoAttrs (lib.makeScope qt515.newScope mkLibsForQt5);
+  libsForQt515 = recurseIntoAttrs (import ./qt5-packages.nix {
+    inherit lib pkgs;
+    qt5 = qt515;
+  });
 
   # TODO bump to 5.14 on darwin once it's not broken; see #95199
   qt5 =        if stdenv.hostPlatform.isDarwin then qt512 else qt515;
   libsForQt5 = if stdenv.hostPlatform.isDarwin then libsForQt512 else libsForQt515;
 
   qt5ct = libsForQt5.callPackage ../tools/misc/qt5ct { };
-
-  mkLibsForQt5 = self: with self; {
-
-    ### KDE FRAMEWORKS
-
-    inherit (kdeFrameworks.override { libsForQt5 = self; })
-      attica baloo bluez-qt kactivities kactivities-stats
-      karchive kauth kbookmarks kcmutils kcalendarcore kcodecs kcompletion kconfig
-      kconfigwidgets kcoreaddons kcrash kdav kdbusaddons kdeclarative kdelibs4support
-      kdesignerplugin kdnssd kemoticons kfilemetadata kglobalaccel kguiaddons
-      khtml ki18n kiconthemes kidletime kimageformats kio kitemmodels kitemviews
-      kjobwidgets kjs kjsembed kmediaplayer knewstuff knotifications
-      knotifyconfig kpackage kparts kpeople kplotting kpty kross krunner
-      kservice ktexteditor ktextwidgets kunitconversion kwallet kwayland
-      kwidgetsaddons kwindowsystem kxmlgui kxmlrpcclient modemmanager-qt
-      networkmanager-qt plasma-framework prison qqc2-desktop-style solid sonnet
-      syntax-highlighting syndication threadweaver kirigami2 kholidays kpurpose
-      kcontacts kquickcharts kdoctools kapidox kdesu kinit kded frameworkintegration
-      kdewebkit breeze-icons
-    ;
-
-    ### KDE PLASMA 5
-
-    inherit (plasma5.override { libsForQt5 = self; })
-      kdecoration khotkeys libkscreen libksysguard bluedevil
-      breeze-gtk breeze-qt5 breeze-grub breeze-plymouth discover kactivitymanagerd
-      kde-cli-tools kde-gtk-config kdeplasma-addons kgamma5 kinfocenter kmenuedit
-      kscreen kscreenlocker ksshaskpass ksysguard kwallet-pam kwayland-integration
-      kwin kwrited milou oxygen plasma-browser-integration plasma-desktop
-      plasma-integration plasma-nm plasma-pa plasma-thunderbolt plasma-vault plasma-workspace
-      plasma-workspace-wallpapers polkit-kde-agent powerdevil sddm-kcm
-      systemsettings xdg-desktop-portal-kde
-    ;
-
-    inherit ((plasma5.override { libsForQt5 = self; }).thirdParty)
-      plasma-applet-caffeine-plus kwin-dynamic-workspaces kwin-tiling krohnkite
-    ;
-
-    ### KDE APPLICATIONS
-
-    inherit (kdeApplications.override { libsForQt5 = self; })
-      libkdcraw libkexiv2 libkipi libkomparediff2 libksane libkcddb akonadi-contacts
-      akonadi-calendar akonadi-notes akonadi-search kaccounts-integration kidentitymanagement
-      kontactinterface kldap akonadi akregator ark bomber bovo dolphin dragon elisa ffmpegthumbs
-      filelight granatier gwenview k3b kaddressbook kalzium kapptemplate kapman kate katomic
-      kblackbox kblocks kbounce kcachegrind kcalc kcharselect kcolorchooser
-      kdenlive kdf kdialog kdiamond keditbookmarks kfind kfloppy kget kgpg khelpcenter
-      kig kigo killbots kitinerary kleopatra klettres klines kmag kmail kmines kmix kmplot
-      knavalbattle knetwalk knights kollision kolourpaint kompare konsole kontact korganizer
-      kpkpass krdc kreversi krfb kshisen ksquares ksystemlog kteatime ktimer ktouch kturtle
-      kwalletmanager kwave marble minuet okular picmi spectacle yakuake
-    ;
-
-    ### LIBRARIES
-
-    accounts-qt = callPackage ../development/libraries/accounts-qt { };
-
-    alkimia = callPackage ../development/libraries/alkimia { };
-
-    appstream-qt = callPackage ../development/libraries/appstream/qt.nix { };
-
-    dxflib = callPackage ../development/libraries/dxflib {};
-
-    drumstick = callPackage ../development/libraries/drumstick { };
-
-    fcitx-qt5 = callPackage ../tools/inputmethods/fcitx/fcitx-qt5.nix { };
-
-    fcitx5-qt = callPackage ../tools/inputmethods/fcitx5/fcitx5-qt.nix { };
-
-    qgpgme = callPackage ../development/libraries/gpgme { };
-
-    grantlee = callPackage ../development/libraries/grantlee/5 { };
-
-    qtcurve = callPackage ../data/themes/qtcurve {};
-
-    herqq = callPackage ../development/libraries/herqq { };
-
-    kdb = callPackage ../development/libraries/kdb { };
-
-    kde2-decoration = callPackage ../data/themes/kde2 { };
-
-    kdiagram = callPackage ../development/libraries/kdiagram { };
-
-    kdsoap = callPackage ../development/libraries/kdsoap { };
-
-    kf5gpgmepp = callPackage ../development/libraries/kf5gpgmepp { };
-
-    kproperty = callPackage ../development/libraries/kproperty { };
-
-    kpeoplevcard = callPackage ../development/libraries/kpeoplevcard { };
-
-    kreport = callPackage ../development/libraries/kreport { };
-
-    kquickimageedit = callPackage ../development/libraries/kquickimageedit { };
-
-    ldutils = callPackage ../development/libraries/ldutils { };
-
-    libcommuni = callPackage ../development/libraries/libcommuni { };
-
-    libdbusmenu = callPackage ../development/libraries/libdbusmenu-qt/qt-5.5.nix { };
-
-    libkeyfinder = callPackage ../development/libraries/libkeyfinder { };
-
-    libktorrent = callPackage ../development/libraries/libktorrent { };
-
-    liblastfm = callPackage ../development/libraries/liblastfm { };
-
-    libopenshot = callPackage ../applications/video/openshot-qt/libopenshot.nix { };
-
-    packagekit-qt = callPackage ../tools/package-management/packagekit/qt.nix { };
-
-    libopenshot-audio = callPackage ../applications/video/openshot-qt/libopenshot-audio.nix {
-      inherit (darwin.apple_sdk.frameworks) AGL Cocoa Foundation;
-    };
-
-    libqglviewer = callPackage ../development/libraries/libqglviewer {
-      inherit (darwin.apple_sdk.frameworks) AGL;
-    };
-
-    libqtav = callPackage ../development/libraries/libqtav { };
-
-    kpmcore = callPackage ../development/libraries/kpmcore { };
-
-    mlt = callPackage ../development/libraries/mlt/qt-5.nix { };
-
-    openbr = callPackage ../development/libraries/openbr { };
-
-    phonon = callPackage ../development/libraries/phonon { };
-
-    phonon-backend-gstreamer = callPackage ../development/libraries/phonon/backends/gstreamer.nix { };
-
-    phonon-backend-vlc = callPackage ../development/libraries/phonon/backends/vlc.nix { };
-
-    plasma-wayland-protocols = callPackage ../development/libraries/plasma-wayland-protocols { };
-
-    polkit-qt = callPackage ../development/libraries/polkit-qt-1/qt-5.nix { };
-
-    poppler = callPackage ../development/libraries/poppler {
-      lcms = lcms2;
-      qt5Support = true;
-      suffix = "qt5";
-    };
-
-    poppler_0_61 = callPackage ../development/libraries/poppler/0.61.nix {
-      lcms = lcms2;
-      qt5Support = true;
-      suffix = "qt5";
-    };
-
-    pulseaudio-qt = callPackage ../development/libraries/pulseaudio-qt { };
-
-    qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
-
-    qcsxcad = callPackage ../development/libraries/science/electronics/qcsxcad { };
-
-    qmltermwidget = callPackage ../development/libraries/qmltermwidget {
-      inherit (darwin.apple_sdk.libs) utmp;
-    };
-
-    qmlbox2d = callPackage ../development/libraries/qmlbox2d { };
-
-    qoauth = callPackage ../development/libraries/qoauth { };
-
-    qscintilla = callPackage ../development/libraries/qscintilla {
-      withQt5 = true;
-    };
-
-    qtutilities = callPackage ../development/libraries/qtutilities { };
-
-    qtinstaller = callPackage ../development/libraries/qtinstaller { };
-
-    qtkeychain = callPackage ../development/libraries/qtkeychain {
-      withQt5 = true;
-    };
-
-    qtpbfimageplugin = callPackage ../development/libraries/qtpbfimageplugin { };
-
-    qtstyleplugins = callPackage ../development/libraries/qtstyleplugins { };
-
-    qtstyleplugin-kvantum = callPackage ../development/libraries/qtstyleplugin-kvantum { };
-
-    quazip = callPackage ../development/libraries/quazip { };
-
-    qwt = callPackage ../development/libraries/qwt/6.nix { };
-
-    soqt = callPackage ../development/libraries/soqt { };
-
-    telepathy = callPackage ../development/libraries/telepathy/qt { };
-
-    qtwebkit-plugins = callPackage ../development/libraries/qtwebkit-plugins { };
-
-    # Not a library, but we do want it to be built for every qt version there
-    # is, to allow users to choose the right build if needed.
-    sddm = callPackage ../applications/display-managers/sddm { };
-
-    signond = callPackage ../development/libraries/signond {};
-  };
 
   qtEnv = qt5.env;
   qt5Full = qt5.full;
@@ -22640,15 +22444,7 @@ in
 
   kapow = libsForQt5.callPackage ../applications/misc/kapow { };
 
-  kdeApplications =
-    let
-      mkApplications = import ../applications/kde;
-      attrs = {
-        inherit libsForQt5;
-        inherit lib fetchurl;
-      };
-    in
-      recurseIntoAttrs (makeOverridable mkApplications attrs);
+  inherit (libsForQt514) kdeApplications;
 
   okteta = libsForQt5.callPackage ../applications/editors/okteta { };
 
@@ -26936,6 +26732,8 @@ in
 
   pantheon = recurseIntoAttrs (callPackage ../desktops/pantheon { });
 
+  inherit (libsForQt5) plasma5;
+
   plasma-applet-volumewin7mixer = libsForQt5.callPackage ../applications/misc/plasma-applet-volumewin7mixer { };
 
   inherit (callPackages ../applications/misc/redshift {
@@ -26957,22 +26755,6 @@ in
   xfce = recurseIntoAttrs (callPackage ../desktops/xfce { });
 
   xrandr-invert-colors = callPackage ../applications/misc/xrandr-invert-colors { };
-
-  ### DESKTOP ENVIRONMENTS / PLASMA 5
-
-  plasma5 =
-    let
-      mkPlasma5 = import ../desktops/plasma-5;
-      attrs = {
-        # ATTN: The Qt version used in the NixOS Plasma module must be updated
-        # whenever this changes!
-        inherit libsForQt5;
-        inherit lib fetchurl;
-        gconf = gnome2.GConf;
-        inherit gsettings-desktop-schemas;
-      };
-    in
-      recurseIntoAttrs (makeOverridable mkPlasma5 attrs);
 
   ### SCIENCE/CHEMISTY
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11510,7 +11510,7 @@ in
   };
 
   # Does not actually depend on Qt 5
-  inherit (kdeFrameworks) extra-cmake-modules;
+  inherit (plasma5Packages) extra-cmake-modules;
 
   coccinelle = callPackage ../development/tools/misc/coccinelle {
     ocamlPackages = ocaml-ng.ocamlPackages_4_05;
@@ -13920,8 +13920,6 @@ in
 
   judy = callPackage ../development/libraries/judy { };
 
-  inherit (libsForQt5) kdeFrameworks;
-
   keybinder = callPackage ../development/libraries/keybinder {
     automake = automake111x;
     lua = lua5_1;
@@ -15835,6 +15833,9 @@ in
   # TODO bump to 5.14 on darwin once it's not broken; see #95199
   qt5 =        if stdenv.hostPlatform.isDarwin then qt512 else qt515;
   libsForQt5 = if stdenv.hostPlatform.isDarwin then libsForQt512 else libsForQt515;
+
+  # plasma5Packages maps to the Qt5 packages set that is used to build the plasma5 desktop
+  plasma5Packages = libsForQt515;
 
   qt5ct = libsForQt5.callPackage ../tools/misc/qt5ct { };
 
@@ -22444,8 +22445,6 @@ in
 
   kapow = libsForQt5.callPackage ../applications/misc/kapow { };
 
-  inherit (libsForQt514) kdeApplications;
-
   okteta = libsForQt5.callPackage ../applications/editors/okteta { };
 
   k4dirstat = libsForQt5.callPackage ../applications/misc/k4dirstat { };
@@ -26731,8 +26730,6 @@ in
   mate = recurseIntoAttrs (callPackage ../desktops/mate { });
 
   pantheon = recurseIntoAttrs (callPackage ../desktops/pantheon { });
-
-  inherit (libsForQt5) plasma5;
 
   plasma-applet-volumewin7mixer = libsForQt5.callPackage ../applications/misc/plasma-applet-volumewin7mixer { };
 

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -1,0 +1,194 @@
+
+# Qt libraries set.
+#
+# Attributes in this file are packages requiring Qt and will be made available
+# for every Qt version. Qt applications are called from `all-packages.nix` via
+# this file.
+
+
+{ lib
+, pkgs
+, qt5
+}:
+
+(lib.makeScope pkgs.newScope ( self:
+
+let
+  libsForQt5 = self;
+  callPackage = self.callPackage;
+
+  kdeFrameworks = let
+    mkFrameworks = import ../development/libraries/kde-frameworks;
+    attrs = {
+      inherit libsForQt5;
+      inherit (pkgs) lib fetchurl;
+    };
+  in (lib.makeOverridable mkFrameworks attrs);
+
+  plasma5 = let
+    mkPlasma5 = import ../desktops/plasma-5;
+    attrs = {
+      inherit libsForQt5;
+      inherit (pkgs) lib fetchurl;
+      gconf = pkgs.gnome2.GConf;
+      inherit (pkgs) gsettings-desktop-schemas;
+    };
+  in (lib.makeOverridable mkPlasma5 attrs);
+
+  kdeApplications = let
+    mkApplications = import ../applications/kde;
+    attrs = {
+      inherit libsForQt5;
+      inherit (pkgs) lib fetchurl;
+    };
+  in (lib.makeOverridable mkApplications attrs);
+
+in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeApplications // qt5 // {
+
+  inherit kdeFrameworks plasma5 kdeApplications qt5;
+
+  ### LIBRARIES
+
+  accounts-qt = callPackage ../development/libraries/accounts-qt { };
+
+  alkimia = callPackage ../development/libraries/alkimia { };
+
+  appstream-qt = callPackage ../development/libraries/appstream/qt.nix { };
+
+  dxflib = callPackage ../development/libraries/dxflib {};
+
+  drumstick = callPackage ../development/libraries/drumstick { };
+
+  fcitx-qt5 = callPackage ../tools/inputmethods/fcitx/fcitx-qt5.nix { };
+
+  qgpgme = callPackage ../development/libraries/gpgme { };
+
+  grantlee = callPackage ../development/libraries/grantlee/5 { };
+
+  qtcurve = callPackage ../data/themes/qtcurve {};
+
+  herqq = callPackage ../development/libraries/herqq { };
+
+  kdb = callPackage ../development/libraries/kdb { };
+
+  kde2-decoration = callPackage ../data/themes/kde2 { };
+
+  kdiagram = callPackage ../development/libraries/kdiagram { };
+
+  kdsoap = callPackage ../development/libraries/kdsoap { };
+
+  kf5gpgmepp = callPackage ../development/libraries/kf5gpgmepp { };
+
+  kproperty = callPackage ../development/libraries/kproperty { };
+
+  kpeoplevcard = callPackage ../development/libraries/kpeoplevcard { };
+
+  kreport = callPackage ../development/libraries/kreport { };
+
+  kquickimageedit = callPackage ../development/libraries/kquickimageedit { };
+
+  ldutils = callPackage ../development/libraries/ldutils { };
+
+  libcommuni = callPackage ../development/libraries/libcommuni { };
+
+  libdbusmenu = callPackage ../development/libraries/libdbusmenu-qt/qt-5.5.nix { };
+
+  libkeyfinder = callPackage ../development/libraries/libkeyfinder { };
+
+  libktorrent = callPackage ../development/libraries/libktorrent { };
+
+  liblastfm = callPackage ../development/libraries/liblastfm { };
+
+  libopenshot = callPackage ../applications/video/openshot-qt/libopenshot.nix { };
+
+  packagekit-qt = callPackage ../tools/package-management/packagekit/qt.nix { };
+
+  libopenshot-audio = callPackage ../applications/video/openshot-qt/libopenshot-audio.nix {
+    inherit (pkgs.darwin.apple_sdk.frameworks) AGL Cocoa Foundation;
+  };
+
+  libqglviewer = callPackage ../development/libraries/libqglviewer {
+    inherit (pkgs.darwin.apple_sdk.frameworks) AGL;
+  };
+
+  libqtav = callPackage ../development/libraries/libqtav { };
+
+  kpmcore = callPackage ../development/libraries/kpmcore { };
+
+  mlt = callPackage ../development/libraries/mlt/qt-5.nix { };
+
+  openbr = callPackage ../development/libraries/openbr { };
+
+  phonon = callPackage ../development/libraries/phonon { };
+
+  phonon-backend-gstreamer = callPackage ../development/libraries/phonon/backends/gstreamer.nix { };
+
+  phonon-backend-vlc = callPackage ../development/libraries/phonon/backends/vlc.nix { };
+
+  plasma-wayland-protocols = callPackage ../development/libraries/plasma-wayland-protocols { };
+
+  polkit-qt = callPackage ../development/libraries/polkit-qt-1/qt-5.nix { };
+
+  poppler = callPackage ../development/libraries/poppler {
+    lcms = pkgs.lcms2;
+    qt5Support = true;
+    suffix = "qt5";
+  };
+
+  poppler_0_61 = callPackage ../development/libraries/poppler/0.61.nix {
+    lcms = pkgs.lcms2;
+    qt5Support = true;
+    suffix = "qt5";
+  };
+
+  pulseaudio-qt = callPackage ../development/libraries/pulseaudio-qt { };
+
+  qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
+
+  qcsxcad = callPackage ../development/libraries/science/electronics/qcsxcad { };
+
+  qmltermwidget = callPackage ../development/libraries/qmltermwidget {
+    inherit (pkgs.darwin.apple_sdk.libs) utmp;
+  };
+
+  qmlbox2d = callPackage ../development/libraries/qmlbox2d { };
+
+  qoauth = callPackage ../development/libraries/qoauth { };
+
+  qscintilla = callPackage ../development/libraries/qscintilla {
+    withQt5 = true;
+  };
+
+  qtutilities = callPackage ../development/libraries/qtutilities { };
+
+  qtinstaller = callPackage ../development/libraries/qtinstaller { };
+
+  qtkeychain = callPackage ../development/libraries/qtkeychain {
+    withQt5 = true;
+  };
+
+  qtpbfimageplugin = callPackage ../development/libraries/qtpbfimageplugin { };
+
+  qtstyleplugins = callPackage ../development/libraries/qtstyleplugins { };
+
+  qtstyleplugin-kvantum = callPackage ../development/libraries/qtstyleplugin-kvantum { };
+
+  quazip = callPackage ../development/libraries/quazip { };
+
+  qwt = callPackage ../development/libraries/qwt/6.nix { };
+
+  soqt = callPackage ../development/libraries/soqt { };
+
+  telepathy = callPackage ../development/libraries/telepathy/qt { };
+
+  qtwebkit-plugins = callPackage ../development/libraries/qtwebkit-plugins { };
+
+  # Not a library, but we do want it to be built for every qt version there
+  # is, to allow users to choose the right build if needed.
+  sddm = callPackage ../applications/display-managers/sddm { };
+
+  signond = callPackage ../development/libraries/signond {};
+
+  soundkonverter = callPackage ../applications/audio/soundkonverter {};
+
+})))


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Reduce the chance of mixing Qt versions by having Qt-based libraries in a separate package set.

Builds upon https://github.com/NixOS/nixpkgs/pull/101369.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


## To do
- [ ] move `callPackage` into `qt-packages.nix`
- [ ] consider https://github.com/NixOS/nixpkgs/pull/105374 for cross-compilation. I do think all the `makeScope` usage for Qt and such itself is going to make this difficult
- [x] update docs
- [ ] rename `libsForQt5`




