### PR TITLE
inxi: add pciutils

### DIFF
--- a/pkgs/tools/system/inxi/default.nix
+++ b/pkgs/tools/system/inxi/default.nix
@@ -3,7 +3,7 @@
 , withRecommends ? false # Install (almost) all recommended tools (see --recommends)
 , withRecommendedSystemPrograms ? withRecommends, util-linuxMinimal, dmidecode
 , file, hddtemp, iproute, ipmitool, usbutils, kmod, lm_sensors, smartmontools
-, binutils, tree, upower
+, binutils, tree, upower, pciutils
 , withRecommendedDisplayInformationPrograms ? withRecommends, glxinfo, xorg
 }:
 
@@ -12,7 +12,7 @@ let
     "--prefix PATH ':' '${stdenv.lib.makeBinPath programs}'";
   recommendedSystemPrograms = lib.optionals withRecommendedSystemPrograms [
     util-linuxMinimal dmidecode file hddtemp iproute ipmitool usbutils kmod
-    lm_sensors smartmontools binutils tree upower
+    lm_sensors smartmontools binutils tree upower pciutils
   ];
   recommendedDisplayInformationPrograms = lib.optionals
     withRecommendedDisplayInformationPrograms


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
No pciutils 
```
 inxi -G
Graphics:  Message: No Device data found.
           Display: wayland server: X.Org 1.20.8 driver: N/A resolution: 1: 2560x1440~144Hz 2: 1080x1920~60Hz
           3: 1920x1080~60Hz
           OpenGL: renderer: Radeon RX Vega (VEGA10 DRM 3.39.0 5.9.1 LLVM 9.0.1) v: 4.6 Mesa 20.1.9
```
With pciutils
```
inxi -G
Graphics:  Device-1: Intel Xeon E3-1200 v3/4th Gen Core Processor Integrated Graphics driver: i915 v: kernel
           Device-2: Advanced Micro Devices [AMD/ATI] Vega 10 XL/XT [Radeon RX Vega 56/64] driver: amdgpu v: kernel
           Display: wayland server: X.Org 1.20.8 driver: amdgpu note: display driver n/a resolution: 1: 2560x1440~144Hz
           2: 1080x1920~60Hz 3: 1920x1080~60Hz
           OpenGL: renderer: Radeon RX Vega (VEGA10 DRM 3.39.0 5.9.1 LLVM 9.0.1) v: 4.6 Mesa 20.1.9
```
i put pciutils in `recommendedSystemPrograms` instead of `recommendedDisplayInformationPrograms` because inxi -G can also be used in a tty to show devices
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`

Idk how to do this since pciutils is hidden under a option

- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
