### PR TITLE
nix-prefetch-github: v3.0 -> v4.0

### DIFF
--- a/pkgs/development/python-modules/nix-prefetch-github/default.nix
+++ b/pkgs/development/python-modules/nix-prefetch-github/default.nix
@@ -15,11 +15,11 @@
 
 buildPythonPackage rec {
   pname = "nix-prefetch-github";
-  version = "3.0";
+  version = "4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-EN+EbVXUaf+id5UsK4EBm/9k9FYaH79g08kblvW60XA=";
+    sha256 = "sha256-STUyMUCWAHfDA6dkpiOqSRBL3/tubedUbWa94Kp/764=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

The package in question ([nix-prefetch-github](https://pypi.org/project/nix-prefetch-github)) changed upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
