### PR TITLE
elixir_1_11: 1.11.1 -> 1.11.2

### DIFF
--- a/pkgs/development/interpreters/elixir/1.11.nix
+++ b/pkgs/development/interpreters/elixir/1.11.nix
@@ -3,7 +3,7 @@
 # How to obtain `sha256`:
 # nix-prefetch-url --unpack https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz
 mkDerivation {
-  version = "1.11.1";
-  sha256 = "0czyv98sq9drlvdwv3gw9vnhn8qa3va4xh5vdqpg7m6b93l1r3p1";
+  version = "1.11.2";
+  sha256 = "0b4nfgxhmi4gwba9h9k103zrkpbxxvk0gmdl0ggrd5xlg6v288ky";
   minimumOTPVersion = "21";
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream release: https://github.com/elixir-lang/elixir/releases/tag/v1.11.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Package closure size impact:

```
/nix/store/s0fy5r3s0j74cadsnr045w3y52hy1p8b-elixir-1.11.2         605687792
/nix/store/b2a9cgvzjj4dbhdwm8krpd64kj441lpw-elixir-1.11.1         615837792
```