### PR TITLE
nixos/anbox: use mainline drivers when available

### DIFF
--- a/nixos/tests/anbox.nix
+++ b/nixos/tests/anbox.nix
@@ -1,0 +1,37 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+{
+  name = "anbox";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ mvnetbiz ];
+  };
+
+  machine = { pkgs, config, ... }: {
+    imports = [
+      ./common/user-account.nix
+      ./common/x11.nix
+    ];
+
+    environment.systemPackages = with pkgs; [ android-tools ];
+
+    test-support.displayManager.auto.user = "alice";
+
+    virtualisation.anbox.enable = true;
+    virtualisation.memorySize = 2500;
+  };
+
+  testScript = { nodes, ... }: let
+    user = nodes.machine.config.users.users.alice;
+    bus = "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${toString user.uid}/bus";
+  in ''
+    machine.wait_for_x()
+
+    machine.wait_until_succeeds(
+        "sudo -iu alice ${bus} anbox wait-ready"
+    )
+
+    machine.wait_until_succeeds("adb shell true")
+
+    print(machine.succeed("adb devices"))
+  '';
+})

--- a/pkgs/os-specific/linux/anbox/default.nix
+++ b/pkgs/os-specific/linux/anbox/default.nix
@@ -76,7 +76,15 @@ stdenv.mkDerivation rec {
     libcap
     libdwarf
     libGL
-    lxc
+    # Broken with lxc 4.0.7 or later
+    # https://github.com/anbox/anbox/issues/1801
+    (lxc.overrideAttrs (old: rec {
+      version = "4.0.6";
+      src = fetchurl {
+        url = "https://linuxcontainers.org/downloads/lxc/lxc-${version}.tar.gz";
+        sha256 = "0qz4l7mlhq7hx53q606qgvkyzyr01glsw290v8ppzvxn1fydlrci";
+      };
+    }))
     mesa
     properties-cpp
     protobuf protobufc

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -845,6 +845,12 @@ let
 
       X86_AMD_PLATFORM_DEVICE = yes;
 
+      ASHMEM =                 { optional = true; tristate = whenAtLeast "5.0" "y";};
+      ANDROID =                { optional = true; tristate = whenAtLeast "5.0" "y";};
+      ANDROID_BINDER_IPC =     { optional = true; tristate = whenAtLeast "5.0" "y";};
+      ANDROID_BINDERFS =       { optional = true; tristate = whenAtLeast "5.0" "y";};
+      ANDROID_BINDER_DEVICES = { optional = true; freeform = whenAtLeast "5.0" "binder,hwbinder,vndbinder";};
+
     } // optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux" || stdenv.hostPlatform.system == "aarch64-linux") {
       # Enable CPU/memory hotplug support
       # Allows you to dynamically add & remove CPUs/memory to a VM client running NixOS without requiring a reboot


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
virtualisation.anbox is broken on Linux 5.x

###### Things done
- updated Anbox package to latest version
- marked anbox kernel modules broken for Linux >= 5.7. They do not build because Linux 5.7 unexported kallsyms_lookup_name()
 - enable CONFIG_ options for the mainline kernel drivers needed
 - change Anbox NixOS module to use the correct drivers if using Linux 5.x

I have confirmed this working with Linux 4.19, 5.4, 5.7
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
