### PR TITLE
libvirt: 6.6.0 -> 6.8.0

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -5,6 +5,7 @@
 , libtasn1, ebtables, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
 , dnsmasq, libnl, libpcap, libxslt, xhtml1, numad, numactl, perlPackages
 , curl, libiconv, gmp, zfs, parted, bridge-utils, dmidecode, dbus, libtirpc, rpcsvc-proto, darwin
+, meson, ninja, audit, cmake, bash-completion, pkg-config
 , enableXen ? false, xen ? null
 , enableIscsi ? false, openiscsi
 , enableCeph ? false, ceph
@@ -17,26 +18,24 @@ let
   buildFromTarball = stdenv.isDarwin;
 in stdenv.mkDerivation rec {
   pname = "libvirt";
-  version = "6.6.0";
+  version = "6.8.0";
 
   src =
     if buildFromTarball then
       fetchurl {
         url = "https://libvirt.org/sources/${pname}-${version}.tar.xz";
-        sha256 = "1y8y13zvh820f4b15287wb77wq7ra7kbfnpblzhm1dki5pfjvrcl";
+        sha256 = "0hhk2r0dnm9zmfwmnsnmnacm4pik6z60llp22axx7kcpqxv98nv5";
       }
     else
       fetchgit {
         url = "https://gitlab.com/libvirt/libvirt.git";
         rev = "v${version}";
-        sha256 = "09hsbm2qmx0jfmm418rf5lx374g85bwgg0kzlga62x5180jhsssn";
+        sha256 = "sha256-BQZPdmDE0g7xWd6QOHMKosP2HgVpIjsfgfohA9VxEHs=";
         fetchSubmodules = true;
       };
 
   nativeBuildInputs = [
-    makeWrapper pkgconfig docutils
-  ] ++ optionals (!buildFromTarball) [
-    autoreconfHook
+    ninja meson cmake makeWrapper pkgconfig docutils
   ] ++ optional (!stdenv.isDarwin) [
     rpcsvc-proto
   ] ++ optionals stdenv.isDarwin [
@@ -44,10 +43,11 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    bash-completion pkg-config
     libxml2 gnutls perl python2 readline gettext libtasn1 libgcrypt yajl
     libxslt xhtml1 perlPackages.XMLXPath curl libpcap glib dbus
   ] ++ optionals stdenv.isLinux [
-    libpciaccess lvm2 utillinux systemd libnl numad zfs
+    audit libpciaccess lvm2 utillinux systemd libnl numad zfs
     libapparmor libcap_ng numactl attr parted libtirpc
   ] ++ optionals (enableXen && stdenv.isLinux && stdenv.isx86_64) [
     xen
@@ -59,58 +59,58 @@ in stdenv.mkDerivation rec {
     libiconv gmp
   ];
 
-  preConfigure = ''
+  preConfigure = let
+    overrides = {
+      QEMU_BRIDGE_HELPER = "/run/wrappers/bin/qemu-bridge-helper";
+      QEMU_PR_HELPER="/run/libvirt/nix-helpers/qemu-pr-helper";
+      EBTABLES_PATH ="${ebtables}/bin/ebtables-legacy";
+    # "CFLAGS"=-I${libtirpc.dev}/include/tirpc";
+    };
+    patchBuilder = var: value: ''
+      sed -i meson.build -e "s|conf.set_quoted('${var}',.*|conf.set_quoted('${var}','${value}')|"
+    '';
+  in ''
     PATH=${stdenv.lib.makeBinPath ([ dnsmasq ] ++ optionals stdenv.isLinux [ iproute iptables ebtables lvm2 systemd numad ] ++ optionals enableIscsi [ openiscsi ])}:$PATH
     # the path to qemu-kvm will be stored in VM's .xml and .save files
     # do not use "''${qemu_kvm}/bin/qemu-kvm" to avoid bound VMs to particular qemu derivations
     substituteInPlace src/lxc/lxc_conf.c \
       --replace 'lxc_path,' '"/run/libvirt/nix-emulators/libvirt_lxc",'
     patchShebangs . # fixes /usr/bin/python references
-    mkdir -p build && cd build
-  '';
-
-  configureScript = "../configure";
-
-  dontAddDisableDepTrack = true;
-
-  configureFlags = [
-    "--with-runstatedir=/run" # TODO: remove when autoconf 2.70 is released
-    "--localstatedir=/var"
-    "--sysconfdir=/var/lib"
-    "--with-libpcap"
-    "--with-qemu"
-    "--with-vmware"
-    "--with-vbox"
-    "--with-test"
-    "--with-esx"
-    "--with-remote"
-    "--with-polkit"
+  ''
+  #"QEMU_BRIDGE_HELPER" "/run/wrappers/bin/qemu-bridge-helper"
+  + (stdenv.lib.concatStringsSep "\n" (stdenv.lib.mapAttrsToList patchBuilder overrides))
+  ;
+  mesonAutoFeatures = "auto";
+  mesonFlags = let
+    opt = option: enable: "-D${option}=${if enable then "enabled" else "disabled"}";
+  in [
+    # "localstatedir=$(TMPDIR)/var"
+    # "sysconfdir=$(out)/var/lib"
+    "-Drunstatedir=/run"
+    # "-Dlocalstatedir=$(TMPDIR)/var"
+    "-Dsysconfdir=$(out)/var/lib"
+    "-Dlibpcap=enabled"
+    "-Ddriver_qemu=enabled"
+    "-Ddriver_vmware=enabled"
+    "-Ddriver_vbox=enabled"
+    "-Ddriver_test=enabled"
+    "-Ddriver_esx=enabled"
+    "-Ddriver_remote=enabled"
+    "-Dpolkit=enabled"
+    # "-Dbus=enabled"
+    (opt "storage_iscsi" enableIscsi)
   ] ++ optionals stdenv.isLinux [
-    "QEMU_BRIDGE_HELPER=/run/wrappers/bin/qemu-bridge-helper"
-    "QEMU_PR_HELPER=/run/libvirt/nix-helpers/qemu-pr-helper"
-    "EBTABLES_PATH=${ebtables}/bin/ebtables-legacy"
-    "CFLAGS=-I${libtirpc.dev}/include/tirpc"
-    "--with-attr"
-    "--with-apparmor"
-    "--with-secdriver-apparmor"
-    "--with-numad"
-    "--with-macvtap"
-    "--with-virtualport"
-    "--with-storage-disk"
-  ] ++ optionals (stdenv.isLinux && zfs != null) [
-    "--with-storage-zfs"
-  ] ++ optionals enableIscsi [
-    "--with-storage-iscsi"
-  ] ++ optionals enableCeph [
-    "--with-storage-rbd"
+    (opt "storage_zfs" (zfs != null))
+    "-Dattr=enabled"
+    "-Dapparmor=enabled"
+    "-Dsecdriver_apparmor=enabled"
+    "-Dnumad=enabled"
+    "-Dmacvtap=enabled"
+    "-Dvirtualport=enabled"
+    "-Dstorage_disk=enabled"
+    (opt "storage_rbd" enableCeph)
   ] ++ optionals stdenv.isDarwin [
-    "--with-init-script=none"
-  ];
-
-  installFlags = [
-    "runstatedir=${placeholder "out"}/run"
-    "localstatedir=$(TMPDIR)/var"
-    "sysconfdir=$(out)/var/lib"
+    "-Dinit_script=none"
   ];
 
   postInstall = let

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "libvirt";
-  version = "6.6.0";
+  version = "6.8.0";
 
   src = assert version == libvirt.version; fetchFromGitLab {
     owner = "libvirt";
     repo = "libvirt-python";
     rev = "v${version}";
-    sha256 = "0jj6b2nlx7qldwbvixz74abn3p0sq4lkf6ak74vynrv5xvlycb9v";
+    sha256 = "sha256-A3eRfzQAfubyPefDlq5bAiFJ/G90D2JKdJO2Em0wE00=";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

I suffer from https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1764171.html / https://gitlab.com/libvirt/libvirt/-/issues/73 with 6.6 so I tried to bump it but they changed the buildsystem to meson (which is my first time playing with).

I've made some good progress until
`meson.build:1561:2: ERROR: Problem encountered: You must install dbus to compile libvirt with polkit-1`
it doesn't seem to detect dbus. I am a bit  short on time to look into it right now will try later but I will welcome hints. Looks like it is looking for headers from dbus.dev

Related PRs:
- https://github.com/NixOS/nixpkgs/pull/85562
- https://github.com/NixOS/nixpkgs/pull/96955

changelog https://libvirt.org/news.html



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
