### PR TITLE
remarkable2-toolchain: init at 2.5.2

### DIFF
--- a/pkgs/development/tools/misc/remarkable/remarkable2-toolchain/default.nix
+++ b/pkgs/development/tools/misc/remarkable/remarkable2-toolchain/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, libarchive, python3, file }:
+
+stdenv.mkDerivation rec {
+  pname = "remarkable2-toolchain";
+  version = "2.5.2";
+
+  src = fetchurl {
+    url = "https://storage.googleapis.com/codex-public-bucket/codex-x86_64-cortexa7hf-neon-rm11x-toolchain-${version}.sh";
+    sha256 = "1v410q1jn8flisdpkrymxd4pa1ylawd0rh3rljjpkqw1bp8a5vw1";
+  };
+
+  nativeBuildInputs = [
+    libarchive
+    python3
+    file
+  ];
+
+  unpackCmd = ''
+    mkdir src
+    install $curSrc src/install-toolchain.sh
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    patchShebangs install-toolchain.sh
+    sed -i -e '3,9d' install-toolchain.sh # breaks PATH
+    sed -i 's|PYTHON=.*$|PYTHON=${python3}/bin/python|' install-toolchain.sh
+    ./install-toolchain.sh -D -y -d $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A toolchain for cross-compiling to reMarkable 2 tablets";
+    homepage = "https://remarkable.engineering/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ tadfisher ];
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9066,6 +9066,8 @@ in
 
   remarkable-toolchain = callPackage ../development/tools/misc/remarkable/remarkable-toolchain { };
 
+  remarkable2-toolchain = callPackage ../development/tools/misc/remarkable/remarkable2-toolchain { };
+
   tacacsplus = callPackage ../servers/tacacsplus { };
 
   tamarin-prover =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add the SDK for the reMarkable 2 tablet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
