### PR TITLE
json_c: 0.14 -> 0.15

### DIFF
--- a/pkgs/development/libraries/json-c/default.nix
+++ b/pkgs/development/libraries/json-c/default.nix
@@ -1,20 +1,13 @@
-{ stdenv, fetchurl, fetchpatch, cmake }:
+{ stdenv, fetchurl, cmake }:
 
 stdenv.mkDerivation rec {
-  name = "json-c-0.14";
-  src = fetchurl {
-    url    = "https://s3.amazonaws.com/json-c_releases/releases/${name}-nodoc.tar.gz";
-    sha256 = "1yia8417qljmczs9w3rn4c4i2p2iywq098pgrj11s81599j4x4cr";
-  };
+  pname = "json-c";
+  version = "0.15";
 
-  patches = [
-    # https://nvd.nist.gov/vuln/detail/CVE-2020-12762
-    (fetchpatch {
-      name = "CVE-2020-12762.patch";
-      url = "https://github.com/json-c/json-c/commit/5d6fa331418d49f1bd488553fd1cfa9ab023fabb.patch";
-      sha256 = "0aar7kgbycqxnhh0lrr61adfbb903nbapalhs5i6h8anxwy1ylcm";
-    })
-  ];
+  src = fetchurl {
+    url    = "https://s3.amazonaws.com/json-c_releases/releases/${pname}-${version}.tar.gz";
+    sha256 = "1im484iz08j3gmzpw07v16brwq46pxxj65i996kkp2vivcfhmn5q";
+  };
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/json-c/json-c/blob/json-c-0.15-20200726/ChangeLog

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).