### PR TITLE
treewide: remove superflous format string when a variable can be used directly

### DIFF
--- a/pkgs/applications/audio/bchoppr/default.nix
+++ b/pkgs/applications/audio/bchoppr/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "sjaehn";
     repo = pname;
-    rev = "${version}";
+    rev = version;
     sha256 = "1nd6byy75f0rbz9dm9drhxmpsfhxhg0y7q3v2m3098llynhy9k2j";
   };
 

--- a/pkgs/applications/audio/bsequencer/default.nix
+++ b/pkgs/applications/audio/bsequencer/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "sjaehn";
     repo = pname;
-    rev = "${version}";
+    rev = version;
     sha256 = "0hagnn104ybzdp13r95idw20fhmzif8p3kmiypnr20m6c64rdd29";
   };
 

--- a/pkgs/applications/audio/bslizr/default.nix
+++ b/pkgs/applications/audio/bslizr/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "sjaehn";
     repo = pname;
-    rev = "${version}";
+    rev = version;
     sha256 = "1f7xrljvsy7a1p8c7wln2zhwarl3ara7gbjxkpyh47wfdpigpdb0";
   };
 

--- a/pkgs/applications/editors/marker/default.nix
+++ b/pkgs/applications/editors/marker/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "fabiocolacio";
     repo = "Marker";
-    rev = "${version}";
+    rev = version;
     fetchSubmodules = true;
     sha256 = "1iy7izyprf050bix8am1krqivgyxnhx3jm775v8f80cgbqxy7m5r";
   };

--- a/pkgs/applications/graphics/drawpile/default.nix
+++ b/pkgs/applications/graphics/drawpile/default.nix
@@ -74,7 +74,7 @@ in mkDerivation rec {
   src = fetchFromGitHub {
     owner = "drawpile";
     repo = "drawpile";
-    rev = "${version}";
+    rev = version;
     sha256 = "sha256-AFFY+FcY9ExAur13OoWR9285RZtBe6jnRIrwi5raiCM=";
   };
 

--- a/pkgs/applications/misc/ausweisapp2/default.nix
+++ b/pkgs/applications/misc/ausweisapp2/default.nix
@@ -8,7 +8,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Governikus";
     repo = "AusweisApp2";
-    rev = "${version}";
+    rev = version;
     sha256 = "1vibk3wmn54qr2mwz537hrr959y0r1zabp0gsijhzj2mk68g9pnb";
   };
 

--- a/pkgs/applications/misc/batsignal/default.nix
+++ b/pkgs/applications/misc/batsignal/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "electrickite";
     repo = "batsignal";
-    rev = "${version}";
+    rev = version;
     sha256 = "12hj0j18db34x0xzgj6xmhvxm966d05z0rl3d9rlrcd2q96lilwf";
   };
 

--- a/pkgs/applications/misc/chewing-editor/default.nix
+++ b/pkgs/applications/misc/chewing-editor/default.nix
@@ -7,8 +7,8 @@ mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "chewing";
-    repo = "${pname}";
-    rev = "${version}";
+    repo = pname;
+    rev = version;
     sha256 = "0kc2hjx1gplm3s3p1r5sn0cyxw3k1q4gyv08q9r6rs4sg7xh2w7w";
   };
 

--- a/pkgs/applications/misc/dupeguru/default.nix
+++ b/pkgs/applications/misc/dupeguru/default.nix
@@ -9,7 +9,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "arsenetar";
     repo = "dupeguru";
-    rev = "${version}";
+    rev = version;
     sha256 = "0ma4f1c6vmpz8gi4sdy43x1ik7wh42wayvk1iq520d3i714kfcpy";
     fetchSubmodules = true;
   };

--- a/pkgs/applications/misc/effitask/default.nix
+++ b/pkgs/applications/misc/effitask/default.nix
@@ -13,8 +13,8 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitHub {
     owner = "sanpii";
-    repo = "${pname}";
-    rev = "${version}";
+    repo = pname;
+    rev = version;
     sha256 = "09bffxdp43s8b1rpmsgqr2kyz3i4jbd2yrwbxw21fj3sf3mwb9ig";
   };
 

