### PR TITLE
haskell: Add documentationTarball to lib

### DIFF
--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -232,6 +232,31 @@ rec {
     fixupPhase = ":";
   });
 
+  /* Create a documentation tarball suitable for uploading to Hackage instead
+     of building the package.
+   */
+  documentationTarball = pkg:
+    pkgs.lib.overrideDerivation pkg (drv: {
+      name = "${drv.name}-docs";
+      # Like sdistTarball, disable the "doc" output here.
+      outputs = [ "out" ];
+      buildPhase = ''
+        runHook preHaddock
+        ./Setup haddock --for-hackage
+        runHook postHaddock
+      '';
+      haddockPhase = ":";
+      checkPhase = ":";
+      installPhase = ''
+        runHook preInstall
+        mkdir -p "$out"
+        tar --format=ustar \
+          -czf "$out/${drv.name}-docs.tar.gz" \
+          -C dist/doc/html "${drv.name}-docs"
+        runHook postInstall
+      '';
+    });
+
   /* Use the gold linker. It is a linker for ELF that is designed
      "to run as fast as possible on modern systems"
    */

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -23,6 +23,7 @@ with pkgs;
   stdenv-inputs = callPackage ./stdenv-inputs { };
 
   haskell-shellFor = callPackage ./haskell-shellFor { };
+  haskell-documentationTarball = callPackage ./haskell-documentationTarball { };
 
   cc-multilib-gcc = callPackage ./cc-wrapper/multilib.nix { stdenv = gccMultiStdenv; };
   cc-multilib-clang = callPackage ./cc-wrapper/multilib.nix { stdenv = clangMultiStdenv; };

--- a/pkgs/test/haskell-documentationTarball/default.nix
+++ b/pkgs/test/haskell-documentationTarball/default.nix
@@ -1,0 +1,17 @@
+{ pkgs, haskellPackages }:
+
+let
+  drv = haskellPackages.vector;
+  docs = pkgs.haskell.lib.documentationTarball drv;
+
+in pkgs.runCommand "test haskell.lib.documentationTarball" { } ''
+  tar xvzf "${docs}/${drv.name}-docs.tar.gz"
+
+  # Check for Haddock html
+  find "${drv.name}-docs" | grep -q "Data-Vector.html"
+
+  # Check for source html
+  find "${drv.name}-docs" | grep -q  "src/Data.Vector.html"
+
+  touch "$out"
+''


### PR DESCRIPTION
##### Motivation for this change

It's nice to be able to build this kind of thing with nix.

I've been using something similar for a few weeks without issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
