### PR TITLE
Move some qt5 style packages to qt5-packages.nix

### DIFF
--- a/nixos/modules/config/qt5.nix
+++ b/nixos/modules/config/qt5.nix
@@ -9,7 +9,7 @@ let
   isQGnome = cfg.platformTheme == "gnome" && builtins.elem cfg.style ["adwaita" "adwaita-dark"];
   isQtStyle = cfg.platformTheme == "gtk2" && !(builtins.elem cfg.style ["adwaita" "adwaita-dark"]);
 
-  packages = if isQGnome then [ pkgs.qgnomeplatform pkgs.libsForQt5.adwaita-qt ]
+  packages = if isQGnome then [ pkgs.libsForQt5.qgnomeplatform pkgs.libsForQt5.adwaita-qt ]
     else if isQtStyle then [ pkgs.libsForQt5.qtstyleplugins ]
     else throw "`qt5.platformTheme` ${cfg.platformTheme} and `qt5.style` ${cfg.style} are not compatible.";
 
@@ -29,7 +29,7 @@ in
         ];
         example = "gnome";
         relatedPackages = [
-          "qgnomeplatform"
+          ["libsForQt5" "qgnomeplatform"]
           ["libsForQt5" "adwaita-qt"]
           ["libsForQt5" "qtstyleplugins"]
         ];

--- a/nixos/modules/config/qt5.nix
+++ b/nixos/modules/config/qt5.nix
@@ -9,7 +9,7 @@ let
   isQGnome = cfg.platformTheme == "gnome" && builtins.elem cfg.style ["adwaita" "adwaita-dark"];
   isQtStyle = cfg.platformTheme == "gtk2" && !(builtins.elem cfg.style ["adwaita" "adwaita-dark"]);
 
-  packages = if isQGnome then [ pkgs.qgnomeplatform pkgs.adwaita-qt ]
+  packages = if isQGnome then [ pkgs.qgnomeplatform pkgs.libsForQt5.adwaita-qt ]
     else if isQtStyle then [ pkgs.libsForQt5.qtstyleplugins ]
     else throw "`qt5.platformTheme` ${cfg.platformTheme} and `qt5.style` ${cfg.style} are not compatible.";
 
@@ -30,6 +30,7 @@ in
         example = "gnome";
         relatedPackages = [
           "qgnomeplatform"
+          ["libsForQt5" "adwaita-qt"]
           ["libsForQt5" "qtstyleplugins"]
         ];
         description = ''

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -182,7 +182,7 @@ in
         hicolor-icon-theme
         lightlocker
         onboard
-        qgnomeplatform
+        libsForQt5.qgnomeplatform
         shared-mime-info
         sound-theme-freedesktop
         xdg-user-dirs

--- a/pkgs/development/libraries/qgnomeplatform/default.nix
+++ b/pkgs/development/libraries/qgnomeplatform/default.nix
@@ -7,22 +7,24 @@
 , gtk3
 , glib
 , qtbase
+, cmake
 , qmake
 , qtx11extras
 , pantheon
+, adwaita-qt
 , substituteAll
 , gsettings-desktop-schemas
 }:
 
 mkDerivation rec {
   pname = "qgnomeplatform";
-  version = "0.6.1";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "FedoraQt";
     repo = "QGnomePlatform";
     rev = version;
-    sha256 = "1mwqg2zk0sfjq54vz2jjahbgi5sxw8rb71h6mgg459wp99mhlqi0";
+    sha256 = "sha256-C/n8i5j0UWfxhP10c4j89U+LrpPozXnam4fIPYMXZAA=";
   };
 
   patches = [
@@ -31,15 +33,11 @@ mkDerivation rec {
       src = ./hardcode-gsettings.patch;
       gds_gsettings_path = glib.getSchemaPath gsettings-desktop-schemas;
     })
-  ] ++ lib.optionals (lib.versionAtLeast qtbase.version "5.15") [
-    (fetchpatch {
-      url = "https://github.com/FedoraQt/QGnomePlatform/commit/c835c9e80cfadd62e01f16591721d2103d28a212.diff";
-      sha256 = "Kcj9w+XorfHd47LYDMTINoStvZbu4MjvSumi3TJu/Vw=";
-    })
   ];
 
   nativeBuildInputs = [
     pkg-config
+    cmake
     qmake
   ];
 
@@ -48,15 +46,9 @@ mkDerivation rec {
     gtk3
     qtbase
     qtx11extras
+    gsettings-desktop-schemas
+    adwaita-qt
   ];
