### PR TITLE
pylance: init at 220.11.0

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage, vscode-utils, llvmPackages_8, llvmPackages_latest }:
+{ stdenv, callPackage, vscode-utils, nodePackages, llvmPackages_8, llvmPackages_latest }:
 
 let
   inherit (vscode-utils) buildVscodeMarketplaceExtension;
@@ -154,6 +154,21 @@ stdenv.lib.mapAttrs (_n: stdenv.lib.recurseIntoAttrs)
   };
 
   ms-vscode.cpptools = callPackage ./cpptools {};
+
+  ms-python.vscode-pylance = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "vscode-pylance";
+      publisher = "MS-python";
+      version = "2020.11.2";
+      sha256 = "0n2dm21vgzir3hx1m3pmx7jq4zy3hdxfsandd2wv5da4fs9b5g50";
+    };
+
+    buildInputs = [ nodePackages.pyright ];
+
+    meta = {
+      license = stdenv.lib.licenses.unfree;
+    };
+  };
 
   ms-vscode-remote.remote-ssh = callPackage ./remote-ssh {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

pylance is the new Python language server by Microsoft for vscode. Probably very useful for a
lot of developers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x ] Ensured that relevant documentation is up to date
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
