### PR TITLE
LAStools: init at 201003

### DIFF
--- a/pkgs/development/libraries/LAStools/default.nix
+++ b/pkgs/development/libraries/LAStools/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, fetchurl}:
+stdenv.mkDerivation rec {
+
+  version = "180812";
+  name = "LAStools-${version}";
+
+  src = fetchFromGitHub {
+    owner = "LAStools";
+    repo = "LAStools";
+    rev = "162cf032f25cac492712a8568a08b224a5fb40c2";
+    sha256 = "117c9csbfwsx424ha695l7d99cswi316k8q338mzk1lxlk8p3xbz";
+  };
+
+  nativeBuildInputs = [cmake];
+
+  meta = {
+    description = "Efficient tools for LiDAR processing.";
+    homepage = https://www.laszip.org;
+    license = stdenv.lib.licenses.lgpl2;
+    maintainers = [ stdenv.lib.maintainers.mpickering ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/LAStools/default.nix
+++ b/pkgs/development/libraries/LAStools/default.nix
@@ -1,23 +1,33 @@
-{ stdenv, fetchFromGitHub, cmake, fetchurl}:
-stdenv.mkDerivation rec {
+{ stdenv, fetchFromGitHub, cmake }:
 
-  version = "180812";
-  name = "LAStools-${version}";
+stdenv.mkDerivation rec {
+  pname = "LAStools";
+  version = "201003"; # LAStools makes release-ish commits with a message containing their version number as YYMMDD; these align with their website changelog
 
   src = fetchFromGitHub {
     owner = "LAStools";
     repo = "LAStools";
-    rev = "162cf032f25cac492712a8568a08b224a5fb40c2";
-    sha256 = "117c9csbfwsx424ha695l7d99cswi316k8q338mzk1lxlk8p3xbz";
+    rev = "635b76b42cc4912762da31b92f875df5310e1714";
+    sha256 = "0682ca3bp51lmfp46vsjnd1bqpn05g95pf4kclvjv1y8qivkxsaq";
   };
 
-  nativeBuildInputs = [cmake];
+  patches = [
+    ./drop-64-suffix.patch # necessary to prevent '64' from being appended to the names of the executables
+  ];
 
-  meta = {
-    description = "Efficient tools for LiDAR processing.";
-    homepage = https://www.laszip.org;
-    license = stdenv.lib.licenses.lgpl2;
-    maintainers = [ stdenv.lib.maintainers.mpickering ];
-    platforms = stdenv.lib.platforms.unix;
+  hardeningDisable = [
+    "format"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Software for rapid LiDAR processing";
+    homepage = http://lastools.org/;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ stephenwithph ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/LAStools/drop-64-suffix.patch
+++ b/pkgs/development/libraries/LAStools/drop-64-suffix.patch
@@ -1,0 +1,13 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -32,6 +32,6 @@ endforeach(TARGET)
+ foreach(TARGET ${ALL_TARGETS})
+ 	target_link_libraries(${TARGET} LASlib)
+ 	set_target_properties(${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../bin64)
+-	set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME ${TARGET}64)
++	set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME ${TARGET})
+ 	install(TARGETS ${TARGET} RUNTIME DESTINATION bin)
+ endforeach(TARGET)
+-- 
+2.28.0
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13461,6 +13461,8 @@ in
 
   lasso = callPackage ../development/libraries/lasso { };
 
+  LAStools = callPackage ../development/libraries/LAStools { };
+
   LASzip = callPackage ../development/libraries/LASzip { };
   LASzip2 = callPackage ../development/libraries/LASzip/LASzip2.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
* Expose the cli tools from https://github.com/LAStools/LAStools / http://lastools.org/.
* complete a portion of https://github.com/NixOS/nixpkgs/pull/45446


###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
