### PR TITLE
[staging-20.09] Add ghc8102BinaryMinimal to stay within hydra limits on aarch64

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -7,8 +7,6 @@
   # regular builds and GHC bootstrapping.
   # This is "useful" for staying within hydra's output limits for at least the
   # aarch64-linux architecture.
-  # Examples of unnecessary files are the bundled documentation and files that
-  # are only needed for profiling builds.
 , minimal ? false
 }:
 
@@ -182,11 +180,15 @@ stdenv.mkDerivation rec {
     done
   '' +
   stdenv.lib.optionalString minimal ''
-    # Remove profiling objects
+    # Remove profiling files
     find $out -type f -name '*.p_o' -delete
+    find $out -type f -name '*.p_hi' -delete
+    find $out -type f -name '*_p.a' -delete
     rm $out/lib/ghc-*/bin/ghc-iserv-prof
-    # Remove docs
-    rm -r $out/share/{doc,man}
+    # Hydra will redistribute this derivation, so we have to keep the docs for
+    # legal reasons (retaining the legal notices etc)
+    # As a last resort we could unpack the docs separately and symlink them in.
+    # They're in $out/share/{doc,man}.
   '';
 
   doInstallCheck = true;

--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -212,18 +212,11 @@ stdenv.mkDerivation rec {
     enableShared = true;
   };
 
-  meta = let
-    platforms = ["x86_64-linux" "armv7l-linux" "aarch64-linux" "i686-linux" "x86_64-darwin"];
-  in {
+  meta = {
     homepage = "http://haskell.org/ghc";
     description = "The Glasgow Haskell Compiler";
     license = stdenv.lib.licenses.bsd3;
-
-    # The minimal variation can not be distributed because it removes the
-    # documentation, including licensing information that is required for
-    # distribution.
-    inherit platforms;
-    hydraPlatforms = stdenv.lib.optionals (!minimal) platforms;
+    platforms = ["x86_64-linux" "armv7l-linux" "aarch64-linux" "i686-linux" "x86_64-darwin"];
     maintainers = with stdenv.lib.maintainers; [ lostnet ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Make ghc buildable on hydra for `aarch64`.


It's currently failing with `Output limit exceeded` https://hydra.nixos.org/build/129487354#tabs-summary
Hydra only allows outputs up to 2<sup>31</sup> NAR bytes.
The new `ghc8102BinaryMinimal` is 2136668000 out of 2147483648 bytes; ~10M under the limit.
This is achieved by removing the documentation and the profiling objects, neither of which are used for bootstrapping.

I have a build of GHC 8.8.4 in that's in progress. 

TODO
 - [x] finish compilation of ghc884
 - [x] inline docs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
