### PR TITLE
csv_fast_export: use python3

### DIFF
--- a/pkgs/applications/version-management/cvs-fast-export/default.nix
+++ b/pkgs/applications/version-management/cvs-fast-export/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl, makeWrapper, flex, bison,
  asciidoc, docbook_xml_dtd_45, docbook_xsl,
  libxml2, libxslt,
- python27, rcs, cvs, git,
+ python3, rcs, cvs, git,
  coreutils, rsync}:
 with stdenv; with lib;
 mkDerivation rec {
@@ -22,7 +22,7 @@ mkDerivation rec {
 
   buildInputs = [
     flex bison asciidoc docbook_xml_dtd_45 docbook_xsl libxml2 libxslt
-    python27 rcs cvs git makeWrapper
+    python3 rcs cvs git makeWrapper
   ];
 
   postPatch = "patchShebangs .";


### PR DESCRIPTION
###### Motivation for this change
related: https://github.com/NixOS/nixpkgs/issues/101964

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
