### PR TITLE
aerc: 0.4.0 -> 0.5.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -6,15 +6,15 @@
 
 buildGoModule rec {
   pname = "aerc";
-  version = "0.4.0";
+  version = "0.5.2";
 
   src = fetchurl {
     url = "https://git.sr.ht/~sircmpwn/aerc/archive/${version}.tar.gz";
-    sha256 = "05qy14k9wmyhsg1hiv4njfx1zn1m9lz4d1p50kc36v7pq0n4csfk";
+    sha256 = "1vk8kxpjjcxn829lwxwchcn4bjyy6xjrjci31lk9zfak1r225fc7";
   };
 
   runVend = true;
-  vendorSha256 = "13zs5113ip85yl6sw9hzclxwlnrhy18d39vh9cwbq97dgnh9rz89";
+  vendorSha256 = "0rn5v1w54xh97zvwpyj0pkybb5fp0ljj8ld9d33c7fr0gm8dvxgl";
 
   doCheck = false;
 

--- a/pkgs/applications/networking/mailreaders/aerc/runtime-sharedir.patch
+++ b/pkgs/applications/networking/mailreaders/aerc/runtime-sharedir.patch
@@ -1,6 +1,6 @@
-From 6cf3c2e42d219b9665a43ca65f321c653b0aa102 Mon Sep 17 00:00:00 2001
+From 160eeb2263bd83e567da73f720db66c12df4a8db Mon Sep 17 00:00:00 2001
 From: Tadeo Kondrak <me@tadeo.ca>
-Date: Mon, 28 Oct 2019 08:36:36 -0600
+Date: Wed, 23 Sep 2020 20:33:04 +0100
 Subject: [PATCH] Fix aerc breaking every time the package is rebuilt.
 
 On NixOS, the SHAREDIR changes on every rebuild to the package, but aerc
@@ -8,28 +8,28 @@ fills it in as part of the default config and then installs that config
 to the users home folder. Fix this by not substituting @SHAREDIR@ in the
 default config until runtime.
 ---
- Makefile         | 2 +-
- config/config.go | 8 ++++++++
- 2 files changed, 9 insertions(+), 1 deletion(-)
+ Makefile         |  2 +-
+ config/config.go | 17 +++++++++++++++++
+ 2 files changed, 18 insertions(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index d1c755d..1185a96 100644
+index 77f5e61..99961f0 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -24,7 +24,7 @@ aerc: $(GOSRC)
+@@ -23,7 +23,7 @@ aerc: $(GOSRC)
  		-o $@
- 
+
  aerc.conf: config/aerc.conf.in
 -	sed -e 's:@SHAREDIR@:$(SHAREDIR):g' > $@ < config/aerc.conf.in
 +	cat config/aerc.conf.in > $@
- 
- DOCS := \
- 	aerc.1 \
+
+ debug: $(GOSRC)
+ 	GOFLAGS="-tags=notmuch" \
 diff --git a/config/config.go b/config/config.go
-index 32d07fc..8ffd3e8 100644
+index 87d183a..6798059 100644
 --- a/config/config.go
 +++ b/config/config.go
-@@ -355,6 +355,11 @@ func LoadConfigFromFile(root *string, sharedir string) (*AercConfig, error) {
+@@ -470,6 +470,11 @@ func LoadConfigFromFile(root *string, sharedir string) (*AercConfig, error) {
  			return nil, err
  		}
  	}
@@ -41,16 +41,24 @@ index 32d07fc..8ffd3e8 100644
  	file.NameMapper = mapName
  	config := &AercConfig{
  		Bindings: BindingConfig{
-@@ -423,6 +428,9 @@ func LoadConfigFromFile(root *string, sharedir string) (*AercConfig, error) {
- 	if err = config.LoadConfig(file); err != nil {
+@@ -547,6 +552,18 @@ func LoadConfigFromFile(root *string, sharedir string) (*AercConfig, error) {
  		return nil, err
  	}
+
 +	for i, filter := range config.Filters {
 +		config.Filters[i].Command = strings.ReplaceAll(filter.Command, "@SHAREDIR@", sharedir)
 +	}
++
++	for i, templateDir := range config.Templates.TemplateDirs {
++		config.Templates.TemplateDirs[i] = strings.ReplaceAll(templateDir, "@SHAREDIR@", sharedir)
++	}
++
++	for i, styleSetDir := range config.Ui.StyleSetDirs {
++		config.Ui.StyleSetDirs[i] = strings.ReplaceAll(styleSetDir, "@SHAREDIR@", sharedir)
++	}
++
  	if ui, err := file.GetSection("general"); err == nil {
  		if err := ui.MapTo(&config.General); err != nil {
  			return nil, err
--- 
-2.23.0
-
+--
+2.29.2


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


I had to remake the `runtime-sharedir` patch as it no longer applied cleanly.