### PR TITLE
nixos/bluetooth: disable restart on unit changes

### DIFF
--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -87,6 +87,8 @@ in {
       bluetooth = {
         wantedBy = [ "bluetooth.target" ];
         aliases  = [ "dbus-org.bluez.service" ];
+        # restarting can leave people without a mouse/keyboard
+        unitConfig.X-RestartIfChanged = false;
       };
     };
 


### PR DESCRIPTION
###### Motivation for this change
Fix issue #93461

###### Things done

- [ ] Tested via one or more NixOS test
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @wmertens 