### PR TITLE
trash-cli: 0.17.1.14 -> 0.20.11.7

### DIFF
--- a/pkgs/tools/misc/trash-cli/default.nix
+++ b/pkgs/tools/misc/trash-cli/default.nix
@@ -3,13 +3,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "trash-cli";
-  version = "0.17.1.14";
+  version = "0.20.11.7";
 
   src = fetchFromGitHub {
     owner = "andreafrancia";
     repo = "trash-cli";
     rev = version;
-    sha256 = "1bqazna223ibqjwbc1wfvfnspfyrvjy8347qlrgv4cpng72n7gfi";
+    sha256 = "0083vagy0jkahb5sw1il7r53ggk45zbjwwjsqd76v7ph3v1awf4v";
   };
 
   patches = [
@@ -18,18 +18,6 @@ python3Packages.buildPythonApplication rec {
       df = "${coreutils}/bin/df";
       libc = let ext = if stdenv.isDarwin then ".dylib" else ".so.6";
              in "${stdenv.cc.libc}/lib/libc${ext}";
-    })
-
-    # Fix build on Python 3.6.
-    (fetchpatch {
-      url = "https://github.com/andreafrancia/trash-cli/commit/a21b80d1e69783bb09376c3f60dd2f2a10578805.patch";
-      sha256 = "0w49rjh433sjfc2cl5a9wlbr6kcn9f1qg905qsyv7ay3ar75wvyp";
-    })
-
-    # Fix listing trashed files over mount points, see https://github.com/andreafrancia/trash-cli/issues/95
-    (fetchpatch {
-      url = "https://github.com/andreafrancia/trash-cli/commit/436dfddb4c2932ba3ff696e4732750b7bdc58461.patch";
-      sha256 = "02pkcz7nj67jbnqpw1943nrv95m8xyjvab4j62fa64r73fagm8m4";
     })
   ];
 


### PR DESCRIPTION
##### Motivation for this change

Bump version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
