### PR TITLE
plater: init at 2020-07-30

### DIFF
--- a/pkgs/applications/misc/plater/default.nix
+++ b/pkgs/applications/misc/plater/default.nix
@@ -1,0 +1,30 @@
+{ mkDerivation
+, cmake
+, fetchFromGitHub
+, lib
+, libGLU
+, qtbase
+}:
+
+mkDerivation rec {
+  pname = "plater";
+  version = "2020-07-30";
+
+  src = fetchFromGitHub {
+    owner = "Rhoban";
+    repo = "Plater";
+    rev = "f8de6d038f95a9edebfcfe142c8e9783697d5b47";
+    sha256 = "0r20mbzd16zv1aiadjqdy7z6sp09rr6lgfxhvir4ll3cpakkynr4";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libGLU qtbase ];
+
+  meta = with lib; {
+    description = "3D-printer parts placer and plate generator";
+    homepage = "https://github.com/Rhoban/Plater";
+    maintainers = with maintainers; [ lovesegfault ];
+    platforms = platforms.linux;
+    license = licenses.cc-by-nc-30;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22989,6 +22989,8 @@ in
 
   pistol = callPackage ../tools/misc/pistol { };
 
+  plater = libsForQt5.callPackage ../applications/misc/plater { };
+
   plexamp = callPackage ../applications/audio/plexamp { };
 
   plex-media-player = libsForQt512.callPackage ../applications/video/plex-media-player { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I need this for my 3D printer.

While they do have a 1.0 release that was before they got their build system
working well and fixed some major bugs, so I opted to package the last commit,
which I have tested to work.

cc. @flokli


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
