### PR TITLE
spidermonkey: 78.1.0 -> 78.4.0

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/78.nix
+++ b/pkgs/development/interpreters/spidermonkey/78.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "spidermonkey";
-  version = "78.1.0";
+  version = "78.4.0";
 
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz";
-    sha256 = "18k47dl9hbnpqw69csxjar5dhwa7r8k7j9kvcfgmwb1iv6ba601n";
+    sha256 = "1z3hj45bnd12z3g6ajv9qrgclca7fymi1sxj9l9nh9q6y6xz0g4f";
   };
 
   outputs = [ "out" "dev" ];
@@ -50,18 +50,6 @@ stdenv.mkDerivation rec {
     nspr
     readline
     zlib
-  ];
-
-  patches = [
-    # https://mail.gnome.org/archives/distributor-list/2020-August/msg00000.html
-    (fetchpatch {
-      url = "https://github.com/ptomato/mozjs/commit/b2974f8a6558d2dc4517b49ee313a9900a853285.patch";
-      sha256 = "1bl5mbx7gmad6fmpc427263i1ychi2linpg69kxlr2w91r5m6ji3";
-    })
-    (fetchpatch {
-      url = "https://github.com/ptomato/mozjs/commit/e5a2eb99f653ae03c67e536df1d55d265a0a1605.patch";
-      sha256 = "0xhy63nw2byibmjc41yh6dwpg282nylganrs5aprn9pbqbcpsvif";
-    })
   ];
 
   preConfigure = ''
@@ -101,9 +89,9 @@ stdenv.mkDerivation rec {
 
   # Remove unnecessary static lib
   preFixup = ''
-    moveToOutput bin/js60-config "$dev"
+    moveToOutput bin/js78-config "$dev"
     rm $out/lib/libjs_static.ajs
-    ln -s $out/bin/js60 $out/bin/js
+    ln -s $out/bin/js78 $out/bin/js
   '';
 
   enableParallelBuilding = true;
@@ -112,7 +100,7 @@ stdenv.mkDerivation rec {
     description = "Mozilla's JavaScript engine written in C/C++";
     homepage = "https://developer.mozilla.org/en/SpiderMonkey";
     license = licenses.gpl2; # TODO: MPL/GPL/LGPL tri-license.
-    maintainers = [ maintainers.abbradar ];
+    maintainers = with maintainers; [ abbradar lostnet ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This is a minor update, but has some security fixes https://www.mozilla.org/en-US/firefox/78.4.0/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
