### PR TITLE
python3Packages.tsfresh: init at 0.17.0

### DIFF
--- a/pkgs/development/python-modules/tsfresh/default.nix
+++ b/pkgs/development/python-modules/tsfresh/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, pytestCheckHook
+, pytestcov
+, pytest_xdist
+, requests
+, numpy
+, pandas
+, scipy
+, statsmodels
+, patsy
+, scikitlearn
+, tqdm
+, dask
+, distributed
+}:
+
+buildPythonPackage rec {
+  pname = "tsfresh";
+  version = "0.17.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f3db06063116c3cca6ef1ad30dcd50a0cc4a4d0688cc34cc8843d9bd400da969";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+    pytestcov
+    pytest_xdist
+  ];
+
+  # Tries to access the network
+  pytestFlagsArray = [
+    "tests/"
+    "--ignore=tests/integrations"
+  ] ++  lib.optionals stdenv.isDarwin [
+      "--ignore=tests/units/utilities/test_distribution.py"
+  ];
+
+  propagatedBuildInputs = [
+    requests
+    numpy
+    pandas
+    scipy
+    statsmodels
+    patsy
+    scikitlearn
+    tqdm
+    dask
+    distributed
+  ];
+
+  meta = with lib; {
+    description = "Time Series Feature extraction based on scalable hypothesis tests";
+    homepage = "https://github.com/blue-yonder/tsfresh";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evax ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7820,6 +7820,8 @@ in {
 
   trytond = callPackage ../development/python-modules/trytond { };
 
+  tsfresh = callPackage ../development/python-modules/tsfresh { };
+
   ttystatus = callPackage ../development/python-modules/ttystatus { };
 
   tunigo = callPackage ../development/python-modules/tunigo { };


### PR DESCRIPTION
###### Motivation for this change

Time Series Feature extraction based on scalable hypothesis tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
