### PR TITLE
4th: init at 3.62.5

### DIFF
--- a/pkgs/development/compilers/4th/default.nix
+++ b/pkgs/development/compilers/4th/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "4th";
+  version = "3.62.5";
+
+  src = fetchurl {
+    url = "https://sourceforge.net/projects/forth-4th/files/${pname}-${version}/${pname}-${version}-unix.tar.gz";
+    sha256 = "sha256-+CL33Yz7CxdEpi1lPG7+kzV4rheJ7GCgiFCaOLyktPw=";
+  };
+
+  dontConfigure = true;
+
+  makeFlags = [
+    "-C sources"
+    "CC=${stdenv.cc}/bin/cc"
+  ];
+
+  preInstall = ''
+    install -d ${placeholder "out"}/bin \
+      ${placeholder "out"}/lib \
+      ${placeholder "out"}/share/doc/${pname} \
+      ${placeholder "out"}/share/man
+  '';
+
+  installFlags = [
+    "BINARIES=${placeholder "out"}/bin"
+    "LIBRARIES=${placeholder "out"}/lib"
+    "DOCDIR=${placeholder "out"}/share/doc"
+    "MANDIR=${placeholder "out"}/share/man"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A portable Forth compiler";
+    homepage = "https://thebeez.home.xs4all.nl/4tH/index.html";
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8557,6 +8557,8 @@ in
 
   ### DEVELOPMENT / COMPILERS
 
+  _4th = callPackage ../development/compilers/4th { };
+
   abcl = callPackage ../development/compilers/abcl {
     jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
     jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add 4th, a small portable Forth compiler

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
