### PR TITLE
wit: init at 3.0.3b

### DIFF
--- a/pkgs/tools/misc/wit/default.nix
+++ b/pkgs/tools/misc/wit/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, ncurses, coreutils }:
+
+stdenv.mkDerivation rec {
+  pname = "wit";
+  version = "3.0.3b";
+
+  src = fetchFromGitHub {
+    owner = "Wiimm";
+    repo = "wiimms-iso-tools";
+    rev = "7f41a7f1edf2bd1698482cafe1b10f6b87b73da7";
+    sha256 = "1vhsi87vwjnmvnwjw8gnqqh9wishzcx885kwxm5j51zizl1mhqi9";
+  };
+
+  hardeningDisable = [ "format" ];
+  buildInputs = [ ncurses ];
+
+  postUnpack = ''
+    sourceRoot=''${sourceRoot}/project
+  '';
+
+  postPatch = ''
+    sed -ie 's|/usr/bin/env|${coreutils}/bin/env|' gen-template.sh
+    sed -ie 's|/usr/bin/env|${coreutils}/bin/env|' gen-text-file.sh
+  '';
+
+  installPhase = ''
+    install -Dm755 bin/wit bin/wdf bin/wtest bin/wwt -t $out/bin
+  '';
+
+  meta = with lib; {
+    description =
+      "Command line tools to extract, modify, and create Wii and GameCube ISO images and WBFS containers.";
+    homepage = "https://wit.wiimm.de/";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ djanatyn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7994,6 +7994,8 @@ in
 
   wireguard-tools = callPackage ../tools/networking/wireguard-tools { };
 
+  wit = callPackage ../tools/misc/wit { };
+
   woff2 = callPackage ../development/web/woff2 { };
 
   woof = callPackage ../tools/misc/woof { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I am writing some nix expressions to patch some Nintendo GameCube images.
Wiimm's ISO Tools are helpful for this, and what I normally use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tried a few new things with this package that I wasn't confident around:
* Setting `sourceRoot`
Everything that needs to be built is under `project/`. I saw that some other packages set `sourceRoot`.
Am I doing this correctly?

* Disabling Hardening
This package doesn't build unless we disable some hardening around format strings.

* No Tags
The GitHub repository does not have tags, so I added the `rev` directly. The version is from this commit:
```
$ git show --no-patch
commit 7f41a7f1edf2bd1698482cafe1b10f6b87b73da7 (HEAD -> master, origin/master, origin/HEAD)
Author: Wiimm <none>
Date:   Sat Aug 22 10:37:50 2020 +0200

    WIT v3.03b: Intermediate version (no release)
```

* Broken `/usr/bin/env ...` Scripts
I'm fixing this with `sed`, using an approach I saw in `pkgs/shells/xonsh/default.nix`.