### PR TITLE
Fix SDL_image loading jpeg and others

### DIFF
--- a/pkgs/development/libraries/SDL_image/default.nix
+++ b/pkgs/development/libraries/SDL_image/default.nix
@@ -17,7 +17,12 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  configureFlags = stdenv.lib.optional stdenv.isDarwin "--disable-sdltest";
+  configureFlags = [
+    # Disable its dynamic loading or dlopen will fail because of no proper rpath
+    "--disable-jpg-shared"
+    "--disable-png-shared"
+    "--disable-tif-shared"
+  ] ++ stdenv.lib.optional stdenv.isDarwin "--disable-sdltest";
 
   buildInputs = [ SDL libpng libjpeg libtiff libungif libXpm ];
 


### PR DESCRIPTION
It was using dlopen and its shared object didn't have the proper rpath
to do so.

This fixes tuxpaint loading of jpeg pictures.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
