### PR TITLE
gimpPlugins.focusblur: remove

### DIFF
--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -85,22 +85,6 @@ stdenv.lib.makeScope pkgs.newScope (self: with self; {
     };
   };
 
-  focusblur = pluginDerivation rec {
-    /* menu:
-       Blur/Focus Blur
-    */
-    name = "focusblur-3.2.6";
-    buildInputs = with pkgs; [ fftwSinglePrec ];
-    patches = [ ./patches/focusblur-glib.patch ];
-    postInstall = "fail";
-    installPhase = "installPlugins src/focusblur";
-    src = fetchurl {
-      url = "http://registry.gimp.org/files/${name}.tar.bz2";
-      sha256 = "1gqf3hchz7n7v5kpqkhqh8kwnxbsvlb5cr2w2n7ngrvl56f5xs1h";
-    };
-    meta.broken = true;
-  };
-
   resynthesizer = pluginDerivation rec {
     /* menu:
       Edit/Fill with pattern seamless...


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This gimp plugin is no more accessible in upstream server.
Freshport did the same: https://www.freshports.org/graphics/gimp-focusblur-plugin/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
