### PR TITLE
1password: add shell completion

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     };
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ xar cpio ];
-  
+
   postPhases = [ "postInstall" ];
 
   unpackPhase = stdenv.lib.optionalString stdenv.isDarwin ''
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -D op $out/bin/op
   '';
-  
+
   postInstall = ''
     installShellCompletion --bash --name op <($out/bin/op completion bash)
     installShellCompletion --zsh --name _op <($out/bin/op completion zsh)

--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, autoPatchelfHook, fetchurl, xar, cpio }:
+{ stdenv, fetchzip, autoPatchelfHook, fetchurl, xar, cpio, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "1password";
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     };
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ xar cpio ];
+  
+  postPhases = [ "postInstall" ];
 
   unpackPhase = stdenv.lib.optionalString stdenv.isDarwin ''
     xar -xf $src
@@ -29,10 +31,15 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -D op $out/bin/op
   '';
+  
+  postInstall = ''
+    installShellCompletion --bash --name op <($out/bin/op completion bash)
+    installShellCompletion --zsh --name _op <($out/bin/op completion zsh)
+  '';
 
   dontStrip = stdenv.isDarwin;
 
-  nativeBuildInputs = stdenv.lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = [ installShellFiles ] ++ stdenv.lib.optionals stdenv.isLinux [ autoPatchelfHook ];
 
   doInstallCheck = true;
 

--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -33,8 +33,11 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    installShellCompletion --bash --name op <($out/bin/op completion bash)
-    installShellCompletion --zsh --name _op <($out/bin/op completion zsh)
+    $out/bin/op completion bash > op.bash
+    $out/bin/op completion zsh > op.zsh
+
+    installShellCompletion --bash --name op ./op.bash
+    installShellCompletion --zsh --name _op ./op.zsh
   '';
 
   dontStrip = stdenv.isDarwin;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
`1password` (`op`) has built-in completion for `bash` and `zsh` but they weren't installed in package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
