### PR TITLE
rdma-core: 31.0 -> 31.1

### DIFF
--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -4,7 +4,7 @@
 } :
 
 let
-  version = "31.0";
+  version = "31.1";
 
 in stdenv.mkDerivation {
   pname = "rdma-core";
@@ -14,7 +14,7 @@ in stdenv.mkDerivation {
     owner = "linux-rdma";
     repo = "rdma-core";
     rev = "v${version}";
-    sha256 = "0qr8a25ylmkwfgyj519zvl74q16bhf4895xjich2r98rl2yg0qdl";
+    sha256 = "1xkmdix6mgv6kjjj6wi844bfddhl0ybalrp5g8pf5izasc43brg7";
   };
 
   nativeBuildInputs = [ cmake pkgconfig pandoc docutils makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Bugfix release, needs backport to 20.09
Changelog: https://github.com/linux-rdma/rdma-core/releases/tag/v31.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
