### PR TITLE
[20.09] libe57format: Fix dependents not finding its cmake config

### DIFF
--- a/pkgs/development/libraries/libe57format/default.nix
+++ b/pkgs/development/libraries/libe57format/default.nix
@@ -5,6 +5,9 @@
   boost,
   xercesc,
   icu,
+
+  dos2unix,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
@@ -25,8 +28,38 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boost
     icu
+  ];
+
+  propagatedBuildInputs = [
+    # Necessary for projects that try to find libE57Format via CMake
+    # due to the way that libe57format's CMake config is written.
     xercesc
   ];
+
+  # TODO: Remove CMake patching when https://github.com/asmaloney/libE57Format/pull/60 is available.
+
+  # GNU patch cannot patch `CMakeLists.txt` that has CRLF endings,
+  # see https://unix.stackexchange.com/questions/239364/how-to-fix-hunk-1-failed-at-1-different-line-endings-message/243748#243748
+  # so convert it first.
+  prePatch = ''
+    ${dos2unix}/bin/dos2unix CMakeLists.txt
+  '';
+  patches = [
+    (fetchpatch {
+      name = "libE57Format-cmake-Fix-config-filename.patch";
+      url = "https://github.com/asmaloney/libE57Format/commit/279d8d6b60ee65fb276cdbeed74ac58770a286f9.patch";
+      sha256 = "0fbf92hs1c7yl169i7zlbaj9yhrd1yg3pjf0wsqjlh8mr5m6rp14";
+    })
+  ];
+  # It appears that while the patch has
+  #     diff --git a/cmake/E57Format-config.cmake b/cmake/e57format-config.cmake
+  #     similarity index 100%
+  #     rename from cmake/E57Format-config.cmake
+  #     rename to cmake/e57format-config.cmake
+  # GNU patch doesn't interpret that.
+  postPatch = ''
+    mv cmake/E57Format-config.cmake cmake/e57format-config.cmake
+  '';
 
   # The build system by default builds ONLY static libraries, and with
   # `-DE57_BUILD_SHARED=ON` builds ONLY shared libraries, see:


### PR DESCRIPTION
###### Motivation for this change

Backport of #103334

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
