### PR TITLE
pythonPackages.pip: make reproducible

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
@@ -12,7 +12,7 @@ pipInstallPhase() {
 
     pushd dist || return 1
     mkdir tmpbuild
-    NIX_PIP_INSTALL_TMPDIR=tmpbuild @pythonInterpreter@ -m pip install ./*.whl --no-index --prefix="$out" --no-cache $pipInstallFlags
+    @pythonInterpreter@ -m pip install ./*.whl --no-index --prefix="$out" --no-cache $pipInstallFlags
     rm -rf tmpbuild
     popd || return 1
 

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
+    # Apply the pip reproducible patch
+    pushd "${pip.src.name}"
+      patch -p1 < ${../pip/reproducible.patch}
+    popd
+
     mkdir -p $out/bin
   '';
 

--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   };
 
   # Remove when solved https://github.com/NixOS/nixpkgs/issues/81441
-  # Also update pkgs/development/interpreters/python/hooks/pip-install-hook.sh accordingly
+  # See also https://github.com/pypa/pip/issues/7808
   patches = [ ./reproducible.patch ];
 
   nativeBuildInputs = [ bootstrapped-pip ];

--- a/pkgs/development/python-modules/pip/reproducible.patch
+++ b/pkgs/development/python-modules/pip/reproducible.patch
@@ -1,13 +1,25 @@
-diff --git a/src/pip/_internal/operations/install/wheel.py b/src/pip/_internal/operations/install/wheel.py
-index e7315ee4..4e36b03d 100644
---- a/src/pip/_internal/operations/install/wheel.py
-+++ b/src/pip/_internal/operations/install/wheel.py
-@@ -615,6 +615,8 @@ def install_wheel(
-     direct_url=None,  # type: Optional[DirectUrl]
- ):
-     # type: (...) -> None
-+    _temp_dir_for_testing = (
-+        _temp_dir_for_testing or os.environ.get("NIX_PIP_INSTALL_TMPDIR"))
-     with TempDirectory(
-         path=_temp_dir_for_testing, kind="unpacked-wheel"
-     ) as unpacked_dir, ZipFile(wheel_path, allowZip64=True) as z:
+diff --git a/src/pip/_internal/utils/temp_dir.py b/src/pip/_internal/utils/temp_dir.py
+index 201ba6d98..f1569fecd 100644
+--- a/src/pip/_internal/utils/temp_dir.py
++++ b/src/pip/_internal/utils/temp_dir.py
+@@ -3,6 +3,7 @@ from __future__ import absolute_import
+ import errno
+ import itertools
+ import logging
++import os
+ import os.path
+ import tempfile
+ from contextlib import contextmanager
+@@ -181,6 +182,11 @@ class TempDirectory(object):
+         # symlinked to another directory.  This tends to confuse build
+         # scripts, so we canonicalize the path by traversing potential
+         # symlinks here.
++        if "SOURCE_DATE_EPOCH" in os.environ:
++            path = os.path.join(tempfile.gettempdir(), "pip-{}-immobile".format(kind))
++            os.mkdir(path)
++            return path
++
+         path = os.path.realpath(
+             tempfile.mkdtemp(prefix="pip-{}-".format(kind))
+         )
+


### PR DESCRIPTION
The previous attempt wasn't covering all of the bases. It relied on
invoking that pip-install-hook, and didn't apply to pip itself.

The core issue is that the generated .pyc files embed some of the
temporary paths, which are randomly generated. See
https://r13y.com/diff/bf8c3ca3148ebff9ecf41f294cc60b9f209c006d49699e356969ff32d736f1c6-8806a7cca91fdd300e48736bfcd57c4d0b54c1cc2fd61609f35143170862b59c.html

In this new attempt, the approach is to patch the TempFile
implementation directly, so that it creates stable temporary
directories. We also assume that if SOURCE_DATE_EPOCH is set, we are in
a scenario where reproducible builds are desirable and enter that
branch.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
