### PR TITLE
python3Packages.pyside,python3Packages.pysideTools,python3Packages.pysideShiboken,pysideApiExtractor,pysideGeneratorrunner: remove dependencies to python2

### DIFF
--- a/pkgs/development/python-modules/pyside/apiextractor.nix
+++ b/pkgs/development/python-modules/pyside/apiextractor.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, cmake, libxml2, libxslt, python2, qt4 }:
+{ stdenv, fetchurl, cmake, libxml2, libxslt, python3, qt4 }:
 
 # This derivation does not provide any Python module and should therefore be called via `all-packages.nix`.
 let
-  pythonEnv = python2.withPackages(ps: with ps; [  sphinx ]);
+  pythonEnv = python3.withPackages(ps: with ps; [  sphinx ]);
 in stdenv.mkDerivation {
   name = "pyside-apiextractor-0.10.10";
 
@@ -13,7 +13,14 @@ in stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ cmake qt4 pythonEnv libxml2 libxslt ];
+  outputs = [ "out" "dev" ];
+
+  preConfigure = ''
+    cmakeFlagsArray=("-DCMAKE_INSTALL_PREFIX=$dev")
+  '';
+
+  nativeBuildInputs = [ cmake pythonEnv ];
+  buildInputs = [ qt4 libxml2 libxslt ];
 
   meta = {
     description = "Eases the development of bindings of Qt-based libraries for high level languages by automating most of the process";

--- a/pkgs/development/python-modules/pyside/default.nix
+++ b/pkgs/development/python-modules/pyside/default.nix
@@ -13,6 +13,12 @@ buildPythonPackage rec {
 
   enableParallelBuilding = true;
 
+  outputs = [ "out" "dev" ];
+
+  preConfigure = ''
+    cmakeFlagsArray=("-DCMAKE_INSTALL_PREFIX=$dev")
+  '';
+
   nativeBuildInputs = [ cmake pysideGeneratorrunner pysideShiboken qt4 ];
 
   buildInputs = [ mesa libGL ];

--- a/pkgs/development/python-modules/pyside/generatorrunner.nix
+++ b/pkgs/development/python-modules/pyside/generatorrunner.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, cmake, pysideApiextractor, python2, qt4 }:
+{ stdenv, fetchurl, cmake, pysideApiextractor, python3, qt4 }:
 
 # This derivation does not provide any Python module and should therefore be called via `all-packages.nix`.
 let
-  pythonEnv = python2.withPackages(ps: with ps; [ sphinx ]);
+  pythonEnv = python3.withPackages(ps: with ps; [ sphinx ]);
   pname = "pyside-generatorrunner";
   version = "0.6.16";
 in stdenv.mkDerivation {
@@ -15,7 +15,14 @@ in stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ cmake pysideApiextractor qt4 pythonEnv ];
+  outputs = [ "out" "dev" ];
+
+  preConfigure = ''
+    cmakeFlagsArray=("-DCMAKE_INSTALL_PREFIX=$dev")
+  '';
+
+  nativeBuildInputs = [ cmake pythonEnv ];
+  buildInputs = [ pysideApiextractor qt4 ];
 
   meta = {
     description = "Eases the development of binding generators for C++ and Qt-based libraries by providing a framework to help automating most of the process";

--- a/pkgs/development/python-modules/pyside/shiboken.nix
+++ b/pkgs/development/python-modules/pyside/shiboken.nix
@@ -33,7 +33,10 @@ buildPythonPackage rec {
 
   buildInputs = [ python libxml2 libxslt ];
 
+  outputs = [ "out" "dev" ];
+
   preConfigure = ''
+    cmakeFlagsArray=("-DCMAKE_INSTALL_PREFIX=$dev")
     echo "preConfigure: Fixing shiboken_generator install target."
     substituteInPlace generator/CMakeLists.txt --replace \
       \"$\{GENERATORRUNNER_PLUGIN_DIR}\" lib/generatorrunner/

--- a/pkgs/development/python-modules/pyside/tools.nix
+++ b/pkgs/development/python-modules/pyside/tools.nix
@@ -12,6 +12,12 @@ buildPythonPackage rec {
     sha256 = "017i2yxgjrisaifxqnl3ym8ijl63l2yl6a3474dsqhlyqz2nx2ll";
   };
 
+  outputs = [ "out" "dev" ];
+
+  preConfigure = ''
+    cmakeFlagsArray=("-DCMAKE_INSTALL_PREFIX=$dev")
+  '';
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ qt4 ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Remove python2 dependencies, and refactor the pyside tools to use multiple outputs to reduce the size of the runtime dependencies

#101964 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
