### PR TITLE
[20.09] sddm: add patch for CVE-2020-28049

### DIFF
--- a/pkgs/applications/display-managers/sddm/default.nix
+++ b/pkgs/applications/display-managers/sddm/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchFromGitHub
+{ mkDerivation, lib, fetchFromGitHub, fetchpatch
 , cmake, extra-cmake-modules, pkgconfig, libxcb, libpthreadstubs
 , libXdmcp, libXau, qtbase, qtdeclarative, qtquickcontrols2, qttools, pam, systemd
 }:
@@ -19,6 +19,11 @@ in mkDerivation {
 
   patches = [
     ./sddm-ignore-config-mtime.patch
+    (fetchpatch {
+      name = "CVE-2020-28049.patch";
+      url = "https://github.com/sddm/sddm/commit/be202f533ab98a684c6a007e8d5b4357846bc222.patch";
+      sha256 = "119zqfldaqs4066wifn64n1xmhv1qd2acd9hcshw9hyl2j84pz8h";
+    })
   ];
 
   postPatch =


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

> Local privilege escalation due to race condition in creation of the Xauthority file.

https://www.openwall.com/lists/oss-security/2020/11/04/2

Fixes: CVE-2020-28049

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
