### PR TITLE
Kicad: 5.1.6 -> 5.1.8

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -55,17 +55,6 @@ stdenv.mkDerivation rec {
 
   src = kicadSrc;
 
-  # quick fix for #72248
-  # should be removed if a a more permanent fix is published
-  patches = [
-    (
-      fetchpatch {
-        url = "https://github.com/johnbeard/kicad/commit/dfb1318a3989e3d6f9f2ac33c924ca5030ea273b.patch";
-        sha256 = "00ifd3fas8lid8svzh1w67xc8kyx89qidp7gm633r014j3kjkgcd";
-      }
-    )
-  ];
-
   # tagged releases don't have "unknown"
   # kicad nightlies use git describe --dirty
   # nix removes .git, so its approximated here

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -212,11 +212,10 @@ stdenv.mkDerivation rec {
 
   # why does $makeWrapperArgs have to be added explicitly?
   # $out and $program_PYTHONPATH don't exist when makeWrapperArgs gets set?
-  # kicad-ogltest's source seems to indicate that crashing is expected behaviour...
   installPhase =
     let
       tools = [ "kicad" "pcbnew" "eeschema" "gerbview" "pcb_calculator" "pl_editor" "bitmap2component" ];
-      utils = [ "dxf2idf" "idf2vrml" "idfcyl" "idfrect" "kicad2step" "kicad-ogltest" ];
+      utils = [ "dxf2idf" "idf2vrml" "idfcyl" "idfrect" "kicad2step" ];
     in
     (concatStringsSep "\n"
       (flatten [

--- a/pkgs/applications/science/electronics/kicad/update.sh
+++ b/pkgs/applications/science/electronics/kicad/update.sh
@@ -110,7 +110,7 @@ for version in "${all_versions[@]}"; do
     echo "Checking src" >&2
     src_rev="$(${get_rev} "${gitlab}"/code/kicad.git "${version}" | cut -f1)"
     has_rev="$(grep -sm 1 "\"${pname}\"" -A 4 "${file}" | grep -sm 1 "${src_rev}" || true)"
-    has_hash="$(grep -sm 1 "\"${pname}\"" -A 5 "${file}" | grep -sm 1 "sha256")"
+    has_hash="$(grep -sm 1 "\"${pname}\"" -A 5 "${file}" | grep -sm 1 "sha256" || true)"
     if [[ -n ${has_rev} && -n ${has_hash} && -z ${clean} ]]; then
       echo "Reusing old ${pname}.src.sha256, already latest .rev" >&2
       grep -sm 1 "\"${pname}\"" -A 5 "${file}" | grep -sm 1 "rev" -A 1
@@ -130,7 +130,7 @@ for version in "${all_versions[@]}"; do
         echo "Checking i18n" >&2
         i18n_rev="$(${get_rev} "${i18n}" "${version}" | cut -f1)"
         has_rev="$(grep -sm 1 "\"${pname}\"" -A 11 "${file}" | grep -sm 1 "${i18n_rev}" || true)"
-        has_hash="$(grep -sm 1 "\"${pname}\"" -A 12 "${file}" | grep -sm 1 "i18n.sha256")"
+        has_hash="$(grep -sm 1 "\"${pname}\"" -A 12 "${file}" | grep -sm 1 "i18n.sha256" || true)"
         if [[ -n ${has_rev} && -n ${has_hash} && -z ${clean} ]]; then
           echo "Reusing old kicad-i18n-${today}.src.sha256, already latest .rev" >&2
           grep -sm 1 "\"${pname}\"" -A 12 "${file}" | grep -sm 1 "i18n" -A 1
@@ -146,7 +146,7 @@ for version in "${all_versions[@]}"; do
             url="${gitlab}/libraries/kicad-${lib}.git"
             lib_rev="$(${get_rev} "${url}" "${version}" | cut -f1 | head -n1)"
             has_rev="$(grep -sm 1 "\"${pname}\"" -A 19 "${file}" | grep -sm 1 "${lib_rev}" || true)"
