### PR TITLE
SDL2: fix cmake interface includes for SDL2::SDL2

### DIFF
--- a/pkgs/development/libraries/SDL2/find-headers.patch
+++ b/pkgs/development/libraries/SDL2/find-headers.patch
@@ -1,7 +1,7 @@
-diff -ru3 SDL2-2.0.4/sdl2-config.cmake.in SDL2-2.0.4-new/sdl2-config.cmake.in
---- SDL2-2.0.4/sdl2-config.cmake.in	2016-01-02 22:56:31.000000000 +0300
-+++ SDL2-2.0.4-new/sdl2-config.cmake.in	2016-08-22 05:26:42.420397323 +0300
-@@ -6,5 +6,6 @@
+diff -ru3 SDL2-2.0.12/sdl2-config.cmake.in SDL2-2.0.12-new/sdl2-config.cmake.in
+--- SDL2-2.0.12/sdl2-config.cmake.in	2020-03-11 02:36:18.000000000 +0100
++++ SDL2-2.0.12-new/sdl2-config.cmake.in	2020-11-11 11:59:05.178703826 +0100
+@@ -6,7 +6,8 @@
  set(SDL2_PREFIX "@prefix@")
  set(SDL2_EXEC_PREFIX "@prefix@")
  set(SDL2_LIBDIR "@libdir@")
@@ -9,9 +9,29 @@ diff -ru3 SDL2-2.0.4/sdl2-config.cmake.in SDL2-2.0.4-new/sdl2-config.cmake.in
 +set(SDL2_INCLUDE_DIRS "@includedir@/SDL2" $ENV{SDL2_PATH})
 +separate_arguments(SDL2_INCLUDE_DIRS)
  set(SDL2_LIBRARIES "-L${SDL2_LIBDIR} @SDL_RLD_FLAGS@ @SDL_LIBS@")
-diff -ru3 SDL2-2.0.4/sdl2-config.in SDL2-2.0.4-new/sdl2-config.in
---- SDL2-2.0.4/sdl2-config.in	2016-01-02 22:56:31.000000000 +0300
-+++ SDL2-2.0.4-new/sdl2-config.in	2016-08-22 05:32:02.256397839 +0300
+ string(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES)
+ 
+@@ -20,14 +21,14 @@
+ 
+   add_library(SDL2::SDL2 SHARED IMPORTED)
+   set_target_properties(SDL2::SDL2 PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES "@includedir@/SDL2"
++    INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
+     IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+     IMPORTED_LOCATION "@libdir@/libSDL2.so"
+     INTERFACE_LINK_LIBRARIES "${SDL2_EXTRA_LINK_FLAGS}")
+ 
+   add_library(SDL2::SDL2-static STATIC IMPORTED)
+   set_target_properties(SDL2::SDL2-static PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES "@includedir@/SDL2"
++    INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
+     IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+     IMPORTED_LOCATION "@libdir@/libSDL2.a"
+     INTERFACE_LINK_LIBRARIES "${SDL2_EXTRA_LINK_FLAGS_STATIC}")
+Només a SDL2-2.0.12-new/: sdl2-config.cmake.in.orig
+diff -ru3 SDL2-2.0.12/sdl2-config.in SDL2-2.0.12-new/sdl2-config.in
+--- SDL2-2.0.12/sdl2-config.in	2020-03-11 02:36:18.000000000 +0100
++++ SDL2-2.0.12-new/sdl2-config.in	2020-11-11 11:56:26.432955479 +0100
 @@ -42,7 +42,11 @@
        echo @SDL_VERSION@
        ;;


### PR DESCRIPTION
Fixes #103346. The environment var for finding the cmake companion libs
headers was missing from the SDL2::SDL2 target, it only worked when
using SDL2_INCLUDE_DIRS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
