### PR TITLE
Change idiom for overriding Dhall package version

### DIFF
--- a/pkgs/development/dhall-modules/Prelude.nix
+++ b/pkgs/development/dhall-modules/Prelude.nix
@@ -1,59 +1,11 @@
-{ buildDhallGitHubPackage, lib }:
+{ buildDhallGitHubPackage }:
 
-let
-  makePrelude =
-    version: { rev, sha256 }:
-      buildDhallGitHubPackage {
-        name      = "Prelude-${version}";
-        owner     = "dhall-lang";
-        repo      = "dhall-lang";
-        directory = "Prelude";
-        file      = "package.dhall";
-
-        inherit rev sha256;
-      };
-
-in
-  lib.mapAttrs makePrelude {
-    # Prelude versions older than 7.0.0 use old-style union literals, which are
-    # no longer supported by the latest version of the standard
-    "7.0.0" = {
-      rev    = "f0509b403ace4b8a72ebb5fa9c473b9aeabeaf33";
-      sha256 = "00ldlvqfh411vnrnc41zfnlvgfanwfd3l8hdia8kni3r8q9qmd71";
-    };
-
-    "8.0.0" = {
-      rev    = "136a3491753fef251b2087031617d1ee1053f285";
-      sha256 = "0haxd5dhi5bmg06a0hx1blpivmwrcnndydwagibj3zvch4knyi2q";
-    };
-
-    "9.0.0" = {
-      rev    = "6cbf57c946e7e6576babc23a38320e53ecfa6bee";
-      sha256 = "1r06fijszyifq5b4j6libwkm06g8693m9n5c4kq61dvzrjfd2gim";
-    };
-
-    "10.0.0" = {
-      rev    = "ecbf82785cff406bbd162bbabf3df6f817c805e0";
-      sha256 = "0gxkr9649jqpykdzqjc98gkwnjry8wp469037brfghyidwsm021m";
-    };
-
-    "11.0.0" = {
-      rev    = "8098184d17c3aecc82674a7b874077a7641be05a";
-      sha256 = "0rdvyxq7mvas82wsfzzpk6imzm8ax4q58l522mx0ks69pacpr3yi";
-    };
-
-    "11.1.0" = {
-      rev    = "31e90e1996f6c4cb50e03ccb1f3c45beb4bd278c";
-      sha256 = "0rdvyxq7mvas82wsfzzpk6imzm8ax4q58l522mx0ks69pacpr3yi";
-    };
-
-    "12.0.0" = {
-      rev    = "9f248138f69ee5e22192dc3d0417d5c77b189e04";
-      sha256 = "1gbr0376sfamp0ibhcbxz4vaxr6ipv42y42p5wyksfhz3ls9x5ph";
-    };
-
-    "13.0.0" = {
-      rev    = "48db9e1ff1f8881fa4310085834fbc19e313ebf0";
-      sha256 = "0kg3rzag3irlcldck63rjspls614bc2sbs3zq44h0pzcz9v7z5h9";
-    };
-  }
+buildDhallGitHubPackage {
+  name      = "Prelude-13.0.0";
+  owner     = "dhall-lang";
+  repo      = "dhall-lang";
+  directory = "Prelude";
+  file      = "package.dhall";
+  rev       = "48db9e1ff1f8881fa4310085834fbc19e313ebf0";
+  sha256    = "0kg3rzag3irlcldck63rjspls614bc2sbs3zq44h0pzcz9v7z5h9";
+}

--- a/pkgs/development/dhall-modules/dhall-kubernetes.nix
+++ b/pkgs/development/dhall-modules/dhall-kubernetes.nix
@@ -1,27 +1,10 @@
-{ buildDhallGitHubPackage, lib }:
+{ buildDhallGitHubPackage }:
 
-let
-  makeDhallKubernetes =
-    version: { rev, sha256 }:
-      buildDhallGitHubPackage {
-        name  = "dhall-kubernetes-${version}";
-        owner = "dhall-lang";
-        repo  = "dhall-kubernetes";
-        file  = "package.dhall";
-
-        inherit rev sha256;
-      };
-
-in
-  lib.mapAttrs makeDhallKubernetes {
-    # 2.1.0 was the first version to introduce a top-level `package.dhall` file
-    "2.1.0" = {
-      rev    = "bbfec3d8548b605f1c9628f34029ab4a7d928839";
-      sha256 = "10zkigj05khiy6w2sqcm5nw7d47r5k52xq8np8q86h0phy798g96";
-    };
-
-    "3.0.0" = {
-      rev    = "3c6d09a9409977cdde58a091d76a6d20509ca4b0";
-      sha256 = "1r4awh770ghsrwabh5ddy3jpmrbigakk0h32542n1kh71w3cdq1h";
-    };
-  }
+buildDhallGitHubPackage {
+  name   = "dhall-kubernetes-3.0.0";
+  owner  = "dhall-lang";
+  repo   = "dhall-kubernetes";
+  file   = "package.dhall";
+  rev    = "3c6d09a9409977cdde58a091d76a6d20509ca4b0";
+  sha256 = "1r4awh770ghsrwabh5ddy3jpmrbigakk0h32542n1kh71w3cdq1h";
+}