--- a/pkgs/applications/misc/fuzzel/default.nix
+++ b/pkgs/applications/misc/fuzzel/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = "https://codeberg.org/dnkl/fuzzel";
-    rev = "${version}";
+    rev = version;
     sha256 = "0c0p9spklzmy9f7abz3mvw0vp6zgnk3ns1i6ks95ljjb3kqy9vs2";
   };
 

--- a/pkgs/applications/misc/keepass-plugins/keepasshttp/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keepasshttp/default.nix
@@ -8,7 +8,7 @@ let
     src = fetchFromGitHub {
       owner = "pfn";
       repo = "keepasshttp";
-      #rev = "${version}";
+      #rev = version;
       # for 1.8.4.2 the tag is at the wrong commit (they fixed stuff
       # afterwards and didn't move the tag), hence reference by commitid
       rev = "c2c4eb5388a02169400cba7a67be325caabdcc37";

--- a/pkgs/applications/misc/pwsafe/default.nix
+++ b/pkgs/applications/misc/pwsafe/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "${version}";
+    rev = version;
     sha256 = "0nh5jnf5yls2qv5hpfhm6i854zsknyh7d93c987a0cg14sg820fv";
   };
 

--- a/pkgs/applications/misc/solaar/default.nix
+++ b/pkgs/applications/misc/solaar/default.nix
@@ -7,7 +7,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "pwr-Solaar";
     repo = "Solaar";
-    rev = "${version}";
+    rev = version;
     sha256 = "0k5z9dap6rawiafkg1x7zjx51ala7wra6j6lvc2nn0y8r79yp7a9";
   };
 

--- a/pkgs/applications/networking/cluster/kubeval/default.nix
+++ b/pkgs/applications/networking/cluster/kubeval/default.nix
@@ -7,7 +7,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "instrumenta";
     repo = "kubeval";
-    rev = "${version}";
+    rev = version;
     sha256 = "05li0qv4q7fy2lr50r6c1r8dhx00jb1g01qmgc72a9zqp378yiq0";
   };
 

--- a/pkgs/applications/networking/instant-messengers/quaternion/default.nix
+++ b/pkgs/applications/networking/instant-messengers/quaternion/default.nix
@@ -10,7 +10,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner = "QMatrixClient";
     repo = "Quaternion";
-    rev = "${version}";
+    rev = version;
     sha256 = "0hqhg7l6wpkdbzrdjvrbqymmahziri07ba0hvbii7dd2p0h248fv";
   };
 

--- a/pkgs/applications/networking/trebleshot/default.nix
+++ b/pkgs/applications/networking/trebleshot/default.nix
@@ -10,7 +10,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner = "genonbeta";
     repo = "TrebleShot-Desktop";
-    rev = "${version}";
+    rev = version;
     sha256 = "1k8wagw6arsi1lqkhn1nl6j11mb122vi1qs0q2np6nznwfy7pn1k";
   };
 

--- a/pkgs/applications/science/electronics/flatcam/default.nix
+++ b/pkgs/applications/science/electronics/flatcam/default.nix
@@ -10,7 +10,7 @@ python3Packages.buildPythonApplication rec {
 
   src = fetchFromBitbucket {
     owner = "jpcgt";
-    repo = "${pname}";
+    repo = pname;
     rev = "533afd6a1772857cb633c011b5e0a15b60b1e92e"; # 8.5 with Red Hat packaging.
     sha256 = "199kiiml18k34z1zhk2hbhibphmnv0kb11kxiajq52alps0mjb3m";
   };

--- a/pkgs/applications/science/logic/potassco/clingcon.nix
+++ b/pkgs/applications/science/logic/potassco/clingcon.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "potassco";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     fetchSubmodules = true;
     sha256 = "1q7517h10jfvjdk2czq8d6y57r8kr1j1jj2k2ip2qxkpyfigk4rs";

--- a/pkgs/applications/version-management/git-and-tools/bump2version/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bump2version/default.nix
@@ -7,7 +7,7 @@ buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "c4urself";
-    repo = "${pname}";
+    repo = pname;
     rev = "refs/tags/v${version}";
     sha256 = "10p7rg569rk3qvzs5kjj17894bqlsg3ihhbln6ciwwfhkfq1kpja";
   };

