### PR TITLE
mu-repo: 1.8.0 → 1.8.1

### DIFF
--- a/pkgs/applications/misc/mu-repo/default.nix
+++ b/pkgs/applications/misc/mu-repo/default.nix
@@ -1,20 +1,19 @@
-{ lib, fetchFromGitHub, buildPythonApplication, pytest, git }:
+{ lib, fetchFromGitHub, buildPythonApplication, pytestCheckHook, git }:
 
 buildPythonApplication rec {
   pname = "mu-repo";
-  version = "1.8.0";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "fabioz";
     repo = pname;
-    rev = with lib;
-      "mu_repo_" + concatStringsSep "_" (splitVersion version);
-    sha256 = "1dxfggzbhiips0ww2s93yba9842ycp0i3x2i8vvcx0vgicv3rv6f";
+    rev = "mu_repo_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    sha256 = "0mmjdkvmdlsndi2q56ybxyz2988ppxsbbr1g54nzzkkvab2bc2na";
   };
 
-  checkInputs = [ pytest git ];
-  # disable test which assumes it's a git repo
-  checkPhase = "py.test mu_repo --ignore=mu_repo/tests/test_checkout.py";
+  propagatedBuildInputs = [ git ];
+
+  checkInputs = [ pytestCheckHook git ];
 
   meta = with lib; {
     description = "Tool to help in dealing with multiple git repositories";


### PR DESCRIPTION
###### Motivation for this change

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
