### PR TITLE
retroarch: fix build on Darwin

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, fetchFromGitHub, fetchFromGitLab, fetchpatch, cmake, pkgconfig, makeWrapper, python27, python37, retroarch
 , alsaLib, fluidsynth, curl, hidapi, libGLU, gettext, glib, gtk2, portaudio, SDL, SDL_net, SDL2, SDL2_image, libGL
 , ffmpeg_3, pcre, libevdev, libpng, libjpeg, libzip, udev, libvorbis, snappy, which, hexdump
-, miniupnpc, sfml, xorg, zlib, nasm, libpcap, boost, icu, openssl
+, miniupnpc, sfml, xorg, zlib, nasm, libpcap, boost, icu, openssl, AppKit, CoreServices
 , buildPackages }:
 
 let
@@ -72,8 +72,8 @@ in with stdenv.lib.licenses;
     core = "atari800";
     src = fetchRetro {
       repo = "libretro-" + core;
-      rev = "f9bf53b864344b8bbe8d425ed2f3c628eb10519c";
-      sha256 = "0sgk93zs423pwiqzvj0x1gfwcn9gacnlrrdq53ps395k64lig6lk";
+      rev = "8ce851fbca0d360763a267322f6a76c3c80ddae6";
+      sha256 = "026yjihqv2zda7lgxgawyy7c5h4v28v5qjsw7p0mxg1fqikzr7ga";
     };
     description = "Port of Atari800 to libretro";
     license = gpl2;
@@ -644,7 +644,9 @@ in with stdenv.lib.licenses;
     description = "Port of MAME ~2016 to libretro";
     license = gpl2Plus;
     extraNativeBuildInputs = [ python27 ];
-    extraBuildInputs = stdenv.lib.optional stdenv.isLinux alsaLib;
+    extraBuildInputs =
+      stdenv.lib.optional stdenv.isLinux alsaLib
+      ++ stdenv.lib.optional stdenv.isDarwin CoreServices;
     postPatch = ''
       # Prevent the failure during the parallel building of:
       # make -C 3rdparty/genie/build/gmake.linux -f genie.make obj/Release/src/host/lua-5.3.0/src/lgc.o
@@ -703,6 +705,7 @@ in with stdenv.lib.licenses;
     };
     description = "Libretro port of Mupen64 Plus, GL only";
     license = gpl2;
+    broken = stdenv.isDarwin; # libretro/mupen64plus-libretro-nx#146
 
     extraBuildInputs = [ libGLU libGL libpng nasm xorg.libX11 ];
     makefile = "Makefile";
@@ -849,7 +852,8 @@ in with stdenv.lib.licenses;
     description = "ppsspp libretro port";
     license = gpl2;
     extraNativeBuildInputs = [ cmake pkgconfig ];
-    extraBuildInputs = [ libGLU libGL libzip ffmpeg_3 python37 snappy xorg.libX11 ];
+    extraBuildInputs = [ libGLU libGL libzip ffmpeg_3 python37 snappy xorg.libX11 ]
+      ++ stdenv.lib.optional stdenv.isDarwin AppKit;
     makefile = "Makefile";
     cmakeFlags = [ "-DLIBRETRO=ON -DUSE_SYSTEM_FFMPEG=ON -DUSE_SYSTEM_SNAPPY=ON -DUSE_SYSTEM_LIBZIP=ON -DOpenGL_GL_PREFERENCE=GLVND" ];
     postBuild = "mv lib/ppsspp_libretro${stdenv.hostPlatform.extensions.sharedLibrary} ppsspp_libretro${stdenv.hostPlatform.extensions.sharedLibrary}";

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, fetchFromGitHub, fetchFromGitLab, fetchpatch, cmake, pkgconfig, makeWrapper, python27, python37, retroarch
 , alsaLib, fluidsynth, curl, hidapi, libGLU, gettext, glib, gtk2, portaudio, SDL, SDL_net, SDL2, SDL2_image, libGL
 , ffmpeg_3, pcre, libevdev, libpng, libjpeg, libzip, udev, libvorbis, snappy, which, hexdump
