### PR TITLE
rsync: disable the bundled zlib explicitly

### DIFF
--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -35,7 +35,13 @@ stdenv.mkDerivation rec {
                 ++ stdenv.lib.optional enableXXHash xxHash;
   nativeBuildInputs = [perl];
 
-  configureFlags = ["--with-nobody-group=nogroup"]
+  configureFlags = [
+    "--with-nobody-group=nogroup"
+
+    # disable the included zlib explicitly as it otherwise still compiles and
+    # links them even.
+    "--with-included-zlib=no"
+  ]
     # Work around issue with cross-compilation:
     #     configure.sh: error: cannot run test program while cross compiling
     # Remove once 3.2.4 or more recent is released.


### PR DESCRIPTION
###### Motivation for this change

We've been providing zlib as a buildInput for some time now but rsync
still builds (& links) it's own copy of zlib unless we disable it
explicitly. This cuts down on compilation time but otherwise shouldn't
have any side effects.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - ran the rsyncd test
