### PR TITLE
nixUnstable: 3.0pre20201020_e0ca98c -> 2.4pre20201102_550e11f

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -32,8 +32,8 @@ common =
       inherit name src;
       version = lib.getVersion name;
 
-      is30 = lib.versionAtLeast version "3.0pre";
-      isExactly30 = lib.versionAtLeast version "2.3" && lib.versionOlder version "3.0";
+      is24 = lib.versionAtLeast version "2.4pre";
+      isExactly24 = lib.versionAtLeast version "2.4" && lib.versionOlder version "2.4";
 
       VERSION_SUFFIX = suffix;
 
@@ -41,7 +41,7 @@ common =
 
       nativeBuildInputs =
         [ pkgconfig ]
-        ++ lib.optionals is30
+        ++ lib.optionals is24
           [ autoreconfHook
             autoconf-archive
             bison flex
@@ -54,7 +54,7 @@ common =
           brotli boost editline
         ]
         ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
-        ++ lib.optionals is30 [ libarchive gmock ]
+        ++ lib.optionals is24 [ libarchive gmock ]
         ++ lib.optional withLibseccomp libseccomp
         ++ lib.optional withAWS
             ((aws-sdk-cpp.override {
@@ -93,9 +93,9 @@ common =
             patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*
           ''}
         '' +
-        # For Nix 3.0, patch around an issue where the Nix configure step pulls in the
+        # For Nix 2.4, patch around an issue where the Nix configure step pulls in the
         # build system's bash and other utilities when cross-compiling
-        lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform && isExactly30) ''
+        lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform && isExactly24) ''
           mkdir tmp/
           substitute corepkgs/config.nix.in tmp/config.nix.in \
             --subst-var-by bash ${bash}/bin/bash \
@@ -198,14 +198,14 @@ in rec {
   });
 
   nixUnstable = lib.lowPrio (callPackage common rec {
-    name = "nix-3.0${suffix}";
-    suffix = "pre20201020_e0ca98c";
+    name = "nix-2.4${suffix}";
+    suffix = "pre20201102_550e11f";
 
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "e0ca98c2071b815578470e280df8fdb750c7e23b";
-      hash = "sha256-KVS/Z6FzMBOl5XCyOLwfiVoX7G2LQRa9HMGNnJRPCoo=";
+      rev = "550e11f077ae508abde5a33998a9d4029880e7b2";
+      sha256 = "186grfxsfqg7r92wgwbma66xc7p3iywn43ff7s59m4g6bvb0qgcl";
     };
 
     inherit storeDir stateDir confDir boehmgc;


### PR DESCRIPTION
###### Motivation for this change

Fixes recursive Nix, nix-copy-closure on drvs, some memory bugs, etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
