### PR TITLE
Frama-c: small tweaks

### DIFF
--- a/pkgs/development/tools/analysis/frama-c/default.nix
+++ b/pkgs/development/tools/analysis/frama-c/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchurl, makeWrapper, writeText
 , autoconf, ncurses, graphviz, doxygen
-, ocamlPackages, ltl2ba, coq, why3,
+, ocamlPackages, ltl2ba, coq, why3
+, gdk-pixbuf, wrapGAppsHook
 }:
 
 let
@@ -33,20 +34,18 @@ stdenv.mkDerivation rec {
 
   preConfigure = lib.optionalString stdenv.cc.isClang "configureFlagsArray=(\"--with-cpp=clang -E -C\")";
 
-  nativeBuildInputs = [ autoconf makeWrapper ];
+  nativeBuildInputs = [ autoconf wrapGAppsHook ];
 
   buildInputs = with ocamlPackages; [
     ncurses ocaml findlib ltl2ba ocamlgraph yojson menhir camlzip
     lablgtk coq graphviz zarith apron why3 mlgmpidl doxygen
+    gdk-pixbuf
   ];
 
   enableParallelBuilding = true;
 
-  fixupPhase = ''
-    for p in $out/bin/frama-c{,-gui};
-    do
-      wrapProgram $p --prefix OCAMLPATH ':' ${ocamlpath}
-    done
+  preFixup = ''
+     gappsWrapperArgs+=(--prefix OCAMLPATH ':' ${ocamlpath})
   '';
 
   # Allow loading of external Frama-C plugins

--- a/pkgs/development/tools/analysis/frama-c/default.nix
+++ b/pkgs/development/tools/analysis/frama-c/default.nix
@@ -52,16 +52,16 @@ stdenv.mkDerivation rec {
   setupHook = writeText "setupHook.sh" ''
     addFramaCPath () {
       if test -d "''$1/lib/frama-c/plugins"; then
-        export FRAMAC_PLUGIN="''${FRAMAC_PLUGIN}''${FRAMAC_PLUGIN:+:}''$1/lib/frama-c/plugins"
-        export OCAMLPATH="''${OCAMLPATH}''${OCAMLPATH:+:}''$1/lib/frama-c/plugins"
+        export FRAMAC_PLUGIN="''${FRAMAC_PLUGIN-}''${FRAMAC_PLUGIN:+:}''$1/lib/frama-c/plugins"
+        export OCAMLPATH="''${OCAMLPATH-}''${OCAMLPATH:+:}''$1/lib/frama-c/plugins"
       fi
 
       if test -d "''$1/lib/frama-c"; then
-        export OCAMLPATH="''${OCAMLPATH}''${OCAMLPATH:+:}''$1/lib/frama-c"
+        export OCAMLPATH="''${OCAMLPATH-}''${OCAMLPATH:+:}''$1/lib/frama-c"
       fi
 
       if test -d "''$1/share/frama-c/"; then
-        export FRAMAC_EXTRA_SHARE="''${FRAMAC_EXTRA_SHARE}''${FRAMAC_EXTRA_SHARE:+:}''$1/share/frama-c"
+        export FRAMAC_EXTRA_SHARE="''${FRAMAC_EXTRA_SHARE-}''${FRAMAC_EXTRA_SHARE:+:}''$1/share/frama-c"
       fi
 
     }


### PR DESCRIPTION
###### Motivation for this change

* frama-c-gui does not work in nix-bundle because GDK_PIXBUF_MODULE_FILE  is not wrapped
* nix-review fails on frama-c because the setupHook fails when FRAMAC_PLUGIN is undefined


###### Things done

* use wrappGAppsHook
* fix the setuphook

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @thoughtpolice @amiddelk as maintainers
