### PR TITLE
pythonPackages.gradient_statsd: Disable tests

### DIFF
--- a/pkgs/development/python-modules/gradient_statsd/default.nix
+++ b/pkgs/development/python-modules/gradient_statsd/default.nix
@@ -16,6 +16,9 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "gradient_statsd" ];
 
+  # Pypi does not contain tests
+  doCheck = false;
+
   meta = with stdenv.lib; {
     description = "Wrapper around the DogStatsd client";
     homepage    = "https://paperspace.com";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

```
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing gradient_statsd.egg-info/PKG-INFO
writing dependency_links to gradient_statsd.egg-info/dependency_links.txt
writing requirements to gradient_statsd.egg-info/requires.txt
writing top-level names to gradient_statsd.egg-info/top_level.txt
reading manifest file 'gradient_statsd.egg-info/SOURCES.txt'
writing manifest file 'gradient_statsd.egg-info/SOURCES.txt'
running build_ext

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
Finished executing setuptoolsCheckPhase
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
