### PR TITLE
macdylibbundler: Should propagate dependency on otool

### DIFF
--- a/pkgs/development/tools/misc/macdylibbundler/default.nix
+++ b/pkgs/development/tools/misc/macdylibbundler/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   postInstall = ''
     wrapProgram $out/bin/dylibbundler \
-      --prefix PATH : "${cctools}/bin"
+      --prefix PATH ":" "${cctools}/bin"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/misc/macdylibbundler/default.nix
+++ b/pkgs/development/tools/misc/macdylibbundler/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, makeWrapper, fetchFromGitHub, cctools }:
 
 stdenv.mkDerivation {
   pname = "macdylibbundler";
@@ -11,7 +11,14 @@ stdenv.mkDerivation {
     sha256 = "149p3dcnap4hs3nhq5rfvr3m70rrb5hbr5xkj1h0gsfp0d7gvxnj";
   };
 
+  buildInputs = [ makeWrapper ];
+
   makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/dylibbundler \
+      --prefix PATH : "${cctools}/bin"
+  '';
 
   meta = with stdenv.lib; {
     description = "Utility to ease bundling libraries into executables for OSX";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22310,7 +22310,7 @@ in
 
   mac = callPackage ../development/libraries/mac { };
 
-  macdylibbundler = callPackage ../development/tools/misc/macdylibbundler { };
+  macdylibbundler = callPackage ../development/tools/misc/macdylibbundler { inherit (darwin) cctools; };
 
   magic-wormhole = with python3Packages; toPythonApplication magic-wormhole;
 


### PR DESCRIPTION
The `macdylibbundler` tool expects the `otool` to be on the PATH, so
this adds it to `propagatedBuildInputs`.

(Is this the right way? Or should this patch the source to put a full path there? Or a wrapper script? Happy to learn.)