### PR TITLE
android-image-utils: init at 2012-08-08

### DIFF
--- a/pkgs/development/mobile/android-image-utils/default.nix
+++ b/pkgs/development/mobile/android-image-utils/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "android-image-utils";
+  version = "2012-08-08";
+
+  src = fetchFromGitHub {
+    owner = "freesmartphone";
+    repo = "utilities";
+    rev = "1097722a3e5c92e6bef32c1c5eb75f199411c944";
+    sha256 = "16qwiazik6yqnp2bdrmg603ddz62xk75xqjn5272c4mw5f7kv2q1";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ zlib ];
+
+  sourceRoot = "source/android/image-utils";
+
+  meta = with stdenv.lib; {
+    description = "extract parts from Android boot.img images";
+    inherit (src.meta) homepage;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ magnetophon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1315,6 +1315,8 @@ in
 
   anbox = callPackage ../os-specific/linux/anbox { };
 
+  android-image-utils = callPackage ../development/mobile/android-image-utils { };
+
   androidenv = callPackage ../development/mobile/androidenv {
     pkgs_i686 = pkgsi686Linux;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).