### PR TITLE
neovim: fix nodejs and ruby providers

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -24,7 +24,7 @@ let
     withPython2 ? false
     /* the function you would have passed to python.withPackages */
     , extraPython2Packages ? (_: [ ])
-    ,  withPython3 ? true
+    , withPython3 ? true
     /* the function you would have passed to python3.withPackages */
     , extraPython3Packages ? (_: [ ])
     , withNodeJs ? false
@@ -44,7 +44,6 @@ let
           ln -sf ${ruby}/bin/* $out/bin
         '';
       };
-
 
       requiredPlugins = vimUtils.requiredPlugins configure;
       getDeps = attrname: map (plugin: plugin.${attrname} or (_: [ ]));
@@ -104,9 +103,11 @@ let
       wrapperArgs = makeWrapperArgs;
       inherit neovimRcContent;
       inherit manifestRc;
-      inherit rubyEnv;
       inherit python2Env;
       inherit python3Env;
+      inherit withNodeJs;
+    } // lib.optionalAttrs withRuby {
+      inherit rubyEnv;
     };
 
     genProviderSettings = prog: withProg:

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -18,8 +18,8 @@ let
     , manifestRc ? null
     , withPython2 ? true, python2Env ? null
     , withPython3 ? true,  python3Env ? null
-    , withNodeJs? false
-    , withRuby ? true, rubyEnv ? null
+    , withNodeJs ? false
+    , rubyEnv ? null
     , vimAlias ? false
     , viAlias ? false
     , ...
@@ -52,7 +52,7 @@ let
       + optionalString withPython3 ''
         makeWrapper ${python3Env}/bin/python3 $out/bin/nvim-python3 --unset PYTHONPATH
       ''
-      + optionalString withRuby ''
+      + optionalString (rubyEnv != null) ''
         ln -s ${rubyEnv}/bin/neovim-ruby-host $out/bin/nvim-ruby
       ''
       + optionalString withNodeJs ''


### PR DESCRIPTION
These were not translated correctly in the new wrapper.
follow up of https://github.com/NixOS/nixpkgs/pull/101265

cc @kalekseev does that fix the issue ?

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
