### PR TITLE
nixos/mautrix-telegram: add documentation for setting arbitrary secrets

### DIFF
--- a/nixos/modules/services/misc/mautrix-telegram.nix
+++ b/nixos/modules/services/misc/mautrix-telegram.nix
@@ -93,12 +93,19 @@ in {
         default = null;
         description = ''
           File containing environment variables to be passed to the mautrix-telegram service,
-          in which secret tokens can be specified securely by defining values for
+          in which secret tokens can be specified securely by defining values for e.g.
           <literal>MAUTRIX_TELEGRAM_APPSERVICE_AS_TOKEN</literal>,
           <literal>MAUTRIX_TELEGRAM_APPSERVICE_HS_TOKEN</literal>,
           <literal>MAUTRIX_TELEGRAM_TELEGRAM_API_ID</literal>,
           <literal>MAUTRIX_TELEGRAM_TELEGRAM_API_HASH</literal> and optionally
           <literal>MAUTRIX_TELEGRAM_TELEGRAM_BOT_TOKEN</literal>.
+          </para>
+
+          <para>
+          These environment variables can also be used to set other options by
+          replacing hierachy levels by <literal>.</literal>, converting the name
+          to uppercase and prepending <literal>MAUTRIX_TELEGRAM_</literal>.
+          For example, the first value above maps to <option>appservice.as_token</option>.
         '';
       };
 


### PR DESCRIPTION
##### Motivation for this change

`services.mautrix-telegram.environmentFile` can be used to set arbitrary options and is not limited
to the five tokens listed in the original documentation.
In my case, I used it to set `bridge.login_shared_secret` (as a secret, it should not be added to the store), which maps to the environment value `MAUTRIX_TELEGRAM_BRIDGE_LOGIN_SHARED_SECRET`.

This PR adds documentation on how to override arbitrary other settings.
This is possible because of the changes here: tulir/mautrix-telegram#332


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


@pacien might want to have a look at this, too.