### PR TITLE
ocamlPackages.dispatch: 0.4.1 → 0.5.0; ocamlPackages.webmachine: 0.6.2 → 0.7.0

### DIFF
--- a/pkgs/development/ocaml-modules/dispatch/default.nix
+++ b/pkgs/development/ocaml-modules/dispatch/default.nix
@@ -1,21 +1,23 @@
-{ lib, buildDunePackage, fetchFromGitHub, alcotest, result }:
+{ lib, buildDunePackage, fetchFromGitHub, ocaml, alcotest, result }:
 
 buildDunePackage rec {
   pname = "dispatch";
-  version = "0.4.1";
+  version = "0.5.0";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "inhabitedtype";
     repo = "ocaml-dispatch";
     rev = version;
-    sha256 = "05kb9zcihk50r2haqz8vrlr7kmaka6vrs4j1z500lmnl877as6qr";
+    sha256 = "12r39ylbxc297cbwjadhd1ghxnwwcdzfjk68r97wim8hcgzxyxv4";
   };
 
   propagatedBuildInputs = [ result ];
 
-  checkInputs = lib.optional doCheck alcotest;
+  checkInputs = [ alcotest ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/development/ocaml-modules/webmachine/default.nix
+++ b/pkgs/development/ocaml-modules/webmachine/default.nix
@@ -5,7 +5,7 @@
 
 buildDunePackage rec {
   pname = "webmachine";
-  version = "0.6.2";
+  version = "0.7.0";
   useDune2 = true;
 
   minimumOCamlVersion = "4.04";
@@ -14,12 +14,12 @@ buildDunePackage rec {
     owner = "inhabitedtype";
     repo = "ocaml-webmachine";
     rev = version;
-    sha256 = "1zi1vsm589y2njwzsqkmdbxvs9s4xlgbd62xqw2scp60mccp09nk";
+    sha256 = "03ynb1l2jjqba88m9r8m5hwlm8izpfp617r4vcab5kmdim1l2ffx";
   };
 
   propagatedBuildInputs = [ cohttp dispatch ptime ];
 
-  checkInputs = lib.optional doCheck ounit;
+  checkInputs = [ ounit ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change

Use Dune2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
