### PR TITLE
nuspell: 4.0.0 -> 4.0.1

### DIFF
--- a/pkgs/development/libraries/nuspell/default.nix
+++ b/pkgs/development/libraries/nuspell/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, icu, catch2, ronn }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, icu, catch2, pandoc }:
 
 stdenv.mkDerivation rec {
   pname = "nuspell";
-  version = "4.0.0";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner = "nuspell";
     repo = "nuspell";
     rev = "v${version}";
-    sha256 = "1jfnwva2i67i9pyh123a5h2zs5p7gw77qh4w7qkx61jigsyxc5v7";
+    sha256 = "1p90a3wv4b8m5fdpbnr9cyd1x3a504q9rc4cghq02xff63h5gclf";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ronn ];
+  nativeBuildInputs = [ cmake pkgconfig pandoc ];
   buildInputs = [ boost icu ];
 
   outputs = [ "out" "lib" "dev" "man" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

Pandoc is now needed for generating the man pages.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/i2jlgbhpxf108iq8zyy17k9mnq0rcpzb-nuspell-4.0.0	  88.2M
/nix/store/d75mmkai18wyikb3vsggliqffw72195l-nuspell-4.0.1	  88.2M
