### PR TITLE
Unbreak qt5.full, add qt3d, qtgamepad, qtremoteobjects

### DIFF
--- a/pkgs/applications/kde/rocs.nix
+++ b/pkgs/applications/kde/rocs.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib,
   extra-cmake-modules, boost,
-  qtbase, qtscript, qtquickcontrols, qtwebkit, qtxmlpatterns, grantlee,
+  qtbase, qtscript, qtquickcontrols, qtxmlpatterns, grantlee,
   kdoctools, karchive, kxmlgui, kcrash, kdeclarative, ktexteditor, kguiaddons
 }:
 
@@ -19,7 +19,7 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     boost
-    qtbase qtscript qtquickcontrols qtwebkit qtxmlpatterns grantlee
+    qtbase qtscript qtquickcontrols qtxmlpatterns grantlee
     kxmlgui kcrash kdeclarative karchive ktexteditor kguiaddons
   ];
 }

--- a/pkgs/applications/office/calligra/default.nix
+++ b/pkgs/applications/office/calligra/default.nix
@@ -8,7 +8,7 @@
   kwindowsystem, kxmlgui, sonnet, threadweaver,
   kcontacts, akonadi, akonadi-calendar, akonadi-contacts,
   eigen, git, gsl, ilmbase, kproperty, kreport, lcms2, marble, pcre, libgit2, libodfgen,
-  librevenge, libvisio, libwpd, libwpg, libwps, okular, openexr, openjpeg, phonon,
+  librevenge, libvisio, libwpd, libwpg, libwps, okular, openexr, phonon,
   poppler, pstoedit, qca-qt5, vc
 # TODO: package Spnav, m2mml LibEtonyek, Libqgit2
 }:
@@ -32,7 +32,7 @@ mkDerivation rec {
     ktextwidgets kwallet kwidgetsaddons kwindowsystem kxmlgui sonnet threadweaver
     kcontacts akonadi akonadi-calendar akonadi-contacts
     eigen git gsl ilmbase kproperty kreport lcms2 marble pcre libgit2 libodfgen librevenge
-    libvisio libwpd libwpg libwps okular openexr openjpeg phonon poppler qca-qt5 vc
+    libvisio libwpd libwpg libwps okular openexr phonon poppler qca-qt5 vc
   ];
 
   propagatedUserEnvPkgs = [ kproperty ];

--- a/pkgs/development/libraries/kreport/default.nix
+++ b/pkgs/development/libraries/kreport/default.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib, fetchurl,
   extra-cmake-modules,
-  qtdeclarative, qtwebkit, kconfig, kcoreaddons, kwidgetsaddons, kguiaddons, kproperty, marble, python2
+  qtdeclarative, kconfig, kcoreaddons, kwidgetsaddons, kguiaddons, kproperty, marble, python2
 }:
 
 mkDerivation rec {
@@ -15,7 +15,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [ extra-cmake-modules ];
 
-  buildInputs = [ qtdeclarative qtwebkit kconfig kcoreaddons kwidgetsaddons kguiaddons kproperty marble python2 ];
+  buildInputs = [ qtdeclarative kconfig kcoreaddons kwidgetsaddons kguiaddons kproperty marble python2 ];
 
   meta = with lib; {
     description = "A framework for creation and generation of reports in multiple formats";

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -161,6 +161,7 @@ let
         inherit developerBuild decryptSslTraffic;
       };
 
+      qt3d = callPackage ../modules/qt3d.nix {};
       qtcharts = callPackage ../modules/qtcharts.nix {};
       qtconnectivity = callPackage ../modules/qtconnectivity.nix {};
       qtdeclarative = callPackage ../modules/qtdeclarative.nix {};
@@ -177,6 +178,7 @@ let
       qtquick1 = null;
       qtquickcontrols = callPackage ../modules/qtquickcontrols.nix {};
       qtquickcontrols2 = callPackage ../modules/qtquickcontrols2.nix {};
+      qtremoteobjects = callPackage ../modules/qtremoteobjects.nix {};
       qtscript = callPackage ../modules/qtscript.nix {};
       qtsensors = callPackage ../modules/qtsensors.nix {};
       qtserialbus = callPackage ../modules/qtserialbus.nix {};
@@ -199,11 +201,11 @@ let
 
       env = callPackage ../qt-env.nix {};
       full = env "qt-full-${qtbase.version}" ([
-        qtcharts qtconnectivity qtdeclarative qtdoc qtgamepad qtgraphicaleffects
-        qtimageformats qtlocation qtmultimedia qtquickcontrols qtquickcontrols2
-        qtscript qtsensors qtserialport qtsvg qttools qttranslations
-        qtvirtualkeyboard qtwebchannel qtwebengine qtwebkit qtwebsockets
-        qtwebview qtx11extras qtxmlpatterns
+        qt3d qtcharts qtconnectivity qtdeclarative qtdoc qtgamepad
+        qtgraphicaleffects qtimageformats qtlocation qtmultimedia
+        qtquickcontrols qtquickcontrols2 qtremoteobjects qtscript qtsensors
+        qtserialport qtsvg qttools qttranslations qtvirtualkeyboard qtwebchannel
+        qtwebengine qtwebkit qtwebsockets qtwebview qtx11extras qtxmlpatterns
       ] ++ optional (!stdenv.isDarwin) qtwayland
         ++ optional (stdenv.isDarwin) qtmacextras);
 

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -135,10 +135,12 @@ let
         inherit developerBuild decryptSslTraffic;
       };
 
