### PR TITLE
nixos/modules/config/pulseaudio: add support for custom ALSA paths and profiles

### DIFF
--- a/pkgs/servers/pulseaudio/custom-dirs.patch
+++ b/pkgs/servers/pulseaudio/custom-dirs.patch
@@ -1,0 +1,59 @@
+diff --git a/src/modules/alsa/alsa-mixer.c b/src/modules/alsa/alsa-mixer.c
+index cd99a75f8..ed4a8f678 100644
+--- a/src/modules/alsa/alsa-mixer.c
++++ b/src/modules/alsa/alsa-mixer.c
+@@ -2573,12 +2573,13 @@ static int path_verify(pa_alsa_path *p) {
+ }
+ 
+ static const char *get_default_paths_dir(void) {
++    char *env = getenv("PA_ALSA_PATHS_DIR");
+ #ifdef HAVE_RUNNING_FROM_BUILD_TREE
+     if (pa_run_from_build_tree())
+         return PA_SRCDIR "/modules/alsa/mixer/paths/";
+     else
+ #endif
+-        return PA_ALSA_PATHS_DIR;
++        return (env ? env : PA_ALSA_PATHS_DIR);
+ }
+ 
+ pa_alsa_path* pa_alsa_path_new(const char *paths_dir, const char *fname, pa_alsa_direction_t direction) {
+@@ -4414,6 +4415,7 @@ pa_alsa_profile_set* pa_alsa_profile_set_new(const char *fname, const pa_channel
+     pa_alsa_profile *p;
+     pa_alsa_mapping *m;
+     pa_alsa_decibel_fix *db_fix;
++    char *env;
+     char *fn;
+     int r;
+     void *state;
+@@ -4459,11 +4461,13 @@ pa_alsa_profile_set* pa_alsa_profile_set_new(const char *fname, const pa_channel
+     if (!fname)
+         fname = "default.conf";
+ 
++    env = getenv("PA_ALSA_PROFILE_SETS_DIR");
++
+     fn = pa_maybe_prefix_path(fname,
+ #ifdef HAVE_RUNNING_FROM_BUILD_TREE
+                               pa_run_from_build_tree() ? PA_SRCDIR "/modules/alsa/mixer/profile-sets/" :
+ #endif
+-                              PA_ALSA_PROFILE_SETS_DIR);
++                              (env ? env : PA_ALSA_PROFILE_SETS_DIR));
+ 
+     r = pa_config_parse(fn, NULL, items, NULL, false, ps);
+     pa_xfree(fn);
+diff --git a/src/tests/alsa-mixer-path-test.c b/src/tests/alsa-mixer-path-test.c
+index ee40587b7..dd5d16bdb 100644
+--- a/src/tests/alsa-mixer-path-test.c
++++ b/src/tests/alsa-mixer-path-test.c
+@@ -15,10 +15,11 @@
+ 
+ /* This function was copied from alsa-mixer.c */
+ static const char *get_default_paths_dir(void) {
++    char *env = getenv("PA_ALSA_PATHS_DIR");
+     if (pa_run_from_build_tree())
+         return PA_SRCDIR "/modules/alsa/mixer/paths/";
+     else
+-        return PA_ALSA_PATHS_DIR;
++        return (env ? env : PA_ALSA_PATHS_DIR);
+ }
+ 
+ static pa_strlist *load_makefile() {

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
+  patches = [ ./custom-dirs.patch ];
+
   nativeBuildInputs = [ pkgconfig autoreconfHook makeWrapper perlPackages.perl perlPackages.XMLParser ];
 
   propagatedBuildInputs =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This is adapted from Jookia's patch [here](https://releases.nixos.org/nix-dev/2015-November/018625.html).

The purpose of these changes is to allow users to change PulseAudio configuration files related to ALSA sound card profiles, which would be stored under `/usr/share` in a FHS distro. This is necessary to, e.g., enable multiple outputs on a sound card at once, and may also be necessary for certain sound cards which are not supported upstream.

It seems plausible that this patch for PulseAudio could be merged upstream, to decrease the maintenance burden eventually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
