### PR TITLE
fluent-bit: mark linux only

### DIFF
--- a/pkgs/tools/misc/fluent-bit/default.nix
+++ b/pkgs/tools/misc/fluent-bit/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake flex bison ];
 
+  patches = [ ./fix-luajit-darwin.patch ];
+
   postPatch = ''
     substituteInPlace src/CMakeLists.txt \
       --replace /lib/systemd $out/lib/systemd

--- a/pkgs/tools/misc/fluent-bit/fix-luajit-darwin.patch
+++ b/pkgs/tools/misc/fluent-bit/fix-luajit-darwin.patch
@@ -1,0 +1,14 @@
+diff -Naur fluent-bit.old/cmake/luajit.cmake fluent-bit.new/cmake/luajit.cmake
+--- fluent-bit.old/cmake/luajit.cmake
++++ fluent-bit.new/cmake/luajit.cmake
+@@ -11,10 +11,6 @@
+ set(LUAJIT_SRC ${CMAKE_CURRENT_SOURCE_DIR}/${FLB_PATH_LIB_LUAJIT})
+ set(LUAJIT_DEST ${CMAKE_CURRENT_BINARY_DIR})
+ 
+-if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+-  set(CFLAGS "${CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
+-endif()
+-
+ # luajit (UNIX)
+ # =============
+ ExternalProject_Add(luajit


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/102057#issuecomment-720188970

```
host/buildvm.h:15:10: fatal error: lj_def.h: No such file or directory
   15 | #include "lj_def.h"
      |          ^~~~~~~~~~
compilation terminated.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
