### PR TITLE
miniscript: init at unstable-20201104

### DIFF
--- a/pkgs/applications/blockchains/miniscript/default.nix
+++ b/pkgs/applications/blockchains/miniscript/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "miniscript";
+  version = "unstable-2020-11-04";
+
+  src = fetchFromGitHub {
+    owner = "sipa";
+    repo = pname;
+    rev = "5115dd0bdf70c3e3b728c2c0e9c8af4b7edd13ed";
+    sha256 = "0bklhlnl4wkb90rpqhs5n0h6rmnyb3js8ldgynppn27b2kbbmik5";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp miniscript $out/bin/miniscript
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description     = "Compiler and inspector for the miniscript Bitcoin policy language";
+    longDescription = "Miniscript is a language for writing (a subset of) Bitcoin Scripts in a structured way, enabling analysis, composition, generic signing and more.";
+    homepage        = "http://bitcoin.sipa.be/miniscript/";
+    license         = licenses.mit;
+    platforms       = platforms.all;
+    maintainers     = with maintainers; [ RaghavSood ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2363,6 +2363,8 @@ in
 
   mididings = callPackage ../tools/audio/mididings { };
 
+  miniscript = callPackage ../applications/blockchains/miniscript { };
+
   miniserve = callPackage ../tools/misc/miniserve {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Miniscript is a tool to compile and work with the miniscript Bitcoin policy language.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
