### PR TITLE
python3Packages.pyserial-asyncio: propagate pyserial

### DIFF
--- a/pkgs/development/python-modules/pyserial-asyncio/default.nix
+++ b/pkgs/development/python-modules/pyserial-asyncio/default.nix
@@ -7,12 +7,12 @@ buildPythonPackage rec {
 
   disabled = !isPy3k; # Doesn't support python older than 3.4
 
-  buildInputs = [ pyserial ];
-
   src = fetchPypi {
     inherit pname version;
     sha256 = "1vlsb0d03krxlj7vpvyhpinnyxyy8s3lk5rs8ba2932dhyl7f1n4";
   };
+
+  propagatedBuildInputs = [ pyserial ];
 
   meta = with stdenv.lib; {
     description = "asyncio extension package for pyserial";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes errors like this:

```
ERROR: Could not find a version that satisfies the requirement pyserial (from pyserial-asyncio>=0.4->pysml==0.0.2) (from versions: none)
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
