### PR TITLE
nixUnstable: 2.4pre20201102_550e11f -> 2.4pre20201105_387f824

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -221,6 +221,11 @@ in rec {
         url = "https://github.com/hercules-ci/nix/commit/bc8eb384e7dd192f1ae91e929f5c9fa249502a2c.patch";
         sha256 = "144ya6vf4brl4bb2bjbvihrcqr9fiwf8pvylgz2zlhbi6q710zq7";
       })
+      # BoehmGCStackAllocator: disable GC with coroutines https://github.com/NixOS/nix/pull/4264
+      (fetchpatch {
+        url = "https://github.com/hercules-ci/nix/commit/ced7f31ac252ebbeb8610dcb329ee09e84aca8aa.patch";
+        sha256 = "0pfhbqvlyr54fygnan0iyzcpxga4j3sdp65khqbn1vbvlk2smjvp";
+      })
     ]; }));
 
   nixFlakes = nixUnstable;

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -199,13 +199,13 @@ in rec {
 
   nixUnstable = lib.lowPrio (callPackage common rec {
     name = "nix-2.4${suffix}";
-    suffix = "pre20201102_550e11f";
+    suffix = "pre20201105_cdc840d";
 
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "550e11f077ae508abde5a33998a9d4029880e7b2";
-      sha256 = "186grfxsfqg7r92wgwbma66xc7p3iywn43ff7s59m4g6bvb0qgcl";
+      rev = "cdc840d60be6a9082de6d2a845d393e0fb2f1475";
+      sha256 = "0jgfmrwln2drgwfrhkyr8xksg3i0cx0hl8262jys8kgpg1jxw59x";
     };
 
     inherit storeDir stateDir confDir boehmgc;

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -216,6 +216,11 @@ in rec {
         url = "https://github.com/hercules-ci/nix/commit/f9e9839bce403f99734682a1eb3e98b14fef7c17.patch";
         sha256 = "0fwkagky9bqx0yvfj7syb6ksk35k9508cvidwwxr60x0jv2zj45b";
       })
+      # BoehmGCStackAllocator: ignore stack protection page https://github.com/NixOS/nix/pull/4264
+      (fetchpatch {
+        url = "https://github.com/hercules-ci/nix/commit/bc8eb384e7dd192f1ae91e929f5c9fa249502a2c.patch";
+        sha256 = "144ya6vf4brl4bb2bjbvihrcqr9fiwf8pvylgz2zlhbi6q710zq7";
+      })
     ]; }));
 
   nixFlakes = nixUnstable;

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -1,4 +1,5 @@
 { lib, fetchurl, fetchFromGitHub, callPackage
+, fetchpatch
 , storeDir ? "/nix/store"
 , stateDir ? "/nix/var"
 , confDir ? "/etc"
@@ -197,9 +198,9 @@ in rec {
     inherit storeDir stateDir confDir boehmgc;
   });
 
-  nixUnstable = lib.lowPrio (callPackage common rec {
+  nixUnstable = lib.lowPrio ((callPackage common rec {
     name = "nix-2.4${suffix}";
-    suffix = "pre20201105_cdc840d";
+    suffix = "pre20201105_cdc840d_patched";
 
     src = fetchFromGitHub {
       owner = "NixOS";
@@ -209,7 +210,13 @@ in rec {
     };
 
     inherit storeDir stateDir confDir boehmgc;
-  });
+  }).overrideAttrs(o: { patches = [
+      # Revert e8c3795 to work around https://github.com/NixOS/nix/issues/4235
+      (fetchpatch {
+        url = "https://github.com/hercules-ci/nix/commit/f9e9839bce403f99734682a1eb3e98b14fef7c17.patch";
+        sha256 = "0fwkagky9bqx0yvfj7syb6ksk35k9508cvidwwxr60x0jv2zj45b";
+      })
+    ]; }));
 
   nixFlakes = nixUnstable;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Most notably

 - Fix a memory corruption and deadlock caused by new constant-memory source filtering implementation (+ fix implementation error)
 - Fix nix-copy-closure with drvs
 - Fix a varargs error in an error message (also a crash?)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
