### PR TITLE
vmpk: 0.5.1 -> 0.7.2

### DIFF
--- a/pkgs/applications/audio/vmpk/default.nix
+++ b/pkgs/applications/audio/vmpk/default.nix
@@ -1,19 +1,22 @@
-{ stdenv, fetchurl, cmake, pkgconfig, alsaLib, libjack2, qt4 }:
+{ mkDerivation, lib, fetchurl, cmake, pkg-config
+, qttools, qtx11extras, drumstick
+, docbook-xsl-nons
+}:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "vmpk";
-  version = "0.5.1";
+  version = "0.7.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "11fqnxgs9hr9255d93n7lazxzjwn8jpmn23nywdksh0pb1ffvfrc";
+    sha256 = "5oLrjQADg59Mxpb0CNLQAE574IOSYLDLJNaQ/9q2cMQ=";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config qttools docbook-xsl-nons ];
 
-  buildInputs = [ alsaLib libjack2 qt4 ];
+  buildInputs = [ qtx11extras drumstick ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Virtual MIDI Piano Keyboard";
     homepage = "http://vmpk.sourceforge.net/";
     license = licenses.gpl3Plus;

--- a/pkgs/development/libraries/drumstick/default.nix
+++ b/pkgs/development/libraries/drumstick/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchurl, alsaLib, cmake, docbook_xsl, docbook_xml_dtd_45, doxygen
-, fluidsynth, pkgconfig, qtbase, qtsvg
+{ stdenv, fetchurl
+, cmake, docbook_xml_dtd_45, docbook_xsl, doxygen, pkg-config, wrapQtAppsHook
+, alsaLib, fluidsynth, qtbase, qtsvg, libpulseaudio
 }:
 
 stdenv.mkDerivation rec {
@@ -11,18 +12,25 @@ stdenv.mkDerivation rec {
     sha256 = "1n9wvg79yvkygrkc8xd8pgrd3d7hqmr7gh24dccf0px23lla9b3m";
   };
 
+  patches = [
+    ./drumstick-fluidsynth.patch
+    ./drumstick-plugins.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace library/rt/backendmanager.cpp --subst-var out
+  '';
+
   outputs = [ "out" "dev" "man" ];
 
   enableParallelBuilding = true;
 
-  #Temporarily remove drumstick-piano; Gives segment fault. Submitted ticket
-  postInstall = ''
-    rm $out/bin/drumstick-vpiano
-    '';
+  nativeBuildInputs = [
+    cmake docbook_xml_dtd_45 docbook_xml_dtd_45 docbook_xsl doxygen pkg-config wrapQtAppsHook
+  ];
 
-  nativeBuildInputs = [ cmake pkgconfig docbook_xsl docbook_xml_dtd_45 docbook_xml_dtd_45 ];
   buildInputs = [
-    alsaLib doxygen fluidsynth qtbase qtsvg
+    alsaLib fluidsynth libpulseaudio qtbase qtsvg
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/drumstick/drumstick-fluidsynth.patch
+++ b/pkgs/development/libraries/drumstick/drumstick-fluidsynth.patch
@@ -1,0 +1,9 @@
+It works with fluidsynth 2.
+
+Backported from r400: https://sourceforge.net/p/drumstick/code/400/
+
+--- a/library/rt-backends/CMakeLists.txt
++++ b/library/rt-backends/CMakeLists.txt
+@@ -54,1 +54,1 @@ if (PKG_CONFIG_FOUND)
+-    pkg_check_modules(FLUIDSYNTH fluidsynth>=1.1.1 fluidsynth<=1.1.11)
++    pkg_check_modules(FLUIDSYNTH fluidsynth>=1.1.1)

--- a/pkgs/development/libraries/drumstick/drumstick-plugins.patch
+++ b/pkgs/development/libraries/drumstick/drumstick-plugins.patch
@@ -1,0 +1,12 @@
+Make it look for its plugin in its own installation directory.
+
+--- a/library/rt/backendmanager.cpp
++++ b/library/rt/backendmanager.cpp
+@@ -159,6 +159,7 @@ namespace rt {
+         foreach(const QString& path, QCoreApplication::libraryPaths()) {
+             d->appendDir( path + QDir::separator() + QSTR_DRUMSTICK, result );
+         }
++        d->appendDir( "@out@/lib/drumstick", result );
+         return result;
+     }
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24268,7 +24268,7 @@ in
     onlyLibVLC = true;
   };
 
-  vmpk = callPackage ../applications/audio/vmpk { };
+  vmpk = libsForQt5.callPackage ../applications/audio/vmpk { };
 
   vmware-horizon-client = callPackage ../applications/networking/remote/vmware-horizon-client { };
 


### PR DESCRIPTION
Also migrate from qt4 to qt5 (#33248)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
