### PR TITLE
babashka,clj-kondo: Depend on graalvm-ce

### DIFF
--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, graalvm8, glibcLocales }:
+{ stdenv, fetchurl, graalvm8-ce, glibcLocales }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   dontUnpack = true;
 
   LC_ALL = "en_US.UTF-8";
-  nativeBuildInputs = [ graalvm8 glibcLocales ];
+  nativeBuildInputs = [ graalvm8-ce glibcLocales ];
 
   buildPhase = ''
     native-image \
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/borkdude/babashka";
     license = licenses.epl10;
-    platforms = graalvm8.meta.platforms;
+    platforms = graalvm8-ce.meta.platforms;
     maintainers = with maintainers; [ bandresen bhougland DerGuteMoritz jlesquembre ];
   };
 }

--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, graalvm8, fetchurl }:
+{ stdenv, lib, graalvm8-ce, fetchurl }:
 
 stdenv.mkDerivation rec {
   pname = "clj-kondo";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  buildInputs = [ graalvm8 ];
+  buildInputs = [ graalvm8-ce ];
 
   buildPhase = ''
     native-image  \
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     description = "A linter for Clojure code that sparks joy";
     homepage = "https://github.com/borkdude/clj-kondo";
     license = licenses.epl10;
-    platforms = graalvm8.meta.platforms;
+    platforms = graalvm8-ce.meta.platforms;
     maintainers = with maintainers; [ jlesquembre bandresen ];
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Now that we have community builds of graalvm landed in #99631, both
clj-kondo and babashka can depend on those versions of graalvm rather
than the one that requires building from source - this can be built in
hydra, and generally is much easier to build and test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @hlolli @volth @bennyandresen 