### PR TITLE
onefetch: 2.6.0 -> 2.7.0

### DIFF
--- a/pkgs/tools/misc/onefetch/default.nix
+++ b/pkgs/tools/misc/onefetch/default.nix
@@ -3,16 +3,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "onefetch";
-  version = "2.6.0";
+  version = "2.7.0";
 
   src = fetchFromGitHub {
     owner = "o2sh";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-KdPr/6wGyoHhEwfPektL+B1khyoRfxDHI4aFcKNU0TM=";
+    sha256 = "sha256-9HZLr/dwr5T1m6H/SHy9ULfKMkyrLNb2Z8W3RlSWzGM=";
   };
 
-  cargoSha256 = "sha256-MLlGz7Sid0G52//XekqkZgzLqFL7xoUwT6OvpaF4jm0=";
+  cargoSha256 = "sha256-cyffVX1XEF5zaNbk/VeZEtKG/Npwv5Yzz9OU5G9UyGc=";
 
   buildInputs = with stdenv;
     lib.optionals isDarwin [ CoreFoundation libiconv libresolv Security ];


### PR DESCRIPTION
###### Motivation for this change
new onefetch version 2.7.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS (without sandbox)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
