### PR TITLE
SBT: Add test, update script, 1.4.0 -> 1.4.2

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -310,6 +310,7 @@ in
   rxe = handleTest ./rxe.nix {};
   samba = handleTest ./samba.nix {};
   sanoid = handleTest ./sanoid.nix {};
+  sbt = handleTest ./sbt.nix {};
   sddm = handleTest ./sddm.nix {};
   service-runner = handleTest ./service-runner.nix {};
   shadowsocks = handleTest ./shadowsocks {};

--- a/nixos/tests/sbt.nix
+++ b/nixos/tests/sbt.nix
@@ -1,0 +1,18 @@
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "sbt";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ nequissimus ];
+  };
+
+  machine = { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.sbt ];
+    };
+
+  testScript =
+    ''
+      machine.succeed(
+          "(sbt --offline --version 2>&1 || true) | grep 'getting org.scala-sbt sbt ${pkgs.sbt.version}  (this may take some time)'"
+      )
+    '';
+})

--- a/pkgs/development/tools/build-managers/sbt/default.nix
+++ b/pkgs/development/tools/build-managers/sbt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, autoPatchelfHook, zlib }:
+{ stdenv, fetchurl, jre, autoPatchelfHook, zlib, writeScript, common-updater-scripts, git, nixfmt, nix, coreutils, gnused }:
 
 stdenv.mkDerivation rec {
   pname = "sbt";
@@ -34,4 +34,22 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ nequissimus ];
     platforms = platforms.unix;
   };
+
+  passthru.updateScript = writeScript "update.sh" ''
+    #!${stdenv.shell}
+    set -o errexit
+    PATH=${stdenv.lib.makeBinPath [ common-updater-scripts git nixfmt nix coreutils gnused ]}
+
+    oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion sbt" | tr -d '"')"
+    latestTag="$(git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags git@github.com:sbt/sbt.git '*.*.*' | tail --lines=1 | cut --delimiter='/' --fields=3 | sed 's|^v||g')"
+
+    if [ ! "$oldVersion" = "$latestTag" ]; then
+      update-source-version sbt "$latestTag" --version-key=version --print-changes
+      nixpkgs="$(git rev-parse --show-toplevel)"
+      default_nix="$nixpkgs/pkgs/development/tools/build-managers/sbt/default.nix"
+      nixfmt "$default_nix"
+    else
+      echo "sbt is already up-to-date"
+    fi
+  '';
 }

--- a/pkgs/development/tools/build-managers/sbt/default.nix
+++ b/pkgs/development/tools/build-managers/sbt/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchurl, jre, autoPatchelfHook, zlib, writeScript, common-updater-scripts, git, nixfmt, nix, coreutils, gnused }:
+{ stdenv, fetchurl, jre, autoPatchelfHook, zlib, writeScript
+, common-updater-scripts, git, nixfmt, nix, coreutils, gnused }:
 
 stdenv.mkDerivation rec {
   pname = "sbt";
-  version = "1.4.0";
+  version = "1.4.2";
 
   src = fetchurl {
     url =
       "https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.tgz";
-    sha256 = "1mgfs732w1c1p7dna7h47x8h073lvjs224fqlpkkvq10153mnxxl";
+    sha256 = "1dw4l91sw4ybqxjid1hsb6r33ka5bl85rfdrbsr9m5vxl82a3mmc";
   };
 
   patchPhase = ''
@@ -38,7 +39,16 @@ stdenv.mkDerivation rec {
   passthru.updateScript = writeScript "update.sh" ''
     #!${stdenv.shell}
     set -o errexit
-    PATH=${stdenv.lib.makeBinPath [ common-updater-scripts git nixfmt nix coreutils gnused ]}
+    PATH=${
+      stdenv.lib.makeBinPath [
+        common-updater-scripts
+        git
+        nixfmt
+        nix
+        coreutils
+        gnused
+      ]
+    }
 
     oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion sbt" | tr -d '"')"
     latestTag="$(git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags git@github.com:sbt/sbt.git '*.*.*' | tail --lines=1 | cut --delimiter='/' --fields=3 | sed 's|^v||g')"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
- Update
- Update script
- Test

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X]  Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
