### PR TITLE
wlroots: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -22,7 +22,9 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    substituteInPlace meson.build --replace "v1.5" "1.5"
+    substituteInPlace meson.build \
+      --replace "v1.5" "1.5" \
+      --replace "wlroots_version = ['>=0.11.0', '<0.12.0']" "wlroots_version = ['>=0.11.0', '<0.13.0']"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "wlroots";
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "wlroots";
     rev = version;
-    sha256 = "08d5d52m8wy3imfc6mdxpx8swhh2k4s1gmfaykg02j59z84awc6p";
+    sha256 = "01j38lmgs2c6fq68v8b75pkilia2wsgzgp46ivfbi9hhx47kgcfn";
   };
 
   # $out for the library and $examples for the example programs (in examples):
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     libpng ffmpeg
   ];
 
-  mesonFlags = [ "-Dlogind-provider=systemd" ];
+  mesonFlags = [ "-Dlogind-provider=systemd" "-Dlibseat=disabled" ];
 
   postFixup = ''
     # Install ALL example programs to $examples:


### PR DESCRIPTION
###### Motivation for this change

WIP, need to wait for updates of the reverse dependencies first or patch them:
- [x] sway-unwrapped/sway (-> sway-contrib.grimshot and waybar)

nixpkgs-review:
```
10 packages built:
cage cagebreak fuzzel hikari qt-video-wlr sway sway-contrib.grimshot sway-unwrapped waybar wlroots
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
