### PR TITLE
[20.03] motion: fix CVE-2020-26566

### DIFF
--- a/pkgs/applications/video/motion/default.nix
+++ b/pkgs/applications/video/motion/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, pkgconfig
 , ffmpeg, libjpeg, libmicrohttpd }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +11,15 @@ stdenv.mkDerivation rec {
     rev    = "Release-${version}";
     sha256 = "08mm7ajgs0qnrydywxxyzcll09z80crjnjkjnckdi6ljsj6s96j8";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-26566.patch";
+      url = "https://github.com/Motion-Project/motion/commit/5c9b907ddd4d096f0485831869a29dc0fbfbb800.diff";
+      sha256 = "0q4yl5k5w37kgxsipxaw20mx238s50lmvhlqrsyh8w31qr3dwgx4";
+      excludes = [ ".travis.yml" ];
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2020-26566

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #102807

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
