### PR TITLE
ssmsh: init at 1.4.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2011,6 +2011,16 @@
     githubId = 49904992;
     name = "Dawid Sowa";
   };
+  dbirks = {
+    email = "david@birks.dev";
+    github = "dbirks";
+    githubId = 7545665;
+    name = "David Birks";
+    keys = [{
+      longkeyid = "ed25519/0xBB999F83D9A19A36";
+      fingerprint = "B26F 9AD8 DA20 3392 EF87  C61A BB99 9F83 D9A1 9A36";
+    }];
+  };
   dbohdan = {
     email = "dbohdan@dbohdan.com";
     github = "dbohdan";

--- a/pkgs/tools/admin/ssmsh/default.nix
+++ b/pkgs/tools/admin/ssmsh/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "ssmsh";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "bwhaley";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0rvvawn4cavqhbrrp616mi5ipn4q6j22227h4rbjh0zxdlna23gm";
+  };
+
+  vendorSha256 = "127xni0i7w42075bspmm5r61j858i1p59jr2ib8f9r1pbizh63xw";
+
+  doCheck = true;
+
+  buildFlagsArray = [ "-ldflags=-w -s -X main.Version=${version}" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/bwhaley/ssmsh";
+    description = "An interactive shell for AWS Parameter Store";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dbirks ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2515,6 +2515,8 @@ in
 
   socklog = callPackage ../tools/system/socklog { };
 
+  ssmsh = callPackage ../tools/admin/ssmsh { };
+
   stagit = callPackage ../development/tools/stagit { };
 
   starboard = callPackage ../applications/networking/cluster/starboard { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Adding a tool that I started using recently. It allows you to browse and edit AWS Parameter Store, kind of in the same way as you would move around in a filesystem (with `cd`, `ls`, `mv`, `rm`). I've found it quite handy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
