### PR TITLE
haskell: Add hoogle option to developPackage

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -5,7 +5,7 @@
  */
 let
 
-  inherit (import ./fixed-points.nix {}) makeExtensible;
+  inherit (import ./fixed-points.nix { inherit lib; }) makeExtensible;
 
   lib = makeExtensible (self: let
     callLibs = file: import file { lib = self; };
@@ -69,7 +69,7 @@ let
       importJSON importTOML warn info showWarnings nixpkgsVersion version mod compare
       splitByAndCompare functionArgs setFunctionArgs isFunction toHexString toBaseDigits;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
-      makeExtensible makeExtensibleWithCustomName;
+      composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
       filterAttrsRecursive foldAttrs collect nameValuePair mapAttrs

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ lib, ... }:
 rec {
   # Compute the fixed point of the given function `f`, which is usually an
   # attribute set that expects its final, non-recursive representation as an
@@ -76,6 +76,15 @@ rec {
       let fApplied = f self super;
           super' = super // fApplied;
       in fApplied // g self super';
+
+  # Compose several extending functions of the type expected by 'extends' into
+  # one where changes made in preceding functions are made available to
+  # subsequent ones.
+  #
+  # composeManyExtensions : [packageSet -> packageSet -> packageSet] -> packageSet -> packageSet -> packageSet
+  #                          ^final        ^prev         ^overrides     ^final        ^prev         ^overrides
+  composeManyExtensions =
+    lib.foldr (x: y: composeExtensions x y) (self: super: {});
 
   # Create an overridable, recursive attribute set. For example:
   #

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -87,6 +87,26 @@ runTests {
     expected = true;
   };
 
+  testComposeManyExtensions0 = {
+    expr = let obj = makeExtensible (self: { foo = true; });
+               emptyComposition = composeManyExtensions [];
+               composed = obj.extend emptyComposition;
+           in composed.foo;
+    expected = true;
+  };
+
+  testComposeManyExtensions =
+    let f = self: super: { bar = false; baz = true; };
+        g = self: super: { bar = super.baz or false; };
+        h = self: super: { qux = super.bar or false; };
+        obj = makeExtensible (self: { foo = self.qux; });
+    in {
+    expr = let composition = composeManyExtensions [f g h];
+               composed = obj.extend composition;
+           in composed.foo;
+    expected = (obj.extend (composeExtensions f (composeExtensions g h))).foo;
+  };
+
   testBitAnd = {
     expr = (bitAnd 3 10);
     expected = 2;

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -228,6 +228,9 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
     # optional set of arbitrary overrides, and an optional haskell package
     # modifier, return a derivation appropriate for nix-build or nix-shell to
     # build that package.
+    # If 'returnShellEnv' is true this returns a derivation which will give you
+    # an environment suitable for developing the listed packages with an
+    # incremental tool like cabal-install.
     developPackage =
       { root
       , name ? builtins.baseNameOf root
@@ -245,6 +248,13 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
 
     ghcWithPackages = selectFrom: withPackages (selectFrom self);
 
+    # Put 'hoogle' into the derivation's PATH with a database containing all
+    # the package's dependencies; run 'hoogle server --local' in a shell to
+    # host a search engine for the dependencies.
+    #
+    # To reload the Hoogle server automatically on .cabal file changes try
+    # this:
+    # echo *.cabal | entr -r -- nix-shell --run 'hoogle server --local'
     ghcWithHoogle = selectFrom:
       let
         packages = selectFrom self;


### PR DESCRIPTION
Also add `composeExtensionss` to lib.

This seems to be a sensible way of getting `ghcWithHoogle` into the mix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
