### PR TITLE
[20.09 backport] tor-browser-bundle-bin: mark as broken

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -410,5 +410,6 @@ stdenv.mkDerivation rec {
     # the compound is "libre" in a strict sense (some components place certain
     # restrictions on redistribution), it's free enough for our purposes.
     license = licenses.free;
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

see https://github.com/NixOS/nixpkgs/pull/102540