### PR TITLE
coconut: init at 1.4.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2827,6 +2827,12 @@
       fingerprint = "50B7 11F4 3DFD 2018 DCE6  E8D0 8A52 A140 BEBF 7D2C";
     }];
   };
+  fabianhjr = {
+    email = "fabianhjr@protonmail.com";
+    github = "fabianhjr";
+    githubId = 303897;
+    name = "Fabián Heredia Montiel";
+  };
   fadenb = {
     email = "tristan.helmich+nixos@gmail.com";
     github = "fadenb";

--- a/pkgs/development/python-modules/coconut/default.nix
+++ b/pkgs/development/python-modules/coconut/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonApplication,
+  fetchFromGitHub,
+  fetchpatch,
+
+  cpyparsing,
+  ipykernel,
+  mypy,
+  pygments,
+  pytest,
+  prompt_toolkit,
+  tkinter,
+  watchdog
+}:
+
+buildPythonApplication rec {
+  pname = "coconut";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "evhub";
+    repo = "coconut";
+    rev = "v${version}";
+    sha256 = "1pz13vza3yy95dbylnq89fzc3mwgcqr7ds096wy25k6vxd9dp9c3";
+  };
+
+  propagatedBuildInputs = [ cpyparsing pygments prompt_toolkit ipykernel mypy watchdog ];
+
+  patches = [
+    (fetchpatch {
+      name = "fix-setuptools-version-check.patch";
+      url = "https://github.com/LibreCybernetics/coconut/commit/2916a087da1e063cc4438b68d4077347fd1ea4a2.patch";
+      sha256 = "136jbd2rvnifw30y73vv667002nf7sbkm5qyihshj4db7ngysr6q";
+    })
+  ];
+
+  checkInputs = [ pytest tkinter ];
+  # Currently most tests do not work on Hydra due to external fetches.
+  checkPhase = ''
+    pytest tests/constants_test.py
+    pytest tests/main_test.py::TestShell::test_compile_to_file
+    pytest tests/main_test.py::TestShell::test_convenience
+  '';
+
+  meta = with lib; {
+    homepage = "http://coconut-lang.org/";
+    description = "Simple, elegant, Pythonic functional programming";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fabianhjr ];
+  };
+}

--- a/pkgs/development/python-modules/cpyparsing/default.nix
+++ b/pkgs/development/python-modules/cpyparsing/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchFromGitHub, cython, python }:
+
+buildPythonPackage rec {
+  pname = "cpyparsing";
+  version = "2.4.5.0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "evhub";
+    repo = pname;
+    rev = "aa8ee45daec5c55328446bad7202ab8f799ab0ce"; # No tags on repo
+    sha256 = "1mxa5q41cb0k4lkibs0d4lzh1w6kmhhdrsm0w0r1m3s80m05ffmw";
+  };
+
+  nativeBuildInputs = [ cython ];
+
+  checkPhase = "${python.interpreter} tests/cPyparsing_test.py";
+
+  meta = with lib; {
+    homepage = "https://github.com/evhub/cpyparsing";
+    description = "Cython PyParsing implementation";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fabianhjr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1061,6 +1061,8 @@ in
 
   cloud-custodian = python3Packages.callPackage ../tools/networking/cloud-custodian  { };
 
+  coconut = with python3Packages; toPythonApplication coconut;
+
   cod = callPackage ../tools/misc/cod { };
 
   codespell = with python3Packages; toPythonApplication codespell;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1246,6 +1246,8 @@ in {
 
   cnvkit = callPackage ../development/python-modules/cnvkit { };
 
+  coconut = callPackage ../development/python-modules/coconut { };
+
   cocotb = callPackage ../development/python-modules/cocotb { };
 
   codecov = callPackage ../development/python-modules/codecov { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1347,6 +1347,8 @@ in {
 
   cppy = callPackage ../development/python-modules/cppy { };
 
+  cpyparsing = callPackage ../development/python-modules/cpyparsing { };
+
   cram = callPackage ../development/python-modules/cram { };
 
   crashtest = callPackage ../development/python-modules/crashtest { };


### PR DESCRIPTION
Add [Coconut](http://coconut-lang.org/) interpreter.

Includes a patch that affected building: https://github.com/evhub/coconut/pull/560

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
