### PR TITLE
gnome3.mutter334: Use full sysprof

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/3.34/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/3.34/default.nix
@@ -35,7 +35,7 @@
 , xorgserver
 , python3
 , wrapGAppsHook
-, libsysprof-capture
+, sysprof
 , desktop-file-utils
 , libcap_ng
 , egl-wayland
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
     libxkbfile
     pango
     pipewire_0_2 # TODO: backport pipewire 0.3 support
-    libsysprof-capture
+    sysprof
     upower
     xkeyboard_config
     xwayland


### PR DESCRIPTION
##### Motivation for this change

Commit 56b944156340a6e1967143887165f2119ebd17bb (#101528) incorrectly switched mutter and mutter334 from full sysprof to libsysprof-capture, causing channel-blocking build failures:

https://hydra.nixos.org/build/129977355 (mutter)
https://hydra.nixos.org/build/130019098 (mutter334)

Commit 752773e0a43fe10a7d3d3aa6d3c3eafc68a26592 (#103142) reverted only the mutter part. This reverts the mutter334 part.

This is blocking nixos-unstable via the via the pantheon test.

Cc @jtojnar @hedning

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
