### PR TITLE
Systemd with the `remote` feature enabled by default

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -340,6 +340,7 @@ in
   systemd-binfmt = handleTestOn ["x86_64-linux"] ./systemd-binfmt.nix {};
   systemd-boot = handleTest ./systemd-boot.nix {};
   systemd-confinement = handleTest ./systemd-confinement.nix {};
+  systemd-journal = handleTest ./systemd-journal.nix {};
   systemd-timesyncd = handleTest ./systemd-timesyncd.nix {};
   systemd-networkd-vrf = handleTest ./systemd-networkd-vrf.nix {};
   systemd-networkd = handleTest ./systemd-networkd.nix {};

--- a/nixos/tests/systemd-journal.nix
+++ b/nixos/tests/systemd-journal.nix
@@ -1,0 +1,20 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+{
+  name = "systemd-journal";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ lewo ];
+  };
+
+  machine = { pkgs, lib, ... }: {
+    services.journald.enableHttpGateway = true;
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed(
+        "${pkgs.curl}/bin/curl -s localhost:19531/machine | ${pkgs.jq}/bin/jq -e '.hostname == \"machine\"'"
+    )
+  '';
+})

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -53,6 +53,7 @@
 , withKexectools ? lib.any (lib.meta.platformMatch stdenv.hostPlatform) kexectools.meta.platforms
 , kexectools
 , bashInteractive
+, libmicrohttpd
 
 , withAnalyze ? true
 , withApparmor ? true
@@ -71,7 +72,7 @@
 , withNss ? true
 , withPCRE2 ? true
 , withPolkit ? true
-, withRemote ? false  # has always been disabled on NixOS, upstream version appears broken anyway
+, withRemote ? true
 , withResolved ? true
 , withShellCompletions ? true
 , withTimedated ? true
@@ -201,6 +202,7 @@ stdenv.mkDerivation {
     ++ lib.optional withPCRE2 pcre2
     ++ lib.optional withResolved libgpgerror
     ++ lib.optional withSelinux libselinux
+    ++ lib.optional withRemote libmicrohttpd
     ;
 
   #dontAddPrefix = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18812,6 +18812,7 @@ in
     withNss = false;
     withPCRE2 = false;
     withPolkit = false;
+    withRemote = false;
     withResolved = false;
     withShellCompletions = false;
     withTimedated = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Since ae896e0, Systemd is no longer compiled with the journal gatewayd service because of an incompatibility between Systemd and libmicrohttpd. However, thanks to some updates, it is now building fine!

Note also the NixOS option `services.systemd.enableHttpGateway` is currently broken and this PR fixes it.

###### Things done

Set `withRemote` to `true` by default in `systemd` and disable this feature in `systemdMinimal`. 

The test `systemd-journal` has been added to ensure the `systemd-journal-gatewayd` is running correctly. 

This test is passing when https://github.com/NixOS/nixpkgs/pull/102156 is reverted (thanks @flokli for the build;)).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
