### PR TITLE
home-assistant: 0.117.2 -> 0.117.3 (+ dependent packages)

### DIFF
--- a/pkgs/development/python-modules/pyairvisual/default.nix
+++ b/pkgs/development/python-modules/pyairvisual/default.nix
@@ -1,29 +1,54 @@
-{ lib, buildPythonPackage, isPy3k, fetchFromGitHub, requests
-, requests-mock, pytest
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, poetry
+, aiohttp
+, numpy
+, pysmb
+, aresponses
+, asynctest
+, pytest-aiohttp
+, pytest-asyncio
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pyairvisual";
-  version = "1.0.0";
+  version = "5.0.4";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "bachya";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0ng6k07n91k5l68zk3hl4fywb33admp84wqdm20qmmw9yc9c64fd";
+    rev = version;
+    sha256 = "0z769xrb6w6bhqcq02sjryl1qyvk9dc1xfn06fc3mdqnrbr0xxj3";
   };
 
-  checkInputs = [ pytest requests-mock ];
-  propagatedBuildInputs = [ requests ];
+  nativeBuildInputs = [ poetry ];
 
-  checkPhase = ''
-    py.test tests
-  '';
+  propagatedBuildInputs = [
+    aiohttp
+    numpy
+    pysmb
+  ];
 
-  disabled = !isPy3k;
+  checkInputs = [
+    aresponses
+    asynctest
+    pytest-aiohttp
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "tests"
+  ];
 
   meta = with lib; {
-    description = "A thin Python wrapper for the AirVisual API";
+    description = "A simple, clean, well-tested Python library for interacting with AirVisual©";
     license = licenses.mit;
     homepage = "https://github.com/bachya/pyairvisual";
   };

--- a/pkgs/development/python-modules/pyatmo/default.nix
+++ b/pkgs/development/python-modules/pyatmo/default.nix
@@ -12,17 +12,26 @@
 
 buildPythonPackage rec {
   pname = "pyatmo";
-  version = "4.1.0";
-  disabled = pythonOlder "3.5"; # uses type hints
+  version = "4.2.0";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "jabesq";
     repo = "netatmo-api-python";
     rev = "v${version}";
-    sha256 = "0x3xq6ni9rl5k3vi0ydqafdzvza785ycnlgyikgqbkppbh3j33ig";
+    sha256 = "0b2k1814zg3994k60xdw5gpsl8k1wy9zndd0b1p4dfb5qkx9f8kp";
   };
 
-  propagatedBuildInputs = [ oauthlib requests requests_oauthlib ];
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "oauthlib==3.1.0" "oauthlib"
+  '';
+
+  propagatedBuildInputs = [
+    oauthlib
+    requests
+    requests_oauthlib
+  ];
 
   checkInputs = [
     freezegun

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.117.2";
+  version = "0.117.3";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.117.3";
+  version = "0.117.4";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -67,7 +67,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.117.3";
+  hassVersion = "0.117.4";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -83,7 +83,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "05vsq3dw02bn3hppxbgw321ray842ck6z559rq92i720bx1vi0qx";
+    sha256 = "0f5a5y6d9wxdfd5l526dz34xz2n1a6ia7vdcr7sqf2qp51brpw52";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -67,7 +67,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.117.2";
+  hassVersion = "0.117.3";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -83,13 +83,16 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "1mpvskr0zjvl065ldw05kc0x5yvibwfm2nmv478wznw3vwmbqrzn";
+    sha256 = "05vsq3dw02bn3hppxbgw321ray842ck6z559rq92i720bx1vi0qx";
   };
+
+  # leave this in, so users don't have to constantly update their downstream patch handling
+  patches = [];
 
   postPatch = ''
     substituteInPlace setup.py \
       --replace "bcrypt==3.1.7" "bcrypt>=3.1.7" \
-      --replace "cryptography==3.2.0" "cryptography" \
+      --replace "cryptography==3.2" "cryptography" \
       --replace "ruamel.yaml==0.15.100" "ruamel.yaml>=0.15.100"
     substituteInPlace tests/test_config.py --replace '"/usr"' '"/build/media"'
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant/core/releases/tag/0.117.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
