### PR TITLE
CODEOWNERS: maintainers for `dockerTools`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -206,6 +206,12 @@
 /nixos/tests/cri-o.nix                       @NixOS/podman @zowoq
 /nixos/tests/podman.nix                      @NixOS/podman @zowoq
 
+# Docker tools
+/pkgs/build-support/docker
+/nixos/tests/docker-tools-overlay.nix
+/nixos/tests/docker-tools.nix
+/doc/builders/images/dockertools.xml
+
 # Blockchains
 /pkgs/applications/blockchains  @mmahut
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -207,10 +207,10 @@
 /nixos/tests/podman.nix                      @NixOS/podman @zowoq
 
 # Docker tools
-/pkgs/build-support/docker
-/nixos/tests/docker-tools-overlay.nix
-/nixos/tests/docker-tools.nix
-/doc/builders/images/dockertools.xml
+/pkgs/build-support/docker                   @roberth
+/nixos/tests/docker-tools-overlay.nix        @roberth
+/nixos/tests/docker-tools.nix                @roberth
+/doc/builders/images/dockertools.xml         @roberth
 
 # Blockchains
 /pkgs/applications/blockchains  @mmahut


### PR DESCRIPTION
###### Motivation for this change

The `dockerTools` currently don't have any documented maintainers. Maintainers for functions go into the `CODEOWNERS` file.

Would you want to be listed as `dockerTools` maintainer? 

cc recent contributors that made multiple/larger changes @roberth @utdemir @zowoq @nlewo @adisbladis @nagisa @grahamc 

