### PR TITLE
[20.09] ant: 1.10.8 -> 1.10.9

### DIFF
--- a/pkgs/development/tools/build-managers/apache-ant/default.nix
+++ b/pkgs/development/tools/build-managers/apache-ant/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, coreutils, makeWrapper }:
 
-let version = "1.10.8"; in
+let version = "1.10.9"; in
 
 stdenv.mkDerivation {
   pname = "ant";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://apache/ant/binaries/apache-ant-${version}-bin.tar.bz2";
-    sha256 = "0zh94csb2hl6ir2ccn18ps506mjgh3mffnrb8wpsmp1x5fcykha5";
+    sha256 = "1ab8ybczvk12501dnj450a3d4v43ca0pjhk33s175hax46s58z47";
   };
 
   contrib = fetchurl {


### PR DESCRIPTION

###### Motivation for this change

Addresses #101143 - CVE-2020-11979

See also #102827 for PR for master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
