### PR TITLE
pass-secret-service: init at unstable-2020-04-12

### DIFF
--- a/pkgs/applications/misc/pass-secret-service/default.nix
+++ b/pkgs/applications/misc/pass-secret-service/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchFromGitHub, python3, dbus, gnupg }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "pass-secret-service";
+  # PyPI has old alpha version. Since then the project has switched from using a
+  # seemingly abandoned D-Bus package pydbus and started using maintained
+  # dbus-next. So let's use latest from GitHub.
+  version = "unstable-2020-04-12";
+
+  src = fetchFromGitHub {
+    owner = "mdellweg";
+    repo = "pass_secret_service";
+    rev = "f6fbca6ac3ccd16bfec407d845ed9257adf74dfa";
+    sha256 = "0rm4pbx1fiwds1v7f99khhh7x3inv9yniclwd95mrbgljk3cc6a4";
+  };
+
+
+  # Need to specify session.conf file for tests because it won't be found under
+  # /etc/ in check phase.
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace \
+        "dbus-run-session" \
+        "dbus-run-session --config-file=${dbus}/share/dbus-1/session.conf"
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    click
+    cryptography
+    dbus-next
+    decorator
+    pypass
+    secretstorage
+  ];
+
+  checkInputs =
+    let
+      ps = python3.pkgs;
+    in
+    [
+      dbus
+      gnupg
+      ps.pytest
+      ps.pytest-asyncio
+      ps.pypass
+    ];
+
+  checkPhase = ''
+    runHook preCheck
+    make test
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Libsecret D-Bus API with pass as the backend";
+    homepage = "https://github.com/mdellweg/pass_secret_service/";
+    license = stdenv.lib.licenses.gpl3Only;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/pypass/default.nix
+++ b/pkgs/development/python-modules/pypass/default.nix
@@ -1,0 +1,84 @@
+{ buildPythonPackage
+, click
+, colorama
+, enum34
+, fetchPypi
+, git
+, gnugrep
+, gnupg
+, nose
+, pbr
+, pexpect
+, pythonAtLeast
+, pythonOlder
+, stdenv
+, substituteAll
+, tree
+, xclip
+}:
+
+# NOTE: pypass can also be used as an application, but probably the most
+# important usecase is as a library. So, let's use buildPythonPackage and
+# support any Python version instead of defining it as an application with
+# buildPythonApplication.
+buildPythonPackage rec {
+  pname = "pypass";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1nm4mj7pd7gz4ghic6b3wrnd1b59hd1f0axavdabfl79wy511l7r";
+  };
+
+  # Set absolute nix store paths to the executables that pypass uses
+  patches = [
+    (substituteAll {
+      src = ./mark-executables.patch;
+      git_exec = "${git}/bin/git";
+      grep_exec = "${gnugrep}/bin/grep";
+      gpg_exec = "${gnupg}/bin/gpg2";
+      tree_exec = "${tree}/bin/tree";
+      xclip_exec = "${xclip}/bin/xclip";
+    })
+  ];
+
+  # Remove enum34 requirement if Python >= 3.4
+  postPatch = stdenv.lib.optionalString (pythonAtLeast "3.4") ''
+    substituteInPlace requirements.txt --replace "enum34" ""
+  '';
+
+  nativeBuildInputs = [ pbr ];
+
+  propagatedBuildInputs = [
+    click
+    colorama
+    pexpect
+  ] ++ stdenv.lib.optional (pythonOlder "3.4") enum34;
+
+  checkInputs = [ nose ];
+
+  # Configuration so that the tests work
+  preCheck = ''
+    HOME=$TEMP ${git}/bin/git config --global user.email "nix-builder@nixos.org"
+    HOME=$TEMP ${git}/bin/git config --global user.name "Nix Builder"
+    HOME=$TEMP ${git}/bin/git config --global pull.ff only
+    HOME=$TEMP make setup_gpg
+  '';
+
+  # Run tests but exclude the test that uses clipboard as I wasn't able to make
+  # it work - probably the X clipboard just doesn't work in the build
+  # environment..
+  checkPhase = ''
+    runHook preCheck
+    HOME=$TEMP GNUPGHOME=pypass/tests/gnupg nosetests -v --exclude=test_show_clip .
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Password manager pass in Python";
+    homepage = "https://github.com/aviau/python-pass";
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/pypass/mark-executables.patch
+++ b/pkgs/development/python-modules/pypass/mark-executables.patch
@@ -1,0 +1,255 @@
+diff --git a/Makefile b/Makefile
+index 1ef67c8..d49031a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -16,5 +16,5 @@ test: kill build
+ setup_gpg: pypass/tests/gnupg
+ pypass/tests/gnupg: pypass/tests/test_key_sec.asc pypass/tests/test_ownertrust.txt
+ 	mkdir -m 700 -p pypass/tests/gnupg
+-	GNUPGHOME=pypass/tests/gnupg gpg --allow-secret-key-import --import pypass/tests/test_key_sec.asc
+-	GNUPGHOME=pypass/tests/gnupg gpg --import-ownertrust pypass/tests/test_ownertrust.txt
++	GNUPGHOME=pypass/tests/gnupg @gpg_exec@ --allow-secret-key-import --import pypass/tests/test_key_sec.asc
++	GNUPGHOME=pypass/tests/gnupg @gpg_exec@ --import-ownertrust pypass/tests/test_ownertrust.txt
+diff --git a/pypass/command.py b/pypass/command.py
+index 4616a5f..a72cf5d 100644
+--- a/pypass/command.py
++++ b/pypass/command.py
+@@ -173,7 +173,7 @@ def show(config, path, clip):
+     if clip:
+         xclip = subprocess.Popen(
+             [
+-                'xclip',
++                '@xclip_exec@',
+                 '-selection', 'clipboard'
+             ],
+             stdin=subprocess.PIPE
+@@ -206,7 +206,7 @@ def connect(config, path):
+ def ls(config, subfolder):
+     tree = subprocess.Popen(
+         [
+-            'tree',
++            '@tree_exec@',
+             '-C',
+             '-l',
+             '--noreport',
+@@ -239,7 +239,7 @@ def find(config, search_terms):
+ 
+     tree = subprocess.Popen(
+         [
+-            'tree',
++            '@tree_exec@',
+             '-C',
+             '-l',
+             '--noreport',
+@@ -273,7 +273,7 @@ def grep(config, search_string):
+             config['password_store'].get_decrypted_password(password)
+ 
+         grep = subprocess.Popen(
+-            ['grep', '-e', search_string],
++            ['@grep_exec@', '-e', search_string],
+             stdout=subprocess.PIPE,
+             stdin=subprocess.PIPE
+         )
+@@ -397,7 +397,7 @@ def git(config, commands):
+     else:
+         subprocess.call(
+             [
+-                'git',
++                '@git_exec@',
+                 '--git-dir=%s' % config['password_store'].git_dir,
+                 '--work-tree=%s' % config['password_store'].path,
+             ] + command_list,
+diff --git a/pypass/passwordstore.py b/pypass/passwordstore.py
+index 9de0376..8cf20a4 100644
+--- a/pypass/passwordstore.py
++++ b/pypass/passwordstore.py
+@@ -26,18 +26,7 @@ import re
+ from .entry_type import EntryType
+ 
+ # Find the right gpg binary
+-if subprocess.call(
+-        ['which', 'gpg2'],
+-        stdout=subprocess.PIPE,
+-        stderr=subprocess.PIPE) == 0:
+-    GPG_BIN = 'gpg2'
+-elif subprocess.call(
+-        ['which', 'gpg'],
+-        stdout=subprocess.PIPE,
+-        stderr=subprocess.PIPE) == 0:
+-    GPG_BIN = 'gpg'
+-else:
+-    raise Exception("Could not find GPG")
++GPG_BIN = '@gpg_exec@'
+ 
+ 
+ class PasswordStore(object):
+@@ -215,7 +204,7 @@ class PasswordStore(object):
+             # Init git repo
+             subprocess.call(
+                 [
+-                    "git",
++                    "@git_exec@",
+                     "--git-dir=%s" % git_dir,
+                     "--work-tree=%s" % git_work_tree,
+                     "init", path
+@@ -226,7 +215,7 @@ class PasswordStore(object):
+             # Add remote repo
+             subprocess.call(
+                 [
+-                    "git",
++                    "@git_exec@",
+                     "--git-dir=%s" % git_dir,
+                     "--work-tree=%s" % git_work_tree,
+                     "remote",
+@@ -241,7 +230,7 @@ class PasswordStore(object):
+             # TODO: add parameters for remote and branch ?
+             subprocess.call(
+                 [
+-                    "git",
++                    "@git_exec@",
+                     "--git-dir=%s" % git_dir,
+                     "--work-tree=%s" % git_work_tree,
+                     "pull",
+@@ -272,7 +261,7 @@ class PasswordStore(object):
+ 
+         subprocess.call(
+             [
+-                'git',
++                '@git_exec@',
+                 "--git-dir=%s" % self.git_dir,
+                 "--work-tree=%s" % self.path,
+                 'init',
+@@ -298,7 +287,7 @@ class PasswordStore(object):
+ 
+         subprocess.call(
+             [
+-                'git',
++                '@git_exec@',
+                 "--git-dir=%s" % self.git_dir,
+                 "--work-tree=%s" % self.path,
+                 'config',
+@@ -311,7 +300,7 @@ class PasswordStore(object):
+ 
+         subprocess.call(
+             [
+-                'git',
++                '@git_exec@',
+                 "--git-dir=%s" % self.git_dir,
+                 "--work-tree=%s" % self.path,
+                 'config',
+@@ -326,7 +315,7 @@ class PasswordStore(object):
+ 
+         subprocess.call(
+             [
+-                'git',
++                '@git_exec@',
+                 "--git-dir=%s" % self.git_dir,
+                 "--work-tree=%s" % self.path,
+                 'add',
+@@ -338,7 +327,7 @@ class PasswordStore(object):
+         if message:
+             subprocess.call(
+                 [
+-                    'git',
++                    '@git_exec@',
+                     "--git-dir=%s" % self.git_dir,
+                     "--work-tree=%s" % self.path,
+                     'commit',
+@@ -350,7 +339,7 @@ class PasswordStore(object):
+         else:
+             subprocess.call(
+                 [
+-                    'git',
++                    '@git_exec@',
+                     "--git-dir=%s" % self.git_dir,
+                     "--work-tree=%s" % self.path,
+                     'commit'
+diff --git a/pypass/tests/test_command.py b/pypass/tests/test_command.py
+index 4966b34..960a8ed 100644
+--- a/pypass/tests/test_command.py
++++ b/pypass/tests/test_command.py
+@@ -127,7 +127,7 @@ class TestCommand(unittest.TestCase):
+ 
+         # Check if the password is in the clipoard
+         xclip = subprocess.Popen(
+-            ['xclip', '-o', '-selection', 'clipboard'],
++            ['@xclip_exec@', '-o', '-selection', 'clipboard'],
+             stdout=subprocess.PIPE)
+         xclip.wait()
+         self.assertEqual(xclip.stdout.read().decode('utf8'), 'clipme999')
+@@ -301,7 +301,7 @@ class TestCommand(unittest.TestCase):
+         # git init should set diff.gpg.binary to True
+         diff_gpg_binary = subprocess.Popen(
+             [
+-                'git',
++                '@git_exec@',
+                 '--git-dir=%s' % os.path.join(self.dir, '.git'),
+                 '--work-tree=%s' % self.dir,
+                 'config',
+@@ -317,7 +317,7 @@ class TestCommand(unittest.TestCase):
+         # git init should set diff.gpg.textconv to 'gpg -d'
+         gpg = subprocess.Popen(
+             [
+-                'git',
++                '@git_exec@',
+                 '--git-dir=%s' % os.path.join(self.dir, '.git'),
+                 '--work-tree=%s' % self.dir,
+                 'config',
+@@ -337,7 +337,7 @@ class TestCommand(unittest.TestCase):
+ 
+         subprocess.Popen(
+             [
+-                'git',
++                '@git_exec@',
+                 '--git-dir=%s' % origin_git_dir,
+                 '--work-tree=%s' % origin_dir,
+                 'init',
+@@ -350,7 +350,7 @@ class TestCommand(unittest.TestCase):
+ 
+         subprocess.call(
+             [
+-                'git',
++                '@git_exec@',
+                 '--git-dir=%s' % origin_git_dir,
+                 '--work-tree=%s' % origin_dir,
+                 'add', 'test_git_init_clone.gpg',
+@@ -359,7 +359,7 @@ class TestCommand(unittest.TestCase):
+ 
+         subprocess.call(
+             [
+-                'git',
++                '@git_exec@',
+                 '--git-dir=%s' % origin_git_dir,
+                 '--work-tree=%s' % origin_dir,
+                 'commit',
+diff --git a/pypass/tests/test_passwordstore.py b/pypass/tests/test_passwordstore.py
+index 6decc5f..ceb5181 100644
+--- a/pypass/tests/test_passwordstore.py
++++ b/pypass/tests/test_passwordstore.py
+@@ -171,7 +171,7 @@ class TestPasswordStore(unittest.TestCase):
+ 
+         subprocess.Popen(
+             [
+-                'git',
++                '@git_exec@',
+                 '--git-dir=%s' % os.path.join(origin_dir, '.git'),
+                 '--work-tree=%s' % origin_dir,
+                 'init',
+@@ -184,7 +184,7 @@ class TestPasswordStore(unittest.TestCase):
+ 
+         subprocess.Popen(
+             [
+-                'git',
++                '@git_exec@',
+                 '--git-dir=%s' % os.path.join(origin_dir, '.git'),
+                 '--work-tree=%s' % origin_dir,
+                 'add', 'test_git_init_clone.gpg',
+@@ -193,7 +193,7 @@ class TestPasswordStore(unittest.TestCase):
+ 
+         subprocess.Popen(
+             [
+-                'git',
++                '@git_exec@',
+                 '--git-dir=%s' % os.path.join(origin_dir, '.git'),
+                 '--work-tree=%s' % origin_dir,
+                 'commit',

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21401,6 +21401,8 @@ in
 
   musikcube = callPackage ../applications/audio/musikcube {};
 
+  pass-secret-service = callPackage ../applications/misc/pass-secret-service { };
+
   pinboard = with python3Packages; toPythonApplication pinboard;
 
   pinboard-notes-backup = haskell.lib.overrideCabal

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5287,6 +5287,8 @@ in {
 
   pyparted = callPackage ../development/python-modules/pyparted { };
 
+  pypass = callPackage ../development/python-modules/pypass { };
+
   pypblib = callPackage ../development/python-modules/pypblib { };
 
   pypcap = callPackage ../development/python-modules/pypcap { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add pass-secret-service program. It makes it possible to use `pass` (Unix password manager) as a backend for libsecret (secret service) D-Bus API.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I ran `nix-review` but I don't know what to make out of this output..

```
$ nix-review rev init-pass-secret-service
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 12, done.
remote: Counting objects: 100% (12/12), done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 12 (delta 5), reused 7 (delta 5), pack-reused 0
Unpacking objects: 100% (12/12), 44.49 KiB | 555.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   f1c65de110f..e33473286ac  master     -> refs/nixpkgs-review/0
$ git worktree add /home/jluttine/.cache/nixpkgs-review/rev-d97f2e6d8ad4b0132f672628a3ed9f982f584a66-1/nixpkgs e33473286ac4165f23c09e5c95c044bfd32cb439
Preparing worktree (detached HEAD e33473286ac)
Updating files: 100% (23093/23093), done.
HEAD is now at e33473286ac Merge pull request #102742 from r-ryantm/auto-update/precice
$ nix-env -f /home/jluttine/.cache/nixpkgs-review/rev-d97f2e6d8ad4b0132f672628a3ed9f982f584a66-1/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit d97f2e6d8ad4b0132f672628a3ed9f982f584a66
Auto-merging pkgs/top-level/python-packages.nix
Auto-merging pkgs/top-level/all-packages.nix
Automatic merge went well; stopped before committing as requested
$ nix-env -f /home/jluttine/.cache/nixpkgs-review/rev-d97f2e6d8ad4b0132f672628a3ed9f982f584a66-1/nixpkgs -qaP --xml --out-path --show-trace --meta
error: while querying the derivation named 'pass_secret_service-unstable-2020-04-12':
while evaluating the attribute 'out.outPath' at /home/jluttine/.cache/nixpkgs-review/rev-d97f2e6d8ad4b0132f672628a3ed9f982f584a66-1/nixpkgs/lib/customisation.nix:156:13:
while evaluating the attribute 'propagatedBuildInputs' of the derivation 'pass_secret_service-unstable-2020-04-12' at /home/jluttine/.cache/nixpkgs-review/rev-d97f2e6d8ad4b0132f672628a3ed9f982f584a66-1/nixpkgs/pkgs/development/interpreters/python/mk-python-derivation.nix:110:5:
while evaluating the attribute 'out.outPath' at /home/jluttine/.cache/nixpkgs-review/rev-d97f2e6d8ad4b0132f672628a3ed9f982f584a66-1/nixpkgs/lib/customisation.nix:156:13:
while evaluating the attribute 'propagatedBuildInputs' of the derivation 'python3.8-pypass-0.2.1' at /home/jluttine/.cache/nixpkgs-review/rev-d97f2e6d8ad4b0132f672628a3ed9f982f584a66-1/nixpkgs/pkgs/development/interpreters/python/mk-python-derivation.nix:110:5:
while evaluating 'chooseDevOutputs' at /home/jluttine/.cache/nixpkgs-review/rev-d97f2e6d8ad4b0132f672628a3ed9f982f584a66-1/nixpkgs/lib/attrsets.nix:475:22, called from undefined position:
undefined variable 'gnupg' at /home/jluttine/.cache/nixpkgs-review/rev-d97f2e6d8ad4b0132f672628a3ed9f982f584a66-1/nixpkgs/pkgs/development/python-modules/pypass/default.nix:36:5
19260 packages removed:
pastebinit (†1.5) pastel (†0.8.0) pastesrht (†0.11.2) pasystray (†0.7.1) .........clip...........

Nothing changed
$ nix-shell /home/jluttine/.cache/nixpkgs-review/rev-d97f2e6d8ad4b0132f672628a3ed9f982f584a66-1/shell.nix
```

(I removed `gnupg` after running that as `nix-review` complained about it.)