### PR TITLE
libreoffice: Use --without-system-libnumbertext instead of --disable-libnumbertext

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -336,8 +336,6 @@ in (mkDrv rec {
     # Schema files for validation are not included in the source tarball
     "--without-export-validation"
 
-    "--disable-libnumbertext" # system-libnumbertext"
-
     # We do tarball prefetching ourselves
     "--disable-fetch-external"
     "--enable-build-opensymbol"
@@ -360,6 +358,7 @@ in (mkDrv rec {
     "--without-system-libfreehand"
     "--without-system-liblangtag"
     "--without-system-libmspub"
+    "--without-system-libnumbertext"
     "--without-system-libpagemaker"
     "--without-system-libstaroffice"
     "--without-system-libepubgen"


### PR DESCRIPTION
Option to disable libnumbertext was removed with
https://git.libreoffice.org/core/commit/c392ecfa734731194c366e869a3c2475c53dc867
It will affect 7.1.

@ofborg build libreoffice-still