### PR TITLE
colobot: init at 0.1.12-alpha

### DIFF
--- a/pkgs/games/colobot/data.nix
+++ b/pkgs/games/colobot/data.nix
@@ -1,0 +1,41 @@
+{ stdenv, lib, fetchFromGitHub, cmake
+, gettext, vorbis-tools
+, xmlstarlet, doxygen, python3 }:
+
+stdenv.mkDerivation rec {
+  pname = "colobot-data";
+  version = "0.1.12-alpha";
+
+  src = fetchFromGitHub {
+    owner = "colobot";
+    repo = "colobot-data";
+    rev = "colobot-gold-${version}";
+    sha256 = "1vm33s52ymwd03x24i9bqiglw5v3wgd7rlzyx9r5ww0nnqzwbwi6";
+  };
+
+  nativeBuildInputs = [ cmake vorbis-tools xmlstarlet doxygen python3 ];
+  buildInputs = [ gettext ];
+
+  enableParallelBuilding = false;
+  # Build procedure requires the data folder
+  patchPhase = ''
+    cp -r $src localSrc
+    chmod +w localSrc/help/bots/po
+    find -type d -exec chmod +w {} \;
+    for po in localSrc/help/{bots,cbot,object,generic,programs}/po/* localSrc/levels/*{/*/*,}/po/*; do
+      rm $po
+      touch $po
+    done
+    # skip music
+    rm localSrc/music/CMakeLists.txt
+    cd localSrc
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://colobot.info/";
+    description = "Game data for colobot";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ freezeboy ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/colobot/default.nix
+++ b/pkgs/games/colobot/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, cmake, boost, SDL2, SDL2_image, SDL2_ttf, libpng
+, glew, gettext, libsndfile, libvorbis, libogg, physfs, openal
+, xmlstarlet, doxygen, python3, callPackage }:
+
+let
+  colobot-data = callPackage ./data.nix {};
+in
+stdenv.mkDerivation rec {
+  pname = "colobot";
+  # Maybe require an update to package colobot-data as well
+  # in file data.nix next to this one
+  version = "0.1.12-alpha";
+
+  src = fetchFromGitHub {
+    owner = "colobot";
+    repo = "colobot";
+    rev = "colobot-gold-${version}";
+    sha256 = "0viq5s4zqs33an7rdmc3anf74ml7mwwcwf60alhvp9hj5jr547s2";
+  };
+
+  nativeBuildInputs = [ cmake xmlstarlet doxygen python3 ];
+  buildInputs = [ boost SDL2 SDL2_image SDL2_ttf libpng glew gettext libsndfile libvorbis libogg physfs openal ];
+
+  enableParallelBuilding = false;
+
+  # The binary ends in games directoy
+  postInstall = ''
+    mv $out/games $out/bin
+    for contents in ${colobot-data}/share/games/colobot/*; do
+      ln -s $contents $out/share/games/colobot
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://colobot.info/";
+    description = "Colobot: Gold Edition is a real-time strategy game, where you can program your bots";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ freezeboy ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -192,6 +192,8 @@ in
 
   corgi = callPackage ../development/tools/corgi { };
 
+  colobot = callPackage ../games/colobot {};
+
   colorz = callPackage ../tools/misc/colorz { };
 
   colorpicker = callPackage ../tools/misc/colorpicker { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Initial integration without the game musics to reduce the size of the
game. It works without them

Data are in another derivation to let them live their live independently
as they are quite big.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
