### PR TITLE
ocamlPackages.mirage-profile: init at 0.9.1

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-profile/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-profile/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchurl, buildDunePackage
+, ppx_cstruct
+, cstruct, lwt
+}:
+
+buildDunePackage rec {
+  pname = "mirage-profile";
+  version = "0.9.1";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-profile/releases/download/v${version}/mirage-profile-v${version}.tbz";
+    sha256 = "0lh3591ad4v7nxpd410b75idmgdq668mqdilvkg4avrwqw1wzdib";
+  };
+
+  buildInputs = [ ppx_cstruct ];
+  propagatedBuildInputs = [ cstruct lwt ];
+
+  meta = {
+    description = "Collect runtime profiling information in CTF format";
+    homepage = "https://github.com/mirage/mirage-profile";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage-profile/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-profile/default.nix
@@ -17,10 +17,10 @@ buildDunePackage rec {
   buildInputs = [ ppx_cstruct ];
   propagatedBuildInputs = [ cstruct lwt ];
 
-  meta = {
+  meta = with lib; {
     description = "Collect runtime profiling information in CTF format";
     homepage = "https://github.com/mirage/mirage-profile";
-    license = lib.licenses.bsd2;
-    maintainers = [ lib.maintainers.vbgl ];
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ vbgl ];
   };
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -569,6 +569,8 @@ let
 
     mirage-net = callPackage ../development/ocaml-modules/mirage-net { };
 
+    mirage-profile = callPackage ../development/ocaml-modules/mirage-profile { };
+
     mirage-protocols = callPackage ../development/ocaml-modules/mirage-protocols { };
 
     mirage-random = callPackage ../development/ocaml-modules/mirage-random { };


### PR DESCRIPTION
###### Motivation for this change

#23955

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
