### PR TITLE
ocamlPackages.camlimages: 5.0.3 → 5.0.4

### DIFF
--- a/pkgs/development/ocaml-modules/camlimages/default.nix
+++ b/pkgs/development/ocaml-modules/camlimages/default.nix
@@ -1,8 +1,10 @@
-{ lib, fetchFromGitLab, buildDunePackage, dune-configurator, cppo, lablgtk, stdio }:
+{ lib, fetchFromGitLab, buildDunePackage, dune-configurator, cppo
+, graphics, lablgtk, stdio
+}:
 
 buildDunePackage rec {
   pname = "camlimages";
-  version = "5.0.3";
+  version = "5.0.4";
 
   useDune2 = true;
 
@@ -12,10 +14,10 @@ buildDunePackage rec {
     owner = "camlspotter";
     repo = pname;
     rev = version;
-    sha256 = "1ng9pkvrzlibfyf97iqvmbsqcykz8v1ln106xhq9nigih5i68zyd";
+    sha256 = "1m2c76ghisg73dikz2ifdkrbkgiwa0hcmp21f2fm2rkbf02rq3f4";
   };
 
-  buildInputs = [ dune-configurator cppo lablgtk stdio ];
+  buildInputs = [ dune-configurator cppo graphics lablgtk stdio ];
 
   meta = with lib; {
     branch = "5.0";


### PR DESCRIPTION
###### Motivation for this change

Adds the `camlimages.graphics` library: https://gitlab.com/camlspotter/camlimages/-/blob/5.0.4/Changes.txt

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
