### PR TITLE
cerebral-debugger: init at 3.1.0

### DIFF
--- a/pkgs/development/cerebral-debugger/default.nix
+++ b/pkgs/development/cerebral-debugger/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, fetchurl
+, makeWrapper
+, electron_4
+}:
+
+stdenv.mkDerivation rec {
+
+  pname = "cerebral-debugger";
+  version = "3.1.0";
+
+  src = fetchurl {
+    url = "https://github.com/cerebral/cerebral-debugger/releases/download/v${version}/cerebral-debugger-${version}.tar.gz";
+    sha256 = "0s4wlbcx1kjrpqkb8a8pljjiylq99s6a80ibr03lkq5r4rw2nw58";
+  };
+
+  dontBuild = true;
+  dontStrip = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ electron_4 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/opt/${pname}}
+    cp -r resources $out/opt/${pname}
+    cp -r locales $out/opt/${pname}
+    mv resources/app.asar $out/opt/${pname}
+
+    makeWrapper ${electron_4}/bin/electron $out/bin/${pname} \
+      --add-flags $out/opt/${pname}/app.asar
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Powerful development tool for Cerebral";
+    longDescription = ''
+      Cerebral is a javascript library, which goal is to support
+      building gui's using declarative code. The concept is built
+      around storing, rendering and updating states. In this regard,
+      it is almost impossible to develop using this library without also
+      having cerebral-debugger available. The Cerebral Debugger makes it
+      easy to trace all state changes over time, and to see the state value
+      at any particular time.
+    '';
+    homepage = "https://github.com/cerebral/cerebral-debugger";
+    license = licenses.mit;
+    maintainers = with maintainers; [ scalavision ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -947,6 +947,8 @@ in
 
   cconv = callPackage ../tools/text/cconv { };
 
+  cerebral-debugger = callPackage ../development/cerebral-debugger { };
+
   go-check = callPackage ../development/tools/check { };
 
   chkcrontab = callPackage ../tools/admin/chkcrontab { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Cerebral is a javascript library that you might have to deal with if you are a front-end javascript developer. Making
it work in NixOS was not straight forward, since it uses `electron` under the hood, so it would be rather nice
having it already in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x ] Ensured that relevant documentation is up to date
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

some CAVEATS:

* The app.asar binary is used directly, hence this is not built from source
* The cerebral is upgraded to electron 4, this version still have security issues

I have notified the author of the library about the security issues, using version 4 of electron instead of version 1 seems not affecting the app. I have used it quite a lot without any problems.

I would be happy to build this completely from source, but would need some guidance, as I have no experience with electron apps and very little experience using node on nixpkgs.