+      qt3d = callPackage ../modules/qt3d.nix {};
       qtcharts = callPackage ../modules/qtcharts.nix {};
       qtconnectivity = callPackage ../modules/qtconnectivity.nix {};
       qtdeclarative = callPackage ../modules/qtdeclarative.nix {};
       qtdoc = callPackage ../modules/qtdoc.nix {};
+      qtgamepad = callPackage ../modules/qtgamepad.nix {};
       qtgraphicaleffects = callPackage ../modules/qtgraphicaleffects.nix {};
       qtimageformats = callPackage ../modules/qtimageformats.nix {};
       qtlocation = callPackage ../modules/qtlocation.nix {};
@@ -150,6 +152,7 @@ let
       qtquick1 = null;
       qtquickcontrols = callPackage ../modules/qtquickcontrols.nix {};
       qtquickcontrols2 = callPackage ../modules/qtquickcontrols2.nix {};
+      qtremoteobjects = callPackage ../modules/qtremoteobjects.nix {};
       qtscript = callPackage ../modules/qtscript.nix {};
       qtsensors = callPackage ../modules/qtsensors.nix {};
       qtserialport = callPackage ../modules/qtserialport.nix {};
@@ -171,11 +174,11 @@ let
 
       env = callPackage ../qt-env.nix {};
       full = env "qt-full-${qtbase.version}" ([
-        qtcharts qtconnectivity qtdeclarative qtdoc qtgraphicaleffects
-        qtimageformats qtlocation qtmultimedia qtquickcontrols qtquickcontrols2
-        qtscript qtsensors qtserialport qtsvg qttools qttranslations
-        qtvirtualkeyboard qtwebchannel qtwebengine qtwebkit qtwebsockets
-        qtwebview qtx11extras qtxmlpatterns
+        qt3d qtcharts qtconnectivity qtdeclarative qtdoc qtgamepad
+        qtgraphicaleffects qtimageformats qtlocation qtmultimedia
+        qtquickcontrols qtquickcontrols2 qtremoteobjects qtscript qtsensors
+        qtserialport qtsvg qttools qttranslations qtvirtualkeyboard qtwebchannel
+        qtwebengine qtwebkit qtwebsockets qtwebview qtx11extras qtxmlpatterns
       ] ++ optional (!stdenv.isDarwin) qtwayland
         ++ optional (stdenv.isDarwin) qtmacextras);
 

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -132,10 +132,12 @@ let
         inherit developerBuild decryptSslTraffic;
       };
 
+      qt3d = callPackage ../modules/qt3d.nix {};
       qtcharts = callPackage ../modules/qtcharts.nix {};
       qtconnectivity = callPackage ../modules/qtconnectivity.nix {};
       qtdeclarative = callPackage ../modules/qtdeclarative.nix {};
       qtdoc = callPackage ../modules/qtdoc.nix {};
+      qtgamepad = callPackage ../modules/qtgamepad.nix {};
       qtgraphicaleffects = callPackage ../modules/qtgraphicaleffects.nix {};
       qtimageformats = callPackage ../modules/qtimageformats.nix {};
       qtlocation = callPackage ../modules/qtlocation.nix {};
