### PR TITLE
blackmagic decklink: init pkg and module at 12.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4661,6 +4661,12 @@
     githubId = 222664;
     name = "Matthew Leach";
   };
+  hexchen = {
+    email = "nix@lilwit.ch";
+    github = "hexchen";
+    githubId = 41522204;
+    name = "hexchen";
+  };
   hh = {
     email = "hh@m-labs.hk";
     github = "HarryMakes";

--- a/nixos/modules/hardware/decklink.nix
+++ b/nixos/modules/hardware/decklink.nix
@@ -1,0 +1,17 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.decklink;
+  kernelPackages = config.boot.kernelPackages;
+in
+{
+  options.hardware.decklink.enable = mkEnableOption "hardware support for the Blackmagic Design Decklink audio/video interfaces";
+
+  config = mkIf cfg.enable {
+    boot.kernelModules = [ "blackmagic" "blackmagic-io" "snd_blackmagic-io" ];
+    boot.extraModulePackages = [ kernelPackages.decklink ];
+    systemd.packages = [ pkgs.blackmagicDesktopVideo ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -47,6 +47,7 @@
   ./hardware/cpu/intel-microcode.nix
   ./hardware/corectrl.nix
   ./hardware/digitalbitbox.nix
+  ./hardware/decklink.nix
   ./hardware/device-tree.nix
   ./hardware/gkraken.nix
   ./hardware/flirc.nix

--- a/pkgs/os-specific/linux/decklink/default.nix
+++ b/pkgs/os-specific/linux/decklink/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, lib, requireFile, fetchpatch, kernel }:
+
+stdenv.mkDerivation rec {
+  pname = "decklink";
+  major = "12.0";
+  version = "${major}a14";
+
+  src = requireFile {
+    name = "Blackmagic_Desktop_Video_Linux_${major}.tar.gz";
+    url = "https://www.blackmagicdesign.com/support/download/76b2edbed5884e1dbbfea104071f1643/Linux";
+    sha256 = "e5a586ee705513cf5e6b024e1ec68621ab91d50b370981023e0bff73a19169c2";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "01-fix-get_user_pages.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/01-fix-get_user_pages.patch?h=decklink&id=212ec426d96db3de0fedad803238d0604cc4df76";
+      sha256 = "193199d59kmwdajhyw9k98636lbxrxwnxwlbhhijp1qms6y1qn2j";
+    })
+    (fetchpatch {
+      name = "02-fix-have_unlocked_ioctl.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/02-fix-have_unlocked_ioctl.patch?h=decklink&id=212ec426d96db3de0fedad803238d0604cc4df76";
+      sha256 = "0yf3bwry28zr1yfnx6wyh650d8kac4q70x95kz4p7sr6r7ajwzdm";
+    })
+  ];
+
+  KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  INSTALL_MOD_PATH = placeholder "out";
+
+  nativeBuildInputs =  kernel.moduleBuildDependencies;
+
+  setSourceRoot = ''
+    tar xf Blackmagic_Desktop_Video_Linux_${major}/other/x86_64/desktopvideo-${version}-x86_64.tar.gz
+    sourceRoot=$NIX_BUILD_TOP/desktopvideo-${version}-x86_64/usr/src
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    make -C $sourceRoot/blackmagic-${version} -j$NIX_BUILD_CORES
+    make -C $sourceRoot/blackmagic-io-${version} -j$NIX_BUILD_CORES
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    make -C $KERNELDIR M=$sourceRoot/blackmagic-${version} modules_install
+    make -C $KERNELDIR M=$sourceRoot/blackmagic-io-${version} modules_install
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.blackmagicdesign.com/support/family/capture-and-playback";
+    maintainers = [ maintainers.hexchen ];
+    license = licenses.unfree;
+    description = "Kernel module for the Blackmagic Design Decklink cards";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/decklink/default.nix
+++ b/pkgs/os-specific/linux/decklink/default.nix
@@ -2,27 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "decklink";
-  major = "12.0";
-  version = "${major}a14";
+  major = "12.2";
+  version = "${major}a12";
 
   src = requireFile {
     name = "Blackmagic_Desktop_Video_Linux_${major}.tar.gz";
-    url = "https://www.blackmagicdesign.com/support/download/76b2edbed5884e1dbbfea104071f1643/Linux";
-    sha256 = "e5a586ee705513cf5e6b024e1ec68621ab91d50b370981023e0bff73a19169c2";
+    url = "https://www.blackmagicdesign.com/support/download/33abc1034cd54cf99101f9acd2edd93d/Linux";
+    sha256 = "62954a18b60d9040aa4a959dff30ac9c260218ef78d6a63cbb243788f7abc05f";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "01-fix-get_user_pages.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/01-fix-get_user_pages.patch?h=decklink&id=212ec426d96db3de0fedad803238d0604cc4df76";
-      sha256 = "193199d59kmwdajhyw9k98636lbxrxwnxwlbhhijp1qms6y1qn2j";
-    })
-    (fetchpatch {
-      name = "02-fix-have_unlocked_ioctl.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/02-fix-have_unlocked_ioctl.patch?h=decklink&id=212ec426d96db3de0fedad803238d0604cc4df76";
-      sha256 = "0yf3bwry28zr1yfnx6wyh650d8kac4q70x95kz4p7sr6r7ajwzdm";
-    })
-  ];
 
   KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   INSTALL_MOD_PATH = placeholder "out";

