### PR TITLE
[20.03] libexif: apply patches for CVE-2020-0198, CVE-2020-0452

### DIFF
--- a/pkgs/development/libraries/libexif/default.nix
+++ b/pkgs/development/libraries/libexif/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, gettext }:
+{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, gettext }:
 
 stdenv.mkDerivation rec {
   pname = "libexif";
@@ -10,6 +10,20 @@ stdenv.mkDerivation rec {
     rev = "${pname}-${builtins.replaceStrings ["."] ["_"] version}-release";
     sha256 = "0mzndakdi816zcs13z7yzp7hj031p2dcyfq2p391r63d9z21jmy1";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-0198.patch";
+      url = "https://github.com/libexif/libexif/commit/ce03ad7ef4e8aeefce79192bf5b6f69fae396f0c.patch";
+      sha256 = "1040278g5dbq3vvlyk8cmzb7flpi9bfsp99268hw69i6ilwbdf2k";
+    })
+    (fetchpatch {
+      name = "CVE-2020-0452.patch";
+      url = "https://github.com/libexif/libexif/commit/9266d14b5ca4e29b970fa03272318e5f99386e06.patch";
+      excludes = [ "NEWS" ];
+      sha256 = "0k4z1gbbkli6wwyy9qm2qvn0h00qda6wqym61nmmbys7yc2zryj6";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook gettext ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backport #103144 with fixed commit message.

* CVE-2020-0198: unsigned integer overflow in exif_data_load_data_content
* CVE-2020-0452: compiler optimization could remove an a bufferoverflow check, making a buffer overflow possible with some EXIF tags

Fixes: CVE-2020-0198, CVE-2020-0452
(cherry picked from commit 602d26e8bd6b45add7aef3bd528e9c20ad3a1249)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
