### PR TITLE
emacs26Packages.prolog-mode: unbreak

### DIFF
--- a/pkgs/applications/editors/emacs-modes/prolog/default.nix
+++ b/pkgs/applications/editors/emacs-modes/prolog/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation {
-  name = "prolog-mode-1.25";
+  pname = "prolog-mode";
+  version = "1.28";
 
   src = fetchurl {
     url = "http://bruda.ca/_media/emacs/prolog.el";
-    sha256 = "0hfd2dr3xc5qxgvc08nkb2l5a05hfldahdc6ymi9vd8798cc46yh";
+    sha256 = "oCMzks4xuor8Il8Ll8PXh1zIvMl5qN0RCFJ9yKiHOHU=";
   };
 
   buildCommand = ''
@@ -17,8 +18,5 @@ stdenv.mkDerivation {
     homepage = "http://bruda.ca/emacs/prolog_mode_for_emacs/";
     description = "Prolog mode for Emacs";
     license = stdenv.lib.licenses.gpl2Plus;
-
-    # Has wrong sha256
-    broken = true;
   };
 }


### PR DESCRIPTION
Unfortunately this package doesn't contain the version number in the URL
so it might break easily again, but it is just a matter of updating the
sha256

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update package: beware it will happen again as the URL of the source doesn't contain the version of the package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