--- a/pkgs/development/dhall-modules/dhall-packages.nix
+++ b/pkgs/development/dhall-modules/dhall-packages.nix
@@ -1,51 +1,51 @@
-{ buildDhallGitHubPackage, dhall-kubernetes, lib, Prelude }:
+{ buildDhallGitHubPackage, dhall-kubernetes, Prelude }:
 
 let
-  makeDhallPackages =
-    version: { rev, sha256, dependencies }:
-      buildDhallGitHubPackage {
-        name  = "dhall-packages-${version}";
-        owner = "EarnestResearch";
-        repo  = "dhall-packages";
-        file  = "package.dhall";
+  Prelude_12_0_0 = Prelude.overridePackage {
+    name = "Prelude-12.0.0";
+    rev    = "9f248138f69ee5e22192dc3d0417d5c77b189e04";
+    sha256 = "1gbr0376sfamp0ibhcbxz4vaxr6ipv42y42p5wyksfhz3ls9x5ph";
+  };
 
-        inherit rev sha256 dependencies;
-      };
+  kubernetes = {
+    "6a47bd" = dhall-kubernetes.overridePackage {
+      name   = "dhall-kubernetes-6a47bd";
+      rev    = "6a47bd50c4d3984a13570ea62382a3ad4a9919a4";
+      sha256 = "1azqs0x2kia3xw93rfk2mdi8izd7gy9aq6qzbip32gin7dncmfhh";
+    };
+
+    "4ad581" = dhall-kubernetes.overridePackage {
+      name   = "dhall-kubernetes-4ad581";
+      rev    = "4ad58156b7fdbbb6da0543d8b314df899feca077";
+      sha256 = "12fm70qbhcainxia388svsay2cfg9iksc6mss0nvhgxhpypgp8r0";
+    };
+
+    "fee24c" = dhall-kubernetes.overridePackage {
+      name   = "dhall-kubernetes-fee24c";
+      rev    = "fee24c0993ba0b20190e2fdb94e386b7fb67252d";
+      sha256 = "11d93z8y0jzrb8dl43gqha9z96nxxqkl7cbxpz8hw8ky9x6ggayk";
+    };
+  };
 
 in
-  lib.mapAttrs makeDhallPackages {
-    "0.11.1" =
-      let
-        k8s_6a47bd = dhall-kubernetes.override {
-          rev    = "6a47bd50c4d3984a13570ea62382a3ad4a9919a4";
-          sha256 = "1azqs0x2kia3xw93rfk2mdi8izd7gy9aq6qzbip32gin7dncmfhh";
-        };
+  buildDhallGitHubPackage {
+    name   = "dhall-packages-0.11.1";
+    owner  = "EarnestResearch";
+    repo   = "dhall-packages";
+    file   = "package.dhall";
+    rev    = "8d228f578fbc7bb16c04a7c9ac8c6c7d2e13d1f7";
+    sha256 = "1v4y1x13lxy6cxf8xqc6sb0mc4mrd4frkxih95v9q2wxw4vkw2h7";
 
-        k8s_4ad581 = dhall-kubernetes.override {
-          rev    = "4ad58156b7fdbbb6da0543d8b314df899feca077";
-          sha256 = "12fm70qbhcainxia388svsay2cfg9iksc6mss0nvhgxhpypgp8r0";
-        };
-
-        k8s_fee24c = dhall-kubernetes.override {
-          rev    = "fee24c0993ba0b20190e2fdb94e386b7fb67252d";
-          sha256 = "11d93z8y0jzrb8dl43gqha9z96nxxqkl7cbxpz8hw8ky9x6ggayk";
-        };
-
-      in
-        { rev    = "8d228f578fbc7bb16c04a7c9ac8c6c7d2e13d1f7";
-          sha256 = "1v4y1x13lxy6cxf8xqc6sb0mc4mrd4frkxih95v9q2wxw4vkw2h7";
-
-          dependencies = [
-            (k8s_6a47bd.override { file = "1.14/package.dhall"; })
-            (k8s_6a47bd.override { file = "1.15/package.dhall"; })
-            (k8s_6a47bd.override { file = "1.16/package.dhall"; })
-            (k8s_4ad581.override { file = "types.dhall"; })
-            (k8s_fee24c.override { file = "types/io.k8s.api.core.v1.ServiceSpec.dhall"; })
-            (k8s_fee24c.override { file = "types/io.k8s.api.core.v1.PodTemplateSpec.dhall"; })
-            Prelude."12.0.0"
-            (Prelude."12.0.0".override { file = "JSON/package.dhall"; })
-            (Prelude."12.0.0".override { file = "JSON/Type"; })
-            (Prelude."12.0.0".override { file = "Map/Type"; })
-          ];
-        };
+    dependencies = [
+      (kubernetes."6a47bd".overridePackage { file = "1.14/package.dhall"; })
+      (kubernetes."6a47bd".overridePackage { file = "1.15/package.dhall"; })
+      (kubernetes."6a47bd".overridePackage { file = "1.16/package.dhall"; })
+      (kubernetes."4ad581".overridePackage { file = "types.dhall"; })
+      (kubernetes."fee24c".overridePackage { file = "types/io.k8s.api.core.v1.ServiceSpec.dhall"; })
+      (kubernetes."fee24c".overridePackage { file = "types/io.k8s.api.core.v1.PodTemplateSpec.dhall"; })
+      Prelude_12_0_0
+      (Prelude_12_0_0.overridePackage { file = "JSON/package.dhall"; })
+      (Prelude_12_0_0.overridePackage { file = "JSON/Type"; })
+      (Prelude_12_0_0.overridePackage { file = "Map/Type"; })
+    ];
   }

--- a/pkgs/development/dhall-modules/lib.nix
+++ b/pkgs/development/dhall-modules/lib.nix
@@ -1,0 +1,25 @@
+{ lib }:
+
+let
+  # This is essentially the same thing as `lib.makeOverridable`, except storing
+  # the override method in a method named `overridePackage` so that it's not
+  # shadowed by the `override` method added by `callPackage`
+  makePackageOverridable = f: args:
+    let
+      result = lib.makeOverridable f args;
+
+      copyArgs = g: lib.setFunctionArgs g (lib.functionArgs f);
+
+      overrideWith =
+        update: args // (if lib.isFunction update then update args else update);
+
+      overridePackage =
+        copyArgs (update: makePackageOverridable f (overrideWith update));
+
+    in
+      result // { inherit overridePackage; };
+
+in
+  lib // {
+    inherit makePackageOverridable;
+  }

