### PR TITLE
python3Packages: init shap at 0.36.0

### DIFF
--- a/pkgs/development/python-modules/shap/default.nix
+++ b/pkgs/development/python-modules/shap/default.nix
@@ -1,0 +1,70 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, pytestCheckHook
+, numpy
+, scipy
+, scikitlearn
+, pandas
+, tqdm
+, slicer
+, numba
+, matplotlib
+, nose
+, ipython
+}:
+
+buildPythonPackage rec {
+  pname = "shap";
+  version = "0.36.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "slundberg";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1wxnxvbz6avzzfqjfbcqd4v879hvpq4021v31fhdpccr2q317rr9";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    scikitlearn
+    pandas
+    tqdm
+    slicer
+    numba
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+    # when importing the local copy the extension is not found
+    rm -r shap
+  '';
+  checkInputs = [ pytestCheckHook matplotlib nose ipython ];
+  # Those tests access the network
+  disabledTests = [
+    "test_kernel_shap_with_a1a_sparse_zero_background"
+    "test_kernel_shap_with_a1a_sparse_nonzero_background"
+    "test_kernel_shap_with_high_dim_sparse"
+    "test_sklearn_random_forest_newsgroups"
+    "test_sum_match_random_forest"
+    "test_sum_match_extra_trees"
+    "test_single_row_random_forest"
+    "test_sum_match_gradient_boosting_classifier"
+    "test_single_row_gradient_boosting_classifier"
+    "test_HistGradientBoostingClassifier_proba"
+    "test_HistGradientBoostingClassifier_multidim"
+    "test_sum_match_gradient_boosting_regressor"
+    "test_single_row_gradient_boosting_regressor"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A unified approach to explain the output of any machine learning model";
+    homepage = "https://github.com/slundberg/shap";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evax ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/slicer/default.nix
+++ b/pkgs/development/python-modules/slicer/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, pytestCheckHook
+, pandas
+, pytorch
+}:
+
+buildPythonPackage rec {
+  pname = "slicer";
+  version = "0.0.4";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "21d53aac4e78c93fd83c0fd2f8f9d8a2195ac079dffdc0da81cd749da0f2f355";
+  };
+
+  checkInputs = [ pytestCheckHook pandas pytorch ];
+
+  meta = with stdenv.lib; {
+    description = "Wraps tensor-like objects and provides a uniform slicing interface via __getitem__";
+    homepage = "https://github.com/interpretml/slicer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evax ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6547,6 +6547,8 @@ in {
 
   shamir-mnemonic = callPackage ../development/python-modules/shamir-mnemonic { };
 
+  shap = callPackage ../development/python-modules/shap { };
+
   shapely = callPackage ../development/python-modules/shapely { };
 
   sharedmem = callPackage ../development/python-modules/sharedmem { };
@@ -6627,6 +6629,8 @@ in {
   sleekxmpp = callPackage ../development/python-modules/sleekxmpp { };
 
   slicedimage = callPackage ../development/python-modules/slicedimage { };
+
+  slicer = callPackage ../development/python-modules/slicer { };
 
   slicerator = callPackage ../development/python-modules/slicerator { };
 


### PR DESCRIPTION
###### Motivation for this change

A unified approach to explain the output of any machine learning model

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
