### PR TITLE
netatalk: remove glibc input

### DIFF
--- a/pkgs/tools/filesystems/netatalk/default.nix
+++ b/pkgs/tools/filesystems/netatalk/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, autoreconfHook, pkgconfig, perl, python
 , db, libgcrypt, avahi, libiconv, pam, openssl, acl
-, ed, glibc, libevent
+, ed, libtirpc, libevent
 }:
 
 stdenv.mkDerivation rec {
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     /^afpd_LDADD
     /am__append_2
     a
-      ${glibc.static}/lib/librpcsvc.a \\
+      ${libtirpc}/lib/libtirpc.so \\
     .
     w
     EOF


### PR DESCRIPTION
###### Motivation for this change
netatalk failes to build

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
