### PR TITLE
Re-enable the Systemd remote support

### DIFF
--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -24,6 +24,8 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     services.journald.extraConfig = "Storage=volatile";
     test-support.displayManager.auto.user = "alice";
 
+    services.journald.enableHttpGateway = true;
+
     systemd.shutdown.test = pkgs.writeScript "test.shutdown" ''
       #!${pkgs.runtimeShell}
       PATH=${lib.makeBinPath (with pkgs; [ utillinux coreutils ])}
@@ -168,5 +170,10 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         machine.succeed("systemctl status systemd-cryptsetup@luks1.service")
         machine.succeed("mkdir -p /tmp/luks1")
         machine.succeed("mount /dev/mapper/luks1 /tmp/luks1")
+
+    with subtest("the systemd-journal-gatewayd service is running"):
+        machine.succeed(
+            "${pkgs.curl}/bin/curl -s localhost:19531/machine | ${pkgs.jq}/bin/jq -e '.hostname == \"machine\"'"
+        )
   '';
 })

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, pkgconfig, intltool, gperf, libcap
 , curl, kmod, gnupg, gnutar, xz, pam, acl, libuuid, m4, e2fsprogs, utillinux, libffi
 , glib, kbd, libxslt, coreutils, libgcrypt, libgpgerror, libidn2, libapparmor
-, audit, lz4, bzip2, pcre2
+, audit, lz4, bzip2, libmicrohttpd, pcre2
 , linuxHeaders ? stdenv.cc.libc.linuxHeaders
 , iptables, gnu-efi, bashInteractive
 , gettext, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_45
@@ -83,7 +83,7 @@ in stdenv.mkDerivation {
   buildInputs =
     [ linuxHeaders libcap curl.dev kmod xz pam acl
       cryptsetup libuuid glib libgcrypt libgpgerror libidn2
-      pcre2 ] ++
+      libmicrohttpd pcre2 ] ++
       stdenv.lib.optional withKexectools kexectools ++
       stdenv.lib.optional withLibseccomp libseccomp ++
     [ libffi audit lz4 bzip2 libapparmor
@@ -112,7 +112,7 @@ in stdenv.mkDerivation {
     "-Dhostnamed=true"
     "-Dnetworkd=true"
     "-Dportabled=false"
-    "-Dremote=false"
+    "-Dremote=true"
     "-Dsysusers=false"
     "-Dtimedated=true"
     "-Dtimesyncd=true"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Since ae896e0, Systemd is no longer compiled with the http gateway because of an incompatibility between Systemd and libmicrohttpd. However, because of some updates, it is now building fine!

I also enable this feature is the systemd test to ensure the option services.journald.enableHttpGateway is working as excepted.

@flokli should i rebase these patches onto `staging-20.09`? 
Note I didn't run the systemd tests yet since a lot of things need to be rebuilt:/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
