### PR TITLE
[20.09] ghc:8.10.2Binary bootstrap for 8.8 on aarch64 (NixOS#97407) #101214

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -1,0 +1,173 @@
+{ stdenv
+, fetchurl, perl, gcc
+, ncurses6, gmp, glibc, libiconv
+, llvmPackages
+}:
+
+# Prebuilt only does native
+assert stdenv.targetPlatform == stdenv.hostPlatform;
+
+let
+  useLLVM = !stdenv.targetPlatform.isx86;
+
+  libPath = stdenv.lib.makeLibraryPath ([
+    ncurses6 gmp
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv);
+
+  libEnvVar = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin "DY"
+    + "LD_LIBRARY_PATH";
+
+  glibcDynLinker = assert stdenv.isLinux;
+    if stdenv.hostPlatform.libc == "glibc" then
+       # Could be stdenv.cc.bintools.dynamicLinker, keeping as-is to avoid rebuild.
+       ''"$(cat $NIX_CC/nix-support/dynamic-linker)"''
+    else
+      "${stdenv.lib.getLib glibc}/lib/ld-linux*";
+
+in
+
+stdenv.mkDerivation rec {
+  version = "8.10.2";
+
+  name = "ghc-${version}-binary";
+
+  # https://downloads.haskell.org/~ghc/8.10.2/
+  src = fetchurl ({
+    i686-linux = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-deb9-linux.tar.xz";
+      sha256 = "0bvwisl4w0z5z8z0da10m9sv0mhm9na2qm43qxr8zl23mn32mblx";
+    };
+    x86_64-linux = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-deb10-linux.tar.xz";
+      sha256 = "0chnzy9j23b2wa8clx5arwz8wnjfxyjmz9qkj548z14cqf13slcl";
+    };
+    armv7l-linux = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-armv7-deb10-linux.tar.xz";
+      sha256 = "1j41cq5d3rmlgz7hzw8f908fs79gc5mn3q5wz277lk8zdf19g75v";
+    };
+    aarch64-linux = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-aarch64-deb10-linux.tar.xz";
+      sha256 = "14smwl3741ixnbgi0l51a7kh7xjkiannfqx15b72svky0y4l3wjw";
+    };
+    x86_64-darwin = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
+      sha256 = "1hngyq14l4f950hzhh2d204ca2gfc98pc9xdasxihzqd1jq75dzd";
+    };
+  }.${stdenv.hostPlatform.system}
+    or (throw "cannot bootstrap GHC on this platform"));
+
+  nativeBuildInputs = [ perl ];
+  propagatedBuildInputs = stdenv.lib.optionals useLLVM [ llvmPackages.llvm ];
+
+  # Cannot patchelf beforehand due to relative RPATHs that anticipate
+  # the final install location/
+  ${libEnvVar} = libPath;
+
+  postUnpack =
+    # GHC has dtrace probes, which causes ld to try to open /usr/lib/libdtrace.dylib
+    # during linking
+    stdenv.lib.optionalString stdenv.isDarwin ''
+      export NIX_LDFLAGS+=" -no_dtrace_dof"
+      # not enough room in the object files for the full path to libiconv :(
+      for exe in $(find . -type f -executable); do
+        isScript $exe && continue
+        ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+        install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib -change /usr/local/lib/gcc/6/libgcc_s.1.dylib ${gcc.cc.lib}/lib/libgcc_s.1.dylib $exe
+      done
+    '' +
+
+    # Some scripts used during the build need to have their shebangs patched
+    ''
+      patchShebangs ghc-${version}/utils/
+      patchShebangs ghc-${version}/configure
+    '' +
+
+    # We have to patch the GMP paths for the integer-gmp package.
+    ''
+      find . -name integer-gmp.buildinfo \
+          -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${gmp.out}/lib@" {} \;
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+      find . -name base.buildinfo \
+          -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${libiconv}/lib@" {} \;
+    '' +
+    # Rename needed libraries and binaries, fix interpreter
+    stdenv.lib.optionalString stdenv.isLinux ''
+      find . -type f -perm -0100 -exec patchelf \
+          --replace-needed libncurses${stdenv.lib.optionalString stdenv.is64bit "w"}.so.6 libncurses.so \
+          --interpreter ${glibcDynLinker} {} \;
+
+      sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+      sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+    '' +
+    # We're kludging a glibc bindist into working with non-glibc...
+    # Here we patch up the use of `__strdup` (part of glibc binary ABI)
+    # to instead use `strdup` since musl doesn't provide __strdup
+    # (`__strdup` is defined to be an alias of `strdup` anyway[1]).
+    # [1] http://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/baselib---strdup-1.html
+    # Use objcopy magic to make the change:
+    stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+      find ./ghc-${version}/rts -name "libHSrts*.a" -exec ''${OBJCOPY:-objcopy} --redefine-sym __strdup=strdup {} \;
+    '';
+
+  # fix for `configure: error: Your linker is affected by binutils #16177`
+  preConfigure = stdenv.lib.optionalString
+    stdenv.targetPlatform.isAarch32
+    "LD=ld.gold";
+
+  configurePlatforms = [ ];
+  configureFlags = [
+    "--with-gmp-libraries=${stdenv.lib.getLib gmp}/lib"
+    "--with-gmp-includes=${stdenv.lib.getDev gmp}/include"
+  ] ++ stdenv.lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}"
+    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "--disable-ld-override";
+
+  # No building is necessary, but calling make without flags ironically
+  # calls install-strip ...
+  dontBuild = true;
+
+  # On Linux, use patchelf to modify the executables so that they can
+  # find editline/gmp.
+  postFixup = stdenv.lib.optionalString stdenv.isLinux ''
+    for p in $(find "$out" -type f -executable); do
+      if isELF "$p"; then
+        echo "Patchelfing $p"
+        patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
+      fi
+    done
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    # not enough room in the object files for the full path to libiconv :(
+    for exe in $(find "$out" -type f -executable); do
+      isScript $exe && continue
+      ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+      install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib -change /usr/local/lib/gcc/6/libgcc_s.1.dylib ${gcc.cc.lib}/lib/libgcc_s.1.dylib $exe
+    done
+
+    for file in $(find "$out" -name setup-config); do
+      substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
+    done
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    unset ${libEnvVar}
+    # Sanity check, can ghc create executables?
+    cd $TMP
+    mkdir test-ghc; cd test-ghc
+    cat > main.hs << EOF
+      {-# LANGUAGE TemplateHaskell #-}
+      module Main where
+      main = putStrLn \$([|"yes"|])
+    EOF
+    $out/bin/ghc --make main.hs || exit 1
+    echo compilation ok
+    [ $(./main) == "yes" ]
+  '';
+
+  passthru = {
+    targetPrefix = "";
+    enableShared = true;
+  };
+
+  meta.license = stdenv.lib.licenses.bsd3;
+  meta.platforms = ["x86_64-linux" "armv7l-linux" "aarch64-linux" "i686-linux" "x86_64-darwin"];
+}

