### PR TITLE
ocamlPackages.mirage: init at 3.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-unix/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-unix/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "mirage-unix";
   version = "4.0.0";
 
+  useDune2 = true;
+
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
     sha256 = "0kyd83bkpjhn382b4mw3a4325xr8vms78znxqvifpcyfvfnlx7hj";

--- a/pkgs/development/ocaml-modules/mirage/default.nix
+++ b/pkgs/development/ocaml-modules/mirage/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, ocaml
+, functoria, mirage-runtime
+}:
+
+buildDunePackage rec {
+  pname = "mirage";
+  inherit (mirage-runtime) version src;
+
+  useDune2 = true;
+
+  outputs = [ "out" "dev" ];
+
+  propagatedBuildInputs = [ functoria mirage-runtime ];
+
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix=$out --libdir=$dev/lib/ocaml/${ocaml.version}/site-lib/ ${pname}
+    runHook postInstall
+  '';
+
+  meta = mirage-runtime.meta // {
+    description = "The MirageOS library operating system";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/mirage/runtime.nix
+++ b/pkgs/development/ocaml-modules/mirage/runtime.nix
@@ -5,6 +5,8 @@ buildDunePackage rec {
   pname = "mirage-runtime";
   version = "3.9.0";
 
+  useDune2 = true;
+
   minimumOCamlVersion = "4.08";
 
   src = fetchurl {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -539,6 +539,8 @@ let
 
     minisat = callPackage ../development/ocaml-modules/minisat { };
 
+    mirage = callPackage ../development/ocaml-modules/mirage { };
+
     mirage-block = callPackage ../development/ocaml-modules/mirage-block { };
 
     mirage-bootvar-unix = callPackage ../development/ocaml-modules/mirage-bootvar-unix { };


### PR DESCRIPTION
###### Motivation for this change

#23955 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
