### PR TITLE
gimpPlugins: clean up

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -163,8 +163,10 @@ in stdenv.mkDerivation rec {
     # The declarations for `gimp-with-plugins` wrapper,
     # used for determining plug-in installation paths
     majorVersion = "${lib.versions.major version}.0";
-    targetPluginDir = "lib/gimp/${majorVersion}/plug-ins";
-    targetScriptDir = "share/gimp/${majorVersion}/scripts";
+    targetLibDir = "lib/gimp/${majorVersion}";
+    targetDataDir = "share/gimp/${majorVersion}";
+    targetPluginDir = "${targetLibDir}/plug-ins";
+    targetScriptDir = "${targetDataDir}/scripts";
 
     # probably its a good idea to use the same gtk in plugins ?
     gtk = gtk2;

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -138,14 +138,14 @@ stdenv.lib.makeScope pkgs.newScope (self: with self; {
        Layer/Liquid Rescale
     */
     pname = "lqr-plugin";
-    version = "0.7.1";
+    version = "0.7.2";
     buildInputs = with pkgs; [ liblqr1 ];
-    src = fetchurl {
-      url = "https://github.com/pixlsus/registry.gimp.org_static/raw/master/registry.gimp.org/files/gimp-lqr-plugin-${version}.tar.bz2";
-      sha256 = "sha256-YpgYPjHZkueJWS51QGmugXavGS+1x4o20St31qoRng4=";
+    src = fetchFromGitHub {
+      owner = "carlobaldassi";
+      repo = "gimp-lqr-plugin";
+      rev = "v${version}";
+      sha256 = "81ajdZ2zQi/THxnBlSeT36tVTEzrS1YqLGpHMhFTKAo=";
     };
-    #postInstall = ''mkdir -p $out/nix-support; echo "${liblqr1}" > "$out/nix-support/propagated-user-env-packages"'';
-    installPhase = "installPlugins src/gimp-lqr-plugin";
   };
 
   gmic = pkgs.gmic-qt.override {

--- a/pkgs/applications/graphics/gimp/wrapper.nix
+++ b/pkgs/applications/graphics/gimp/wrapper.nix
@@ -2,7 +2,7 @@
 
 let
 allPlugins = lib.filter (pkg: lib.isDerivation pkg && !pkg.meta.broken or false) (lib.attrValues gimpPlugins);
-selectedPlugins = if plugins == null then allPlugins else plugins;
+selectedPlugins = lib.filter (pkg: pkg != gimpPlugins.gimp) (if plugins == null then allPlugins else plugins);
 extraArgs = map (x: x.wrapArgs or "") selectedPlugins;
 versionBranch = stdenv.lib.versions.majorMinor gimp.version;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
- gimp: expose gimpdatadir & gimplibdir
- gimpPlugins: clean up using gimp.targetLibDir
- gimpPlugins.lqrPlugin: 0.7.1 → 0.7.2

cc @erictapen


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
