### PR TITLE
ocamlPackages.mirage-logs: init at 1.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-logs/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-logs/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchurl, buildDunePackage
+, logs, lwt, mirage-clock, mirage-profile, ptime
+, alcotest
+}:
+
+buildDunePackage rec {
+  pname = "mirage-logs";
+  version = "1.2.0";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-logs/releases/download/v${version}/mirage-logs-v${version}.tbz";
+    sha256 = "0h0amzjxy067jljscib7fvw5q8k0adqa8m86affha9hq5jsh07a1";
+  };
+
+  propagatedBuildInputs = [ logs lwt mirage-clock mirage-profile ptime ];
+
+  doCheck = true;
+  checkInputs = [ alcotest ];
+
+  meta = {
+    description = "A reporter for the Logs library that writes log messages to stderr, using a Mirage `CLOCK` to add timestamps";
+    homepage = "https://github.com/mirage/mirage-logs";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -569,6 +569,8 @@ let
 
     mirage-kv = callPackage ../development/ocaml-modules/mirage-kv { };
 
+    mirage-logs = callPackage ../development/ocaml-modules/mirage-logs { };
+
     mirage-net = callPackage ../development/ocaml-modules/mirage-net { };
 
     mirage-profile = callPackage ../development/ocaml-modules/mirage-profile { };


### PR DESCRIPTION
###### Motivation for this change

#23955 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
