### PR TITLE
ocamlPackages.owl: 0.9.0 → 0.10.0

### DIFF
--- a/pkgs/development/ocaml-modules/owl-base/default.nix
+++ b/pkgs/development/ocaml-modules/owl-base/default.nix
@@ -1,23 +1,19 @@
-{ stdenv, buildDunePackage, fetchFromGitHub, stdlib-shims }:
+{ lib, buildDunePackage, fetchurl }:
 
 buildDunePackage rec {
   pname = "owl-base";
-  version = "0.9.0";
+  version = "0.10.0";
 
   useDune2 = true;
 
-  src = fetchFromGitHub {
-    owner = "owlbarn";
-    repo = "owl";
-    rev  = version;
-    sha256 = "0xxchsymmdbwszs6barqq8x4vqz5hbap64yxq82c2la9sdxgk0vv";
+  src = fetchurl {
+    url = "https://github.com/owlbarn/owl/releases/download/${version}/owl-${version}.tbz";
+    sha256 = "148ny2cdzga1l36kcibvlz5xlyi5zvkywifxaqn8lf79n1swmlzf";
   };
-
-  propagatedBuildInputs = [ stdlib-shims ];
 
   minimumOCamlVersion = "4.10";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Numerical computing library for Ocaml";
     homepage = "https://ocaml.xyz";
     changelog = "https://github.com/owlbarn/owl/releases";


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/owlbarn/owl/releases/tag/0.10.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
