### PR TITLE
tree-sitter: 0.17.1 -> 0.17.3; run make install

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -11,9 +11,9 @@ let
   # 1) change all these hashes
   # 2) nix-build -A tree-sitter.updater.update-all-grammars
   # 3) run the ./result script that is output by that (it updates ./grammars)
-  version = "0.17.1";
-  sha256 = "sha256-k61actAEyao/Ea8aw9PCm252U+1I0d43MAYC68/lui4=";
-  cargoSha256 = "sha256-Jp/Fl20ZZfaIdWinOOujNVH5JjJNtyUYHfyTrmeeoRg=";
+  version = "0.17.3";
+  sha256 = "sha256-uQs80r9cPX8Q46irJYv2FfvuppwonSS5HVClFujaP+U=";
+  cargoSha256 = "sha256-fonlxLNh9KyEwCj7G5vxa7cM/DlcHNFbQpp0SwVQ3j4=";
 
   src = fetchFromGitHub {
     owner = "tree-sitter";
@@ -66,6 +66,11 @@ in rustPlatform.buildRustPackage {
   # JS dependencies for installation.
   preBuild = ''
     bash ./script/build-wasm --debug
+  '';
+
+  postInstall = ''
+    export PREFIX=$out
+    make install
   '';
 
   # test result: FAILED. 120 passed; 13 failed; 0 ignored; 0 measured; 0 filtered out

--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -3,6 +3,8 @@
 , writeShellScript, runCommand, which
 , rustPlatform, jq, nix-prefetch-git, xe, curl, emscripten
 , callPackage
+, enableShared ? true
+, enableStatic ? false
 }:
 
 # TODO: move to carnix or https://github.com/kolloch/crate2nix
@@ -69,8 +71,9 @@ in rustPlatform.buildRustPackage {
   '';
 
   postInstall = ''
-    export PREFIX=$out
-    make install
+    PREFIX=$out make install
+    ${lib.optionalString (!enableShared) "rm $out/lib/*.so{,.*}"}
+    ${lib.optionalString (!enableStatic) "rm $out/lib/*.a"}
   '';
 
   # test result: FAILED. 120 passed; 13 failed; 0 ignored; 0 measured; 0 filtered out

--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -5,6 +5,7 @@
 , callPackage
 , enableShared ? true
 , enableStatic ? false
+, Security
 }:
 
 # TODO: move to carnix or https://github.com/kolloch/crate2nix
@@ -50,6 +51,8 @@ let
 in rustPlatform.buildRustPackage {
   pname = "tree-sitter";
   inherit src version cargoSha256;
+
+  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
 
   nativeBuildInputs = [ emscripten which ];
 
@@ -103,9 +106,8 @@ in rustPlatform.buildRustPackage {
     '';
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ Profpatsch ];
-    # Darwin needs some more work with default libraries
     # Aarch has test failures with how tree-sitter compiles the generated C files
-    broken = stdenv.isDarwin || stdenv.isAarch64;
+    broken = stdenv.isAarch64;
   };
 
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -5,6 +5,7 @@
   embedded-template = (builtins.fromJSON (builtins.readFile ./tree-sitter-embedded-template.json));
   go = (builtins.fromJSON (builtins.readFile ./tree-sitter-go.json));
   html = (builtins.fromJSON (builtins.readFile ./tree-sitter-html.json));
+  java = (builtins.fromJSON (builtins.readFile ./tree-sitter-java.json));
   javascript = (builtins.fromJSON (builtins.readFile ./tree-sitter-javascript.json));
   jsdoc = (builtins.fromJSON (builtins.readFile ./tree-sitter-jsdoc.json));
   json = (builtins.fromJSON (builtins.readFile ./tree-sitter-json.json));

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "5e7476bd014445abdae879661e9caf299215478a",
-  "date": "2020-05-14T11:46:56-07:00",
-  "path": "/nix/store/xz540ah1xx06n3wwmk3ym72nj0bz82hh-tree-sitter-cpp",
-  "sha256": "0v2l5269bhbpzcd929r3pn88gqcczx6spsq7p6ibsvsydbwj95wx",
+  "rev": "fb8250eef8b4cf1ce104806c50dc206e388b0e72",
+  "date": "2020-11-02T09:46:58-08:00",
+  "path": "/nix/store/qmza43f0fraa111bg50vaxsgnrs5kqs1-tree-sitter-cpp",
+  "sha256": "1sbk5a2p1fh6798naiswsap6fpj7n7bqhwd3xdyi35xf613qpwsi",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-go",
-  "rev": "34181774b3e86b7801c939c79c7b80a82df91a2b",
-  "date": "2020-08-13T12:21:50-07:00",
-  "path": "/nix/store/3a5w7pz1m74y0lhbzq3bw3k2297lypqs-tree-sitter-go",
-  "sha256": "0cfi7ghs0m3iqwd4jvsqgsj4gnfikn1j2q0wbkdfvz2j25l0qwq0",
+  "rev": "dadfd9c9aab2630632e61cfce645c13c35aa092f",
+  "date": "2020-10-27T13:42:16-04:00",
+  "path": "/nix/store/91a8w265vjc955hyp7cqvpm8ks9zcmqv-tree-sitter-go",
+  "sha256": "1pwbzkg7s0l2fhr4p1rpcldjcpxbkaqsm3q81543almc75k38x8w",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/tree-sitter/tree-sitter-java",
+  "rev": "f7b62ac33d63bea56ce202ace107aaa4285e50af",
+  "date": "2020-10-27T13:41:02-04:00",
+  "path": "/nix/store/h51zjbzdrm89gczcdv7nyih54vnd2xps-tree-sitter-java",
+  "sha256": "0jbh79brs1dskfqw05s9ndrp46hibyc37nfvhxlvanmgj3pjwgxb",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "3d5493495b62b4ff8e8c24aee7519dd904e25813",
-  "date": "2020-09-21T17:18:41-07:00",
-  "path": "/nix/store/bhjws8yif1ihhvhfsrdrp4inf03ks08r-tree-sitter-javascript",
-  "sha256": "10fscmclcgl1a0314ppkfy0s7pmiiz5vjipbmks76608kic8nzpp",
+  "rev": "852f11b394804ac2a8986f8bcaafe77753635667",
+  "date": "2020-10-27T13:43:40-04:00",
+  "path": "/nix/store/7a9nd3prxbv2izvilqdxf58his097ak7-tree-sitter-javascript",
+  "sha256": "1cdqx75fm7fvna0iymw7n03a7f6gayfg97qwqz3himi0775fz9ir",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-python",
-  "rev": "30f538aa1f932a2864c102694761d3127a61dc68",
-  "date": "2020-09-21T13:21:51-07:00",
-  "path": "/nix/store/bxv85lm636xdsdqjf4n7sxjlhhh35qnv-tree-sitter-python",
-  "sha256": "0hzzz90pn1qwyl5xk03cah62rbvp1c1yp1pw2m3hifqflxg4rs1g",
+  "rev": "d245768132eb6cb74d8a394ca4d29dc57169b096",
+  "date": "2020-10-27T13:20:04-04:00",
+  "path": "/nix/store/afv7ibxpf5c2shafa89cnza88hsfb7kj-tree-sitter-python",
+  "sha256": "075r5i2id2rn76xm3pcrn5cpvj63dlaxcpvphig39a4c9f9hrpdx",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ruby",
-  "rev": "a6fcb529e9097a2efbbb3f4857e42773e7f2474f",
-  "date": "2020-05-26T16:18:48-07:00",
-  "path": "/nix/store/yqd5b7ky21scahnhrik9psalbkwi3ab3-tree-sitter-ruby",
-  "sha256": "0bxg5lfdazz5mlfnf0amcygvc8b2ydzl2blvbbhnziyx92r8di6q",
+  "rev": "f86d90cce578e28c824afdcdbdca7d031b88c0b0",
+  "date": "2020-11-02T20:49:49-08:00",
+  "path": "/nix/store/gs0hhb1dlgmv0y60zyyz7ki30yvpddfx-tree-sitter-ruby",
+  "sha256": "1n1irdjfmv27p5ia2vqzv8zfsq19pxi0as0wrkb7z7s1lqr1gwrb",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "40620bf4097cbc9cea79504d7e877865df43a19e",
-  "date": "2020-05-15T10:53:35-07:00",
-  "path": "/nix/store/r24bba6gxchb5zqzghna8yjvqnngbv4a-tree-sitter-rust",
-  "sha256": "0hjp6nsskw341g97x41481b3zfwh8g853fs9six6j1mh92irmv6y",
+  "rev": "cf47ff80cbd8bdc6dd649a005c5f5d73f9c347e2",
+  "date": "2020-11-04T06:23:40-08:00",
+  "path": "/nix/store/8cvjxw8cz5jrkqwvgq88r7rfm269xwk1-tree-sitter-rust",
+  "sha256": "0yzcag0yy3ncxwpnb3fmsw8bxaidp7z8kbl8wwaxaj2vvxxf6sam",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "5a38a5bd04364d9f48b902fd1514e075b98b0edc",
-  "date": "2020-09-17T10:19:01-07:00",
-  "path": "/nix/store/b3q7vz9zhgjdbv3c2xap4k2ghpdjp2yf-tree-sitter-typescript",
-  "sha256": "1mxwvzqbaaq11cz7zidiwr29fs0b6ycf3nadwdkgiz8c6x2xx398",
+  "rev": "73afadbd117a8e8551758af9c3a522ef46452119",
+  "date": "2020-10-20T12:15:52-07:00",
+  "path": "/nix/store/wrgp1j5l50cigv5cmlxikw693a55i6g9-tree-sitter-typescript",
+  "sha256": "0dsbmcvjzys9s229drp1l8anram7d6nsx1nixl5m9znw54hr4w9p",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11885,7 +11885,9 @@ in
 
   travis = callPackage ../development/tools/misc/travis { };
 
-  tree-sitter = callPackage ../development/tools/parsing/tree-sitter { };
+  tree-sitter = callPackage ../development/tools/parsing/tree-sitter {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   trellis = callPackage ../development/tools/trellis { };
 

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -286,6 +286,11 @@ in {
 
   libexecinfo = super.libexecinfo.override { enableShared = false; };
 
+  tree-sitter = super.tree-sitter.override {
+    enableShared = false;
+    enableStatic = true;
+  };
+
   xorg = super.xorg.overrideScope' (xorgself: xorgsuper: {
     libX11 = xorgsuper.libX11.overrideAttrs (attrs: {
       depsBuildBuild = attrs.depsBuildBuild ++ [ (self.buildPackages.stdenv.cc.libc.static or null) ];


### PR DESCRIPTION
###### Motivation for this change

Update `tree-sitter` to latest.

Also, this is necessary to actually install the lib/include/pkgconfig files. (neovim nightly now needs this and I know there are a number of us)

cc: @teto @mjlbach 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
