### PR TITLE
wally-cli: enable on darwin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7065,6 +7065,12 @@
       fingerprint = "7573 56D7 79BB B888 773E  415E 736C CDF9 EF51 BD97";
     }];
   };
+  r-burns = {
+    email = "rtburns@protonmail.com";
+    github = "r-burns";
+    githubId = 52847440;
+    name = "Ryan Burns";
+  };
   raboof = {
     email = "arnout@bzzt.net";
     github = "raboof";

--- a/pkgs/development/tools/wally-cli/default.nix
+++ b/pkgs/development/tools/wally-cli/default.nix
@@ -27,8 +27,8 @@ buildGoModule rec {
   meta = with lib; {
     description = "A tool to flash firmware to mechanical keyboards";
     homepage = "https://ergodox-ez.com/pages/wally-planck";
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     license = licenses.mit;
-    maintainers = [ maintainers.spacekookie ];
+    maintainers = with maintainers; [ spacekookie r-burns ];
   };
 }


### PR DESCRIPTION
Works for me on my mac! Since @spacekookie might not have signed up for darwin maintenance, I can help out on that front.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
