### PR TITLE
audiofile: fix static build

### DIFF
--- a/pkgs/development/libraries/audiofile/default.nix
+++ b/pkgs/development/libraries/audiofile/default.nix
@@ -28,6 +28,21 @@ stdenv.mkDerivation rec {
   # fix build with gcc9
   NIX_CFLAGS_LINK = lib.optional (stdenv.system == "i686-linux") "-lgcc";
 
+  # Even when statically linking, libstdc++.la is put in dependency_libs here,
+  # and hence libstdc++.so passed to the linker, just pass -lstdc++ and let the
+  # compiler do what it does best.  (libaudiofile.la is a generated file, so we
+  # have to run `make` that far first).
+  #
+  # Without this, the executables in this package (sfcommands and examples)
+  # fail to build: https://github.com/NixOS/nixpkgs/issues/103215
+  #
+  # There might be a more sensible way to do this with autotools, but I am not
+  # smart enough to discover it.
+  preBuild = lib.optionalString stdenv.targetPlatform.isStatic ''
+    make -C libaudiofile $makeFlags
+    sed -i "s/dependency_libs=.*/dependency_libs=' -lstdc++'/" libaudiofile/libaudiofile.la
+  '';
+
   patches = [
     ./gcc-6.patch
     ./CVE-2015-7747.patch


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/103215

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
