### PR TITLE
pythonPackages.notmuch2: init at 0.31

### DIFF
--- a/pkgs/development/python-modules/notmuch/2.nix
+++ b/pkgs/development/python-modules/notmuch/2.nix
@@ -1,0 +1,22 @@
+{ stdenv
+, buildPythonPackage
+, notmuch
+, python
+, cffi
+}:
+
+buildPythonPackage {
+  pname = "notmuch2";
+  inherit (notmuch) version src;
+
+  sourceRoot = "${notmuch.src.name}/bindings/python-cffi";
+
+  buildInputs = [ python notmuch cffi ];
+
+  meta = with stdenv.lib; {
+    description = "Pythonic bindings for the notmuch mail database using CFFI";
+    homepage = "https://notmuchmail.org/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4114,6 +4114,7 @@ in {
   notify-py = callPackage ../development/python-modules/notify-py { };
 
   notmuch = callPackage ../development/python-modules/notmuch { inherit (pkgs) notmuch; };
+  notmuch2 = callPackage ../development/python-modules/notmuch/2.nix { inherit (pkgs) notmuch; };
 
   nototools = callPackage ../data/fonts/noto-fonts/tools.nix { };
 


### PR DESCRIPTION
generates bindings via cffi

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
wanted to test alot master. I don't think these bindings have been released yet, hence the draft status.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