-, miniupnpc, sfml, xorg, zlib, nasm, libpcap, boost, icu, openssl, AppKit, Cocoa, CoreAudioKit, ForceFeedback, libobjc, libiconv
+, miniupnpc, sfml, xorg, zlib, nasm, libpcap, boost, icu, openssl, AppKit, Cocoa, CoreAudioKit, ForceFeedback, Foundation, libiconv
 , buildPackages }:
 
 let
@@ -351,12 +351,11 @@ in with stdenv.lib.licenses;
     extraBuildInputs = [ libGLU libGL pcre sfml gettext hidapi ]
       ++ (with xorg; [ libSM libX11 libXi libpthreadstubs libxcb xcbutil libXext libXrandr libXinerama libXxf86vm ])
       ++ stdenv.lib.optionals stdenv.isLinux [ libevdev udev ]
-      ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa CoreAudioKit ForceFeedback ];
+      ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa CoreAudioKit ForceFeedback Foundation ];
     makefile = "Makefile";
     cmakeFlags = [
       "-DCMAKE_BUILD_TYPE=Release"
       "-DLIBRETRO=ON"
-      "-DLIBRETRO_STATIC=1"
       "-DENABLE_QT=OFF"
       "-DENABLE_LTO=OFF"
       "-DUSE_UPNP=OFF"
@@ -556,7 +555,7 @@ in with stdenv.lib.licenses;
 
     extraBuildInputs = [ libGLU libGL portaudio python27 xorg.libX11 ]
       ++ stdenv.lib.optional stdenv.isLinux alsaLib
-      ++ stdenv.lib.optionals stdenv.isDarwin [ libpcap Cocoa CoreAudioKit ForceFeedback ];
+      ++ stdenv.lib.optionals stdenv.isDarwin [ libpcap Cocoa CoreAudioKit ForceFeedback Foundation ];
     postPatch = ''
       # Prevent the failure during the parallel building of:
       # make -C 3rdparty/genie/build/gmake.linux -f genie.make obj/Release/src/host/lua-5.3.0/src/lgc.o
@@ -853,7 +852,7 @@ in with stdenv.lib.licenses;
     license = bsd2;
     extraNativeBuildInputs = [ cmake openssl curl icu libGL libGLU xorg.libX11 ];
     extraBuildInputs = [ boost ]
-      ++ stdenv.lib.optional stdenv.isDarwin libobjc;
+      ++ stdenv.lib.optional stdenv.isDarwin Foundation;
     makefile = "Makefile";
     cmakeFlags = [ "-DBUILD_PLAY=OFF -DBUILD_LIBRETRO_CORE=ON" ];
     postBuild = "mv Source/ui_libretro/play_libretro${stdenv.hostPlatform.extensions.sharedLibrary} play_libretro${stdenv.hostPlatform.extensions.sharedLibrary}";
@@ -873,6 +872,12 @@ in with stdenv.lib.licenses;
       ++ stdenv.lib.optional stdenv.isDarwin AppKit;
     makefile = "Makefile";
     cmakeFlags = [ "-DLIBRETRO=ON -DUSE_SYSTEM_FFMPEG=ON -DUSE_SYSTEM_SNAPPY=ON -DUSE_SYSTEM_LIBZIP=ON -DOpenGL_GL_PREFERENCE=GLVND" ];
+    postPatch = ''
+      ${stdenv.lib.optionalString stdenv.isDarwin ''
+      # -Bsymbolic is not supported by the macOS toolchain.
+      sed -i 's/-Wl,-Bsymbolic//' libretro/CMakeLists.txt
+      ''}
+    '';
     postBuild = "mv lib/ppsspp_libretro${stdenv.hostPlatform.extensions.sharedLibrary} ppsspp_libretro${stdenv.hostPlatform.extensions.sharedLibrary}";
   };
 

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, fetchFromGitHub, fetchFromGitLab, fetchpatch, cmake, pkgconfig, makeWrapper, python27, python37, retroarch
 , alsaLib, fluidsynth, curl, hidapi, libGLU, gettext, glib, gtk2, portaudio, SDL, SDL_net, SDL2, SDL2_image, libGL
 , ffmpeg_3, pcre, libevdev, libpng, libjpeg, libzip, udev, libvorbis, snappy, which, hexdump
