### PR TITLE
postgresql: add debug versions

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -13,7 +13,7 @@ let
       , this, self, newScope, buildEnv
 
       # source specification
-      , version, sha256, psqlSchema, enableDebug ? false
+      , version, sha256, psqlSchema
     }:
   let
     atLeast = lib.versionAtLeast version;
@@ -54,8 +54,8 @@ let
       "--sysconfdir=/etc"
       "--libdir=$(lib)/lib"
       "--with-system-tzdata=${tzdata}/share/zoneinfo"
+      "--enable-debug"
       (lib.optionalString enableSystemd "--with-systemd")
-      (lib.optionalString enableDebug "--enable-debug")
       (if stdenv.isDarwin then "--with-uuid=e2fs" else "--with-ossp-uuid")
     ] ++ lib.optionals icuEnabled [ "--with-icu" ];
 
@@ -163,6 +163,8 @@ let
     ];
     buildInputs = [ makeWrapper ];
 
+    separateDebugInfo = true;
+
     # We include /bin to ensure the $out/bin directory is created, which is
     # needed because we'll be removing the files from that directory in postBuild
     # below. See #22653
@@ -192,29 +194,11 @@ in self: {
     inherit self;
   };
 
-  postgresql_9_5_debug = self.callPackage generic {
-    version = "9.5.23";
-    psqlSchema = "9.5";
-    sha256 = "0rl31jc3kg2wq6hazyd297gnmx3cibjvivllbsivii2m6dzgl573";
-    this = self.postgresql_9_5;
-    enableDebug = true;
-    inherit self;
-  };
-
   postgresql_9_6 = self.callPackage generic {
     version = "9.6.19";
     psqlSchema = "9.6";
     sha256 = "1c2wnl5bbpjs1s1rpzvlnzsqlpb0p823zw7s38nhpgnxrja3myb1";
     this = self.postgresql_9_6;
-    inherit self;
-  };
-
-  postgresql_9_6_debug = self.callPackage generic {
-    version = "9.6.19";
-    psqlSchema = "9.6";
-    sha256 = "1c2wnl5bbpjs1s1rpzvlnzsqlpb0p823zw7s38nhpgnxrja3myb1";
-    this = self.postgresql_9_6;
-    enableDebug = true;
     inherit self;
   };
 
@@ -226,29 +210,11 @@ in self: {
     inherit self;
   };
 
-  postgresql_10_debug = self.callPackage generic {
-    version = "10.14";
-    psqlSchema = "10.0"; # should be 10, but changing it is invasive
-    sha256 = "0fxj30jvwq5pqpbj97vhlxgmn2ah59a78s9jyjr7vxyqj7sdh71q";
-    this = self.postgresql_10;
-    enableDebug = true;
-    inherit self;
-  };
-
   postgresql_11 = self.callPackage generic {
     version = "11.9";
     psqlSchema = "11.1"; # should be 11, but changing it is invasive
     sha256 = "0db6pfphc5rp12abnkvv2l9pbl7bdyf3hhiwj8ghjwh35skqlq9m";
     this = self.postgresql_11;
-    inherit self;
-  };
-
-  postgresql_11_debug = self.callPackage generic {
-    version = "11.9";
-    psqlSchema = "11.1"; # should be 11, but changing it is invasive
-    sha256 = "0db6pfphc5rp12abnkvv2l9pbl7bdyf3hhiwj8ghjwh35skqlq9m";
-    this = self.postgresql_11;
-    enableDebug = true;
     inherit self;
   };
 
@@ -260,15 +226,6 @@ in self: {
     inherit self;
   };
 
-  postgresql_12_debug = self.callPackage generic {
-    version = "12.4";
-    psqlSchema = "12";
-    sha256 = "1k06wryy8p4s1fim9qafcjlak3f58l0wqaqnrccr9x9j5jz3zsdy";
-    this = self.postgresql_12;
-    enableDebug = true;
-    inherit self;
-  };
-
   postgresql_13 = self.callPackage generic {
     version = "13.0";
     psqlSchema = "13";
@@ -276,14 +233,4 @@ in self: {
     this = self.postgresql_13;
     inherit self;
   };
-
-  postgresql_13_debug = self.callPackage generic {
-    version = "13.0";
-    psqlSchema = "13";
-    sha256 = "15i2b7m9a9430idqdgvrcyx66cpxz0v2d81nfqcm8ss3inz51rw0";
-    this = self.postgresql_13;
-    enableDebug = true;
-    inherit self;
-  };
-
 }

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -41,6 +41,8 @@ let
 
     enableParallelBuilding = !stdenv.isDarwin;
 
+    separateDebugInfo = true;
+
     buildFlags = [ "world" ];
 
     NIX_CFLAGS_COMPILE = "-I${libxml2.dev}/include/libxml2";
@@ -163,7 +165,6 @@ let
     ];
     buildInputs = [ makeWrapper ];
 
-    separateDebugInfo = true;
 
     # We include /bin to ensure the $out/bin directory is created, which is
     # needed because we'll be removing the files from that directory in postBuild

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -13,7 +13,7 @@ let
       , this, self, newScope, buildEnv
 
       # source specification
-      , version, sha256, psqlSchema
+      , version, sha256, psqlSchema, enableDebug ? false
     }:
   let
     atLeast = lib.versionAtLeast version;
@@ -55,6 +55,7 @@ let
       "--libdir=$(lib)/lib"
       "--with-system-tzdata=${tzdata}/share/zoneinfo"
       (lib.optionalString enableSystemd "--with-systemd")
