### PR TITLE
asciigraph: init at 0.5.1

### DIFF
--- a/pkgs/tools/text/asciigraph/default.nix
+++ b/pkgs/tools/text/asciigraph/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "asciigraph";
+  version = "0.5.1";
+
+  goPackagePath = "github.com/guptarohit/asciigraph";
+
+  src = fetchFromGitHub {
+    owner = "guptarohit";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0aqf64b5d5lf9scvxdx5f3p0vvx5s59mrvr6hcjljg1prksah9ns";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/guptarohit/asciigraph";
+    description = "Lightweight ASCII line graph ╭┈╯ command line app";
+    license = licenses.bsd3;
+    maintainers = maintainers.mmahut;
+  };
+}

--- a/pkgs/tools/text/asciigraph/default.nix
+++ b/pkgs/tools/text/asciigraph/default.nix
@@ -17,6 +17,6 @@ buildGoPackage rec {
     homepage = "https://github.com/guptarohit/asciigraph";
     description = "Lightweight ASCII line graph ╭┈╯ command line app";
     license = licenses.bsd3;
-    maintainers = maintainers.mmahut;
+    maintainers = [ maintainers.mmahut ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8067,6 +8067,8 @@ in
 
   arachne-pnr = callPackage ../development/compilers/arachne-pnr { };
 
+  asciigraph = callPackage ../tools/text/asciigraph { };
+
   asn1c = callPackage ../development/compilers/asn1c { };
 
   aspectj = callPackage ../development/compilers/aspectj { };


### PR DESCRIPTION
###### Motivation for this change

Handly little tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
