### PR TITLE
[staging] python39Packages: recurseintoAttrs for package set

### DIFF
--- a/pkgs/development/python-modules/pyflakes/default.nix
+++ b/pkgs/development/python-modules/pyflakes/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, unittest2 }:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, unittest2 }:
 
 buildPythonPackage rec {
   pname = "pyflakes";
@@ -10,6 +10,9 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ unittest2 ];
+
+  # some tests are output dependent, which have changed slightly
+  doCheck = pythonOlder "3.9";
 
   meta = with stdenv.lib; {
     homepage = "https://launchpad.net/pyflakes";

--- a/pkgs/development/python-modules/tensorflow/1/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/1/bin.nix
@@ -2,7 +2,7 @@
 , lib
 , fetchurl
 , buildPythonPackage
-, isPy3k, pythonOlder, isPy38
+, isPy3k, pythonOlder, pythonAtLeast
 , astor
 , gast
 , google-pasta
@@ -50,8 +50,7 @@ in buildPythonPackage {
   inherit pname;
   inherit (packages) version;
   format = "wheel";
-
-  disabled = isPy38;
+  disabled = pythonAtLeast "3.8";
 
   src = let
     pyVerNoDot = lib.strings.stringAsChars (x: if x == "." then "" else x) python.pythonVersion;

--- a/pkgs/development/python-modules/tensorflow/2/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/2/bin.nix
@@ -2,7 +2,7 @@
 , lib
 , fetchurl
 , buildPythonPackage
-, isPy3k, pythonOlder, isPy38
+, isPy3k, pythonOlder, pythonAtLeast, isPy38
 , astor
 , gast
 , google-pasta
@@ -54,7 +54,7 @@ in buildPythonPackage {
   inherit (packages) version;
   format = "wheel";
 
-  disabled = isPy38;
+  disabled = pythonAtLeast "3.8";
 
   src = let
     pyVerNoDot = lib.strings.stringAsChars (x: if x == "." then "" else x) python.pythonVersion;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10450,7 +10450,7 @@ in
   python36Packages = python36.pkgs;
   python37Packages = recurseIntoAttrs python37.pkgs;
   python38Packages = recurseIntoAttrs python38.pkgs;
-  python39Packages = python39.pkgs;
+  python39Packages = recurseIntoAttrs python39.pkgs;
   python310Packages = python310.pkgs;
   pypyPackages = pypy.pkgs;
   pypy2Packages = pypy2.pkgs;


### PR DESCRIPTION
###### Motivation for this change
Allow for hydra to build the package set, should be done before 21.03

closes: #100382
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
