### PR TITLE
zoxide: 0.4.3 -> 0.5.0

### DIFF
--- a/pkgs/tools/misc/zoxide/default.nix
+++ b/pkgs/tools/misc/zoxide/default.nix
@@ -1,11 +1,20 @@
 { lib
+, stdenv
 , fetchFromGitHub
 , rustPlatform
 , withFzf ? true
 , fzf
+
+  # checkInputs
+, fish
+, powershell
+, shellcheck
+, shfmt
+, xonsh
+, zsh
 }:
 let
-  version = "0.4.3";
+  version = "0.5.0";
 in
 rustPlatform.buildRustPackage {
   pname = "zoxide";
@@ -15,15 +24,32 @@ rustPlatform.buildRustPackage {
     owner = "ajeetdsouza";
     repo = "zoxide";
     rev = "v${version}";
-    sha256 = "1ghdal6pqkp56rqawhj26ch1x4cvnjj032xz3626aiddqgn134zj";
+    sha256 = "143lh94mw31pm9q7ib63h2k842g3h222mdabhf25hpb19lka2w5y";
   };
+
+  # tests are broken on darwin
+  doCheck = !stdenv.isDarwin;
+
+  # fish needs a writable HOME for whatever reason
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  checkInputs = [
+    fish
+    powershell
+    shellcheck
+    shfmt
+    xonsh
+    zsh
+  ];
 
   postPatch = lib.optionalString withFzf ''
     substituteInPlace src/fzf.rs \
       --replace '"fzf"' '"${fzf}/bin/fzf"'
   '';
 
-  cargoSha256 = "0klnjmda77bq9i9f0rz48jzaw4rcf7hafcjjpb0i570d7hlxnwsr";
+  cargoSha256 = "05mp101yk1zkjj1gwbkldizq6f9f8089gqgvq42c4ngq88pc7v9a";
 
   meta = with lib; {
     description = "A fast cd command that learns your habits";


### PR DESCRIPTION
https://github.com/ajeetdsouza/zoxide/compare/v0.4.3...v0.5.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
