### PR TITLE
nixos/jitsi-meet: add nat configuration in the documentation

### DIFF
--- a/nixos/modules/services/web-apps/jitsi-meet.xml
+++ b/nixos/modules/services/web-apps/jitsi-meet.xml
@@ -44,7 +44,14 @@
       SHOW_WATERMARK_FOR_GUESTS = false;
     };
   };
-  <link linkend="opt-services.jitsi-videobridge.openFirewall">services.jitsi-videobridge.openFirewall</link> = true;
+  services.jitsi-videobridge = {
+    <link linkend="opt-services.jitsi-videobridge.openFirewall">openFirewall</link> = true;
+    # The following is necessary if the server is behind a NAT
+    nat = {
+      <link linkend="opt-services.jitsi-videobridge.nat.localAddress">localAddress</link> = "192.168.0.23";
+      <link linkend="opt-services.jitsi-videobridge.nat.publicAddress">publicAddress</link> = "1.1.1.1";
+    };
+  };
   <link linkend="opt-networking.firewall.allowedTCPPorts">networking.firewall.allowedTCPPorts</link> = [ 80 443 ];
   <link linkend="opt-security.acme.email">security.acme.email</link> = "me@example.com";
   <link linkend="opt-security.acme.acceptTerms">security.acme.acceptTerms</link> = true;


### PR DESCRIPTION
The localAddress and publicAddress configuration is required when jitsi meet is run behind a NAT: https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-manual#running-behind-nat. I think it would be a good idea to add it to the manual, since jitsi meet won't work for many without those settings.
This adds example nat settings to the second example in the jitsi meet doc.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
