### PR TITLE
ungoogled-chromium: 86.0.4240.111-1 -> 86.0.4240.183-1

### DIFF
--- a/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/common.nix
@@ -344,7 +344,12 @@ let
       patchelf --set-rpath "${libGL}/lib:$origRpath" "$chromiumBinary"
     '';
 
-    passthru.updateScript = ./update.py;
+    passthru = {
+      updateScript = ./update.py;
+      chromiumDeps = {
+        gn = gnChromium;
+      };
+    };
   };
 
 # Remove some extraAttrs we supplied to the base attributes already.

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/default.nix
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/default.nix
@@ -37,26 +37,15 @@ let
       inherit channel gnome gnomeSupport gnomeKeyringSupport proprietaryCodecs
               cupsSupport pulseSupport useOzone;
       inherit ungoogled;
-      # TODO: Remove after we can update gn for the stable channel (backward incompatible changes):
       gnChromium = gn.overrideAttrs (oldAttrs: {
-        version = "2020-07-20";
+        inherit (upstream-info.deps.gn) version;
         src = fetchgit {
-          url = "https://gn.googlesource.com/gn";
-          rev = "3028c6a426a4aaf6da91c4ebafe716ae370225fe";
-          sha256 = "0h3wf4152zdvrbb0jbj49q6814lfl3rcy5mj8b2pl9s0ahvkbc6q";
+          inherit (upstream-info.deps.gn) url rev sha256;
         };
       });
     } // lib.optionalAttrs (lib.versionAtLeast upstream-info.version "87") {
       useOzone = true; # YAY: https://chromium-review.googlesource.com/c/chromium/src/+/2382834 \o/
       useVaapi = !stdenv.isAarch64; # TODO: Might be best to not set use_vaapi anymore (default is fine)
