### PR TITLE
[WIP] fhs-userenv-bubblewrap: Support ld.so.conf/cache

### DIFF
--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -64,10 +64,14 @@ let
     for i in ${env}/*; do
       path="/''${i##*/}"
       if [[ $path == '/etc' ]]; then
-        continue
+        :
+      elif [[ -L $i ]]; then
+        symlinks="$symlinks --symlink $(readlink $i) $path"
+        blacklist="$blacklist $path"
+      else
+        ro_mounts="$ro_mounts --ro-bind $i $path"
+        blacklist="$blacklist $path"
       fi
-      ro_mounts="$ro_mounts --ro-bind $i $path"
-      blacklist="$blacklist $path"
     done
 
     if [[ -d ${env}/etc ]]; then
@@ -97,6 +101,7 @@ let
       --ro-bind /nix /nix \
       ${etcBindFlags} \
       $ro_mounts \
+      $symlinks \
       "''${auto_mounts[@]}" \
       ${init runScript}/bin/${name}-init ${initArgs}
   '';

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, runCommandLocal, writeShellScriptBin, stdenv, coreutils, bubblewrap }:
+{ callPackage, runCommandLocal, writeShellScriptBin, stdenv, glibc, coreutils, bubblewrap }:
 
 let buildFHSEnv = callPackage ./env.nix { }; in
 
@@ -53,8 +53,27 @@ let
   in concatStringsSep " \\\n  "
   (map (file: "--ro-bind-try /etc/${file} /etc/${file}") files);
 
+  # Create this on the fly instead of linking from /nix
+  # The container might have to modify it and re-run ldconfig if there are
+  # issues running some binary with LD_LIBRARY_PATH
+  createLdConfCache = ''
+    cat > /etc/ld.so.conf <<EOF
+    /lib
+    /lib/x86_64-linux-gnu
+    /lib64
+    /usr/lib
+    /usr/lib/x86_64-linux-gnu
+    /usr/lib64
+    /lib/i386-linux-gnu
+    /lib32
+    /usr/lib/i386-linux-gnu
+    /usr/lib32
+    EOF
+    ldconfig &> /dev/null
+  '';
   init = run: writeShellScriptBin "${name}-init" ''
     source /etc/profile
+    ${createLdConfCache}
     exec ${run} "$@"
   '';
 
@@ -99,6 +118,11 @@ let
       --share-net \
       --die-with-parent \
       --ro-bind /nix /nix \
+      --tmpfs ${glibc}/etc \
+      --symlink /etc/ld.so.conf ${glibc}/etc/ld.so.conf \
+      --symlink /etc/ld.so.cache ${glibc}/etc/ld.so.cache \
+      --ro-bind ${glibc}/etc/rpc ${glibc}/etc/rpc \
+      --remount-ro ${glibc}/etc \
       ${etcBindFlags} \
       $ro_mounts \
       $symlinks \


### PR DESCRIPTION
##### Motivation for this change

This is an effort to fix compatibility with the new steam runtime. See also #100655

There are currently 2 parts to this:

1. Preserve the symlink structure that is created for the FHS environment when launching the bwrap container (`bin` --> `usr/bin`, ...). This is to allow things like bind-mounting another `/usr` inside to work like they would on another distribution with a "usr-merge" implemented and also overwrite the things in `/bin`.
2. Create the setup some symlinks to allow `/etc/ld.so.conf` and `/etc/ld.so.cache` to function with our glibc. This should make our current setting of `LD_LIBRARY_PATH` obsolete as well and improves compatibility e.g. with games that incorrectly overwrite that instead of appending to it.

There is still a bit more testing needed until the linked issue is fully resolved. However as far as I can currently tell these changes are all that is necessarily NixOS specific.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
