### PR TITLE
go-moduls: clarify future of vend tool

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -22,6 +22,7 @@
 , deleteVendor ? false
 # Whether to run the vend tool to regenerate the vendor directory.
 # This is useful if any dependency contain C files.
+# TODO: adapt to https://github.com/go-modules-by-example/index/blob/master/012_modvendor/README.md
 , runVend ? false
 
 # We want parallel builds by default


### PR DESCRIPTION
###### Motivation for this change

https://github.com/go-modules-by-example/index/blob/master/012_modvendor/README.md


- Over time, the `vend` approach is likely to become deprecated.
- Breadcrumb trail to lower R&D barrier for future pair of eyes (includig my own)