### PR TITLE
vim: Get rid of Python 2 dependency

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -143,6 +143,11 @@
      <link xlink:href="http://www.mutt.org/relnotes/2.0/">release notes for Mutt 2.0</link>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      <literal>vim</literal> switched to Python 3, dropping all Python 2 support.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -1,5 +1,5 @@
 { source ? "default", callPackage, stdenv, ncurses, pkgconfig, gettext
-, writeText, config, glib, gtk2-x11, gtk3-x11, lua, python, perl, tcl, ruby
+, writeText, config, glib, gtk2-x11, gtk3-x11, lua, python3, perl, tcl, ruby
 , libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu
 , libICE
 , vimPlugins
@@ -62,8 +62,6 @@ let
 
   common = callPackage ./common.nix {};
 
-  isPython3 = python.isPy3 or false;
-
 in stdenv.mkDerivation rec {
 
   pname = "vim_configurable";
@@ -106,9 +104,10 @@ in stdenv.mkDerivation rec {
     "--with-luajit"
   ]
   ++ stdenv.lib.optionals pythonSupport [
-    "--enable-python${if isPython3 then "3" else ""}interp=yes"
-    "--with-python${if isPython3 then "3" else ""}-config-dir=${python}/lib"
-    "--disable-python${if (!isPython3) then "3" else ""}interp"
+    "--enable-python3interp=yes"
+    "--with-python3-config-dir=${python3}/lib"
+    # Disables Python 2
+    "--disable-pythoninterp"
   ]
   ++ stdenv.lib.optional nlsSupport          "--enable-nls"
   ++ stdenv.lib.optional perlSupport         "--enable-perlinterp"
@@ -134,7 +133,7 @@ in stdenv.mkDerivation rec {
     ++ stdenv.lib.optional (guiSupport == "gtk3") gtk3-x11
     ++ stdenv.lib.optionals darwinSupport [ CoreServices CoreData Cocoa Foundation libobjc ]
     ++ stdenv.lib.optional luaSupport lua
-    ++ stdenv.lib.optional pythonSupport python
+    ++ stdenv.lib.optional pythonSupport python3
     ++ stdenv.lib.optional tclSupport tcl
     ++ stdenv.lib.optional rubySupport ruby;
 
@@ -163,7 +162,7 @@ in stdenv.mkDerivation rec {
 
     ln -sfn '${nixosRuntimepath}' "$out"/share/vim/vimrc
   '' + stdenv.lib.optionalString wrapPythonDrv ''
-    wrapProgram "$out/bin/vim" --prefix PATH : "${python}/bin"
+    wrapProgram "$out/bin/vim" --prefix PATH : "${python3}/bin"
   '' + stdenv.lib.optionalString (guiSupport == "gtk3") ''
 
     rewrap () {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Python 2 is unsupported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) (607534224 → 649524120)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
