### PR TITLE
v2ray: 4.31.0 -> 4.32.1

### DIFF
--- a/pkgs/tools/networking/v2ray/default.nix
+++ b/pkgs/tools/networking/v2ray/default.nix
@@ -3,33 +3,33 @@
 }:
 
 let
-  version = "4.31.0";
+  version = "4.32.1";
 
   src = fetchFromGitHub {
-    owner = "v2ray";
+    owner = "v2fly";
     repo = "v2ray-core";
     rev = "v${version}";
-    sha256 = "0s0blc05nrqm78qslv5xb42pjlx5v8qqwg0pwbzhxn9s71x2669m";
+    sha256 = "1mlrl5fz1v3bcb83pczqp859d8w9mi7jj600a2yw7xm372w2irk8";
   };
 
-  vendorSha256 = "0n2mf19fvgk5x0j2wwm4zk9xikzvl6cdvw26qar91wzcsraf5z2d";
+  vendorSha256 = "1mz1acdj8ailgyqrr1v47n36qc24ggzw5rmj4p2awfwz3gp2yz6z";
 
   assets = {
     # MIT licensed
     "geoip.dat" = let
-      geoipRev = "202009300006";
-      geoipSha256 = "1ss2izqlmrp5b5kpw804jk6c1nyimwlccbkikix3bwfaz4vlv1nc";
+      geoipRev = "202011050012";
+      geoipSha256 = "1d2n3hskgdmcfk1nl7a8lxxz325p84i7gz44cs77z1m9r7c2vsjy";
     in fetchurl {
-      url = "https://github.com/v2ray/geoip/releases/download/${geoipRev}/geoip.dat";
+      url = "https://github.com/v2fly/geoip/releases/download/${geoipRev}/geoip.dat";
       sha256 = geoipSha256;
     };
 
     # MIT licensed
     "geosite.dat" = let
-      geositeRev = "20201010021828";
-      geositeSha256 = "0gpfhcf4iyx7ip7rlkb0l1q64w84zvmcah52qyjwljs6l4p3hrj9";
+      geositeRev = "20201102141726";
+      geositeSha256 = "0sn2f5vd6w94ryh845mnbfyjzycg7cvb66rkzh37pg9l7fvgs4jh";
     in fetchurl {
-      url = "https://github.com/v2ray/domain-list-community/releases/download/${geositeRev}/dlc.dat";
+      url = "https://github.com/v2fly/domain-list-community/releases/download/${geositeRev}/dlc.dat";
       sha256 = geositeSha256;
     };
 
@@ -59,19 +59,22 @@ let
     installPhase = ''
       install -Dm755 v2ray v2ctl -t $out/bin
     '';
+
+    meta = {
+      homepage = "https://www.v2ray.com/en/index.html";
+      description = "A platform for building proxies to bypass network restrictions";
+      # The license of the dependency `https://github.com/XTLS/Go` doesn't allowed user to modify its source code,
+      # which made it unfree.
+      license = with lib.licenses; [ mit unfree ];
+      maintainers = with lib.maintainers; [ servalcatty ];
+    };
   };
 
 in runCommand "v2ray-${version}" {
   inherit version;
+  inherit (core) meta;
 
   nativeBuildInputs = [ makeWrapper ];
-
-  meta = {
-    homepage = "https://www.v2ray.com/en/index.html";
-    description = "A platform for building proxies to bypass network restrictions";
-    license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ servalcatty ];
-  };
 
   passthru = {
     updateScript = ./update.sh;

--- a/pkgs/tools/networking/v2ray/update.sh
+++ b/pkgs/tools/networking/v2ray/update.sh
@@ -14,7 +14,7 @@ echo "Current version:" >&2
 echo "core: $old_core_rev, geoip: $old_geoip_rev, geosite: $old_geosite_rev" >&2
 
 function fetch_latest_rev {
-    curl "https://api.github.com/repos/v2ray/$1/releases" |
+    curl "https://api.github.com/repos/v2fly/$1/releases" |
         jq '.[0].tag_name' --raw-output
 }
 
@@ -28,7 +28,7 @@ echo "core: $core_rev, geoip: $geoip_rev, geosite: $geosite_rev" >&2
 if [[ $core_rev != $old_core_rev ]]; then
     echo "Prefetching core..." >&2
     { read hash; read store_path; } < <(
-        nix-prefetch-url --unpack --print-path "https://github.com/v2ray/v2ray-core/archive/v$core_rev.zip"
+        nix-prefetch-url --unpack --print-path "https://github.com/v2fly/v2ray-core/archive/v$core_rev.zip"
     )
 
     sed --in-place \
@@ -40,7 +40,7 @@ fi
 
 if [[ $geoip_rev != $old_geoip_rev ]]; then
     echo "Prefetching geoip..." >&2
-    hash=$(nix-prefetch-url "https://github.com/v2ray/geoip/releases/download/$geoip_rev/geoip.dat")
+    hash=$(nix-prefetch-url "https://github.com/v2fly/geoip/releases/download/$geoip_rev/geoip.dat")
     sed --in-place \
         -e "s/\bgeoipRev = \".*\"/geoipRev = \"$geoip_rev\"/" \
         -e "s/\bgeoipSha256 = \".*\"/geoipSha256 = \"$hash\"/" \
@@ -49,7 +49,7 @@ fi
 
 if [[ $geosite_rev != $old_geosite_rev ]]; then
     echo "Prefetching geosite..." >&2
-    hash=$(nix-prefetch-url "https://github.com/v2ray/domain-list-community/releases/download/$geosite_rev/dlc.dat")
+    hash=$(nix-prefetch-url "https://github.com/v2fly/domain-list-community/releases/download/$geosite_rev/dlc.dat")
     sed --in-place \
         -e "s/\bgeositeRev = \".*\"/geositeRev = \"$geosite_rev\"/" \
         -e "s/\bgeositeSha256 = \".*\"/geositeSha256 = \"$hash\"/" \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
1. According to [README](https://github.com/v2ray/v2ray-core#move-to-httpsgithubcomv2flyv2ray-core), `v2ray/v2ray-core` is moved to `v2fly/v2ray-core`. Urls are updated.
1. Bump version.
1. A new dependency introduced has an unfree license. Change the package license to unfree. (See also https://github.com/v2ray/v2ray-core/issues/2789)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