--- a/pkgs/applications/version-management/git-and-tools/ghorg/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/ghorg/default.nix
@@ -7,7 +7,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "gabrie30";
     repo = "ghorg";
-    rev = "${version}";
+    rev = version;
     sha256 = "0diwndkckv6fga45j9zngizycn5m71r67cziv0zrx6c66ssbj49w";
   };
 

--- a/pkgs/data/icons/zafiro-icons/default.nix
+++ b/pkgs/data/icons/zafiro-icons/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "zayronxio";
     repo = pname;
-    rev = "${version}";
+    rev = version;
     sha256 = "05h8qm9izjbp8pnl9jpbw3y9sddhp0zmg94fm1k4d4hhdqnakqhv";
   };
 

--- a/pkgs/desktops/gnome-3/games/aisleriot/default.nix
+++ b/pkgs/desktops/gnome-3/games/aisleriot/default.nix
@@ -22,10 +22,10 @@ stdenv.mkDerivation rec {
   version = "3.22.11";
 
   src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = pname;
-    domain = "gitlab.gnome.org";
-    rev    = "${version}";
+    rev = version;
     sha256 = "1asm0y6485xqsysdg586y3hzz8bhxqwnc82k6vhfnxpxz7l62qa1";
   };
 

--- a/pkgs/development/compilers/llvm/11/default.nix
+++ b/pkgs/development/compilers/llvm/11/default.nix
@@ -7,7 +7,7 @@
 
 let
   release_version = "11.0.0";
-  version = "${release_version}"; # differentiating these (variables) is important for RCs
+  version = release_version; # differentiating these (variables) is important for RCs
   targetConfig = stdenv.targetPlatform.config;
 
   fetch = name: sha256: fetchurl {

--- a/pkgs/development/interpreters/acl2/default.nix
+++ b/pkgs/development/interpreters/acl2/default.nix
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "acl2-devel";
     repo = "acl2-devel";
-    rev = "${version}";
+    rev = version;
     sha256 = "0c0wimaf16nrr3d6cxq6p7nr7rxffvpmn66hkpwc1m6zpcipf0y5";
   };
 

--- a/pkgs/development/interpreters/clojurescript/lumo/default.nix
+++ b/pkgs/development/interpreters/clojurescript/lumo/default.nix
@@ -145,7 +145,7 @@ stdenv.mkDerivation {
 
   src = fetchgit {
     url = "https://github.com/anmonteiro/lumo.git";
-    rev = "${version}";
+    rev = version;
     sha256 = "12agi6bacqic2wq6q3l28283badzamspajmajzqm7fbdl2aq1a4p";
   };
 

--- a/pkgs/development/interpreters/wasmtime/default.nix
+++ b/pkgs/development/interpreters/wasmtime/default.nix
@@ -6,7 +6,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitHub {
     owner = "bytecodealliance";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "01k1fpk2qp4kv0xr4f0xmrjkr98j5ws48r1aks8l80mffs4ynqfr";
     fetchSubmodules = true;

--- a/pkgs/development/libraries/gensio/default.nix
+++ b/pkgs/development/libraries/gensio/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "cminyard";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "0c44qhhrknjl7sp94q34z7nv7bvnlqs8wzm385661liy4mnfn4dc";
   };

--- a/pkgs/development/libraries/pcaudiolib/default.nix
+++ b/pkgs/development/libraries/pcaudiolib/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rhdunn";
     repo = "pcaudiolib";
-    rev = "${version}";
+    rev = version;
     sha256 = "0c55hlqqh0m7bcb3nlgv1s4a22s5bgczr1cakjh3767rjb10khi0";
   };
 

--- a/pkgs/development/libraries/wiiuse/default.nix
+++ b/pkgs/development/libraries/wiiuse/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "wiiuse";
     repo = "wiiuse";
