### PR TITLE
mkl: fix .pc file, add test

### DIFF
--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -1,4 +1,5 @@
-{ stdenvNoCC
+{ callPackage
+, stdenvNoCC
 , fetchurl
 , rpmextract
 , undmg
@@ -156,6 +157,8 @@ in stdenvNoCC.mkDerivation {
   # Per license agreement, do not modify the binary
   dontStrip = true;
   dontPatchELF = true;
+
+  passthru.tests.pkg-config = callPackage ./test { };
 
   meta = with stdenvNoCC.lib; {
     description = "Intel Math Kernel Library";

--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -90,7 +90,8 @@ in stdenvNoCC.mkDerivation {
       substituteInPlace $f \
         --replace "prefix=<INSTALLDIR>/mkl" "prefix=$out" \
         --replace $\{MKLROOT} "$out" \
-        --replace "lib/intel64_lin" "lib"
+        --replace "lib/intel64_lin" "lib" \
+        --replace "lib/intel64" "lib"
     done
 
     for f in $(find opt/intel -name 'mkl*iomp.pc') ; do

--- a/pkgs/development/libraries/science/math/mkl/test/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/test/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, pkg-config, mkl }:
+
+stdenv.mkDerivation {
+  pname = "mkl-test";
+  version = mkl.version;
+
+  src = ./.;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ mkl ];
+
+  doCheck = true;
+
+  buildPhase = ''
+    # Check regular Nix build.
+    gcc $(pkg-config --cflags --libs mkl-dynamic-ilp64-seq) test.c -o test
+
+    # Clear flags to ensure that we are purely relying on options
+    # provided by pkg-config.
+    NIX_CFLAGS_COMPILE="" \
+    NIX_LDFLAGS="" \
+      gcc $(pkg-config --cflags --libs mkl-dynamic-ilp64-seq) test.c -o test
+  '';
+
+  installPhase = ''
+    touch $out
+  '';
+
+  checkPhase = ''
+    ./test
+  '';
+}

--- a/pkgs/development/libraries/science/math/mkl/test/test.c
+++ b/pkgs/development/libraries/science/math/mkl/test/test.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+
+#include <mkl_cblas.h>
+
+int main() {
+  float u[] = {1., 2., 3.};
+  float v[] = {4., 5., 6.};
+
+  float dp = cblas_sdot(3, u, 1, v, 1);
+
+  assert(dp == 32.);
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

There was a spurious `intel64` in some library paths, which is fixed
in the first commit.

The MKL pkg-config files often change and are then incorrect for our
paths. pkg-config validation finds some issues, but not incorrect
paths. The second commit adds a small test program to test whether the
generated pkg-config files can actually be used to build a functioning
binary. Hopefully this catches future regressions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
