### PR TITLE
pango: Import a patch to fix an issue with Pidgin

### DIFF
--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -27,6 +27,13 @@ in stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/pango/commit/fe1ee773310bac83d8e5d3c062b13a51fb5fb4ad.patch";
       sha256 = "1px66g31l2jx4baaqi4md59wlmvw0ywgspn6zr919fxl4h1kkh0h";
     })
+    # Fix issue with Pango which is breaking Pidgin
+    # See https://gitlab.gnome.org/GNOME/pango/-/issues/490
+    # Remove on next release.
+    (pkgs.fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/pango/-/commit/948e0b0cb5319adfa956f08c40dd1ea85855a424.patch";
+      sha256 = "03vhqpnsq6gzvsd0sz7n5126zrp1b4kfbbfmhc1pmay3rp2ifz7w";
+    })
   ];
 
   # FIXME: docs fail on darwin


### PR DESCRIPTION
###### Motivation for this change

There is a [bug](https://issues.imfreedom.org/issue/PIDGIN-17434) in Pidgin which seems to happen due to a [bug](https://gitlab.gnome.org/GNOME/pango/-/issues/490) in Pango.

I have only tested the patch by using a custom derivation:

```nix
pkgs.pidgin.override {
  gtk2 = (pkgs.gtk2.override {
    pango = (pkgs.pango.overrideAttrs (old:
      {
        patches = old.patches ++ [
          (pkgs.fetchpatch {
            url = "https://gitlab.gnome.org/GNOME/pango/-/commit/948e0b0cb5319adfa956f08c40dd1ea85855a424.patch";
            sha256 = "03vhqpnsq6gzvsd0sz7n5126zrp1b4kfbbfmhc1pmay3rp2ifz7w";
          })
        ];
      }));
  });
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
