### PR TITLE
unit: 1.19.0 -> 1.20.0

### DIFF
--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -30,14 +30,14 @@ let
   php74-unit = php74.override phpConfig;
 
 in stdenv.mkDerivation rec {
-  version = "1.19.0";
+  version = "1.20.0";
   pname = "unit";
 
   src = fetchFromGitHub {
     owner = "nginx";
     repo = "unit";
     rev = version;
-    sha256 = "0k3q42q198sb0w6hyyymw92dbhz67axn6w6vnzr0d883xw3sva7k";
+    sha256 = "1qmcz01ifmd80qgpvf1y8nhad6yk56772xdhqvwfxn3mdjfqvcs8";
   };
 
   nativeBuildInputs = [ which ];


### PR DESCRIPTION

###### Motivation for this change
Update unit to 1.20.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
