### PR TITLE
indilib: 1.1.0 -> 1.8.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3487,6 +3487,12 @@
     email = "t@larkery.com";
     name = "Tom Hinton";
   };
+  hjones2199 = {
+    email = "hjones2199@gmail.com";
+    github = "hjones2199";
+    githubId = 5525217;
+    name = "Hunter Jones";
+  };
   hkjn = {
     email = "me@hkjn.me";
     name = "Henrik Jonsson";

--- a/pkgs/applications/science/astronomy/kstars/default.nix
+++ b/pkgs/applications/science/astronomy/kstars/default.nix
@@ -1,27 +1,30 @@
 {
-  mkDerivation, lib, fetchgit,
-  extra-cmake-modules,
+  stdenv, extra-cmake-modules, fetchurl,
 
   kconfig, kdoctools, kguiaddons, ki18n, kinit, kiconthemes, kio,
-  knewstuff, kplotting, kwidgetsaddons, kxmlgui,
+  knewstuff, kplotting, kwidgetsaddons, kxmlgui, wrapQtAppsHook,
 
   qtx11extras, qtwebsockets,
 
   eigen, zlib,
 
-  cfitsio, indilib, xplanet
+  cfitsio, indilib, xplanet, libnova, gsl
 }:
 
-mkDerivation {
-  name = "kstars";
-  
-  src = fetchgit {
-    url = "https://anongit.kde.org/kstars.git";
-    rev = "7acc527939280edd22823371dc4e22494c6c626a";
-    sha256 = "1n1lgi7p3dj893fdnzjbnrha40p4apl0dy8zppcabxwrb1khb84v";
+stdenv.mkDerivation rec {
+  pname = "kstars";
+  version = "3.4.3";
+
+  src = fetchurl {
+    url = "https://mirrors.mit.edu/kde/stable/kstars/kstars-${version}.tar.xz";
+    sha256 = "0j5yxg6ay6sic194skz6vjzg6yvrpb3gvypvs0frjrcjbsl1j4f8";
   };
-  
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+
+  patches = [
+    ./indi-fix.patch
+  ];
+
+  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapQtAppsHook ];
   buildInputs = [
     kconfig kdoctools kguiaddons ki18n kinit kiconthemes kio
     knewstuff kplotting kwidgetsaddons kxmlgui
@@ -30,10 +33,14 @@ mkDerivation {
 
     eigen zlib
 
-    cfitsio indilib xplanet
+    cfitsio indilib xplanet libnova gsl
   ];
 
-  meta = with lib; {
+  cmakeFlags = [
+    "-DINDI_NIX_ROOT=${indilib}"
+  ];
+
+  meta = with stdenv.lib; {
     description = "Virtual planetarium astronomy software";
     homepage = "https://kde.org/applications/education/org.kde.kstars";
     longDescription = ''

--- a/pkgs/applications/science/astronomy/kstars/indi-fix.patch
+++ b/pkgs/applications/science/astronomy/kstars/indi-fix.patch
@@ -1,0 +1,50 @@
+--- CMakeLists.txt	2020-11-02 13:58:06.119743710 -0600
++++ kstars-3.4.3/CMakeLists.txt	2020-11-02 14:05:01.707799274 -0600
+@@ -4,5 +4,7 @@
+ set (KStars_VERSION_REVISION 3)
+ set (CMAKE_CXX_STANDARD 11)
+ 
++add_definitions(-DINDI_NIX_ROOT=${INDI_NIX_ROOT})
++
+ # Build KStars Lite with -DBUILD_KSTARS_LITE=ON
+ option(BUILD_KSTARS_LITE "Build KStars Lite" OFF)
+
+--- ksutils.cpp	2020-11-02 13:47:44.883596916 -0600
++++ kstars-3.4.3/kstars/auxiliary/ksutils.cpp	2020-11-02 17:41:44.961937090 -0600
+@@ -1076,6 +1076,9 @@
+ {
+     QString snap = QProcessEnvironment::systemEnvironment().value("SNAP");
+     QString flat = QProcessEnvironment::systemEnvironment().value("FLATPAK_DEST");
++#define STR_EXPAND(x) #x
++#define STR(x) STR_EXPAND(x)
++    QString nix = QString(STR(INDI_NIX_ROOT));
+ 
+     if (option == "fitsDir")
+     {
+@@ -1089,7 +1091,7 @@
+         if (flat.isEmpty() == false)
+             return flat + "/bin/indiserver";
+         else
+-            return snap + "/usr/bin/indiserver";
++            return nix + "/bin/indiserver";
+     }
+     else if (option == "INDIHubAgent")
+     {
+@@ -1099,7 +1101,7 @@
+         if (flat.isEmpty() == false)
+             return flat + "/bin/indihub-agent";
+         else
+-            return snap + "/usr/bin/indihub-agent";
++            return nix + "/bin/indihub-agent";
+     }
+     else if (option == "indiDriversDir")
+     {
+@@ -1109,7 +1111,7 @@
+         if (flat.isEmpty() == false)
+             return flat + "/share/indi";
+         else
+-            return snap + "/usr/share/indi";
++            return nix + "/share/indi";
+ #else
+         return QStandardPaths::locate(QStandardPaths::GenericDataLocation, "indi", QStandardPaths::LocateDirectory);
+ #endif

--- a/pkgs/development/libraries/indilib/default.nix
+++ b/pkgs/development/libraries/indilib/default.nix
@@ -1,5 +1,5 @@
 { stdenv
-, fetchurl
+, fetchFromGitHub
 , cmake
 , cfitsio
 , libusb1
@@ -9,14 +9,18 @@
 , curl
 , libjpeg
 , gsl
+, fftw
 }:
 
-stdenv.mkDerivation {
-  name = "indilib-1.1.0";
+stdenv.mkDerivation rec {
+  pname = "indilib";
+  version = "1.8.6";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/indi/libindi_1.1.0.tar.gz";
-    sha256 = "1bs6lkwqd4aashg93mqqkc7nrg7fbx9mdw85qs5263jqa6sr780w";
+  src = fetchFromGitHub {
+    owner = "indilib";
+    repo = "indi";
+    rev = "v${version}";
+    sha256 = "1yzvcm7lwhwssnvv6gp8f7igmnvs35bpidmzz6z15awm5841yw30";
   };
 
   patches = [
@@ -36,12 +40,14 @@ stdenv.mkDerivation {
     libnova
     libjpeg
     gsl
+    fftw
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "https://www.indilib.org/";
-    license = stdenv.lib.licenses.lgpl2Plus;
-    description = "Implementaion of the INDI protocol for POSIX operating systems";
-    platforms = stdenv.lib.platforms.unix;
+    description = "Implementation of the INDI protocol for POSIX operating systems";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ hjones2199 ];
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/development/libraries/indilib/udev-dir.patch
+++ b/pkgs/development/libraries/indilib/udev-dir.patch
@@ -1,12 +1,11 @@
-diff -Naur libindi-1.0.0-upstream/CMakeLists.txt libindi-1.0.0/CMakeLists.txt
---- libindi-1.0.0-upstream/CMakeLists.txt	2015-03-28 21:06:49.576863460 -0430
-+++ libindi-1.0.0/CMakeLists.txt	2015-03-28 21:07:48.420677548 -0430
-@@ -28,7 +28,7 @@
+--- indi-1.8.6/CMakeLists.txt	2020-08-21 05:56:59.000000000 -0500
++++ CMakeLists.txt	2020-11-01 12:50:57.621293870 -0600
+@@ -77,7 +77,7 @@
  ## the following are directories where stuff will be installed to
  set(INCLUDE_INSTALL_DIR      "${CMAKE_INSTALL_PREFIX}/include/")
- set(PKGCONFIG_INSTALL_PREFIX "${LIB_DESTINATION}/pkgconfig/")
+ set(PKGCONFIG_INSTALL_PREFIX "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 -set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
 +set(UDEVRULES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
  
- ##################  Includes  ################################
- Include (CheckCXXSourceCompiles)
+ set(PKG_CONFIG_LIBDIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Receive upstream bugfixes and new astronomical equipment support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
