### PR TITLE
sddm: 0.18.1 -> 0.19.0

### DIFF
--- a/pkgs/applications/display-managers/sddm/default.nix
+++ b/pkgs/applications/display-managers/sddm/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  version = "0.18.1";
+  version = "0.19.0";
 
 in mkDerivation {
   pname = "sddm";
@@ -14,7 +14,7 @@ in mkDerivation {
     owner = "sddm";
     repo = "sddm";
     rev = "v${version}";
-    sha256 = "0an1zafz0yhxd9jgd3gzdwmaw5f9vs4c924q56lp2yxxddbmzjcq";
+    sha256 = "1s6icb5r1n6grfs137gdzfrcvwsb3hvlhib2zh6931x8pkl1qvxa";
   };
 
   patches = [

--- a/pkgs/applications/display-managers/sddm/sddm-ignore-config-mtime.patch
+++ b/pkgs/applications/display-managers/sddm/sddm-ignore-config-mtime.patch
@@ -1,8 +1,8 @@
 diff --git a/src/common/ConfigReader.cpp b/src/common/ConfigReader.cpp
-index 4b5983c..911c511 100644
+index 041e5ed..efb1324 100644
 --- a/src/common/ConfigReader.cpp
 +++ b/src/common/ConfigReader.cpp
-@@ -147,16 +147,13 @@ namespace SDDM {
+@@ -148,17 +148,14 @@ namespace SDDM {
          // * m_path (classic fallback /etc/sddm.conf)
  
          QStringList files;
@@ -13,18 +13,20 @@ index 4b5983c..911c511 100644
              QDir dir(m_sysConfigDir);
              if (dir.exists()) {
 -                latestModificationTime = std::max(latestModificationTime,  QFileInfo(m_sysConfigDir).lastModified());
-                 foreach (const QFileInfo &file, dir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot, QDir::LocaleAware)) {
+                 const auto dirFiles = dir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot, QDir::LocaleAware);
+                 for (const QFileInfo &file : dirFiles) {
                      files << (file.absoluteFilePath());
 -                    latestModificationTime = std::max(latestModificationTime, file.lastModified());
                  }
              }
          }
-@@ -164,21 +161,14 @@ namespace SDDM {
+@@ -166,22 +163,15 @@ namespace SDDM {
              //include the configDir in modification time so we also reload on any files added/removed
              QDir dir(m_configDir);
              if (dir.exists()) {
 -                latestModificationTime = std::max(latestModificationTime,  QFileInfo(m_configDir).lastModified());
-                 foreach (const QFileInfo &file, dir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot, QDir::LocaleAware)) {
+                 const auto dirFiles = dir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot, QDir::LocaleAware);
+                 for (const QFileInfo &file : dirFiles) {
                      files << (file.absoluteFilePath());
 -                    latestModificationTime = std::max(latestModificationTime, file.lastModified());
                  }
@@ -38,6 +40,6 @@ index 4b5983c..911c511 100644
 -        }
 -        m_fileModificationTime = latestModificationTime;
 -
-         foreach (const QString &filepath, files) {
+         for (const QString &filepath : qAsConst(files)) {
              loadInternal(filepath);
          }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/sddm/sddm/releases/tag/v0.19.0

Fixes: CVE-2020-28049

https://www.openwall.com/lists/oss-security/2020/11/04/2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
