### PR TITLE
jsoncpp: 1.9.2 -> 1.9.4

### DIFF
--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchFromGitHub, cmake, python, validatePkgConfig, fetchpatch }:
+{ stdenv, lib, fetchFromGitHub, cmake, python3, validatePkgConfig, static ? false }:
 
 stdenv.mkDerivation rec {
   pname = "jsoncpp";
-  version = "1.9.2";
+  version = "1.9.4";
 
   src = fetchFromGitHub {
     owner = "open-source-parsers";
     repo = "jsoncpp";
     rev = version;
-    sha256 = "037d1b1qdmn3rksmn1j71j26bv4hkjv7sn7da261k853xb5899sg";
+    sha256 = "m0tz8w8HbtDitx3Qkn3Rxj/XhASiJVkThdeBxIwv3WI=";
   };
+
+  outputs = if static then [ "out" ] else [ "out" "dev" ];
 
   /* During darwin bootstrap, we have a cp that doesn't understand the
    * --reflink=auto flag, which is used in the default unpackPhase for dirs
@@ -23,34 +25,21 @@ stdenv.mkDerivation rec {
   # Hack to be able to run the test, broken because we use
   # CMAKE_SKIP_BUILD_RPATH to avoid cmake resetting rpath on install
   preBuild = if stdenv.isDarwin then ''
-    export DYLD_LIBRARY_PATH="`pwd`/src/lib_json''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH"
+    export DYLD_LIBRARY_PATH="`pwd`/lib''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH"
   '' else ''
-    export LD_LIBRARY_PATH="`pwd`/src/lib_json''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
+    export LD_LIBRARY_PATH="`pwd`/lib''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
   '';
 
-  nativeBuildInputs = [ cmake python validatePkgConfig ];
-
-  patches = [
-    # Fix generation of pkg-config file (https://github.com/open-source-parsers/jsoncpp/pull/1199)
-    (fetchpatch {
-      url = "https://github.com/open-source-parsers/jsoncpp/commit/b05a21342a646a986b11c28ba6b19665756d21d2.patch";
-      sha256 = "0dn4cvvkcp9mnxbzyaqb49z6bv5yqsx1wlf1lyki1n2rni2hn63p";
-    })
-  ] ++ stdenv.lib.optionals (stdenv.isAarch64 || stdenv.isAarch32) [
-    # fix inverted sense in isAnyCharRequiredQuoting on arm. See: https://github.com/open-source-parsers/jsoncpp/pull/1120
-    (fetchpatch {
-      url = "https://github.com/open-source-parsers/jsoncpp/commit/9093358efae9e5981aa60013487fc7215f040a59.patch";
-      sha256 = "1wiqp70sck2md14sfc0zdkblqk9750cl55ykf9d6b9vs1ifzzzq5";
-     })
-  ];
+  nativeBuildInputs = [ cmake python3 ] ++ lib.optional (!static) [ validatePkgConfig ];
 
   cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DBUILD_STATIC_LIBS=OFF"
     "-DJSONCPP_WITH_CMAKE_PACKAGE=ON"
-  ];
+    "-DJSONCPP_WITH_PKGCONFIG_SUPPORT=ON"
+    "-DBUILD_OBJECT_LIBS=OFF"
+  ] ++ lib.optional static    "-DBUILD_SHARED_LIBS=OFF"
+    ++ lib.optional (!static) "-DBUILD_STATIC_LIBS=OFF";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     inherit version;
     homepage = "https://github.com/open-source-parsers/jsoncpp";
     description = "A C++ library for interacting with JSON";

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -151,6 +151,9 @@ in {
   gifsicle = super.gifsicle.override {
     static = true;
   };
+  jsoncpp = super.jsoncpp.override {
+    static = true;
+  };
   bzip2 = super.bzip2.override {
     linkStatic = true;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Removing obsolete patches in the process

Adding new features:

* static flag (disabled by default) to generate a static library instead
* pkgsStatic override to use it
* addition of python3 test support
* removal of the intermediate object files in output
* split into multiple outputs
* pkgconfig .pc support files in $dev

Was not able to test the darwin build to check the local preBuild phase there

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
