### PR TITLE
[20.09] isso: build from master

### DIFF
--- a/pkgs/servers/isso/default.nix
+++ b/pkgs/servers/isso/default.nix
@@ -1,26 +1,32 @@
-{ stdenv, python2, fetchFromGitHub }:
+{ stdenv, python3Packages, fetchFromGitHub }:
 
-with python2.pkgs; buildPythonApplication rec {
+with python3Packages; buildPythonApplication rec {
+
   pname = "isso";
-  version = "0.12.2";
+  # Can not use 0.12.2 because of:
+  # https://github.com/posativ/isso/issues/617
+  version = "unstable-2020-09-14";
 
   # no tests on PyPI
   src = fetchFromGitHub {
     owner = "posativ";
     repo = pname;
-    rev = version;
-    sha256 = "18v8lzwgl5hcbnawy50lfp3wnlc0rjhrnw9ja9260awkx7jra9ba";
+    rev = "f4d2705d4f1b51f444d0629355a6fcbcec8d57b5";
+    sha256 = "02jgfzq3svd54zj09jj7lm2r7ypqqjynzxa9dgnnm0pqvq728wzr";
   };
 
   propagatedBuildInputs = [
-    bleach
-    cffi
-    configparser
-    html5lib
-    ipaddr
+    itsdangerous
     jinja2
     misaka
+    html5lib
     werkzeug
+    bleach
+    flask-caching
+  ];
+
+  buildInputs = [
+    cffi
   ];
 
   checkInputs = [ nose ];
@@ -30,7 +36,6 @@ with python2.pkgs; buildPythonApplication rec {
   '';
 
   meta = with stdenv.lib; {
-    broken = true;
     description = "A commenting server similar to Disqus";
     homepage = "https://posativ.org/isso/";
     license = licenses.mit;


### PR DESCRIPTION

###### Motivation for this change

Backport of #97717, wasn't backported during ZHF: #97479

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
