### PR TITLE
pythonPackages.psautohint: 2.1.1 → 2.1.2

### DIFF
--- a/pkgs/development/python-modules/psautohint/default.nix
+++ b/pkgs/development/python-modules/psautohint/default.nix
@@ -6,14 +6,14 @@
 
 buildPythonPackage rec {
   pname = "psautohint";
-  version = "2.1.1";
+  version = "2.1.2";
 
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner  = "adobe-type-tools";
     repo   = pname;
-    sha256 = "00n9bycjmvx1fb4332bdj53f01q86ajndrvid9idpiyzybmd5vp4";
+    sha256 = "1s2l54gzn11y07zaggprwif7r3ia244qijjhkbvjdx4jsgc5df8n";
     rev    = "v${version}";
     fetchSubmodules = true; # data dir for tests
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/adobe-type-tools/psautohint/blob/master/NEWS.md#v212---november-6-2020>

Version bounds have been pushed to 4.16.1 for `fonttools` as well, probably a good idea to merge #99012 as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
