### PR TITLE
dosemu2: init at git 2020-11-04

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1727,6 +1727,12 @@
     githubId = 2552981;
     name = "Jonas Hörsch";
   };
+  cosarara = {
+    email = "jaume@delclos.com";
+    github = "cosarara";
+    githubId = 1713879;
+    name = "Jaume Delclòs Coll";
+  };
   costrouc = {
     email = "chris.ostrouchov@gmail.com";
     github = "costrouc";

--- a/pkgs/misc/emulators/dosemu2/default.nix
+++ b/pkgs/misc/emulators/dosemu2/default.nix
@@ -48,26 +48,26 @@ stdenv.mkDerivation {
   '';
 
   postUnpack = ''
-        sed -i -e "s|DATE=.*|DATE='Mon, 2 Nov 2020 15:49:15 +0300'|" "$sourceRoot/git-rev.sh"
-        sed -i -e "s:^}$:  prefix $prefix\n&:g" "$sourceRoot/compiletime-settings"
+    sed -i -e "s|DATE=.*|DATE='Mon, 2 Nov 2020 15:49:15 +0300'|" "$sourceRoot/git-rev.sh"
+    sed -i -e "s:^}$:  prefix $prefix\n&:g" "$sourceRoot/compiletime-settings"
   '';
 
   preConfigure = ''
-        ./autogen.sh
+    ./autogen.sh
   '';
 
   installPhase = ''
-        if [ -n "$prefix" ]; then
-          mkdir -p "$prefix";
-        fi;
-        make SHELL="$(which bash)" PREFIX="$prefix" install
-
+    if [ -n "$prefix" ]; then
+      mkdir -p "$prefix";
+    fi;
+    make SHELL="$(which bash)" PREFIX="$prefix" install
   '';
 
   meta = with stdenv.lib; {
     description = "DOS emulator for linux";
     homepage = "http://dosemu2.github.io/dosemu2/";
     license = licenses.gpl2Only;
-    maintainers = [ "Jaume Delclòs Coll <jaume@delclos.com>" ];
+    maintainers = [ maintainers.cosarara ];
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/misc/emulators/dosemu2/default.nix
+++ b/pkgs/misc/emulators/dosemu2/default.nix
@@ -1,0 +1,73 @@
+{ stdenv, fetchFromGitHub, fetchurl,
+bison, flex, SDL2, udev, libslirp, json_c, autoconf, automake,
+pkg-config, libbsd, hexdump, slang, xorg, readline, libao,
+gpm, munt, libieee1284 }:
+stdenv.mkDerivation {
+  name = "dosemu2";
+  srcs = [
+    (fetchFromGitHub {
+      owner = "dosemu2";
+      repo = "dosemu2";
+      rev = "7d2ee11c2111394b73a6b18b5b9404474f000ef6";
+      sha256 = "1sapq4mhzj6frpn95fs1ndi0za4w7spidl2y9p27pshpfs2xc4im";
+    })
+    (fetchurl {
+      url = "mirror://sourceforge/dosemu/dosemu-freedos-1.0-bin.tgz";
+      sha256 = "1izbq2lvbbggay52n21qpz949sv8y9i60ik4zmhih7k13dm30308";
+    })
+  ];
+
+  buildInputs = [
+    bison flex SDL2 udev libslirp json_c
+    autoconf automake pkg-config libbsd hexdump
+    slang xorg.mkfontdir readline libao gpm munt
+    libieee1284
+  ];
+
+  configureFlags = [
+    "--disable-fdpp"
+    "--with-fdtarball=dosemu-freedos-1.0-bin.tgz"
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    read -a arr <<< "$srcs"
+    dosemu2="''${arr[0]}"
+    freedostar="''${arr[1]}"
+    unpackFile "$dosemu2"
+    sourceRoot="source"
+
+    if [ "${dontMakeSourcesWritable:-0}" != 1 ]; then
+      chmod -R u+w -- "$sourceRoot"
+    fi
+
+    cp "$freedostar" "$sourceRoot/$(stripHash $freedostar)"
+
+    runHook postUnpack
+  '';
+
+  postUnpack = ''
+        sed -i -e "s|DATE=.*|DATE='Mon, 2 Nov 2020 15:49:15 +0300'|" "$sourceRoot/git-rev.sh"
+        sed -i -e "s:^}$:  prefix $prefix\n&:g" "$sourceRoot/compiletime-settings"
+  '';
+
+  preConfigure = ''
+        ./autogen.sh
+  '';
+
+  installPhase = ''
+        if [ -n "$prefix" ]; then
+          mkdir -p "$prefix";
+        fi;
+        make SHELL="$(which bash)" PREFIX="$prefix" install
+
+  '';
+
+  meta = with stdenv.lib; {
+    description = "DOS emulator for linux";
+    homepage = "http://dosemu2.github.io/dosemu2/";
+    license = licenses.gpl2Only;
+    maintainers = [ "Jaume Delclòs Coll <jaume@delclos.com>" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27126,6 +27126,8 @@ in
 
   dosbox = callPackage ../misc/emulators/dosbox { };
 
+  dosemu2 = callPackage ../misc/emulators/dosemu2 { };
+
   emu2 = callPackage ../misc/emulators/emu2 { };
 
   dpkg = callPackage ../tools/package-management/dpkg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I wanted to run dosemu2 on nixos so I made a package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
