### PR TITLE
lunar-client: init at version 2.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9748,6 +9748,12 @@
     githubId = 10643;
     name = "Jason A. Donenfeld";
   };
+  zyansheep = {
+    email = "zyansheep@protonmail.com";
+    github = "zyansheep";
+    githubId = 20029431;
+    name = "Zyansheep";
+  };
   zzamboni = {
     email = "diego@zzamboni.org";
     github = "zzamboni";

--- a/pkgs/games/lunar-client/default.nix
+++ b/pkgs/games/lunar-client/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, appimageTools, lib, fetchurl, makeDesktopItem }:
+let
+  name = "lunar-client";
+  version = "2.4.0";
+
+  desktopItem = makeDesktopItem {
+    name = "Lunar Client";
+    exec = "lunar-client";
+    icon = "lunarclient";
+    comment = "Optimized Minecraft Client for 1.7.10 and 1.8.9";
+    desktopName = "Lunar Client";
+    genericName = "Minecraft Client";
+    categories = "Game;";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit name src;
+  };
+
+  src = fetchurl {
+    url = "https://launcherupdates.lunarclientcdn.com/Lunar%20Client-${version}.AppImage";
+    name = "lunar-client.AppImage";
+    sha256 = "bb85a62127a9b3848cc60796c20ac75655794f1d3cd17cb6b5499bbf19d16019";
+  };
+in appimageTools.wrapType1 rec {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications
+    cp -r ${appimageContents}/usr/share/icons/ $out/share/
+  '';
+
+  meta = with lib; {
+    description = "Minecraft 1.7.10 & 1.8.9 PVP Client";
+    homepage = "https://www.lunarclient.com/";
+    license = with licenses; [ unfree ];
+    maintainers = with maintainers; [ zyansheep ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5112,6 +5112,8 @@ in
 
   ltwheelconf = callPackage ../applications/misc/ltwheelconf { };
 
+  lunar-client = callPackage ../games/lunar-client {};
+
   lvmsync = callPackage ../tools/backup/lvmsync { };
 
   kdbg = libsForQt5.callPackage ../development/tools/misc/kdbg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Lunar Client is a pretty popular minecraft client / launcher

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
^^^ This is on by default on NixOS right?
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
