### PR TITLE
glimpse: init at 0.2.0

### DIFF
--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -35,7 +35,7 @@ let
   }
   // attrs
   // {
-      name = "gimp-plugin-${name}";
+      name = "${gimp.name}-plugin-${name}";
       buildInputs = [
         gimp
         gimp.gtk

--- a/pkgs/applications/graphics/glimpse/default.nix
+++ b/pkgs/applications/graphics/glimpse/default.nix
@@ -1,0 +1,197 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, substituteAll
+, pkg-config
+, intltool
+, babl
+, gegl
+, gtk2
+, glib
+, gdk-pixbuf
+, isocodes
+, pango
+, cairo
+, freetype
+, fontconfig
+, lcms
+, libpng
+, libjpeg
+, poppler
+, poppler_data
+, libtiff
+, libmng
+, librsvg
+, libwmf
+, zlib
+, libzip
+, ghostscript
+, aalib
+, shared-mime-info
+, python2
+, libexif
+, gettext
+, xorg
+, glib-networking
+, libmypaint
+, gexiv2
+, harfbuzz
+, mypaint-brushes1
+, libwebp
+, libheif
+, libgudev
+, openexr
+, AppKit
+, Cocoa
+, gtk-mac-integration-gtk2
+, libxslt
+, automake
+, autoconf
+, libtool
+, makeWrapper
+, autoreconfHook
+, gtk-doc
+}:
+let
+  python = python2.withPackages (pp: [ pp.pygtk ]);
+in
+stdenv.mkDerivation rec {
+  pname = "glimpse";
+  version = "0.2.0";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "glimpse-editor";
+    repo = "Glimpse";
+    rev = "v${version}";
+    sha256 = "sha256-qbZQmAo7fuJWWbn0QTyxAwAenZOdsGueUq5/3IV8Njc=";
+  };
+
+  patches = [
+    # to remove compiler from the runtime closure, reference was retained via
+    # gimp --version --verbose output
+    (substituteAll {
+      src = ./remove-cc-reference.patch;
+      cc_version = stdenv.cc.cc.name;
+    })
+    ../gimp/hardcode-plugin-interpreters.patch
+  ];
+
+  postPatch = ''
+    ln -s ${gtk-doc}/share/gtk-doc/data/gtk-doc.make .
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    intltool
+    gettext
+    automake
+    autoconf
+    makeWrapper
+    gtk-doc
+    libxslt
+    libtool
+  ];
+
+  buildInputs = [
+    babl
+    gegl
+    gtk2
+    glib
+    gdk-pixbuf
+    pango
+    cairo
+    gexiv2
+    harfbuzz
+    isocodes
+    freetype
+    fontconfig
+    lcms
+    libpng
+    libjpeg
+    poppler
+    poppler_data
+    libtiff
+    openexr
+    libmng
+    librsvg
+    libwmf
+    zlib
+    libzip
+    ghostscript
+    aalib
+    shared-mime-info
+    libwebp
+    libheif
+    python
+    libexif
+    xorg.libXpm
+    glib-networking
+    libmypaint
+    mypaint-brushes1
+  ] ++ lib.optionals stdenv.isDarwin [
+    AppKit
+    Cocoa
+    gtk-mac-integration-gtk2
+  ] ++ lib.optionals stdenv.isLinux [
+    libgudev
+  ];
+
+  # needed by gimp-2.0.pc
+  propagatedBuildInputs = [
+    gegl
+  ];
+
+  # Check if librsvg was built with --disable-pixbuf-loader.
+  PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_MODULEDIR = "${librsvg}/${gdk-pixbuf.moduleDir}";
+
+  preAutoreconf = ''
+    # The check runs before glib-networking is registered
+    export GIO_EXTRA_MODULES="${glib-networking}/lib/gio/modules:$GIO_EXTRA_MODULES"
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/glimpse-${lib.versions.majorMinor version} \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+  '';
+
+  passthru = rec {
+    # The declarations for `glimpse-with-plugins` wrapper,
+    # used for determining plug-in installation paths
+    majorVersion = "2.0";
+    targetPluginDir = "lib/glimpse/${majorVersion}/plug-ins";
+    targetScriptDir = "share/glimpse/${majorVersion}/scripts";
+    targetDataDir = "share/gimp/${majorVersion}";
+    targetLibDir = "lib/gimp/${majorVersion}";
+
+    # probably its a good idea to use the same gtk in plugins ?
+    gtk = gtk2;
+  };
+
+  configureFlags = [
+    "--without-webkit" # old version is required
+    "--with-bug-report-url=https://github.com/NixOS/nixpkgs/issues/new"
+    "--with-icc-directory=/run/current-system/sw/share/color/icc"
+    # fix libdir in pc files (${exec_prefix} needs to be passed verbatim)
+    "--libdir=\${exec_prefix}/lib"
+  ];
+
+  # on Darwin,
+  # test-eevl.c:64:36: error: initializer element is not a compile-time constant
+  doCheck = !stdenv.isDarwin;
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "An open source image editor based on the GNU Image Manipulation Program";
+    longDescription = ''
+      Glimpse is an open source image editor based on the GNU Image Manipulation Program (GIMP). The goal is to experiment with new ideas and expand the use of free software.
+    '';
+    homepage = "https://glimpse-editor.org";
+    maintainers = with maintainers; [ ashkitten erictapen ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/graphics/glimpse/plugins/default.nix
+++ b/pkgs/applications/graphics/glimpse/plugins/default.nix
@@ -1,0 +1,11 @@
+# Use `glimpse-with-plugins` package for Glimpse with all plug-ins.
+# If you just want a subset of plug-ins, you can specify them explicitly:
+# `glimpse-with-plugins.override { plugins = with glimpsePlugins; [ gap ]; }`.
+
+{ gimpPlugins, glimpse }:
+
+# This attrs can be extended in the future if there happen to be glimpse-only
+# plugins or some that need further modification in order to work with Glimpse.
+gimpPlugins.overrideScope' (self: super: {
+  gimp = glimpse;
+})