--- a/pkgs/development/interpreters/dhall/build-dhall-directory-package.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-directory-package.nix
@@ -5,7 +5,7 @@
 # the `file`
 #
 # This function is used by `dhall-to-nixpkgs` when given a directory
-lib.makeOverridable
+lib.makePackageOverridable
   ( { # Arguments passed through to `buildDhallPackage`
       name
     , dependencies ? []

--- a/pkgs/development/interpreters/dhall/build-dhall-github-package.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-github-package.nix
@@ -1,7 +1,7 @@
 { buildDhallPackage, fetchFromGitHub, lib }:
 
 # This function is used by `dhall-to-nixpkgs` when given a GitHub repository
-lib.makeOverridable
+lib.makePackageOverridable
   ( { # Arguments passed through to `buildDhallPackage`
       name
     , dependencies ? []

--- a/pkgs/top-level/dhall-packages.nix
+++ b/pkgs/top-level/dhall-packages.nix
@@ -8,16 +8,6 @@ let
     let
       callPackage = newScope self;
 
-      prefer = version: path:
-        let
-          packages = callPackage path { };
-
-        in
-          packages."${version}".overrideAttrs (_: {
-              passthru = packages;
-            }
-          );
-
       buildDhallPackage =
         callPackage ../development/interpreters/dhall/build-dhall-package.nix { };
 
@@ -34,14 +24,16 @@ let
           buildDhallDirectoryPackage
         ;
 
+        lib = import ../development/dhall-modules/lib.nix { inherit lib; };
+
         dhall-kubernetes =
-          prefer "3.0.0" ../development/dhall-modules/dhall-kubernetes.nix;
+          callPackage ../development/dhall-modules/dhall-kubernetes.nix { };
 
         dhall-packages =
-          prefer "0.11.1" ../development/dhall-modules/dhall-packages.nix;
+          callPackage ../development/dhall-modules/dhall-packages.nix { };
 
         Prelude =
-          prefer "13.0.0" ../development/dhall-modules/Prelude.nix;
+          callPackage ../development/dhall-modules/Prelude.nix { };
       };
 
 in


### PR DESCRIPTION
Before this change, a Dhall package like the Prelude would be
encoded as a record with one field per supported version.  Then
downstream packages would specify which package to override
by selecting a different record field.

The problem with that approach is that it did not provide an
easy way to override a package to a version other than the default
ones supplied by Nixpkgs.  Normally you would use the `.override`
method for this purpose, but the `override` method added by
`buildDhall{Directory,GitHub}Package` is clobbered by the
`override` method added by `callPackage` in
`./pkgs/top-level/dhall-packages.nix`.

The solution is to add a separate `.overridePackage` method which is
essentially the exact same as `.override`, except that it is no
longer clobbered by `callPackage`.  This `.overridePackage` method
allows one to override the arguments supplied to
`buildDhall{Directory,GitHub}Package`, making it easier to specify
package versions outside of the ones supported by Nixpkgs..

This also includes a change to only build one (preferred) version of each
package (instead of multiple supported versions per package), in order to
minimize the maintenance burden for the Dhall package set.

I verified that all of the supported Dhall packages still build after this change.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
