### PR TITLE
doxygen: 1.8.19 -> 1.8.20

### DIFF
--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -1,15 +1,14 @@
-{ stdenv, cmake, fetchurl, python3, flex, bison, qt4, CoreServices, libiconv }:
+{ stdenv, cmake, fetchFromGitHub, python3, flex, bison, qt5, CoreServices, libiconv }:
 
 stdenv.mkDerivation rec {
+  pname = "doxygen";
+  version = "1.8.20";
 
-  name = "doxygen-1.8.19";
-
-  src = fetchurl {
-    urls = [
-      "mirror://sourceforge/doxygen/${name}.src.tar.gz" # faster, with https, etc.
-      "http://doxygen.nl/files/${name}.src.tar.gz"
-    ];
-    sha256 = "1lvqfw2yzba588c5ggl8yhw7aw4xkk44mrghsd9yqlajc48x25dc";
+  src = fetchFromGitHub {
+    owner = "doxygen";
+    repo = "doxygen";
+    rev = "Release_${stdenv.lib.replaceStrings [ "." ] [ "_" ] version}";
+    sha256 = "17chvi3i80rj4750smpizf562xjzd2xcv5rfyh997pyvc1zbq5rh";
   };
 
   nativeBuildInputs = [
@@ -20,19 +19,18 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs =
-       stdenv.lib.optional (qt4 != null) qt4
+       stdenv.lib.optionals (qt5 != null) (with qt5; [ qtbase wrapQtAppsHook ])
     ++ stdenv.lib.optional stdenv.isSunOS libiconv
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices libiconv ];
 
   cmakeFlags =
     [ "-DICONV_INCLUDE_DIR=${libiconv}/include" ] ++
-    stdenv.lib.optional (qt4 != null) "-Dbuild_wizard=YES";
+    stdenv.lib.optional (qt5 != null) "-Dbuild_wizard=YES";
 
   NIX_CFLAGS_COMPILE =
     stdenv.lib.optionalString stdenv.isDarwin "-mmacosx-version-min=10.9";
 
-  enableParallelBuilding = true;
-  doCheck = false; # fails
+  enableParallelBuilding = false;
 
   meta = {
     license = stdenv.lib.licenses.gpl2Plus;
@@ -47,6 +45,6 @@ stdenv.mkDerivation rec {
       manual (in LaTeX) from a set of documented source files.
     '';
 
-    platforms = if qt4 != null then stdenv.lib.platforms.linux else stdenv.lib.platforms.unix;
+    platforms = if qt5 != null then stdenv.lib.platforms.linux else stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11024,11 +11024,11 @@ in
   dot2tex = with python3.pkgs; toPythonApplication dot2tex;
 
   doxygen = callPackage ../development/tools/documentation/doxygen {
-    qt4 = null;
+    qt5 = null;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
-  doxygen_gui = lowPrio (doxygen.override { inherit qt4; });
+  doxygen_gui = lowPrio (doxygen.override { inherit qt5; });
 
   drake = callPackage ../development/tools/build-managers/drake { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Replace #100881

That was against master, plus I took the chance to make some more changes.
1. move doxygen_gui to qt5
2. modernize the expression a bit
3. disable enableParallel, since it reproducably failed on my dual-socket Xeon machine

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NeQuissimus