### PR TITLE
Fix GHC bootstrap in pkgsMusl and include patch for binutils/16177

### DIFF
--- a/pkgs/development/tools/misc/binutils/R_ARM_COPY.patch
+++ b/pkgs/development/tools/misc/binutils/R_ARM_COPY.patch
@@ -1,0 +1,29 @@
+@@ -, +, @@ 
+---
+ bfd/elf32-arm.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+--- a/bfd/elf32-arm.c	
++++ a/bfd/elf32-arm.c	
+@@ -15398,7 +15398,11 @@ elf32_arm_adjust_dynamic_symbol (struct bfd_link_info * info,
+      linker to copy the initial value out of the dynamic object and into
+      the runtime process image.  We need to remember the offset into the
+      .rel(a).bss section we are going to use.  */
+-  if ((h->root.u.def.section->flags & SEC_READONLY) != 0)
++  if (info->nocopyreloc == 0
++      && (h->root.u.def.section->flags & SEC_ALLOC) != 0
++      /* PR 16177: A copy is only needed if the input section is readonly.  */
++      && (h->root.u.def.section->flags & SEC_READONLY) != 0
++      && h->size != 0)
+     {
+       s = globals->root.sdynrelro;
+       srel = globals->root.sreldynrelro;
+@@ -15410,6 +15414,8 @@ elf32_arm_adjust_dynamic_symbol (struct bfd_link_info * info,
+     }
+   if (info->nocopyreloc == 0
+       && (h->root.u.def.section->flags & SEC_ALLOC) != 0
++      /* PR 16177: A copy is only needed if the input section is readonly.  */
++      && (h->root.u.def.section->flags & SEC_READONLY) != 0
+       && h->size != 0)
+     {
+       elf32_arm_allocate_dynrelocs (info, srel, 1);
+

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -101,6 +101,14 @@ stdenv.mkDerivation {
     ./patches/2.31/0001-x86-Properly-add-X86_ISA_1_NEEDED-property.patch
   ]
   ++ lib.optional stdenv.targetPlatform.isiOS ./support-ios.patch
+  ++ # This patch was suggested by Nick Clifton to fix
+     # https://sourceware.org/bugzilla/show_bug.cgi?id=16177
+     # It can be removed when that 7-year-old bug is closed.
+     # This binutils bug causes GHC to emit broken binaries on armv7, and
+     # indeed GHC will refuse to compile with a binutils suffering from it. See
+     # this comment for more information:
+     # https://gitlab.haskell.org/ghc/ghc/issues/4210#note_78333
+     lib.optional stdenv.targetPlatform.isAarch32 ./R_ARM_COPY.patch
   ;
 
   outputs = [ "out" "info" "man" ];


### PR DESCRIPTION
###### Motivation for this change

This allows one to cross compile statically linked Haskell programs for armv7

Fixes https://github.com/NixOS/nixpkgs/issues/85924 using Ben's patch from there. A similar patch should probably be applied to ghc8102-binary.

Fixes https://sourceware.org/bugzilla/show_bug.cgi?id=16177 by applying the patch mentioned there.

Although there was some talk about the efficacy of the binutils patch (https://sourceware.org/bugzilla/show_bug.cgi?id=16177#c9 and expipiplus1@14efdb2) the resulting binary seems to run without issue on the target platform. Jessica's patch there caused ld to fail linking some programs.

It would be good if there was some resolution to the discussion on the binutils ticket, however this does seem to be an improvement over the broken state of things at the moment. 

Obviously this would require rebuilding everything Haskell, and everything on armv7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
