### PR TITLE
nuclear: init at 0.6.6

### DIFF
--- a/pkgs/applications/audio/nuclear/default.nix
+++ b/pkgs/applications/audio/nuclear/default.nix
@@ -1,0 +1,32 @@
+{ appimageTools, lib, fetchurl }:
+let
+  pname = "nuclear";
+  version = "0.6.6";
+  name = "${pname}-v${version}";
+
+  src = fetchurl {
+    url = "https://github.com/nukeop/nuclear/releases/download/v${version}/${name}.AppImage";
+    sha256 = "0c1335m76fv0wfbk07s8r6ln7zbmlqd66052gqfisakl8a1aafl6";
+  };
+
+  appimageContents = appimageTools.extract { inherit name src; };
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun' 'Exec=$out/bin/nuclear'
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "Streaming music player that finds free music for you";
+    homepage = "https://nuclear.js.org/";
+    license = licenses.agpl3Plus;
+    maintainers = [ maintainers.ivar ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19414,6 +19414,8 @@ in
   inherit (callPackages ../data/fonts/noto-fonts {})
     noto-fonts noto-fonts-cjk noto-fonts-emoji noto-fonts-emoji-blob-bin noto-fonts-extra;
 
+  nuclear = callPackage ../applications/audio/nuclear { };
+
   nullmailer = callPackage ../servers/mail/nullmailer {
     stdenv = gccStdenv;
   };


### PR DESCRIPTION

###### Motivation for this change
Building from source is a pain due to electron, so for now I've used the provided appimage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
