### PR TITLE
python3Packages.kaggle: 1.5.6 -> 1.5.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3341,6 +3341,12 @@
     githubId = 1882000;
     name = "Guillaume Desforges";
   };
+  guillaumecherel = {
+    email = "guillaume.cherel@cosimus.com";
+    github = "guillaumecherel";
+    githubId = 6168820;
+    name = "Guillaume Chérel";
+  };
   guillaumekoenig = {
     email = "guillaume.edward.koenig@gmail.com";
     github = "guillaumekoenig";

--- a/pkgs/development/python-modules/kaggle/default.nix
+++ b/pkgs/development/python-modules/kaggle/default.nix
@@ -5,6 +5,7 @@
 , python-dateutil
 , python-slugify
 , six
+, slugify
 , requests
 , tqdm
 , urllib3
@@ -12,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "kaggle";
-  version = "1.5.6";
+  version = "1.5.9";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0f5qrkgklcpgbwncrif7aw4f86dychqplh7k3f4rljwnr9yhjb1w";
+    sha256 = "14rv7qykawnp5f7z0wjzp2if6gznf6q2mvk7qy4vins6nv7ywjj4";
   };
 
   # The version bounds in the setup.py file are unnecessarily restrictive.
@@ -31,6 +32,7 @@ buildPythonPackage rec {
     python-slugify
     requests
     six
+    slugify
     tqdm
     urllib3
   ];

--- a/pkgs/development/python-modules/slugify/default.nix
+++ b/pkgs/development/python-modules/slugify/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchPypi, buildPythonPackage, python, text-unidecode }:
+
+buildPythonPackage rec {
+    pname = "slugify";
+    version = "0.0.1";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "0k2y4cc0zkh3lzsifdx5hidbpf36cwqbps1wdx9lfs8s3k0kqw65";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = "https://github.com/zacharyvoase/slugify";
+      description = "A generic slugifier utility, inspired by Django’s slugify template filter.";
+      license = licenses.unlicense;
+      platforms = platforms.all;
+      maintainers = with maintainers; [  ];
+    };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6658,6 +6658,8 @@ in {
 
   slowaes = callPackage ../development/python-modules/slowaes { };
 
+  slugify = callPackage ../development/python-modules/slugify { };
+
   sly = callPackage ../development/python-modules/sly { };
 
   smartdc = callPackage ../development/python-modules/smartdc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Upgrade the kaggle command line API to its latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
