### PR TITLE
exim: unconditionally build with dsearch lookups enabled

### DIFF
--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
       s:^# \(RM_COMMAND\)=.*:\1=${coreutils}/bin/rm:
       s:^# \(TOUCH_COMMAND\)=.*:\1=${coreutils}/bin/touch:
       s:^# \(PERL_COMMAND\)=.*:\1=${perl}/bin/perl:
+      s:^# \(LOOKUP_DSEARCH=yes\)$:\1:
       ${stdenv.lib.optionalString enableLDAP ''
         s:^# \(LDAP_LIB_TYPE=OPENLDAP2\)$:\1:
         s:^# \(LOOKUP_LDAP=yes\)$:\1:


### PR DESCRIPTION
###### Motivation for this change

dsearch is required to do untainted lookups in directories. There's no reason not to build it in and it's a standard feature in other distributions. While it's been there forever the security changes around tainted inputs make its availability crucial.

Before:

```
$ nix-env -iA nixpkgs.exim
installing 'exim-4.94'
$ exim -C /dev/null -be '${lookup {passwd} dsearch {/etc}}' 
Failed: unknown lookup type "dsearch"
```

After:

```
/nix/store/wkyzw58lwlm7n72f93fph8fal39kiw6a-exim-4.94$ bin/exim -C /dev/null -be '${lookup {passwd} dsearch {/etc}}' 
passwd
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS

    *NOTE:* Tested using a local override instead of the real deal:

    ```
    exim = pkgs.exim.overrideDerivation (oldAttrs: {
      preBuild = ''
        ${oldAttrs.preBuild}
        echo "LOOKUP_DSEARCH=yes" >> Local/Makefile
      '';
    });
    ```

   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
