### PR TITLE
[20.09] thunderbird, thunderbird-bin: 78.4.0 -> 78.4.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.4.0";
+  version = "78.4.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/af/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/af/thunderbird-78.4.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "589fe4c9a7ceffb4d027f493e0b074647bb958a62046deef5b8268fd43e6aae9";
+      sha256 = "36268a7fe6ec5a0ea0243f83ffbd73204d5c4ef257b0c8857a50428304b2d4c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ar/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ar/thunderbird-78.4.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "b94d46899a7458f9c94849db71975e0028004bf93d5b0695a454fbac24a41ec6";
+      sha256 = "831e70f807f05ce2f82bb11db35d05ed80dac53ad00c12ff6e191a627d0d42d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ast/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ast/thunderbird-78.4.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "c6057f5e2937a05f84decc3c2f26de4555314c627210a961882773b2c745ddbf";
+      sha256 = "e6efde72ce7aeeda5f7c6d7cc0f3a08265c44546a0f8fc84a2adbc11cc038601";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/be/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/be/thunderbird-78.4.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "94d7bd38e35745f4829abe6cf3ada8e947a2df881dcb1e5f6ef823bbd6e0aa75";
+      sha256 = "07fe33390caf37a96c000e0f5435d07711f7a95dbe04f85a222b17ae5a13f1bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/bg/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/bg/thunderbird-78.4.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "d482c6a6873ddb34dc49002b8ecac94e82579fde7d24514500f2de28fc777e18";
+      sha256 = "d460e201cbe4a1d6548a52121a33c2aaa7cbbf0e126fa1c4e8a431423424fb9e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/br/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/br/thunderbird-78.4.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "18fc5e174942874ecc41838451aec780485a263584121decfb9f9607ee35322c";
+      sha256 = "9e85928f1145391d9c3f238612b93e6344a2ad5e6179bf09502b1b69c8ad1b03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ca/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ca/thunderbird-78.4.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "269762ee175f69ecc9ffdeab2ad66788d24d2b9ba1e8d05f74ff222848077735";
+      sha256 = "1516236c252f22933adf23bfe93d73fa272a4574deb674aef6e1f35006a6cc50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/cak/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/cak/thunderbird-78.4.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "735baa9541d1dfad828db27a2cba54caa681973f792c0712300e4f952803dbfb";
+      sha256 = "c46508321d32c468d067d86c04973ca345b09b0e983954eaa123d02778d61fbd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/cs/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/cs/thunderbird-78.4.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "04763e1461106c76b51c31522de9bd6376d531c9f93e79d4a4c00d5bacb9de29";
+      sha256 = "227209429c07238f38d334e5ac8a5fd895a4c87f51b21b4376df89c50bb6a789";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/cy/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/cy/thunderbird-78.4.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "974885f8e17be1b744f65c0e392747921508d7e0f286ab9fa20580cc205a56ee";
+      sha256 = "b272926205e5470df8aec8b22d6733e4f47993e76123fe81d4be26ad5a153062";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/da/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/da/thunderbird-78.4.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "f0e13b8952478b5ebc46552405421b796d645fbb0a16aa759a045b48fd43739d";
+      sha256 = "13f9fe10c84d2b8d8d0215cb58a9852486741f5bc8c6979f0a701bef14a70f4f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/de/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/de/thunderbird-78.4.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "735eb8e1d318e09d9dca6560074960cf9ce2fcd5a720754608886f6e51e87266";
+      sha256 = "590f9a5a975544d2effedda942e3989a13be23b95f4e6707f9905fed3fc08214";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/dsb/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/dsb/thunderbird-78.4.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "b1b5fad405049cc62784dbb6e938cce6492df3b620c25a0987a594a88d0caaa1";
+      sha256 = "5b572c847f9ec76b25c225652c23ecf8c56523ffc3071b437310f0d8f9049b05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/el/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/el/thunderbird-78.4.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "1bb01c5fa05d3dae7d1216a0b3e01354655e96f728f63b8213d1ac4ca08e5b8e";
+      sha256 = "7cad76ea5a07dce6bdd3db78485f83a998ff27037f8ca68f8617659a06910a05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/en-CA/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/en-CA/thunderbird-78.4.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "cc7280af5ca21c82ae8e4fbcceac117b1b3c2a2e95db418cd60322161eeaa0ba";
+      sha256 = "f261b38fbc8d83c20be63015a444644a95f7d8b6584fcfc193145abcc69a4164";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/en-GB/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/en-GB/thunderbird-78.4.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "6bf5112867c3493df18880858e483b684946b657bd10960f55a0e55bc364d8a5";
+      sha256 = "5c0c364b1408182c0cbae1c2d05041781e2e4f3a17fb1735d61196c9b647dba4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/en-US/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/en-US/thunderbird-78.4.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "24780daa2b17799f263a6c16b770b0e6710d14f7f1f502f4868fe48d81ca8e48";
+      sha256 = "a152c3b8c6ad4ba3a92a8a1f909b99599d8c3ded62b57e9721fb333b47f6509d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/es-AR/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/es-AR/thunderbird-78.4.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "ac6e82b950f6cd0d7a964815c58a28f602580813ce29cb33bfcde36205d06def";
+      sha256 = "dc06a64e0b20dd174d6158e5d2f393bf6a6907f8f515120220bb2a8480f58d1c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/es-ES/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/es-ES/thunderbird-78.4.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "67a03e3c7b00d5e0953ae9eae031ddb42337e23ff9e65ed7c0b759e1c2fa4426";
+      sha256 = "7d3b7ff0ffb9b19f10bd7c2cffb5dbff8216c65c01fd4032ba5b7924c73ce343";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/et/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/et/thunderbird-78.4.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "fe5af4823e15422da39c49c3fed60fe460ad23b7c78f6b4fc85ce247a09cd0a8";
+      sha256 = "a9a8e610bc1c696137ee650fa11f2cbf8dece4ba32d1f0961ae697f6433cf1b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/eu/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/eu/thunderbird-78.4.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "94699170301daed68a6d8554816c37cc8c51d72fbd1642cc5a066ae4d5a394b2";
+      sha256 = "6835e8459b4191cd4bb5ae8011d032d475631e7a532450b98f0b087ed0a80fb6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/fa/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/fa/thunderbird-78.4.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "fd22c75cb11bf3fe1a3d2faec1cb7a2332131ac62324bffdd51cc8f03e95a372";
+      sha256 = "7cfd8681a7ed38364a823881fbb42af8cf33d17bf911e9f5b97dd18102b412f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/fi/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/fi/thunderbird-78.4.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "df3632903e77b9eb5fda1ff1d8a155b1f3c4861a8821efeb1fef4d39878a9349";
+      sha256 = "8c84662afb60e3dc94eace5a493f7feef6598b78613fe99f195408e4ee2b0a11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/fr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/fr/thunderbird-78.4.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "5100b9facddae8451550fa0a65b9bd345066e7e465916ed3728b40cc9ac06e65";
+      sha256 = "24449816c690757b05d1913ff1fa12eed47f316ac13c76a195ae0628c6950da0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/fy-NL/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/fy-NL/thunderbird-78.4.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "40c7fe9bea5b5edc5a3e62f7d1cf18ae036544c0172954440d036086f90ee119";
+      sha256 = "9a0334f032333eda16cdabd5dffb05f5a22edb1dcf4bcd0b47495defd0d9f3dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ga-IE/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ga-IE/thunderbird-78.4.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "4ec2f91ba73d3a7ab99d69af2a7d99cfb2280c3872fd4dcd7436ae9362586d06";
+      sha256 = "33e5a54e2259984ff29d3394fe936b5af8830e489e0775ff36eace4c6b3dc145";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/gd/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/gd/thunderbird-78.4.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "f6d168939a0157c2d450c43d818005e3b9a59e8caad5796492e8078947234b29";
+      sha256 = "b91c4b3aafa2166cd27c52977711c55aa425f68c5f7cca64be1dd07fd533bc05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/gl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/gl/thunderbird-78.4.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "2fb6b4995f722e82503bf88fbb3b5275faa4d392bfa5832735ac1d40bbe3ee38";
+      sha256 = "d1c03b3b92bef4f3c94518981cf99840944c8a36aab7b2cfe3f72f1f0e57e045";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/he/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/he/thunderbird-78.4.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "70f0bf4db60ad4f1656f0aca1575fadce3a697634f60353bc3d63e3336225d2f";
+      sha256 = "7fdaf0e83eeb39b66a6d1c2600f2c6f1b69ec4f67dd7b33a39132e838a699f06";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/hr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/hr/thunderbird-78.4.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "d37ac64cd63a4cd66fff1bd30ee3643be75cb977581f2182a95c27a16607f3a0";
+      sha256 = "4ba99eaa25964bde6108eeab702b096ba50b45d8db7e36f3203b0a71cc1e30cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/hsb/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/hsb/thunderbird-78.4.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "85e823db225258e9f74e04c61faa89e7c9553445900083f22b7aceb22ef3d901";
+      sha256 = "187a5f2b2e1b16fad948356f31b2ac903fe318432d9a3f105055c23d1225d11b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/hu/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/hu/thunderbird-78.4.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "da897b48a2e4a5a3734016ef18c503864792d5c0943bcb2644c272c1a7c63f16";
+      sha256 = "8f6b79692143e6e27cc844985366004d06c8e55184a73477fd20020575947ad8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/hy-AM/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/hy-AM/thunderbird-78.4.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "dbe1276b14b5864be5fc2de3708ea320d2dcc80eb654e9bad56950f818903484";
+      sha256 = "4066683e4a635b163b9b14e1921d834b37a95cee8dd04fc6885094c5e0394dee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/id/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/id/thunderbird-78.4.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "86c7be9b6385ef437323069a7e2497b3a18a552af9d9c4523789be4ee2e07b22";
+      sha256 = "1fed6d3a9a11d303db2f2c6f7a92639b92ca144ce3b45eed4607696ea4617511";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/is/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/is/thunderbird-78.4.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "8e062c75b579d52d1a887d2165bcd3eb1d0c4e435dffc05d0d76d4404dd061eb";
+      sha256 = "a627c95d2284b4e828a466865aa19262aa84a1a2267235c3f62d13c52081c580";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/it/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/it/thunderbird-78.4.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "932de1926441066a472d5e68b933fd4035f2e858fdabd4b9d4e71ee6e64202a3";
+      sha256 = "6b01e88da702deee95a3a6d526e563e854be7ae13414fed3a2c9cc427e906ffa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ja/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ja/thunderbird-78.4.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "2bacdb192fda85f10f747a8c8a2ef3bc60345075c1ba33947594fcc66eb35e5a";
+      sha256 = "3b63cf4c45945f4a40159a417ed217b77128905de82812fe2165c0c5f66410a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ka/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ka/thunderbird-78.4.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "110d71951f0f3235ab63c02e8d979b2777de4abd4906409b96107fac1f6d7466";
+      sha256 = "c9d11ae298691f2e302078f865b047b1c2b568ae763495fbfe2f2d4f04a9ef6a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/kab/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/kab/thunderbird-78.4.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "f765a32900f0100f03aac4cdce7f33abb44e53911011cef6f6db8f9dddd11124";
+      sha256 = "b6367ccb74b2ced8708ca9f4c2c06aeaaf4f3bcba0b2b2fdf2c552aa10fcfc03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/kk/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/kk/thunderbird-78.4.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "9af2ab317e0736e0dbab419f5061a6a5c83e521d15f38911455a2d57f6bae945";
+      sha256 = "99ece9975a3981fa33887d3b5d60cd6874e1dab7c51d830dc0d13c28c103ca79";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ko/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ko/thunderbird-78.4.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "06669829857f1c49acf7a58f6a7f0e5a4d8e4ce93703cde0d36525f5bb9697cb";
+      sha256 = "d81c844cbd490e5eeeb2739a9b040062baf3bbdf13ddfbceb59b5630019b935d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/lt/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/lt/thunderbird-78.4.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "f85e547d17b6bae2597d4b780b14f9076d70dc7c63ae85427b54c01f0c559b72";
+      sha256 = "56b5813a5b0debfe90fa2a20fb9a13ea210e2eed37f180f3e23e851f871241e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ms/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ms/thunderbird-78.4.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "e21639c89686480be875a0514c1b1d99fefca6b79da80a5406f37a63e316348d";
+      sha256 = "8dc3f341a69b9ef458c1203ff15779beecf3db2dede1cd8740ee19a9552f22f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/nb-NO/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/nb-NO/thunderbird-78.4.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "652d43cabbab6ab158b3d3ab70cf83d8ed3ae3524232aa340d17c248dc5fa869";
+      sha256 = "0fe431d3773de39431cd777cf301d2c3d8074dd41596bf6a6f1bef96870413b4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/nl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/nl/thunderbird-78.4.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "2c5f173545ef0ddd0c93c921931850e9a7f457575188a91d243245236fe09384";
+      sha256 = "4127bdb6338210d9928fc84838a57cfb731aa3254aa5427471deca00bb12beca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/nn-NO/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/nn-NO/thunderbird-78.4.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "f89082f26cb871befb4f8c82c31a9d1cdd5587d20ad3a9a1e78515f947ce4271";
+      sha256 = "cf0c6d67115ee36b80010d93d50991a544af332ca19f1ed1199f49c7dd125049";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/pa-IN/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/pa-IN/thunderbird-78.4.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "75d7f3bbe88ef2bab33e62834a765f814f75a28e2277afef2517a91be98201ba";
+      sha256 = "283c2be7f9bc0aa3d505f1838f1c03721a4b956870ac2b1e762b966e87767ce0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/pl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/pl/thunderbird-78.4.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "c016668ef5f80043eb3e3eff6c8d2327adc3ed86375e81318fb8a4a9fc4689bb";
+      sha256 = "4c07e4500ad4c0d698942e3c47ced3bbd6142e4a70292629ebbe53ef5f1816f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/pt-BR/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/pt-BR/thunderbird-78.4.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "637a97f3b584e315ebec350a08fa54d17cde8825385736a2bc4ca1937dd552f3";
+      sha256 = "c6ace3452d1720681e668da50d16811286c1e73021bd06ab9b538c6f6fc5fda6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/pt-PT/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/pt-PT/thunderbird-78.4.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "9719af4fc96ecc0e01f8ad4829f8a94004cdeb518d10f12deb41073f6b0d6f32";
+      sha256 = "b9ab4d38b271e2987b5e425a277042dc149794cf461283114553133e7fed5f06";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/rm/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/rm/thunderbird-78.4.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "d3467e689f512a3032f9dd8b022af58bf7d61dcdcb1c69317629f0c0b37aa2d4";
+      sha256 = "50fc69135b789b2bb5d8008292d3fc25f1a0a30bba35c6e24ddfeabe55231407";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ro/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ro/thunderbird-78.4.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "25985053e562792ffdc5757f201d6171cd7f30199eae7ae2f50cf39b5090feeb";
+      sha256 = "1e050b33a942dc815e739c57944a0d705982e18e74637172b0366a9b06916f7b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ru/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ru/thunderbird-78.4.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "2c0769be95e0a21471197a1f1b979bd36b9793f4242f7ac329c7fe0fe88fc5a3";
+      sha256 = "c295bda57db84e07f28affa4201c4f612478efce733cb9c69962f6d7a797218b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/si/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/si/thunderbird-78.4.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "2a6d7e47e92166ac1636495e5cbd1849285576cdd812d650767130730002aa6c";
+      sha256 = "63dc83cfab8be94893ca6a0d60e448d14db1afcae55192149a882456dca77e9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/sk/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sk/thunderbird-78.4.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "5d0de7356dd46a9ac1cb98254167fa7be34b6897e5ea69ca093e71a850d53363";
+      sha256 = "5ab5ea76649582ddf10fa77bbb95040d157883e0905df72f5bc0ae79167d97be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/sl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sl/thunderbird-78.4.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "8c7e69e7fbe49ba34277e8cb7cbf45eeade086eb460a92e243698824cdf3d5ce";
+      sha256 = "da3f8a30797386bc7c9ba135ba360cee01143bc76a2315e7a2223bab90e2283e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/sq/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sq/thunderbird-78.4.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "95cfe7b956bb590c790c156f22ac3c5cdc1dd3e4d7b64422583597fc9ccd8c28";
+      sha256 = "f2f9639c4b4dc4bfba476aa92814fee65ecd3fca27652177614d1107e4200246";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/sr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sr/thunderbird-78.4.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "82573f011da92f7d93d6cf0a700c9eae31a46c6d09671afa63afa533f063e5bd";
+      sha256 = "3bcad0c845e4481a22c1b330b6cd94c3c6fc46c33597ce5af0594368579a8260";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/sv-SE/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sv-SE/thunderbird-78.4.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "5fda7b6e8095bc456e684887a82cb2adcc14fdfdd9f14731f2bdf2789eac4930";
+      sha256 = "9b09d4ab71000429c5015dd8a0642cfe0eeeaa785d2cac6e876b1cd6aadaeb44";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/th/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/th/thunderbird-78.4.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "0e33b43cb7fdb2ae4c30480e264e00651181f2034af42d7a3ac2bfb57c148896";
+      sha256 = "b33e42f0271ee84a581a737513197d5f036695706b19697a53000834c199c75f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/tr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/tr/thunderbird-78.4.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "05019602190a28ecefbdc5100b40409d3d6288f076d589136724d07e111bf324";
+      sha256 = "f419ed9f0f06575da2f89486d830ab7fd2b439dcfcac92f1b31c573901e7b9ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/uk/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/uk/thunderbird-78.4.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "2940500895c734857b258550b85f846e9eb5be68b6faaf808ed7a9867c423d14";
+      sha256 = "bcecec66a6ef8b928da2aa5d52d89f4f1587d4e45bf0e836b71912b0e5a43f7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/uz/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/uz/thunderbird-78.4.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "de82b265c6e19495abc70c36f377cef705137f352da0aa7d01aa874e2a9f1f70";
+      sha256 = "2b33f40b9da386e61f3bdcacd9c16fc06dac18d2b36865292700744dfbe2da25";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/vi/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/vi/thunderbird-78.4.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "cf02606c0eff0b941c1c2ef654e250d5d6a8cb7deda752468e779af1b616c0e1";
+      sha256 = "b5d005c45221c41e1e81234b755f6a9d380220cc03f43012c40440a0378c19e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/zh-CN/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/zh-CN/thunderbird-78.4.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "54a1a869a746ff3af8d5ec27b11f1d3a0efeb49480043fbf776e9646b5be944d";
+      sha256 = "c08765cc8562cce08b4cda04123cd8672f5abb130b597f36f4c143d74b09b9b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/zh-TW/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/zh-TW/thunderbird-78.4.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "0c9530adcb5029ae570a8d25d790f243c0a3d6ad7701ed071fad326d3718bea3";
+      sha256 = "56f84ea43a5288a6cd34f8de5f69dde05737474f11c70d638981ef2ff4ea5bfa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/af/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/af/thunderbird-78.4.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "29b39333cfd9919830cecf1b0043faf4dd829c36554fdcbcff6a8dbf11882060";
+      sha256 = "95384cf3d0ab6ad8d3bb133e8ff7c1881523c0f7be840c5ab6016325ebc7f9ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ar/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ar/thunderbird-78.4.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "49896345d391f22f262592e055b2bc5fc1852d5fe1f9812392ef09b9f329afee";
+      sha256 = "c2cf87579a092bec69042b35743574872b8b791d54628c35c28d44c1dc605b6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ast/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ast/thunderbird-78.4.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "71a952590eec188661f8cf95f62efb2c9f2465aadec361c990bb62481938b128";
+      sha256 = "127ce24b2c06606e9567e2106ba5cb9628d8bda10620b01cbfe60bc287977c94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/be/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/be/thunderbird-78.4.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "d99a81043f6c158376c960d0dbd60f6d2e73ee1e6a015aee55ff42786e58fc21";
+      sha256 = "e8acd7cc25f91af91caee7487598cf1f60512864cf1fee714d2289a65f0cc195";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/bg/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/bg/thunderbird-78.4.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "1226b669b2b2e7c890a1de0a628e663069c2279369587a8b819756584be2ba0d";
+      sha256 = "461e4ec0b0f3dcb78426a99f0b8dc32b14dbc561b89e8d422433f5360425448d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/br/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/br/thunderbird-78.4.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "2f656a4269f37dd8513cf2f0b799d97225ffe55b00e778dbeedac66bf7b00d47";
+      sha256 = "ba3902a457d0570d3eeaa63cc83a67e35532e547127b71f38781158bc3cc5e60";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ca/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ca/thunderbird-78.4.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "34dcc816776f2da32bf7412a802a8d3d7a0b31afcfb1811c617f1295ced05adc";
+      sha256 = "609de3623c6f4075bedee741533843f6f9fd1afc5933fe3a8709f5c16c7d7bc5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/cak/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/cak/thunderbird-78.4.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "f9fb448edc5238b69fe3c08c665a30320e5662c1df78101ba4807d371a6a15d4";
+      sha256 = "4a5aa707eca53cf5490189a09d222abaa8290ea3366d4bf081273c23e89b3fc0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/cs/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/cs/thunderbird-78.4.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "156c36781f43fbaa3eb5d1d32ca7d6b3c9573261757dc9c78e8cf0be24a6c717";
+      sha256 = "0450c73284b274af21f3f0c4c21842e11fa2a86fcb38f96332c1ca8984149c62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/cy/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/cy/thunderbird-78.4.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "0e48e453cddf00929e189546f0dd478e273dcd8bc891fe875f553825f0b4fcc4";
+      sha256 = "5686316ec53a76dab272934dbd274a47802c5c31f2ae8719bcf85c22e12cc3f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/da/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/da/thunderbird-78.4.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "e614911f79a2a86055e6914aa0f4922979eebe4229b26b18f6ff31cc6bb49c89";
+      sha256 = "2025f5946989905fd197fe5bf6c51160e7c9d281d6cfd220ea3ee0393cc54ca0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/de/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/de/thunderbird-78.4.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "a8c916da07945657672b5b71a722485fa7117dd912896bc9eec8b9b82dfcc48b";
+      sha256 = "906e8a5de0aa12b496f4d4447df25432b11c88d79b7ab4a55291a9d65434aa03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/dsb/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/dsb/thunderbird-78.4.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "0b3ac7ec984e26b66cd3c5df733c3cac6b83f4388cd65344dc40310651798c05";
+      sha256 = "d6bfb2b790d8391344916515d1cc6ca2eb68a3e58934cacba14e77788aec6b09";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/el/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/el/thunderbird-78.4.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "dbfd90c1810dcad51bda6a7d2de6a132f428a5c6151c107cd09a98a48b2ce98d";
+      sha256 = "5f96345a945697326b24fcd73a96fa2f49edb66b02f4c23b6d392fad87935e08";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/en-CA/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/en-CA/thunderbird-78.4.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "3ccd8193d486596ebd70e3e1803563a3a8d59ca25c29eeaaeab78ab78cb0e72c";
+      sha256 = "b57e44fd16e33b178778a60f0bd47519585a3e648b3b621f1fd693836c5fb598";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/en-GB/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/en-GB/thunderbird-78.4.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "6d74ef15e0196a2b07302f40bc3992acc8ffc94ff7d90433a00d766a0840226a";
+      sha256 = "6f656dcbd7aaab5995beb11a9847e32f8820199272e2f9ce27583cd3d7e50a76";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/en-US/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/en-US/thunderbird-78.4.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "718e57f9b1d7f1ca5c52dfa8aa109f8cdda279cfb6dea649add651b6637fc6bc";
+      sha256 = "8c6bccc757df947bed74a3f7448a3885932a4f6c21d24ab6b5c7a94ab83ebae5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/es-AR/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/es-AR/thunderbird-78.4.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "26dea055b9c6ea2b8f7e15b0c93cd3d880c83bd1c9f23f8d572a92659740986a";
+      sha256 = "55bbc629ceadf359e0ad05e763a31479f6c57c38f372e55812b028681a5ff32a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/es-ES/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/es-ES/thunderbird-78.4.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "90d115cb34ae852332e5bd792067c66f1bad920721da68f59b38a2a86a8a0105";
+      sha256 = "bf30dd8882b2b35bfaa62a6c4b40a823333476128a6d5dd3e3d2c8eb16303b9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/et/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/et/thunderbird-78.4.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "a82aed816b1ea065e21120a8e6e0345c477b90f9c672c04cee9d15ffed85ef28";
+      sha256 = "5b977eab7f203e230d6a03b36afebdb32c481f1eb8129e454977791469ed5651";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/eu/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/eu/thunderbird-78.4.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "7f1bf5742159e15fd566827db713421778262377a8da9ac269fc6af635f1b20b";
+      sha256 = "f2d606a6f825640c0f344cf470d87a1dea5fc6ff538239ce25c3d7c9fc76237d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/fa/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/fa/thunderbird-78.4.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "25d97499486a7c3d38c4686f7ff5daf930694f6614d3d556af85c3cb99193403";
+      sha256 = "95d0d3d1b456c035cc6ed09df970e9e772a71af3703f05e9388e844d7f80edab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/fi/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/fi/thunderbird-78.4.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "5531179571b0306ae2c1d5f4af40047ea9a5fdf65137bc7c255ee7f5dae2bab6";
+      sha256 = "e0be2532774bbe017a6091d7e1ec79901f692c39e04e01fe4094f7c8179fbaf4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/fr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/fr/thunderbird-78.4.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "12e33246e17aebac0547801d5d4e23db0523ff260b5345b8f0a19fc5cf44f2b5";
+      sha256 = "48cc16a61958160f369b32e8a0dcd2979ee65e18efe3d1dd3a4af1109842718b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/fy-NL/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/fy-NL/thunderbird-78.4.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "50c6dff9614b113ea57d4c75dd0768a8524743a7b9f462f84f27f10daadbc1f5";
+      sha256 = "386d0a2ed01b158f0fe18eb6820ff9a17fbbea61241eaf873782271ac84eb103";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ga-IE/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ga-IE/thunderbird-78.4.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "6c6229aa064098560b13369a0d11133156d47193a8f8b2fdc241fbcba3cb3f9c";
+      sha256 = "c0c15410e6812e8652181ab347b3fe60fdce3b5b9958d54ef3f96ecc46a4d344";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/gd/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/gd/thunderbird-78.4.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "6e5f686d98b02bc97e14f5788eac7b93e5e2652e9feaab0906cb026a883b1485";
+      sha256 = "3989f0c0f87ebfca3e4cfad0ac9ca2964791ab8f1163f1bec340444ae4a72a7b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/gl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/gl/thunderbird-78.4.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "2ccde2411bb2c3e4b492b4cacbe8d756dc22c2164fbe7364bc2381c1ff582f75";
+      sha256 = "eb1b58c93e492a79f92660909e671ee7ec504701b8e074d3dc6f3d3fe3619660";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/he/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/he/thunderbird-78.4.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "30fe226741e47f86f07c5acbb8fe3d2aa2fb7102fb4743189f12612c817415c1";
+      sha256 = "f584e117ba4fbfbb7d2c28b68377a88aad87929657141adac5ce960bcf5f4fa3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/hr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/hr/thunderbird-78.4.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "4230396816f72ce2784bab21fa2fe731ea378f1ceeace609e0423e2b5e7ea83e";
+      sha256 = "633eab2f8ac99426dd85b614f04d96509125f0799c187305b7678496d9ceff0f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/hsb/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/hsb/thunderbird-78.4.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "155a4e98c597f7876ab44276ab8814ab185a5a59e1fdb743260bef2f78b27e4a";
+      sha256 = "80e4b98bbc9874de9b4c8e35633f6eea7b5707cfc4943df7264cf0bbfba49d99";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/hu/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/hu/thunderbird-78.4.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "bb0b46dc74b926e9d13c4bd8b0371d730ce03aeffa5c41689eeb797ae1ce4382";
+      sha256 = "5a9339a876a7e0dced6769a99a948329f6eaa400acb6920a24d06695120f682a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/hy-AM/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/hy-AM/thunderbird-78.4.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "7ee0ee79ac2143fe3ce8930c3916f201910d6d7a40437fdc49a8c617d49871d8";
+      sha256 = "286542d67a76a6e8f0c34e7aca9c23c8922bf85f8be77c913285e208f8b195a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/id/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/id/thunderbird-78.4.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "e1a4072dfdccfdf35401e9a58e77cbff2277703ff2c78a52fc0df801bca8f91a";
+      sha256 = "930cbbe1520c544a25cfbdf8d10b4e6ae19a812c8a20ce51053ba0d5fc2b4b24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/is/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/is/thunderbird-78.4.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "d4d63add23724c58fd92d992165748f7002540f73df591914540f6361dc0089b";
+      sha256 = "7fca3c4c9d3a309ec182d1486438973741fe2f1e39afd3ccb769256657db20a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/it/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/it/thunderbird-78.4.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "28ec9beacfb8b27b80e1f1deba83d81324a2d3baa0d9572a41a94f920c8c60aa";
+      sha256 = "3b44f63975cfe7460f3eadd9f71f13db9ded5d9e5622ec322f556692f979434b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ja/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ja/thunderbird-78.4.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "ad1f9e091cfd66683964f8d683653b3134068174daf24fe061aad00d0c864176";
+      sha256 = "1284e52cda834b1ef9b5ac6a1dc29858f6e1519d0fd47d330744c0d294338650";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ka/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ka/thunderbird-78.4.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "9074e7b2eb10943f6b87e79be9ec9ae706eeb4300c85ffe456bb34f11798b81a";
+      sha256 = "b12a79e20fce3db2541dcde61e04206e82530d1d79b58637bfcede87294fd801";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/kab/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/kab/thunderbird-78.4.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "7b7d17a26dc9914d46de8959c08d56ed92b263d3eae383ca71d45a1b37a9650f";
+      sha256 = "9766eab276e77b0e33ad7ecbf8f26b84aa2a079a4fc9e4dfc992c41074513e40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/kk/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/kk/thunderbird-78.4.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "b38db92efa1b4bc1067eeee7eaf7307d6e86e6c6d3f4dd1b81496768c981d5af";
+      sha256 = "aec202db7c28ae69c9f7684a2e4f30a16ab29ec983aacb32bbe4b5bd31b76e94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ko/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ko/thunderbird-78.4.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "951a2e6e2cae525618646f8f054d127b32a535028930eeb3be7dfd2720c4ccea";
+      sha256 = "b0e553c14925413461a87f1d81591bfa4e2ce2c5ad87e8ec609fef76ba4f17d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/lt/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/lt/thunderbird-78.4.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "5e76866c25f63aa283e54c871e1014a10e4ecdb8182ca6bc3ac1d16a344ae8f8";
+      sha256 = "6036247e3025c2b513762577e7de1d1eda050572f674c31391e583ccd16e80f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ms/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ms/thunderbird-78.4.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "74e28f4ed81a233bd8aa721515667b31e83f7a6d6bad0aaef421f1f1e4b0c4c9";
+      sha256 = "0852cb745130e22af327e2ce39249751ed482c8216c18f4545bd294f4afb4e29";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/nb-NO/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/nb-NO/thunderbird-78.4.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "4cfa6097b0879de04314773d96d3e03aee3b7e1680e97cee3dbb6fca9e4010ca";
+      sha256 = "eebec58d3a20956894711266715ce5a4afcfd44b5eb7b334dc0c22068fbb10a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/nl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/nl/thunderbird-78.4.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "e097065367e8bcaa331803c779ff71e43dfa7dcc5b516fd5d73f60b1c614c7a0";
+      sha256 = "0c6d35960d89681087bcfbf403ff727f53ba2e67de9c69d04f96b68447b616d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/nn-NO/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/nn-NO/thunderbird-78.4.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "e3bc6a3754f13db3dc5f70c3fd9b70b4250be494a47c7d20546dccb57b914ae5";
+      sha256 = "b761b921ba2e604dcde7ac0e03a83ef29a3311309cb95bc39801b8bcfd80ef98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/pa-IN/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/pa-IN/thunderbird-78.4.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "80a785335bd49d5d0e8c669a7d548c0e077c413c184eb50133aaf5790fe1148a";
+      sha256 = "fa350ad64a3ff760a6e2cc6ac6b6ad1d6b9ad300b6c3420477148152bc207499";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/pl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/pl/thunderbird-78.4.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "bc20f221babef7c3a3992d57ab5a3afcad12faa0263ff8978c96a1267af54c28";
+      sha256 = "8b187d44bc1364dc76258ff3452610483b2ab3d060c9de43e47c25fd3103c5d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/pt-BR/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/pt-BR/thunderbird-78.4.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "6dd040a2046c418d51bd7103d93a50b58e3345de5ed0c8917c0a8a8c7bf87c7c";
+      sha256 = "1ff199f91e49d72bd9821bfe3e2d33cb4a750a6c46aaf16a80554c195694ed43";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/pt-PT/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/pt-PT/thunderbird-78.4.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "45f67266e6af96dccae07d6db4f5d62c3d6d26e1a76e4951f08591c664122359";
+      sha256 = "098043202612b362a16353c84a5b9e662331c2311679357592b5a77a6690b68d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/rm/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/rm/thunderbird-78.4.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "1d53a7290332375212c0d58af23265d59502bce1a6a4629b56bc86d048be65a9";
+      sha256 = "ab9bb22e53da48744885634a14886ddb23dd5ccab376e5323824daa3f22ae0cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ro/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ro/thunderbird-78.4.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "de3e5496ce5b8c4dff6fcbcf2b8a47b0c81d026fb5334e2668b8f9fc293c5216";
+      sha256 = "fb3e61830c5693c7f3b84eb4e3c60ff97324c5654352008aabbe9f16ea40cb0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ru/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ru/thunderbird-78.4.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "838b9a02684541ef7df67a23b9966282ff9d8b12b64dfcbcfea8e8381b24951a";
+      sha256 = "f9fceef81a605ebc66fd90e2759205c4eb7160095312579eb7543b4293dd7a7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/si/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/si/thunderbird-78.4.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "202f815bdf7538d50f4770e601d10c8a1ffddb042a3c7dfd1a1b65e9b5dc5ec6";
+      sha256 = "0903c3d1bf790c5c10167839e3bc60d80a23e4230895703f7c931856cb617038";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/sk/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sk/thunderbird-78.4.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "44c5aa3723919798493e7f43c927ac48891eecf94a69c79b86be107984e9e068";
+      sha256 = "2018e5685fbcb5c2cc8925be39b04f6d98347cb59446af62846378818d6435f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/sl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sl/thunderbird-78.4.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "2d5125d9625f916788265db46ee1fb47ace3b6099dae26ecb734aecf36160949";
+      sha256 = "d20b13b5caa2f5c9c431f3e69095f094800fa520b3a5a57c27a4c9c565961fb8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/sq/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sq/thunderbird-78.4.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "2aa337b0fd8ccfe86feadef605ca863499f21c3ca7f194121064fc060d5a3de7";
+      sha256 = "164041c3958f57f90d17fe1457205a420f326c17e88da0197732435cf6a5dfca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/sr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sr/thunderbird-78.4.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "fe690670c6702ed63684eac68a3f3f29f12bd27af7d34c63af768e0362a1eb11";
+      sha256 = "8ffcd2dea1b4980519220a27346b5c0fa955b89580836c38711c21c8eb7d26c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/sv-SE/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sv-SE/thunderbird-78.4.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "74525ce44ca330e8fd29785842992c62cf3b5494675ec9a8148ea14d945fcaae";
+      sha256 = "83536011e7bfe2e7a0a760ed879e041b4caa3ee27e95829331faefd29e8deebb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/th/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/th/thunderbird-78.4.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "0503e2ed79dae95302bf2d9d8055589ed1ca511c16c35a9b84445548a7a306d4";
+      sha256 = "13be237b698dc9b468af7a2b8ff062118421a7b798771f1db4f82bcb1098f83c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/tr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/tr/thunderbird-78.4.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "c4b14f4f22549c66f5f445a2ad5826d0e90332c9d76783851078625245625bbb";
+      sha256 = "c70d085f6ceed58e7ea55ab01d121627a55df2f5e961ef160f4965db941660b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/uk/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/uk/thunderbird-78.4.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "cf06114027f9bf14ef506fe37e6a7ef6a1cbdb201cde061a754c82d9b3ef0c39";
+      sha256 = "c1b7b0efe7af03a488c80020247e2d8038d6dffa313188083bb75c1bc09c35fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/uz/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/uz/thunderbird-78.4.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "c805d88694b105412f05dd840e038edfef90b4a48b5a79b0bac5b5575d50a14a";
+      sha256 = "f4b8d20603c5e1dcc72760623803fc4cb34fffffd7b394c1998b860b5e3bc129";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/vi/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/vi/thunderbird-78.4.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "ca30574d981964eed7c3a100dd76f90c518a24d7dcde74f0790ede4a0a8d3285";
+      sha256 = "6d9d7885ba742ae28766ed98e64aa59892ffb51ad67eb9bc47d5a3974b8a7f50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/zh-CN/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/zh-CN/thunderbird-78.4.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "6cb1566d330e36b03e86bcfe96ad887fee511ba314167d235facba6c47871688";
+      sha256 = "e47c2e9b66c99c8ba02c60f739d31ea2d679cdc4d6f1f407257ef3372cabf364";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/zh-TW/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/zh-TW/thunderbird-78.4.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "7af0d92565a54bef6c962dd8b9b100198e2cac8d47ede749bade87c30d5ee37b";
+      sha256 = "1cbab249ae670a204e464a9082365967a74ce2533bdab60682c14fe65dafba16";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -70,13 +70,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.4.0";
+  version = "78.4.1";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "04b6n3gsan0a5abh371ws3c3rry4dcb3c6rbqmcxkzrdjg2xr5vn6xhlg3dgl3l01p0hp1xqpckj8g5yb2dq2x07xgg1hnyhs9aadh5";
+      "2mbb139xdi69bnvvg7zabwbw181xnz7y154viynmkwyh4iww0hcsvr88q246gnif8a7jns3pi4qgqxgzflyl6mzpsvfdrbjs5hylanx";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23401,7 +23401,9 @@ in
 
   thunderbird = thunderbird-78;
   thunderbird-78 = callPackage ../applications/networking/mailreaders/thunderbird {
-    inherit (rustPackages_1_44) cargo rustc;
+    # Using older Rust for workaround:
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1663715
+    inherit (rustPackages_1_45) cargo rustc;
     libpng = libpng_apng;
     icu = icu67;
     libvpx = libvpx_1_8;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

#103069 for 20.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