-      gnChromium = gn.overrideAttrs (oldAttrs: {
-        version = "2020-08-17";
-        src = fetchgit {
-          url = "https://gn.googlesource.com/gn";
-          rev = "6f13aaac55a977e1948910942675c69f2b4f7a94";
-          sha256 = "01hpma1sllpdx09mvr4d6073sg6zmk6iv44kd3r28khymcj4s251";
-        };
-      });
     });
 
     browser = callPackage ./browser.nix { inherit channel enableWideVine; };

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/ungoogled-src.nix
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/ungoogled-src.nix
@@ -1,6 +1,6 @@
 {
-  "86.0.4240.111" = {
-    rev = "86.0.4240.111-1";
-    sha256 = "0fkk0lxbvik8q8d5njxmwiam64qz5g74hlb56w24nh5mh1jm59a8";
+  "86.0.4240.183" = {
+    rev = "86.0.4240.183-1";
+    sha256 = "0528l2wr5bpl1cwsxzl5zxz1gw91kffkh5j1kzmc5n7m4mscqxyc";
   };
 }

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/update.py
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/update.py
@@ -1,13 +1,15 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python -p python3 nix
+#! nix-shell -i python -p python3 nix nix-prefetch-git
 
 import csv
 import json
+import re
 import subprocess
 import sys
 
 from codecs import iterdecode
 from collections import OrderedDict
+from datetime import datetime
 from os.path import abspath, dirname
 from urllib.request import urlopen
 
@@ -25,6 +27,30 @@ def nix_prefetch_url(url, algo='sha256'):
     print(f'nix-prefetch-url {url}')
     out = subprocess.check_output(['nix-prefetch-url', '--type', algo, url])
     return out.decode('utf-8').rstrip()
+
+def nix_prefetch_git(url, rev):
+    print(f'nix-prefetch-git {url} {rev}')
+    out = subprocess.check_output(['nix-prefetch-git', '--quiet', '--url', url, '--rev', rev])
+    return json.loads(out)
+
+def get_file_revision(revision, file_path):
+    url = f'https://raw.githubusercontent.com/chromium/chromium/{revision}/{file_path}'
+    with urlopen(url) as http_response:
+        return http_response.read()
+
+def get_channel_dependencies(channel):
+    deps = get_file_revision(channel['version'], 'DEPS')
+    gn_pattern = b"'gn_version': 'git_revision:([0-9a-f]{40})'"
+    gn_commit = re.search(gn_pattern, deps).group(1).decode()
+    gn = nix_prefetch_git('https://gn.googlesource.com/gn', gn_commit)
+    return {
+        'gn': {
+            'version': datetime.fromisoformat(gn['date']).date().isoformat(),
+            'url': gn['url'],
+            'rev': gn['rev'],
+            'sha256': gn['sha256']
+        }
+    }
 
 channels = {}
 last_channels = load_json(JSON_PATH)
@@ -57,6 +83,8 @@ with urlopen(HISTORY_URL) as resp:
             # This build isn't actually available yet.  Continue to
             # the next one.
             continue
+
+        channel['deps'] = get_channel_dependencies(channel)
 
         channels[channel_name] = channel
 

--- a/pkgs/applications/networking/browsers/ungoogled-chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/ungoogled-chromium/upstream-info.json
@@ -1,17 +1,41 @@
 {
   "stable": {
-    "version": "86.0.4240.111",
-    "sha256": "05y7lwr89awkhvgmwkx3br9j4ap2aypg2wsc0nz8mi7kxc1dnyzj",
-    "sha256bin64": "10aqiiydw4i3jxnw8xxdgkgcqbfqc67n1fbrg40y54kg0v5dz8l6"
+    "version": "86.0.4240.183",
+    "sha256": "1g39i82js7fm4fqb8i66d6xs0kzqjxzi4vzvvwz5y9rkbikcc4ma",
+    "sha256bin64": "1r0dxqsx6j19hgwr3v2sdlb2vd7gb961c4wba4ymd8wy8j8pzly9",
+    "deps": {
+      "gn": {
+        "version": "2020-08-07",
+        "url": "https://gn.googlesource.com/gn",
+        "rev": "e327ffdc503815916db2543ec000226a8df45163",
+        "sha256": "0kvlfj3www84zp1vmxh76x8fdjm9hyk8lkh2vdsidafpmm75fphr"
+      }
+    }
   },
   "beta": {
-    "version": "87.0.4280.27",
-    "sha256": "0w0asxj7jlsw69cssfia8km4q9cx1c2mliks2rmhf4jk0hsghasm",
-    "sha256bin64": "1lsx4mhy8nachfb8c9f3mrx5nqw2bi046dqirb4lnv7y80jjjs1k"
+    "version": "87.0.4280.40",
+    "sha256": "07xh76fl257np68way6i5rf64qbvirkfddy7m5gvqb0fzcqd7dp3",
+    "sha256bin64": "1b2z0aqlh28pqrk6dmabxp1d4mvp9iyfmi4kqmns4cdpg0qgaf41",
+    "deps": {
+      "gn": {
+        "version": "2020-09-09",
+        "url": "https://gn.googlesource.com/gn",
+        "rev": "e002e68a48d1c82648eadde2f6aafa20d08c36f2",
+        "sha256": "0x4c7amxwzxs39grqs3dnnz0531mpf1p75niq7zhinyfqm86i4dk"
+      }
+    }
   },
   "dev": {
-    "version": "88.0.4298.4",
-    "sha256": "0ka11gmpkyrmifajaxm66c16hrj3xakdvhjqg04slyp2sv0nlhrl",
-    "sha256bin64": "0768y31jqbl1znp7yp6mvl5j12xl1nwjkh2l8zdga81q0wz52hh6"
+    "version": "88.0.4300.0",
+    "sha256": "00cfs2rp4h8ybn2snr1d8ygg635hx7q5gv2aqriy1j6f8a1pgh1b",
+    "sha256bin64": "110r1m14h91212nx6pfhn8wkics7wlwx1608l5cqsxxcpvpzl3pv",
+    "deps": {
+      "gn": {
+        "version": "2020-09-09",
+        "url": "https://gn.googlesource.com/gn",
+        "rev": "e002e68a48d1c82648eadde2f6aafa20d08c36f2",
+        "sha256": "0x4c7amxwzxs39grqs3dnnz0531mpf1p75niq7zhinyfqm86i4dk"
+      }
+    }
   }
 }


### PR DESCRIPTION
This updates ungoogled-chromium. This change was created by manually copying the regular chromium expressions and applying a small diff to support the ungoogled patchset.

Performed a cursory test and everything looks good.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @danielfullmer 