### PR TITLE
upterm: init at 0.4.6

### DIFF
--- a/pkgs/tools/misc/upterm/default.nix
+++ b/pkgs/tools/misc/upterm/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "upterm";
+  version = "0.4.6";
+
+  src = fetchFromGitHub {
+    owner = "owenthereal";
+    repo = "upterm";
+    rev = "v${version}";
+    sha256 = "1p7bwg8zlp45j5758wfbkpc95rpsa8xq0hn439bd2knrdsdadnnk";
+  };
+
+  doCheck = false;
+
+  vendorSha256 = null;
+
+  meta = with lib; {
+    description = "secure terminal-session sharing";
+    homepage = "https://upterm.dev";
+    license = licenses.asl20;
+    maintainers = [ maintainers.gilligan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7772,6 +7772,8 @@ in
 
   up = callPackage ../tools/misc/up { };
 
+  upterm = callPackage ../tools/misc/upterm { };
+
   upx = callPackage ../tools/compression/upx { };
 
   uq = callPackage ../misc/uq { };


### PR DESCRIPTION
###### Motivation for this change
Add [upterm](https://upterm.dev/) to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
