### PR TITLE
pmix: 3.1.5 -> 3.2.0

### DIFF
--- a/pkgs/development/libraries/pmix/default.nix
+++ b/pkgs/development/libraries/pmix/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchFromGitHub, perl, autoconf, automake
-, libtool, flex, libevent, hwloc, munge, zlib
+, libtool, flex, libevent, hwloc, munge, zlib, pandoc
 } :
 
 let
-  version = "3.1.5";
+  version = "3.2.0";
 
 in stdenv.mkDerivation {
   pname = "pmix";
@@ -13,7 +13,7 @@ in stdenv.mkDerivation {
     repo = "openpmix";
     owner = "openpmix";
     rev = "v${version}";
-    sha256 = "0fvfsig20amcigyn4v3gcdxc0jif44vqg37b8zzh0s8jqqj7jz5w";
+    sha256 = "171hpz0m6lpyjd1hkxy7fl06fcgymz8cssqgbxzg92b7x595276b";
   };
 
   postPatch = ''
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
     patchShebangs ./config
   '';
 
-  nativeBuildInputs = [ perl autoconf automake libtool flex ];
+  nativeBuildInputs = [ pandoc perl autoconf automake libtool flex ];
 
   buildInputs = [ libevent hwloc munge zlib ];
 


### PR DESCRIPTION
###### Motivation for this change
Changelog: https://github.com/openpmix/openpmix/blob/master/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
