### PR TITLE
xautoclick: 0.31 -> 0.34

### DIFF
--- a/pkgs/applications/misc/xautoclick/default.nix
+++ b/pkgs/applications/misc/xautoclick/default.nix
@@ -1,32 +1,30 @@
-{ stdenv, fetchurl, xorg, pkgconfig
-, gtkSupport ? true, gtk2
-, qtSupport ? true, qt4
+{ stdenv, fetchFromGitHub, xorg, pkg-config
+, cmake, libevdev
+, gtkSupport ? true, gtk3, pcre, glib, wrapGAppsHook
+, fltkSupport ? true, fltk
+, qtSupport ? true, qt5
 }:
 
-stdenv.mkDerivation {
-  version = "0.31";
+stdenv.mkDerivation rec {
   pname = "xautoclick";
-  src = fetchurl {
-    url = "mirror://sourceforge/project/xautoclick/xautoclick/xautoclick-0.31/xautoclick-0.31.tar.gz";
-    sha256 = "0h522f12a7v2b89411xm51iwixmjp2mp90rnizjgiakx9ajnmqnm";
+  version = "0.34";
+
+  src = fetchFromGitHub {
+    owner = "qarkai";
+    repo = "xautoclick";
+    rev = "v${version}";
+    sha256 = "GN3zI5LQnVmRC0KWffzUTHKrxcqnstiL55hopwTTwpE=";
   };
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ xorg.libX11 xorg.libXtst xorg.xinput xorg.libXi xorg.libXext ]
-    ++ stdenv.lib.optionals gtkSupport [ gtk2 ]
-    ++ stdenv.lib.optionals qtSupport [ qt4 ];
-  patchPhase = ''
-    substituteInPlace configure --replace /usr/X11R6 ${xorg.libX11.dev}
-  '';
-  preConfigure = stdenv.lib.optional qtSupport ''
-    mkdir .bin
-    ln -s ${qt4}/bin/moc .bin/moc-qt4
-    addToSearchPath PATH .bin
-    sed -i -e "s@LD=\$_cc@LD=\$_cxx@" configure
-  '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libevdev xorg.libXtst ]
+    ++ stdenv.lib.optionals gtkSupport [ gtk3 pcre glib wrapGAppsHook ]
+    ++ stdenv.lib.optionals fltkSupport [ fltk ]
+    ++ stdenv.lib.optionals qtSupport [ qt5.qtbase qt5.wrapQtAppsHook ];
 
   meta = with stdenv.lib; {
     description = "Autoclicker application, which enables you to automatically click the left mousebutton";
-    homepage = "http://xautoclick.sourceforge.net";
+    homepage = "https://github.com/qarkai/xautoclick";
     license = licenses.gpl2;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Migrate to Gtk3 and Qt5
Adds support for fltk too
#33248

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
