### PR TITLE
nixos/murmur: add iniPath, config, user, group options

### DIFF
--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -71,6 +71,18 @@ in
         description = "-ini argument to pass to murmurd";
       };
 
+      user = mkOption {
+        type = types.str;
+        default = "murmur";
+        description = "User to run murmurd as";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "";
+        description = "Group to run murmurd as";
+      };
+
       autobanAttempts = mkOption {
         type = types.int;
         default = 10;
@@ -314,8 +326,8 @@ in
         Restart = "always";
         RuntimeDirectory = "murmur";
         RuntimeDirectoryMode = "0700";
-        User = "murmur";
-        Group = "murmur";
+        User      = cfg.user;
+        Group     = cfg.group;
         ExecStart = ''
           ${pkgs.murmur}/bin/murmurd -ini \
             ${if cfg.iniPath != "" then cfg.iniPath else configFile}

--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -67,7 +67,7 @@ in
 
       iniPath = mkOption {
         type = types.str;
-        default = "/run/murmur/murmur.ini";
+        default = "/run/murmur/murmurd.ini";
         description = "-ini argument to pass to murmurd";
       };
 

--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -67,7 +67,7 @@ in
 
       iniPath = mkOption {
         type = types.str;
-        default = "";
+        default = "/run/murmur/murmur.ini";
         description = "-ini argument to pass to murmurd";
       };
 
@@ -79,7 +79,7 @@ in
 
       group = mkOption {
         type = types.str;
-        default = "";
+        default = "murmur";
         description = "Group to run murmurd as";
       };
 
@@ -329,8 +329,7 @@ in
         User      = cfg.user;
         Group     = cfg.group;
         ExecStart = ''
-          ${pkgs.murmur}/bin/murmurd -ini \
-            ${if cfg.iniPath != "" then cfg.iniPath else configFile}
+          ${pkgs.murmur}/bin/murmurd -ini ${cfg.iniPath}
         '';
       };
     };

--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -59,6 +59,18 @@ in
         description = "If enabled, start the Murmur Mumble server.";
       };
 
+      config = mkOption {
+        type = types.str;
+        default = lib.readFile configFile;
+        description = "Contents of the murmur.ini config file";
+      };
+
+      iniPath = mkOption {
+        type = types.str;
+        default = "";
+        description = "-ini argument to pass to murmurd";
+      };
+
       autobanAttempts = mkOption {
         type = types.int;
         default = 10;
@@ -299,12 +311,15 @@ in
         Type = if forking then "forking" else "simple";
         PIDFile = mkIf forking "/run/murmur/murmurd.pid";
         EnvironmentFile = mkIf (cfg.environmentFile != null) cfg.environmentFile;
-        ExecStart = "${pkgs.murmur}/bin/murmurd -ini /run/murmur/murmurd.ini";
         Restart = "always";
         RuntimeDirectory = "murmur";
         RuntimeDirectoryMode = "0700";
         User = "murmur";
         Group = "murmur";
+        ExecStart = ''
+          ${pkgs.murmur}/bin/murmurd -ini \
+            ${if cfg.iniPath != "" then cfg.iniPath else configFile}
+        '';
       };
     };
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Make it possible to provide a password through NixOps's deployment.keys
```
deployment.keys = with lib; {
      murmurIni.text = ''
      ${config.services.murmur.config}
      serverpassword=${readFile ./keys/murmurPassword}
      '';
};

services.murmur = {
  iniPath = "/run/keys/murmurIni";
  group = "keys";
};
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
