### PR TITLE
klog: init at 1.3.2

### DIFF
--- a/pkgs/applications/radio/klog/default.nix
+++ b/pkgs/applications/radio/klog/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, hamlib, pkgconfig, qt5, qtbase, qttools, qtserialport, qtcharts, qmake, wrapQtAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "klog";
+  version = "1.3.2";
+
+  src = fetchurl {
+    url = "https://download.savannah.nongnu.org/releases/klog/${pname}-${version}.tar.gz";
+    sha256 = "1d5x7rq0mgfrqws3q1y4z8wh2qa3gvsmd0ssf2yqgkyq3fhdrb5c";
+  };
+
+  nativeBuildInputs = [ pkgconfig wrapQtAppsHook qmake qttools ];
+  buildInputs = [ hamlib qtbase qtserialport qtcharts ];
+
+  qmakeFlags = [ "KLog.pro" ];
+
+  meta = with stdenv.lib; {
+    description = "A multiplatform free hamradio logger";
+    longDescription = ''
+      KLog provides QSO management, useful QSL management DX-Cluster client, DXCC management,
+      ClubLog integration, WSJT-X, DX-Marathon support and much more.
+      '';
+    homepage = "https://www.klog.xyz/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ pulsation ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2302,6 +2302,8 @@ in
 
   klipper = callPackage ../servers/klipper { };
 
+  klog = qt5.callPackage ../applications/radio/klog { };
+
   lcdproc = callPackage ../servers/monitoring/lcdproc { };
 
   languagetool = callPackage ../tools/text/languagetool {  };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

KLog is a multiplatform free hamradio logger.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
