### PR TITLE
copilot-cli: init at 0.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2017,6 +2017,16 @@
     githubId = 49904992;
     name = "Dawid Sowa";
   };
+  dbirks = {
+    email = "david@birks.dev";
+    github = "dbirks";
+    githubId = 7545665;
+    name = "David Birks";
+    keys = [{
+      longkeyid = "ed25519/0xBB999F83D9A19A36";
+      fingerprint = "B26F 9AD8 DA20 3392 EF87  C61A BB99 9F83 D9A1 9A36";
+    }];
+  };
   dbohdan = {
     email = "dbohdan@dbohdan.com";
     github = "dbohdan";

--- a/pkgs/tools/admin/copilot-cli/default.nix
+++ b/pkgs/tools/admin/copilot-cli/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "copilot-cli";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "copilot-cli";
+    rev = "v${version}";
+    sha256 = "1r84sim4fy58sdkpi47a8k7zx9ybxi84bdsa0kdb60ir4dig2ga6";
+  };
+
+  vendorSha256 = "1px4z747bnv1igxq6y4hvnfnn9y3r6hnb0q2sfk21mg8w0aj249c";
+
+  buildPhase = ''
+    make VERSION=${src.rev} compile-local
+  '';
+
+  installPhase = ''
+    install -Dm 555 ./bin/local/copilot $out/bin/copilot
+  '';
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    $out/bin/copilot completion bash > copilot.bash
+    $out/bin/copilot completion zsh > copilot.zsh
+    installShellCompletion copilot.{bash,zsh}
+  '';
+
+  meta = with lib; {
+    description = "A CLI for deploying containerized applications on Amazon ECS and AWS Fargate";
+    homepage = "https://aws.github.io/copilot-cli";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dbirks ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1819,6 +1819,8 @@ in
 
   compsize = callPackage ../os-specific/linux/compsize { };
 
+  copilot-cli = callPackage ../tools/admin/copilot-cli { };
+
   cot = with python3Packages; toPythonApplication cot;
 
   coturn = callPackage ../servers/coturn { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Wanted to add Amazon's new copilot-cli. Set the version to the most recent that was released today.

The `ldflags` are long, but I believe `binaryS3BucketPath` is needed based on the [Makefile](https://github.com/aws/copilot-cli/blob/master/Makefile#L17-L20). Looks like it's used in the buildspec [template file](https://github.com/aws/copilot-cli/blob/mainline/templates/cicd/buildspec.yml#L12), to be used when setting up a pipeline.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