-
-  postPatch = ''
-    # Fix plugin dir
-    substituteInPlace decoration/decoration.pro \
-      --replace "\$\$[QT_INSTALL_PLUGINS]" "$out/$qtPluginPrefix"
-    substituteInPlace theme/theme.pro \
-      --replace "\$\$[QT_INSTALL_PLUGINS]" "$out/$qtPluginPrefix"
-  '';
 
   passthru = {
     updateScript = nix-update-script {

--- a/pkgs/development/libraries/qgnomeplatform/default.nix
+++ b/pkgs/development/libraries/qgnomeplatform/default.nix
@@ -1,6 +1,7 @@
 { mkDerivation
 , lib
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , gtk3
@@ -29,6 +30,11 @@ mkDerivation rec {
     (substituteAll {
       src = ./hardcode-gsettings.patch;
       gds_gsettings_path = glib.getSchemaPath gsettings-desktop-schemas;
+    })
+  ] ++ lib.optionals (lib.versionAtLeast qtbase.version "5.15") [
+    (fetchpatch {
+      url = "https://github.com/FedoraQt/QGnomePlatform/commit/c835c9e80cfadd62e01f16591721d2103d28a212.diff";
+      sha256 = "Kcj9w+XorfHd47LYDMTINoStvZbu4MjvSumi3TJu/Vw=";
     })
   ];
 

--- a/pkgs/development/libraries/qgnomeplatform/hardcode-gsettings.patch
+++ b/pkgs/development/libraries/qgnomeplatform/hardcode-gsettings.patch
@@ -1,13 +1,37 @@
-diff --git a/common/gnomehintssettings.cpp b/common/gnomehintssettings.cpp
-index 9860e57..40fa6ec 100644
---- a/common/gnomehintssettings.cpp
-+++ b/common/gnomehintssettings.cpp
-@@ -80,9 +80,17 @@ void gtkMessageHandler(const gchar *log_domain,
- GnomeHintsSettings::GnomeHintsSettings()
-     : QObject(0)
+diff --git i/cmake/modules/FindGSettingSchemas.cmake w/cmake/modules/FindGSettingSchemas.cmake
+index 6d70a2e..311b63f 100644
+--- i/cmake/modules/FindGSettingSchemas.cmake
++++ w/cmake/modules/FindGSettingSchemas.cmake
+@@ -1,16 +1,7 @@
+ find_package(PkgConfig)
+ 
+-pkg_check_modules(PC_GLIB2 REQUIRED glib-2.0)
+-
+-find_path(GLIB_SCHEMAS_DIR org.gnome.desktop.interface.gschema.xml
+-    HINTS ${PC_GLIB2_PREFIX}/share
+-    PATH_SUFFIXES glib-2.0/schemas)
+-
+-if (GLIB_SCHEMAS_DIR)
+-    set(GSettingSchemas_FOUND true)
+-else()
+-    set(GSettingSchemas_FOUND false)
+-endif()
++set(GLIB_SCHEMAS_DIR, "@gds_gsettings_path@")
++set(GSettingSchemas_FOUND true)
+ 
+ include(FindPackageHandleStandardArgs)
+ find_package_handle_standard_args(GSettingSchemas
+diff --git i/src/common/gnomesettings.cpp w/src/common/gnomesettings.cpp
+index e35fb85..2bcfb3a 100644
+--- i/src/common/gnomesettings.cpp
++++ w/src/common/gnomesettings.cpp
+@@ -145,10 +145,18 @@ GnomeSettingsPrivate::GnomeSettingsPrivate(QObject *parent)
+     : GnomeSettings(parent)
      , m_usePortal(checkUsePortalSupport())
+     , m_canUseFileChooserPortal(!m_usePortal)
 -    , m_gnomeDesktopSettings(g_settings_new("org.gnome.desktop.wm.preferences"))
 -    , m_settings(g_settings_new("org.gnome.desktop.interface"))
+     , m_fallbackFont(new QFont(QLatin1String("Sans"), 10))
  {
 +    g_autoptr(GSettingsSchemaSource) schemaSource = nullptr;
 +    g_autoptr(GSettingsSchema) gnomeDesktopSchema = nullptr;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1137,6 +1137,8 @@ mapAliases ({
   ;
   inherit (libsForQt5)
     sddm
+    # Added after https://github.com/NixOS/nixpkgs/issues/98009#issuecomment-720941017
+    adwaita-qt
   ;
 
   # LLVM packages for (integration) testing that should not be used inside Nixpkgs:

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1139,6 +1139,7 @@ mapAliases ({
     sddm
     # Added after https://github.com/NixOS/nixpkgs/issues/98009#issuecomment-720941017
     adwaita-qt
+    qgnomeplatform
   ;
 
   # LLVM packages for (integration) testing that should not be used inside Nixpkgs:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18188,8 +18188,6 @@ in
 
   qrupdate = callPackage ../development/libraries/qrupdate { };
 
-  qgnomeplatform =  libsForQt514.callPackage ../development/libraries/qgnomeplatform { };
-
   randomx = callPackage ../development/libraries/randomx { };
 
   retro-gtk = callPackage ../development/libraries/retro-gtk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22011,8 +22011,6 @@ in
 
   adementary-theme = callPackage ../data/themes/adementary { };
 
-  adwaita-qt = libsForQt5.callPackage ../data/themes/adwaita-qt { };
-
   agave = callPackage ../data/fonts/agave { };
 
   aileron = callPackage ../data/fonts/aileron { };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -166,6 +166,8 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeGear // qt5 // {
 
   qcsxcad = callPackage ../development/libraries/science/electronics/qcsxcad { };
 
+  qgnomeplatform =  callPackage ../development/libraries/qgnomeplatform { };
+
   qmltermwidget = callPackage ../development/libraries/qmltermwidget {
     inherit (pkgs.darwin.apple_sdk.libs) utmp;
   };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -52,6 +52,8 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeGear // qt5 // {
 
   ### LIBRARIES
 
+  adwaita-qt = callPackage ../data/themes/adwaita-qt { };
+
   accounts-qt = callPackage ../development/libraries/accounts-qt { };
 
   alkimia = callPackage ../development/libraries/alkimia { };


### PR DESCRIPTION

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/98009

###### Things done

Didn't test a thing.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
