### PR TITLE
tempo: init at 0.2.0

### DIFF
--- a/pkgs/servers/tracing/tempo/default.nix
+++ b/pkgs/servers/tracing/tempo/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  version = "0.2.0";
+  pname = "tempo";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "grafana";
+    repo = "tempo";
+    sha256 = "061l72il8arxa53zfbasiwyjdxc4bf498glxrdj5ijcwgvx14275";
+  };
+
+  vendorSha256 = null;
+
+  # tests use docker
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A high volume, minimal dependency trace storage";
+    license = licenses.asl20;
+    homepage = "https://grafana.com/oss/tempo/";
+    maintainers = with maintainers; [ willibutz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23730,6 +23730,8 @@ in
 
   teleprompter = callPackage ../applications/misc/teleprompter {};
 
+  tempo = callPackage ../servers/tracing/tempo {};
+
   tendermint = callPackage ../tools/networking/tendermint { };
 
   termdown = python3Packages.callPackage ../applications/misc/termdown { };


### PR DESCRIPTION
###### Motivation for this change
This adds a package for Grafana Labs' new tracing backend "Tempo".
https://grafana.com/oss/tempo/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).