### PR TITLE
capitaine-cursors: fix build with inkscape => 1.0

### DIFF
--- a/pkgs/data/icons/capitaine-cursors/default.nix
+++ b/pkgs/data/icons/capitaine-cursors/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, fetchFromGitHub, fetchpatch, makeFontsConf
 , inkscape, xcursorgen, bc }:
 
 stdenv.mkDerivation rec {
@@ -12,11 +12,23 @@ stdenv.mkDerivation rec {
     sha256 = "0652ydy73x29z7wc6ccyqihmfg4bk0ksl7yryycln6c7i0iqfmc9";
   };
 
+  patches = [
+    # Fixes the build on inscape => 1.0, without this it generates empty cursor files
+    (fetchpatch {
+      name = "inkscape-1.0-compat";
+      url = "https://github.com/keeferrourke/capitaine-cursors/commit/9da0b53e6098ed023c5c24c6ef6bfb1f68a79924.patch";
+      sha256 = "0lx5i60ahy6a2pir4zzlqn5lqsv6claqg8mv17l1a028h9aha3cv";
+    })
+  ];
+
   postPatch = ''
     patchShebangs .
   '';
 
-  buildInputs  =[
+  # Complains about not being able to find the fontconfig config file otherwise
+  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+
+  buildInputs = [
     inkscape
     xcursorgen
     bc
@@ -36,14 +48,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = ''
-      An x-cursor theme inspired by macOS and based on KDE Breeze
-    '';
+    description = "An x-cursor theme inspired by macOS and based on KDE Breeze";
     homepage = "https://github.com/keeferrourke/capitaine-cursors";
     license = licenses.lgpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [
-      eadwu
-    ];
+    maintainers = with maintainers; [ eadwu ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Without this, all cursors are empty resulting in X to fall back to the default cursors. 

As shown [on hydra](https://hydra.nixos.org/build/129286243/log), there were a bunch of warnings about a function being deprecated, and `xcursorgen` failed to read the PNG files generated.

###### Things done

I've added a patch which is already merged upstream, but barely didnt make it into an release which fixes all of these problems. Also did some minor formatting changes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
