### PR TITLE
dbus: docs: make id's reproducible

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -30,7 +30,13 @@ stdenv.mkDerivation rec {
     sha256 = "1zp5gpx61v1cpqf2zwb1cidhp9xylvw49d3zydkxqk6b1qa20xpp";
   };
 
-  patches = lib.optional stdenv.isSunOS ./implement-getgrouplist.patch;
+  patches = [
+    # 'generate.consistent.ids=1' ensures reproducible docs, for further details see
+    # http://docbook.sourceforge.net/release/xsl/current/doc/html/generate.consistent.ids.html
+    # Also applied upstream in https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/189,
+    # expected in version 1.14
+    ./docs-reproducible-ids.patch
+  ] ++ (lib.optional stdenv.isSunOS ./implement-getgrouplist.patch);
 
   postPatch = ''
     substituteInPlace tools/Makefile.in \

--- a/pkgs/development/libraries/dbus/docs-reproducible-ids.patch
+++ b/pkgs/development/libraries/dbus/docs-reproducible-ids.patch
@@ -1,0 +1,15 @@
+diff --color -Naur dbus-1.12.20-original/doc/Makefile.in dbus-1.12.20-hacked2/doc/Makefile.in
+--- dbus-1.12.20-original/doc/Makefile.in	2020-07-02 12:10:41.000000000 +0200
++++ dbus-1.12.20-hacked2/doc/Makefile.in	2020-11-07 09:57:15.297694773 +0100
+@@ -870,8 +870,10 @@
+ .PRECIOUS: Makefile
+ 
+ 
++# 'generate.consistent.ids=1' ensures reproducible docs, for further details see
++# http://docbook.sourceforge.net/release/xsl/current/doc/html/generate.consistent.ids.html
+ @DBUS_XML_DOCS_ENABLED_TRUE@%.html: %.xml
+-@DBUS_XML_DOCS_ENABLED_TRUE@	$(XMLTO) html-nochunks $<
++@DBUS_XML_DOCS_ENABLED_TRUE@	$(XMLTO) --stringparam generate.consistent.ids=1 html-nochunks $<
+ 
+ @DBUS_XML_DOCS_ENABLED_TRUE@%.1: %.1.xml
+ @DBUS_XML_DOCS_ENABLED_TRUE@	$(XMLTO) man $<


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

With this parameter, generating docs from the same sources will produce the
same 'bit-by-bit' result each time.

This is particularly important since dbus is part of the 'minimal' testset at
https://r13y.com/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested for reproducibility with 'nix-build -A dbus --check'

Also submitted for upstream master (though it's a bit different there due to changes since the last stable release): https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/189