### PR TITLE
httpie: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/tools/networking/httpie/default.nix
+++ b/pkgs/tools/networking/httpie/default.nix
@@ -2,29 +2,20 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "httpie";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "jakubroztocil";
     repo = "httpie";
     rev = version;
-    sha256 = "0caazv24jr0844c4mdx77vzwwi5m869n10wa42cydb08ppx1xxj6";
+    sha256 = "1aiy40p0i7rfb66m57hxxchym5nckqs0syxzz634safa0pfg5m77";
   };
 
   outputs = [ "out" "doc" "man" ];
 
-  propagatedBuildInputs = with python3Packages; [ pygments requests setuptools ];
+  propagatedBuildInputs = with python3Packages; [ pygments requests requests-toolbelt ];
   dontUseSetuptoolsCheck = true;
-  patches = [
-    ./strip-venv.patch
-
-    # Fix `test_ciphers_none_can_be_selected`
-    # TODO: remove on next release
-    (fetchpatch {
-      url = "https://github.com/jakubroztocil/httpie/commit/49e71d252f54871a6bc49cb1cba103d385a543b8.patch";
-      sha256 = "13b2faf50gimj7f17dlx4gmd8ph8ipgihpzfqbvmfjlbf1v95fsj";
-    })
-  ];
+  patches = [ ./strip-venv.patch ];
 
   checkInputs = with python3Packages; [
     mock
@@ -32,6 +23,8 @@ python3Packages.buildPythonApplication rec {
     pytest-httpbin
     pytestCheckHook
   ];
+
+  doCheck = !stdenv.isDarwin;
 
   postInstall = ''
     # install completions

--- a/pkgs/tools/networking/httpie/strip-venv.patch
+++ b/pkgs/tools/networking/httpie/strip-venv.patch
@@ -1,19 +1,22 @@
 diff --git a/tests/test_docs.py b/tests/test_docs.py
-index 7a41822..720ecf6 100644
+index 340e64d..b346ae9 100644
 --- a/tests/test_docs.py
 +++ b/tests/test_docs.py
-@@ -41,12 +41,10 @@ assert filenames
- 
+@@ -42,15 +42,9 @@ assert filenames
  # HACK: hardcoded paths, venv should be irrelevant, etc.
- # TODO: replaces the process with Python code
+ # TODO: simplify by using the Python API instead of a subprocess
+ #       then we wont’t need the paths.
 -VENV_BIN = Path(__file__).parent.parent / 'venv/bin'
 -VENV_PYTHON = VENV_BIN / 'python'
 -VENV_RST2PSEUDOXML = VENV_BIN / 'rst2pseudoxml.py'
 +VENV_PYTHON = 'python'
 +VENV_RST2PSEUDOXML = 'rst2pseudoxml.py'
  
- 
--@pytest.mark.skipif(not os.path.exists(VENV_RST2PSEUDOXML), reason='docutils not installed')
+-
+-@pytest.mark.skipif(
+-    not VENV_RST2PSEUDOXML.exists(),
+-    reason='docutils not installed',
+-)
  @pytest.mark.parametrize('filename', filenames)
  def test_rst_file_syntax(filename):
      p = subprocess.Popen(


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Bump `httpie` to 2.3.0.
- [x] Add `requests-toolbelt` dependency
- [x] Update patch for `test_docs.py`
- [x] Removed already fixed patch for `test_ssl.py`
- [x] Disabled `doCheck` for darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
