### PR TITLE
apacheAnt_1_9: 1.9.6 -> 1.9.15 [20.03]

### DIFF
--- a/pkgs/development/tools/build-managers/apache-ant/1.9.nix
+++ b/pkgs/development/tools/build-managers/apache-ant/1.9.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, coreutils, makeWrapper }:
 
-let version = "1.9.6"; in
+let version = "1.9.15"; in
 
 stdenv.mkDerivation {
   pname = "ant";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://apache/ant/binaries/apache-ant-${version}-bin.tar.bz2";
-    sha256 = "1cwd5vq175gyicw0hkm8idwa33zxwhf7xlxywaqxcqqdjql0jfx4";
+    sha256 = "0yfx5qsvrg12lar4908ndbnlpppy7g7qk8ay41y4sz9g873v07mr";
   };
 
   contrib = fetchurl {


### PR DESCRIPTION
(cherry picked from commit 9072b63bcbfbc2033faa7f19de866929cd7ab198)

###### Motivation for this change

Corrects issue, #90746  =  CVE-2020-1945

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
