### PR TITLE
nixos/vector: add module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3411,6 +3411,12 @@
       fingerprint = "74B1 F67D 8E43 A94A 7554  0768 9CCC E364 02CB 49A6";
     }];
   };
+  happysalada = {
+    email = "raphael@megzari.com";
+    github = "happysalada";
+    githubId = 5317234;
+    name = "Raphael Megzari";
+  };
   haslersn = {
     email = "haslersn@fius.informatik.uni-stuttgart.de";
     github = "haslersn";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -396,6 +396,7 @@
   ./services/logging/rsyslogd.nix
   ./services/logging/syslog-ng.nix
   ./services/logging/syslogd.nix
+  ./services/logging/vector.nix
   ./services/mail/clamsmtp.nix
   ./services/mail/davmail.nix
   ./services/mail/dkimproxy-out.nix

--- a/nixos/modules/services/logging/vector.nix
+++ b/nixos/modules/services/logging/vector.nix
@@ -1,0 +1,61 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.services.vector;
+
+in {
+  options.services.vector = {
+    enable = mkEnableOption "Vector";
+
+    journaldAccess = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable Vector to access journald.
+      '';
+    };
+
+    settings = mkOption {
+      type = (pkgs.formats.json { }).type;
+      default = { };
+      description = ''
+        Specify the configuration for Vector in Nix.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    users.groups.vector = { };
+    users.users.vector = {
+      description = "Vector service user";
+      group = "vector";
+      isSystemUser = true;
+    };
+    systemd.services.vector = {
+      description = "Vector event and log aggregator";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      requires = [ "network-online.target" ];
+      serviceConfig = let
+        format = pkgs.formats.toml { };
+        conf = format.generate "vector.toml" cfg.settings;
+        validateConfig = file:
+          pkgs.runCommand "validate-vector-conf" { } ''
+            ${pkgs.vector}/bin/vector validate --no-topology --no-environment "${file}"
+            ln -s "${file}" "$out"
+          '';
+      in {
+        ExecStart = "${pkgs.vector}/bin/vector --config ${validateConfig conf}";
+        User = "vector";
+        Group = "vector";
+        Restart = "no";
+        StateDirectory = "vector";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        # This group is required for accessing journald.
+        SupplementaryGroups = mkIf cfg.journaldAccess "systemd-journal";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -376,6 +376,7 @@ in
   uwsgi = handleTest ./uwsgi.nix {};
   v2ray = handleTest ./v2ray.nix {};
   vault = handleTest ./vault.nix {};
+  vector = handleTest ./vector.nix {};
   victoriametrics = handleTest ./victoriametrics.nix {};
   virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix {};
   wasabibackend = handleTest ./wasabibackend.nix {};

--- a/nixos/tests/vector.nix
+++ b/nixos/tests/vector.nix
@@ -1,0 +1,37 @@
+{ system ? builtins.currentSystem, config ? { }
+, pkgs ? import ../.. { inherit system config; } }:
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+with pkgs.lib;
+
+{
+  test1 = makeTest {
+    name = "vector-test1";
+    meta.maintainers = [ pkgs.stdenv.lib.maintainers.thoughtpolice ];
+
+    machine = { config, pkgs, ... }: {
+      services.vector = {
+        enable = true;
+        journaldAccess = true;
+        settings = {
+          sources.journald.type = "journald";
+
+          sinks = {
+            file = {
+              type = "file";
+              inputs = [ "journald" ];
+              path = "/var/lib/vector/logs.log";
+              encoding = { codec = "ndjson"; };
+            };
+          };
+        };
+      };
+    };
+
+    # ensure vector is forwarding the messages appropriately
+    testScript = ''
+      machine.wait_for_unit("vector.service")
+      machine.succeed("test -f /var/lib/vector/logs.log")
+    '';
+  };
+}

--- a/nixos/tests/vector.nix
+++ b/nixos/tests/vector.nix
@@ -7,7 +7,7 @@ with pkgs.lib;
 {
   test1 = makeTest {
     name = "vector-test1";
-    meta.maintainers = [ pkgs.stdenv.lib.maintainers.thoughtpolice ];
+    meta.maintainers = [ pkgs.stdenv.lib.maintainers.happysalada ];
 
     machine = { config, pkgs, ... }: {
       services.vector = {

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -60,6 +60,6 @@ rustPlatform.buildRustPackage rec {
     description = "A high-performance logs, metrics, and events router";
     homepage    = "https://github.com/timberio/vector";
     license     = with licenses; [ asl20 ];
-    maintainers = with maintainers; [ thoughtpolice ];
+    maintainers = with maintainers; [ thoughtpolice happysalada ];
   };
 }


### PR DESCRIPTION

###### Motivation for this change

add the vector service on nixos

###### Things done

I took inspiration from https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/monitoring/loki.nix
Not sure exactly what all the options should be.

I'm testing with the following in my configuration
```
    vector = {
      enable = true;
      configuration = {
        sources.input.type = "journald";

        transforms.level = {
          type = "lua";
          inputs = ["input"];
          version = "2";

          hooks = {
            process = ''
            function (event, emit)
              message = event.log.message
              level = string.match(message, "le?ve?l=(%w+)")
              msg = string.match(message, "me?ss?a?ge?=(.+)")
              if level then
                event.log.level = level
                event.log.message = msg
              end
              -- Very important! Emit the processed event.
              emit(event)
            end
            '';
          };
        };


        sinks = {

          file = {
            type = "file";
            inputs = ["level"];
            path = "./logs/day-%d.log";
            encoding = {
              codec = "ndjson";
            };
          };


          loki = {
            endpoint = "http://localhost:3100";
            inputs = ["level"]; 
            type = "loki";

            # Labels
            labels = {
              level = "{{ level }}";
            };
          };
        };
      };
```

The corresponding generated vector.toml file looks correct
```
[sinks]
[sinks.file]
inputs = ["level"]
path = "./logs/day-%d.log"
type = "file"

[sinks.file.encoding]
codec = "ndjson"

[sinks.loki]
endpoint = "http://localhost:3100"
inputs = ["level"]
type = "loki"

[sinks.loki.labels]
level = "{{ level }}"

[sources]
[sources.input]
type = "journald"

[transforms]
[transforms.level]
inputs = ["input"]
type = "lua"
version = "2"

[transforms.level.hooks]
process = "function (event, emit)\n  message = event.log.message\n  level = string.match(message, \"le?ve?l=(%w+)\")\n  msg = string.match(message, \"me?ss?a?ge?=(.+)\")\n  if level then\n    event.log.level = level\n    event.log.message = msg\n  end\n  -- Very important! Emit the processed event.\n  emit(event)\nend\n"
```

However I get an error starting up vector
```
Nov 11 03:35:55.482 ERROR vector: Configuration error: "/nix/store/pqjw0696125zylh3912f289rpwblsnm8-vector.toml": unknown variant `file`, there are no variants for key `sinks.file`
```

I can't figure out why. I'm currently using a similar vector.toml file with a docker setup and I don't have this error.

@thoughtpolice if you have any thoughts on this, I'm happy to try them.
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