--- a/pkgs/applications/graphics/glimpse/remove-cc-reference.patch
+++ b/pkgs/applications/graphics/glimpse/remove-cc-reference.patch
@@ -1,0 +1,13 @@
+diff --git a/app/gimp-version.c b/app/gimp-version.c
+index b584398231..1b40a1570f 100644
+--- a/app/gimp-version.c
++++ b/app/gimp-version.c
+@@ -230,7 +230,7 @@ gimp_version (gboolean be_verbose,
+                                       GIMP_BUILD_ID,
+                                       gimp_version_get_revision (),
+                                       GIMP_BUILD_PLATFORM_FAMILY,
+-                                      CC_VERSION,
++                                      "@cc_version@",
+                                       lib_versions);
+       g_free (lib_versions);
+ 

--- a/pkgs/applications/graphics/glimpse/wrapper.nix
+++ b/pkgs/applications/graphics/glimpse/wrapper.nix
@@ -1,0 +1,30 @@
+{ lib, symlinkJoin, glimpse, makeWrapper, glimpsePlugins, gnome3, plugins ? null }:
+
+let
+  allPlugins = lib.filter (pkg: lib.isDerivation pkg && !pkg.meta.broken or false) (lib.attrValues glimpsePlugins);
+  selectedPlugins = if plugins == null then allPlugins else plugins;
+  extraArgs = map (x: x.wrapArgs or "") selectedPlugins;
+  versionBranch = lib.versions.majorMinor glimpse.version;
+
+in
+symlinkJoin {
+  name = "glimpse-with-plugins-${glimpse.version}";
+
+  paths = [ glimpse ] ++ selectedPlugins;
+
+  buildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    for each in glimpse-${versionBranch} glimpse-console-${versionBranch}; do
+      wrapProgram $out/bin/$each \
+        --set GIMP2_PLUGINDIR "$out/lib/glimpse/2.0" \
+        --set GIMP2_DATADIR "$out/share/glimpse/2.0" \
+        --prefix GTK_PATH : "${gnome3.gnome-themes-extra}/lib/gtk-2.0" \
+        ${toString extraArgs}
+    done
+
+    for each in glimpse glimpse-console; do
+      ln -sf "$each-${versionBranch}" $out/bin/$each
+    done
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22142,6 +22142,19 @@ in
 
   gimpPlugins = recurseIntoAttrs (callPackage ../applications/graphics/gimp/plugins {});
 
+  glimpse = callPackage ../applications/graphics/glimpse {
+    autoreconfHook = buildPackages.autoreconfHook269;
+    gegl = gegl_0_4;
+    lcms = lcms2;
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;
+  };
+
+  glimpse-with-plugins = callPackage ../applications/graphics/glimpse/wrapper.nix {
+    plugins = null; # All packaged plugins enabled, if not explicit plugin list supplied
+  };
+
+  glimpsePlugins = recurseIntoAttrs (callPackage ../applications/graphics/glimpse/plugins {});
+
   girara = callPackage ../applications/misc/girara {
     gtk = gtk3;
   };


### PR DESCRIPTION

###### Motivation for this change

Closes #77157

Succeeds #81563

Pinging @grahamc @jtojnar as they already started reviewing #81563.

Thanks to @ashkitten @lourkeur for previous work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