-    rev = "${version}";
+    rev = version;
     sha256 = "05gc3s0wxx7ga4g32yyibyxdh46rm9bbslblrc72ynrjxq98sg13";
   };
 

--- a/pkgs/development/libraries/x265/default.nix
+++ b/pkgs/development/libraries/x265/default.nix
@@ -30,7 +30,7 @@ let
   src = fetchFromBitbucket {
     owner = "multicoreware";
     repo = "x265_git";
-    rev = "${version}";
+    rev = version;
     sha256 = "1jzgv2hxhcwmsdf6sbgyzm88a46dp09ll1fqj92g9vckvh9a7dsn";
   };
 

--- a/pkgs/development/ocaml-modules/dispatch/default.nix
+++ b/pkgs/development/ocaml-modules/dispatch/default.nix
@@ -7,7 +7,7 @@ buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "inhabitedtype";
     repo = "ocaml-dispatch";
-    rev = "${version}";
+    rev = version;
     sha256 = "05kb9zcihk50r2haqz8vrlr7kmaka6vrs4j1z500lmnl877as6qr";
   };
 

--- a/pkgs/development/ocaml-modules/lua-ml/default.nix
+++ b/pkgs/development/ocaml-modules/lua-ml/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "lindig";
     repo = pname;
-    rev = "${version}";
+    rev = version;
     sha256 = "04lv98nxmzanvyn4c0k6k0ax29f5xfdl8qzpf5hwadslq213a044";
   };
 

--- a/pkgs/development/ocaml-modules/webmachine/default.nix
+++ b/pkgs/development/ocaml-modules/webmachine/default.nix
@@ -13,7 +13,7 @@ buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "inhabitedtype";
     repo = "ocaml-webmachine";
-    rev = "${version}";
+    rev = version;
     sha256 = "1zi1vsm589y2njwzsqkmdbxvs9s4xlgbd62xqw2scp60mccp09nk";
   };
 

--- a/pkgs/development/python-modules/django-postgresql-netfields/default.nix
+++ b/pkgs/development/python-modules/django-postgresql-netfields/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jimfunk";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "1rrh38f3zl3jk5ijs6g75dxxvxygf4lczbgc7ahrgzf58g4a48lm";
   };

--- a/pkgs/development/python-modules/ovito/default.nix
+++ b/pkgs/development/python-modules/ovito/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitLab {
     owner = "stuko";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "0rm1qxa0fanaaqg0idr6rf2s2xlbyn1dzjzwh3rddy9mgl60lj2h";
   };

--- a/pkgs/development/python-modules/pa-ringbuffer/default.nix
+++ b/pkgs/development/python-modules/pa-ringbuffer/default.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "spatialaudio";
     repo = "python-pa-ringbuffer";
-    rev = "${version}";
+    rev = version;
     sha256 = "0afpydy1l20hd1xncjppjhqa2c8dj5h9nlv4z8m55cs9hc9h1mxv";
   };
 

--- a/pkgs/development/python-modules/pyfcm/default.nix
+++ b/pkgs/development/python-modules/pyfcm/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "olucurious";
     repo = "pyfcm";
-    rev = "${version}";
+    rev = version;
     sha256 = "0aj10yvjsc04j15zbn403i83j7ra5yg35pi3ywkyakk8n1s0s3qg";
   };
 

--- a/pkgs/development/python-modules/rtmixer/default.nix
+++ b/pkgs/development/python-modules/rtmixer/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "spatialaudio";
     repo = "python-rtmixer";
-    rev = "${version}";
+    rev = version;
     sha256 = "1bvgzzxiypvvb3qacbcry6761x9sk3dnx7jga7pli63f69vakg4y";
     fetchSubmodules = true;
   };

--- a/pkgs/development/python-modules/sacremoses/default.nix
+++ b/pkgs/development/python-modules/sacremoses/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "alvations";
     repo = pname;
-    rev = "${version}";
+    rev = version;
     sha256 = "1gzr56w8yx82mn08wax5m0xyg15ym4ri5l80gmagp8r53443j770";
   };
 

