### PR TITLE
ocaml-libvirt: 0.6.1.4.2017-11-08-unstable -> 0.6.1.5

### DIFF
--- a/pkgs/applications/virtualization/virt-top/default.nix
+++ b/pkgs/applications/virtualization/virt-top/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, ocamlPackages, autoreconfHook }:
+{ stdenv, fetchgit, fetchpatch, ocamlPackages, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "virt-top";
@@ -9,6 +9,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0m7pm8lzlpngsj0vjv0hg8l9ck3gvwpva7r472f8f03xpjffwiga";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "ocaml-libvirt-0.6.1.5-fix.patch";
+      url = "http://git.annexia.org/?p=virt-top.git;a=patch;h=24a461715d5bce47f63cb0097606fc336230589f";
+      sha256 = "15w7w9iggvlw8m9w8g4h08251wzb3m3zkb58glr7ifsgi3flbn61";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = with ocamlPackages; [ ocaml findlib ocaml_extlib ocaml_libvirt gettext-stub curses csv xml-light ];

--- a/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
@@ -1,27 +1,23 @@
-{ stdenv, fetchgit, libvirt, autoconf, ocaml, findlib }:
+{ stdenv, fetchFromGitLab, libvirt, autoreconfHook, pkg-config, ocaml, findlib, perl }:
 
 stdenv.mkDerivation rec {
   pname = "ocaml-libvirt";
-  rev = "bab7f84ade84ceaddb08b6948792d49b3d04b897";
-  version = "0.6.1.4.2017-11-08-unstable"; # libguestfs-1.34+ needs ocaml-libvirt newer than the latest release 0.6.1.4
+  version = "0.6.1.5";
 
-  src = fetchgit {
-    url = "git://git.annexia.org/git/ocaml-libvirt.git";
-    rev = rev;
-    sha256 = "0vxgx1n58fp4qmly6i5zxiacr7303127d6j78a295xin1p3a8xcw";
+  src = fetchFromGitLab {
+    owner = "libvirt";
+    repo = "libvirt-ocaml";
+    rev = "v${version}";
+    sha256 = "0xpkdmknk74yqxgw8z2w8b7ss8hpx92xnab5fsqg2byyj55gzf2k";
   };
 
   propagatedBuildInputs = [ libvirt ];
 
-  nativeBuildInputs = [ autoconf findlib ];
+  nativeBuildInputs = [ autoreconfHook pkg-config findlib perl ];
 
   buildInputs = [ ocaml ];
 
   createFindlibDestdir = true;
-
-  preConfigure = ''
-    autoconf
-  '';
 
   buildPhase = "make all opt CPPFLAGS=-Wno-error";
 


### PR DESCRIPTION
###### Motivation for this change

Fix a few problems and bumps it to the latest version:

* `git://git.annexia.org/git/ocaml-libvirt.git` was not working, it should have been `git://git.annexia.org/ocaml-libvirt.git`
* Anyway http://git.annexia.org/?p=ocaml-libvirt.git;a=summary says the repo is obsolete, suggesting https://libvirt.org/git/?p=libvirt-ocaml.git;a=summary which in turn is a mirror of https://gitlab.com/libvirt/libvirt-ocaml.git which seems to be a right source to use
* Comments from git log suggest other packages needed 0.6.1.5 version while it wasn't even released. It is released now, so let's use it.
* Plus build fixes for new version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
