### PR TITLE
pythonPackages.qutip: init at 4.5.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5534,6 +5534,12 @@
     githubId = 158568;
     name = "Matthias C. M. Troffaes";
   };
+  mcncm = {
+    email = "33966432+mcncm@users.noreply.github.com";
+    github = "mcncm";
+    githubId = 33966432;
+    name = "mcncm";
+  };
   McSinyx = {
     email = "vn.mcsinyx@gmail.com";
     github = "McSinyx";

--- a/pkgs/development/python-modules/qutip/default.nix
+++ b/pkgs/development/python-modules/qutip/default.nix
@@ -1,9 +1,8 @@
 { stdenv
-, lib
 , python
 , buildPythonPackage
 , pythonOlder
-, fetchPypi
+, fetchFromGitHub
 , setuptoolsBuildHook
 , gcc
 , hypothesis
@@ -19,10 +18,11 @@ buildPythonPackage rec {
   version = "4.5.2";
   disabled = pythonOlder "3.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    extension = "tar.gz";
-    sha256 = "18iz5wyixyj6v559my6rgi1w1gxg7b3wm5lfavkjz3ldjhd9m8sn";
+  src = fetchFromGitHub {
+    owner = "qutip";
+    repo = "qutip";
+    rev = "v${version}";
+    sha256 = "107jgkrhh6kwvcskx59jys5kf31jrwg1cdzd2b651hh3yhndh91r";
   };
 
   postPatch = ''
@@ -43,19 +43,23 @@ buildPythonPackage rec {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
+  buildPhase = ''
+  ${python.interpreter} setup.py --with-openmp bdist_wheel
+  '';
+
+  doCheck = false;
 
   checkInputs = [ hypothesis ];
 
   checkPhase = ''
     runHook preCheck
     pushd dist
-    ${python.interpreter} -c 'import numpy; numpy.test("fast", verbose=10)'
+    ${python.interpreter} -c 'import qutip.testing as qt; qt.run()'
     popd
     runHook postCheck
   '';
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "Quantum Toolbox in Python";
     homepage = "https://qutip.org";
     changelog = "http://qutip.org/docs/latest/changelog.html";

--- a/pkgs/development/python-modules/qutip/default.nix
+++ b/pkgs/development/python-modules/qutip/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, lib
+, python
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, setuptoolsBuildHook
+, gcc
+, hypothesis
+, numpy
+, scipy
+, matplotlib
+, cython
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "qutip";
+  version = "4.5.2";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "tar.gz";
+    sha256 = "18iz5wyixyj6v559my6rgi1w1gxg7b3wm5lfavkjz3ldjhd9m8sn";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "cython>=0.21" "cython" \
+      --replace "numpy>=1.12" "numpy" \
+      --replace "scipy>=1.0" "scipy"
+  '';
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    matplotlib
+    cython
+  ];
+
+  nativeBuildInputs = [ numpy scipy cython pytest setuptoolsBuildHook ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  checkInputs = [ hypothesis ];
+
+  checkPhase = ''
+    runHook preCheck
+    pushd dist
+    ${python.interpreter} -c 'import numpy; numpy.test("fast", verbose=10)'
+    popd
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Quantum Toolbox in Python";
+    homepage = "https://qutip.org";
+    changelog = "http://qutip.org/docs/latest/changelog.html";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mcncm ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6116,6 +6116,8 @@ in {
 
   queuelib = callPackage ../development/python-modules/queuelib { };
 
+  qutip = callPackage ../development/python-modules/qutip { };
+
   r2pipe = callPackage ../development/python-modules/r2pipe { };
 
   rabbitpy = callPackage ../development/python-modules/rabbitpy { };


### PR DESCRIPTION
* Does not use OpenMP by default
* May be overly conservative in disabling python versions older than 3.5
* Note that build time is a bit long, in part due to tests. It might be
  preferable to disable these in the future.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

This is a fairly popular quantum simulation package that it would be nice to have easy access to.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- ~~[ ] Tested execution of all binary files (usually in `./result/bin/`)~~ (N/A)
- [x] Built the package with `nix-shell -p 'python$X.withPackages (ps: [ ps.qutip ])'`, for `X`={`36`,`37`,`38`}, and imported the module in a repl of the respective Python version.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
