### PR TITLE
xorg.libX11: fix static build

### DIFF
--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -287,9 +287,6 @@ in {
   libexecinfo = super.libexecinfo.override { enableShared = false; };
 
   xorg = super.xorg.overrideScope' (xorgself: xorgsuper: {
-    libX11 = xorgsuper.libX11.overrideAttrs (attrs: {
-      depsBuildBuild = attrs.depsBuildBuild ++ [ (self.buildPackages.stdenv.cc.libc.static or null) ];
-    });
     xauth = xorgsuper.xauth.overrideAttrs (attrs: {
       # missing transitive dependencies
       preConfigure = attrs.preConfigure or "" + ''


### PR DESCRIPTION
Fix the incorrect linking of the build tool `makekeys` during the build
process as described here https://github.com/NixOS/nixpkgs/issues/103195

Note: I have not tested this

CC @symphorien

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).