### PR TITLE
[20.09] python3Packages.google_cloud_pubsub: disable tests

### DIFF
--- a/pkgs/development/python-modules/google_cloud_pubsub/default.nix
+++ b/pkgs/development/python-modules/google_cloud_pubsub/default.nix
@@ -20,9 +20,13 @@ buildPythonPackage rec {
   checkInputs = [ pytest mock ];
   propagatedBuildInputs = [ enum34 grpc_google_iam_v1 google_api_core ];
 
+  # tests don't clean up file descriptors correctly
+  doCheck = false;
   checkPhase = ''
     pytest tests/unit
   '';
+
+  pythonImportsCheck = [ "google.cloud.pubsub" ];
 
   meta = with stdenv.lib; {
     description = "Google Cloud Pub/Sub API client library";


### PR DESCRIPTION
 ###### Motivation for this change
backport #102403 

tests fail due to file handle issues, then just loops
in an invalid state until timing out on hydra

https://hydra.nixos.org/build/129081889
(cherry picked from commit 9d5b01eb5700c45f72c93b56e7d76a1ed2507f46)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
