### PR TITLE
devour: init at 12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5468,6 +5468,12 @@
     githubId = 1191859;
     name = "Maxim Krivchikov";
   };
+  mazurel = {
+    email = "mateusz.mazur@yahoo.com";
+    github = "Mazurel";
+    githubId = 22836301;
+    name = "Mateusz Mazur";
+  };
   mbakke = {
     email = "mbakke@fastmail.com";
     github = "mbakke";

--- a/pkgs/tools/X11/devour/default.nix
+++ b/pkgs/tools/X11/devour/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, libX11 }:
+
+stdenv.mkDerivation rec {
+  pname = "devour";
+  version = "12";
+
+  src = fetchFromGitHub {
+    owner = "salman-abedin";
+    repo = "devour";
+    rev = version;
+    sha256 = "1qq5l6d0fn8azg7sj7a4m2jsmhlpswl5793clcxs1p34vy4wb2lp";
+  };
+
+  installPhase = ''
+    install -Dm555 -t $out/bin devour
+  '';
+
+  buildInputs = [ libX11 ];
+
+  meta = with stdenv.lib; {
+    description = "Devour hides your current window when launching an external program";
+    longDescription = "Devour hides your current window before launching an external program and unhides it after quitting";
+    homepage = "https://github.com/salman-abedin/devour";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ mazurel ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -226,6 +226,8 @@ in
 
   device-tree_rpi = callPackage ../os-specific/linux/device-tree/raspberrypi.nix {};
 
+  devour = callPackage ../tools/X11/devour {};
+
   diffPlugins = (callPackage ../build-support/plugins.nix {}).diffPlugins;
 
   dieHook = makeSetupHook {} ../build-support/setup-hooks/die.sh;


### PR DESCRIPTION
###### Motivation for this change

Added devour, simple x11 tool that hides your current window before launching an external program.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
