### PR TITLE
melmatcheq.lv2: init at 0.1

### DIFF
--- a/pkgs/applications/audio/melmatcheq.lv2/default.nix
+++ b/pkgs/applications/audio/melmatcheq.lv2/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, xorg, xorgproto, cairo, lv2, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "MelMatchEQ.lv2";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "brummer10";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1s805jgb9msxfq9047s7pxrngizb00w8sm4z94iii80ba65rd20x";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    xorg.libX11 xorgproto cairo lv2
+  ];
+
+  installFlags = [ "INSTALL_DIR=$(out)/lib/lv2" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/brummer10/MelMatchEQ.lv2";
+    description = "a profiling EQ using a 26 step Mel Frequency Band";
+    maintainers = with maintainers; [ magnetophon ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21924,6 +21924,8 @@ in
 
   meli = callPackage ../applications/networking/mailreaders/meli { };
 
+  melmatcheq.lv2 = callPackage ../applications/audio/melmatcheq.lv2 { };
+
   melonDS = callPackage ../misc/emulators/melonDS { };
 
   meme = callPackage ../applications/graphics/meme { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).