--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -1,6 +1,6 @@
 { stdenv
 , fetchurl, perl, gcc
-, ncurses6, gmp, glibc, libiconv
+, ncurses6, gmp, glibc, libiconv, numactl
 , llvmPackages
 }:
 
@@ -12,7 +12,8 @@ let
 
   libPath = stdenv.lib.makeLibraryPath ([
     ncurses6 gmp
-  ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv);
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv
+    ++ stdenv.lib.optional (stdenv.hostPlatform.isAarch64) numactl);
 
   libEnvVar = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin "DY"
     + "LD_LIBRARY_PATH";

--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -82,7 +82,6 @@ stdenv.mkDerivation rec {
       patchShebangs ghc-${version}/utils/
       patchShebangs ghc-${version}/configure
     '' +
-
     # We have to patch the GMP paths for the integer-gmp package.
     ''
       find . -name integer-gmp.buildinfo \
@@ -90,6 +89,12 @@ stdenv.mkDerivation rec {
     '' + stdenv.lib.optionalString stdenv.isDarwin ''
       find . -name base.buildinfo \
           -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${libiconv}/lib@" {} \;
+    '' +
+    # aarch64 does HAVE_NUMA so -lnuma requires it in library-dirs in rts/package.conf.in
+    # FFI_LIB_DIR is a good indication of places it must be needed.
+    stdenv.lib.optionalString stdenv.hostPlatform.isAarch64 ''
+      find . -name package.conf.in \
+          -exec sed -i "s@FFI_LIB_DIR@FFI_LIB_DIR ${numactl.out}/lib@g" {} \;
     '' +
     # Rename needed libraries and binaries, fix interpreter
     stdenv.lib.optionalString stdenv.isLinux ''
@@ -128,14 +133,35 @@ stdenv.mkDerivation rec {
 
   # On Linux, use patchelf to modify the executables so that they can
   # find editline/gmp.
-  postFixup = stdenv.lib.optionalString stdenv.isLinux ''
-    for p in $(find "$out" -type f -executable); do
-      if isELF "$p"; then
-        echo "Patchelfing $p"
-        patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
-      fi
-    done
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  postFixup = stdenv.lib.optionalString stdenv.isLinux
+    (if stdenv.hostPlatform.isAarch64 then
+      # Keep rpath as small as possible on aarch64 for patchelf#244.  All Elfs
+      # are 2 directories deep from $out/lib, so pooling symlinks there makes
+      # a short rpath.
+      ''
+      (cd $out/lib; ln -s ${ncurses6.out}/lib/libtinfo.so.6)
+      (cd $out/lib; ln -s ${gmp.out}/lib/libgmp.so.10)
+      (cd $out/lib; ln -s ${numactl.out}/lib/libnuma.so.1)
+      for p in $(find "$out/lib" -type f -name "*\.so*"); do
+        (cd $out/lib; ln -s $p)
+      done
+
+      for p in $(find "$out/lib" -type f -executable); do
+        if isELF "$p"; then
+          echo "Patchelfing $p"
+          patchelf --set-rpath "\$ORIGIN:\$ORIGIN/../.." $p
+        fi
+      done
+      ''
+    else
+      ''
+      for p in $(find "$out" -type f -executable); do
+        if isELF "$p"; then
+          echo "Patchelfing $p"
+          patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
+        fi
+      done
+    '') + stdenv.lib.optionalString stdenv.isDarwin ''
     # not enough room in the object files for the full path to libiconv :(
     for exe in $(find "$out" -type f -executable); do
       isScript $exe && continue
@@ -169,6 +195,11 @@ stdenv.mkDerivation rec {
     enableShared = true;
   };
 
-  meta.license = stdenv.lib.licenses.bsd3;
-  meta.platforms = ["x86_64-linux" "armv7l-linux" "aarch64-linux" "i686-linux" "x86_64-darwin"];
+  meta = {
+    homepage = "http://haskell.org/ghc";
+    description = "The Glasgow Haskell Compiler";
+    license = stdenv.lib.licenses.bsd3;
+    platforms = ["x86_64-linux" "armv7l-linux" "aarch64-linux" "i686-linux" "x86_64-darwin"];
+    maintainers = with stdenv.lib.maintainers; [ lostnet ];
+  };
 }

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -119,7 +119,11 @@ stdenv.mkDerivation (rec {
   postPatch = "patchShebangs .";
 
   # GHC is a bit confused on its cross terminology.
-  preConfigure = ''
+  preConfigure = stdenv.lib.optionalString stdenv.isAarch64 ''
+    # Aarch64 allow backward bootstrapping since earlier versions are unstable.
+    find . -name \*\.cabal\* -exec sed -i -e 's/\(base.*\)4.14/\14.16/' {} \; \
+      -exec sed -i -e 's/\(prim.*\)0.6/\10.8/' {} \;
+  '' + ''
     for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
       export "''${env#TARGET_}=''${!env}"
     done

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1,4 +1,4 @@
-{ buildPackages, pkgs, newScope }:
+{ buildPackages, pkgs, newScope, stdenv }:
 
 let
   # These are attributes in compiler and packages that don't support integer-simple.
@@ -72,7 +72,11 @@ in {
       llvmPackages = pkgs.llvmPackages_7;
     };
     ghc884 = callPackage ../development/compilers/ghc/8.8.4.nix {
-      bootPkgs = packages.ghc865Binary;
+      # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
+      bootPkgs = if stdenv.isAarch64 then
+          packages.ghc8102Binary
+        else
+          packages.ghc865Binary;
       inherit (buildPackages.python3Packages) sphinx;
       buildLlvmPackages = buildPackages.llvmPackages_7;
       llvmPackages = pkgs.llvmPackages_7;
@@ -84,7 +88,11 @@ in {
       llvmPackages = pkgs.llvmPackages_9;
     };
     ghc8102 = callPackage ../development/compilers/ghc/8.10.2.nix {
-      bootPkgs = packages.ghc865Binary;
+      # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
+      bootPkgs = if stdenv.isAarch64 then
+          packages.ghc8102Binary
+        else
+          packages.ghc865Binary;
       inherit (buildPackages.python3Packages) sphinx;
       buildLlvmPackages = buildPackages.llvmPackages_9;
       llvmPackages = pkgs.llvmPackages_9;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -49,6 +49,10 @@ in {
 
     ghc865Binary = callPackage ../development/compilers/ghc/8.6.5-binary.nix { };
 
+    ghc8102Binary = callPackage ../development/compilers/ghc/8.10.2-binary.nix {
+      llvmPackages = pkgs.llvmPackages_9;
+    };
+
     ghc865 = callPackage ../development/compilers/ghc/8.6.5.nix {
       bootPkgs = packages.ghc822Binary;
       inherit (buildPackages.python3Packages) sphinx;
@@ -137,6 +141,12 @@ in {
       buildHaskellPackages = bh.packages.ghc865Binary;
       ghc = bh.compiler.ghc865Binary;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.6.x.nix { };
+      packageSetConfig = bootstrapPackageSet;
+    };
+    ghc8102Binary = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc8102Binary;
+      ghc = bh.compiler.ghc8102Binary;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
       packageSetConfig = bootstrapPackageSet;
     };
     ghc865 = callPackage ../development/haskell-modules {


### PR DESCRIPTION

###### Motivation for this change

Fix the GHC build on aarch64-linux. Backport of #101214 

Refs #97407

Feel free to close if it's better merged via staging-20.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
