### PR TITLE
[staging] openblas: fix seg fault on some architectures

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, perl, which
+{ stdenv, fetchFromGitHub, perl, which, fetchpatch
 # Most packages depending on openblas expect integer width to match
 # pointer width, but some expect to use 32-bit integers always
 # (for compatibility with reference BLAS).
@@ -132,6 +132,15 @@ stdenv.mkDerivation rec {
     "strictoverflow"
     # don't interfere with dynamic target detection
     "relro" "bindnow"
+  ];
+
+  patches = [
+    (fetchpatch {
+      # still a PR, fix seg fault crashes on some architectures
+      name = "revert-lazily-reinit-thread-after-fork";
+      url = "https://github.com/xianyi/OpenBLAS/commit/7c71f9448fb78dd36d7a8a0742c67b1a01a27d81.patch";
+      sha256 = "1kqmywa14b1rxni277n6kc05pvcfyalvqraz1016mr00x2pnp3sy";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
got tired of seeing:
```
builder for '/nix/store/y222lb4h1pd8rdawnwrydixk7iwsrig0-python3.9-numpy-1.19.4.drv' failed with exit code 139; last 10 log lines:
    File "/nix/store/lqndcw0by4f8r23mzbj5sdwj4mzwcmy2-python3.9-pytest-5.4.3/lib/python3.9/site-packages/_pytest/main.py", line 191 in wrap_session
    File "/nix/store/lqndcw0by4f8r23mzbj5sdwj4mzwcmy2-python3.9-pytest-5.4.3/lib/python3.9/site-packages/_pytest/main.py", line 240 in pytest_cmdline_main
    File "/nix/store/6k3k52ziq3hnfspm27vw8xrk6ymgxjgl-python3.9-pluggy-0.13.1/lib/python3.9/site-packages/pluggy/callers.py", line 187 in _multicall
    File "/nix/store/6k3k52ziq3hnfspm27vw8xrk6ymgxjgl-python3.9-pluggy-0.13.1/lib/python3.9/site-packages/pluggy/manager.py", line 84 in <lambda>
    File "/nix/store/6k3k52ziq3hnfspm27vw8xrk6ymgxjgl-python3.9-pluggy-0.13.1/lib/python3.9/site-packages/pluggy/manager.py", line 93 in _hookexec
    File "/nix/store/6k3k52ziq3hnfspm27vw8xrk6ymgxjgl-python3.9-pluggy-0.13.1/lib/python3.9/site-packages/pluggy/hooks.py", line 286 in __call__
    File "/nix/store/lqndcw0by4f8r23mzbj5sdwj4mzwcmy2-python3.9-pytest-5.4.3/lib/python3.9/site-packages/_pytest/config/__init__.py", line 124 in main
    File "/nix/store/ciql00608lqcfysm8b5a9zl945qvn1kv-python3.9-numpy-1.19.4/lib/python3.9/site-packages/numpy/_pytesttester.py", line 206 in __call__
    File "<string>", line 1 in <module>
  /nix/store/77983lbcimy5h6rqhfq6hvvif4ngmsak-stdenv-linux/setup: line 1303:  3449 Segmentation fault      (core dumped) /nix/store/pylx4vzz5kf0x64bf8cx164l5hd02vgn-python3-3.9.0/bin/python3.9 -c 'import numpy; numpy.test("fast", verbose=10)'
```
when doing reviews. So I did `git bisect` to pinpoint the issue, located https://github.com/xianyi/OpenBLAS/issues/2970#issuecomment-725069635

upstream PR: https://github.com/xianyi/OpenBLAS/pull/2982

related: https://github.com/NixOS/nixpkgs/pull/103360 https://github.com/NixOS/nixpkgs/pull/101780#issuecomment-717440602

But, I'm able to build numpy again with tests:
```
= 10883 passed, 78 skipped, 108 deselected, 21 xfailed, 1 warning in 122.57s (0:02:02) =
/build/numpy-1.19.4
pythonCatchConflictsPhase
pythonRemoveBinBytecodePhase
pythonImportsCheckPhase
Executing pythonImportsCheckPhase
pytestcachePhase
/nix/store/15l44v85rl5ichmbbyjg0701k04hx7dq-python3.8-numpy-1.19.4
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
