### PR TITLE
convertall: init at 0.8.0

### DIFF
--- a/pkgs/applications/science/misc/convertall/default.nix
+++ b/pkgs/applications/science/misc/convertall/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, python3, wrapQtAppsHook }:
+
+let
+  inherit (python3.pkgs) wrapPython pyqt5;
+in stdenv.mkDerivation rec {
+  pname = "convertall";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "doug-101";
+    repo = "ConvertAll";
+    rev = "v${version}";
+    sha256 = "02xxasgbjbivsbhyfpn3cpv52lscdx5kc95s6ns1dvnmdg0fpng0";
+  };
+
+  nativeBuildInputs = [ python3 wrapPython wrapQtAppsHook ];
+
+  propagatedBuildInputs = [ pyqt5 ];
+
+  installPhase = ''
+    python3 install.py -p $out -x
+  '';
+
+  postFixup = ''
+    buildPythonPath $out
+    patchPythonScript $out/share/convertall/convertall.py
+    makeQtWrapper $out/share/convertall/convertall.py $out/bin/convertall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://convertall.bellz.org/";
+    description = "Graphical unit converter";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ orivej ];
+    platforms = pyqt5.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26885,6 +26885,8 @@ in
     inherit (pkgs.gnome2) gtkglext;
   };
 
+  convertall = qt5.callPackage ../applications/science/misc/convertall { };
+
   cytoscape = callPackage ../applications/science/misc/cytoscape {
     jre = openjdk11;
   };


### PR DESCRIPTION
#### Motivation for this change

This is an interactive GUI alternative to GNU Units.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
