### PR TITLE
wine: add MinGW-w64 support

### DIFF
--- a/pkgs/misc/emulators/wine/default.nix
+++ b/pkgs/misc/emulators/wine/default.nix
@@ -44,6 +44,7 @@
   sdlSupport ? false,
   faudioSupport ? false,
   vkd3dSupport ? false,
+  mingwSupport ? false,
 }:
 
 let wine-build = build: release:
@@ -56,7 +57,7 @@ let wine-build = build: release:
                   gsmSupport gphoto2Support ldapSupport fontconfigSupport alsaSupport
                   pulseaudioSupport xineramaSupport gtkSupport openclSupport xmlSupport tlsSupport
                   openglSupport gstreamerSupport udevSupport vulkanSupport sdlSupport faudioSupport
-                  vkd3dSupport;
+                  vkd3dSupport mingwSupport;
         };
       });
 

--- a/pkgs/misc/emulators/wine/packages.nix
+++ b/pkgs/misc/emulators/wine/packages.nix
@@ -1,4 +1,4 @@
-{ stdenv_32bit, lib, pkgs, pkgsi686Linux, callPackage,
+{ stdenv_32bit, lib, pkgs, pkgsi686Linux, pkgsCross, callPackage,
   wineRelease ? "stable",
   supportFlags
 }:
@@ -10,6 +10,7 @@ in with src; {
     inherit src version supportFlags;
     pkgArches = [ pkgsi686Linux ];
     geckos = [ gecko32 ];
+    mingwGccs = with pkgsCross; [ mingw32.buildPackages.gcc ];
     monos =  [ mono ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };
@@ -17,6 +18,7 @@ in with src; {
     name = "wine64-${version}";
     inherit src version supportFlags;
     pkgArches = [ pkgs ];
+    mingwGccs = with pkgsCross; [ mingwW64.buildPackages.gcc ];
     geckos = [ gecko64 ];
     monos =  [ mono ];
     configureFlags = [ "--enable-win64" ];
@@ -28,6 +30,7 @@ in with src; {
     stdenv = stdenv_32bit;
     pkgArches = [ pkgs pkgsi686Linux ];
     geckos = [ gecko32 gecko64 ];
+    mingwGccs = with pkgsCross; [ mingw32.buildPackages.gcc mingwW64.buildPackages.gcc ];
     monos =  [ mono ];
     buildScript = ./builder-wow.sh;
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
###### Motivation for this change
Makes it easier to compile wine with MinGW-64 support (See #103102)

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)

  Currently, the closure size is dramatically increased by this change:
  - **wine32** (minimal): 829.3M -> 2.6G
  - **wine64** (minimal): 912.5M -> 2.6G
  - **wineWow** (minimal): 1.5G -> 4.9G

   It looks like development header files from `mingw-64-gcc` are being referenced in all DLLS under `lib/wine`. For example, these paths are referenced in the wine32 build:
   ```
   /nix/store/4pif79nqpcigcrq3934p0jaijq24dy3v-i686-w64-mingw32-stage-final-gcc-debug-9.3.0/i686-w64-mingw32/sys-include
   /nix/store/lwlaj95fph6gbvvcnnzg1pws9vqa1np7-mingw-w64-6.0.0-i686-w64-mingw32-dev/include
   /nix/store/xrswl3dhfjb3zi4dri7ijwzp2ql4zjkv-mingw-w64-6.0.0-i686-w64-mingw32-headers/include
   /nix/store/xrswl3dhfjb3zi4dri7ijwzp2ql4zjkv-mingw-w64-6.0.0-i686-w64-mingw32-headers/include/psdk_inc
   ```

   Once binutils 2.34 is [merged to master](https://github.com/bminor/binutils-gdb/commit/70cf683455e1a3429d517a2e25a36c438474cfde) we can re-enable stripping to avoid this closure size increase.
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@avnik @bendlas @7c6f434c @cawilliamson