### PR TITLE
onlykey-cli: init 1.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7107,6 +7107,12 @@
     githubId = 14829269;
     name = "Ram Kromberg";
   };
+  ranfdev = {
+    email = "ranfdev@gmail.com";
+    name = "Lorenzo Miglietta";
+    github = "ranfdev";
+    githubId = 23294184;
+  };
   rardiol = {
     email = "ricardo.ardissone@gmail.com";
     github = "rardiol";

--- a/pkgs/tools/security/onlykey-cli/default.nix
+++ b/pkgs/tools/security/onlykey-cli/default.nix
@@ -1,0 +1,24 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "onlykey-cli";
+  version = "1.2.2";
+
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname = "onlykey";
+    sha256 = "1qkbgab5xlg7bd0jfzf8k5ppb1zhib76r050fiaqi5wibrqrfwdi";
+  };
+
+  # Requires having the physical onlykey (a usb security key)
+  doCheck = false;
+  propagatedBuildInputs =
+    with python3Packages; [ hidapi aenum six prompt_toolkit pynacl ecdsa cython ];
+
+  meta = with lib; {
+    description = "OnlyKey client and command-line tool";
+    homepage = "https://github.com/trustcrypto/python-onlykey";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ranfdev ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6075,6 +6075,8 @@ in
 
   onioncircuits = callPackage ../tools/security/onioncircuits { };
 
+  onlykey-cli = callPackage ../tools/security/onlykey-cli { };
+
   openapi-generator-cli = callPackage ../tools/networking/openapi-generator-cli { };
   openapi-generator-cli-unstable = callPackage ../tools/networking/openapi-generator-cli/unstable.nix { };
 


### PR DESCRIPTION
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