@@ -147,6 +149,7 @@ let
       qtquick1 = null;
       qtquickcontrols = callPackage ../modules/qtquickcontrols.nix {};
       qtquickcontrols2 = callPackage ../modules/qtquickcontrols2.nix {};
+      qtremoteobjects = callPackage ../modules/qtremoteobjects.nix {};
       qtscript = callPackage ../modules/qtscript.nix {};
       qtsensors = callPackage ../modules/qtsensors.nix {};
       qtserialport = callPackage ../modules/qtserialport.nix {};
@@ -168,11 +171,11 @@ let
 
       env = callPackage ../qt-env.nix {};
       full = env "qt-full-${qtbase.version}" ([
-        qtcharts qtconnectivity qtdeclarative qtdoc qtgraphicaleffects
-        qtimageformats qtlocation qtmultimedia qtquickcontrols qtquickcontrols2
-        qtscript qtsensors qtserialport qtsvg qttools qttranslations
-        qtvirtualkeyboard qtwebchannel qtwebengine qtwebkit qtwebsockets
-        qtwebview qtx11extras qtxmlpatterns
+        qt3d qtcharts qtconnectivity qtdeclarative qtdoc qtgamepad
+        qtgraphicaleffects qtimageformats qtlocation qtmultimedia
+        qtquickcontrols qtquickcontrols2 qtremoteobjects qtscript qtsensors
+        qtserialport qtsvg qttools qttranslations qtvirtualkeyboard qtwebchannel
+        qtwebengine qtwebkit qtwebsockets qtwebview qtx11extras qtxmlpatterns
       ] ++ optional (!stdenv.isDarwin) qtwayland
         ++ optional (stdenv.isDarwin) qtmacextras);
 

--- a/pkgs/development/libraries/qt-5/modules/qt3d.nix
+++ b/pkgs/development/libraries/qt-5/modules/qt3d.nix
@@ -1,0 +1,7 @@
+{ qtModule, qtbase, qtdeclarative }:
+
+qtModule {
+  name = "qt3d";
+  qtInputs = [ qtbase qtdeclarative ];
+  outputs = [ "out" "dev" "bin" ];
+}

--- a/pkgs/development/libraries/qt-5/modules/qtremoteobjects.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtremoteobjects.nix
@@ -1,0 +1,7 @@
+{ qtModule, qtbase, qtdeclarative }:
+
+qtModule {
+  name = "qtremoteobjects";
+  qtInputs = [ qtbase qtdeclarative ];
+  outputs = [ "out" ];
+}

--- a/pkgs/development/libraries/qt-5/qt-env.nix
+++ b/pkgs/development/libraries/qt-5/qt-env.nix
@@ -5,7 +5,7 @@ buildEnv {
   paths = [ qtbase ] ++ paths;
 
   pathsToLink = [ "/bin" "/mkspecs" "/include" "/lib" "/share" ];
-  extraOutputsToInstall = [ "dev" ];
+  extraOutputsToInstall = [ "out" "dev" ];
 
   postBuild = ''
     rm "$out/bin/qmake"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20646,11 +20646,7 @@ in
 
   calibre = calibre-py3;
 
-  calligra = libsForQt5.callPackage ../applications/office/calligra {
-    openjpeg = openjpeg_1;
-    # Must use the same Qt version as Calligra itself:
-    poppler = libsForQt5.poppler_0_61;
-  };
+  calligra = libsForQt5.callPackage ../applications/office/calligra { };
 
   perkeep = callPackage ../applications/misc/perkeep { };
 


### PR DESCRIPTION
###### Motivation for this change

`qtwebkit` was already marked broken for qt 5.15 and the last commit I found is more than a year old so it is unlikely to be fixed. It broke `qt5.full` by being a part of it so I removed it.

For some qt modules, the default output is `bin` while the shared objects are still in `out`. I added `out` to the used outputs of the `qt5.full` environment so all shared objects are included. Maybe the default output of the qt modules should always be out instead?

Added more qt modules: qt3d, qtgamepad, qtremoteobjects

I tested the changes by building `qt5{12,14,15}.full` and running an application that depends on the added qt modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
