### PR TITLE
libtorch-bin: cleanup passthru test

### DIFF
--- a/pkgs/development/libraries/science/math/libtorch/bin.nix
+++ b/pkgs/development/libraries/science/math/libtorch/bin.nix
@@ -100,7 +100,7 @@ in stdenv.mkDerivation {
 
   outputs = [ "out" "dev" ];
 
-  passthru.tests = callPackage ./test { };
+  passthru.tests.cmake = callPackage ./test { };
 
   meta = with stdenv.lib; {
     description = "C++ API of the PyTorch machine learning framework";

--- a/pkgs/development/libraries/science/math/libtorch/test/default.nix
+++ b/pkgs/development/libraries/science/math/libtorch/test/default.nix
@@ -6,15 +6,11 @@ stdenv.mkDerivation {
 
   src = ./.;
 
-  postPatch = ''
-    cat CMakeLists.txt
-  '';
-
-  makeFlags = [ "VERBOSE=1" ];
-
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ libtorch-bin ];
+
+  doCheck = true;
 
   installPhase = ''
     touch $out

--- a/pkgs/development/libraries/science/math/libtorch/test/test.cpp
+++ b/pkgs/development/libraries/science/math/libtorch/test/test.cpp
@@ -1,7 +1,20 @@
-#include <torch/torch.h>
+#undef NDEBUG
+#include <cassert>
+
 #include <iostream>
+
+#include <torch/torch.h>
 
 int main() {
   torch::Tensor tensor = torch::eye(3);
-  std::cout << tensor << std::endl;
+
+  float checkData[] = {
+    1, 0, 0,
+    0, 1, 0,
+    0, 0, 1
+  };
+
+  torch::Tensor check = torch::from_blob(checkData, {3, 3});
+
+  assert(tensor.allclose(check));
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Make passthru.tests an attrset.
- Remove CMake VERBOSE option.
- Remove spurious `cat CMakeLists.txt`.
- Run the test as well.
- Actually test some functionality.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
