### PR TITLE
balsa: 2.5.9 -> 2.5.11 [20.03]

### DIFF
--- a/pkgs/applications/networking/mailreaders/balsa/default.nix
+++ b/pkgs/applications/networking/mailreaders/balsa/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib, gtk3, gmime, gnutls,
   webkitgtk, libesmtp, openssl, libnotify, gtkspell3, gpgme,
   libcanberra-gtk3, libsecret, gtksourceview, gobject-introspection,
-  wrapGAppsHook
+  wrapGAppsHook, libical
 }:
 
 stdenv.mkDerivation rec {
   pname = "balsa";
-  version = "2.5.9";
+  version = "2.5.11";
 
   src = fetchurl {
     url = "https://pawsa.fedorapeople.org/balsa/${pname}-${version}.tar.bz2";
-    sha256 = "19gs1qfvbk9qx4rjmgrmvid00kl9k153zjjx8zjii2lz09w7g19i";
+    sha256 = "1w8cbrj0w90fc2kxdf94krkwdh58w5px9qmkiqcb6rlm06n0wg9d";
   };
 
   nativeBuildInputs = [
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     gtksourceview
     libsecret
     libesmtp
+    libical
   ];
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

Addresses #90734 and #94729,  CVE-2020-13645 and CVE-2020-16118 

Also had to add libical as a dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
