### PR TITLE
hdr-plus: init at 2020-10-29

### DIFF
--- a/pkgs/applications/graphics/hdr-plus/default.nix
+++ b/pkgs/applications/graphics/hdr-plus/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, fetchpatch
+, cmake, halide
+, libpng, libjpeg, libtiff, libraw
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hdr-plus-unstable";
+  version = "2020-10-29";
+
+  src = fetchFromGitHub {
+    owner = "timothybrooks";
+    repo = "hdr-plus";
+    rev = "132bd73ccd4eaef9830124605c93f06a98607cfa";
+    sha256 = "1n49ggrppf336p7n510kapzh376791bysxj3f33m3bdzksq360ps";
+  };
+
+  patches = [
+    # PR #70, fixes incompatibility with Halide 10.0.0
+    (fetchpatch {
+      url = "https://github.com/timothybrooks/hdr-plus/pull/70/commits/077e1a476279539c72e615210762dca27984c57b.patch";
+      sha256 = "1sg2l1bqs2smpfpy4flwg86fzhcc4yf7zx998v1bfhim43yyrx59";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ halide libpng libjpeg libtiff libraw ];
+
+  installPhase = ''
+    for bin in hdrplus stack_frames; do
+      install -Dm755 $bin $out/bin/$bin
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Burst photography pipeline based on Google's HDR+";
+    homepage = "https://www.timothybrooks.com/tech/hdr-plus/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21594,6 +21594,10 @@ in
 
   hdhomerun-config-gui = callPackage ../applications/video/hdhomerun-config-gui { };
 
+  hdr-plus = callPackage ../applications/graphics/hdr-plus {
+    stdenv = clangStdenv;
+  };
+
   heimer = libsForQt5.callPackage ../applications/misc/heimer { };
 
   hello = callPackage ../applications/misc/hello { };


### PR DESCRIPTION
###### Motivation for this change
`hdr-plus` is a burst photography pipeline implementation based on Google's HDR+ pipeline. More details can be found [here](https://www.timothybrooks.com/tech/hdr-plus/). I'm packaging this for the Megapixels app (#98479) which [greatly benefits](https://blog.brixit.nl/pinephone-camera-pt4/#hdr-and-stacking) from using the `stack_frames` binary provided by this project.

The included patch is required for building against Halide 10.0.0, it's a squashed version of my upstream PR https://github.com/timothybrooks/hdr-plus/pull/70.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
