### PR TITLE
cde: update expression

### DIFF
--- a/pkgs/tools/package-management/cde/default.nix
+++ b/pkgs/tools/package-management/cde/default.nix
@@ -5,10 +5,10 @@ stdenv.mkDerivation rec {
   version = "0.1";
 
   src = fetchFromGitHub {
-    owner = "pgbovine";
-    repo = "CDE";
-    sha256 = "0raiz7pczkbnzxpg7g59v7gdp1ipkwgms2vh3431snw1va1gjzmk";
+    owner = "usnistgov";
+    repo = "corr-CDE";
     rev = "v${version}";
+    sha256 = "sha256-s375gtqBWx0GGXALXR+fN4bb3tmpvPNu/3bNz+75UWU=";
   };
 
   # The build is small, so there should be no problem
@@ -18,19 +18,22 @@ stdenv.mkDerivation rec {
   preferLocalBuild = true;
 
   patchBuild = ''
-    sed '/install/d' $src/Makefile > $src/Makefile
+    sed -i -e '/install/d' $src/Makefile
   '';
-  
+
+  preBuild = ''
+    patchShebangs .
+  '';
+
   installPhase = ''
-    mkdir -p $out/bin
-    cp cde $out/bin
-    cp cde-exec $out/bin
+    install -d $out/bin
+    install -t $out/bin cde cde-exec
   '';
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/pgbovine/CDE";
+    homepage = "https://pg.ucsd.edu/cde/manual/";
     description = "A packaging tool for building portable packages";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = [ maintainers.rlupton20 ];
     platforms = platforms.linux;
     # error: architecture aarch64 is not supported by strace


### PR DESCRIPTION
The old Github repository was deleted; usnistgov/corr-CDE will be used instead.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
