### PR TITLE
bambootracker: 0.4.4 -> 0.4.5

### DIFF
--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , qmake
 , qtbase
-, qtmultimedia
 , qttools
 , alsaSupport ? stdenv.hostPlatform.isLinux
 , alsaLib
@@ -19,20 +18,20 @@ let
 in
 mkDerivation rec {
   pname = "bambootracker";
-  version = "0.4.4";
+  version = "0.4.5";
 
   src = fetchFromGitHub {
     owner = "rerrahkr";
     repo = "BambooTracker";
     rev = "v${version}";
-    sha256 = "0d0f4jqzknsiq725pvfndarfjg183f92rb0lim3wzshnsixr5vdc";
+    sha256 = "0ibi0sykxf6cp5la2c4pgxf5gvy56yv259fbmdwdrdyv6vlddf42";
   };
 
   sourceRoot = "source/BambooTracker";
 
   nativeBuildInputs = [ qmake qttools ];
 
-  buildInputs = [ qtbase qtmultimedia ]
+  buildInputs = [ qtbase ]
     ++ optional alsaSupport alsaLib
     ++ optional pulseSupport libpulseaudio
     ++ optional jackSupport libjack2;


### PR DESCRIPTION
###### Motivation for this change
Simple version bump with one dropped dependency.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
