### PR TITLE
firmwareLinuxNonfree: 2020-09-18 -> 2020-10-22

### DIFF
--- a/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "firmware-linux-nonfree";
-  version = "2020-09-18";
+  version = "2020-10-22";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git";
     rev = lib.replaceStrings ["-"] [""] version;
-    sha256 = "06k2x6y9dhzs6nnbs1ws7rxbz0xijzmyn24sa223n0bmbb96n4f0";
+    sha256 = "15l32993pfm0albx7ky64c5i60vph150hrdkg87md15919a6naia";
   };
 
   installFlags = [ "DESTDIR=$(out)" ];
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   outputHashMode = "recursive";
   outputHashAlgo = "sha256";
-  outputHash = "1avpf2x1g7dlpva76pcnldxngkjabsyaknkkjbrhg1mj6z9g1mx7";
+  outputHash = "0y2dpp3gklzym2gr0w9wddf6cn6p0sv9n2xh401j1299sjsr57m9";
 
   meta = with stdenv.lib; {
     description = "Binary firmware collection packaged by kernel.org";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).