### PR TITLE
libcap: fix static build

### DIFF
--- a/pkgs/os-specific/linux/libcap/no-shared-lib.patch
+++ b/pkgs/os-specific/linux/libcap/no-shared-lib.patch
@@ -1,0 +1,22 @@
+diff --git a/libcap/Makefile b/libcap/Makefile
+index de6a28d..7e4d8ac 100644
+--- a/libcap/Makefile
++++ b/libcap/Makefile
+@@ -22,7 +22,7 @@ MAJLIBNAME=$(LIBNAME).$(VERSION)
+ MINLIBNAME=$(MAJLIBNAME).$(MINOR)
+ GPERF_OUTPUT = _caps_output.gperf
+ 
+-all: $(MINLIBNAME) $(STACAPLIBNAME) pcs $(STAPSXLIBNAME)
++all: $(STACAPLIBNAME) pcs $(STAPSXLIBNAME)
+ 
+ pcs: libcap.pc libpsx.pc
+ 
+@@ -93,7 +93,7 @@ cap_test: cap_test.c libcap.h
+ test: cap_test
+ 	./cap_test
+ 
+-install: install-static install-shared
++install: install-static
+ 
+ install-static: install-static-cap install-static-psx
+ 

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -309,4 +309,6 @@ in {
       configureFlags = attrs.configureFlags ++ [ "--disable-shared" ];
     });
   });
+
+  libcap = super.libcap.override { pam = null; };
 }


### PR DESCRIPTION
This makes the build correct when cap==null

It also patches the Makefiles so that shared libraries aren't built during the install phase

To be honest, I don't fully understand the relationship between libcap
and pam, someone who does will probably have a better opinion of whether
this is correct.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).