### PR TITLE
Added Orchis-Theme and Reversal-Icon-Theme

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3585,6 +3585,12 @@
     githubId = 3661115;
     name = "Ingo Blechschmidt";
   };
+  icy-thought = {
+    name = "Icy-Thought"
+    email = "gilganyx@gmail.com";
+    github = "Icy-Thought";
+    githubId = 53710398;
+  };
   idontgetoutmuch = {
     email = "dominic@steinitz.org";
     github = "idontgetoutmuch";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3586,7 +3586,7 @@
     name = "Ingo Blechschmidt";
   };
   icy-thought = {
-    name = "Icy-Thought"
+    name = "Icy-Thought";
     email = "gilganyx@gmail.com";
     github = "Icy-Thought";
     githubId = 53710398;

--- a/pkgs/data/icons/reversal-icon-theme/default.nix
+++ b/pkgs/data/icons/reversal-icon-theme/default.nix
@@ -1,22 +1,7 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
 { stdenv, fetchFromGitHub, gtk3, gnome-themes-extra }:
 stdenv.mkDerivation rec {
   pname = "reversal-icon-theme";
   version = "unstable-2020-10-31";
-=======
-{ stdenv, fetchFromGitHub, gtk3, gnome-themes-extra, gtk-engine-murrine, bc }:
-=======
-{ stdenv, fetchFromGitHub, gtk3, gnome-themes-extra }:
->>>>>>> 67ab5177fbf (reversal-icon-theme: gtk3 moved, bc opt-ed out.)
-stdenv.mkDerivation rec {
-  pname = "reversal-icon-theme";
-<<<<<<< HEAD
-  version = "unstable";
->>>>>>> 81ee8dca964 (reversal-icon-theme: fb6cb29 packaged by @ImExtends)
-=======
-  version = "unstable-2020-10-31";
->>>>>>> 910e16a6f9e (Fixed wrong installation directory + date.)
 
   src = fetchFromGitHub {
     repo = "Reversal-icon-theme";
@@ -25,25 +10,13 @@ stdenv.mkDerivation rec {
     sha256 = "15vml083kd40hzfb6s1f5xndwqz6ys58sg076cvpz9vsbxhwbjnl";
   };
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   nativeBuildInputs = [ gtk3 ];
 
   buildInputs = [ gnome-themes-extra ];
-=======
-  buildInputs = [ gtk3 gnome-themes-extra gtk-engine-murrine bc ];
->>>>>>> 81ee8dca964 (reversal-icon-theme: fb6cb29 packaged by @ImExtends)
-=======
-  nativeBuildInputs = [ gtk3 ];
-
-  buildInputs = [ gnome-themes-extra ];
->>>>>>> 67ab5177fbf (reversal-icon-theme: gtk3 moved, bc opt-ed out.)
 
   patchPhase = ''patchShebangs install.sh'';
 
   installPhase = ''
-<<<<<<< HEAD
-<<<<<<< HEAD
     mkdir -p $out/share/icons
     ./install.sh --dest $out/share/icons
   '';
@@ -55,34 +28,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ icy-thought ];
   };
-
-=======
-    mkdir -p $out/share/themes
-    ./install.sh --dest $out/share/themes
-=======
-    mkdir -p $out/share/icons
-    ./install.sh --dest $out/share/icons
->>>>>>> 910e16a6f9e (Fixed wrong installation directory + date.)
-  '';
-<<<<<<< HEAD
-<<<<<<< HEAD
-
->>>>>>> 81ee8dca964 (reversal-icon-theme: fb6cb29 packaged by @ImExtends)
-=======
-  
-=======
-
->>>>>>> 67ab5177fbf (reversal-icon-theme: gtk3 moved, bc opt-ed out.)
-  meta = with stdenv.lib; {
-    description = "Reversal icon theme";
-    homepage = "https://github.com/yeyushengfan258/Reversal-icon-theme";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ Icy-Thought ];
-  };
-<<<<<<< HEAD
->>>>>>> 62ba3936025 (Added meta)
-=======
-
->>>>>>> 67ab5177fbf (reversal-icon-theme: gtk3 moved, bc opt-ed out.)
 }

