### PR TITLE
seaweedfs: init at 2.07

### DIFF
--- a/pkgs/applications/networking/seaweedfs/default.nix
+++ b/pkgs/applications/networking/seaweedfs/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "seaweedfs";
+  version = "2.07";
+
+  src = fetchFromGitHub {
+    owner = "chrislusf";
+    repo = "seaweedfs";
+    rev = version;
+    sha256 = "0yrfpj4ph9f321vqfn1zadv44pqa3ivjq9rx6gsz9hlv50gfaqn1";
+  };
+
+  vendorSha256 = "1ysqagi4y25bi84h5fhkdimnsigy43klf6hrcqn7q75382fb4bzn";
+
+  subPackages = [ "weed" ];
+
+  meta = with lib; {
+    description = "Simple and highly scalable distributed file system";
+    homepage = "https://github.com/chrislusf/seaweedfs";
+    maintainers = [ maintainers.raboof ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7031,6 +7031,8 @@ in
 
   skim = callPackage ../tools/misc/skim { };
 
+  seaweedfs = callPackage ../applications/networking/seaweedfs { };
+
   sec = callPackage ../tools/admin/sec { };
 
   seccure = callPackage ../tools/security/seccure { };


### PR DESCRIPTION
###### Motivation for this change

Submitted on behalf of kvtb who chose not to create a GitHub account yet.

https://discourse.nixos.org/t/casual-nixpkgs-contributions/9607/7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).