### PR TITLE
glslviewer: 2019-04-22 -> 1.6.8, use python3

### DIFF
--- a/pkgs/development/tools/glslviewer/default.nix
+++ b/pkgs/development/tools/glslviewer/default.nix
@@ -1,28 +1,28 @@
 { stdenv, fetchFromGitHub, glfw, pkgconfig, libXrandr, libXdamage
 , libXext, libXrender, libXinerama, libXcursor, libXxf86vm, libXi
-, libX11, libGLU, python2Packages, ensureNewerSourcesForZipFilesHook
+, libX11, libGLU, python3Packages, ensureNewerSourcesForZipFilesHook
 , Cocoa
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "glslviewer";
-  version = "2019-04-22";
+  version = "1.6.8";
 
   src = fetchFromGitHub {
     owner = "patriciogonzalezvivo";
     repo = "glslViewer";
-    rev = "fa3e2ed4810927d189e480b704366cca22f281f3";
-    sha256 = "1888jxi84f2nnc0kpzqrn2cada1z4zqyq8ss4ppb5y3wy7d87qjn";
+    rev = version;
+    sha256 = "0v7x93b61ama0gmzlx1zc56jgi7bvzsfvbkfl82xzwf2h5g1zni7";
   };
 
-  nativeBuildInputs = [ pkgconfig ensureNewerSourcesForZipFilesHook ];
+  nativeBuildInputs = [ pkgconfig ensureNewerSourcesForZipFilesHook python3Packages.six ];
   buildInputs = [
     glfw libGLU glfw libXrandr libXdamage
     libXext libXrender libXinerama libXcursor libXxf86vm
     libXi libX11
-  ] ++ (with python2Packages; [ python setuptools wrapPython ])
+  ] ++ (with python3Packages; [ python setuptools wrapPython ])
     ++ stdenv.lib.optional stdenv.isDarwin Cocoa;
-  pythonPath = with python2Packages; [ requests ];
+  pythonPath = with python3Packages; [ pyyaml requests ];
 
   # Makefile has /usr/local/bin hard-coded for 'make install'
   preConfigure = ''
@@ -31,6 +31,7 @@ stdenv.mkDerivation {
         --replace '/usr/bin/clang++' 'clang++'
     substituteInPlace Makefile \
         --replace 'python setup.py install' "python setup.py install --prefix=$out"
+    2to3 -w bin/*
   '';
 
   preInstall = ''


### PR DESCRIPTION
###### Motivation for this change
bump to latest stable

wrap using python3 instead of 2, had to run `2to3` to get it to be valid python3 code.

issue upstream: https://github.com/patriciogonzalezvivo/glslViewer/issues/191

related: https://github.com/NixOS/nixpkgs/issues/101964
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