--- a/pkgs/development/python-modules/tensorflow-probability/default.nix
+++ b/pkgs/development/python-modules/tensorflow-probability/default.nix
@@ -31,7 +31,7 @@ let
     src = fetchFromGitHub {
       owner = "tensorflow";
       repo = "probability";
-      rev = "${version}";
+      rev = version;
       sha256 = "07cm8zba8n0ihzdm3k4a4rsg5v62xxsfvcw4h0niz91c0parqjqy";
     };
 

--- a/pkgs/development/tools/analysis/cargo-tarpaulin/default.nix
+++ b/pkgs/development/tools/analysis/cargo-tarpaulin/default.nix
@@ -7,7 +7,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "xd009642";
     repo = "tarpaulin";
-    rev = "${version}";
+    rev = version;
     sha256 = "0ga2zfq4365hxvr3wd3isc146ibivy3bfcy24rb6cq3av3b90a8k";
   };
 

--- a/pkgs/development/tools/eclipse-mat/default.nix
+++ b/pkgs/development/tools/eclipse-mat/default.nix
@@ -31,7 +31,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "eclipse-mat";
-  version = "${pVersion}";
+  version = pVersion;
 
   src = fetchurl {
     url = "http://ftp.halifax.rwth-aachen.de/eclipse//mat/${baseVersion}/rcp/MemoryAnalyzer-${version}-linux.gtk.x86_64.zip";

--- a/pkgs/development/tools/misc/argbash/default.nix
+++ b/pkgs/development/tools/misc/argbash/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "matejak";
     repo = "argbash";
-    rev = "${version}";
+    rev = version;
     sha256 = "1xdhpbnc0xjv6ydcm122hhdjcl77jhiqnccjfqjp3cd1lfmzvg8v";
   };
 

--- a/pkgs/development/tools/misc/editorconfig-checker/default.nix
+++ b/pkgs/development/tools/misc/editorconfig-checker/default.nix
@@ -7,7 +7,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "editorconfig-checker";
     repo = "editorconfig-checker";
-    rev = "${version}";
+    rev = version;
     sha256 = "18gz94h2x1z6g6r7v9cdixkbcaigd7cl08af6smlkaa89j0aki32";
   };
 

--- a/pkgs/development/tools/misc/fujprog/default.nix
+++ b/pkgs/development/tools/misc/fujprog/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "kost";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "08kzkzd5a1wfd1aycywdynxh3qy6n7z9i8lihkahmb4xac3chmz5";
   };

--- a/pkgs/development/tools/sourcetrail/default.nix
+++ b/pkgs/development/tools/sourcetrail/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "CoatiSoftware";
     repo = "Sourcetrail";
-    rev = "${version}";
+    rev = version;
     sha256 = "0jp9y86xzkcxikc1cn4f6gqgg6zdssck08677ldagw25p1zadvzw";
   };
 

--- a/pkgs/development/tools/swiftformat/default.nix
+++ b/pkgs/development/tools/swiftformat/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "nicklockwood";
     repo = "SwiftFormat";
-    rev = "${version}";
+    rev = version;
     sha256 = "0zajvbaf3r02k53lv5zdxf13apc6chnjmj69zkyac48lpnpbcxq6";
   };
 

--- a/pkgs/games/cockatrice/default.nix
+++ b/pkgs/games/cockatrice/default.nix
@@ -9,7 +9,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Cockatrice";
     repo = "Cockatrice";
-    rev = "${version}";
+    rev = version;
     sha256 = "1yaxm7q0ja3rgx197hh8ynjc6ncc4hm0qdn9v7f0l4fbv0bdpv34";
   };
 

--- a/pkgs/games/eidolon/default.nix
+++ b/pkgs/games/eidolon/default.nix
@@ -6,7 +6,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchgit {
     url = "https://git.sr.ht/~nicohman/eidolon";
-    rev = "${version}";
+    rev = version;
     sha256 = "1yn3k569pxzw43mmsk97088xpkdc714rks3ncchbb6ccx25kgxrr";
   };
   cargoPatches = [ ./cargo-lock.patch ];

--- a/pkgs/games/mari0/default.nix
+++ b/pkgs/games/mari0/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "Stabyourself";
     repo = pname;
