### PR TITLE
soundtouch: 2.1.2 -> 2.2

### DIFF
--- a/pkgs/development/libraries/soundtouch/default.nix
+++ b/pkgs/development/libraries/soundtouch/default.nix
@@ -2,23 +2,26 @@
 
 stdenv.mkDerivation rec {
   pname = "soundtouch";
-  version = "2.1.2";
+  version = "2.2";
 
   src = fetchFromGitLab {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "174wgm3s0inmbnkrlnspxjwm2014qhjhkbdqa5r8rbfi0nzqxzsz";
+    sha256 = "12i6yg8vvqwyk412lxl2krbfby6hnxld8qxy0k4m5xp4g94jiq4p";
   };
 
   nativeBuildInputs = [ autoconf automake libtool ];
 
   preConfigure = "./bootstrap";
 
+  enableParallelBuilding = true;
+
   meta = with lib; {
     description = "A program and library for changing the tempo, pitch and playback rate of audio";
-    homepage = "http://www.surina.net/soundtouch/";
-    license = licenses.lgpl21;
+    homepage = "https://www.surina.net/soundtouch/";
+    license = licenses.lgpl21Plus;
     platforms = platforms.all;
+    maintainers = with maintainers; [ orivej ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Regular update. Changes: https://gitlab.com/soundtouch/soundtouch/-/compare/2.1.2...2.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - it rebuilds ~350 packages, I've only rebuilt ardour 
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
