### PR TITLE
nixos: mutually exclusive services; application to acme

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -662,6 +662,7 @@ in {
       } // (mapAttrs' (cert: conf: nameValuePair "acme-selfsigned-${cert}" conf.selfsignService) certConfigs)));
 
       systemd.timers = mapAttrs' (cert: conf: nameValuePair "acme-${cert}" conf.renewTimer) certConfigs;
+      systemd.mutex.acme = map (cert: "acme-${cert}.service") (attrNames certConfigs);
 
       # .lego and .lego/accounts specified to fix any incorrect permissions
       systemd.tmpfiles.rules = [


### PR DESCRIPTION
##### Motivation for this change

In #101445  one of the hypothetical solutions is to ensure certs are renewed one at a time. But this is not the first time I wanted to be able to specify that some oneshot systemd services must not run simultaneously. Notably, I have some periodic io intensive jobs with a timer. To prevent them from running at the same time, I have to choose a unique hour for each of them myself. Instead I would like to set them all to "daily" and mark them as mutually exclusive.

So I implemented a generic solution.

This introduces a `systemd.mutex` options to define sets of mutually exclusive services, working by adding After= and Before= stanzas. The nix implementation is not very pretty and limited to services (does it really make sense on non-services?).
As illustrations, I added a test and applied it to acme to see if it fixes #101445. Unfortunately, as it seems we cannot reproduce the issue reliably, it's hard to say if it really fixes it...

I can split the acme commit from the generic implementation if you want, and if the nix code is to ugly I can try other things, but before I'd like to hear some opinions about whether we want this mechanism at all.

Tested with the systemd.nix and acme.nix tests.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
