### PR TITLE
pipewire: 0.3.13 -> 0.3.15

### DIFF
--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -40,7 +40,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "pipewire";
-  version = "0.3.13";
+  version = "0.3.15";
 
   outputs = [
     "out"
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     owner = "pipewire";
     repo = "pipewire";
     rev = version;
-    sha256 = "19j5kmb7iaivkq2agfzncfm2qms41ckqi0ddxvhpc91ihwprdc5w";
+    sha256 = "1lmsn13pbr0cigb5ri9nd3102ffbaf8nsz5c8aawf6lsz7mhkx9x";
   };
 
   patches = [
@@ -65,13 +65,6 @@ stdenv.mkDerivation rec {
     ./alsa-profiles-use-libdir.patch
     # Move installed tests into their own output.
     ./installed-tests-path.patch
-
-    # TODO Remove this on next update
-    # Fixes rpath referencecs.
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/pipewire/pipewire/commit/2e3556fa128b778be62a7ffad5fbe78393035825.diff";
-      sha256 = "039yysb8j1aiqml54rxnaqfmzqz1b6m8sv5w3vz52grvav3kyr1l";
-    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/whfvrjrv3wdcz8bfybm9ha7vclka8knc-pipewire-0.3.13	 326.9M
/nix/store/k9fnfpf6s7rjb3k7yv6230gn0yry1hnm-pipewire-0.3.14	 327.1M

```
cd nixpkgs/nixos/tests/installed-tests
nix-build -A pipewire

[...]
machine # [   22.407894] gnome-desktop-testing-runner[679]: PASS: pipewire-0.3/spa-benchmark-dict.test
machine # [   22.423440] gnome-desktop-testing-runner[679]: PASS: pipewire-0.3/pw-test-client.test
machine # [   22.438886] gnome-desktop-testing-runner[679]: PASS: pipewire-0.3/pw-test-properties.test
machine # [   22.505593] gnome-desktop-testing-runner[679]: PASS: pipewire-0.3/pw-test-context.test
machine # [   23.001419] gnome-desktop-testing-runner[679]: Executing: pipewire-0.3/spa-stress-ringbuffer.test
machine # [   24.529835] gnome-desktop-testing-runner[679]: PASS: pipewire-0.3/spa-stress-ringbuffer.test
machine # [   24.545912] gnome-desktop-testing-runner[679]: PASS: pipewire-0.3/spa-test-node.test
machine # [   24.559084] gnome-desktop-testing-runner[679]: PASS: pipewire-0.3/spa-test-utils.test
machine # [   24.575278] gnome-desktop-testing-runner[679]: PASS: pipewire-0.3/pw-test-array.test
machine # [   24.584764] gnome-desktop-testing-runner[679]: SUMMARY: total=25; passed=25; skipped=0; failed=0; user=4.4s; system=11.1s; maxrss=5444
(25.83 seconds)
(25.83 seconds)
test script finished in 25.85s
cleaning up
killing machine (pid 9)
(0.00 seconds)
/nix/store/80l3257a0xl15ciklmcd2g807brfw28x-vm-test-run-pipewire-0.3.14
```