### PR TITLE
pulseaudio: add hsphfpd support

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -259,7 +259,7 @@ in {
           (drv: drv.override { pulseaudio = overriddenPackage; })
           cfg.extraModules;
         modulePaths = builtins.map
-          (drv: "${drv}/lib/pulse-${overriddenPackage.version}/modules")
+          (drv: "${drv}/${overriddenPackage.pulseDir}/modules")
           # User-provided extra modules take precedence
           (overriddenModules ++ [ overriddenPackage ]);
       in lib.concatStringsSep ":" modulePaths;

--- a/pkgs/applications/audio/pulseaudio-modules-bt/default.nix
+++ b/pkgs/applications/audio/pulseaudio-modules-bt/default.nix
@@ -61,7 +61,7 @@ in stdenv.mkDerivation rec {
 
     # Pulseaudio version is detected with a -rebootstrapped suffix which build system assumptions
     substituteInPlace config.h.in --replace PulseAudio_VERSION ${pulseaudio.version}
-    substituteInPlace CMakeLists.txt --replace '${"\${PulseAudio_VERSION}"}' ${pulseaudio.version}
+    substituteInPlace CMakeLists.txt --replace '${"\${PULSE_DIR}"}' ${pulseaudio.pulseDir}
 
     # Fraunhofer recommends to enable afterburner but upstream has it set to false by default
     substituteInPlace src/modules/bluetooth/a2dp/a2dp_aac.c \
@@ -72,7 +72,7 @@ in stdenv.mkDerivation rec {
     for so in $out/lib/pulse-${pulseaudio.version}/modules/*.so; do
       orig_rpath=$(patchelf --print-rpath "$so")
       patchelf \
-        --set-rpath "${ldacbt}/lib:${lib.getLib ffmpeg}/lib:$out/lib/pulse-${pulseaudio.version}/modules:$orig_rpath" \
+        --set-rpath "${ldacbt}/lib:${lib.getLib ffmpeg}/lib:$out/${pulseaudio.pulseDir}/modules:$orig_rpath" \
         "$so"
     done
   '';

--- a/pkgs/applications/audio/pulseaudio-modules-bt/default.nix
+++ b/pkgs/applications/audio/pulseaudio-modules-bt/default.nix
@@ -18,8 +18,12 @@
 let
   pulseSources = runCommand "pulseaudio-sources" {} ''
     mkdir $out
-    tar -xf ${pulseaudio.src}
-    mv pulseaudio*/* $out/
+    if [ -d ${pulseaudio.src} ]; then
+      ln -s ${pulseaudio.src}/* $out/
+    else
+      tar -xf ${pulseaudio.src}
+      mv pulseaudio*/* $out/
+    fi
   '';
 
 in stdenv.mkDerivation rec {

--- a/pkgs/applications/audio/pulseaudio-modules-bt/fix-install-path.patch
+++ b/pkgs/applications/audio/pulseaudio-modules-bt/fix-install-path.patch
@@ -8,4 +8,4 @@ index 8d20dbf..63fe7ba 100644
          module-bluetooth-policy
 -        LIBRARY DESTINATION ${PulseAudio_modlibexecdir})
 -
-+        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pulse-${PulseAudio_VERSION}/modules/)
++        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/${PULSE_DIR}/modules/)

--- a/pkgs/servers/pulseaudio/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/servers/pulseaudio/add-option-for-installation-sysconfdir.patch
@@ -1,0 +1,100 @@
+
+diff --git a/meson.build b/meson.build
+index 86af7243e..e2d48ab94 100644
+--- a/meson.build
++++ b/meson.build
+@@ -65,6 +65,11 @@ datadir = join_paths(prefix, get_option('datadir'))
+ localedir = join_paths(prefix, get_option('localedir'))
+ localstatedir = join_paths(prefix, get_option('localstatedir'))
+ sysconfdir = join_paths(prefix, get_option('sysconfdir'))
++if get_option('sysconfdir_install') != ''
++  sysconfdir_install = join_paths(get_option('prefix'), get_option('sysconfdir_install'))
++else
++  sysconfdir_install = sysconfdir
++endif
+ privlibdir = join_paths(libdir, 'pulseaudio')
+ 
+ alsadatadir = get_option('alsadatadir')
+@@ -75,6 +80,11 @@ endif
+ pkgconfigdir = join_paths(libdir, 'pkgconfig')
+ pulselibexecdir = join_paths(libexecdir, 'pulse')
+ pulsesysconfdir = join_paths(sysconfdir, 'pulse')
++if get_option('sysconfdir_install') != ''
++  pulsesysconfdir_install = join_paths(get_option('prefix'),  get_option('sysconfdir_install'), 'pulse')
++else
++  pulsesysconfdir_install = pulsesysconfdir
++endif
+ 
+ modlibexecdir = get_option('modlibexecdir')
+ if modlibexecdir == ''
+diff --git a/meson_options.txt b/meson_options.txt
+index 824f24e08..59a2b57ab 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -66,6 +66,9 @@ option('bashcompletiondir',
+ option('zshcompletiondir',
+        type : 'string',
+        description : 'Directory for zsh completion scripts ["no" disables]')
++option('sysconfdir_install',
++       type: 'string', value: '',
++       description: 'sysconfdir to use during installation')
+ 
+ # Optional features
+ 
+diff --git a/src/daemon/meson.build b/src/daemon/meson.build
+index 9c9f807e7..425cecb46 100644
+--- a/src/daemon/meson.build
++++ b/src/daemon/meson.build
+@@ -53,7 +53,7 @@ if x11_dep.found()
+     po_dir : po_dir,
+     type : 'desktop',
+     install : true,
+-    install_dir : join_paths(sysconfdir, 'xdg', 'autostart'),
++    install_dir : join_paths(sysconfdir_install, 'xdg', 'autostart'),
+   )
+ 
+   desktop_utils = find_program('desktop-file-validate', required: false)
+@@ -85,7 +85,7 @@ custom_target('daemon.conf',
+   command : [m4, '@INPUT@'],
+   build_by_default : true,
+   install : true,
+-  install_dir : pulsesysconfdir,
++  install_dir : pulsesysconfdir_install,
+ )
+ 
+ default_conf = configuration_data()
+@@ -111,7 +111,7 @@ custom_target('default.pa',
+   command : [m4, '@INPUT@'],
+   build_by_default : true,
+   install : true,
+-  install_dir : pulsesysconfdir,
++  install_dir : pulsesysconfdir_install,
+ )
+ 
+ system_conf = configuration_data()
+@@ -132,12 +132,12 @@ custom_target('system.pa',
+   command : [m4, '@INPUT@'],
+   build_by_default : true,
+   install : true,
+-  install_dir : pulsesysconfdir,
++  install_dir : pulsesysconfdir_install,
+ )
+ 
+ if dbus_dep.found()
+   install_data('pulseaudio-system.conf',
+-    install_dir : join_paths(sysconfdir, 'dbus-1', 'system.d')
++    install_dir : join_paths(sysconfdir_install, 'dbus-1', 'system.d')
+   )
+ endif
+ 
+diff --git a/src/pulse/meson.build b/src/pulse/meson.build
+index aaebff53e..05a29a0d0 100644
+--- a/src/pulse/meson.build
++++ b/src/pulse/meson.build
+@@ -130,5 +130,5 @@ client_conf_file = configure_file(
+   input : 'client.conf.in',
+   output : 'client.conf',
+   configuration : client_conf,
+-  install_dir : pulsesysconfdir,
++  install_dir : pulsesysconfdir_install,
+ )

--- a/pkgs/servers/pulseaudio/correct-ldflags.patch
+++ b/pkgs/servers/pulseaudio/correct-ldflags.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 45df103f0..d57d13172 100644
+--- a/meson.build
++++ b/meson.build
+@@ -342,7 +342,7 @@ cdata.set('MESON_BUILD', 1)
+ # On ELF systems we don't want the libraries to be unloaded since we don't clean them up properly,
+ # so we request the nodelete flag to be enabled.
+ # On other systems, we don't really know how to do that, but it's welcome if somebody can tell.
+-nodelete_link_args = ['-Wl,-z,nodelete']
++nodelete_link_args = cc.get_supported_link_arguments(['-Wl,-z,nodelete'])
+ 
+ # Code coverage
+ 

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -124,6 +124,10 @@ stdenv.mkDerivation rec {
      --prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules"
   '';
 
+  passthru = {
+    pulseDir = "lib/pulse-" + lib.versions.majorMinor version;
+  };
+
   meta = {
     description = "Sound server for POSIX and Win32 systems";
     homepage    = "http://www.pulseaudio.org/";

--- a/pkgs/servers/pulseaudio/hsphfpd.nix
+++ b/pkgs/servers/pulseaudio/hsphfpd.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, makeWrapper, perlPackages }:
+
+let
+  perlLibs = with perlPackages; [ NetDBus XMLTwig XMLParser ];
+in
+stdenv.mkDerivation {
+  pname = "hsphfpd";
+  version = "2020-10-25";
+
+  src = fetchFromGitHub {
+    owner = "pali";
+    repo = "hsphfpd-prototype";
+    rev = "601bf8f7bf2da97257aa6f786ec4cbb69b0ecbc8";
+    sha256 = "06hh0xmp143334x8dg5nmp5727g38q2m5kqsvlrfia6vw2hcq0v0";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ perlPackages.perl ];
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/dbus-1/system.d
+    cp org.hsphfpd.conf $out/share/dbus-1/system.d
+
+    mkdir -p $out/bin
+    cp *.pl $out/bin
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    for f in $out/bin/*.pl; do
+      wrapProgram "$f" --set PERL5LIB "${perlPackages.makePerlPath perlLibs}"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Bluetooth HSP/HFP daemon";
+    homepage = "https://github.com/pali/hsphfpd-prototype";
+    license = licenses.artistic1;
+    maintainers = with maintainers; [ gebner ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/pulseaudio/pali.nix
+++ b/pkgs/servers/pulseaudio/pali.nix
@@ -1,0 +1,219 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchFromGitLab
+, meson
+, ninja
+, pkgconfig
+, libsndfile
+, libtool
+, makeWrapper
+, perlPackages
+, xorg
+, libcap
+, alsaLib
+, glib
+, dconf
+, avahi
+, libjack2
+, libasyncns
+, lirc
+, dbus
+, sbc
+, bluez5
+, udev
+, openssl
+, fftwFloat
+, soxr
+, speexdsp
+, systemd
+, webrtc-audio-processing
+, gtk3
+, tdb
+, orc
+, check
+, gettext
+, gst_all_1
+, libopenaptx
+
+, x11Support ? true
+
+, # Whether to support the JACK sound system as a backend.
+  jackaudioSupport ? false
+
+, airtunesSupport ? true
+
+, bluetoothSupport ? true
+
+, remoteControlSupport ? true
+
+, zeroconfSupport ? true
+
+, # Whether to build only the library.
+  libOnly ? false
+
+# Building from Git source
+, fromGit ? true
+
+, CoreServices
+, AudioUnit
+, Cocoa
+}:
+
+stdenv.mkDerivation rec {
+  pname = "${if libOnly then "lib" else ""}pulseaudio-hsphfpd";
+  version = "13.99.2";
+
+  outputs = [ "out" "dev" ];
+
+  # https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/288
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "pali";
+    repo = "pulseaudio";
+    rev = "5336b39e7e03cf50386e719e287a712b59730eb8";
+    sha256 = "0vc0i5rzkns3xw6y2q0c94p2qdi5k3mgjvhicgq1b0py2qxmji16";
+  };
+
+  patches = [
+    ./add-option-for-installation-sysconfdir.patch
+    ./correct-ldflags.patch
+  ];
+
+  # Says it should be v${version} but it's parsing logic is broken
+  preConfigure = lib.optionalString fromGit ''
+    sed -i "s@version : run_command.*@version: '${version}',@" meson.build
+  '';
+
+  nativeBuildInputs = [
+    gettext
+    makeWrapper
+    meson
+    ninja
+    pkgconfig
+    perlPackages.perl
+    perlPackages.XMLParser
+  ];
+
+  checkInputs = [
+    check
+  ];
+
+  propagatedBuildInputs = lib.optional stdenv.isLinux libcap;
+
+  buildInputs = [
+    libopenaptx
+    fftwFloat
+    libsndfile
+    libtool
+    orc
+    soxr
+    speexdsp
+    tdb
+    sbc
+    gst_all_1.gst-plugins-base
+  ] ++ lib.optionals bluetoothSupport [
+    bluez5
+  ] ++ lib.optionals stdenv.isLinux [
+    dbus
+    glib
+    gtk3
+    libasyncns
+  ] ++ lib.optionals stdenv.isDarwin [
+    AudioUnit
+    Cocoa
+    CoreServices
+  ] ++ lib.optionals (!libOnly) (
+    lib.optionals x11Support [
+      xorg.libXi
+      xorg.libXtst
+      xorg.xlibsWrapper
+    ] ++ lib.optionals stdenv.isLinux [
+      alsaLib
+      systemd
+      udev
+    ] ++ lib.optional airtunesSupport openssl
+    ++ lib.optional jackaudioSupport libjack2
+    ++ lib.optional remoteControlSupport lirc
+    ++ lib.optional zeroconfSupport avahi
+    ++ [ webrtc-audio-processing ]
+  );
+
+  mesonFlags = [
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+    "-Daccess_group=audio"
+    "-Dbashcompletiondir=${placeholder "out"}/share/bash-completions/completions"
+    "-Dman=false" # TODO: needs xmltoman; also doesn't check for this
+    "-Dsysconfdir_install=${placeholder "out"}/etc"
+    "-Dsystemduserunitdir=${placeholder "out"}/lib/systemd/user"
+    "-Dudevrulesdir=${placeholder "out"}/lib/udev/rules.d"
+    "-Dzshcompletiondir=${placeholder "out"}/share/zsh/site-functions"
+  ] ++ lib.optionals (!stdenv.isLinux) [
+    "-Dasyncns=disabled"
+    "-Ddbus=disabled"
+    "-Dglib=disabled"
+    "-Dgsettings=disabled"
+    "-Dgtk=disabled"
+  ] ++ lib.optionals (!stdenv.isLinux || libOnly) [
+    "-Dalsa=disabled"
+    "-Dsystemd=disabled"
+    "-Dudev=disabled"
+  ] ++ lib.optional libOnly "-Dwebrtc-aec=disabled"
+    ++ lib.optional (!x11Support) "-Dx11=disabled"
+    ++ lib.optional (!bluetoothSupport) "-Dbluez5=false"
+    ++ lib.optional (!airtunesSupport) "-Dopenssl=disabled"
+    ++ lib.optional (!jackaudioSupport) "-Djack=disabled"
+    ++ lib.optional (!remoteControlSupport) "-Dlirc=disabled"
+    ++ lib.optional (!zeroconfSupport) "-Davahi=disabled"
+    ++ lib.optional (!doCheck) "-Dtests=false";
+
+  # To create ~/.config/pulse
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  doCheck = true;
+
+  # not sure what the best practices are here -- can't seem to find a way
+  # for the compiler to bring in stdlib and stdio (etc.) properly
+  # the alternative is to copy the files from /usr/include to src, but there are
+  # probably a large number of files that would need to be copied (I stopped
+  # after the seventh)
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I/usr/include";
+
+  NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-framework CoreServices -framework Cocoa -framework AudioUnit";
+
+  postInstall = ''
+    moveToOutput lib/cmake "$dev"
+    rm -f $out/bin/qpaeq # this is packaged by the "qpaeq" package now, because of missing deps
+  '' + lib.optionalString libOnly ''
+    rm -rf $out/{bin,share,etc,lib/{pulse-*,systemd}}
+  '';
+
+  preFixup = lib.optionalString (stdenv.isLinux && !libOnly) ''
+    wrapProgram $out/libexec/pulse/gsettings-helper \
+     --prefix XDG_DATA_DIRS : "$out/share/gsettings-schemas/${pname}-${version}" \
+     --prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules"
+  '';
+
+  passthru = {
+    pulseDir = "lib/pulse-" + lib.versions.majorMinor version;
+  };
+
+  meta = with lib; {
+    description = "A featureful, general-purpose sound server";
+    homepage = "http://www.pulseaudio.org/";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ lovek323 ];
+    platforms = platforms.unix;
+    longDescription = ''
+      PulseAudio is a sound system for POSIX OSes, meaning that it is
+      a proxy for your sound applications. It allows you to do advanced
+      operations on your sound data as it passes between your application
+      and your hardware. Things like transferring the audio to a different machine,
+      changing the sample format or channel count and mixing several sounds into one
+      are easily achieved using a sound server.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16995,6 +16995,8 @@ in
 
   # PulseAudio daemons
 
+  hsphfpd = callPackage ../servers/pulseaudio/hsphfpd.nix { };
+
   pulseaudio-hsphfpd = callPackage ../servers/pulseaudio/pali.nix {
     inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16995,6 +16995,10 @@ in
 
   # PulseAudio daemons
 
+  pulseaudio-hsphfpd = callPackage ../servers/pulseaudio/pali.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
+  };
+
   pulseaudio = callPackage ../servers/pulseaudio {
     inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

HFP is a bluetooth protocol used for headsets with microphones.  This PR packages an [in-progress](https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/288) patch to pulseaudio that supports HFP using the new hsphfpd daemon.

Warning: missing codec support is a big pain point for now.  You get microphone support, but only at 8kHz because the mSBC codec is not implemented yet.  And `pulseaudio-modules-bt` doesn't work, so there's no AAC/etc. support.

To enable:
```nix
{
hardware.pulseaudio.package = pkgs.pulseaudio-hsphfpd;
hardware.bluetooth.hsphfpd.enable = true;
}
```

This is a reworked version of #101787.  Thanks to @eadwu for doing all the work! cc @jtojnar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
