### PR TITLE
gp-saml-gui: init at c557c32

### DIFF
--- a/pkgs/tools/networking/gp-saml-gui/default.nix
+++ b/pkgs/tools/networking/gp-saml-gui/default.nix
@@ -1,0 +1,27 @@
+{ lib, python3Packages, fetchFromGitHub, gtk3, gobject-introspection, webkitgtk,
+  wrapGAppsHook, glib-networking }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "gp-saml-gui";
+  version = "c557c32ce9429fec2d7054f63195b30b97cba47d";
+
+  src = fetchFromGitHub {
+    owner = "dlenski";
+    repo = pname;
+    rev = version;
+    sha256 = "1yaqd8rf9lhahhdycpdrih70imp771b0ihs66clc7j7c3nxr8lym";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook webkitgtk gobject-introspection ];
+  buildInputs = [
+    gtk3 glib-networking
+  ];
+
+  propagatedBuildInputs = with python3Packages; [ requests pygobject3 ];
+
+  meta = with lib; {
+    description = "A tool to authenticate to GlobalProtect VPN which uses SAML for authentication";
+    license = licenses.gpl3Only;
+    homepage = "https://github.com/dlenski/gp-saml-gui";
+  };
+}

--- a/pkgs/tools/networking/gp-saml-gui/default.nix
+++ b/pkgs/tools/networking/gp-saml-gui/default.nix
@@ -3,7 +3,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gp-saml-gui";
-  version = "2020-10-13";
+  version = "unstable-2020-10-13";
 
   src = fetchFromGitHub {
     owner = "dlenski";

--- a/pkgs/tools/networking/gp-saml-gui/default.nix
+++ b/pkgs/tools/networking/gp-saml-gui/default.nix
@@ -3,7 +3,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gp-saml-gui";
-  version = "c557c32ce9429fec2d7054f63195b30b97cba47d";
+  version = "2020-10-13";
 
   src = fetchFromGitHub {
     owner = "dlenski";
@@ -13,9 +13,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [ wrapGAppsHook webkitgtk gobject-introspection ];
-  buildInputs = [
-    gtk3 glib-networking
-  ];
+  buildInputs = [ gtk3 glib-networking ];
 
   propagatedBuildInputs = with python3Packages; [ requests pygobject3 ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2214,6 +2214,8 @@ in
 
   gotify-cli = callPackage ../tools/misc/gotify-cli { };
 
+  gp-saml-gui = callPackage ../tools/networking/gp-saml-gui { };
+
   gping = callPackage ../tools/networking/gping { };
 
   greg = callPackage ../applications/audio/greg {


### PR DESCRIPTION
###### Motivation for this change

#103167 gp-saml-gui is a wrapper to authenticate with GlobalProtect when using SAML authorization, which requires a web browser. This is usually used in addition to openconnect.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
