### PR TITLE
nixos/tests/prometheus: remove invalid thanos config flag

### DIFF
--- a/nixos/tests/prometheus.nix
+++ b/nixos/tests/prometheus.nix
@@ -19,7 +19,6 @@ let
       secret_key = s3.secretKey;
       insecure = true;
       signature_version2 = false;
-      encrypt_sse =  false;
       put_user_metadata = {};
       http_config = {
         idle_conn_timeout = "0s";


### PR DESCRIPTION
###### Motivation for this change

Upstream has apparently changed the configuration format and is now
throwing an error when the `encrypt_sse` option is set. According to the
current version of the documentation encryption moved to the
`sse_config` option that (is optional and) offers all the features we do
not use or care about for this test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
