### PR TITLE
bisoncpp: init

### DIFF
--- a/pkgs/development/libraries/bobcat/default.nix
+++ b/pkgs/development/libraries/bobcat/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchFromGitHub, icmake
+{ stdenv, fetchFromGitLab, icmake
 , libmilter, libX11, openssl, readline
 , utillinux, yodl }:
 
 stdenv.mkDerivation rec {
   pname = "bobcat";
-  version = "4.08.03";
+  version = "5.05.00";
 
-  src = fetchFromGitHub {
-    sha256 = "163mdl8hxids7123bjxmqhcaqyc1dv7hv8k33s713ac6lzawarq2";
+  src = fetchFromGitLab {
+    sha256 = "sha256:14lvxzkxmkk54s97ah996m6s1wbw1g3iwawbhsf8qw7sf75vlp1h";
+    domain = "gitlab.com";
     rev = version;
     repo = "bobcat";
     owner = "fbb-git";
@@ -36,7 +37,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Brokken's Own Base Classes And Templates";
-    homepage = "https://fbb-git.github.io/bobcat/";
+    homepage = "https://fbb-git.gitlab.io/bobcat/";
     license = licenses.gpl3;
     platforms = platforms.linux;
   };

--- a/pkgs/development/tools/parsing/bisonc++/default.nix
+++ b/pkgs/development/tools/parsing/bisonc++/default.nix
@@ -45,12 +45,12 @@ stdenv.mkDerivation rec {
     ./build install x
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     inherit version;
     description = "A parser generator like bison, but it generates C++ code";
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
     homepage = "https://fbb-git.gitlab.io/bisoncpp/";
   };
 }

--- a/pkgs/development/tools/parsing/bisonc++/default.nix
+++ b/pkgs/development/tools/parsing/bisonc++/default.nix
@@ -1,0 +1,57 @@
+{stdenv, fetchurl, fetchFromGitLab
+, yodl, icmake, flexcpp, bobcat
+}:
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "bisonc++";
+  version = "6.04.00";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.com";
+    owner = "fbb-git";
+    repo = "bisoncpp";
+    rev = "6.04.00";
+    sha256 = "sha256:0aa9bij4g08ilsk6cgrbgi03vyhqr9fn6j2164sjin93m63212wl";
+  };
+
+  buildInputs = [ bobcat ];
+
+  nativeBuildInputs = [ yodl icmake flexcpp ];
+
+  setSourceRoot = ''
+    sourceRoot="$(echo */bisonc++)"
+  '';
+
+  gpl = fetchurl {
+    url = "https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt";
+    sha256 = "sha256:0hq6i0dm4420825fdm0lnnppbil6z67ls67n5kgjcd912dszjxw1";
+  };
+
+  postPatch = ''
+    substituteInPlace INSTALL.im --replace /usr $out
+    patchShebangs .
+    for file in $(find documentation -type f); do
+      substituteInPlace "$file" --replace /usr/share/common-licenses/GPL ${gpl}
+      substituteInPlace "$file" --replace /usr $out
+    done
+  '';
+
+  buildPhase = ''
+    ./build program
+    ./build man
+    ./build manual
+  '';
+
+  installPhase = ''
+    ./build install x
+  '';
+
+  meta = {
+    inherit version;
+    description = "A parser generator like bison, but it generates C++ code";
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = [stdenv.lib.maintainers.raskin];
+    platforms = stdenv.lib.platforms.linux;
+    homepage = "https://fbb-git.gitlab.io/bisoncpp/";
+  };
+}

--- a/pkgs/development/tools/parsing/bisonc++/default.nix
+++ b/pkgs/development/tools/parsing/bisonc++/default.nix
@@ -2,7 +2,6 @@
 , yodl, icmake, flexcpp, bobcat
 }:
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "bisonc++";
   version = "6.04.00";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10889,6 +10889,8 @@ in
     };
   });
 
+  bisoncpp = callPackage ../development/tools/parsing/bisonc++ { };
+
   black = with python3Packages; toPythonApplication black;
 
   blackfire = callPackage ../development/tools/misc/blackfire { };


### PR DESCRIPTION
###### Motivation for this change

bisonc++ needed

(will self-merge if all the tests pass)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).