### PR TITLE
php: Refactor to have the different versions as separate files

### DIFF
--- a/pkgs/development/interpreters/php/7.3.nix
+++ b/pkgs/development/interpreters/php/7.3.nix
@@ -1,0 +1,20 @@
+{ callPackage, lib, stdenv, nixosTests, ... }@_args:
+
+let
+  generic = (import ./generic.nix) _args;
+
+  base = callPackage generic (_args // {
+    version = "7.3.24";
+    sha256 = "1655rj4w63n5fkvdj3kz9f5jfyjgvzw8a6j8zkzgic1p42xszdsm";
+
+    # https://bugs.php.net/bug.php?id=76826
+    extraPatches = lib.optional stdenv.isDarwin ./php73-darwin-isfinite.patch;
+  });
+
+in base.withExtensions ({ all, ... }: with all; ([
+  bcmath calendar curl ctype dom exif fileinfo filter ftp gd
+  gettext gmp hash iconv intl json ldap mbstring mysqli mysqlnd
+  opcache openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite
+  pgsql posix readline session simplexml sockets soap sodium sqlite3
+  tokenizer xmlreader xmlwriter zip zlib
+] ++ lib.optionals (!stdenv.isDarwin) [ imap ]))

--- a/pkgs/development/interpreters/php/7.4.nix
+++ b/pkgs/development/interpreters/php/7.4.nix
@@ -1,0 +1,17 @@
+{ callPackage, lib, stdenv, nixosTests, ... }@_args:
+
+let
+  generic = (import ./generic.nix) _args;
+
+  base = callPackage generic (_args // {
+    version = "7.4.12";
+    sha256 = "0rwrl7xgfq2bbgmy34klgfsqa7v935074ibanmic9pwy4g676vvf";
+  });
+
+in base.withExtensions ({ all, ... }: with all; ([
+  bcmath calendar curl ctype dom exif fileinfo filter ftp gd
+  gettext gmp iconv intl json ldap mbstring mysqli mysqlnd opcache
+  openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql
+  posix readline session simplexml sockets soap sodium sqlite3
+  tokenizer xmlreader xmlwriter zip zlib
+] ++ lib.optionals (!stdenv.isDarwin) [ imap ]))

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -1,7 +1,7 @@
 # We have tests for PCRE and PHP-FPM in nixos/tests/php/ or
 # both in the same attribute named nixosTests.php
 
-{ callPackage, lib, stdenv, nixosTests }@_args:
+{ callPackage, lib, stdenv, nixosTests, ... }:
 
 let
   generic =
@@ -271,34 +271,4 @@ let
             outputsToInstall = [ "out" "dev" ];
           };
         };
-
-  php73base = callPackage generic (_args // {
-    version = "7.3.24";
-    sha256 = "1655rj4w63n5fkvdj3kz9f5jfyjgvzw8a6j8zkzgic1p42xszdsm";
-
-    # https://bugs.php.net/bug.php?id=76826
-    extraPatches = lib.optional stdenv.isDarwin ./php73-darwin-isfinite.patch;
-  });
-
-  php74base = callPackage generic (_args // {
-    version = "7.4.12";
-    sha256 = "0rwrl7xgfq2bbgmy34klgfsqa7v935074ibanmic9pwy4g676vvf";
-  });
-
-  defaultPhpExtensions = { all, ... }: with all; ([
-    bcmath calendar curl ctype dom exif fileinfo filter ftp gd
-    gettext gmp iconv intl json ldap mbstring mysqli mysqlnd opcache
-    openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql
-    posix readline session simplexml sockets soap sodium sqlite3
-    tokenizer xmlreader xmlwriter zip zlib
-  ] ++ lib.optionals (!stdenv.isDarwin) [ imap ]);
-
-  defaultPhpExtensionsWithHash = { all, ... }:
-    (defaultPhpExtensions { inherit all; }) ++ [ all.hash ];
-
-  php74 = php74base.withExtensions defaultPhpExtensions;
-  php73 = php73base.withExtensions defaultPhpExtensionsWithHash;
-
-in {
-  inherit php73 php74;
-}
+in generic

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10315,19 +10315,28 @@ in
 
   pachyderm = callPackage ../applications/networking/cluster/pachyderm { };
 
-  php = php74;
 
+  # PHP interpreters, packages and extensions.
+  #
+  # Set default PHP interpreter, extensions and packages
+  php = php74;
+  phpExtensions = php74Extensions;
   phpPackages = php74Packages;
-  php73Packages = recurseIntoAttrs php73.packages;
+
+  # Import PHP74 interpreter, extensions and packages
+  php74 = callPackage ../development/interpreters/php/7.4.nix {
+    stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
+  };
+  php74Extensions = recurseIntoAttrs php74.extensions;
   php74Packages = recurseIntoAttrs php74.packages;
 
-  phpExtensions = php74Extensions;
-  php73Extensions = recurseIntoAttrs php73.extensions;
-  php74Extensions = recurseIntoAttrs php74.extensions;
-
-  inherit (callPackage ../development/interpreters/php {
+  # Import PHP73 interpreter, extensions and packages
+  php73 = callPackage ../development/interpreters/php/7.3.nix {
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
-  }) php74 php73;
+  };
+  php73Extensions = recurseIntoAttrs php73.extensions;
+  php73Packages = recurseIntoAttrs php73.packages;
+
 
   picoc = callPackage ../development/interpreters/picoc {};
 


### PR DESCRIPTION
###### Motivation for this change
This should enable easier auto updates of the packages.

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
