### PR TITLE
pythonPackages.imantics: init at 0.1.12

### DIFF
--- a/pkgs/development/python-modules/imantics/default.nix
+++ b/pkgs/development/python-modules/imantics/default.nix
@@ -1,0 +1,46 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, numpy
+, opencv3
+, sphinx_rtd_theme
+, lxml
+, xmljson
+}:
+
+buildPythonPackage rec {
+  pname = "imantics";
+  version = "0.1.12";
+
+  src = fetchFromGitHub {
+    owner = "jsbroks";
+    repo = "imantics";
+    rev = "76d81036d8f92854d63ad9938dd76c718f8b482e";
+    sha256 = "1zv2gj8cbakhh2fyr2611cbqhfk37a56x973ny9n43y70n26pzm8";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    opencv3
+    sphinx_rtd_theme
+    lxml
+    xmljson
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'opencv-python>=3'," ""
+  '';
+
+  # failing on NixOS
+  doCheck = false;
+
+  pythonImportsCheck = [ "imantics" ];
+
+  meta = with lib; {
+    description = "Convert and visualize many annotation formats for object dectection and localization";
+    homepage = "https://github.com/jsbroks/imantics";
+    license = with licenses; [ mit ];
+    maintainers = [ maintainers.rakesh4g ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2875,6 +2875,8 @@ in {
 
   imagesize = callPackage ../development/python-modules/imagesize { };
 
+  imantics = callPackage ../development/python-modules/imantics { };
+
   IMAPClient = callPackage ../development/python-modules/imapclient { };
 
   imaplib2 = callPackage ../development/python-modules/imaplib2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
pythonPackages.imantics: init at 0.1.12
Requires : https://github.com/NixOS/nixpkgs/pull/102440
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
