### PR TITLE
python3Packages.mlxtend: init at 0.17.3

### DIFF
--- a/pkgs/development/python-modules/mlxtend/default.nix
+++ b/pkgs/development/python-modules/mlxtend/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, pytestCheckHook
+, scipy
+, numpy
+, scikitlearn
+, pandas
+, matplotlib
+, joblib
+}:
+
+buildPythonPackage rec {
+  pname = "mlxtend";
+  version = "0.17.3";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "rasbt";
+    repo = pname;
+    rev = version;
+    sha256 = "1515wgmj5rhwpmky7apmmvys1630sfg534fai6559s13hp11pdcl";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+  # image tests download files over the network
+  pytestFlagsArray = [ "-sv" "--ignore=mlxtend/image" ];
+  # Fixed in master, but failing in release version
+  # see: https://github.com/rasbt/mlxtend/pull/721
+  disabledTests = [ "test_variance_explained_ratio" ];
+
+  propagatedBuildInputs = [
+    scipy
+    numpy
+    scikitlearn
+    pandas
+    matplotlib
+    joblib
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A library of Python tools and extensions for data science";
+    homepage = "https://github.com/rasbt/mlxtend";
+    license= licenses.bsd3;
+    maintainers = with maintainers; [ evax ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3754,6 +3754,8 @@ in {
 
   mlrose = callPackage ../development/python-modules/mlrose { };
 
+  mlxtend = callPackage ../development/python-modules/mlxtend { };
+
   mmh3 = callPackage ../development/python-modules/mmh3 { };
 
   mmpython = callPackage ../development/python-modules/mmpython { };


### PR DESCRIPTION
###### Motivation for this change

A library of Python tools and extensions for data science

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
