### PR TITLE
pcsx2: update deps needed by upstream

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3311,6 +3311,16 @@
     githubId = 1621335;
     name = "Andrew Trachenko";
   };
+  govanify = {
+    name = "Gauvain 'GovanifY' Roussel-Tarbouriech";
+    email = "gauvain@govanify.com";
+    github = "govanify";
+    githubId = 6375438;
+    keys = [{
+      longkeyid = "rsa4096/0xDE62E1E2A6145556";
+      fingerprint = "5214 2D39 A7CE F8FA 872B  CA7F DE62 E1E2 A614 5556";
+    }];
+  };
   gpyh = {
     email = "yacine.hmito@gmail.com";
     github = "yacinehmito";

--- a/pkgs/misc/emulators/pcsx2/default.nix
+++ b/pkgs/misc/emulators/pcsx2/default.nix
@@ -1,17 +1,41 @@
-{ alsaLib, cmake, fetchFromGitHub, gcc-unwrapped, gettext, glib, gtk3, harfbuzz
-, libaio, libpcap, libpng, libxml2, makeWrapper, perl, pkgconfig, portaudio
-, SDL2, soundtouch, stdenv, udev, wrapGAppsHook, wxGTK, zlib
+{ alsaLib
+, cmake
+, fetchFromGitHub
+, fmt
+, gcc-unwrapped
+, gettext
+, glib
+, gtk3
+, harfbuzz
+, libaio
+, libpcap
+, libpng
+, libpulseaudio
+, libsamplerate
+, libxml2
+, makeWrapper
+, perl
+, pkgconfig
+, portaudio
+, SDL2
+, soundtouch
+, stdenv
+, udev
+, wrapGAppsHook
+, wxGTK
+, zlib
 }:
 
 stdenv.mkDerivation {
   pname = "pcsx2";
-  version = "unstable-2020-10-10";
+  version = "unstable-2020-11-13";
 
   src = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2";
-    rev = "7e2ccd64e8e6049b6059141e8767037463421c33";
-    sha256 = "0c7m74ch68p4y9xlld34a9r38kb2py6wlkg4vranc6dicxvi1b3r";
+    fetchSubmodules = true;
+    rev = "319287dbe552c8405720b25dfdf5fa518deeee0b";
+    sha256 = "1kswc8vw9hbv2nigp8cxrgf2s0ik7p4i203cbqci8zjmnkaqpsai";
   };
 
   cmakeFlags = [
@@ -48,6 +72,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     alsaLib
+    fmt
     gettext
     glib
     gtk3
@@ -55,6 +80,8 @@ stdenv.mkDerivation {
     libaio
     libpcap
     libpng
+    libpulseaudio
+    libsamplerate
     libxml2
     portaudio
     SDL2
@@ -74,7 +101,7 @@ stdenv.mkDerivation {
       PC, with many additional features and benefits.
     '';
     homepage = "https://pcsx2.net";
-    maintainers = with maintainers; [ hrdinka samuelgrf ];
+    maintainers = with maintainers; [ hrdinka samuelgrf govanify ];
 
     # PCSX2's source code is released under LGPLv3+. It However ships
     # additional data files and code that are licensed differently.


### PR DESCRIPTION
###### Motivation for this change

Upstream now requires more mandatory dependencies. As one of the core developer of upstream I also added myself as a maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