--- a/pkgs/data/icons/reversal-icon-theme/default.nix
+++ b/pkgs/data/icons/reversal-icon-theme/default.nix
@@ -1,0 +1,88 @@
+<<<<<<< HEAD
+<<<<<<< HEAD
+{ stdenv, fetchFromGitHub, gtk3, gnome-themes-extra }:
+stdenv.mkDerivation rec {
+  pname = "reversal-icon-theme";
+  version = "unstable-2020-10-31";
+=======
+{ stdenv, fetchFromGitHub, gtk3, gnome-themes-extra, gtk-engine-murrine, bc }:
+=======
+{ stdenv, fetchFromGitHub, gtk3, gnome-themes-extra }:
+>>>>>>> 67ab5177fbf (reversal-icon-theme: gtk3 moved, bc opt-ed out.)
+stdenv.mkDerivation rec {
+  pname = "reversal-icon-theme";
+<<<<<<< HEAD
+  version = "unstable";
+>>>>>>> 81ee8dca964 (reversal-icon-theme: fb6cb29 packaged by @ImExtends)
+=======
+  version = "unstable-2020-10-31";
+>>>>>>> 910e16a6f9e (Fixed wrong installation directory + date.)
+
+  src = fetchFromGitHub {
+    repo = "Reversal-icon-theme";
+    owner = "yeyushengfan258";
+    rev = "fb6cb29e02991915931cf1ed9b88d5257f177ed2";
+    sha256 = "15vml083kd40hzfb6s1f5xndwqz6ys58sg076cvpz9vsbxhwbjnl";
+  };
+
+<<<<<<< HEAD
+<<<<<<< HEAD
+  nativeBuildInputs = [ gtk3 ];
+
+  buildInputs = [ gnome-themes-extra ];
+=======
+  buildInputs = [ gtk3 gnome-themes-extra gtk-engine-murrine bc ];
+>>>>>>> 81ee8dca964 (reversal-icon-theme: fb6cb29 packaged by @ImExtends)
+=======
+  nativeBuildInputs = [ gtk3 ];
+
+  buildInputs = [ gnome-themes-extra ];
+>>>>>>> 67ab5177fbf (reversal-icon-theme: gtk3 moved, bc opt-ed out.)
+
+  patchPhase = ''patchShebangs install.sh'';
+
+  installPhase = ''
+<<<<<<< HEAD
+<<<<<<< HEAD
+    mkdir -p $out/share/icons
+    ./install.sh --dest $out/share/icons
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Reversal icon theme";
+    homepage = "https://github.com/yeyushengfan258/Reversal-icon-theme";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ icy-thought ];
+  };
+
+=======
+    mkdir -p $out/share/themes
+    ./install.sh --dest $out/share/themes
+=======
+    mkdir -p $out/share/icons
+    ./install.sh --dest $out/share/icons
+>>>>>>> 910e16a6f9e (Fixed wrong installation directory + date.)
+  '';
+<<<<<<< HEAD
+<<<<<<< HEAD
+
+>>>>>>> 81ee8dca964 (reversal-icon-theme: fb6cb29 packaged by @ImExtends)
+=======
+  
+=======
+
+>>>>>>> 67ab5177fbf (reversal-icon-theme: gtk3 moved, bc opt-ed out.)
+  meta = with stdenv.lib; {
+    description = "Reversal icon theme";
+    homepage = "https://github.com/yeyushengfan258/Reversal-icon-theme";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Icy-Thought ];
+  };
+<<<<<<< HEAD
+>>>>>>> 62ba3936025 (Added meta)
+=======
+
+>>>>>>> 67ab5177fbf (reversal-icon-theme: gtk3 moved, bc opt-ed out.)
+}