-    rev = "${version}";
+    rev = version;
     sha256 = "1zqaq4w599scsjvy1rsb21fd2r8j3srx9vym4ir9bh666dp36gxa";
   };
 

--- a/pkgs/games/wyvern/default.nix
+++ b/pkgs/games/wyvern/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchgit {
     url = "https://git.sr.ht/~nicohman/wyvern";
-    rev = "${version}";
+    rev = version;
     sha256 = "1sl3yhash1527amc8rs4374fd7jbgnkyy7qpw94ms2gs80sdv3s5";
   };
   cargoPatches = [ ./cargo-lock.patch ];

--- a/pkgs/misc/emulators/mednaffe/default.nix
+++ b/pkgs/misc/emulators/mednaffe/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "AmatCoder";
     repo = "mednaffe";
-    rev = "${version}";
+    rev = version;
     sha256 = "15qk3a3l1phr8bap2ayh3c0vyvw2jwhny1iz1ajq2adyjpm9fhr7";
   };
 

--- a/pkgs/servers/monitoring/do-agent/default.nix
+++ b/pkgs/servers/monitoring/do-agent/default.nix
@@ -7,7 +7,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "digitalocean";
     repo = "do-agent";
-    rev = "${version}";
+    rev = version;
     sha256 = "16mmh1kz6zbncfisd9qnb3ssgpkcb4hb7700jlzbdjqxyjmy0qsf";
   };
 

--- a/pkgs/servers/monitoring/prometheus/promscale.nix
+++ b/pkgs/servers/monitoring/prometheus/promscale.nix
@@ -10,7 +10,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "timescale";
     repo = pname;
-    rev = "${version}";
+    rev = version;
     sha256 = "sha256:00mhkp3nf6h2zsvmmwyza1lahvmm05isfi7rqkx24c0dmkmif3x9";
   };
 

--- a/pkgs/servers/ser2net/default.nix
+++ b/pkgs/servers/ser2net/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "cminyard";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "01w82nrgffsfz2c80p4cyppg3bz56d90jm6i6356j0nva3784haw";
   };

--- a/pkgs/servers/web-apps/dokuwiki/default.nix
+++ b/pkgs/servers/web-apps/dokuwiki/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "splitbrain";
-    repo = "${pname}";
+    repo = pname;
     rev = "release_stable_${version}";
     sha256 = "09swcqyd06l3481k190gmlr3b33dlv1lw1kk9nyh5b4sa5p3k7kk";
   };

--- a/pkgs/servers/web-apps/jirafeau/default.nix
+++ b/pkgs/servers/web-apps/jirafeau/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "mojo42";
     repo = "Jirafeau";
-    rev = "${version}";
+    rev = version;
     sha256 = "09gq5zhynygpqj0skq7ifnn9yjjg7qnc6kjvaas7f53av2707z4c";
   };
 

--- a/pkgs/servers/web-apps/rss-bridge/default.nix
+++ b/pkgs/servers/web-apps/rss-bridge/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "RSS-Bridge";
     repo = "rss-bridge";
-    rev = "${version}";
+    rev = version;
     sha256 = "075k4bylx9308d083ry5a9q4629ccnrnndqqdqp1g42rzlqrw79q";
   };
 

--- a/pkgs/tools/backup/stenc/default.nix
+++ b/pkgs/tools/backup/stenc/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "scsitape";
     repo = "stenc";
-    rev = "${version}";
+    rev = version;
     sha256 = "1778m1zcyzyf42k5m496yqh0gv6kqhb0sq5983dhky1fccjl905k";
   };
 

--- a/pkgs/tools/misc/eva/default.nix
+++ b/pkgs/tools/misc/eva/default.nix
@@ -8,7 +8,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitHub {
     owner = "NerdyPepper";
-    repo = "${pname}";
+    repo = pname;
     rev = "6ce0fc0212a34ffb647b24d9d903029ac4518165";
     sha256 = "10242vnq2ph0g3p2hdacs4lmx3f474xm04nadplxbpv9xh4nbag3";
   };