--- a/pkgs/tools/video/blackmagic-desktop-video/default.nix
+++ b/pkgs/tools/video/blackmagic-desktop-video/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, requireFile, lib,
+  libcxx, libcxxabi
+}:
+
+stdenv.mkDerivation rec {
+  pname = "blackmagic-desktop-video";
+  major = "12.0";
+  version = "${major}a14";
+
+  buildInputs = [
+    libcxx libcxxabi
+  ];
+
+  src = requireFile {
+    name = "Blackmagic_Desktop_Video_Linux_${major}.tar.gz";
+    url = "https://www.blackmagicdesign.com/support/download/76b2edbed5884e1dbbfea104071f1643/Linux";
+    sha256 = "e5a586ee705513cf5e6b024e1ec68621ab91d50b370981023e0bff73a19169c2";
+  };
+
+  setSourceRoot = ''
+    tar xf Blackmagic_Desktop_Video_Linux_${major}/other/x86_64/desktopvideo-${version}-x86_64.tar.gz
+    sourceRoot=$NIX_BUILD_TOP/desktopvideo-${version}-x86_64
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/doc,lib/systemd/system}
+    cp -r $sourceRoot/usr/share/doc/desktopvideo $out/share/doc
+    cp $sourceRoot/usr/lib/*.so $out/lib
+    cp $sourceRoot/usr/lib/systemd/system/DesktopVideoHelper.service $out/lib/systemd/system
+    ln -s ${libcxx}/lib/* ${libcxxabi}/lib/* $out/lib
+    cp $sourceRoot/usr/lib/blackmagic/DesktopVideo/libgcc_s.so.1 $out/lib/
+    cp $sourceRoot/usr/lib/blackmagic/DesktopVideo/DesktopVideoHelper $out/bin/
+
+    substituteInPlace $out/lib/systemd/system/DesktopVideoHelper.service --replace "/usr/lib/blackmagic/DesktopVideo/DesktopVideoHelper" "$out/bin/DesktopVideoHelper"
+
+    runHook postInstall
+  '';
+
+
+  postFixup = ''
+    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+      --set-rpath "$out/lib:${lib.makeLibraryPath [ libcxx libcxxabi ]}" \
+      $out/bin/DesktopVideoHelper
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.blackmagicdesign.com/support/family/capture-and-playback";
+    maintainers = [ maintainers.hexchen ];
+    license = licenses.unfree;
+    description = "Supporting applications for Blackmagic Decklink. Doesn't include the desktop applications, only the helper required to make the driver work.";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/video/blackmagic-desktop-video/default.nix
+++ b/pkgs/tools/video/blackmagic-desktop-video/default.nix
@@ -4,8 +4,8 @@
 
 stdenv.mkDerivation rec {
   pname = "blackmagic-desktop-video";
-  major = "12.0";
-  version = "${major}a14";
+  major = "12.2";
+  version = "${major}a12";
 
   buildInputs = [
     libcxx libcxxabi
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
 
   src = requireFile {
     name = "Blackmagic_Desktop_Video_Linux_${major}.tar.gz";
-    url = "https://www.blackmagicdesign.com/support/download/76b2edbed5884e1dbbfea104071f1643/Linux";
-    sha256 = "e5a586ee705513cf5e6b024e1ec68621ab91d50b370981023e0bff73a19169c2";
+    url = "https://www.blackmagicdesign.com/support/download/33abc1034cd54cf99101f9acd2edd93d/Linux";
+    sha256 = "62954a18b60d9040aa4a959dff30ac9c260218ef78d6a63cbb243788f7abc05f";
   };
 
   setSourceRoot = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1493,6 +1493,8 @@ with pkgs;
 
   bklk = callPackage ../applications/misc/bklk { };
 
+  blackmagicDesktopVideo = callPackage ../tools/video/blackmagic-desktop-video { };
+
   bkyml = callPackage ../tools/misc/bkyml { };
 
   blockbench-electron = callPackage ../applications/graphics/blockbench-electron { };

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -282,6 +282,8 @@ in {
 
     ddcci-driver = callPackage ../os-specific/linux/ddcci { };
 
+    decklink = callPackage ../os-specific/linux/decklink { };
+
     digimend = callPackage ../os-specific/linux/digimend { };
 
     dpdk-kmods = callPackage ../os-specific/linux/dpdk-kmods { };


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
There's currently no support for the Blackmagic Design Decklink hardware in nixos. The driver for these AV-interface cards is available from the manufacturer directly, but it only supports DEB and RPM-based distros natively. This PR adds in the required driver as well as one of the userspace services that are required to make the hardware work.

It does not include any of the userspace GUI tools that can be used to configure and monitor the capture cards, since those proprietary applications depend on QT and I have yet to repackage them for nix.

I'll leave the PR marked as a draft until I have tested the module on hardware with a Decklink card.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
