### PR TITLE
nss: fix build on ppc64[le]

### DIFF
--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -68,6 +68,9 @@ in stdenv.mkDerivation rec {
           else if platform.isx86_32 then "ia32"
           else if platform.isAarch32 then "arm"
           else if platform.isAarch64 then "arm64"
+          else if platform.isPower && platform.is64bit then (
+            if platform.isLittleEndian then "ppc64le" else "ppc64"
+          )
           else platform.parsed.cpu.name;
     # yes, this is correct. nixpkgs uses "host" for the platform the binary will run on whereas nss uses "host" for the platform that the build is running on
     target = getArch stdenv.hostPlatform;


### PR DESCRIPTION
NSS configure scripts use the abbreviated form ppc64/ppc64le:
https://github.com/nss-dev/nss/blob/NSS_3_57_RTM/coreconf/config.gypi#L209

Whereas nixpkgs uses the longer form:
`nix eval nixpkgs.pkgsCross.powernv.hostPlatform.parsed.cpu.name`
`powerpc64le`

cc @CrystalGamma 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
