### PR TITLE
krusader: added qtbase in mkDerivation

### DIFF
--- a/pkgs/applications/misc/krusader/default.nix
+++ b/pkgs/applications/misc/krusader/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, fetchurl, lib,
+  mkDerivation, fetchurl, lib, qtbase,
   extra-cmake-modules, kdoctools, wrapGAppsHook,
   karchive, kconfig, kcrash, kguiaddons, kinit, kparts, kwindowsystem
 }:


### PR DESCRIPTION
Motivation for this change: https://github.com/NixOS/nixpkgs/issues/103033
Error description is here: https://nixos.wiki/wiki/Qt   Paragraph: qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
https://github.com/NixOS/nixpkgs/issues/65399