### PR TITLE
python3.pkgs.bme680: init at 1.0.5

### DIFF
--- a/pkgs/development/python-modules/bme680/default.nix
+++ b/pkgs/development/python-modules/bme680/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, smbus-cffi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "bme680";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "pimoroni";
+    repo = "bme680-python";
+    rev = "v${version}";
+    sha256 = "sha256-oIXh1JnGTI/Cj4MQFpWq+sWR2X+ioCsK0Q+T7wPITCQ=";
+  };
+
+  propagatedBuildInputs = [ smbus-cffi ];
+
+  preBuild = ''
+    cd library
+  '';
+  checkInputs = [ pytestCheckHook ];
+
+  # next release will have tests, but not the current one
+  doCheck = false;
+
+  pythonImportsCheck = [ "bme680" ];
+
+  meta = with lib; {
+    description = "Python library for driving the Pimoroni BME680 Breakout";
+    homepage = "https://github.com/pimoroni/bme680-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mic92 ];
+  };
+}

--- a/pkgs/development/python-modules/smbus-cffi/default.nix
+++ b/pkgs/development/python-modules/smbus-cffi/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cffi
+, pytestCheckHook
+, pyserial
+, fetchpatch
+}:
+
+buildPythonPackage rec {
+  pname = "smbus-cffi";
+  version = "0.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fb4195aaabfc01586863f60d3190b5cb1bf8f12622fd597e23e48768dad6bde8";
+  };
+
+  patches = [
+    # https://github.com/bivab/smbus-cffi/pull/24
+    (fetchpatch {
+      url = "https://github.com/bivab/smbus-cffi/commit/ba79ae174a9d84e767d95f165c43ee212b1bbb92.patch";
+      sha256 = "sha256-WtRuK5y6fWDEhm0Xy5XqS5yCkn7vXXYtjlOjS90gla4=";
+    })
+  ];
+
+  propagatedBuildInputs = [ cffi ];
+
+  installCheckPhase = ''
+    # we want to import the installed module that also contains the compiled library
+    rm -rf smbus
+    runHook pytestCheckPhase
+  '';
+
+  # requires hardware access
+  pytestFlagsArray = [ "--ignore=test/test_smbus_integration.py" ];
+
+  checkInputs = [ pytestCheckHook pyserial ];
+
+  meta = with lib; {
+    description = "Python module for SMBus access through Linux I2C /dev interface";
+    homepage = "https://github.com/bivab/smbus-cffi";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ mic92 ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -74,7 +74,7 @@
     "bbb_gpio" = ps: with ps; [ ]; # missing inputs: Adafruit_BBIO
     "bbox" = ps: with ps; [ ]; # missing inputs: pybbox
     "beewi_smartclim" = ps: with ps; [ ]; # missing inputs: beewi_smartclim
-    "bh1750" = ps: with ps; [ ]; # missing inputs: i2csense smbus-cffi
+    "bh1750" = ps: with ps; [ smbus-cffi ]; # missing inputs: i2csense
     "binary_sensor" = ps: with ps; [ ];
     "bitcoin" = ps: with ps; [ ]; # missing inputs: blockchain
     "bizkaibus" = ps: with ps; [ ]; # missing inputs: bizkaibus
@@ -88,8 +88,8 @@
     "bluesound" = ps: with ps; [ xmltodict ];
     "bluetooth_le_tracker" = ps: with ps; [ ]; # missing inputs: pygatt[GATTTOOL]
     "bluetooth_tracker" = ps: with ps; [ bt_proximity ]; # missing inputs: pybluez
-    "bme280" = ps: with ps; [ ]; # missing inputs: i2csense smbus-cffi
-    "bme680" = ps: with ps; [ ]; # missing inputs: bme680 smbus-cffi
+    "bme280" = ps: with ps; [ smbus-cffi ]; # missing inputs: i2csense
+    "bme680" = ps: with ps; [ bme680 smbus-cffi ];
     "bmp280" = ps: with ps; [ ]; # missing inputs: RPi.GPIO adafruit-circuitpython-bmp280
     "bmw_connected_drive" = ps: with ps; [ ]; # missing inputs: bimmer_connected
     "bond" = ps: with ps; [ ]; # missing inputs: bond-api
@@ -222,7 +222,7 @@
     "enphase_envoy" = ps: with ps; [ ]; # missing inputs: envoy_reader
     "entur_public_transport" = ps: with ps; [ ]; # missing inputs: enturclient
     "environment_canada" = ps: with ps; [ ]; # missing inputs: env_canada
-    "envirophat" = ps: with ps; [ ]; # missing inputs: envirophat smbus-cffi
+    "envirophat" = ps: with ps; [ smbus-cffi ]; # missing inputs: envirophat
     "envisalink" = ps: with ps; [ ]; # missing inputs: pyenvisalink
     "ephember" = ps: with ps; [ ]; # missing inputs: pyephember
     "epson" = ps: with ps; [ ]; # missing inputs: epson-projector
@@ -358,7 +358,7 @@
     "hp_ilo" = ps: with ps; [ ]; # missing inputs: python-hpilo
     "html5" = ps: with ps; [ aiohttp-cors pywebpush ];
     "http" = ps: with ps; [ aiohttp-cors ];
-    "htu21d" = ps: with ps; [ ]; # missing inputs: i2csense smbus-cffi
+    "htu21d" = ps: with ps; [ smbus-cffi ]; # missing inputs: i2csense
     "huawei_lte" = ps: with ps; [ getmac stringcase ]; # missing inputs: huawei-lte-api url-normalize
     "huawei_router" = ps: with ps; [ ];
     "hue" = ps: with ps; [ aiohue ];
@@ -657,7 +657,7 @@
     "rainforest_eagle" = ps: with ps; [ ]; # missing inputs: eagle200_reader uEagle
     "rainmachine" = ps: with ps; [ ]; # missing inputs: regenmaschine
     "random" = ps: with ps; [ ];
-    "raspihats" = ps: with ps; [ ]; # missing inputs: raspihats smbus-cffi
+    "raspihats" = ps: with ps; [ smbus-cffi ]; # missing inputs: raspihats
     "raspyrfm" = ps: with ps; [ ]; # missing inputs: raspyrfm-client
     "recollect_waste" = ps: with ps; [ ]; # missing inputs: recollect-waste
     "recorder" = ps: with ps; [ sqlalchemy ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6664,6 +6664,8 @@ in {
 
   smartypants = callPackage ../development/python-modules/smartypants { };
 
+  smbus-cffi = callPackage ../development/python-modules/smbus-cffi { };
+
   smmap2 = throw "smmap2 has been deprecated, use smmap instead."; # added 2020-03-14
 
   smmap = callPackage ../development/python-modules/smmap { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -913,6 +913,8 @@ in {
 
   bluepy = callPackage ../development/python-modules/bluepy { };
 
+  bme680 = callPackage ../development/python-modules/bme680 { };
+
   bokeh = callPackage ../development/python-modules/bokeh { };
 
   boltons = callPackage ../development/python-modules/boltons { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

home-assistant + [bme680-mqtt](https://github.com/Mic92/bme680-mqtt)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
