### PR TITLE
maestral-gui: 1.2.1 -> 1.2.2

### DIFF
--- a/pkgs/applications/networking/maestral-qt/default.nix
+++ b/pkgs/applications/networking/maestral-qt/default.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "maestral-qt";
-  version = "1.2.1";
+  version = "1.2.2";
   disabled = python3.pkgs.pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral-qt";
     rev = "v${version}";
-    sha256 = "sha256-7qpVyQUbT+GChJl1TnKOONSyRDvzQ0M2z9RdN7PNl9U=";
+    sha256 = "sha256-Ax1D4QupSIYNsvhWu4IiT5L5N5A4TLVNz3B6CQOpZGk=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -24,6 +24,8 @@ python3.pkgs.buildPythonApplication rec {
     maestral
     packaging
     pyqt5
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    python3.pkgs.importlib-resources
   ];
 
   nativeBuildInputs = [ wrapQtAppsHook ];

--- a/pkgs/development/python-modules/maestral/default.nix
+++ b/pkgs/development/python-modules/maestral/default.nix
@@ -4,19 +4,21 @@
 , pythonOlder
 , python
 , alembic, bugsnag, click, dropbox, fasteners, keyring, keyrings-alt, packaging, pathspec, Pyro5, requests, setuptools, sdnotify, sqlalchemy, watchdog
+, importlib-metadata
+, importlib-resources
 , dbus-next
 }:
 
 buildPythonPackage rec {
   pname = "maestral";
-  version = "1.2.1";
+  version = "1.2.2";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral";
     rev = "v${version}";
-    sha256 = "sha256-kh3FYBSVOU4ywrYl6ONEIbLbkSuZmexNJC9dB+JtUjM=";
+    sha256 = "sha256-dwSMWjmLcBoBMdpv7OS3Cry2VmCU6Iw+Q7HfBnDT5Vo=";
   };
 
   propagatedBuildInputs = [
@@ -35,6 +37,10 @@ buildPythonPackage rec {
     sdnotify
     sqlalchemy
     watchdog
+  ] ++ stdenv.lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ] ++ stdenv.lib.optionals (pythonOlder "3.9") [
+    importlib-resources
   ] ++ stdenv.lib.optionals stdenv.isLinux [
     dbus-next
   ];


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

###### Things done

```
$ nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
[...]
4 package updated:
maestral (1.2.1 → 1.2.2) maestral-qt (1.2.1 → 1.2.2) python3.7-maestral (1.2.1 → 1.2.2) python3.8-maestral (1.2.1 → 1.2.2)
[...]
3 package built:
maestral maestral-gui python37Packages.maestral
```

I'm not sure why it doesn't do the python38Python variant?

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
