### PR TITLE
autogen: make reproducible

### DIFF
--- a/pkgs/development/tools/misc/autogen/default.nix
+++ b/pkgs/development/tools/misc/autogen/default.nix
@@ -42,13 +42,23 @@ stdenv.mkDerivation rec {
     guile libxml2
   ];
 
-  configureFlags = stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "--with-libxml2=${libxml2.dev}"
-    "--with-libxml2-cflags=-I${libxml2.dev}/include/libxml2"
-    # the configure check for regcomp wants to run a host program
-    "libopts_cv_with_libregex=yes"
-    #"MAKEINFO=${buildPackages.texinfo}/bin/makeinfo"
-  ];
+  configureFlags =
+    [
+      # Make sure to use a static value for the timeout. If we do not set a value
+      # here autogen will select one based on the execution time of the configure
+      # phase which is not really reproducible.
+      #
+      # If you are curious about the number 78, it has been cargo-culted from
+      # Debian: https://salsa.debian.org/debian/autogen/-/blob/master/debian/rules#L21
+      "--enable-timeout=78"
+    ]
+    ++ (stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "--with-libxml2=${libxml2.dev}"
+      "--with-libxml2-cflags=-I${libxml2.dev}/include/libxml2"
+      # the configure check for regcomp wants to run a host program
+      "libopts_cv_with_libregex=yes"
+      #"MAKEINFO=${buildPackages.texinfo}/bin/makeinfo"
+    ]);
 
   #doCheck = true; # not reliable
 


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).