### PR TITLE
python3Packages.emv: init at 1.0.11

### DIFF
--- a/pkgs/development/python-modules/emv/default.nix
+++ b/pkgs/development/python-modules/emv/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, click, enum-compat, pyscard, pycountry, terminaltables
+, pytestCheckHook, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "emv";
+  version = "1.0.11";
+  disabled = pythonOlder "3.4";
+
+  src = fetchFromGitHub {
+    owner = "russss";
+    repo = "python-emv";
+    rev = "v${version}";
+    hash = "sha256:1715hcba3fdi0i5awnrjdjnk74p66sxm9349pd8bb717zrh4gpj7";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+  propagatedBuildInputs = [
+    enum-compat
+    click
+    pyscard
+    pycountry
+    terminaltables
+  ];
+
+  # argparse is part of the standardlib
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace '"argparse==1.4.0",' ""
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/russss/python-emv";
+    description = "Implementation of the EMV chip-and-pin smartcard protocol";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lukegb ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1900,6 +1900,8 @@ in {
 
   emcee = callPackage ../development/python-modules/emcee { };
 
+  emv = callPackage ../development/python-modules/emv { };
+
   emoji = callPackage ../development/python-modules/emoji { };
 
   enaml = callPackage ../development/python-modules/enaml { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add emv (which includes the emvtool CLI, but really it's useful independently as a library).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
