### PR TITLE
linuxPackages.wireguard: fix the build on linux 5.4.76

### DIFF
--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
     sha256 = "1nd2kc3c62907kxm1084dw7krd8xsy3hxydmcpz4jvk03vm5dnkg";
   };
 
+  patches = [
+    ./linux-5.4.76-fix.patch
+  ];
+
   hardeningDisable = [ "pic" ];
 
   KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";

--- a/pkgs/os-specific/linux/wireguard/linux-5.4.76-fix.patch
+++ b/pkgs/os-specific/linux/wireguard/linux-5.4.76-fix.patch
@@ -1,0 +1,12 @@
+diff -u -r wireguard-linux-compat-1.0.20200908/src/compat/compat-asm.h wireguard-linux-compat-1.0.20200908-lts/src/compat/compat-asm.h
+--- wireguard-linux-compat-1.0.20200908/src/compat/compat-asm.h	2020-09-08 16:22:40.000000000 +0000
++++ wireguard-linux-compat-1.0.20200908-lts/src/compat/compat-asm.h	2020-11-10 15:05:43.720093522 +0000
+@@ -40,7 +40,7 @@
+ #undef pull
+ #endif
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 0)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 76)
+ #define SYM_FUNC_START ENTRY
+ #define SYM_FUNC_END ENDPROC
+ #endif


### PR DESCRIPTION
###### Motivation for this change

This fixes the WireGuard build on Linux 5.4.76+, see #103368.

Please cherry-pick onto the release branches as well.

I tested this on 20.09 but it seems to build on master as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