--- a/pkgs/data/themes/orchis-theme/default.nix
+++ b/pkgs/data/themes/orchis-theme/default.nix
@@ -1,0 +1,72 @@
+{ stdenv, fetchFromGitHub, gtk3, gnome-themes-extra, gtk-engine-murrine, bc }:
+stdenv.mkDerivation rec {
+  pname = "orchis-theme";
+<<<<<<< HEAD
+<<<<<<< HEAD
+  version = "unstable-2020-10-25";
+=======
+  version = "unstable";
+>>>>>>> d6e57063ca5 (orchis-theme: latest commit packaged by @ImExtends)
+=======
+  version = "unstable-2020-10-25";
+>>>>>>> 776f1ce64ef (Fixed missing date.)
+
+  src = fetchFromGitHub {
+    repo = "Orchis-theme";
+    owner = "vinceliuice";
+    rev = "6369f17e4b98599bb8113b52e4ed6ca7bd20103e";
+    sha256 = "1l3icm7z8rq962bp47kklgivi2hlxnmv99q06h0qz7nsp0jaimzi";
+  };
+
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 6eef0e5e706 (orchis-theme: gtk3 moved to nativeBuildInputs.)
+  nativeBuildInputs = [ gtk3 bc ];
+
+  buildInputs = [ gnome-themes-extra ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+<<<<<<< HEAD
+=======
+  buildInputs = [ gtk3 gnome-themes-extra gtk-engine-murrine bc ];
+>>>>>>> d6e57063ca5 (orchis-theme: latest commit packaged by @ImExtends)
+=======
+>>>>>>> 6eef0e5e706 (orchis-theme: gtk3 moved to nativeBuildInputs.)
+
+  patchPhase = ''patchShebangs install.sh'';
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    ./install.sh --dest $out/share/themes
+  '';
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+
+=======
+    
+>>>>>>> d157e6abf9e (Added meta.)
+=======
+
+>>>>>>> 6eef0e5e706 (orchis-theme: gtk3 moved to nativeBuildInputs.)
+  meta = with stdenv.lib; {
+    description = "Orchis is a theme for GNOME/GTK based desktop environments";
+    homepage = "https://github.com/vinceliuice/Orchis-theme";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+<<<<<<< HEAD
+    maintainers = with maintainers; [ icy-ihought ];
+  };
+
+=======
+>>>>>>> d6e57063ca5 (orchis-theme: latest commit packaged by @ImExtends)
+=======
+    maintainers = with maintainers; [ Icy-Thought ];
+  };
+<<<<<<< HEAD
+>>>>>>> d157e6abf9e (Added meta.)
+=======
+
+>>>>>>> 6eef0e5e706 (orchis-theme: gtk3 moved to nativeBuildInputs.)
+}

--- a/pkgs/data/themes/orchis-theme/default.nix
+++ b/pkgs/data/themes/orchis-theme/default.nix
@@ -1,15 +1,7 @@
 { stdenv, fetchFromGitHub, gtk3, gnome-themes-extra, gtk-engine-murrine, bc }:
 stdenv.mkDerivation rec {
   pname = "orchis-theme";
-<<<<<<< HEAD
-<<<<<<< HEAD
   version = "unstable-2020-10-25";
-=======
-  version = "unstable";
->>>>>>> d6e57063ca5 (orchis-theme: latest commit packaged by @ImExtends)
-=======
-  version = "unstable-2020-10-25";
->>>>>>> 776f1ce64ef (Fixed missing date.)
 
   src = fetchFromGitHub {
     repo = "Orchis-theme";
@@ -18,21 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "1l3icm7z8rq962bp47kklgivi2hlxnmv99q06h0qz7nsp0jaimzi";
   };
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 6eef0e5e706 (orchis-theme: gtk3 moved to nativeBuildInputs.)
   nativeBuildInputs = [ gtk3 bc ];
 
   buildInputs = [ gnome-themes-extra ];
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
-<<<<<<< HEAD
-=======
-  buildInputs = [ gtk3 gnome-themes-extra gtk-engine-murrine bc ];
->>>>>>> d6e57063ca5 (orchis-theme: latest commit packaged by @ImExtends)
-=======
->>>>>>> 6eef0e5e706 (orchis-theme: gtk3 moved to nativeBuildInputs.)
 
   patchPhase = ''patchShebangs install.sh'';
 
@@ -40,33 +22,13 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/themes
     ./install.sh --dest $out/share/themes
   '';
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-
-=======
     
->>>>>>> d157e6abf9e (Added meta.)
-=======
-
->>>>>>> 6eef0e5e706 (orchis-theme: gtk3 moved to nativeBuildInputs.)
   meta = with stdenv.lib; {
     description = "Orchis is a theme for GNOME/GTK based desktop environments";
     homepage = "https://github.com/vinceliuice/Orchis-theme";
     license = licenses.gpl3;
     platforms = platforms.linux;
-<<<<<<< HEAD
     maintainers = with maintainers; [ icy-ihought ];
   };
 
-=======
->>>>>>> d6e57063ca5 (orchis-theme: latest commit packaged by @ImExtends)
-=======
-    maintainers = with maintainers; [ Icy-Thought ];
-  };
-<<<<<<< HEAD
->>>>>>> d157e6abf9e (Added meta.)
-=======
-
->>>>>>> 6eef0e5e706 (orchis-theme: gtk3 moved to nativeBuildInputs.)
 }


### PR DESCRIPTION
###### Motivation for this change
Adding both Orchis-Theme and Reversal-Icon-Theme packages to nixpkgs due to their absence in the nixpkgs repository.

Both `default.nix` files were written and shared by @ImExtends in the discord server as a solution to my request and after being granted the authorization to share the `default.nix` files, I chose to submit the packages to the main repository.

Due to me not being an experienced packager/maintainer, I would kindly request your help to help push forward the PR after confirming its working state.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
