### PR TITLE
verilog: unstable-2020-08-24 -> 11.0

### DIFF
--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -1,40 +1,47 @@
-{ stdenv, fetchFromGitHub, autoconf, gperf, flex, bison, readline, ncurses
-, bzip2, zlib
-# Test inputs
+{ stdenv
+, fetchFromGitHub
+, autoconf
+, bison
+, bzip2
+, flex
+, gperf
+, ncurses
 , perl
+, readline
+, zlib
 }:
 
 let
   iverilog-test = fetchFromGitHub {
     owner  = "steveicarus";
     repo   = "ivtest";
-    rev    = "d4c80beb845cad92136c05074b3910b822a9315f";
-    sha256 = "13cpnkki3xmhsh2v4bp2s35mhwknapcikdh85g4q6925ka940r45";
+    rev    = "253609b89576355b3bef2f91e90db62223ecf2be";
+    sha256 = "18i7jlr2csp7mplcrwjhllwvb6w3v7x7mnx7vdw48nd3g5scrydx";
   };
 in
 stdenv.mkDerivation rec {
   pname   = "iverilog";
-  version = "unstable-2020-10-24";
+  version = "11.0";
 
   src = fetchFromGitHub {
     owner  = "steveicarus";
     repo   = pname;
-    rev    = "d6e01d0c557253414109a4dde46b2966a5a3fb08";
-    sha256 = "1bl75mbycj9zpjbpay8z12384yk9ih5q9agsrjh9pva0vv3h4y4y";
+    rev    = "v${stdenv.lib.replaceStrings ["."] ["_"] version}";
+    sha256 = "0nzcyi6l2zv9wxzsv9i963p3igyjds0n55x0ph561mc3pfbc7aqp";
   };
 
-  nativeBuildInputs = [ autoconf gperf flex bison ];
-  buildInputs = [ readline ncurses bzip2 zlib ];
+  nativeBuildInputs = [ autoconf bison flex gperf ];
 
-  preConfigure = "bash $PWD/autoconf.sh";
+  buildInputs = [ bzip2 ncurses readline zlib ];
+
+  preConfigure = "sh autoconf.sh";
 
   enableParallelBuilding = true;
+
   doCheck = true;
 
-  # most tests pass, but some that rely on exact text of floating-point numbers
-  # fail on aarch64.
-  doInstallCheck = !stdenv.isAarch64;
   installCheckInputs = [ perl ];
+
   installCheckPhase = ''
     # copy tests to allow writing results
     export TESTDIR=$(mktemp -d)
@@ -53,7 +60,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Icarus Verilog compiler";
-    homepage    = "http://iverilog.icarus.com/";
+    homepage    = "http://iverilog.icarus.com/";  # https does not work
     license     = with licenses; [ gpl2Plus lgpl21Plus ];
     maintainers = with maintainers; [ winden thoughtpolice ];
     platforms   = platforms.all;

--- a/pkgs/applications/science/electronics/vhd2vl/default.nix
+++ b/pkgs/applications/science/electronics/vhd2vl/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , bison
 , flex
 , verilog
@@ -15,6 +16,15 @@ stdenv.mkDerivation rec {
     rev = "37e3143395ce4e7d2f2e301e12a538caf52b983c";
     sha256 = "17va2pil4938j8c93anhy45zzgnvq3k71a7glj02synfrsv6fs8n";
   };
+
+  patches = stdenv.lib.optionals (!stdenv.isAarch64) [
+    # fix build with verilog 11.0 - https://github.com/ldoolitt/vhd2vl/pull/15
+    # for some strange reason, this is not needed for aarch64
+    (fetchpatch {
+      url = "https://github.com/ldoolitt/vhd2vl/commit/ce9b8343ffd004dfe8779a309f4b5a594dbec45e.patch";
+      sha256 = "1qaqhm2mk66spb2dir9n91b385rarglc067js1g6pcg8mg5v3hhf";
+    })
+  ];
 
   nativeBuildInputs = [
     bison


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

1. update to the latest stable version of verilog
2. re-enable verilog tests on aarch64 as they work now
3. fix vhd2vl compatibility with verilog 11 on aarch64

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
