### PR TITLE
python3Packages.pandas-datareader: init at 0.9.0

### DIFF
--- a/pkgs/development/python-modules/pandas-datareader/default.nix
+++ b/pkgs/development/python-modules/pandas-datareader/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, isPy27
+, pandas
+, lxml
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pandas-datareader";
+  version = "0.9.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b2cbc1e16a6ab9ff1ed167ae2ea92839beab9a20823bd00bdfb78155fa04f891";
+  };
+
+  # Tests are trying to load data over the network
+  doCheck = false;
+  pythonImportsCheck = [ "pandas_datareader" ];
+
+  propagatedBuildInputs = [ pandas lxml requests ];
+
+  meta = with stdenv.lib; {
+    description = "Up to date remote data access for pandas, works for multiple versions of pandas";
+    homepage = "https://github.com/pydata/pandas-datareader";
+    license= licenses.bsd3;
+    maintainers = with maintainers; [ evax ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4304,6 +4304,8 @@ in {
   else
     callPackage ../development/python-modules/pandas/2.nix { };
 
+  pandas-datareader = callPackage ../development/python-modules/pandas-datareader { };
+
   pandoc-attributes = callPackage ../development/python-modules/pandoc-attributes { };
 
   pandocfilters = callPackage ../development/python-modules/pandocfilters { };


### PR DESCRIPTION
###### Motivation for this change

Up to date remote data access for pandas, works for multiple versions of pandas.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