--- a/pkgs/tools/misc/nix-direnv/default.nix
+++ b/pkgs/tools/misc/nix-direnv/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nix-direnv";
-    rev = "${version}";
+    rev = version;
     sha256 = "sha256-xMz6e0OLeB3eltGrLV3Hew0lMjH5LSgqJ1l7JT2Ho/M=";
   };
 

--- a/pkgs/tools/misc/rpcsvc-proto/default.nix
+++ b/pkgs/tools/misc/rpcsvc-proto/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "thkukuk";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "006l1f824r9bcbwn1s1vbs33cdwhs66jn6v97yas597y884y40z9";
   };

--- a/pkgs/tools/networking/goimapnotify/default.nix
+++ b/pkgs/tools/networking/goimapnotify/default.nix
@@ -9,7 +9,7 @@ buildGoPackage rec {
   src = fetchFromGitLab {
     owner = "shackra";
     repo = "goimapnotify";
-    rev = "${version}";
+    rev = version;
     sha256 = "1d42gd3m2rkvy985d181dbcm5i3f7xsg2z8z6s4bpvw24pfnzs42";
   };
 

--- a/pkgs/tools/networking/network-manager/dmenu/default.nix
+++ b/pkgs/tools/networking/network-manager/dmenu/default.nix
@@ -9,7 +9,7 @@ in stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "firecat53";
     repo = "networkmanager-dmenu";
-    rev = "${version}";
+    rev = version;
     sha256 = "1liidqh8c33pxyb07qyj0jkd0fdak73g9r2iwiq62vfzrpik09k0";
   };
 

--- a/pkgs/tools/networking/nfstrace/default.nix
+++ b/pkgs/tools/networking/nfstrace/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "epam";
     repo = "nfstrace";
-    rev = "${version}";
+    rev = version;
     sha256 = "1djsyn7i3xp969rnmsdaf5vwjiik9wylxxrc5nm7by00i76c1vsg";
   };
 

--- a/pkgs/tools/package-management/cargo-about/default.nix
+++ b/pkgs/tools/package-management/cargo-about/default.nix
@@ -6,7 +6,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "EmbarkStudios";
     repo = "cargo-about";
-    rev = "${version}";
+    rev = version;
     sha256 = "00ing1v6vjqfvirp3mbayn8rwvxf72wnhz9249k2iifw8bl2r2hd";
   };
 

--- a/pkgs/tools/security/honggfuzz/default.nix
+++ b/pkgs/tools/security/honggfuzz/default.nix
@@ -10,7 +10,7 @@ let
     src = fetchFromGitHub {
       owner = "google";
       repo = pname;
-      rev = "${version}";
+      rev = version;
       sha256 = "0dcl5a5jykgfmnfj42vl7kah9k26wg38l2g6yfh5pssmlf0nax33";
     };
 

--- a/pkgs/tools/security/rbw/default.nix
+++ b/pkgs/tools/security/rbw/default.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchCrate {
     inherit version;
-    crateName = "${pname}";
+    crateName = pname;
     sha256 = "0p37kwkp153mkns4bh7k7gnksk6c31214wlw3faf42daav32mmgw";
   };
 

--- a/pkgs/tools/security/rustscan/default.nix
+++ b/pkgs/tools/security/rustscan/default.nix
@@ -7,7 +7,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "RustScan";
     repo = pname;
-    rev = "${version}";
+    rev = version;
     sha256 = "0dhy7b73ipsxsr7wlc3r5yy39i3cjrdszhsw9xwjj31692s3b605";
   };
 

--- a/pkgs/tools/text/ledger2beancount/default.nix
+++ b/pkgs/tools/text/ledger2beancount/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "zacchiro";
     repo = "ledger2beancount";
-    rev = "${version}";
+    rev = version;
     sha256 = "0w88jb1x0w02jwwf6ipx3cxr89kzffrrdqws3556zrvvs01bh84j";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Replaces 

```
foo = "${bar}";
```

with

```
foo = bar;
```

when `bar` is of type string.

This very commonly used for `rev = "${version}";` and `repo = "${pname}";`, where `rev = version;` and `repo = pname;` would be enough.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
