### PR TITLE
nanorc: 2020-01-25 -> 2020-10-10

### DIFF
--- a/pkgs/applications/editors/nano/nanorc/default.nix
+++ b/pkgs/applications/editors/nano/nanorc/default.nix
@@ -1,14 +1,17 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, writeScript, nixosTests, common-updater-scripts
+, coreutils, git, gnused, nix, nixfmt }:
 
-stdenv.mkDerivation {
+let
+  owner = "scopatz";
+  repo = "nanorc";
+in stdenv.mkDerivation rec {
   pname = "nanorc";
-  version = "2020-01-25";
+  version = "2020-10-10";
 
   src = fetchFromGitHub {
-    owner = "scopatz";
-    repo = "nanorc";
-    rev = "2020.1.25";
-    sha256 = "1y8jk3jsl4bd6r4hzmxzcf77hv8bwm0318yv7y2npkkd3a060z8d";
+    inherit owner repo;
+    rev = builtins.replaceStrings [ "-" ] [ "." ] version;
+    sha256 = "3B2nNFYkwYHCX6pQz/hMO/rnVqlCiw1BSNmGmJ6KCqE=";
   };
 
   dontBuild = true;
@@ -17,6 +20,32 @@ stdenv.mkDerivation {
     mkdir -p $out/share
 
     install *.nanorc $out/share/
+  '';
+
+  passthru.updateScript = writeScript "update.sh" ''
+    #!${stdenv.shell}
+    set -o errexit
+    PATH=${
+      stdenv.lib.makeBinPath [
+        common-updater-scripts
+        coreutils
+        git
+        gnused
+        nix
+        nixfmt
+      ]
+    }
+    oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion ${pname}" | tr -d '"' | sed 's|\\.|-|g')"
+    latestTag="$(git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags git@github.com:${owner}/${repo} '*.*.*' | tail --lines=1 | cut --delimiter='/' --fields=3)"
+    if [ "$oldVersion" != "$latestTag" ]; then
+      nixpkgs="$(git rev-parse --show-toplevel)"
+      default_nix="$nixpkgs/pkgs/applications/editors/nano/nanorc/default.nix"
+      newTag=$(echo $latestTag | sed 's|\.|-|g')
+      update-source-version ${pname} "$newTag" --version-key=version --print-changes
+      nixfmt "$default_nix"
+    else
+      echo "${pname} is already up-to-date"
+    fi
   '';
 
   meta = {


### PR DESCRIPTION
Add update script

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
- Update
- Add update script

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
