### PR TITLE
librdf_raptor2: add patch for CVE-2017-18926

### DIFF
--- a/pkgs/development/libraries/librdf/raptor2.nix
+++ b/pkgs/development/libraries/librdf/raptor2.nix
@@ -1,12 +1,21 @@
 { stdenv, fetchurl, libxml2, libxslt }:
 
 stdenv.mkDerivation rec {
-  name = "raptor2-2.0.15";
+  pname = "raptor2";
+  version = "2.0.15";
 
   src = fetchurl {
-    url = "http://download.librdf.org/source/${name}.tar.gz";
+    url = "http://download.librdf.org/source/${pname}-${version}.tar.gz";
     sha256 = "ada7f0ba54787b33485d090d3d2680533520cd4426d2f7fb4782dd4a6a1480ed";
   };
+
+  patches = [
+    (fetchurl {
+      name = "CVE-2017-18926.patch";
+      url = "https://github.com/dajobe/raptor/commit/590681e546cd9aa18d57dc2ea1858cb734a3863f.patch";
+      sha256 = "1qlpb5rm3j2yi0x6zgdi5apymg5zlvwq3g1zl417gkjrlvxmndgp";
+    })
+  ];
 
   buildInputs = [ libxml2 libxslt ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes two heap overflows in the raptor2 rdf parsing library.

https://www.openwall.com/lists/oss-security/2017/06/07/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
