### PR TITLE
oven-media-engine: 0.10.4 -> 0.10.8

### DIFF
--- a/pkgs/servers/misc/oven-media-engine/default.nix
+++ b/pkgs/servers/misc/oven-media-engine/default.nix
@@ -12,7 +12,7 @@
 , libopus
 , srtp
 , jemalloc
-, ... }:
+}:
 
 let
   ffmpeg = ffmpeg_3_4.overrideAttrs (super: {
@@ -20,20 +20,20 @@ let
     src = fetchFromGitHub {
       owner = "Airensoft";
       repo = "FFmpeg";
-      rev = "142b4bb64b64e337f80066e6af935a68627fedae";  # ome/3.4
+      rev = "142b4bb64b64e337f80066e6af935a68627fedae";  # on branch ome/3.4
       sha256 = "0fla3940q3z0c0ik2xzkbvdfvrdg06ban7wi6y94y8mcipszpp11";
     };
   });
 in
 stdenv.mkDerivation rec {
   pname = "oven-media-engine";
-  version = "0.10.4";
+  version = "0.10.8";
 
   src = fetchFromGitHub {
     owner = "AirenSoft";
     repo = "OvenMediaEngine";
     rev = "v${version}";
-    sha256 = "15lrlynsldlpa21ryzccf5skgiih6y5fc9qg0bfqh557wnnmml6w";
+    sha256 = "ec4yvS+4/rTBHGEx2OP0yoNGDtzPucFOcZJ0o0cCAHg=";
   };
 
   sourceRoot = "source/src";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
