### PR TITLE
maxima: 5.42.2 -> 5.44.0

### DIFF
--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation ({
   ];
 
   postPatch = ''
-    sed -e 's|/usr/bin/env perl|${perl}/bin/perl|' -i doc/info/Makefile.am
+    substituteInPlace doc/info/Makefile.am --replace "/usr/bin/env perl" "${perl}/bin/perl"
   '';
 
   postInstall = ''

--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchurl, fetchpatch, sbcl, texinfo, perl, python, makeWrapper, rlwrap ? null
-, tk ? null, gnuplot ? null, ecl ? null, ecl-fasl ? false
+{ stdenv, fetchurl, fetchpatch, sbcl, texinfo, perl, python, makeWrapper, autoreconfHook
+, rlwrap ? null, tk ? null, gnuplot ? null, ecl ? null, ecl-fasl ? false
 }:
 
 let
   name    = "maxima";
-  version = "5.42.2";
+  version = "5.44.0";
 
   searchPath =
     stdenv.lib.makeBinPath
@@ -16,13 +16,19 @@ stdenv.mkDerivation ({
 
   src = fetchurl {
     url = "mirror://sourceforge/${name}/${name}-${version}.tar.gz";
-    sha256 = "0kdncy6137sg3rradirxzj10mkcvafxd892zlclwhr9sa7b12zhn";
+    sha256 = "1v6jr5s6hhj6r18gfk6hgxk2qd6z1dxkrjq9ss2z1y6sqi45wgyr";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = stdenv.lib.filter (x: x != null) [
     sbcl ecl texinfo perl python makeWrapper
     gnuplot   # required in the test suite
   ];
+
+  postPatch = ''
+    sed -e 's|/usr/bin/env perl|${perl}/bin/perl|' -i doc/info/Makefile.am
+  '';
 
   postInstall = ''
     # Make sure that maxima can find its runtime dependencies.
@@ -57,13 +63,6 @@ stdenv.mkDerivation ({
       url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/undoing_true_false_printing_patch.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
       sha256 = "0fvi3rcjv6743sqsbgdzazy9jb6r1p1yq63zyj9fx42wd1hgf7yx";
     })
-
-    # upstream bug https://sourceforge.net/p/maxima/bugs/2520/ (not fixed)
-    # introduced in https://trac.sagemath.org/ticket/13364
-    (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/0001-taylor2-Avoid-blowing-the-stack-when-diff-expand-isn.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-      sha256 = "0xa0b6cr458zp7lc7qi0flv5ar0r3ivsqhjl0c3clv86di2y522d";
-    })
   ] ++ stdenv.lib.optionals ecl-fasl [
     # build fasl, needed for ECL support
     (fetchpatch {
@@ -74,11 +73,13 @@ stdenv.mkDerivation ({
 
   # The test suite is disabled since 5.42.2 because of the following issues:
   #
-  #   Errors found in /build/maxima-5.42.2/share/linearalgebra/rtest_matrixexp.mac, problems:
+  #   Error(s) found:
+  #   /build/maxima-5.44.0/share/linearalgebra/rtest_matrixexp.mac problems:
   #   (20 21 22)
-  #   Error found in rtest_arag, problem:
-  #   (error break)
-  #   3 tests failed out of 3,881 total tests.
+  #   Tests that were expected to fail but passed:
+  #   /build/maxima-5.44.0/share/vector/rtest_vect.mac problem:
+  #   (19)
+  #   3 tests failed out of 16,184 total tests.
   #
   # These failures don't look serious. It would be nice to fix them, but I
   # don't know how and probably won't have the time to find out.


### PR DESCRIPTION
###### Motivation for this change

This change updates Maxima to the latest release. The change logs for [5.43](https://sourceforge.net/p/maxima/code/ci/master/tree/ChangeLog-5.43.md) and [5.44](https://sourceforge.net/p/maxima/code/ci/master/tree/ChangeLog-5.44.md) are available.

```shell
$ nix path-info -S nixpkgs#maxima
/nix/store/n3j4fqwypjayckkkjvc7akw4hilagj41-maxima-5.42.2         275446544
$ nix path-info -S ./result
/nix/store/nf8i698s6dhv0z9dp8aph92rgyd0hbd1-maxima-5.44.0         278350072
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
