### PR TITLE
pipreqs: use python3

### DIFF
--- a/pkgs/tools/misc/pipreqs/default.nix
+++ b/pkgs/tools/misc/pipreqs/default.nix
@@ -1,16 +1,17 @@
-{ lib, python2Packages }:
+{ lib, python3 }:
 
-# Using python 2 because when packaging with python 3 pipreqs fails to parse python 2 code.
-python2Packages.buildPythonApplication rec {
+with python3.pkgs;
+
+buildPythonApplication rec {
   pname = "pipreqs";
   version = "0.4.10";
 
-  src = python2Packages.fetchPypi {
+  src = fetchPypi {
     inherit pname version;
     sha256 = "0fdr3mbxjpmrxr7yfc1sn9kbpcyb0qwafimhhrrqvf989dj1sdcy";
   };
 
-  propagatedBuildInputs = with python2Packages; [ yarg docopt ];
+  propagatedBuildInputs = [ yarg docopt ];
 
   # Tests requires network access. Works fine without sandboxing
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
related: #101964 

although this may lose support to parse python2 code, I think the compromise is worth it for not introducing vulnerabilities to a user's system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
