### PR TITLE
check-esxi-hardware: refactor from python2 to python3

### DIFF
--- a/pkgs/development/python-modules/nocasedict/default.nix
+++ b/pkgs/development/python-modules/nocasedict/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchPypi
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "nocasedict";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "bl1b0R3jP5PSJUXZ7SOguY+EDyzawNdJ0vqkYXrcd3I=";
+  };
+
+  checkInputs = [
+    pytest
+  ];
+
+  pythonImportsCheck = [
+    "nocasedict"
+  ];
+
+  meta = with lib; {
+    description = "A case-insensitive ordered dictionary for Python";
+    homepage = "https://github.com/pywbem/nocasedict";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ freezeboy ];
+  };
+}

--- a/pkgs/development/python-modules/nocaselist/default.nix
+++ b/pkgs/development/python-modules/nocaselist/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchPypi
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "nocaselist";
+  version = "1.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fm3st9hVY7kESRPJCH70tpG8PaTXrR2IlozepAlVMyY=";
+  };
+
+  checkInputs = [
+    pytest
+  ];
+
+  pythonImportsCheck = [
+    "nocaselist"
+  ];
+
+  meta = with lib; {
+    description = "A case-insensitive list for Python";
+    homepage = "https://github.com/pywbem/nocaselist";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ freezeboy ];
+  };
+}

--- a/pkgs/development/python-modules/pywbem/default.nix
+++ b/pkgs/development/python-modules/pywbem/default.nix
@@ -1,52 +1,43 @@
 { lib, buildPythonPackage, fetchPypi, libxml2
 , m2crypto, ply, pyyaml, six, pbr, pythonOlder, isPy37
+, nocasedict, nocaselist, yamlloader, requests-mock
 , httpretty, lxml, mock, pytest, requests, decorator, unittest2
+, FormEncode, testfixtures, pytz
 }:
 
 buildPythonPackage rec {
   pname = "pywbem";
-  version = "1.0.3";
-
-  # Support added in master https://github.com/pywbem/pywbem/commit/b2f2f1a151a30355bbc6652dca69a7b30bfe941e awaiting release
-  disabled = isPy37;
+  version = "1.1.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a6c53d9426326e0e722a5b1af3a1d55810259cb3afa92ca5e4029a6d533cab37";
+    sha256 = "9GpxbgNsXZJj2M5MvosNnEe+9pY+Qz64RD/7ZIDqmII=";
   };
 
   propagatedBuildInputs = [
     mock
+    nocasedict
+    nocaselist
     pbr
     ply
     pyyaml
     six
+    yamlloader
   ] ++ lib.optionals (pythonOlder "3.0") [ m2crypto ];
 
   checkInputs = [
     decorator
+    FormEncode
     httpretty
     libxml2
     lxml
     pytest
+    pytz
     requests
+    requests-mock
+    testfixtures
     unittest2
   ];
-
-  postPatch = ''
-    # Uses deprecated library yamlordereddictloader
-    rm testsuite/test_client.py
-
-    # Wants `wbemcli` in PATH
-    rm testsuite/test_wbemcli.py
-
-    # Disables tests that use testfixtures which is currently broken by nonbuilding zope_component
-    rm testsuite/{test_logging,test_recorder,test_wbemconnection_mock}.*
-  '';
-
-  checkPhase = ''
-    pytest testsuite/
-  '';
 
   meta = with lib; {
     description = "Support for the WBEM standard for systems management";

--- a/pkgs/development/python-modules/yamlloader/default.nix
+++ b/pkgs/development/python-modules/yamlloader/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildPythonPackage, fetchPypi
+, pytest, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "yamlloader";
+  version = "0.5.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3KtfFrObsD0Q3aTNTzDJQ2dexMd3GAf8Z+fxuzGb9Mg=";
+  };
+
+  propagatedBuildInputs = [
+    pyyaml
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  pythonImportsCheck = [
+    "yaml"
+    "yamlloader"
+  ];
+
+  meta = with lib; {
+    description = "A case-insensitive list for Python";
+    homepage = "https://github.com/Phynix/yamlloader";
+    license = licenses.mit;
+    maintainers = with maintainers; [ freezeboy ];
+  };
+}

--- a/pkgs/servers/monitoring/plugins/esxi.nix
+++ b/pkgs/servers/monitoring/plugins/esxi.nix
@@ -1,18 +1,17 @@
-{ stdenv, fetchFromGitHub, python2Packages }:
+{ stdenv, fetchFromGitHub, python3Packages }:
 
 let
   bName = "check_esxi_hardware";
-  pName = stdenv.lib.replaceStrings [ "_" ] [ "-" ] bName;
 
-in python2Packages.buildPythonApplication rec {
-  name = "${pName}-${version}";
-  version = "20181001";
+in python3Packages.buildPythonApplication rec {
+  pname = stdenv.lib.replaceStrings [ "_" ] [ "-" ] bName;
+  version = "20200710";
 
   src = fetchFromGitHub {
     owner  = "Napsty";
     repo   = bName;
     rev    = version;
-    sha256 = "0azfacxcnnxxfqzrhh29k8cnjyr88gz35bi6h8fq931fl3plv10l";
+    sha256 = "EC6np/01S+5SA2H9z5psJ9Pq/YoEyGdHL9wHUKKsNas=";
   };
 
   dontBuild = true;
@@ -21,13 +20,13 @@ in python2Packages.buildPythonApplication rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 -t $out/bin                ${bName}.py
-    install -Dm644 -t $out/share/doc/${pName} README.md
+    install -Dm755 ${bName}.py $out/bin/${bName}
+    install -Dm644 -t $out/share/doc/${pname} README.md
 
     runHook postInstall
   '';
 
-  propagatedBuildInputs = with python2Packages; [ pywbem ];
+  propagatedBuildInputs = with python3Packages; [ pywbem requests setuptools ];
 
   meta = with stdenv.lib; {
     homepage = "https://www.claudiokuenzler.com/nagios-plugins/";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7826,6 +7826,8 @@ in {
 
   yamllint = callPackage ../development/python-modules/yamllint { };
 
+  yamlloader = callPackage ../development/python-modules/yamlloader { };
+
   yamlordereddictloader = callPackage ../development/python-modules/yamlordereddictloader { };
 
   yanc = callPackage ../development/python-modules/yanc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4105,6 +4105,8 @@ in {
 
   nmigen-soc = callPackage ../development/python-modules/nmigen-soc { };
 
+  nocaselist = callPackage ../development/python-modules/nocaselist { };
+
   nodeenv = callPackage ../development/python-modules/nodeenv { };
 
   node-semver = callPackage ../development/python-modules/node-semver { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4105,6 +4105,8 @@ in {
 
   nmigen-soc = callPackage ../development/python-modules/nmigen-soc { };
 
+  nocasedict = callPackage ../development/python-modules/nocasedict { };
+
   nocaselist = callPackage ../development/python-modules/nocaselist { };
 
   nodeenv = callPackage ../development/python-modules/nodeenv { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Working on issue: #101964 

I took the opportunity to update the dependencies to support python3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
