### PR TITLE
[20.09] libraw: 0.20.0 -> 0.20.2

### DIFF
--- a/pkgs/development/libraries/libraw/default.nix
+++ b/pkgs/development/libraries/libraw/default.nix
@@ -1,25 +1,29 @@
-{ stdenv, fetchurl, lcms2, pkgconfig }:
+{ stdenv, fetchFromGitHub, autoreconfHook, lcms2, pkgconfig }:
 
 stdenv.mkDerivation rec {
   pname = "libraw";
-  version = "0.20.0";
+  version = "0.20.2";
 
-  src = fetchurl {
-    url = "https://www.libraw.org/data/LibRaw-${version}.tar.gz";
-    sha256 = "18wlsvj6c1rv036ph3695kknpgzc3lk2ikgshy8417yfl8ykh2hz";
+  src = fetchFromGitHub {
+    owner = "LibRaw";
+    repo = "LibRaw";
+    rev = version;
+    sha256 = "16nm4r2l5501c9zvz25pzajq5id592jhn068scjxhr8np2cblybc";
   };
 
   outputs = [ "out" "lib" "dev" "doc" ];
 
   propagatedBuildInputs = [ lcms2 ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  meta = {
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
     description = "Library for reading RAW files obtained from digital photo cameras (CRW/CR2, NEF, RAF, DNG, and others)";
     homepage = "https://www.libraw.org/";
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
   };
 }
 


### PR DESCRIPTION
https://github.com/LibRaw/LibRaw/blob/0.20.2/Changelog.txt
https://nvd.nist.gov/vuln/detail/CVE-2020-15365
https://nvd.nist.gov/vuln/detail/CVE-2020-15503
https://nvd.nist.gov/vuln/detail/CVE-2020-24890
(cherry picked from commit 0594e27df32346d3953d3f025d283451bfd7561a)

###### Motivation for this change

Addresses: #99802 - CVE-2020-24890

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
