### PR TITLE
sonobuoy: Fixes wrong "v" behaviour

### DIFF
--- a/pkgs/applications/networking/cluster/sonobuoy/default.nix
+++ b/pkgs/applications/networking/cluster/sonobuoy/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
     let t = goPackagePath;
     in ''
       -ldflags=
-        -s -X ${t}/pkg/buildinfo.Version=${version}
+        -s -X ${t}/pkg/buildinfo.Version=v${version}
            -X ${t}/pkg/buildinfo.GitSHA=${rev}
            -X ${t}/pkg/buildDate=unknown
     '';


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adjust the generated manifests by placing the character v in the sonobuoy version, successfully pulling the image within the cluster and running smoothly.

Tested on minikube and a stage kubernetes cluster. Both quick and default tests.

Fixes  #102432 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
