### PR TITLE
kube3d: 3.1.5 -> 3.2.0

### DIFF
--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -23,12 +23,11 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  # TODO: Move to enhanced installShellCompletion when in master: PR #83630
   postInstall = ''
-    $out/bin/k3d completion bash > k3d.bash
-    $out/bin/k3d completion fish > k3d.fish
-    $out/bin/k3d completion zsh  > _k3d
-    installShellCompletion k3d.{bash,fish} --zsh _k3d
+    installShellCompletion --cmd k3d \
+      --bash <($out/bin/k3d completion bash) \
+      --fish <($out/bin/k3d completion fish) \
+      --zsh <($out/bin/k3d completion zsh)
   '';
 
   vendorSha256 = null;

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "kube3d";
-  version = "3.1.5";
+  version = "3.2.0";
   k3sVersion = "1.18.9-k3s1";
 
   excludedPackages = ''tools'';
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner  = "rancher";
     repo   = "k3d";
     rev    = "v${version}";
-    sha256 = "0aspkar9im323d8117k48fvh1yylyspi2p2l2f5rdg1ilpa6hm53";
+    sha256 = "0jy0l8rvmwi0qznnvv97v50lfkpc2bwjmbnq4pxnmf9ih970wjwh";
   };
 
   buildFlagsArray = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Bump kube3d (k3d) to `3.2.0` and use new completion format

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
