### PR TITLE
nixos/zone-firewall: initial version (DRAFT)

### DIFF
--- a/nixos/modules/config/zfw/core.nix
+++ b/nixos/modules/config/zfw/core.nix
@@ -1,0 +1,138 @@
+{config, lib, packages, ...}:
+
+with lib;
+
+let
+  nftlib = import ./nftlib.nix {inherit lib;};
+  cfg = config.networking.nftables;
+  
+  sortRules = sort (a: b: a.priority > b.priority);
+
+  indentLol = indent: lol:
+      let
+        indent' = prefix: list:
+          if isNull list then
+            null
+          else if isString list then
+            prefix + list
+          else
+            map (indent' (prefix + indent)) list;
+      in
+        map (indent' "") lol;
+
+
+  processChain = name: chain:
+    let
+      hookStr =
+        if !isNull chain.hook then
+          let
+            inherit (chain.hook) hook policy type priority;
+            policyStr = if !isNull policy
+                        then " policy ${chain.hook.policy};"
+                        else "";
+          in
+            "type ${type} hook ${hook} priority ${priority};" + policyStr
+        else
+          null;
+
+      getRuleText = {rule, ...}:
+        if isList rule then
+          rule
+        else
+          [ rule ];
+      
+      rules = concatMap getRuleText (sortRules chain.rules);
+    in [
+      "chain ${name} {"
+      [ hookStr ]
+      rules
+      "}"
+    ];
+  
+  tableChains = table: concatLists (mapAttrsToList processChain table.chains);
+  
+  processTable = family: name: table:
+    [
+      "table ${family} ${name} {"
+      (tableChains table)
+      "}"
+    ];
+
+  processFamily = family: tables:
+    concatLists (mapAttrsToList (processTable family) tables);
+
+  rulesetLol = concatLists (mapAttrsToList processFamily cfg.tables);
+
+  ruleset = concatStringsSep "\n"
+    (filter (x: ! isNull x)
+      (flatten
+        (indentLol "\t" rulesetLol)));
+  
+in {
+  options.networking.nftables =
+    with types;
+    {
+      tables = mkOption {
+        description = "An nftables table. The names of these should be the address type";
+
+        default = {};
+        type = attrsOf ( attrsOf (submodule {
+
+          options = {
+            chains = mkOption {
+              description = "The chains that go in this table";
+
+              type = attrsOf (submodule {
+                options = {
+                  hook = mkOption {
+                    description = "Options for a base chain";
+
+                    default = null;
+                    
+                    type = nullOr (submodule {
+                      options = {
+                        hook = mkOption {
+                          type = enum [
+                            "prerouting"
+                            "input"
+                            "forward"
+                            "output"
+                            "postrouting"
+                            "ingress"
+                          ];
+                        };
+
+                        type = mkOption {
+                          description = "Base chain type";
+
+                          type = enum [ "filter" "nat" "route" ];
+                        };
+
+                        priority = mkOption {
+                          type = coercedTo int toString str;
+                          default = 0;
+                        };
+
+                        policy = mkOption {
+                          description = "Default verdict for this chain";
+                          type = nullOr (enum ["accept" "drop"]);
+                          default = null;
+                        };
+                      };
+                    });
+                  }; # End of hook options
+                  
+                  rules = mkOption {
+                    default = [];
+                    type = listOf (submodule { options = nftlib.ruleBaseOptions; });
+                  };
+                };
+              });
+            };
+          };
+        }));
+      };
+    };
+
+  config.networking.nftables.ruleset = ruleset;
+}

--- a/nixos/modules/config/zfw/default.nix
+++ b/nixos/modules/config/zfw/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./core.nix
+    ./zone-firewall.nix
+  ];
+}

