### PR TITLE
ocamlPackages.ocaml-lsp: init at 1.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -1,0 +1,66 @@
+{ stdenv
+, buildDunePackage
+, stdlib-shims
+, ppx_yojson_conv_lib
+, ocaml-syntax-shims
+, omd
+, octavius
+, dune-build-info
+, uutf
+, csexp
+, cmdliner
+, fetchzip
+, lib
+}:
+let
+  version = "1.1.0";
+  src = fetchzip {
+    url = "https://github.com/ocaml/ocaml-lsp/releases/download/${version}/ocaml-lsp-server-${version}.tbz";
+    sha256 = "0al89waw43jl80k9z06kh44byhjhwb5hmzx07sddwi1kr1vc6jrb";
+  };
+
+  # unvendor some (not all) dependencies.
+  # They are vendored by upstream only because it is then easier to install
+  # ocaml-lsp without messing with your opam switch, but nix should prevent
+  # this type of problems without resorting to vendoring.
+  preBuild = ''
+    rm -r vendor/{octavius,uutf,ocaml-syntax-shims,omd,cmdliner}
+  '';
+
+  buildInputs = [
+    stdlib-shims
+    ppx_yojson_conv_lib
+    ocaml-syntax-shims
+    octavius
+    uutf
+    csexp
+    dune-build-info
+    omd
+    cmdliner
+  ];
+
+  lsp = buildDunePackage {
+    pname = "lsp";
+    inherit version src;
+    useDune2 = true;
+
+    inherit buildInputs preBuild;
+  };
+
+in
+buildDunePackage {
+  pname = "ocaml-lsp-server";
+  inherit version src;
+  useDune2 = true;
+
+  inherit preBuild;
+
+  buildInputs = buildInputs ++ [ lsp ];
+
+  meta = with lib; {
+    description = "OCaml Language Server Protocol implementation";
+    license = lib.licenses.isc;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.symphorien ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -658,6 +658,8 @@ let
 
     ocaml-r = callPackage ../development/ocaml-modules/ocaml-r { };
 
+    ocaml-lsp = callPackage ../development/ocaml-modules/ocaml-lsp { };
+
     ocaml-sat-solvers = callPackage ../development/ocaml-modules/ocaml-sat-solvers { };
 
     ocamlscript = callPackage ../development/tools/ocaml/ocamlscript { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


I've been using it for a week and the quicker feedback on errors is nice to have, imo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
