### PR TITLE
setuptoolsCheckPhase: allow providing arguments via setuptoolsCheckFl…

### DIFF
--- a/pkgs/development/interpreters/python/hooks/setuptools-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-check-hook.sh
@@ -6,7 +6,7 @@ setuptoolsCheckPhase() {
     runHook preCheck
 
     cp -f @setuppy@ nix_run_setup
-    @pythonCheckInterpreter@ nix_run_setup test
+    @pythonCheckInterpreter@ nix_run_setup test "${setuptoolsCheckFlagsArray[@]}"
 
     runHook postCheck
     echo "Finished executing setuptoolsCheckPhase"


### PR DESCRIPTION
…agsArray

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


cherry-picked from https://github.com/NixOS/nixpkgs/pull/102306/files#diff-78e272fcdca196c9997e1a2da70702ea519a5ebcea9a396bbb7f876750130844

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
