### PR TITLE
Add md4c, pymd4c and mdpo packages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2859,6 +2859,10 @@
       fingerprint = "67FE 98F2 8C44 CF22 1828  E12F D57E FA62 5C9A 925F";
     }];
   };
+  euandreh = {
+    name = "EuAndreh";
+    email = "eu@euandre.org";
+  };
   euank = {
     email = "euank-nixpkg@euank.com";
     github = "euank";

--- a/pkgs/development/libraries/md4c/default.nix
+++ b/pkgs/development/libraries/md4c/default.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "md4c";
+  version = "0.4.6";
+
+  src = fetchFromGitHub {
+    owner = "mity";
+    repo = "md4c";
+    rev = "release-${version}";
+    sha256 = "0km84rmcrczq4n87ryf3ffkfbjh4jim361pbld0z8wgp60rz08dh";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "C Markdown parser compliant to CommonMark";
+    homepage = "https://github.com/mity/md4c/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ euandreh ];
+  };
+}

--- a/pkgs/development/python-modules/mdpo/default.nix
+++ b/pkgs/development/python-modules/mdpo/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, polib
+, pymd4c
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "mdpo";
+  version = "0.3.5";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0d5w759k0a8kfyclxdvfihlbmk19vp81w1mh9fc3nx13wcc64581";
+  };
+
+  propagatedBuildInputs = [ polib pymd4c ];
+
+  # package does not contain any tests
+  doCheck = false;
+  pythonImportsCheck = [ "mdpo" ];
+
+  meta = with stdenv.lib; {
+    description = "Markdown file translation utilities using pofiles";
+    homepage = "https://github.com/mondeja/mdpo";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ euandreh ];
+  };
+}

--- a/pkgs/development/python-modules/pymd4c/default.nix
+++ b/pkgs/development/python-modules/pymd4c/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, md4c
+, pkg-config  # pkgs
+, pkgconfig   # pythonPackages
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pymd4c";
+  version = "0.4.6.0b1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "07s3arn85ri92im6x3ipljdmrxmpik7irs06i6lm17j1x6j9841d";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  propagatedBuildInputs = [ md4c pkgconfig ];
+
+  # package does not contain any test
+  doCheck = false;
+  pythonImportsCheck = [ "md4c" ];
+
+  meta = with stdenv.lib; {
+    description = "Python bindings for MD4C";
+    homepage = "https://github.com/dominickpastore/pymd4c";
+    license = licenses.mit;
+    maintainers = with maintainers; [ euandreh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2474,6 +2474,8 @@ in
 
   maxcso = callPackage ../tools/archivers/maxcso {};
 
+  mdpo = with python3Packages; toPythonApplication mdpo;
+
   medusa = callPackage ../tools/security/medusa { };
 
   megasync = libsForQt515.callPackage ../applications/misc/megasync { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15505,6 +15505,8 @@ in
 
   mbedtls = callPackage ../development/libraries/mbedtls { };
 
+  md4c = callPackage ../development/libraries/md4c { };
+
   mdctags = callPackage ../development/tools/misc/mdctags { };
 
   mdds = callPackage ../development/libraries/mdds { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3917,6 +3917,8 @@ in {
 
   MDP = callPackage ../development/python-modules/mdp { };
 
+  mdpo = callPackage ../development/python-modules/mdpo { };
+
   measurement = callPackage ../development/python-modules/measurement { };
 
   mecab-python3 = callPackage ../development/python-modules/mecab-python3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5534,6 +5534,10 @@ in {
 
   pymc3 = callPackage ../development/python-modules/pymc3 { };
 
+  pymd4c = callPackage ../development/python-modules/pymd4c {
+    inherit (pkgs) pkg-config;
+  };
+
   pymediainfo = callPackage ../development/python-modules/pymediainfo { };
 
   pymeeus = callPackage ../development/python-modules/pymeeus { };


### PR DESCRIPTION
###### Motivation for this change

Add `mdpo` package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Execution of binary tested with:
```
nix-shell -I nixpkgs=. -p md4c --run 'md2html -h'
nix-shell -I nixpkgs=. -p 'python3.withPackages (p: [ p.mdpo ])' --run 'md2po --help'
```