### PR TITLE
ocamlPackages.digestif: 0.8.0 → 0.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/digestif/default.nix
+++ b/pkgs/development/ocaml-modules/digestif/default.nix
@@ -1,27 +1,27 @@
-{ lib, fetchurl, fetchpatch, buildDunePackage
+{ lib, ocaml, fetchurl, buildDunePackage
 , bigarray-compat, eqaf, stdlib-shims
-, alcotest
+, alcotest, astring, bos, findlib, fpath
 }:
 
 buildDunePackage rec {
   pname = "digestif";
-  version = "0.8.0";
+  version = "0.9.0";
+
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/digestif/releases/download/v${version}/digestif-v${version}.tbz";
-    sha256 = "09g4zngqiw97cljv8ds4m063wcxz3y7c7vzaprsbpjzi0ja5jdcy";
+    sha256 = "0vk9prgjp46xs8qizq7szkj6mqjj2ymncs2016bc8zswcdc1a3q4";
   };
 
-  # Fix tests with alcotest ≥ 1
-  patches = [ (fetchpatch {
-    url = "https://github.com/mirage/digestif/commit/b65d996c692d75da0a81323253429e07d14b72b6.patch";
-    sha256 = "0sf7qglcp19dhs65pwrrc7d9v57icf18jsrhpmvwskx8b4dchfiv";
-  })];
-
-  buildInputs = lib.optional doCheck alcotest;
   propagatedBuildInputs = [ bigarray-compat eqaf stdlib-shims ];
 
-  doCheck = true;
+  checkInputs = [ alcotest astring bos fpath ];
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
+
+  postCheck = ''
+    ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib/ test/test_runes.ml
+  '';
 
   meta = {
     description = "Simple hash algorithms in OCaml";


### PR DESCRIPTION
###### Motivation for this change

SHA3: https://github.com/mirage/digestif/releases/tag/v0.9.0

Use Dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
