### PR TITLE
modules/security/pam.nix: add enableSSHAgentAuthNoHome

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -152,6 +152,15 @@ let
         '';
       };
 
+      sshAgentAuthPaths = mkOption {
+        default = ["~/.ssh/authorized_keys" "~/.ssh/authorized_keys2" "/etc/ssh/authorized_keys.d/%u"];
+        example = ["/etc/ssh/authorized_keys.d/%u"];
+        type = types.listOf types.str;
+        description = ''
+          Paths to search for authorized keys for sshAgentAuth.
+        '';
+      };
+
       duoSecurity = {
         enable = mkOption {
           default = false;
@@ -395,8 +404,8 @@ let
               "auth required pam_wheel.so use_uid"}
           ${optionalString cfg.logFailures
               "auth required pam_tally.so"}
-          ${optionalString (config.security.pam.enableSSHAgentAuth && cfg.sshAgentAuth)
-              "auth sufficient ${pkgs.pam_ssh_agent_auth}/libexec/pam_ssh_agent_auth.so file=~/.ssh/authorized_keys:~/.ssh/authorized_keys2:/etc/ssh/authorized_keys.d/%u"}
+          ${optionalString cfg.sshAgentAuth
+              "auth sufficient ${pkgs.pam_ssh_agent_auth}/libexec/pam_ssh_agent_auth.so file=${lib.concatStringsSep ":" cfg.sshAgentAuthPaths}"}
           ${optionalString cfg.fprintAuth
               "auth sufficient ${pkgs.fprintd}/lib/security/pam_fprintd.so"}
           ${let p11 = config.security.pam.p11; in optionalString cfg.p11Auth

--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -223,7 +223,7 @@ in
 
     environment.systemPackages = [ sudo ];
 
-    security.pam.services.sudo = { sshAgentAuth = true; };
+    security.pam.services.sudo = lib.optionalAttrs config.security.pam.enableSSHAgentAuth { sshAgentAuth = true; };
 
     environment.etc.sudoers =
       { source =


### PR DESCRIPTION
This variant of the old sshAgentAuth is useful, if sudo is
being used by authenticating as the user and not
as root as is the default as user could normally just
edit the ~/.ssh/authorized_keys to get access as root.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Make pam_ssh_agent_auth useful for sudo default settings

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
