### PR TITLE
Gnome 3.38 fixes

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -32,7 +32,7 @@
 , xorgserver
 , python3
 , wrapGAppsHook
-, libsysprof-capture
+, sysprof
 , desktop-file-utils
 , libcap_ng
 , egl-wayland
@@ -110,7 +110,7 @@ let self = stdenv.mkDerivation rec {
     libxkbfile
     pango
     pipewire
-    libsysprof-capture
+    sysprof
     xkeyboard_config
     xwayland
     wayland-protocols
@@ -128,7 +128,7 @@ let self = stdenv.mkDerivation rec {
   PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
 
   passthru = {
-    libdir = "${self}/lib/mutter-6";
+    libdir = "${self}/lib/mutter-7";
 
     tests = {
       libdirExists = runCommand "mutter-libdir-exists" {} ''

--- a/pkgs/desktops/gnome-3/misc/gnome-tweaks/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-tweaks/default.nix
@@ -1,6 +1,6 @@
 { stdenv, meson, ninja, gettext, fetchurl
 , pkgconfig, gtk3, glib, libsoup, gsettings-desktop-schemas
-, itstool, libxml2, python3Packages, libhandy
+, itstool, libxml2, python3Packages, libhandy_0
 , gnome3, gdk-pixbuf, libnotify, gobject-introspection, wrapGAppsHook }:
 
 let
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
     libnotify gnome3.gnome-shell python3Packages.pygobject3
     libsoup gnome3.gnome-settings-daemon gnome3.nautilus
     gnome3.mutter gnome3.gnome-desktop gobject-introspection
-    gnome3.nautilus libhandy
+    gnome3.nautilus libhandy_0
     # Makes it possible to select user themes through the `user-theme` extension
     gnome3.gnome-shell-extensions
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Mutter needs sysprof's dbus interface at build time:  https://hydra.nixos.org/build/129977355
- gnome-tweaks isn't ported to libhandy-1 yet (only fails on runtime though)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
