### PR TITLE
dbus: Add AppArmor support

### DIFF
--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -11,6 +11,7 @@ let
   homeDir = "/run/dbus";
 
   configDir = pkgs.makeDBusConf {
+    inherit (cfg) apparmor;
     suidHelper = "${config.security.wrapperDir}/dbus-daemon-launch-helper";
     serviceDirectories = cfg.packages;
   };
@@ -49,6 +50,20 @@ in
           <filename><replaceable>pkg</replaceable>/share/dbus-1/session.d</filename>
           <filename><replaceable>pkg</replaceable>/share/dbus-1/services</filename>
         '';
+      };
+
+      apparmor = mkOption {
+        type = types.enum [ "enabled" "disabled" "required" ];
+        description = ''
+          AppArmor mode for dbus.
+
+          <literal>enabled</literal> enables mediation when it's
+          supported in the kernel, <literal>disabled</literal>
+          always disables AppArmor even with kernel support, and
+          <literal>required</literal> fails when AppArmor was not found
+          in the kernel.
+        '';
+        default = "disabled";
       };
 
       socketActivated = mkOption {

--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -5,6 +5,8 @@
 , expat
 , enableSystemd ? stdenv.isLinux && !stdenv.hostPlatform.isMusl
 , systemd
+, audit
+, libapparmor
 , libX11 ? null
 , libICE ? null
 , libSM ? null
@@ -70,7 +72,8 @@ stdenv.mkDerivation rec {
       libX11
       libICE
       libSM
-    ] ++ lib.optional enableSystemd systemd;
+    ] ++ lib.optional enableSystemd systemd
+    ++ lib.optionals (!stdenv.isDarwin) [ audit libapparmor ];
   # ToDo: optional selinux?
 
   configureFlags = [
@@ -86,7 +89,8 @@ stdenv.mkDerivation rec {
     "--with-system-socket=/run/dbus/system_bus_socket"
     "--with-systemdsystemunitdir=${placeholder ''out''}/etc/systemd/system"
     "--with-systemduserunitdir=${placeholder ''out''}/etc/systemd/user"
-  ] ++ lib.optional (!x11Support) "--without-x";
+  ] ++ lib.optional (!x11Support) "--without-x"
+  ++ lib.optionals (!stdenv.isDarwin) [ "--enable-apparmor" "--enable-libaudit" ];
 
   # Enable X11 autolaunch support in libdbus. This doesn't actually depend on X11
   # (it just execs dbus-launch in dbus.tools), contrary to what the configure script demands.

--- a/pkgs/development/libraries/dbus/make-dbus-conf.nix
+++ b/pkgs/development/libraries/dbus/make-dbus-conf.nix
@@ -1,6 +1,7 @@
 { runCommand, writeText, libxslt, dbus
 , serviceDirectories ? []
 , suidHelper ? "/var/setuid-wrappers/dbus-daemon-launch-helper"
+, apparmor ? "disabled" # one of enabled, disabled, required
 }:
 
 /* DBus has two configuration parsers -- normal and "trivial", which is used
@@ -10,7 +11,7 @@
  */
 runCommand "dbus-1"
   {
-    inherit serviceDirectories suidHelper;
+    inherit serviceDirectories suidHelper apparmor;
     preferLocalBuild = true;
     allowSubstitutes = false;
     XML_CATALOG_FILES = writeText "dbus-catalog.xml" ''
@@ -33,10 +34,12 @@ runCommand "dbus-1"
     xsltproc --nonet \
       --stringparam serviceDirectories "$serviceDirectories" \
       --stringparam suidHelper "$suidHelper" \
+      --stringparam apparmor "$apparmor" \
       ${./make-system-conf.xsl} ${dbus}/share/dbus-1/system.conf \
       > $out/system.conf
     xsltproc --nonet \
       --stringparam serviceDirectories "$serviceDirectories" \
+      --stringparam apparmor "$apparmor" \
       ${./make-session-conf.xsl} ${dbus}/share/dbus-1/session.conf \
       > $out/session.conf
   ''

--- a/pkgs/development/libraries/dbus/make-session-conf.xsl
+++ b/pkgs/development/libraries/dbus/make-session-conf.xsl
@@ -15,11 +15,15 @@
   <xsl:output method='xml' encoding="UTF-8" doctype-system="busconfig.dtd" />
 
   <xsl:param name="serviceDirectories" />
+  <xsl:param name="apparmor" />
 
   <xsl:template match="/busconfig">
     <busconfig>
       <!-- We leave <standard_session_servicedirs/> because it includes XDG dirs and therefore user Nix profile. -->
       <xsl:copy-of select="child::node()[name() != 'include' and name() != 'servicedir' and name() != 'includedir']" />
+
+      <!-- configure AppArmor -->
+      <apparmor mode="{$apparmor}"/>
 
       <xsl:for-each select="str:tokenize($serviceDirectories)">
         <servicedir><xsl:value-of select="." />/share/dbus-1/services</servicedir>

--- a/pkgs/development/libraries/dbus/make-system-conf.xsl
+++ b/pkgs/development/libraries/dbus/make-system-conf.xsl
@@ -16,10 +16,14 @@
 
   <xsl:param name="serviceDirectories" />
   <xsl:param name="suidHelper" />
+  <xsl:param name="apparmor" />
 
   <xsl:template match="/busconfig">
     <busconfig>
       <xsl:copy-of select="child::node()[name() != 'include' and name() != 'standard_system_servicedirs' and name() != 'servicehelper' and name() != 'servicedir' and name() != 'includedir']" />
+
+      <!-- configure AppArmor -->
+      <apparmor mode="{$apparmor}"/>
 
       <!-- set suid helper -->
       <servicehelper><xsl:value-of select="$suidHelper" /></servicehelper>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12471,9 +12471,9 @@ in
   dbus-sharp-glib-1_0 = callPackage ../development/libraries/dbus-sharp-glib/dbus-sharp-glib-1.0.nix { };
   dbus-sharp-glib-2_0 = callPackage ../development/libraries/dbus-sharp-glib { };
 
-  makeDBusConf = { suidHelper, serviceDirectories }:
+  makeDBusConf = { suidHelper, serviceDirectories, apparmor }:
     callPackage ../development/libraries/dbus/make-dbus-conf.nix {
-      inherit suidHelper serviceDirectories;
+      inherit suidHelper serviceDirectories apparmor;
     };
 
   dee = callPackage ../development/libraries/dee { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I'd like to do AppArmor mediation on dbus.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
