### PR TITLE
Initial implementation of remarkable1 cross-compile

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -34,6 +34,11 @@ rec {
     platform = platforms.raspberrypi;
   };
 
+  remarkable1 = {
+    config = "armv7l-unknown-linux-gnueabihf";
+    platform = platforms.zero-gravitas;
+  };
+
   armv7l-hf-multiplatform = {
     config = "armv7l-unknown-linux-gnueabihf";
     platform = platforms.armv7l-hf-multiplatform;

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -203,6 +203,20 @@ rec {
   # Legacy attribute, for compatibility with existing configs only.
   raspberrypi2 = armv7l-hf-multiplatform;
 
+  zero-gravitas = {
+    name = "zero-gravitas";
+    kernelBaseConfig = "zero-gravitas_defconfig";
+    kernelArch = "arm";
+    # kernelTarget verified by checking /boot on reMarkable 1 device
+    kernelTarget = "zImage";
+    kernelAutoModules = false;
+    kernelDTB = true;
+    gcc = {
+      fpu = "neon";
+      cpu = "cortex-a9";
+    };
+  };
+
   scaleway-c1 = armv7l-hf-multiplatform // {
     gcc = {
       cpu = "cortex-a9";


### PR DESCRIPTION
###### Motivation for this change
Initial implementation of reMarkable 1 cross-compile. Doesn't rely on the company-provided toolchain, so if the user wants to run Nix-build binaries on the device they have two options:

- compile to static binaries
- install Nix on the device and use `nix-copy-closure`

Try out a build with

```bash
$ nix-build --argstr system 'x86_64-linux' -A pkgs.pkgsCross.remarkable1.hello
$ sha256sum ./result/bin/hello 
ab10b198df6f61efaa98ef1ced6ec94c651489871c556b365138b5a42891820d  ./result/bin/hello
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Pinging some people who I've talked to on IRC/seen add infra in the commits. @cleverca22 @matthewbauer . Thanks!