### PR TITLE
manual: nginx: Mention ProtectHome in release notes. See #85567

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -885,6 +885,17 @@ php.override {
 systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
        </programlisting>
      </para>
+     <para>
+       Nginx is also started with the systemd option <literal>ProtectHome = mkDefault true;</literal>
+       which forbids it to read anything from <literal>/home</literal>, <literal>/root</literal>
+       and <literal>/run/user</literal> (see
+       <link xlink:href="https://www.freedesktop.org/software/systemd/man/systemd.exec.html#ProtectHome=">ProtectHome docs</link>
+       for details).
+       If you require serving files from home directories, you may choose to set e.g.
+<programlisting>
+systemd.services.nginx.serviceConfig.ProtectHome = "read-only";
+</programlisting>
+     </para>
    </listitem>
    <listitem>
     <para>

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -879,7 +879,7 @@ php.override {
    <listitem>
      <para>
        Nginx web server now starting with additional sandbox/hardening options. By default, write access
-       to <literal>services.nginx.stateDir</literal> is allowed. To allow writing to other folders,
+       to <literal>/var/log/nginx</literal> and <literal>/var/cache/nginx</literal> is allowed. To allow writing to other folders,
        use <literal>systemd.services.nginx.serviceConfig.ReadWritePaths</literal>
        <programlisting>
 systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/85567#pullrequestreview-525820684.

With the upgrade to 20.09, trying to set

```nix
{
  services.nginx = {
    enable = true;
    virtualHosts."example.com".root = "/home/niklas/web"; # Requires `chmod o+x /home/niklas`.
  };
}
```

I got permission errors in nginx logs:

```
[error] ...: *2 "/home/niklas/web/index.html" is forbidden (13: Permission denied), ...
```

and in strace:

```
stat("/home/niklas/web/index.html", 0x7ffc40253550) = -1 EACCES (Permission denied)
```

despite my file system permissions being set up correctly.

`sudo -u nginx stat /home/niklas/web/index.html` completed successfully.

Eventually I found that this is because of the new `ProtectHome = mkDefault true;` systemd sandboxing option introduced in https://github.com/NixOS/nixpkgs/blob/29cb4d04d0dd6d8fb5d0c896fd325bf06729092e/nixos/modules/services/web-servers/nginx/default.nix#L725

(PR #85567).

---

This changelog update makes the user aware of this. It needs to be backported to 20.09.