### PR TITLE
texmacs: 1.99.13 -> 1.99.14

### DIFF
--- a/pkgs/applications/editors/texmacs/default.nix
+++ b/pkgs/applications/editors/texmacs/default.nix
@@ -16,7 +16,7 @@
 
 let
   pname = "TeXmacs";
-  version = "1.99.13";
+  version = "1.99.14";
   common = callPackage ./common.nix {
     inherit tex extraFonts chineseFonts japaneseFonts koreanFonts;
   };
@@ -26,21 +26,8 @@ mkDerivation {
 
   src = fetchurl {
     url = "https://www.texmacs.org/Download/ftp/tmftp/source/TeXmacs-${version}-src.tar.gz";
-    sha256 = "Aq0cS47QqmFQHelxRjANeJlgXCXagnYRykpAq7wHqbQ=";
+    sha256 = "1zbl1ddhppgnn3j213jl1b9mn8zmwnknxiqswm25p4llj0mqcgna";
   };
-
-  patches = [
-    # Minor patch for Qt 5.15 support, should be included in next release.
-    (fetchpatch {
-      url = "https://github.com/texmacs/texmacs/commit/3cf56af92326b74538f5e943928199ba6e963d0b.patch";
-      sha256 = "+OBQmnKgvQZZkLx6ea773Dwq0o7L92Sex/kcVUhmg6Q=";
-    })
-    # Fix returned version, lets hope they remember to bump the version next release.
-    (fetchpatch {
-      url = "https://github.com/texmacs/texmacs/commit/da5b67005d2fc31bb32ea1ead882c26af12d8cbb.patch";
-      sha256 = "czMgdraQErrdvN83jY76P673L52BpQkDwntmKvF0Ykg=";
-    })
-  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/texmacs/texmacs/releases/tag/v1.99.14

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The texmacs GUI works well for me.