+      (lib.optionalString enableDebug "--enable-debug")
       (if stdenv.isDarwin then "--with-uuid=e2fs" else "--with-ossp-uuid")
     ] ++ lib.optionals icuEnabled [ "--with-icu" ];
 
@@ -191,11 +192,29 @@ in self: {
     inherit self;
   };
 
+  postgresql_9_5_debug = self.callPackage generic {
+    version = "9.5.23";
+    psqlSchema = "9.5";
+    sha256 = "0rl31jc3kg2wq6hazyd297gnmx3cibjvivllbsivii2m6dzgl573";
+    this = self.postgresql_9_5;
+    enableDebug = true;
+    inherit self;
+  };
+
   postgresql_9_6 = self.callPackage generic {
     version = "9.6.19";
     psqlSchema = "9.6";
     sha256 = "1c2wnl5bbpjs1s1rpzvlnzsqlpb0p823zw7s38nhpgnxrja3myb1";
     this = self.postgresql_9_6;
+    inherit self;
+  };
+
+  postgresql_9_6_debug = self.callPackage generic {
+    version = "9.6.19";
+    psqlSchema = "9.6";
+    sha256 = "1c2wnl5bbpjs1s1rpzvlnzsqlpb0p823zw7s38nhpgnxrja3myb1";
+    this = self.postgresql_9_6;
+    enableDebug = true;
     inherit self;
   };
 
@@ -207,11 +226,29 @@ in self: {
     inherit self;
   };
 
+  postgresql_10_debug = self.callPackage generic {
+    version = "10.14";
+    psqlSchema = "10.0"; # should be 10, but changing it is invasive
+    sha256 = "0fxj30jvwq5pqpbj97vhlxgmn2ah59a78s9jyjr7vxyqj7sdh71q";
+    this = self.postgresql_10;
+    enableDebug = true;
+    inherit self;
+  };
+
   postgresql_11 = self.callPackage generic {
     version = "11.9";
     psqlSchema = "11.1"; # should be 11, but changing it is invasive
     sha256 = "0db6pfphc5rp12abnkvv2l9pbl7bdyf3hhiwj8ghjwh35skqlq9m";
     this = self.postgresql_11;
+    inherit self;
+  };
+
+  postgresql_11_debug = self.callPackage generic {
+    version = "11.9";
+    psqlSchema = "11.1"; # should be 11, but changing it is invasive
+    sha256 = "0db6pfphc5rp12abnkvv2l9pbl7bdyf3hhiwj8ghjwh35skqlq9m";
+    this = self.postgresql_11;
+    enableDebug = true;
     inherit self;
   };
 
@@ -223,11 +260,29 @@ in self: {
     inherit self;
   };
 
+  postgresql_12_debug = self.callPackage generic {
+    version = "12.4";
+    psqlSchema = "12";
+    sha256 = "1k06wryy8p4s1fim9qafcjlak3f58l0wqaqnrccr9x9j5jz3zsdy";
+    this = self.postgresql_12;
+    enableDebug = true;
+    inherit self;
+  };
+
   postgresql_13 = self.callPackage generic {
     version = "13.0";
     psqlSchema = "13";
     sha256 = "15i2b7m9a9430idqdgvrcyx66cpxz0v2d81nfqcm8ss3inz51rw0";
     this = self.postgresql_13;
+    inherit self;
+  };
+
+  postgresql_13_debug = self.callPackage generic {
+    version = "13.0";
+    psqlSchema = "13";
+    sha256 = "15i2b7m9a9430idqdgvrcyx66cpxz0v2d81nfqcm8ss3inz51rw0";
+    this = self.postgresql_13;
+    enableDebug = true;
     inherit self;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17215,7 +17215,7 @@ in
     postgresql_9_5
     postgresql_9_6
     postgresql_10
-    postgresql_11_local
+    postgresql_11
     postgresql_12
     postgresql_13
   ;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17213,11 +17213,17 @@ in
 
   inherit (import ../servers/sql/postgresql pkgs)
     postgresql_9_5
+    postgresql_9_5_debug
     postgresql_9_6
+    postgresql_9_6_debug
     postgresql_10
+    postgresql_10_debug
     postgresql_11
+    postgresql_11_debug
     postgresql_12
+    postgresql_12_debug
     postgresql_13
+    postgresql_13_debug
   ;
   postgresql = postgresql_11.override { this = postgresql; };
   postgresqlPackages = recurseIntoAttrs postgresql.pkgs;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17213,17 +17213,11 @@ in
 
   inherit (import ../servers/sql/postgresql pkgs)
     postgresql_9_5
-    postgresql_9_5_debug
     postgresql_9_6
-    postgresql_9_6_debug
     postgresql_10
-    postgresql_10_debug
-    postgresql_11
-    postgresql_11_debug
+    postgresql_11_local
     postgresql_12
-    postgresql_12_debug
     postgresql_13
-    postgresql_13_debug
   ;
   postgresql = postgresql_11.override { this = postgresql; };
   postgresqlPackages = recurseIntoAttrs postgresql.pkgs;


### PR DESCRIPTION
##### Motivation for this change

Add postgres versions with debug symbols to get backtrace in case of a segfault

Not sure yet what the best approach is. This is my naive first approach.

closes https://github.com/NixOS/nixpkgs/issues/103024

@ocharles @thoughtpolice @danbst @globin @marsam 

Interested in your thoughts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
