### PR TITLE
genpass: 0.4.1 -> 0.4.9

### DIFF
--- a/pkgs/tools/security/genpass/default.nix
+++ b/pkgs/tools/security/genpass/default.nix
@@ -1,5 +1,5 @@
 { stdenv
-, fetchFromGitHub
+, fetchgit
 , rustPlatform
 , CoreFoundation
 , libiconv
@@ -7,22 +7,21 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "genpass";
-  version = "0.4.1";
+  version = "0.4.9";
 
-  src = fetchFromGitHub {
-    owner = "cyplo";
-    repo = pname;
+  src = fetchgit {
+    url = "https://git.sr.ht/~cyplo/genpass";
     rev = "v${version}";
-    sha256 = "1b22m7g55k5ry0vwyd8pakh8rmfkhk37qy5r74cn3n5pv3fcwini";
+    sha256 = "1dpv2iyd48xd8yw9bmymjjrkhsgmpwvsl5b9zx3lpaaq59ypi9g9";
   };
 
-  cargoSha256 = "1p6l64s9smhwka8bh3pamqimamxziad859i62nrmxzqc49nq5s7m";
+  cargoSha256 = "1cwxpc3xkw673wiamr4v7clrzwxl8ma1vdr6bw0hixm37gxdxz7x";
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation libiconv Security ];
 
   meta = with stdenv.lib; {
     description = "A simple yet robust commandline random password generator";
-    homepage = "https://github.com/cyplo/genpass";
+    homepage = "https://sr.ht/~cyplo/genpass/";
     license = licenses.agpl3;
     maintainers = with maintainers; [ cyplo ];
   };


### PR DESCRIPTION
* caught up with the newest released version
* genpass main repo moved to sourcehut

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
