### PR TITLE
tree-wide: unify Bash completions outputs

### DIFF
--- a/pkgs/applications/misc/gammu/bashcomp-dir.patch
+++ b/pkgs/applications/misc/gammu/bashcomp-dir.patch
@@ -5,7 +5,7 @@
      macro_optional_find_package (BashCompletion)
      if (NOT BASH_COMPLETION_FOUND)
 -      set (BASH_COMPLETION_COMPLETIONSDIR "/etc/bash_completion.d" CACHE PATH "Location of bash_completion.d")
-+      set (BASH_COMPLETION_COMPLETIONSDIR "${CMAKE_INSTALL_PREFIX}/etc/bash_completion.d" CACHE PATH "Location of bash_completion.d")
++      set (BASH_COMPLETION_COMPLETIONSDIR "${CMAKE_INSTALL_PREFIX}/share/bash-completion/completions" CACHE PATH "Location of bash_completion.d")
      endif (NOT BASH_COMPLETION_FOUND)
      install (
          FILES bash-completion/gammu

--- a/pkgs/applications/misc/prevo/tools.nix
+++ b/pkgs/applications/misc/prevo/tools.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ glib expat ];
 
   postInstall = ''
-    installShellCompletion --bash $out/etc/bash_completion.d/prevo-completion
+    installShellCompletion --bash src/prevo-completion
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/office/todo.txt-cli/default.nix
+++ b/pkgs/applications/office/todo.txt-cli/default.nix
@@ -13,8 +13,8 @@ in stdenv.mkDerivation {
   installPhase = ''
     install -vd $out/bin
     install -vm 755 todo.sh $out/bin
-    install -vd $out/etc/bash_completion.d
-    install -vm 644 todo_completion $out/etc/bash_completion.d/todo
+    install -vd $out/share/bash-completion/completions
+    install -vm 644 todo_completion $out/share/bash-completion/completions/todo
     install -vd $out/etc/todo
     install -vm 644 todo.cfg $out/etc/todo/config
   '';

--- a/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
   '';
 
   postInstall = ''
-    install -D -m 0644 misc/bash_completion/git-bug "$out/etc/bash_completion.d/git-bug"
+    install -D -m 0644 misc/bash_completion/git-bug "$out/share/bash-completion/completions/git-bug"
     install -D -m 0644 misc/zsh_completion/git-bug "$out/share/zsh/site-functions/git-bug"
     install -D -m 0644 -t "$out/share/man/man1" doc/man/*
   '';

--- a/pkgs/applications/version-management/git-and-tools/git-stree/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-stree/default.nix
@@ -12,9 +12,9 @@ stdenv.mkDerivation {
   };
 
   installPhase = ''
-    mkdir -p $out/bin $out/etc/bash_completion.d
+    mkdir -p $out/bin $out/share/bash-completion/completions
     install -m 0755 git-stree $out/bin/
-    install -m 0644 git-stree-completion.bash $out/etc/bash_completion.d/
+    install -m 0644 git-stree-completion.bash $out/share/bash-completion/completions/
   '';
 
   meta = with lib; {

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -153,8 +153,8 @@ stdenv.mkDerivation {
       cp -a contrib $out/share/git/
       mkdir -p $out/share/bash-completion/completions
       ln -s $out/share/git/contrib/completion/git-completion.bash $out/share/bash-completion/completions/git
-      mkdir -p $out/etc/bash_completion.d
-      ln -s $out/share/git/contrib/completion/git-prompt.sh $out/etc/bash_completion.d/
+      mkdir -p $out/share/bash-completion/completions
+      ln -s $out/share/git/contrib/completion/git-prompt.sh $out/share/bash-completion/completions/
 
       # grep is a runtime dependency, need to patch so that it's found
       substituteInPlace $out/libexec/git-core/git-sh-setup \

--- a/pkgs/applications/version-management/git-and-tools/topgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/topgit/default.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ perl git ];
 
   postInstall = ''
-    install -Dm644 README -t"$out/share/doc/${pname}-${version}/"
-    install -Dm755 contrib/tg-completion.bash -t "$out/etc/bash_completion.d/"
+    install -Dm644 README -t "$out/share/doc/${pname}-${version}/"
+    install -Dm755 contrib/tg-completion.bash -t "$out/share/bash-completion/completions/"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -47,8 +47,8 @@ in stdenv.mkDerivation rec {
     install -D -m555 -T purs $PURS
     ${patchelf libPath}
 
-    mkdir -p $out/etc/bash_completion.d/
-    $PURS --bash-completion-script $PURS > $out/etc/bash_completion.d/purs-completion.bash
+    mkdir -p $out/share/bash-completion/completions
+    $PURS --bash-completion-script $PURS > $out/share/bash-completion/completions/purs-completion.bash
   '';
 
   passthru.tests = {

--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -35,8 +35,8 @@ python3Packages.buildPythonApplication rec {
 
     sed 's/b2/backblaze-b2/' -i contrib/bash_completion/b2
 
-    mkdir -p "$out/etc/bash_completion.d"
-    cp contrib/bash_completion/b2 "$out/etc/bash_completion.d/backblaze-b2"
+    mkdir -p "$out/share/bash-completion/completions"
+    cp contrib/bash_completion/b2 "$out/share/bash-completion/completions/backblaze-b2"
   '';
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
     "man_dir=${placeholder "man"}/share/man"
     "libdir=${placeholder "lib"}/lib"
     "includedir=${placeholder "dev"}/include"
-    "BASH_COMPLETE_DIR=${placeholder "out"}/etc/bash_completion.d"
+    "BASH_COMPLETE_DIR=${placeholder "out"}/share/bash-completion/completions"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -47,10 +47,12 @@ in with py.pkgs; buildPythonApplication rec {
   ];
 
   postInstall = ''
-    mkdir -p $out/etc/bash_completion.d
-    echo "complete -C $out/bin/aws_completer aws" > $out/etc/bash_completion.d/awscli
+    mkdir -p $out/share/bash-completion/completions
+    echo "complete -C $out/bin/aws_completer aws" > $out/share/bash-completion/completions/awscli
+
     mkdir -p $out/share/zsh/site-functions
     mv $out/bin/aws_zsh_completer.sh $out/share/zsh/site-functions
+
     rm $out/bin/aws.cmd
   '';
 

--- a/pkgs/tools/admin/awscli2/default.nix
+++ b/pkgs/tools/admin/awscli2/default.nix
@@ -67,10 +67,12 @@ with py.pkgs; buildPythonApplication rec {
   ];
 
   postInstall = ''
-    mkdir -p $out/etc/bash_completion.d
-    echo "complete -C $out/bin/aws_completer aws" > $out/etc/bash_completion.d/awscli
+    mkdir -p $out/share/bash-completion/completions
+    echo "complete -C $out/bin/aws_completer aws" > $out/share/bash-completion/completions/awscli
+
     mkdir -p $out/share/zsh/site-functions
     mv $out/bin/aws_zsh_completer.sh $out/share/zsh/site-functions
+
     rm $out/bin/aws.cmd
   '';
 

--- a/pkgs/tools/admin/bluemix-cli/default.nix
+++ b/pkgs/tools/admin/bluemix-cli/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     install -m755 -D -t $out/bin/cfcli bin/cfcli/cf
     ln -sv $out/bin/ibmcloud $out/bin/bx
     ln -sv $out/bin/ibmcloud $out/bin/bluemix
-    install -D -t "$out/etc/bash_completion.d" bx/bash_autocomplete
+    install -D -t "$out/share/bash-completion/completions" bx/bash_autocomplete
     install -D -t "$out/share/zsh/site-functions" bx/zsh_autocomplete
   '';
 

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -74,8 +74,8 @@ in stdenv.mkDerivation rec {
     disable_update_check = true" >> $out/google-cloud-sdk/properties
 
     # setup bash completion
-    mkdir -p $out/etc/bash_completion.d
-    mv $out/google-cloud-sdk/completion.bash.inc $out/etc/bash_completion.d/gcloud.inc
+    mkdir -p $out/share/bash-completion/completions
+    mv $out/google-cloud-sdk/completion.bash.inc $out/share/bash-completion/completions/gcloud.inc
 
     # This directory contains compiled mac binaries. We used crcmod from
     # nixpkgs instead.

--- a/pkgs/tools/backup/tarsnap/default.nix
+++ b/pkgs/tools/backup/tarsnap/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    configureFlags="--with-bash-completion-dir=$out/etc/bash_completion.d"
+    configureFlags="--with-bash-completion-dir=$out/share/bash-completion/completions"
   '';
 
   patchPhase = ''

--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   postPatch = "sed -i s/-O1/-O2/ configure";
 
   postInstall = ''
-    install -v -m 444 -D btrfs-completion $out/etc/bash_completion.d/btrfs
+    install -v -m 444 -D btrfs-completion $out/share/bash-completion/completions/btrfs
   '';
 
   configureFlags = stdenv.lib.optional stdenv.hostPlatform.isMusl "--disable-backtrace";

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -208,12 +208,12 @@ in rec {
   ceph-client = runCommand "ceph-client-${version}" {
       meta = getMeta "Tools needed to mount Ceph's RADOS Block Devices";
     } ''
-      mkdir -p $out/{bin,etc,${sitePackages}}
+      mkdir -p $out/{bin,etc,${sitePackages},share/bash-completion/completions}
       cp -r ${ceph}/bin/{ceph,.ceph-wrapped,rados,rbd,rbdmap} $out/bin
       cp -r ${ceph}/bin/ceph-{authtool,conf,dencoder,rbdnamer,syn} $out/bin
       cp -r ${ceph}/bin/rbd-replay* $out/bin
       cp -r ${ceph}/${sitePackages} $out/${sitePackages}
-      cp -r ${ceph}/etc/bash_completion.d $out/etc
+      cp -r ${ceph}/etc/bash_completion.d $out/share/bash-completion/completions
       # wrapPythonPrograms modifies .ceph-wrapped, so lets just update its paths
       substituteInPlace $out/bin/ceph          --replace ${ceph} $out
       substituteInPlace $out/bin/.ceph-wrapped --replace ${ceph} $out

--- a/pkgs/tools/filesystems/yandex-disk/default.nix
+++ b/pkgs/tools/filesystems/yandex-disk/default.nix
@@ -32,12 +32,13 @@ stdenv.mkDerivation rec {
     cd unpacked
     ${rpmextract}/bin/rpmextract $src
 
+    mkdir -p $out/share/bash-completion/completions
     cp -r -t $out/bin usr/bin/*
     cp -r -t $out/share usr/share/*
-    cp -r -t $out/etc etc/*
+    cp -r -t $out/share/bash-completion/completions etc/bash_completion.d/*
 
     sed -i 's@have@${which}/bin/which >/dev/null 2>\&1@' \
-      $out/etc/bash_completion.d/yandex-disk-completion.bash
+      $out/share/bash-completion/completions/yandex-disk-completion.bash
 
     ${patchelf}/bin/patchelf \
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \

--- a/pkgs/tools/misc/gibo/default.nix
+++ b/pkgs/tools/misc/gibo/default.nix
@@ -14,15 +14,15 @@ stdenv.mkDerivation rec {
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
 
   installPhase = ''
-    mkdir -p $out/bin $out/etc/bash_completion.d
+    mkdir -p $out/bin $out/share/bash-completion/completions
     cp gibo $out/bin
-    cp gibo-completion.bash $out/etc/bash_completion.d
+    cp gibo-completion.bash $out/share/bash-completion/completions
 
     sed -e 's|\<git |${git}/bin/git |g' \
         -e 's|\<basename |${coreutils}/bin/basename |g' \
         -i "$out/bin/gibo"
     sed -e 's|\<find |${findutils}/bin/find |g' \
-        -i "$out/etc/bash_completion.d/gibo-completion.bash"
+        -i "$out/share/bash-completion/completions/gibo-completion.bash"
   '';
 
   meta = {

--- a/pkgs/tools/misc/powerline-rs/default.nix
+++ b/pkgs/tools/misc/powerline-rs/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   COMPLETION_OUT = "out";
   postInstall = ''
-    install -Dm 755 "${COMPLETION_OUT}/${pname}.bash" "$out/etc/bash_completion.d/${pname}"
+    install -Dm 755 "${COMPLETION_OUT}/${pname}.bash" "$out/share/bash-completion/completions/${pname}"
     install -Dm 755 "${COMPLETION_OUT}/${pname}.fish" "$out/share/fish/vendor_completions.d/${pname}"
   '';
 

--- a/pkgs/tools/security/pass/extensions/import.nix
+++ b/pkgs/tools/security/pass/extensions/import.nix
@@ -38,7 +38,7 @@ in stdenv.mkDerivation rec {
 
   installFlags = [
     "PREFIX=$(out)"
-    "BASHCOMPDIR=$(out)/etc/bash_completion.d"
+    "BASHCOMPDIR=$(out)/share/bash-completion/completions"
   ];
 
   postFixup = ''

--- a/pkgs/tools/security/pass/extensions/update.nix
+++ b/pkgs/tools/security/pass/extensions/update.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace "BASHCOMPDIR ?= /etc/bash_completion.d" "BASHCOMPDIR ?= $out/etc/bash_completion.d"
+      --replace "BASHCOMPDIR ?= /etc/bash_completion.d" "BASHCOMPDIR ?= $out/share/bash-completion/completions"
   '';
 
   dontBuild = true;

--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -83,8 +83,8 @@ in with localPython.pkgs; buildPythonApplication rec {
   ];
 
   postInstall = ''
-    mkdir -p $out/etc/bash_completion.d
-    mv $out/bin/eb_completion.bash $out/etc/bash_completion.d
+    mkdir -p $out/share/bash-completion/completions
+    mv $out/bin/eb_completion.bash $out/share/bash-completion/completions/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/virtualization/nixos-container/default.nix
+++ b/pkgs/tools/virtualization/nixos-container/default.nix
@@ -10,7 +10,7 @@ substituteAll {
     inherit utillinux;
 
     postInstall = ''
-      t=$out/etc/bash_completion.d
+      t=$out/share/bash-completion/completions
       mkdir -p $t
       cp ${./nixos-container-completion.sh} $t/nixos-container
     '';

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -511,10 +511,10 @@ let
     buildInputs = [ DataDump FileWhich Readonly TestDifferences TestTrap ];
     preCheck = "rm t/30cluster.t"; # do not run failing tests
     postInstall = ''
-      mkdir -p $out/etc/bash_completion.d
+      mkdir -p $out/share/bash-completion/completions
       mv $out/bin/clusterssh_bash_completion.dist \
-         $out/etc/bash_completion.d/clusterssh_bash_completion
-      substituteInPlace $out/etc/bash_completion.d/clusterssh_bash_completion \
+         $out/share/bash-completion/completions/clusterssh_bash_completion
+      substituteInPlace $out/share/bash-completion/completions/clusterssh_bash_completion \
          --replace '/bin/true' '${pkgs.coreutils}/bin/true' \
          --replace 'grep' '${pkgs.gnugrep}/bin/grep' \
          --replace 'sed' '${pkgs.gnused}/bin/sed'


### PR DESCRIPTION
###### Motivation for this change

Unify the output location where bash completions are being stored. Both
`$out/share/bash-completion/completions` and `$out/etc/bash_completion.d` were
being used. This PR starts the unification under the former location.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


* [x] gammu
* [x] prevo-tools
* [x] todo-txt-cli
* [x] gitAndTools.git-bug
* [x] gitAndTools.git-stree
* [x] gitAndTools.git
* [x] gitAndTools.top-git
* [x] purescript
* [x] backblaze-b2
* [ ] ceph-client - was already broken
* [x] trace-cmd
* [x] awscli
* [x] awscli2
* [x] google-cloud-sdk
* [x] tarsnap
* [x] btrfs-progs
* [x] yandex-disk
* [x] gibo
* [x] powerline-rs
* [x] pass.extensions.pass-import
* [x] pass.extensions.pass-update
* [x] awsebcli
* [x] nixos-container
* [x] perlPackages.AppClusterSSH