### PR TITLE
buildPythonPackage: add api version for automation tools

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -137,6 +137,16 @@ in {
 
   recursivePthLoader = callPackage ../development/python-modules/recursive-pth-loader { };
 
+  # meta
+
+  _meta.apiVersion = {
+    # Increase version if buildPythonPackage is changed
+    # in a backwards incompatible manner.
+    buildPythonPackage = 1;
+  };
+
+  # packages
+
   setuptools = if isPy27 then
     callPackage ../development/python-modules/setuptools/44.0.nix { }
   else


### PR DESCRIPTION
###### Motivation for this change
Facing the upcoming backwards incompatible buildPythonPackage API changes in #102613 , I'd like to introduce an API version number for it, so automation tools like mach-nix can stay compatible to multiple versions of nixpkgs, without introducing weird hacks.

###### Things done
Add attribute `python.pkgs._meta.apiVersion.buildPythonPackage` which is meant to be increased on all backwards incompatible changes on buildPythonPackage.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
