### PR TITLE
pam_mount: add support for LUKS2

### DIFF
--- a/pkgs/os-specific/linux/pam_mount/default.nix
+++ b/pkgs/os-specific/linux/pam_mount/default.nix
@@ -1,37 +1,48 @@
-{ stdenv, fetchurl, autoconf, automake, pkgconfig, libtool, pam, libHX, libxml2, pcre, perl, openssl, cryptsetup, utillinux }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, libtool, pam, libHX, libxml2, pcre, perl, openssl, cryptsetup, utillinux }:
 
 stdenv.mkDerivation rec {
-  name = "pam_mount-2.16";
+  pname = "pam_mount";
+  version = "2.16";
 
   src = fetchurl {
-    url = "mirror://sourceforge/pam-mount/pam_mount/2.16/${name}.tar.xz";
+    url = "mirror://sourceforge/pam-mount/pam_mount/${version}/${pname}-${version}.tar.xz";
     sha256 = "1rvi4irb7ylsbhvx1cr6islm2xxw1a4b19q6z4a9864ndkm0f0mf";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ autoconf automake libtool pam libHX utillinux libxml2 pcre perl openssl cryptsetup ];
+  patches = [
+    ./insert_utillinux_path_hooks.patch
+    ./support_luks2.patch
+  ];
 
-  patches = [ ./insert_utillinux_path_hooks.patch ];
+  postPatch = ''
+    substituteInPlace src/mtcrypt.c \
+      --replace @@NIX_UTILLINUX@@ ${utillinux}/bin
+  '';
 
-  preConfigure = ''
-    substituteInPlace src/mtcrypt.c --replace @@NIX_UTILLINUX@@ ${utillinux}/bin
-    sh autogen.sh --prefix=$out
-    '';
+  nativeBuildInputs = [ autoreconfHook libtool pkgconfig ];
 
-  makeFlags = [ "DESTDIR=$(out)" ];
+  buildInputs = [ pam libHX utillinux libxml2 pcre perl openssl cryptsetup ];
 
-  # Probably a hack, but using DESTDIR and PREFIX makes everything work!
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--prefix=${placeholder "out"}"
+    "--localstatedir=${placeholder "out"}/var"
+    "--sbindir=${placeholder "out"}/bin"
+    "--sysconfdir=${placeholder "out"}/etc"
+    "--with-slibdir=${placeholder "out"}/lib"
+    "--with-ssbindir=${placeholder "out"}/bin"
+  ];
+
   postInstall = ''
-    mkdir -p $out
-    cp -r $out/$out/* $out
-    rm -r $out/nix
-    '';
+    rm -r $out/var
+  '';
 
   meta = with stdenv.lib; {
-    homepage = "http://pam-mount.sourceforge.net/";
     description = "PAM module to mount volumes for a user session";
-    maintainers = [ maintainers.tstrobel ];
+    homepage = "https://pam-mount.sourceforge.net/";
     license = with licenses; [ gpl2 gpl3 lgpl21 lgpl3 ];
+    maintainers = with maintainers; [ tstrobel ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/pam_mount/support_luks2.patch
+++ b/pkgs/os-specific/linux/pam_mount/support_luks2.patch
@@ -1,0 +1,47 @@
+commit d4434c05e7c0cf05d87089404cfa2deedc60811a
+Author: Ingo Franzki <ifranzki@linux.ibm.com>
+Date:   Mon Oct 29 16:47:40 2018 +0100
+
+    crypto: Add support for LUKS2
+    
+    Cryptsetup version 2.0 added support for LUKS2.
+    This patch adds support for mounting LUKS2 volumes with
+    pam_mount.
+    
+    Signed-off-by: Ingo Franzki <ifranzki@linux.ibm.com>
+
+diff --git a/src/crypto-dmc.c b/src/crypto-dmc.c
+index d0ab6ca..abd0358 100644
+--- a/src/crypto-dmc.c
++++ b/src/crypto-dmc.c
+@@ -21,6 +21,12 @@
+ #include "libcryptmount.h"
+ #include "pam_mount.h"
+ 
++#ifndef CRYPT_LUKS
++	#define CRYPT_LUKS	NULL /* Passing NULL to crypt_load will
++					default to LUKS(1) on older
++					libcryptsetup versions. */
++#endif
++
+ /**
+  * dmc_is_luks - check if @path points to a LUKS volume (cf. normal dm-crypt)
+  * @path:	path to the crypto container
+@@ -48,7 +54,7 @@ EXPORT_SYMBOL int ehd_is_luks(const char *path, bool blkdev)
+ 
+ 	ret = crypt_init(&cd, device);
+ 	if (ret == 0) {
+-		ret = crypt_load(cd, CRYPT_LUKS1, NULL);
++		ret = crypt_load(cd, CRYPT_LUKS, NULL);
+ 		if (ret == -EINVAL)
+ 			ret = false;
+ 		else if (ret == 0)
+@@ -106,7 +112,7 @@ static bool dmc_run(const struct ehd_mount_request *req,
+ #endif
+ 	}
+ 
+-	ret = crypt_load(cd, CRYPT_LUKS1, NULL);
++	ret = crypt_load(cd, CRYPT_LUKS, NULL);
+ 	if (ret == 0) {
+ 		ret = crypt_activate_by_passphrase(cd, mt->crypto_name,
+ 		      CRYPT_ANY_SLOT, req->key_data, req->key_size, flags);


### PR DESCRIPTION
###### Motivation for this change

Shortly after v2.16 was released, a single commit was added to master
that adds support for mounting LUKS2 volumes which is now the default
for `cryptsetup`. This adds that.

As there is no easy way to fetch that commit as a patch, I have added it
to nixpkgs.

Tested on both LUKS1 and LUKS2 volumes.

Also some build cleanups.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).