### PR TITLE
mediatomb: Allow users to customize duktape/js script imports

### DIFF
--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -65,6 +65,14 @@ let
     </transcoding>
 '';
 
+  virtualLayout =
+    let toCustomImportScript = import-script-path: "<import-script>${import-script-path}</import-script>\n";
+    in if ((builtins.length cfg.customImportJS) > 0) then ''
+        <virtual-layout type="js">${concatMapStrings toCustomImportScript cfg.customImportJS}</virtual-layout>
+      '' else ''
+        <virtual-layout type="builtin"><import-script>${pkg}/share/${name}/js/import.js</import-script></virtual-layout>
+      '';
+
   configText = optionalString (! cfg.customCfg) ''
 <?xml version="1.0" encoding="UTF-8"?>
 <config version="2" xmlns="http://mediatomb.cc/config/2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://mediatomb.cc/config/2 http://mediatomb.cc/config/2.xsd">
@@ -113,9 +121,7 @@ let
       <scripting script-charset="UTF-8">
         <common-script>${pkg}/share/${name}/js/common.js</common-script>
         <playlist-script>${pkg}/share/${name}/js/playlists.js</playlist-script>
-        <virtual-layout type="builtin">
-          <import-script>${pkg}/share/${name}/js/import.js</import-script>
-        </virtual-layout>
+        ${virtualLayout}
       </scripting>
       <mappings>
         <extension-mimetype ignore-unknown="no">
@@ -332,6 +338,18 @@ in {
         example = [
           { path = "/data/pictures"; recursive = false; hidden-files = false; }
           { path = "/data/audio"; recursive = true; hidden-files = false; }
+        ];
+      };
+
+      customImportJS = mkOption {
+        type = with types; listOf path;
+        default = [];
+        description = ''
+          A list of user customized javascript files to import. If unspecified,
+          the default, this uses the default builtin engine.
+        '';
+        example = [
+          ./import.js
         ];
       };
 


### PR DESCRIPTION
# Motivation

With no customization, the default behavior is kept (virtual-layout using the
builtin engine with the default import.js provided by gerbera).

This allows user to develop and provide their own list of customized
duktape/javascript scripts [1]

[1] http://docs.gerbera.io/en/latest/scripting.html

(supersedes #101296)

# Actions

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS: odroid [2]
   - [ ] macOS
   - [x] other Linux distributions: debian with nix
- [x] Tested via one or more NixOS test(s) [3]
- [x] nixpkgs-review wip [4]
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

[2] https://gitlab.com/ardumont/nixos/-/blob/master/odroid/mediatomb/default.nix#L24

[3]
```
$ sudo chmod 666 /dev/kvm # for some reason otherwise permission denied (user is in kvm group though)
$ cd nixos/tests
$ nix-build mediatomb.nix
...
client # [   12.927208] reboot: Power down
(0.59 seconds)
(13.67 seconds)
test script finished in 13.67s
cleaning up
(0.00 seconds)
/nix/store/pxc71jg8vgra3iywvxljgsh20clfcn79-vm-test-run-mediatomb
```

[4]
```
$ nixpkgs-review pr 102393
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0 pull/102393/head:refs/nixpkgs-review/1
remote: Enumerating objects: 10, done.
remote: Counting objects: 100% (10/10), done.
remote: Compressing objects: 100% (2/2), done.
remote: Total 12 (delta 8), reused 8 (delta 8), pack-reused 2
Unpacking objects: 100% (12/12), 92.33 KiB | 373.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   02daf3f0768..9c87b3271a6  master                -> refs/nixpkgs-review/0
 + 7c389b0c3ff...ba9ade5c557 refs/pull/102393/head -> refs/nixpkgs-review/1  (forced update)
$ git worktree add /home/tony/.cache/nixpkgs-review/pr-102393/nixpkgs 9c87b3271a6558f9adc60500424ca2a9e376a8c1
Preparing worktree (detached HEAD 9c87b3271a6)
Updating files: 100% (23083/23083), done.
HEAD is now at 9c87b3271a6 Merge pull request #102386 from seppeljordan/update-nix-prefetch-github-4.0
$ nix-env -f /home/tony/.cache/nixpkgs-review/pr-102393/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit ba9ade5c557138a69983fd100a6348ec8ab28ce4
Automatic merge went well; stopped before committing as requested
$ nix-env -f /home/tony/.cache/nixpkgs-review/pr-102393/nixpkgs -qaP --xml --out-path --show-trace --meta
Nothing to be built.
https://github.com/NixOS/nixpkgs/pull/102393
$ nix-shell /home/tony/.cache/nixpkgs-review/pr-102393/shell.nix
```
