### PR TITLE
extra-container: init at 0.8

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -135,6 +135,7 @@
   ./programs/droidcam.nix
   ./programs/environment.nix
   ./programs/evince.nix
+  ./programs/extra-container.nix
   ./programs/feedbackd.nix
   ./programs/file-roller.nix
   ./programs/firejail.nix

--- a/nixos/modules/programs/extra-container.nix
+++ b/nixos/modules/programs/extra-container.nix
@@ -1,0 +1,17 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+let
+  cfg = config.programs.extra-container;
+in {
+  options = {
+    programs.extra-container.enable = mkEnableOption ''
+      extra-container, a tool for running declarative NixOS containers
+      without host system rebuilds
+    '';
+  };
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.extra-container ];
+    boot.extraSystemdUnitPaths = [ "/etc/systemd-mutable/system" ];
+  };
+}

--- a/pkgs/tools/virtualization/extra-container/default.nix
+++ b/pkgs/tools/virtualization/extra-container/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, nixos-container, openssh, glibcLocales, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "extra-container";
+  version = "0.8";
+
+  src = fetchFromGitHub {
+    owner = "erikarvstedt";
+    repo = pname;
+    rev = version;
+    hash = "sha256-/AetqDPkz32JMdjbSdzZCBVmGbvzjeAb8Wv82iTgHFE=";
+  };
+
+  buildCommand = ''
+    install -D $src/extra-container $out/bin/extra-container
+    patchShebangs $out/bin
+    share=$out/share/extra-container
+    install $src/eval-config.nix -Dt $share
+
+    # Use existing PATH for systemctl and machinectl
+    scriptPath="export PATH=${lib.makeBinPath [ nixos-container openssh ]}:\$PATH"
+
+    sed -i \
+      -e "s|evalConfig=.*|evalConfig=$share/eval-config.nix|" \
+      -e "s|LOCALE_ARCHIVE=.*|LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive|" \
+      -e "2i$scriptPath" \
+      $out/bin/extra-container
+  '';
+
+  meta = with lib; {
+    description = "Run declarative containers without full system rebuilds";
+    homepage = https://github.com/erikarvstedt/extra-container;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.earvstedt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31922,6 +31922,8 @@ with pkgs;
 
   nixos-rebuild = callPackage ../os-specific/linux/nixos-rebuild { };
 
+  extra-container = callPackage ../tools/virtualization/extra-container { };
+
   norwester-font = callPackage ../data/fonts/norwester  {};
 
   nut = callPackage ../applications/misc/nut { };


### PR DESCRIPTION
[extra-container](https://github.com/erikarvstedt/extra-container/) is a tool for running declarative NixOS containers without host system rebuilds.

cc @Lassulus

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).