### PR TITLE
ocamlPackages.mirage-console: init at 3.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-console/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-console/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchurl, buildDunePackage
+, lwt, mirage-device, mirage-flow
+}:
+
+buildDunePackage rec {
+  pname = "mirage-console";
+  version = "3.0.2";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-console/releases/download/v${version}/mirage-console-v${version}.tbz";
+    sha256 = "1fygk7pvlmwx6vd0h4cv9935xxhi64k2dgym41wf6qfkxgpp31lm";
+  };
+
+  propagatedBuildInputs = [ lwt mirage-device mirage-flow ];
+
+  meta = {
+    description = "Implementations of Mirage console devices";
+    homepage = "https://github.com/mirage/mirage-console";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -547,6 +547,8 @@ let
 
     mirage-clock-unix = callPackage ../development/ocaml-modules/mirage-clock/unix.nix { };
 
+    mirage-console = callPackage ../development/ocaml-modules/mirage-console { };
+
     mirage-crypto = callPackage ../development/ocaml-modules/mirage-crypto { };
 
     mirage-crypto-pk = callPackage ../development/ocaml-modules/mirage-crypto/pk.nix { };


### PR DESCRIPTION
###### Motivation for this change

#23955

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
