### PR TITLE
[20.09] python-miio: fix

### DIFF
--- a/pkgs/development/python-modules/python-miio/default.nix
+++ b/pkgs/development/python-modules/python-miio/default.nix
@@ -4,14 +4,18 @@
 , appdirs
 , click
 , construct
+, croniter
 , cryptography
+, importlib-metadata
 , pytest
+, pytest-mock
 , zeroconf
 , attrs
 , pytz
 , tqdm
 , netifaces
 }:
+
 
 buildPythonPackage rec {
   pname = "python-miio";
@@ -22,8 +26,17 @@ buildPythonPackage rec {
     sha256 = "3be5275b569844dfa267c80a1e23dc0957411dd501cae0ed3cccf43467031ceb";
   };
 
-  checkInputs = [ pytest ];
-  propagatedBuildInputs = [ appdirs click construct cryptography zeroconf attrs pytz tqdm netifaces ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace  "zeroconf>=0.25.1,<0.26.0" "zeroconf"
+    substituteInPlace setup.py \
+      --replace  "pytz>=2019.3,<2020.0" "pytz"
+    substituteInPlace setup.py \
+      --replace  "cryptography>=2.9,<3.0" "cryptography"
+    '';
+
+  checkInputs = [ pytest pytest-mock];
+  propagatedBuildInputs = [ appdirs click construct croniter cryptography importlib-metadata zeroconf attrs pytz tqdm netifaces ];
 
   checkPhase = ''
     pytest

--- a/pkgs/development/python-modules/python-miio/default.nix
+++ b/pkgs/development/python-modules/python-miio/default.nix
@@ -43,7 +43,6 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    broken = true;
     description = "Python library for interfacing with Xiaomi smart appliances";
     homepage = "https://github.com/rytilahti/python-miio";
     license = licenses.gpl3;


### PR DESCRIPTION
Backport of #102183. 

###### Motivation for this change

Fix the python-miio package for the 20.09 relase as well.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
