### PR TITLE
Initial implementation of cross-compilation to Knuth's MMIX

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -36,6 +36,8 @@ let
     "riscv64-none" "riscv32-none"
     "vc4-none"
 
+    "mmix-mmixware"
+
     "js-ghcjs"
 
     "aarch64-genode" "i686-genode" "x86_64-genode"
@@ -56,6 +58,7 @@ in {
   i686          = filterDoubles predicates.isi686;
   x86_64        = filterDoubles predicates.isx86_64;
   mips          = filterDoubles predicates.isMips;
+  mmix          = filterDoubles predicates.isMmix;
   riscv         = filterDoubles predicates.isRiscV;
   vc4           = filterDoubles predicates.isVc4;
   js            = filterDoubles predicates.isJavaScript;

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -109,6 +109,11 @@ rec {
     platform = platforms.riscv-multiplatform "32";
   };
 
+  mmix = {
+    config = "mmix-unknown-mmixware";
+    libc = "newlib";
+  };
+
   msp430 = {
     config = "msp430-elf";
     libc = "newlib";

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -17,6 +17,7 @@ rec {
     isAarch32      = { cpu = { family = "arm"; bits = 32; }; };
     isAarch64      = { cpu = { family = "arm"; bits = 64; }; };
     isMips         = { cpu = { family = "mips"; }; };
+    isMmix         = { cpu = { family = "mmix"; }; };
     isRiscV        = { cpu = { family = "riscv"; }; };
     isSparc        = { cpu = { family = "sparc"; }; };
     isWasm         = { cpu = { family = "wasm"; }; };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -93,6 +93,8 @@ rec {
     mips64   = { bits = 64; significantByte = bigEndian;    family = "mips"; };
     mips64el = { bits = 64; significantByte = littleEndian; family = "mips"; };
 
+    mmix     = { bits = 64; significantByte = bigEndian;    family = "mmix"; };
+
     powerpc  = { bits = 32; significantByte = bigEndian;    family = "power"; };
     powerpc64 = { bits = 64; significantByte = bigEndian; family = "power"; };
     powerpc64le = { bits = 64; significantByte = littleEndian; family = "power"; };
@@ -268,19 +270,20 @@ rec {
   kernels = with execFormats; with kernelFamilies; setTypes types.openKernel {
     # TODO(@Ericson2314): Don't want to mass-rebuild yet to keeping 'darwin' as
     # the nnormalized name for macOS.
-    macos   = { execFormat = macho;   families = { inherit darwin; }; name = "darwin"; };
-    ios     = { execFormat = macho;   families = { inherit darwin; }; };
-    freebsd = { execFormat = elf;     families = { inherit bsd; }; };
-    linux   = { execFormat = elf;     families = { }; };
-    netbsd  = { execFormat = elf;     families = { inherit bsd; }; };
-    none    = { execFormat = unknown; families = { }; };
-    openbsd = { execFormat = elf;     families = { inherit bsd; }; };
-    solaris = { execFormat = elf;     families = { }; };
-    wasi    = { execFormat = wasm;    families = { }; };
-    redox   = { execFormat = elf;     families = { }; };
-    windows = { execFormat = pe;      families = { }; };
-    ghcjs   = { execFormat = unknown; families = { }; };
-    genode  = { execFormat = elf;     families = { }; };
+    macos    = { execFormat = macho;   families = { inherit darwin; }; name = "darwin"; };
+    ios      = { execFormat = macho;   families = { inherit darwin; }; };
+    freebsd  = { execFormat = elf;     families = { inherit bsd; }; };
+    linux    = { execFormat = elf;     families = { }; };
+    netbsd   = { execFormat = elf;     families = { inherit bsd; }; };
+    none     = { execFormat = unknown; families = { }; };
+    openbsd  = { execFormat = elf;     families = { inherit bsd; }; };
+    solaris  = { execFormat = elf;     families = { }; };
+    wasi     = { execFormat = wasm;    families = { }; };
+    redox    = { execFormat = elf;     families = { }; };
+    windows  = { execFormat = pe;      families = { }; };
+    ghcjs    = { execFormat = unknown; families = { }; };
+    genode   = { execFormat = elf;     families = { }; };
+    mmixware = { execFormat = unknown; families = { }; };
   } // { # aliases
     # 'darwin' is the kernel for all of them. We choose macOS by default.
     darwin = kernels.macos;
@@ -382,7 +385,7 @@ rec {
       else if (elemAt l 1) == "elf"
         then { cpu = elemAt l 0; vendor = "unknown";  kernel = "none";     abi = elemAt l 1; }
       else   { cpu = elemAt l 0;                      kernel = elemAt l 1;                   };
-    "3" = # Awkwards hacks, beware!
+    "3" = # Awkward hacks, beware!
       if elemAt l 1 == "apple"
         then { cpu = elemAt l 0; vendor = "apple";    kernel = elemAt l 2;                   }
       else if (elemAt l 1 == "linux") || (elemAt l 2 == "gnu")
@@ -393,6 +396,8 @@ rec {
         then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = "wasi";                       }
       else if (elemAt l 2 == "redox")
         then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = "redox";                      }
+      else if (elemAt l 2 == "mmixware")
+        then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = "mmixware";                   }
       else if hasPrefix "netbsd" (elemAt l 2)
         then { cpu = elemAt l 0; vendor = elemAt l 1;    kernel = elemAt l 2;                }
       else if (elem (elemAt l 2) ["eabi" "eabihf" "elf"])

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -11,12 +11,14 @@ let
     expr     = lib.sort lib.lessThan x;
     expected = lib.sort lib.lessThan y;
   };
-in with lib.systems.doubles; lib.runTests {
-  testall = mseteq all (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ wasi ++ windows ++ embedded ++ js ++ genode ++ redox);
+in
+with lib.systems.doubles; lib.runTests {
+  testall = mseteq all (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ wasi ++ windows ++ embedded ++ mmix ++ js ++ genode ++ redox);
 
   testarm = mseteq arm [ "armv5tel-linux" "armv6l-linux" "armv6l-none" "armv7a-linux" "armv7l-linux" "arm-none" "armv7a-darwin" ];
   testi686 = mseteq i686 [ "i686-linux" "i686-freebsd" "i686-genode" "i686-netbsd" "i686-openbsd" "i686-cygwin" "i686-windows" "i686-none" "i686-darwin" ];
   testmips = mseteq mips [ "mipsel-linux" ];
+  testmmix = mseteq mmix [ "mmix-mmixware" ];
   testx86_64 = mseteq x86_64 [ "x86_64-linux" "x86_64-darwin" "x86_64-freebsd" "x86_64-genode" "x86_64-redox" "x86_64-openbsd" "x86_64-netbsd" "x86_64-cygwin" "x86_64-solaris" "x86_64-windows" "x86_64-none" ];
 
   testcygwin = mseteq cygwin [ "i686-cygwin" "x86_64-cygwin" ];

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -179,6 +179,7 @@ stdenv.mkDerivation {
           mips64   = "btsmip";
           mips64el = "ltsmip";
         }.${targetPlatform.parsed.cpu.name}
+      else if targetPlatform.isMmix then "mmix"
       else if targetPlatform.isPower then if targetPlatform.isBigEndian then "ppc" else "lppc"
       else if targetPlatform.isSparc then "sparc"
       else if targetPlatform.isMsp430 then "msp430"

--- a/pkgs/development/tools/mmixware/default.nix
+++ b/pkgs/development/tools/mmixware/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchFromGitLab, tetex }:
+
+stdenv.mkDerivation {
+  pname = "mmixware";
+  version = "unstable-2019-02-19";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.lrz.de";
+    owner = "mmix";
+    repo = "mmixware";
+    rev = "a330d68aafcfe739ecaaece888a669b8e7d9bcb8";
+    sha256 = "0bq0d19vqhfbpk4mcqzmd0hygbkhapl1mzlfkcr6afx0fhlhi087";
+  };
+
+  hardeningDisable = [ "format" ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace 'rm abstime.h' ""
+  '';
+
+  nativeBuildInputs = [ tetex ];
+  enableParallelBuilding = true;
+
+  makeFlags = [ "all" "doc" "CFLAGS=-O2" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/doc
+    cp *.ps $out/share/doc
+    install -Dm755 mmixal -t $out/bin
+    install -Dm755 mmix -t $out/bin
+    install -Dm755 mmotype -t $out/bin
+    install -Dm755 mmmix -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description  = "MMIX simulator and assembler";
+    homepage     = "https://www-cs-faculty.stanford.edu/~knuth/mmix-news.html";
+    maintainers  = with maintainers; [ siraben ];
+    platforms    = platforms.unix;
+    license      = licenses.publicDomain;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5642,6 +5642,8 @@ in
 
   mmake = callPackage ../tools/misc/mmake { };
 
+  mmixware = callPackage ../development/tools/mmixware { };
+
   modemmanager = callPackage ../tools/networking/modem-manager {};
 
   modem-manager-gui = callPackage ../applications/networking/modem-manager-gui {};


### PR DESCRIPTION
###### Motivation for this change

Let's make Nix one of the first Linux package managers to have cross-compile support for [MMIX](https://en.wikipedia.org/wiki/MMIX)!

The following command cross-builds GNU Hello and runs it in Knuth's `mmixware` simulator for MMIX showing that indeed it works.
```sh
$ nix-shell -E 'with import ./. { }; runCommand "" { buildInputs = [ pkgsCross.mmix.hello mmixware ]; } ""' \                            
            --run 'mmix $(which hello)'
Hello, world!
```

Some variations I'm trying (failed ones are strikethroughed)
- [x] `mmix-unknown-mmixware` `libc = newlib`
- [x] ~`mmix-unknown-linux-uclib`~
- [x] ~`mmix-unknown-elf`~
- [x] ~`mmix-none-elf`~
- [ ] `mmix-elf`
- [x] `mmix`

Looks like we will only be able to use `newlib`, as it has `mmixware` [support](https://sourceware.org/git/?p=newlib-cygwin.git;a=tree;f=newlib/libc/sys/mmixware).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
