### PR TITLE
buildPython*: remove pythonRecompileBytecodeHook as dependency

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -17,7 +17,6 @@
 , pythonCatchConflictsHook
 , pythonImportsCheckHook
 , pythonNamespacesHook
-, pythonRecompileBytecodeHook
 , pythonRemoveBinBytecodeHook
 , pythonRemoveTestsDirHook
 , setuptoolsBuildHook
@@ -113,7 +112,6 @@ let
       python
       wrapPython
       ensureNewerSourcesForZipFilesHook  # move to wheel installer (pip) or builder (setuptools, flit, ...)?
-      pythonRecompileBytecodeHook  # Remove when solved https://github.com/NixOS/nixpkgs/issues/81441
       pythonRemoveTestsDirHook
     ] ++ lib.optionals catchConflicts [
       setuptools pythonCatchConflictsHook
@@ -166,9 +164,6 @@ let
 
     # Python packages built through cross-compilation are always for the host platform.
     disallowedReferences = lib.optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [ python.pythonForBuild ];
-
-    # For now, revert recompilation of bytecode.
-    dontUsePythonRecompileBytecode = true;
 
     meta = {
       # default to python's platforms

--- a/pkgs/development/python-modules/3to2/default.nix
+++ b/pkgs/development/python-modules/3to2/default.nix
@@ -24,8 +24,6 @@ buildPythonPackage rec {
   # Test failing due to upstream issue (https://bitbucket.org/amentajo/lib3to2/issues/50/testsuite-fails-with-new-python-35)
   doCheck = false;
 
-  dontUsePythonRecompileBytecode = true;
-
   meta = {
     homepage = "https://bitbucket.org/amentajo/lib3to2";
     description = "Refactors valid 3.x syntax into valid 2.x syntax, if a syntactical conversion is possible";

--- a/pkgs/development/python-modules/invoke/default.nix
+++ b/pkgs/development/python-modules/invoke/default.nix
@@ -20,9 +20,6 @@ buildPythonPackage rec {
   # errors with vendored libs
   doCheck = false;
 
-  # has vendored python2 code
-  dontUsePythonRecompileBytecode = true;
-
   meta = {
     description = "Pythonic task execution";
     license = lib.licenses.bsd2;

--- a/pkgs/development/python-modules/linecache2/default.nix
+++ b/pkgs/development/python-modules/linecache2/default.nix
@@ -5,7 +5,7 @@
 , isPy3k
 }:
 
-buildPythonPackage (rec {
+buildPythonPackage rec {
   pname = "linecache2";
   version = "1.0.0";
 
@@ -23,8 +23,4 @@ buildPythonPackage (rec {
     homepage = "https://github.com/testing-cabal/linecache2";
     license = licenses.psfl;
   };
-# TODO: move into main set, this was to avoid a rebuild
-} // stdenv.lib.optionalAttrs (!isPy3k ) {
-  # syntax error in tests. Tests are likely Python 3 only.
-  dontUsePythonRecompileBytecode = !isPy3k;
-})
+}

--- a/pkgs/development/python-modules/pexpect/default.nix
+++ b/pkgs/development/python-modules/pexpect/default.nix
@@ -41,8 +41,4 @@ buildPythonPackage (rec {
       any platform that supports the standard Python pty module.
     '';
   };
-# TODO: move into main set, this was to avoid a rebuild
-} // lib.optionalAttrs (!isPy3k ) {
-  # syntax error in _async module, likely intended only for Python 3.
-  dontUsePythonRecompileBytecode = !isPy3k;
 })

--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -68,10 +68,6 @@ python3.pkgs.buildPythonApplication rec {
       --replace "${python3}" ""
   '';
 
-  # find: ‘...-gtk-doc-1.32/lib/python3.8/site-packages’: No such file or directory
-  # https://github.com/NixOS/nixpkgs/pull/90208#issuecomment-644051108
-  dontUsePythonRecompileBytecode = true;
-
   passthru = {
     # Consumers are expected to copy the m4 files to their source tree, let them reuse the patch
     respect_xml_catalog_files_var_patch = ./respect-xml-catalog-files-var.patch;

--- a/pkgs/development/tools/poetry2nix/poetry2nix/plugins.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/plugins.nix
@@ -23,7 +23,6 @@ let
 
       dontConfigure = true;
       dontBuild = true;
-      dontUsePythonRecompileBytecode = true;
 
       passthru = {
         inherit (drv.passthru) withPlugins;


### PR DESCRIPTION
This hook was added to get reproducible bytecode. Because it was causing
issues it was disabled, but still kept as a dependency. Now the main
issue with bytecode reproducibility has been resolved by updating pip to
20.2.4, we remove this hook as a dependency.

If a package with Python code is not yet reproducible, one could add
this hook to `nativeBuildInputs`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