-            has_hash="$(grep -sm 1 "\"${pname}\"" -A 20 "${file}" | grep -sm 1 "${lib}.sha256")"
+            has_hash="$(grep -sm 1 "\"${pname}\"" -A 20 "${file}" | grep -sm 1 "${lib}.sha256" || true)"
             if [[ -n ${has_rev} && -n ${has_hash} && -z ${clean} ]]; then
               echo "Reusing old kicad-${lib}-${today}.src.sha256, already latest .rev" >&2
               grep -sm 1 "\"${pname}\"" -A 20 "${file}" | grep -sm 1 "${lib}" -A 1

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,25 +3,25 @@
 {
   "kicad" = {
     kicadVersion = {
-      version = "5.1.6";
+      version =			"5.1.7";
       src = {
-        rev = "c6e7f7de7df655fd59b57823499efc443009de6b";
-        sha256 = "1pa3z0h0679jmgxlzc833h6q85b5paxdp69kf2h93vkaryj58622";
+        rev =			"a382d34a883a5bf4250e86ec4bc390aa0a385012";
+        sha256 =		"1gjh0rny4pw52kpljfim51sivs8x1cvy11hx1isgp4dsn2zdwg95";
       };
     };
     libVersion = {
-      version = "5.1.6";
+      version =			"5.1.7";
       libSources = {
-        i18n.rev = "5ad171ce5c8d90f4740517c2adecb310d8be51bd";
-        i18n.sha256 = "0qryi8xjm23ka363zfl7bbga0v5c31fr3d4nyxp3m168vkv9zhha";
-        symbols.rev = "5150eaa2a7d15cfc6bb1459c527c4ebaa66d7708";
-        symbols.sha256 = "12w3rdy085drlikkpb27n9ni7cyg9l0pqy7hnr86cxjcw3l5wcx6";
-        templates.rev = "9213d439f757e6049b7e54f3ea08272a0d0f44a9";
-        templates.sha256 = "1hppcsrkn4dk6ggby6ckh0q65qxkywrbyxa4lwpaf7pxjyv498xg";
-        footprints.rev = "a61b4e49762fb355f654e65a1c7db1aaf7bb2332";
-        footprints.sha256 = "1kmf91a5mmvj9izrv40mkaw1w36yjgn8daczd9rq2wlmd0rdp1zx";
-        packages3d.rev = "150ff1caf0b01dc04c84f4f966f4f88fedfa8f8c";
-        packages3d.sha256 = "0b9jglf77fy0n0r8xs4yqkv6zvipyfvp0z5dnqlzp32csy5aqpi1";
+        i18n.rev =		"d24af2da8cab4ce1081c401909a4a880514e5549";
+        i18n.sha256 =		"0r0sv52k84sw4jxf10lrmzwmn58d2fv5h57fdrspnmvnh10q63xf";
+        symbols.rev =		"bf475af94877e8fd9cf80e667578ff61835e02bb";
+        symbols.sha256 =	"1ii3r813653ng2ycggnknqx4g3ja7dbm4qyxrf9aq48ws0xkvhx3";
+        templates.rev =		"1ccbaf3704e8ff4030d0915f71e051af621ef7d7";
+        templates.sha256 =	"1a8xfcbdbb4ylrb5m7n2jjk9kwvgmlx1pmnn2cwj327a2b3m4jjs";
+        footprints.rev =	"302ac78bac21825532f970fb92714fa5973ad79b";
+        footprints.sha256 =	"0gyqxryda273hjn2rv8dha461j9bjh054y5dlpiw1wiha65lrf9i";
+        packages3d.rev =	"7abe02f30fd79b8f4f66c01589861df7f8f72f04";
+        packages3d.sha256 =	"1szcin52fcsyb55bj7xq7lz6ig187dpz3lk7blwab7b9c4dn3c3y";
       };
     };
   };

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,17 +3,17 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"5.1.7";
+      version =			"5.1.8";
       src = {
-        rev =			"a382d34a883a5bf4250e86ec4bc390aa0a385012";
-        sha256 =		"1gjh0rny4pw52kpljfim51sivs8x1cvy11hx1isgp4dsn2zdwg95";
+        rev =			"db9833491010954bc27fac92c83d2864bd95c23c";
+        sha256 =		"08ni9j2lw2hjc1csk6rkydcxwdal6da17ch60zkjij5vfsif2hix";
       };
     };
     libVersion = {
-      version =			"5.1.7";
+      version =			"5.1.8";
       libSources = {
-        i18n.rev =		"d24af2da8cab4ce1081c401909a4a880514e5549";
-        i18n.sha256 =		"0r0sv52k84sw4jxf10lrmzwmn58d2fv5h57fdrspnmvnh10q63xf";
+        i18n.rev =		"78adcd19e7ed53f4889d6db65a33dd8ec2d323e9";
+        i18n.sha256 =		"0x0w2m6d3xfm22y4anp5j2j67iwzby149ynj6qjlw2kcsi8kwk1j";
         symbols.rev =		"bf475af94877e8fd9cf80e667578ff61835e02bb";
         symbols.sha256 =	"1ii3r813653ng2ycggnknqx4g3ja7dbm4qyxrf9aq48ws0xkvhx3";
         templates.rev =		"1ccbaf3704e8ff4030d0915f71e051af621ef7d7";

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -27,17 +27,17 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2020-10-09";
+      version =			"2020-11-07";
       src = {
-        rev =			"560428a70f0196fb4ade620042c5ddefc1685ebe";
-        sha256 =		"0rzn83bpl06v1d49lcvwfg93nirn684bqqq536zxhmjm0ayx29ka";
+        rev =			"9454f9df9245aea037d1ad5baf050c2d9101159c";
+        sha256 =		"03bd0dk234ihqnwrv4n40gi856xcjqgxplfwjzlwcq521gwykv30";
       };
     };
     libVersion = {
-      version =			"2020-10-09";
+      version =			"2020-11-07";
       libSources = {
-        i18n.rev =		"d24af2da8cab4ce1081c401909a4a880514e5549";
-        i18n.sha256 =		"0r0sv52k84sw4jxf10lrmzwmn58d2fv5h57fdrspnmvnh10q63xf";
+        i18n.rev =		"e89d9a89bec59199c1ade56ee2556591412ab7b0";
+        i18n.sha256 =		"04zaqyhj3qr4ymyd3k5vjpcna64j8klpsygcgjcv29s3rdi8glfl";
         symbols.rev =		"9c50f4333bafc5a1abf7786436db5ffb6a66758d";
         symbols.sha256 =	"06ic59svz0256isy93863i5ay4k8wshvp1kspnqrc776wmq03l3k";
         templates.rev =		"41eae4ccd3ac02fdb969e3aa272c07ab51dcf5af";


### PR DESCRIPTION
includes and closes #99201

###### Motivation for this change
a new release

###### Things done

- fix update.sh to be able to generate versions.nix from scratch again
- update all versions to the latest revision
  - includes bumping kicad-unstable to the latest revision at the time

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - before `/nix/store/bszi8bh2nyaw1njljihxj46ywps46zc4-kicad-5.1.6	 6662184496`
  - after `/nix/store/5ncgzbr4szv9c7rfy75wcxyvp8nwj01b-kicad-5.1.8	 6786043024`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/marvin opt-in
/status needs_reviewer