### PR TITLE
python3Packages.gcsfs: init at 0.7.1

### DIFF
--- a/pkgs/development/python-modules/gcsfs/default.nix
+++ b/pkgs/development/python-modules/gcsfs/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, fsspec
+, google_auth
+, google-auth-oauthlib
+, requests
+, decorator
+, aiohttp
+}:
+
+buildPythonPackage rec {
+  pname = "gcsfs";
+  version = "0.7.1";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03658dfbf1a734d987aab3631e0a342b3d7e24a24998b4d8d2491fdd21053720";
+  };
+
+  # tests are accessing the network
+  doCheck = false;
+  pythonImportsCheck = [ "gcsfs" ];
+
+  propagatedBuildInputs = [
+    fsspec
+    google_auth
+    google-auth-oauthlib
+    requests
+    decorator
+    aiohttp
+  ];
+
+  meta = with lib; {
+    description = "Pythonic file-system for Google Cloud Storage";
+    homepage = "https://github.com/dask/gcsfs";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ evax ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2472,6 +2472,8 @@ in {
 
   gcovr = callPackage ../development/python-modules/gcovr { };
 
+  gcsfs = callPackage ../development/python-modules/gcsfs { };
+
   gdal = toPythonModule (pkgs.gdal.override { pythonPackages = self; });
 
   gdata = callPackage ../development/python-modules/gdata { };


### PR DESCRIPTION
###### Motivation for this change

Pythonic file-system for Google Cloud Storage

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
