### PR TITLE
compcert: remove annoying assertions

### DIFF
--- a/pkgs/development/compilers/compcert/default.nix
+++ b/pkgs/development/compilers/compcert/default.nix
@@ -3,9 +3,6 @@
 , tools ? stdenv.cc
 }:
 
-assert lib.versionAtLeast ocamlPackages.ocaml.version "4.02";
-assert lib.versionAtLeast coq.coq-version "8.8.0";
-
 let
   ocaml-pkgs      = with ocamlPackages; [ ocaml findlib menhir ];
   ccomp-platform = if stdenv.isDarwin then "x86_64-macosx" else "x86_64-linux";


### PR DESCRIPTION
###### Motivation for this change

Currently, when trying to override the derivation for CompCert in order to build a different version (e.g., an earlier version that requires Coq 8.8), you are greeted with:

> error: assertion (((lib).versionAtLeast  (coq).coq-version)  "8.8.0") failed

This PR just removes this nonsensical assertion and its neighbor.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