--- a/nixos/modules/config/zfw/nftlib.nix
+++ b/nixos/modules/config/zfw/nftlib.nix
@@ -1,0 +1,29 @@
+{lib}:
+with lib;
+rec {
+  priorityOption = {
+    description = ''
+      The priority of this rule. Rules with lower priority values
+       will be processed later.
+     '';
+    type = types.int;
+    default = 500;
+  };
+
+  ruleBaseOptions = {
+    priority = mkOption priorityOption;
+    rule = mkOption {
+      description = "nftables rule";
+      type = nestedListOf types.str;
+    };
+  };
+
+  normalizeRule = {priority, rule, ...}: { inherit priority rule; };
+
+  nestedListOf = type:
+    let
+      innerType = types.either (types.listOf innerType) type;
+    in
+      types.coercedTo type singleton innerType;
+    
+}

--- a/nixos/modules/config/zfw/zone-firewall.nix
+++ b/nixos/modules/config/zfw/zone-firewall.nix
@@ -1,0 +1,352 @@
+{ config, lib, pkgs, ...}:
+
+with lib;
+with import ./nftlib.nix {inherit lib;};
+let
+  cfg = config.networking.zone-firewall;
+
+  zones = unique ((attrValues cfg.interfaces) ++ [cfg.localZone]);
+
+  ruleMatches = situation: rule:
+    let conditionMatches = cond:
+          all (key: let condValue = cond.${key} or "*";
+                    in
+                      (elem situation.${key} condValue) ||
+                      (elem "*" condValue))
+            (attrNames situation);
+    in
+      any conditionMatches
+        (if rule.conditions != null
+         then rule.conditions
+         else [{}]);
+    
+  rulesForZone = type: from: to: 
+    let
+      matcher = ruleMatches { inherit from to; };
+
+      filteredRules = filter matcher (attrValues cfg.rules);
+      isHairpin = 
+        cfg.allowHairpin
+        && (from == to)
+        && (! isNull from);
+      acceptRule =
+        optional isHairpin
+          { rule = "accept"; priority = -10000000; };
+
+    in
+      (map normalizeRule filteredRules) ++ acceptRule;
+
+  globalRules = genAttrs ["filter" "nat"]
+    (type: map normalizeRule
+      (filter (rule: rule.type == type) (attrValues cfg.globalRules)));
+
+  chainForZonePair = from: to:
+      "nixos-zone-${serializedZoneName from}/${serializedZoneName to}";
+  
+  serializedZoneName = name:
+      if isNull name 
+      then "nixos-unknown"
+      else name;
+
+  filterZoneChains =
+    let
+      makeChain = from: to:
+        nameValuePair (chainForZonePair from to) {
+          rules = rulesForZone "filter" from to;
+        };
+      extendedZones = zones ++ [null];
+    in
+      listToAttrs (lists.crossLists makeChain [extendedZones extendedZones]);
+
+  zoneListT = with types;
+    coercedTo
+      (nullOr str)
+      lists.singleton
+      (listOf (nullOr str));
+
+  filterHookChain =
+    hook: chain: {
+      hook = {
+        type = "filter";
+        hook = hook;
+        priority = 0;
+        policy = cfg.policy;
+      };
+      
+      rules = globalRules.filter ++ [
+        { rule = "jump ${chain}"; priority = 0; }
+      ];
+    };
+  
+in {
+  options.networking.zone-firewall = with types; {
+    enable = mkOption {
+      description = "Whether to use TQ's nftables-based zone firewall";
+      default = false;
+      type = bool;
+    };
+
+    localZone = mkOption {
+      description = ''
+        The zone that this machine should be considered part of.
+      '';
+
+      default = "local";
+      type = str;
+    };
+
+    interfaces = mkOption {
+      description = ''
+        Mapping of interfaces to zones.  Each interface may be in at most one zone.
+      '';
+      example = ''
+        {
+          eth0 = "wan";
+          eth1 = "lan";
+          eth2 = "lan";
+          eth3 = "mgmt";
+        }
+      '';
+        
+      default = {};
+      type = attrsOf str;
+    };
+
+    rules = mkOption {
+      description = ''
+        Rules for filtering packets.
+
+        Values are a list of rules. A rule must be an nftables filter
+        string (as you might write on an "nft add rule" command line,
+        just without the table or chain parameters).
+      '';
+
+      default = {};
+      type = attrsOf (submodule {
+        options = ruleBaseOptions // {
+          type = mkOption {
+            description = ''
+              Rule type (nat or filter).
+
+              NAT rules may have at most one of fromZone or toZone set.
+            '';
+            type = enum [ "nat" "filter" ];
+            default = "filter";
+          };
+
+          conditions = mkOption {
+            description = ''
+              List of conditions under which the rule should apply. If
+              any item in this list matches, the associated rule is
+              added to the chain.
+            '';
+            example = [
+              { from = "*"; to = "local"; }
+            ];
+            type = listOf (submodule {
+              options = {
+                from = mkOption {
+                  description = ''
+                    Source zone. May be one of the zones in 'interfaces',
+                    the local zone, '*' for all zones, null for a packet that
+                    doesn't match an existing zone, or a list of the above.
+                  '';
+                  default = "*";
+                  type = zoneListT;
+                };
+
+                to = mkOption {
+                  description = "Destination zone. See from for details";
+                  default = "*";
+                  type = zoneListT;
+                };
+              };
+            });
+          };
+        };
+      });
+    };
+
+    policy = mkOption {
+      description = "What to do with unhandled packets";
+      type = nullOr (enum [ "accept" "drop" ]);
+      default = "drop";
+    };
+
+    globalRules = mkOption {
+      description = ''
+        Rules that should always be run.
+      '';
+
+      default = {};
+
+      type = attrsOf (submodule {
+        options = ruleBaseOptions // {
+          priority = mkOption (priorityOption // {
+            description = priorityOption.description + ''
+              Zone-specific processing happens at priority 0. Negative
+              priorities can be used to add postprocessing steps.
+            '';
+          });
+
+          type = mkOption {
+            type = enum [ "filter" "nat" ];
+            description = "Type of rule";
+            default = "filter";
+          };
+        };
+      });
+    };
+
+    saneDefaults = mkOption {
+      description = ''
+        Enable default rules allowing outbound traffic, ICMP traffic,
+        and the standard related,established jazz. You probably want
+        this enabled unless you want complete control over your
+        firewall.
+
+        Equivalent to:
+
+        globalRules = {
+          sanePacketTrace = { priority = 2000; rule = "jump nixos-pkt-trace"; };
+          saneRelEst = { priority = 1000; rule = "jump nixos-relest"; };
+          saneICMP = { priority = 900; rule = "jump nixos-global-icmp"; };
+        };
+
+        rules.acceptFromLocal =
+          { conditions = [ {from = "local"; }]; rule = "accept"; priority = -1000; };
+
+        Note that the referenced chains always exist, and can be used even if 
+      '';
+
+      default = true;
+      type = bool;
+    };
+
+    allowHairpin = mkOption {
+      description = ''
+        Automatically add a default accept rule from each zone to itself.
+      '';
+      type = bool;
+      default = true;
+    };
+  };
+  
+  config = mkMerge [
+    (mkIf cfg.saneDefaults {
+      networking.zone-firewall = {
+        globalRules = {
+          sanePacketTrace = { priority = 2000; rule = "jump nixos-pkt-trace"; };
+          saneRelEst = { priority = 1000; rule = "jump nixos-relest"; };
+          saneICMP = { priority = 900; rule = "jump nixos-global-icmp"; };
+        };
+
+        # Default accept packets from the local zone.
+        rules.acceptFromLocal = {
+          conditions = [{from = cfg.localZone; }];
+          rule = "accept"; priority = -1000;
+        };
+      };
+    })
+    (mkIf cfg.enable {
+      networking.firewall.enable = false;
+
+      networking.nftables.tables = {
+        inet.nixos-zfw = {
+          chains = filterZoneChains // {
+            nixos-pkt-trace = {};
+            nixos-relest.rules = [
+              { rule = "ct state established,related accept"; }
+              { rule = "ct state invalid drop"; }
+            ];
+            nixos-global-icmp.rules = [
+              { rule = "ip protocol icmp accept"; }
+              { rule = "ip6 nexthdr icmpv6 accept"; }
+            ];
+
+            nixos-input-zone.rules =
+              let
+                vmapArgs =
+                  mapAttrsToList
+                    (iface: zone:
+                      "${iface} : goto ${chainForZonePair zone cfg.localZone}, ")
+                    cfg.interfaces;
+                
+              in [
+                {
+                  rule = ["iifname vmap {" vmapArgs "}"];
+                  priority = 300;
+                }
+                {
+                  rule = "goto ${chainForZonePair null cfg.localZone}";
+                  priority = 200;
+                }
+              ];
+
+            nixos-output-zone.rules =
+              let
+                vmapArgs =
+                  mapAttrsToList
+                    (iface: zone:
+                      "${iface} : goto ${chainForZonePair cfg.localZone zone}, ")
+                    cfg.interfaces;
+                
+              in [
+                {
+                  rule = ["oifname vmap {" vmapArgs "}"];
+                  priority = 300;
+                }
+                {
+                  rule = "goto ${chainForZonePair cfg.localZone null}";
+                  priority = 200;
+                }
+              ];
+
+            nixos-forward-zone.rules =
+              let
+                ifaceList = mapAttrsToList nameValuePair cfg.interfaces;
+                
+                knownVmap =
+                  crossLists
+                    (from: to:
+                      "${from.name} . ${to.name} : goto ${ chainForZonePair from.value to.value },")
+                    [ifaceList ifaceList];
+                unknownSourceVmap =
+                  mapAttrsToList
+                    (iface: zone:
+                      "${iface} : goto ${chainForZonePair null zone},")
+                    cfg.interfaces;
+                
+                unknownDestVmap =
+                  mapAttrsToList
+                    (iface: zone:
+                      "${iface} : goto ${chainForZonePair zone null},")
+                    cfg.interfaces;
+              in [
+                {
+                  rule = [
+                    "iifname . oifname vmap {" knownVmap "}"
+                    "iifname vmap {" unknownDestVmap "}"
+                    "oifname vmap {" unknownSourceVmap "}"
+                    "goto ${chainForZonePair null null}"
+                  ];
+                }
+              ];
+                
+            
+            nixos-input = filterHookChain "input" "nixos-input-zone";
+            nixos-output = filterHookChain "output" "nixos-output-zone";
+            nixos-forward = filterHookChain "forward" "nixos-forward-zone";
+          };
+        };
+      };
+      
+      assertions = [
+        {
+          assertion = (config.networking.firewall.enable == false);
+          message = "Zone-based firewall and nix-based firewall cannot be enabled at the same time";
+        }
+      ];
+    })
+  ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -9,6 +9,8 @@
   ./config/xdg/menus.nix
   ./config/xdg/mime.nix
   ./config/xdg/portal.nix
