### PR TITLE
openvpn: 2.4.9 -> 2.5.0

### DIFF
--- a/pkgs/tools/networking/openvpn/default.nix
+++ b/pkgs/tools/networking/openvpn/default.nix
@@ -1,14 +1,23 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, makeWrapper
-, iproute, lzo, openssl, pam
-, useSystemd ? stdenv.isLinux, systemd ? null, utillinux ? null
-, pkcs11Support ? false, pkcs11helper ? null,
+{ stdenv
+, fetchurl
+, pkg-config
+, makeWrapper
+, runtimeShell
+, iproute ? null
+, lzo
+, openssl
+, pam
+, useSystemd ? stdenv.isLinux
+, systemd ? null
+, utillinux ? null
+, pkcs11Support ? false
+, pkcs11helper ? null
 }:
 
 assert useSystemd -> (systemd != null);
 assert pkcs11Support -> (pkcs11helper != null);
 
 with stdenv.lib;
-
 let
   # Check if the script needs to have other binaries wrapped when changing this.
   update-resolved = fetchurl {
@@ -16,49 +25,68 @@ let
     sha256 = "021qzv1k0zxgv1rmyfpqj3zlzqr28xa7zff1n7vrbjk36ijylpsc";
   };
 
-in stdenv.mkDerivation rec {
-  pname = "openvpn";
-  version = "2.4.9";
+  generic = { version, sha256 }:
+    let
+      withIpRoute = stdenv.isLinux && (versionOlder version "2.5");
+    in
+    stdenv.mkDerivation
+      rec {
+        pname = "openvpn";
+        inherit version;
 
-  src = fetchurl {
-    url = "https://swupdate.openvpn.net/community/releases/${pname}-${version}.tar.xz";
+        src = fetchurl {
+          url = "https://swupdate.openvpn.net/community/releases/${pname}-${version}.tar.xz";
+          inherit sha256;
+        };
+
+        nativeBuildInputs = [ makeWrapper pkg-config ];
+
+        buildInputs = [ lzo openssl ]
+          ++ optional stdenv.isLinux pam
+          ++ optional withIpRoute iproute
+          ++ optional useSystemd systemd
+          ++ optional pkcs11Support pkcs11helper;
+
+        configureFlags = optionals withIpRoute [
+          "--enable-iproute2"
+          "IPROUTE=${iproute}/sbin/ip"
+        ]
+        ++ optional useSystemd "--enable-systemd"
+        ++ optional pkcs11Support "--enable-pkcs11"
+        ++ optional stdenv.isDarwin "--disable-plugin-auth-pam";
+
+        postInstall = ''
+          mkdir -p $out/share/doc/openvpn/examples
+          cp -r sample/sample-config-files/ $out/share/doc/openvpn/examples
+          cp -r sample/sample-keys/ $out/share/doc/openvpn/examples
+          cp -r sample/sample-scripts/ $out/share/doc/openvpn/examples
+        '' + optionalString useSystemd ''
+          install -Dm555 ${update-resolved} $out/libexec/update-systemd-resolved
+          wrapProgram $out/libexec/update-systemd-resolved \
+            --prefix PATH : ${makeBinPath [ runtimeShell iproute systemd utillinux ]}
+        '';
+
+        enableParallelBuilding = true;
+
+        meta = with stdenv.lib; {
+          description = "A robust and highly flexible tunneling application";
+          downloadPage = "https://openvpn.net/community-downloads/";
+          homepage = "https://openvpn.net/";
+          license = licenses.gpl2;
+          maintainers = with maintainers; [ viric peterhoeg ];
+          platforms = platforms.unix;
+        };
+      };
+
+in
+{
+  openvpn_24 = generic {
+    version = "2.4.9";
     sha256 = "1qpbllwlha7cffsd5dlddb8rl22g9rar5zflkz1wrcllhvfkl7v4";
   };
 
-  nativeBuildInputs = [ makeWrapper pkgconfig ];
-
-  buildInputs = [ lzo openssl ]
-                  ++ optionals stdenv.isLinux [ pam iproute ]
-                  ++ optional useSystemd systemd
-                  ++ optional pkcs11Support pkcs11helper;
-
-  configureFlags = optionals stdenv.isLinux [
-    "--enable-iproute2"
-    "IPROUTE=${iproute}/sbin/ip" ]
-    ++ optional useSystemd "--enable-systemd"
-    ++ optional pkcs11Support "--enable-pkcs11"
-    ++ optional stdenv.isDarwin "--disable-plugin-auth-pam";
-
-  postInstall = ''
-    mkdir -p $out/share/doc/openvpn/examples
-    cp -r sample/sample-config-files/ $out/share/doc/openvpn/examples
-    cp -r sample/sample-keys/ $out/share/doc/openvpn/examples
-    cp -r sample/sample-scripts/ $out/share/doc/openvpn/examples
-  '' + optionalString useSystemd ''
-    install -Dm555 ${update-resolved} $out/libexec/update-systemd-resolved
-    wrapProgram $out/libexec/update-systemd-resolved \
-      --prefix PATH : ${makeBinPath [ stdenv.shell iproute systemd utillinux ]}
-  '';
-
-  enableParallelBuilding = true;
-
-  meta = with stdenv.lib; {
-    description = "A robust and highly flexible tunneling application";
-    downloadPage = "https://openvpn.net/community-downloads/";
-    homepage = "https://openvpn.net/";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [ viric ];
-    platforms = platforms.unix;
-    updateWalker = true;
+  openvpn = generic {
+    version = "2.5.0";
+    sha256 = "sha256-AppCbkTWVstOEYkxnJX+b8mGQkdyT1WZ2Z35xMNHj70=";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6153,7 +6153,9 @@ in
 
   opentsdb = callPackage ../tools/misc/opentsdb {};
 
-  openvpn = callPackage ../tools/networking/openvpn {};
+  inherit (callPackages ../tools/networking/openvpn {})
+    openvpn_24
+    openvpn;
 
   openvpn_learnaddress = callPackage ../tools/networking/openvpn/openvpn_learnaddress.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

2.5.0 drops some functionality, so we will need to maintain both 2.4.x
and 2.5.y for quite some time.

As I need 2.4 for some time, I'm adding myself as maintainer for this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).