### PR TITLE
Kwallet pam fix

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -6,6 +6,7 @@
 with lib;
 
 let
+
   parentConfig = config;
 
   pamOpts = { config, name, ... }: let cfg = config; in let config = parentConfig; in {
@@ -430,7 +431,8 @@ let
               ${optionalString cfg.pamMount
                 "auth optional ${pkgs.pam_mount}/lib/security/pam_mount.so"}
               ${optionalString cfg.enableKwallet
-                ("auth optional ${pkgs.plasma5Packages.kwallet-pam}/lib/security/pam_kwallet5.so" +
+                ("auth substack system-login\n"+
+                 " auth optional ${pkgs.plasma5Packages.kwallet-pam}/lib/security/pam_kwallet5.so" +
                  " kwalletd=${pkgs.plasma5Packages.kwallet.bin}/bin/kwalletd5")}
               ${optionalString cfg.enableGnomeKeyring
                 "auth optional ${pkgs.gnome3.gnome-keyring}/lib/security/pam_gnome_keyring.so"}

--- a/pkgs/applications/display-managers/sddm/default.nix
+++ b/pkgs/applications/display-managers/sddm/default.nix
@@ -19,6 +19,9 @@ in mkDerivation {
 
   patches = [
     ./sddm-ignore-config-mtime.patch
+    # Fix pam rule for autologin https://github.com/sddm/sddm/issues/1265
+    # Apply sed -i '/^auth/ s/include/substack/' services/sddm.pam to sources
+    ./sddm-gentoo-pam-fix.patch
   ];
 
   postPatch =

--- a/pkgs/applications/display-managers/sddm/sddm-gentoo-pam-fix.patch
+++ b/pkgs/applications/display-managers/sddm/sddm-gentoo-pam-fix.patch
@@ -1,0 +1,20 @@
+diff --color -U 1000 -r a/services/sddm.pam b/services/sddm.pam
+--- a/services/sddm.pam	2021-01-18 12:01:11.232929452 +0100
++++ b/services/sddm.pam	2021-01-18 12:01:59.941494939 +0100
+@@ -1,15 +1,15 @@
+ #%PAM-1.0
+ 
+-auth		include		system-login
++auth		substack		system-login
+ -auth		optional	pam_gnome_keyring.so
+ -auth   optional  pam_kwallet5.so
+ 
+ account		include		system-login
+ 
+ password	include		system-login
+ -password	optional	pam_gnome_keyring.so use_authtok
+ 
+ session		optional	pam_keyinit.so force revoke
+ session		include		system-login
+ -session		optional	pam_gnome_keyring.so auto_start
+ -session  optional  pam_kwallet5.so auto_start


### PR DESCRIPTION
##### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/101904

###### Things done
Tried the fix provided by the gentoo guys, this seems to cause massive rebuilds, I don't have the processing power to try it. https://github.com/sddm/sddm/issues/1265

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
