### PR TITLE
dockerTools: fix absent /proc during runAsRoot

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -410,7 +410,11 @@ rec {
         # details on what's going on here; basically this command
         # means that the runAsRootScript will be executed in a nearly
         # completely isolated environment.
-        unshare -imnpuf --mount-proc chroot mnt ${runAsRootScript}
+        #
+        # Ideally we would use --mount-proc=mnt/proc or similar, but this
+        # doesn't work. The workaround is to setup proc after unshare.
+        # See: https://github.com/karelzak/util-linux/issues/648
+        unshare -imnpuf --mount-proc sh -c 'mount --rbind /proc mnt/proc && chroot mnt ${runAsRootScript}'
 
         # Unmount directories and remove them.
         umount -R mnt/dev mnt/sys mnt${storeDir}


### PR DESCRIPTION
The chroot environment under mnt had /dev and /sys via bind mounts,
but nothing setting up /proc. The `--mount-proc` argument to unshare
defaults to /proc, which is outside of the chroot envirnoment.

###### Motivation for this change

A recent combination of coreutils/glibc seems to rely on `/proc` during copy for some edge cases, for example, copying a readonly directory. This use case can occur when copying from the store. Motivating test cases:

```nix
let
  pkgs = import <nixpkgs> {};

  testScript = ''
    set -x
    [ -e /proc/mounts ] && cat /proc/mounts
    cd /
    id
    pwd
    mkdir -p a/b
    chmod 555 -R a
    cp -r a a2
    set +x
  '';
in
{
  vm = pkgs.vmTools.runInLinuxVM (
    pkgs.runCommand "test-run-in-linux-vm" {} testScript
  );

  dockerWithProc = pkgs.dockerTools.buildImage {
    name = "test-docker-with-proc";
    runAsRoot = ''
      [ -e /proc/mounts ] || ${pkgs.utillinux}/bin/mount -t proc proc /proc
    '' + testScript;
  };

  dockerWithoutProc = pkgs.dockerTools.buildImage {
    name = "test-docker-without-proc";
    runAsRoot = testScript;
  };
}

```

On current master, `vm` and `dockerWithProc` should build while `dockerWithoutProc` should fail with:
```
cp: setting permissions for 'a2': Operation not supported
```

After this change, all cases are expected to pass.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
