### PR TITLE
[WIP] gimp: 2.10.22 -> 2.99.2

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -3,19 +3,22 @@
 , fetchurl
 , substituteAll
 , autoreconfHook
+, appstream-glib
 , pkgconfig
 , intltool
 , babl
 , gegl
-, gtk2
+, gtk3
 , glib
 , gdk-pixbuf
+, gobject-introspection
 , isocodes
 , pango
 , cairo
 , freetype
 , fontconfig
 , lcms
+, libarchive
 , libpng
 , libjpeg
 , poppler
@@ -38,6 +41,7 @@
 , libmypaint
 , gexiv2
 , harfbuzz
+, vala
 , mypaint-brushes1
 , libwebp
 , libheif
@@ -52,13 +56,13 @@ let
   python = python2.withPackages (pp: [ pp.pygtk ]);
 in stdenv.mkDerivation rec {
   pname = "gimp";
-  version = "2.10.22";
+  version = "2.99.2";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "http://download.gimp.org/pub/gimp/v${lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
-    sha256 = "1fqqyshakvdarf1jipk2n33ibqr23ni22z3d8srq13bpydblpf1d";
+    sha256 = "0wxfqglxlnzablc7vhxzirwb04myyx3g4sv8sslszfhvb2hrkp1r";
   };
 
   patches = [
@@ -71,7 +75,7 @@ in stdenv.mkDerivation rec {
 
     # Use absolute paths instead of relying on PATH
     # to make sure plug-ins are loaded by the correct interpreter.
-    ./hardcode-plugin-interpreters.patch
+    #./hardcode-plugin-interpreters.patch
   ];
 
   nativeBuildInputs = [
@@ -80,12 +84,16 @@ in stdenv.mkDerivation rec {
     intltool
     gettext
     makeWrapper
+    vala
   ];
 
   buildInputs = [
+    gobject-introspection
+    appstream-glib
+    libarchive
     babl
     gegl
-    gtk2
+    gtk3
     glib
     gdk-pixbuf
     pango
@@ -167,7 +175,7 @@ in stdenv.mkDerivation rec {
     targetScriptDir = "share/gimp/${majorVersion}/scripts";
 
     # probably its a good idea to use the same gtk in plugins ?
-    gtk = gtk2;
+    gtk = gtk3;
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
https://www.gimp.org/news/2020/11/06/gimp-2-99-2-released/

waiting on gegl-0.4 to do another release
```
Error: GIMP configuration failed.

  - Error: missing dependency gegl-0.4 >= 0.4.27
```
but the latest release is still 0.4.26 https://download.gimp.org/pub/gegl/0.4/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
