### PR TITLE
libsForQt.kpeoplevcard: fix homepage

### DIFF
--- a/pkgs/development/libraries/kpeoplevcard/default.nix
+++ b/pkgs/development/libraries/kpeoplevcard/default.nix
@@ -32,7 +32,7 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "Pulseaudio bindings for Qt";
-    homepage    = "KPeople VCard Support";
+    homepage    = "https://github.com/KDE/kpeoplevcard";
     license     = with licenses; [ lgpl2 ];
     maintainers = with maintainers; [ doronbehar ];
   };


### PR DESCRIPTION
###### Motivation for this change
noticed this in https://repology.org/log/3878951

cc @doronbehar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
