### PR TITLE
llvmPackages_latest: llvmPackages_10 -> llvmPackages_11

### DIFF
--- a/pkgs/development/libraries/google-cloud-cpp/default.nix
+++ b/pkgs/development/libraries/google-cloud-cpp/default.nix
@@ -58,5 +58,6 @@ in stdenv.mkDerivation rec {
     homepage = "https://github.com/googleapis/google-cloud-cpp";
     description = "C++ Idiomatic Clients for Google Cloud Platform services";
     maintainers = with maintainers; [ andir flokli ];
+    broken = true; # Broken on Hydra since 2020-05-19
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9624,7 +9624,7 @@ in
     stdenv = gcc7Stdenv;
   });
 
-  llvmPackages_latest = llvmPackages_10;
+  llvmPackages_latest = llvmPackages_11;
 
   llvmPackages_rocm = callPackage ../development/compilers/llvm/rocm { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

nixpkgs-review:
```
1 package added:
lldb_10 (init at 10.0.1)

11 packages updated:
bat-extras-prettybat clang-tools (10.0.1 → 11.0.0) cloudcompare google-cloud-cpp lldb (10.0.1 → 11.0.0) pdal python3.7-tiledb python3.8-tiledb tiledb vscode-extension-ms-vscode-cpptools vscode-extension-vscode-lldb

1 package removed:
lldb (†11.0.0)

$ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/michael/.cache/nixpkgs-review/rev-c743b16e70180d3b23540192a7834662a5e87e73-1/build.nix
builder for '/nix/store/2yxvnpr6hak2c9lyz2cxs67j2v3gkjkp-googleapis-cpp-cmakefiles-0.1.5.drv' failed with exit code 1; last 10 log lines:
  -- Generating done
  CMake Warning:
    Manually-specified variables were not used by the project:

      BUILD_TESTING
      CMAKE_EXPORT_NO_PACKAGE_REGISTRY
      CMAKE_POLICY_DEFAULT_CMP0025


  CMake Generate step failed.  Build files cannot be regenerated correctly.
cannot build derivation '/nix/store/illc2kyh6hycr08m6vw1ic8w8i2fwic6-google-cloud-cpp-0.14.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/54f6aibzwrv96mpcqlyd8yb58iilh1g5-env.drv': 1 dependencies couldn't be built
[16 built (1 failed), 371 copied (4271.4 MiB), 898.4 MiB DL]
error: build of '/nix/store/54f6aibzwrv96mpcqlyd8yb58iilh1g5-env.drv' failed
1 package failed to build:
google-cloud-cpp

11 packages built:
bat-extras.prettybat clang-tools cloudcompare lldb lldb_10 pdal python37Packages.tiledb python38Packages.tiledb tiledb vscode-extensions.ms-vscode.cpptools vscode-extensions.vadimcn.vscode-lldb
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
