### PR TITLE
Timekeeper gtk app

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1260,6 +1260,12 @@
     githubId = 7214361;
     name = "Roman Gerasimenko";
   };
+  bburdette = {
+    email = "bburdette@protonmail.com";
+    github = "bburdette";
+    githubId = 157330;
+    name = "Ben Burdette";
+  };
   bzizou = {
     email = "Bruno@bzizou.net";
     github = "bzizou";

--- a/pkgs/applications/office/timekeeper/default.nix
+++ b/pkgs/applications/office/timekeeper/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchFromGitHub
+, poco
+, pkg-config
+, gnome2
+, gtkmm2
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "timekeeper";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "bburdette";
+    repo = "TimeKeeper";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "03rvzkygnn7igcindbb5bcmfy0l83n0awkzprsnhlb6ndxax3k9w";
+  };
+
+  nativeBuildInputs = [
+    poco
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtkmm2
+    gnome2.libglademm
+    gnome2.libglade
+  ];
+
+  installPhase = ''
+    install -Dm755 TimeKeeper/TimeKeeper $out/bin/timekeeper
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Log hours worked and make reports";
+    homepage = "https://github.com/bburdette/TimeKeeper";
+    maintainers = with maintainers; [ bburdette ];
+    platforms = [ "x86_64-linux" ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7379,6 +7379,8 @@ in
 
   timetable = callPackage ../applications/office/timetable { };
 
+  timekeeper = callPackage ../applications/office/timekeeper { };
+
   timezonemap = callPackage ../development/libraries/timezonemap { };
 
   tzupdate = callPackage ../applications/misc/tzupdate { };


### PR DESCRIPTION
###### Motivation for this change

Add my TimeKeeper gtk app for tracking hours.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ x] Ensured that relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
