### PR TITLE
dasel: init at 1.1.0

### DIFF
--- a/pkgs/applications/misc/dasel/default.nix
+++ b/pkgs/applications/misc/dasel/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "dasel";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "TomWright";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256:11xm47p7n79mq2zkv9q9m5v4a1gga01pkzi2j42gq1ma9hwz4idz";
+  };
+
+  vendorSha256 = "sha256:1552k85z4s6gv7sss7dccv3h8x22j2sr12icp6s7s0a3i4iwyksw";
+
+  meta = with stdenv.lib; {
+    description = "Query and update data structures from the command line";
+    longDescription = ''
+      Dasel (short for data-selector) allows you to query and modify data structures using selector strings.
+      Comparable to jq / yq, but supports JSON, YAML, TOML and XML with zero runtime dependencies.
+    '';
+    homepage = "https://github.com/TomWright/dasel";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ _0x4A6F ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1854,6 +1854,8 @@ in
 
   dapr-cli = callPackage ../development/tools/dapr/cli {};
 
+  dasel = callPackage ../applications/misc/dasel { };
+
   dasher = callPackage ../applications/accessibility/dasher { };
 
   datamash = callPackage ../tools/misc/datamash { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Include [dasel](https://github.com/TomWright/dasel) into nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
