### PR TITLE
ghc8102BinaryMinimal: fix docs as legally required

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -7,8 +7,6 @@
   # regular builds and GHC bootstrapping.
   # This is "useful" for staying within hydra's output limits for at least the
   # aarch64-linux architecture.
-  # Examples of unnecessary files are the bundled documentation and files that
-  # are only needed for profiling builds.
 , minimal ? false
 }:
 
@@ -182,11 +180,15 @@ stdenv.mkDerivation rec {
     done
   '' +
   stdenv.lib.optionalString minimal ''
-    # Remove profiling objects
+    # Remove profiling files
     find $out -type f -name '*.p_o' -delete
+    find $out -type f -name '*.p_hi' -delete
+    find $out -type f -name '*_p.a' -delete
     rm $out/lib/ghc-*/bin/ghc-iserv-prof
-    # Remove docs
-    rm -r $out/share/{doc,man}
+    # Hydra will redistribute this derivation, so we have to keep the docs for
+    # legal reasons (retaining the legal notices etc)
+    # As a last resort we could unpack the docs separately and symlink them in.
+    # They're in $out/share/{doc,man}.
   '';
 
   doInstallCheck = true;

--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -212,18 +212,11 @@ stdenv.mkDerivation rec {
     enableShared = true;
   };
 
-  meta = let
-    platforms = ["x86_64-linux" "armv7l-linux" "aarch64-linux" "i686-linux" "x86_64-darwin"];
-  in {
+  meta = {
     homepage = "http://haskell.org/ghc";
     description = "The Glasgow Haskell Compiler";
     license = stdenv.lib.licenses.bsd3;
-
-    # The minimal variation can not be distributed because it removes the
-    # documentation, including licensing information that is required for
-    # distribution.
-    inherit platforms;
-    hydraPlatforms = stdenv.lib.optionals (!minimal) platforms;
+    platforms = ["x86_64-linux" "armv7l-linux" "aarch64-linux" "i686-linux" "x86_64-darwin"];
     maintainers = with stdenv.lib.maintainers; [ lostnet ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Distribute docs, which is a legal requirement.
This variation of GHC was not intended to be distributed, but it turns out we can't not distribute it.

Forward port of #102504

Please merge with haskell mass-rebuild or after https://github.com/NixOS/nixpkgs/pull/102662 to keep hydra aarch64-linux load in check

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
