### PR TITLE
neovim: revert change to extraMakeWrapperArgs

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -118,7 +118,7 @@ let
 
   # to keep backwards compatibility
   legacyWrapper = neovim: {
-    extraMakeWrapperArgs ? []
+    extraMakeWrapperArgs ? ""
     , withPython ? true
     /* the function you would have passed to python.withPackages */
     , extraPythonPackages ? (_: [])
@@ -147,13 +147,9 @@ let
       };
     in
     wrapNeovimUnstable neovim (res // {
-      wrapperArgs = res.wrapperArgs
-      ++ [
-        "--add-flags" "-u ${writeText "init.vim" res.neovimRcContent}"
-      ]
-      ++ (if builtins.isList extraMakeWrapperArgs then extraMakeWrapperArgs
-      else lib.warn "Passing a string as extraMakeWrapperArgs to the neovim wrapper is
-        deprecated, please use a list instead")
+      wrapperArgs = lib.escapeShellArgs (
+        res.wrapperArgs ++ [ "--add-flags" "-u ${writeText "init.vim" res.neovimRcContent}" ])
+        + " " + extraMakeWrapperArgs
       ;
   });
 in

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -14,7 +14,7 @@ neovim:
 let
   wrapper = {
       # should contain all args but the binary
-      wrapperArgs ? []
+      wrapperArgs ? ""
     , manifestRc ? null
     , withPython2 ? true, python2Env ? null
     , withPython3 ? true,  python3Env ? null
@@ -33,7 +33,7 @@ let
   # wrapper with most arguments we need, excluding those that cause problems to
   # generate rplugin.vim, but still required for the final wrapper.
   finalMakeWrapperArgs =
-    [ "${neovim}/bin/nvim" "${placeholder "out"}/bin/nvim" ] ++ wrapperArgs ++
+    [ "${neovim}/bin/nvim" "${placeholder "out"}/bin/nvim" ] ++
       [ "--set" "NVIM_SYSTEM_RPLUGIN_MANIFEST" "${placeholder "out"}/rplugin.vim" ];
   in
   symlinkJoin {
@@ -66,11 +66,11 @@ let
       ''
       + optionalString (manifestRc != null) (let
         manifestWrapperArgs =
-          [ "${neovim}/bin/nvim" "${placeholder "out"}/bin/nvim-wrapper" ] ++ wrapperArgs;
+          [ "${neovim}/bin/nvim" "${placeholder "out"}/bin/nvim-wrapper" ];
       in ''
         echo "Generating remote plugin manifest"
         export NVIM_RPLUGIN_MANIFEST=$out/rplugin.vim
-        makeWrapper ${lib.escapeShellArgs manifestWrapperArgs}
+        makeWrapper ${lib.escapeShellArgs manifestWrapperArgs} ${wrapperArgs}
 
         # Some plugins assume that the home directory is accessible for
         # initializing caches, temporary files, etc. Even if the plugin isn't
@@ -100,7 +100,7 @@ let
       '')
       + ''
         rm $out/bin/nvim
-        makeWrapper ${lib.escapeShellArgs finalMakeWrapperArgs}
+        makeWrapper ${lib.escapeShellArgs finalMakeWrapperArgs} ${wrapperArgs}
       '';
 
     paths = [ neovim ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23984,7 +23984,7 @@ in
   # more usecases when wrapping neovim. The interface is being actively worked on
   # so expect breakage. use wrapNeovim instead if you want a stable alternative
   wrapNeovimUnstable = callPackage ../applications/editors/neovim/wrapper.nix { };
-  wrapNeovim = neovimUtils.legacyWrapper;
+  wrapNeovim = neovim-unwrapped: lib.makeOverridable (neovimUtils.legacyWrapper neovim-unwrapped);
   neovim-unwrapped = callPackage ../applications/editors/neovim {
     lua =
       # neovim doesn't work with luajit on aarch64: https://github.com/neovim/neovim/issues/7879


### PR DESCRIPTION
The changes in https://github.com/NixOS/nixpkgs/pull/101265 changed wrapNeovim to incite users to use a list instead of a string for extraMakeWrapperArgs. This reverts that since the change is not super useful (also I want the wrapper to be low-level so passing a string may actually make more sense) while breaking home-manager see https://github.com/nix-community/home-manager/issues/1577
@SenchoPens  does that fix your issue ?

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
