### PR TITLE
ocamlPackages.apron: split into multiple outputs

### DIFF
--- a/pkgs/development/ocaml-modules/apron/default.nix
+++ b/pkgs/development/ocaml-modules/apron/default.nix
@@ -13,8 +13,21 @@ stdenv.mkDerivation rec {
   buildInputs = [ perl gmp mpfr ppl ocaml findlib camlidl ];
   propagatedBuildInputs = [ mlgmpidl ];
 
-  prefixKey = "-prefix ";
-  preBuild = "mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs";
+  outputs = [ "out" "bin" "dev" ];
+
+  configurePhase = ''
+    runHook preConfigure
+    ./configure -prefix $out
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs
+    runHook postConfigure
+  '';
+
+  postInstall = ''
+    mkdir -p $dev/lib
+    mv $out/lib/ocaml $dev/lib/
+    mkdir -p $bin
+    mv $out/bin $bin/
+  '';
 
   meta = {
     license = stdenv.lib.licenses.lgpl21;


### PR DESCRIPTION
###### Motivation for this change

Smaller closure of programs using apron.

For instance, here are the sizes of the closures of ikos:

 - before: 2,303,402,704
 - after: 1,942,264,344

In particular (in this example), OCaml and MPFR-dev have been removed from the closure.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
