### PR TITLE
pythonPackages.sumtypes: init at 0.1a5

### DIFF
--- a/pkgs/development/python-modules/sumtypes/default.nix
+++ b/pkgs/development/python-modules/sumtypes/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchFromGitHub, attrs, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "sumtypes";
+  version = "0.1a5";
+
+  src = fetchFromGitHub {
+    owner = "radix";
+    repo = "sumtypes";
+    rev = version;
+    sha256 = "0wcw1624xxx2h6lliv13b59blg60j8sgf5v2ni3cwx3j4wld4csr";
+  };
+
+  propagatedBuildInputs = [ attrs ];
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Algebraic data types for Python";
+    homepage = "https://github.com/radix/sumtypes";
+    license = licenses.mit;
+    maintainers = with maintainers; [ NieDzejkob ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6926,6 +6926,8 @@ in {
 
   sumo = callPackage ../development/python-modules/sumo { };
 
+  sumtypes = callPackage ../development/python-modules/sumtypes { };
+
   sunpy = callPackage ../development/python-modules/sunpy { };
 
   supervise_api = callPackage ../development/python-modules/supervise_api { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - takes too much RAM
- ~~[ ] Tested execution of all binary files (usually in `./result/bin/`)~~ (N/A)
- [x] Tested importing the package in `nix-shell -p 'python$V.withPackages (ps: [ ps.sumtypes ])'`, for python38, python37, python36 and python27
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
