### PR TITLE
minecraft-server: 1.16.3 -> 1.16.4

### DIFF
--- a/pkgs/games/minecraft-server/default.nix
+++ b/pkgs/games/minecraft-server/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, jre_headless }:
 stdenv.mkDerivation {
   pname = "minecraft-server";
-  version = "1.16.3";
+  version = "1.16.4";
 
   src = fetchurl {
-    url = "https://launcher.mojang.com/v1/objects/f02f4473dbf152c23d7d484952121db0b36698cb/server.jar";
+    url = "https://launcher.mojang.com/v1/objects/35139deedbd5182953cf1caa23835da59ca3d7cd/server.jar";
     # sha1 because that comes from mojang via api
-    sha1 = "f02f4473dbf152c23d7d484952121db0b36698cb";
+    sha1 = "35139deedbd5182953cf1caa23835da59ca3d7cd";
   };
 
   preferLocalBuild = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

New Minecraft server release. Used update script to perform the update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Update script run:

```
[matt@servnerr-3:~/src/nixpkgs/pkgs/games/minecraft-server]$ ./update.sh 
these paths will be fetched (1.06 MiB download, 4.22 MiB unpacked):
  /nix/store/0qbx1glbcvdsr1nxb2rkfp05rifvslia-libssh2-1.9.0-dev
  /nix/store/2hkxrg8xzcpckixpszfvgbifgjdcjz4g-common-updater-scripts
  /nix/store/333six1faw9bhccsx9qw5718k6b1wiq2-stdenv-linux
  /nix/store/4smsd9i84s5dmnvp1i89mfafxhmjxh3r-nghttp2-1.41.0
  /nix/store/8ndl9ija1bc4j5ybvagvygpdwiiclgy9-nghttp2-1.41.0-bin
  /nix/store/9m978hhby7pzdhwaq5pir0b05hy11jmv-jq-1.6-dev
  /nix/store/apvjbfi8b3rwh41b3c67rlx4g7gfrija-curl-7.72.0-dev
  /nix/store/cvm6h1j9dcayp47glqfxpx7bjzfkdn2p-libev-4.33
  /nix/store/kmvs83cihlf7vp28yjfrldizkynpb4iy-libkrb5-1.18-dev
  /nix/store/mkr9vr7zsw5hzbp37kw52b1x1r7hvh9s-c-ares-1.15.0
  /nix/store/rlknkw60sngvky1rkrdws0qik3scjcln-bash-interactive-4.4-p23-dev
  /nix/store/yc2npbij60jxn3fvdys5pyvnjb1wasa6-zlib-1.2.11-dev
  /nix/store/yclz0jqjz72fwgbmdydp4gdi1kcf334k-nghttp2-1.41.0-dev
copying path '/nix/store/rlknkw60sngvky1rkrdws0qik3scjcln-bash-interactive-4.4-p23-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/2hkxrg8xzcpckixpszfvgbifgjdcjz4g-common-updater-scripts' from 'https://cache.nixos.org'...
copying path '/nix/store/9m978hhby7pzdhwaq5pir0b05hy11jmv-jq-1.6-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/4smsd9i84s5dmnvp1i89mfafxhmjxh3r-nghttp2-1.41.0' from 'https://cache.nixos.org'...
copying path '/nix/store/333six1faw9bhccsx9qw5718k6b1wiq2-stdenv-linux' from 'https://cache.nixos.org'...
copying path '/nix/store/kmvs83cihlf7vp28yjfrldizkynpb4iy-libkrb5-1.18-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/0qbx1glbcvdsr1nxb2rkfp05rifvslia-libssh2-1.9.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/yc2npbij60jxn3fvdys5pyvnjb1wasa6-zlib-1.2.11-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/mkr9vr7zsw5hzbp37kw52b1x1r7hvh9s-c-ares-1.15.0' from 'https://cache.nixos.org'...
copying path '/nix/store/cvm6h1j9dcayp47glqfxpx7bjzfkdn2p-libev-4.33' from 'https://cache.nixos.org'...
copying path '/nix/store/8ndl9ija1bc4j5ybvagvygpdwiiclgy9-nghttp2-1.41.0-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/yclz0jqjz72fwgbmdydp4gdi1kcf334k-nghttp2-1.41.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/apvjbfi8b3rwh41b3c67rlx4g7gfrija-curl-7.72.0-dev' from 'https://cache.nixos.org'...
"1.16.4": "https://launcher.mojang.com/v1/objects/35139deedbd5182953cf1caa23835da59ca3d7cd/server.jar":"35139deedbd5182953cf1caa23835da59ca3d7cd"
```