### PR TITLE
bluetooth_battery: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1583,6 +1583,12 @@
     githubId = 33503784;
     name = "Yucheng Zhang";
   };
+  cheriimoya = {
+    email = "github@hausch.xyz";
+    github = "cheriimoya";
+    githubId = 28303440;
+    name = "Max Hausch";
+  };
   chessai = {
     email = "chessai1996@gmail.com";
     github = "chessai";

--- a/pkgs/applications/misc/bluetooth_battery/default.nix
+++ b/pkgs/applications/misc/bluetooth_battery/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchFromGitHub, buildPythonApplication, pybluez }:
+
+buildPythonApplication rec {
+  pname = "bluetooth_battery";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "TheWeirdDev";
+    repo = "Bluetooth_Headset_Battery_Level";
+    rev = "v${version}";
+    sha256 = "121pkaq9z8p2i35cqs32aygjvf82r961w0axirpmsrbmrwq2hh6g";
+  };
+
+  propagatedBuildInputs = [ pybluez ];
+
+  format = "other";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/bluetooth_battery.py $out/bin/bluetooth_battery
+  '';
+
+  meta = with lib; {
+    description = "Fetch the battery charge level of some Bluetooth headsets";
+    homepage = "https://github.com/TheWeirdDev/Bluetooth_Headset_Battery_Level";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ cheriimoya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3217,6 +3217,8 @@ in
 
   biosdevname = callPackage ../tools/networking/biosdevname { };
 
+  bluetooth_battery = python3Packages.callPackage ../applications/misc/bluetooth_battery { };
+
   code-browser-qt = libsForQt5.callPackage ../applications/editors/code-browser { withQt = true;
                                                                                 };
   code-browser-gtk = callPackage ../applications/editors/code-browser { withGtk = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I have a bluetooth headset that's capable of reporting the battery state. This tool allows for reading the battery percentage from my bluetooth headphones. I'd like to have this upstream, because i use it in my statusbar and it may be useful to many people.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
