### PR TITLE
popeye: 0.8.10 -> 0.9.0

### DIFF
--- a/pkgs/applications/networking/cluster/popeye/default.nix
+++ b/pkgs/applications/networking/cluster/popeye/default.nix
@@ -2,24 +2,24 @@
 
 buildGoModule rec {
   pname = "popeye";
-  version = "0.8.10";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "derailed";
     repo = "popeye";
-    sha256 = "1cx39xipvvhb12nhvg7kfssnqafajni662b070ynlw8p870bj0sn";
+    sha256 = "1rslmcdjs53zvv0xaf00vxqsfc3jh2p584j3q6nfgrghc978xmpf";
   };
 
   buildFlagsArray = ''
     -ldflags=
       -s -w
       -X github.com/derailed/popeye/cmd.version=${version}
-      -X github.com/derailed/popeye/cmd.commit=b7a876eafd4f7ec5683808d8d6880c41c805056a
-      -X github.com/derailed/popeye/cmd.date=2020-08-25T23:02:30Z
+      -X github.com/derailed/popeye/cmd.commit=022c3104b642aab6bdb287468fb79068a33e1b0d
+      -X github.com/derailed/popeye/cmd.date=2020-10-31T16:44:45Z
   '';
 
-  vendorSha256 = "0b2bawc9wnqwgvrv614rq5y4ns9di65zqcbb199y2ijpsaw5d9a7";
+  vendorSha256 = "08195dnka7rs38py3kjii9zh9nifg2fnbi1wzjl0pc38i2bbrz0k";
 
   doCheck = false;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update **popeye** package to take advantage of the resources available in the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
