### PR TITLE
libtensorflow_2: add TensorFlow 2 as a library

### DIFF
--- a/pkgs/development/libraries/science/math/tensorflow/bin.nix
+++ b/pkgs/development/libraries/science/math/tensorflow/bin.nix
@@ -6,25 +6,20 @@
 
 with stdenv.lib;
 let
-  unavailable = throw "libtensorflow is not available for this platform!";
+  broken = !stdenv.isLinux && !stdenv.isDarwin;
 
   tfType = if cudaSupport then "gpu" else "cpu";
 
-  system = 
-    if      stdenv.isLinux  then "linux"
-    else if stdenv.isDarwin then "darwin"
-    else unavailable;
+  system =
+    if stdenv.isLinux then "linux"
+    else "darwin";
 
-  platform =
-    if stdenv.isx86_64 then "x86_64"
-    else unavailable;
+  platform =  "x86_64";
 
-  rpath = makeLibraryPath ([stdenv.cc.libc stdenv.cc.cc.lib] ++
-            optionals cudaSupport [ cudatoolkit.out cudatoolkit.lib cudnn nvidia_x11 ]);
+  rpath = makeLibraryPath ([stdenv.cc.libc stdenv.cc.cc.lib]
+                           ++ optionals cudaSupport [ cudatoolkit.out cudatoolkit.lib cudnn nvidia_x11 ]);
 
   packages = import ./binary-hashes.nix;
-  packageName = "${tfType}-${system}-${platform}";
-  url = packages.${packageName} or unavailable;
 
   patchLibs =
     if stdenv.isDarwin
@@ -44,7 +39,7 @@ in stdenv.mkDerivation rec {
   pname = "libtensorflow";
   inherit (packages) version;
 
-  src = fetchurl url;
+  src = fetchurl packages."${tfType}-${system}-${platform}";
 
   nativeBuildInputs = optional cudaSupport addOpenGLRunpath;
 
@@ -72,6 +67,5 @@ in stdenv.mkDerivation rec {
     homepage = "https://www.tensorflow.org/install/lang_c";
     license = licenses.asl20;
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
-    maintainers = with maintainers; [ basvandijk ];
   };
 }

--- a/pkgs/development/libraries/science/math/tensorflow/binary-hashes.nix
+++ b/pkgs/development/libraries/science/math/tensorflow/binary-hashes.nix
@@ -1,15 +1,15 @@
 {
-version = "1.14.0";
-cpu-linux-x86_64 = {
-  url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.14.0.tar.gz";
-  sha256 = "04bi3ijq4sbb8c5vk964zlv0j9mrjnzzxd9q9knq3h273nc1a36k";
+version = "2.4.0";
+"cpu-linux-x86_64" = {
+  url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.4.0.tar.gz";
+  sha256 = "022p5jjwmb8rhyyis3cpk2lw45apl2vz49m2rgxmd75h783x1gjk";
 };
-gpu-linux-x86_64 = {
-  url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-1.14.0.tar.gz";
-  sha256 = "1ffnpyj9jjgwxpjfiyjvq4dm3n6nwiksim5jld9zw7fdswh215x6";
+"gpu-linux-x86_64" = {
+  url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-2.4.0.tar.gz";
+  sha256 = "1fclvbrn3fs8qmhmh3lzni7s7wl1w30a071b4gzh9ifnxdhip6lq";
 };
-cpu-darwin-x86_64 = {
-  url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.14.0.tar.gz";
-  sha256 = "0zsd5ils1a17j6jzh0c7q1z56fw46gkzybbnms7h2rgg8al0rh92";
+"cpu-darwin-x86_64" = {
+  url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-2.4.0.tar.gz";
+  sha256 = "09x096nslg04c8sr7bd5v68a5gfinc0f1h36lbzn8bahs8b1agi3";
 };
 }

--- a/pkgs/development/libraries/science/math/tensorflow/prefetcher.sh
+++ b/pkgs/development/libraries/science/math/tensorflow/prefetcher.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-version=1.14.0
-hashfile=binary-hashes.nix
+# ./prefetcher.sh 2.4.0 binary-hashes.nix
+
+version="$1"
+hashfile="$2"
 rm -f $hashfile
 echo "{" >> $hashfile
 echo "version = \"$version\";" >> $hashfile


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

libtensorflow is currently TensorFlow 1. Tensorflow 2 is available as a Python library, but not as a C library. I went with the naming convention of the Python TensorFlow 2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