-, miniupnpc, sfml, xorg, zlib, nasm, libpcap, boost, icu, openssl, AppKit, Cocoa, CoreAudioKit, ForceFeedback, Foundation, libiconv
+, miniupnpc, sfml, xorg, zlib, nasm, libpcap, boost, icu, openssl, AppKit, Cocoa, CoreAudioKit, ForceFeedback, Foundation, MetalKit, libiconv
 , buildPackages }:
 
 let
@@ -555,7 +555,7 @@ in with stdenv.lib.licenses;
 
     extraBuildInputs = [ libGLU libGL portaudio python27 xorg.libX11 ]
       ++ stdenv.lib.optional stdenv.isLinux alsaLib
-      ++ stdenv.lib.optionals stdenv.isDarwin [ libpcap Cocoa CoreAudioKit ForceFeedback Foundation ];
+      ++ stdenv.lib.optionals stdenv.isDarwin [ libpcap Cocoa CoreAudioKit ForceFeedback Foundation MetalKit ];
     postPatch = ''
       # Prevent the failure during the parallel building of:
       # make -C 3rdparty/genie/build/gmake.linux -f genie.make obj/Release/src/host/lua-5.3.0/src/lgc.o

--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -32,8 +32,9 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
   };
 
-  nativeBuildInputs = [ pkgconfig wayland ]
-                      ++ optional withVulkan makeWrapper;
+  nativeBuildInputs = [ pkgconfig ]
+                      ++ optional withVulkan makeWrapper
+                      ++ optional stdenv.isLinux wayland;
 
   buildInputs = [ ffmpeg_3 freetype libxml2 libGLU libGL python3 SDL2 which ]
                 ++ optional enableNvidiaCgToolkit nvidia_cg_toolkit

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27629,7 +27629,7 @@ in
 
   libretro = recurseIntoAttrs (callPackage ../misc/emulators/retroarch/cores.nix {
     retroarch = retroarchBare;
-    inherit (darwin.apple_sdk.frameworks) AppKit CoreServices;
+    inherit (darwin.apple_sdk.frameworks) AppKit CoreAudioKit ForceFeedback libobjc;
   });
 
   retrofe = callPackage ../misc/emulators/retrofe { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27629,8 +27629,7 @@ in
 
   libretro = recurseIntoAttrs (callPackage ../misc/emulators/retroarch/cores.nix {
     retroarch = retroarchBare;
-    inherit (darwin) libobjc;
-    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa CoreAudioKit ForceFeedback;
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa CoreAudioKit ForceFeedback Foundation;
   });
 
   retrofe = callPackage ../misc/emulators/retrofe { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27629,7 +27629,8 @@ in
 
   libretro = recurseIntoAttrs (callPackage ../misc/emulators/retroarch/cores.nix {
     retroarch = retroarchBare;
-    inherit (darwin.apple_sdk.frameworks) AppKit CoreAudioKit ForceFeedback libobjc;
+    inherit (darwin) libobjc;
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa CoreAudioKit ForceFeedback;
   });
 
   retrofe = callPackage ../misc/emulators/retrofe { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27629,7 +27629,7 @@ in
 
   libretro = recurseIntoAttrs (callPackage ../misc/emulators/retroarch/cores.nix {
     retroarch = retroarchBare;
-    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa CoreAudioKit ForceFeedback Foundation;
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa CoreAudioKit ForceFeedback Foundation MetalKit;
   });
 
   retrofe = callPackage ../misc/emulators/retrofe { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27629,6 +27629,7 @@ in
 
   libretro = recurseIntoAttrs (callPackage ../misc/emulators/retroarch/cores.nix {
     retroarch = retroarchBare;
+    inherit (darwin.apple_sdk.frameworks) AppKit CoreServices;
   });
 
   retrofe = callPackage ../misc/emulators/retrofe { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

The newer MAME cores for libretro don't seem to build on Darwin (probably not on BSD either). See comments in #102078.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
