### PR TITLE
distrho: unstable-2019-10-09 -> 2020-07-14

### DIFF
--- a/pkgs/applications/audio/distrho/default.nix
+++ b/pkgs/applications/audio/distrho/default.nix
@@ -1,55 +1,77 @@
-{ stdenv, fetchFromGitHub, alsaLib, fftwSinglePrec, freetype, libjack2
-, pkgconfig, ladspa-sdk, premake3
-, libX11, libXcomposite, libXcursor, libXext, libXinerama, libXrender
+{ stdenv
+, alsaLib
+, fetchFromGitHub
+, freetype
+, libGL
+, libX11
+, libXcursor
+, libXext
+, libXrender
+, meson
+, ninja
+, pkg-config
 }:
 
-let
-  premakeos = if stdenv.hostPlatform.isDarwin then "osx"
-              else if stdenv.hostPlatform.isWindows then "mingw"
-              else "linux";
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "distrho-ports";
-  version = "unstable-2019-10-09";
+  version = "2020-07-14";
 
   src = fetchFromGitHub {
     owner = "DISTRHO";
     repo = "DISTRHO-Ports";
-    rev = "7e62235e809e59770d0d91d2c48c3f50ce7c027a";
-    sha256 = "10hpsjcmk0cgcsic9r1wxyja9x6q9wb8w8254dlrnzyswl54r1f8";
+    rev = version;
+    sha256 = "03ji41i6dpknws1vjwfxnl8c8bgisv2ng8xa4vqy2473k7wgdw4v";
   };
 
-  configurePhase = ''
-    runHook preConfigure
+  nativeBuildInputs = [ pkg-config meson ninja ];
 
-    sh ./scripts/premake-update.sh ${premakeos}
-
-    runHook postConfigure
-  '';
-
-  postPatch = ''
-    sed -e "s#@./scripts#sh scripts#" -i Makefile
-  '';
-
-  nativeBuildInputs = [ pkgconfig premake3 ];
   buildInputs = [
-    alsaLib fftwSinglePrec freetype libjack2
-    libX11 libXcomposite libXcursor libXext
-    libXinerama libXrender ladspa-sdk
+    alsaLib
+    freetype
+    libGL
+    libX11
+    libXcursor
+    libXext
+    libXrender
   ];
 
-  makeFlags = [ "PREFIX=$(out)" ];
-
   meta = with stdenv.lib; {
-    homepage = "http://distrho.sourceforge.net";
-    description = "A collection of cross-platform audio effects and plugins";
+    homepage = "http://distrho.sourceforge.net/ports";
+    description = "Linux audio plugins and LV2 ports";
     longDescription = ''
       Includes:
-      Dexed drowaudio-distortion drowaudio-distortionshaper drowaudio-flanger
-      drowaudio-reverb drowaudio-tremolo drumsynth EasySSP eqinox HiReSam
-      JuceDemoPlugin KlangFalter LUFSMeter LUFSMeterMulti Luftikus Obxd
-      PitchedDelay ReFine StereoSourceSeparation TAL-Dub-3 TAL-Filter
-      TAL-Filter-2 TAL-NoiseMaker TAL-Reverb TAL-Reverb-2 TAL-Reverb-3
-      TAL-Vocoder-2 TheFunction ThePilgrim Vex Wolpertinger
+        arctican-function
+        arctican-pilgrim
+        dexed
+        drowaudio-distortion
+        drowaudio-distortionshaper
+        drowaudio-flanger
+        drowaudio-reverb
+        drowaudio-tremolo
+        drumsynth
+        easySSP
+        eqinox
+        HiReSam
+        juce-opl
+        klangfalter
+        LUFSMeter
+        LUFSMeter-Multi
+        luftikus
+        obxd
+        pitchedDelay
+        refine
+        stereosourceseparation
+        tal-dub-3
+        tal-filter
+        tal-filter-2
+        tal-noisemaker
+        tal-reverb
+        tal-reverb-2
+        tal-reverb-3
+        tal-vocoder-2
+        temper
+        vex
+        wolpertinger
     '';
     license = with licenses; [ gpl2 gpl3 gpl2Plus lgpl3 mit ];
     maintainers = [ maintainers.goibhniu ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

To be clear: ``2020-07-14`` is the name of the release, it's not another unstable.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).