### PR TITLE
opencv: 2.4.13 -> 2.4.13.7

### DIFF
--- a/pkgs/development/libraries/opencv/default.nix
+++ b/pkgs/development/libraries/opencv/default.nix
@@ -19,13 +19,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "opencv";
-  version = "2.4.13";
+  version = "2.4.13.7";
 
   src = fetchFromGitHub {
-    owner = "Itseez";
+    owner = "opencv";
     repo = "opencv";
     rev = version;
-    sha256 = "1k29rxlvrhgc5hadg2nc50wa3d2ls9ndp373257p756a0aividxh";
+    sha256 = "062js7zhh4ixi2wk61wyi23qp9zsk5vw24iz2i5fab2hp97y5zq3";
   };
 
   patches =

--- a/pkgs/development/libraries/opencv/default.nix
+++ b/pkgs/development/libraries/opencv/default.nix
@@ -87,6 +87,5 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ ];
     platforms = platforms.linux;
-    broken = true;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This change updates OpenCV 2 to the latest version in 2.4 series hosted at `opencv/opencv`.
`opencv2`, `p2pvc` and `pfstools` are built without errors but they are not really tested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
