### PR TITLE
ocamlPackages.checkseum: 0.1.1 → 0.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/checkseum/default.nix
+++ b/pkgs/development/ocaml-modules/checkseum/default.nix
@@ -1,19 +1,21 @@
-{ lib, fetchurl, buildDunePackage
+{ lib, fetchurl, buildDunePackage, dune-configurator
 , bigarray-compat, optint
-, cmdliner, fmt, rresult
+, fmt, rresult
 , alcotest
 }:
 
 buildDunePackage rec {
-  version = "0.1.1";
+  version = "0.2.1";
   pname = "checkseum";
+
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/checkseum/releases/download/v${version}/checkseum-v${version}.tbz";
-    sha256 = "0aa2r1l65a5hcgciw6n8r5ij4gpgg0cf9k24isybxiaiz63k94d3";
+    sha256 = "1swb44c64pcs4dh9ka9lig6d398qwwkd3kkiajicww6qk7jbh3n5";
   };
 
-  buildInputs = [ cmdliner fmt rresult ];
+  buildInputs = [ dune-configurator fmt rresult ];
   propagatedBuildInputs = [ bigarray-compat optint ];
   checkInputs = lib.optionals doCheck [ alcotest ];
 

--- a/pkgs/development/ocaml-modules/decompress/default.nix
+++ b/pkgs/development/ocaml-modules/decompress/default.nix
@@ -7,6 +7,8 @@ buildDunePackage rec {
 	version = "0.9.0";
 	pname = "decompress";
 
+	useDune2 = true;
+
 	src = fetchurl {
 		url = "https://github.com/mirage/decompress/releases/download/v${version}/decompress-v${version}.tbz";
 		sha256 = "0fryhcvv96vfca51c7kqdn3n3canqsbbvfbi75ya6lca4lmpipbh";

--- a/pkgs/development/ocaml-modules/imagelib/default.nix
+++ b/pkgs/development/ocaml-modules/imagelib/default.nix
@@ -4,6 +4,9 @@ buildDunePackage rec {
   minimumOCamlVersion = "4.07";
   version = "20191011";
   pname = "imagelib";
+
+  useDune2 = true;
+
   src = fetchFromGitHub {
     owner = "rlepigre";
     repo = "ocaml-imagelib";

--- a/pkgs/development/ocaml-modules/imagelib/unix.nix
+++ b/pkgs/development/ocaml-modules/imagelib/unix.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage {
   pname = "imagelib-unix";
-  inherit (imagelib) version src meta;
+  inherit (imagelib) version src useDune2 meta;
 
   propagatedBuildInputs = [ imagelib ];
 }


### PR DESCRIPTION
###### Motivation for this change

Use dune 2.
Fixes & improvements: https://github.com/mirage/checkseum/blob/master/CHANGES.md

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
