### PR TITLE
python3Packages.ppscore: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/ppscore/default.nix
+++ b/pkgs/development/python-modules/ppscore/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, pandas
+, scikitlearn
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ppscore";
+  version = "1.1.1";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "8080labs";
+    repo = pname;
+    rev = version;
+    sha256 = "11y6axhj0nlagf7ax6gas1g06krrmddb1jlmf0mmrmyi7z0vldk2";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  propagatedBuildInputs = [
+    pandas
+    scikitlearn
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A Python implementation of the Predictive Power Score (PPS)";
+    homepage = "https://github.com/8080labs/ppscore/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evax ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4640,6 +4640,8 @@ in {
 
   pproxy = callPackage ../development/python-modules/pproxy { };
 
+  ppscore = callPackage ../development/python-modules/ppscore { };
+
   pq = callPackage ../development/python-modules/pq { };
 
   prance = callPackage ../development/python-modules/prance { };


### PR DESCRIPTION
###### Motivation for this change

ppscore - a Python implementation of the Predictive Power Score (PPS)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
