### PR TITLE
asymptote: 2.66 -> 2.67; fix build with fresh ghostscript

### DIFF
--- a/pkgs/tools/graphics/asymptote/default.nix
+++ b/pkgs/tools/graphics/asymptote/default.nix
@@ -1,23 +1,31 @@
-{ stdenv, fetchFromGitHub, fetchurl
+{ stdenv, fetchFromGitHub, fetchurl, fetchpatch
 , autoreconfHook, bison, glm, yacc, flex
 , freeglut, ghostscriptX, imagemagick, fftw
 , boehmgc, libGLU, libGL, mesa, ncurses, readline, gsl, libsigsegv
 , python3Packages
-, zlib, perl
+, zlib, perl, curl
 , texLive, texinfo
 , darwin
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.66";
+  version = "2.67";
   pname = "asymptote";
 
   src = fetchFromGitHub {
     owner = "vectorgraphics";
     repo = pname;
     rev = version;
-    sha256 = "0c445j950n6nxgr1zxj7a26daa5d9f3i91506b7r7627s943b1kd";
+    sha256 = "sha256:1lawj2gf0985clzbyym26s5mxxp2syl1dqqxfzk0sq9s30l2rj3l";
   };
+
+  patches =
+    (stdenv.lib.optional (stdenv.lib.versionOlder version "2.68")
+      (fetchpatch {
+        url = "https://github.com/vectorgraphics/asymptote/commit/3361214340d58235f4dbb8f24017d0cd5d94da72.patch";
+        sha256 = "sha256:1z2b41x8v7683myd45lq6niixpdjy0b185x0xl61130vrijhq5nm";
+      }))
+  ;
 
   nativeBuildInputs = [
     autoreconfHook
@@ -30,7 +38,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     ghostscriptX imagemagick fftw
     boehmgc ncurses readline gsl libsigsegv
-    zlib perl
+    zlib perl curl
     texLive
   ] ++ (with python3Packages; [
     python

--- a/pkgs/tools/graphics/asymptote/default.upstream
+++ b/pkgs/tools/graphics/asymptote/default.upstream
@@ -1,4 +1,0 @@
-url https://sourceforge.net/projects/asymptote/files/
-SF_version_dir
-version_link 'src[.]tgz/download$'
-SF_redirect


### PR DESCRIPTION
###### Motivation for this change

https://github.com/vectorgraphics/asymptote/issues/176

Will self-merge

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
