### PR TITLE
python310: 3.10.0a1 -> 3.10.0a2

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.10/no-ldconfig.patch
+++ b/pkgs/development/interpreters/python/cpython/3.10/no-ldconfig.patch
@@ -1,18 +1,18 @@
-From 597e73f2a4b2f0b508127931b36d5540d6941823 Mon Sep 17 00:00:00 2001
-From: Frederik Rietdijk <fridh@fridh.nl>
-Date: Mon, 28 Aug 2017 09:24:06 +0200
-Subject: [PATCH] Don't use ldconfig
+From 084c6dd6352077e64f10cf7aa168f95d800f3819 Mon Sep 17 00:00:00 2001
+From: Jonathan Ringer <jonringer117@gmail.com>
+Date: Mon, 9 Nov 2020 10:24:35 -0800
+Subject: [PATCH] CPython: Don't use ldconfig
 
 ---
- Lib/ctypes/util.py | 70 ++----------------------------------------------------
- 1 file changed, 2 insertions(+), 68 deletions(-)
+ Lib/ctypes/util.py | 77 ++--------------------------------------------
+ 1 file changed, 2 insertions(+), 75 deletions(-)
 
 diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
-index 5e8b31a854..7b45ce6c15 100644
+index 0c2510e..7fb98af 100644
 --- a/Lib/ctypes/util.py
 +++ b/Lib/ctypes/util.py
-@@ -94,46 +94,7 @@ elif os.name == "posix":
-     import re, tempfile
+@@ -100,53 +100,7 @@ elif os.name == "posix":
+             return thefile.read(4) == elf_header
  
      def _findLib_gcc(name):
 -        # Run GCC's linker with the -t (aka --trace) option and examine the
@@ -51,15 +51,22 @@ index 5e8b31a854..7b45ce6c15 100644
 -                # Raised if the file was already removed, which is the normal
 -                # behaviour of GCC if linking fails
 -                pass
--        res = re.search(expr, trace)
+-        res = re.findall(expr, trace)
 -        if not res:
 -            return None
--        return os.fsdecode(res.group(0))
+-
+-        for file in res:
+-            # Check if the given file is an elf file: gcc can report
+-            # some files that are linker scripts and not actual
+-            # shared objects. See bpo-41976 for more details
+-            if not _is_elf(file):
+-                continue
+-            return os.fsdecode(file)
 +        return None
  
  
      if sys.platform == "sunos5":
-@@ -255,34 +216,7 @@ elif os.name == "posix":
+@@ -268,34 +222,7 @@ elif os.name == "posix":
      else:
  
          def _findSoname_ldconfig(name):
@@ -96,5 +103,5 @@ index 5e8b31a854..7b45ce6c15 100644
          def _findLib_ld(name):
              # See issue #9998 for why this is needed
 -- 
-2.15.0
+2.28.0
 

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -14,6 +14,7 @@
 , self
 , configd
 , autoreconfHook
+, autoconf-archive
 , python-setup-hook
 , nukeReferences
 # For the Python package set
@@ -67,6 +68,8 @@ let
 
   nativeBuildInputs = optionals (!stdenv.isDarwin) [
     autoreconfHook
+  ] ++ optionals (!stdenv.isDarwin && passthru.pythonAtLeast "3.10") [
+    autoconf-archive # needed for AX_CHECK_COMPILE_FLAG
   ] ++ [
     nukeReferences
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -122,9 +122,9 @@ in {
       major = "3";
       minor = "10";
       patch = "0";
-      suffix = "a1";
+      suffix = "a2";
     };
-    sha256 = "0q59a99w1yad808mx4w6l0j7bk7dbd2kakngbk0w1h9z4dhr8wyv";
+    sha256 = "0zl5h61s8n2w2v1n40af0mwaw7lqh5fl1ys7kyjgcph60vb9wzjr";
     inherit (darwin) configd;
     inherit passthruFun;
   };


### PR DESCRIPTION
###### Motivation for this change
bump dev version

doesn't fix wheel installation sadly:
```
/build/coverage-5.2.1/dist /build/coverage-5.2.1
ERROR: coverage-5.2.1-cp310-cp310-linux_x86_64.whl is not a supported wheel on this platform.
```

no ld-config.patch need to be regenerated

cc @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
