### PR TITLE
[20.09] qemu: apply patch for CVE-2020-27617

### DIFF
--- a/pkgs/applications/virtualization/qemu/CVE-2020-27617.patch
+++ b/pkgs/applications/virtualization/qemu/CVE-2020-27617.patch
@@ -1,0 +1,43 @@
+From 6d19c0cc6c5a9bba308fc29d7c0edc2dc372c41b Mon Sep 17 00:00:00 2001
+From: Prasad J Pandit <pjp@fedoraproject.org>
+Date: Wed, 21 Oct 2020 11:35:50 +0530
+Subject: [PATCH] net: remove an assert call in eth_get_gso_type
+
+eth_get_gso_type() routine returns segmentation offload type based on
+L3 protocol type. It calls g_assert_not_reached if L3 protocol is
+unknown, making the following return statement unreachable. Remove the
+g_assert call, it maybe triggered by a guest user.
+
+Reported-by: Gaoning Pan <pgn@zju.edu.cn>
+Signed-off-by: Prasad J Pandit <pjp@fedoraproject.org>
+---
+ net/eth.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/net/eth.c b/net/eth.c
+index 0c1d413ee2..eee77071f9 100644
+--- a/net/eth.c
++++ b/net/eth.c
+@@ -16,6 +16,7 @@
+  */
+ 
+ #include "qemu/osdep.h"
++#include "qemu/log.h"
+ #include "net/eth.h"
+ #include "net/checksum.h"
+ #include "net/tap.h"
+@@ -71,9 +72,8 @@ eth_get_gso_type(uint16_t l3_proto, uint8_t *l3_hdr, uint8_t l4proto)
+             return VIRTIO_NET_HDR_GSO_TCPV6 | ecn_state;
+         }
+     }
+-
+-    /* Unsupported offload */
+-    g_assert_not_reached();
++    qemu_log_mask(LOG_GUEST_ERROR, "%s: probably not GSO frame, "
++        "unknown L3 protocol: 0x%04"PRIx16"\n", __func__, l3_proto);
+ 
+     return VIRTIO_NET_HDR_GSO_NONE | ecn_state;
+ }
+-- 
+2.28.0
+

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -79,6 +79,7 @@ stdenv.mkDerivation rec {
     ./no-etc-install.patch
     ./fix-qemu-ga.patch
     ./9p-ignore-noatime.patch
+    ./CVE-2020-27617.patch
   ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch
     ++ optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backport #102481 

An assert(3) failure issue was found in the networking helper functions of QEMU. It could occur in the eth_get_gso_type() routine, if a packet does not have a valid networking L3 protocol (ex. IPv4, IPv6) value. A guest user may use this flaw to crash the QEMU process on the host resulting in DoS scenario.

Fixes: CVE-2020-27617
(cherry picked from commit 0c54b757e9c2eeeb086b0977b14dff4c456b7d4a)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
