### PR TITLE
vk-messenger: 5.0.1 → 5.2.3, enable on darwin

### DIFF
--- a/pkgs/applications/networking/instant-messengers/vk-messenger/default.nix
+++ b/pkgs/applications/networking/instant-messengers/vk-messenger/default.nix
@@ -1,54 +1,73 @@
-{ stdenv, lib, fetchurl, rpmextract, autoPatchelfHook
+{ stdenv, lib, fetchurl, rpmextract, undmg, autoPatchelfHook
 , xorg, gtk3, gnome2, nss, alsaLib, udev, libnotify
 , wrapGAppsHook }:
 
 let
-  version = "5.0.1";
-in stdenv.mkDerivation {
   pname = "vk-messenger";
-  inherit version;
+  version = "5.2.3";
+
   src = {
     i686-linux = fetchurl {
       url = "https://desktop.userapi.com/rpm/master/vk-${version}.i686.rpm";
-      sha256 = "1ji23x13lzbkiqfrrwx1pj6gmms0p58cjmjc0y4g16kqhlxl60v6";
+      sha256 = "09zi2rzsank6lhw1z9yar1rp634y6qskvr2i0rvqg2fij7cy6w19";
     };
     x86_64-linux = fetchurl {
       url = "https://desktop.userapi.com/rpm/master/vk-${version}.x86_64.rpm";
-      sha256 = "01vvmia2qrxvrvavk9hkkyvfg4pg15m01grwb28884vy4nqw400y";
+      sha256 = "1m6saanpv1k5wc5s58jpf0wsgjsj7haabx8nycm1fjyhky1chirb";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://web.archive.org/web/20210310071550/https://desktop.userapi.com/mac/master/vk.dmg";
+      sha256 = "0j5qsr0fyl55d0x46xm4h2ykwr4y9z1dsllhqx5lnc15nc051s9b";
     };
   }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
-
-  nativeBuildInputs = [ rpmextract autoPatchelfHook wrapGAppsHook ];
-  buildInputs = (with xorg; [
-    libXdamage libXtst libXScrnSaver libxkbfile
-  ]) ++ [
-    gtk3 nss alsaLib
-  ];
-  runtimeDependencies = [ (lib.getLib udev) libnotify ];
-
-  unpackPhase = ''
-    rpmextract $src
-  '';
-
-  buildPhase = ''
-    substituteInPlace usr/share/applications/vk.desktop \
-      --replace /usr/share/pixmaps/vk.png vk
-  '';
-
-  installPhase = ''
-    mkdir $out
-    cd usr
-    cp -r --parents bin $out
-    cp -r --parents share/vk $out
-    cp -r --parents share/applications $out
-    cp -r --parents share/pixmaps $out
-  '';
 
   meta = with lib; {
     description = "Simple and Convenient Messaging App for VK";
     homepage = "https://vk.com/messenger";
     license = licenses.unfree;
     maintainers = [ maintainers.gnidorah ];
-    platforms = ["i686-linux" "x86_64-linux"];
+    platforms = ["i686-linux" "x86_64-linux" "x86_64-darwin"];
   };
-}
+
+  linux = stdenv.mkDerivation {
+    inherit pname version src meta;
+
+    nativeBuildInputs = [ rpmextract autoPatchelfHook wrapGAppsHook ];
+    buildInputs = (with xorg; [
+      libXdamage libXtst libXScrnSaver libxkbfile
+    ]) ++ [ gtk3 nss alsaLib ];
+
+    runtimeDependencies = [ (lib.getLib udev) libnotify ];
+
+    unpackPhase = ''
+      rpmextract $src
+    '';
+
+    buildPhase = ''
+      substituteInPlace usr/share/applications/vk.desktop \
+        --replace /usr/share/pixmaps/vk.png vk
+    '';
+
+    installPhase = ''
+      mkdir $out
+      cd usr
+      cp -r --parents bin $out
+      cp -r --parents share/vk $out
+      cp -r --parents share/applications $out
+      cp -r --parents share/pixmaps $out
+    '';
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version src meta;
+
+    nativeBuildInputs = [ undmg ];
+
+    sourceRoot = ".";
+
+    installPhase = ''
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications
+    '';
+  };
+in if stdenv.isDarwin then darwin else linux


### PR DESCRIPTION
###### Motivation for this change
Update and enable on darwin.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @gnidorah