### PR TITLE
gnumake: --disable-posix-spawn

### DIFF
--- a/pkgs/development/tools/build-managers/gnumake/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/default.nix
@@ -33,7 +33,12 @@ stdenv.mkDerivation {
     # a second. So, tell Make to ignore nanoseconds in mtime here by
     # overriding the autoconf test for the struct.
     # See https://github.com/NixOS/nixpkgs/issues/51221 for discussion.
-    ++ stdenv.lib.optional stdenv.isDarwin "ac_cv_struct_st_mtim_nsec=no";
+    ++ stdenv.lib.optional stdenv.isDarwin "ac_cv_struct_st_mtim_nsec=no"
+
+    # Disable use of posix_spawn breaking on-device builds in Nix-on-Droid,
+    # which currently piggy-backs on regular aarch64 nixpkgs builds.
+    # https://discourse.nixos.org/t/9875
+    ++ [ "--disable-posix-spawn" ];
 
   outputs = [ "out" "man" "info" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Side-stepping a problem with Nix-on-Droid.

Disables use of posix_spawn breaking on-device builds in Nix-on-Droid,
which currently piggy-backs on regular aarch64 nixpkgs builds.
https://discourse.nixos.org/t/9875

I understand this is a long shot, and generally not a very sane request,
but I'm desperate for options, and maybe it isn't that bad after all.

I'll totally understand if this won't be merged, but I thought it won't hurt to ask.

@vrthra


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