+  ./config/zfw/core.nix
+  ./config/zfw/zone-firewall.nix
   ./config/appstream.nix
   ./config/console.nix
   ./config/xdg/sounds.nix


### PR DESCRIPTION
This adds a zone-based firewall configured using Nix and backed by
nftables.  It is ideal for use on routers and servers, and useful for
any system with more than one network connection. At the time of this
commit, it has already been used in production on multiple machines
for several months.

###### Motivation for this change

The existing nix firewall is very rudimentary; it is only suitable for systems with a single interface, or for which all interfaces should be treated equally. Anything more complex needs to be handled via hand-written iptables scripts (which, admittedly, can be maintained using nix).

This new zone-based firewall allows declaratively adding rules that apply to any desired combination of zones (where a "zone" is some combination of interfaces or the local machine). Each rule has an attached priority, which allows the firewall rules for a given service to be kept next to the configuration for the service, while still being able to rely on some rules being evaluated before other rules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This PR is intended as a draft; it is still missing (and desperately needs) documentation and tests. I will write documentation in the coming weeks, but I'm not particularly sure how to test this module and could use some advice.

This started out being developed in [thequux/nix-zone-firewall](https://github.com/thequux/nix-zone-firewall); the README there is a decent starting point for seeing how to use it, but it hasn't been updated for significant configuration changes in the last commit of that repo.