### PR TITLE
nixos/activation: expose activation scripts

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -64,7 +64,7 @@ in
 
       type = types.attrsOf types.unspecified; # FIXME
 
-      apply = set: {
+      apply = set: set // {
         script =
           ''
             #! ${pkgs.runtimeShell}
@@ -127,7 +127,7 @@ in
 
       type = types.attrsOf types.unspecified;
 
-      apply = set: {
+      apply = set: set // {
         script = ''
           unset PATH
           for i in ${toString path}; do


### PR DESCRIPTION
###### Motivation for this change

Currently, you can't access the activation scripts once they've been set (try eval --json config.system.activationScripts). This makes them accessible, in a non-breaking way. 