### PR TITLE
Make gdk-pixbuf support avif

### DIFF
--- a/pkgs/development/libraries/libavif/default.nix
+++ b/pkgs/development/libraries/libavif/default.nix
@@ -7,6 +7,7 @@
 , libpng
 , libjpeg
 , dav1d
+, gdk-pixbuf
 }:
 
 stdenv.mkDerivation rec {
@@ -22,11 +23,14 @@ stdenv.mkDerivation rec {
 
   # reco: encode libaom slowest but best, decode dav1d fastest
 
+  PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_MODULEDIR = "${placeholder "out"}/${gdk-pixbuf.moduleDir}";
+
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
     "-DAVIF_CODEC_AOM=ON"
     "-DAVIF_CODEC_DAV1D=ON"
     "-DAVIF_BUILD_APPS=ON"
+    "-DAVIF_BUILD_GDK_PIXBUF=ON"
   ];
 
   nativeBuildInputs = [
@@ -35,6 +39,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    gdk-pixbuf
     libaom
     zlib
     libpng

--- a/pkgs/development/libraries/libavif/default.nix
+++ b/pkgs/development/libraries/libavif/default.nix
@@ -47,6 +47,11 @@ stdenv.mkDerivation rec {
     dav1d
   ];
 
+  postInstall = ''
+    mkdir -p $out/share/thumbnailers
+    cat ${./thumbnailer} | sed "s|@bindir@|${gdk-pixbuf}/bin|g" > $out/share/thumbnailers/libavif.thumbnailer
+  '';
+
   meta = with stdenv.lib; {
     description  = "C implementation of the AV1 Image File Format";
     longDescription = ''

--- a/pkgs/development/libraries/libavif/default.nix
+++ b/pkgs/development/libraries/libavif/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   pname = "libavif";
   version = "0.8.1";
 
+  outputs = [ "out" "gdkPixbufLoader" ];
+
   src = fetchFromGitHub {
     owner = "AOMediaCodec";
     repo = pname;
@@ -23,7 +25,7 @@ stdenv.mkDerivation rec {
 
   # reco: encode libaom slowest but best, decode dav1d fastest
 
-  PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_MODULEDIR = "${placeholder "out"}/${gdk-pixbuf.moduleDir}";
+  PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_MODULEDIR = "${placeholder "gdkPixbufLoader"}/${gdk-pixbuf.moduleDir}";
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
@@ -48,8 +50,8 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = ''
-    mkdir -p $out/share/thumbnailers
-    cat ${./thumbnailer} | sed "s|@bindir@|${gdk-pixbuf}/bin|g" > $out/share/thumbnailers/libavif.thumbnailer
+    mkdir -p ${placeholder "gdkPixbufLoader"}/share/thumbnailers
+    substitute "${./thumbnailer}" "${placeholder "gdkPixbufLoader"}/share/thumbnailers/libavif.thumbnailer" --subst-var-by bindir "${gdk-pixbuf}/bin"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libavif/thumbnailer
+++ b/pkgs/development/libraries/libavif/thumbnailer
@@ -1,0 +1,5 @@
+[Thumbnailer Entry]
+TryExec=@bindir@/gdk-pixbuf-thumbnailer
+Exec=@bindir@/gdk-pixbuf-thumbnailer -s %s %u %o
+MimeType=image/avif;image/avif-sequence;
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Staying up-to-date with technical progress

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
