### PR TITLE
ocamlPackages.mirage-channel: init at 4.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-channel/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-channel/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchurl, buildDunePackage
+, cstruct, logs, lwt, mirage-flow
+, alcotest, mirage-flow-combinators
+}:
+
+buildDunePackage rec {
+  pname = "mirage-channel";
+  version = "4.0.1";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-channel/releases/download/v${version}/mirage-channel-v${version}.tbz";
+    sha256 = "0wmb2zhiyp8n78xgcspcsyd19bhcml3kyli2caw3778wc1gyvfpc";
+  };
+
+  propagatedBuildInputs = [ cstruct logs lwt mirage-flow ];
+
+  doCheck = true;
+  checkInputs = [ alcotest mirage-flow-combinators ];
+
+  meta = {
+    description = "Buffered channels for MirageOS FLOW types";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+    homepage = "https://github.com/mirage/mirage-channel";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -543,6 +543,8 @@ let
 
     mirage-bootvar-unix = callPackage ../development/ocaml-modules/mirage-bootvar-unix { };
 
+    mirage-channel = callPackage ../development/ocaml-modules/mirage-channel { };
+
     mirage-clock = callPackage ../development/ocaml-modules/mirage-clock { };
 
     mirage-clock-unix = callPackage ../development/ocaml-modules/mirage-clock/unix.nix { };


### PR DESCRIPTION
###### Motivation for this change

#23955

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
