### PR TITLE
mlterm: darwin support

### DIFF
--- a/pkgs/applications/terminal-emulators/mlterm/default.nix
+++ b/pkgs/applications/terminal-emulators/mlterm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, autoconf, makeDesktopItem
+{ stdenv, lib, fetchurl, pkgconfig, autoconf, makeDesktopItem
 , libX11, gdk-pixbuf, cairo, libXft, gtk3, vte
 , harfbuzz #substituting glyphs with opentype fonts
 , fribidi, m17n_lib #bidi and encoding
@@ -46,9 +46,9 @@ stdenv.mkDerivation rec {
     -L${stdenv.cc.cc.lib}/lib
     -lX11 -lgdk_pixbuf-2.0 -lcairo -lfontconfig -lfreetype -lXft
     -lvte-2.91 -lgtk-3 -lharfbuzz -lfribidi -lm17n
-  " + stdenv.lib.optionalString (openssl != null) "
+  " + lib.optionalString (openssl != null) "
     -lcrypto
-  " + stdenv.lib.optionalString (libssh2 != null) "
+  " + lib.optionalString (libssh2 != null) "
     -lssh2
   ";
 
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
     "--with-tools=mlclient,mlconfig,mlcc,mlterm-menu,mlimgloader,registobmp,mlfc"
      #mlterm-menu and mlconfig depend on enabling gnome3.at-spi2-core
      #and configuring ~/.mlterm/key correctly.
- ] ++ stdenv.lib.optional (libssh2 == null) "--disable-ssh2";
+ ] ++ lib.optional (libssh2 == null) "--disable-ssh2";
 
   postInstall = ''
     install -D contrib/icon/mlterm-icon.svg "$out/share/icons/hicolor/scalable/apps/mlterm.svg"
@@ -80,13 +80,13 @@ stdenv.mkDerivation rec {
     comment = "Terminal emulator";
     desktopName = "mlterm";
     genericName = "Terminal emulator";
-    categories = stdenv.lib.concatStringsSep ";" [
+    categories = lib.concatStringsSep ";" [
       "Application" "System" "TerminalEmulator"
     ];
     startupNotify = "false";
   };
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Multi Lingual TERMinal emulator on X11";
     homepage = "http://mlterm.sourceforge.net/";
     license = licenses.bsd3;

--- a/pkgs/applications/terminal-emulators/mlterm/default.nix
+++ b/pkgs/applications/terminal-emulators/mlterm/default.nix
@@ -5,6 +5,7 @@
 , openssl, libssh2 #build-in ssh
 , fcitx, ibus, uim #IME
 , wrapGAppsHook #color picker in mlconfig
+, Cocoa #Darwin
 }:
 
 stdenv.mkDerivation rec {
@@ -18,9 +19,25 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig autoconf wrapGAppsHook ];
   buildInputs = [
-    libX11 gdk-pixbuf.dev cairo libXft gtk3 vte
-    harfbuzz fribidi m17n_lib openssl libssh2
-    fcitx ibus uim
+    libX11
+    gdk-pixbuf.dev
+    cairo
+    libXft
+    gtk3
+    harfbuzz
+    fribidi
+  ] ++ lib.optionals (!stdenv.isDarwin) [
+    # need linker magic, not adapted for Darwin yet
+    openssl
+    libssh2
+
+    # Not supported on Darwin
+    vte
+    m17n_lib
+
+    fcitx
+    ibus
+    uim
   ];
 
   #bad configure.ac and Makefile.in everywhere
@@ -42,7 +59,7 @@ stdenv.mkDerivation rec {
       --replace "-m 2755 -g utmp" " " \
       --replace "-m 4755 -o root" " "
   '';
-  NIX_LDFLAGS = "
+  NIX_LDFLAGS = lib.optionalString (!stdenv.isDarwin) "
     -L${stdenv.cc.cc.lib}/lib
     -lX11 -lgdk_pixbuf-2.0 -lcairo -lfontconfig -lfreetype -lXft
     -lvte-2.91 -lgtk-3 -lharfbuzz -lfribidi -lm17n
@@ -53,23 +70,30 @@ stdenv.mkDerivation rec {
   ";
 
   configureFlags = [
-    "--with-x=yes"
-    "--with-gui=xlib,fb"
     "--with-imagelib=gdk-pixbuf" #or mlimgloader depending on your bugs of choice
     "--with-type-engines=cairo,xft,xcore"
     "--with-gtk=3.0"
     "--enable-ind" #indic scripts
     "--enable-fribidi" #bidi scripts
-    "--enable-m17nlib" #character encodings
     "--with-tools=mlclient,mlconfig,mlcc,mlterm-menu,mlimgloader,registobmp,mlfc"
      #mlterm-menu and mlconfig depend on enabling gnome3.at-spi2-core
      #and configuring ~/.mlterm/key correctly.
- ] ++ lib.optional (libssh2 == null) "--disable-ssh2";
+ ] ++ lib.optionals (!stdenv.isDarwin) [
+   "--with-x=yes"
+   "--with-gui=xlib,fb"
+    "--enable-m17nlib" #character encodings
+ ] ++ lib.optionals stdenv.isDarwin [
+    "--with-gui=quartz"
+ ] ++ lib.optionals (libssh2 == null) [ " --disable-ssh2" ];
 
   postInstall = ''
     install -D contrib/icon/mlterm-icon.svg "$out/share/icons/hicolor/scalable/apps/mlterm.svg"
     install -D contrib/icon/mlterm-icon-gnome2.png "$out/share/icons/hicolor/48x48/apps/mlterm.png"
     install -D -t $out/share/applications $desktopItem/share/applications/*
+  '' + lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications/
+    cp -a cocoa/mlterm.app $out/Applications/
+    install $out/bin/mlterm -Dt $out/Applications/mlterm.app/Contents/MacOS/
   '';
 
   desktopItem = makeDesktopItem {
@@ -87,10 +111,10 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    description = "Multi Lingual TERMinal emulator on X11";
+    description = "Multi Lingual TERMinal emulator";
     homepage = "http://mlterm.sourceforge.net/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ vrthra ramkromberg ];
-    platforms = with platforms; linux;
+    platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/terminal-emulators/mlterm/default.nix
+++ b/pkgs/applications/terminal-emulators/mlterm/default.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
     description = "Multi Lingual TERMinal emulator";
     homepage = "http://mlterm.sourceforge.net/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ vrthra ramkromberg ];
+    maintainers = with maintainers; [ vrthra ramkromberg atemu ];
     platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -722,6 +722,7 @@ in
   mlterm = callPackage ../applications/terminal-emulators/mlterm {
     libssh2 = null;
     openssl = null;
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
   mrxvt = callPackage ../applications/terminal-emulators/mrxvt { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Mlterm has Darwin support and I've been missing it.

Some things don't actually work on Darwin but disabling them doesn't change anything (not even closure size) and support for them may be added in future versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
