### PR TITLE
hsetroot: 1.0.2 ->  1.0.5

### DIFF
--- a/pkgs/tools/X11/hsetroot/default.nix
+++ b/pkgs/tools/X11/hsetroot/default.nix
@@ -1,36 +1,40 @@
-{ stdenv, fetchurl, autoconf, automake, imlib2, libtool, libX11, pkgconfig, xorgproto }:
+{ stdenv
+, fetchFromGitHub
+, pkg-config
+, imlib2
+, libX11
+, libXinerama
+}:
 
 stdenv.mkDerivation rec {
   pname = "hsetroot";
-  version = "1.0.2";
+  version = "1.0.5";
 
-  # The primary download site seems to no longer exist; use Gentoo's mirror for now.
-  src = fetchurl {
-    url = "http://mirror.datapipe.net/gentoo/distfiles/hsetroot-${version}.tar.gz";
-    sha256 = "d6712d330b31122c077bfc712ec4e213abe1fe71ab24b9150ae2774ca3154fd7";
+  src = fetchFromGitHub {
+    owner = "himdel";
+    repo = "hsetroot";
+    rev = version;
+    sha256 = "1jbk5hlxm48zmjzkaq5946s58rqwg1v1ds2sdyd2ba029hmvr722";
   };
 
-  # See https://bugs.gentoo.org/show_bug.cgi?id=504056
-  underlinkingPatch = fetchurl {
-    url = "http://www.gtlib.gatech.edu/pub/gentoo/gentoo-x86-portage/x11-misc/hsetroot/files/hsetroot-1.0.2-underlinking.patch";
-    name = "hsetroot-1.0.2-underlinking.patch";
-    sha256 = "1px1p3wz7ji725z9nlwb0x0h6lnnvnpz15sblzzq7zrijl3wz65x";
-  };
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    imlib2
+    libX11
+    libXinerama
+  ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ autoconf automake imlib2 libtool libX11 xorgproto ];
+  makeFlags = [ "PREFIX=$(out)" ];
 
-  patches = [ underlinkingPatch ];
-
-  patchFlags = [ "-p0" ];
-
-  preConfigure = "./autogen.sh";
+  preInstall = ''
+    mkdir -p "$out/bin"
+  '';
 
   meta = with stdenv.lib; {
     description = "Allows you to compose wallpapers ('root pixmaps') for X";
-    homepage = "https://thegraveyard.org/hsetroot.html";
+    homepage = "https://github.com/himdel/hsetroot";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.henrytill ];
+    maintainers = with maintainers; [ henrytill shamilton ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/103457

###### Things done
Upgraded hsetroot to 1.0.5

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
