### PR TITLE
scheherazade-new: init at 3.000

### DIFF
--- a/pkgs/data/fonts/scheherazade/default.nix
+++ b/pkgs/data/fonts/scheherazade/default.nix
@@ -1,11 +1,16 @@
-{ lib, fetchzip }:
+{ lib, fetchzip, version ? "3.000" }:
 
 let
-  version = "2.100";
-in fetchzip rec {
-  name = "scheherazade-${version}";
+  new = lib.versionAtLeast version "3.000";
+  sha256 = {
+    "2.100" = "1g5f5f9gzamkq3kqyf7vbzvl4rdj3wmjf6chdrbxksrm3rnb926z";
+    "3.000" = "12sd2mjqb80ijc73y7p0iw6j3wy9i60a3aar3ywrxz4khpya48jw";
+  }."${version}";
 
-  url = "http://software.sil.org/downloads/r/scheherazade/Scheherazade-${version}.zip";
+in fetchzip rec {
+  name = "scheherazade${lib.optionalString new "-new"}-${version}";
+
+  url = "http://software.sil.org/downloads/r/scheherazade/Scheherazade${lib.optionalString new "New"}-${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/{doc,fonts}
@@ -15,16 +20,17 @@ in fetchzip rec {
     unzip -j $downloadedFile \*/documentation/\*           -d $out/share/doc/${name}/documentation
   '';
 
-  sha256 = "1g5f5f9gzamkq3kqyf7vbzvl4rdj3wmjf6chdrbxksrm3rnb926z";
+  inherit sha256;
 
   meta = with lib; {
     homepage = "https://software.sil.org/scheherazade/";
     description = "A font designed in a similar style to traditional Naskh typefaces";
     longDescription = ''
-      Scheherazade, named after the heroine of the classic Arabian Nights tale,
-      is designed in a similar style to traditional typefaces such as Monotype
-      Naskh, extended to cover the Unicode Arabic repertoire through Unicode
-      8.0.
+
+      Scheherazade${lib.optionalString new " New"}, named after the heroine of
+      the classic Arabian Nights tale, is designed in a similar style to
+      traditional typefaces such as Monotype Naskh, extended to cover the
+      Unicode Arabic repertoire through Unicode ${if new then "13.0" else "8.0"}.
 
       Scheherazade provides a “simplified” rendering of Arabic script, using
       basic connecting glyphs but not including a wide variety of additional

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19622,7 +19622,9 @@ in
 
   shared_desktop_ontologies = callPackage ../data/misc/shared-desktop-ontologies { };
 
-  scheherazade = callPackage ../data/fonts/scheherazade { };
+  scheherazade = callPackage ../data/fonts/scheherazade { version = "2.100"; };
+
+  scheherazade-new = callPackage ../data/fonts/scheherazade { };
 
   signwriting = callPackage ../data/fonts/signwriting { };
 


### PR DESCRIPTION
###### Motivation for this change

Major update: https://software.sil.org/scheherazade/release-3-000/

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
