### PR TITLE
slack: add auto-updater script

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -39,9 +39,16 @@ let
   throwSystem = throw "Unsupported system: ${system}";
 
   pname = "slack";
+
+  x86_64-darwin-version = "4.10.3";
+  x86_64-darwin-sha256 = "0r77l57vr603xamich4h4gbdd5vdcj0sjs6yjpymfx9s0f98v8bb";
+
+  x86_64-linux-version = "4.10.3";
+  x86_64-linux-sha256 = "1gnjj2iyk8cwjajg8h9qpmzx10j4qjxjzciq8csg45qfzwkr3drf";
+
   version = {
-    x86_64-darwin = "4.10.3";
-    x86_64-linux = "4.10.3";
+    x86_64-darwin = x86_64-darwin-version;
+    x86_64-linux = x86_64-linux-version;
   }.${system} or throwSystem;
 
   src = let
@@ -49,11 +56,11 @@ let
   in {
     x86_64-darwin = fetchurl {
       url = "${base}/releases/macos/${version}/prod/x64/Slack-${version}-macOS.dmg";
-      sha256 = "0r77l57vr603xamich4h4gbdd5vdcj0sjs6yjpymfx9s0f98v8bb";
+      sha256 = x86_64-darwin-sha256;
     };
     x86_64-linux = fetchurl {
       url = "${base}/linux_releases/slack-desktop-${version}-amd64.deb";
-      sha256 = "1gnjj2iyk8cwjajg8h9qpmzx10j4qjxjzciq8csg45qfzwkr3drf";
+      sha256 = x86_64-linux-sha256;
     };
   }.${system} or throwSystem;
 

--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -75,6 +75,8 @@ let
   linux = stdenv.mkDerivation rec {
     inherit pname version src meta;
 
+    passthru.updateScript = ./update.sh;
+
     rpath = stdenv.lib.makeLibraryPath [
       alsaLib
       at-spi2-atk
@@ -158,6 +160,8 @@ let
 
   darwin = stdenv.mkDerivation {
     inherit pname version src meta;
+
+    passthru.updateScript = ./update.sh;
 
     nativeBuildInputs = [ undmg ];
 

--- a/pkgs/applications/networking/instant-messengers/slack/update.sh
+++ b/pkgs/applications/networking/instant-messengers/slack/update.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p curl gnused
+
+set -eou pipefail
+
+latest_linux_version=$(curl --silent https://slack.com/downloads/linux | sed -n 's/.*Version \([0-9\.]\+\).*/\1/p')
+latest_mac_version=$(curl --silent https://slack.com/downloads/mac | sed -n 's/.*Version \([0-9\.]\+\).*/\1/p')
+
+# Double check that the latest mac and linux versions are in sync.
+if [[ "$latest_linux_version" != "$latest_mac_version" ]]; then
+  echo "the latest linux ($latest_linux_version) and mac ($latest_mac_version) versions are not the same"
+  exit 1
+fi
+
+nixpkgs="$(git rev-parse --show-toplevel)"
+slack_nix="$nixpkgs/pkgs/applications/networking/instant-messengers/slack/default.nix"
+nixpkgs_linux_version=$(cat "$slack_nix" | sed -n 's/.*x86_64-linux-version = \"\([0-9\.]\+\)\";.*/\1/p')
+nixpkgs_mac_version=$(cat "$slack_nix" | sed -n 's/.*x86_64-darwin-version = \"\([0-9\.]\+\)\";.*/\1/p')
+
+if [[ "$nixpkgs_linux_version" == "$latest_linux_version" && "$nixpkgs_mac_version" == "$latest_mac_version" ]]; then
+  echo "nixpkgs versions are all up to date!"
+  exit 0
+fi
+
+linux_url="https://downloads.slack-edge.com/linux_releases/slack-desktop-${latest_linux_version}-amd64.deb"
+mac_url="https://downloads.slack-edge.com/releases/macos/${latest_mac_version}/prod/x64/Slack-${latest_mac_version}-macOS.dmg"
+linux_sha256=$(nix-prefetch-url ${linux_url})
+mac_sha256=$(nix-prefetch-url ${mac_url})
+
+sed -i "s/x86_64-linux-version = \".*\"/x86_64-linux-version = \"${latest_linux_version}\"/" "$slack_nix"
+sed -i "s/x86_64-darwin-version = \".*\"/x86_64-darwin-version = \"${latest_mac_version}\"/" "$slack_nix"
+sed -i "s/x86_64-linux-sha256 = \".*\"/x86_64-linux-sha256 = \"${linux_sha256}\"/" "$slack_nix"
+sed -i "s/x86_64-darwin-sha256 = \".*\"/x86_64-darwin-sha256 = \"${mac_sha256}\"/" "$slack_nix"
+
+if ! nix-build -A slack "$nixpkgs"; then
+  echo "The updated slack failed to build."
+  exit 1
+fi
+
+echo "Successfully updated"
+echo "slack: $nixpkgs_linux_version -> $latest_linux_version"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Save hooman time by spending computer time. This will enable adding slack to https://github.com/samuela/nixpkgs-upkeep.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
