### PR TITLE
[20.09] cherrypick working graalvm-ce, clj-kondo + babashka from master

### DIFF
--- a/pkgs/development/compilers/graalvm/community-edition.nix
+++ b/pkgs/development/compilers/graalvm/community-edition.nix
@@ -1,0 +1,167 @@
+{ stdenv, fetchurl, perl, unzip, glibc, zlib, setJavaClassPath }:
+
+let
+  common = javaVersion:
+    let
+      graalvmXXX-ce = stdenv.mkDerivation rec {
+        pname = "graalvm${javaVersion}-ce";
+        version = "20.2.0";
+        srcs = [
+          (fetchurl {
+             sha256 = {  "8" = "1s64zkkrns1ykh6dwpjrqy0hs9m1bb08cf7ss7msx33h9ivir5b0";
+                        "11" = "0aaf0sjsnlckhgsh3j4lph0shahw6slf4yndqcm2swc8i1dlpdsx";
+                      }.${javaVersion};
+             url    = "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/graalvm-ce-java${javaVersion}-linux-amd64-${version}.tar.gz";
+          })
+          (fetchurl {
+             sha256 = {  "8" = "1cisyyzab4pdvzavnivhy9w6dwn36ybaxw40w767m142fbi06m3b";
+                        "11" = "0p4j6mxajmb0xl41c79154pk4vb8bffgg1nmwislahqjky9jkd4j";
+                      }.${javaVersion};
+             url    = "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/native-image-installable-svm-java${javaVersion}-linux-amd64-${version}.jar";
+          })
+          (fetchurl {
+             sha256 = {  "8" = "0rwwvk1mkfnl0b50xg7kh6015kjmsw2ra0ckrzmabl88z4bnzh2y";
+                        "11" = "0lc9as2a00j74lp7jby4p10vn5bbkiydzvzk28zfcbsp28p4wvwn";
+                      }.${javaVersion};
+             url    = "https://github.com/oracle/truffleruby/releases/download/vm-${version}/ruby-installable-svm-java${javaVersion}-linux-amd64-${version}.jar";
+          })
+          (fetchurl {
+             sha256 = {  "8" = "0mj8p72qgvvrwpsbk0bsqldynlz1wq07icf951wq5xdbr0whj1gz";
+                        "11" = "1lkszqn4islsza011iabayv6riym0dwnkv83pkmk06b230qjfhzb";
+                      }.${javaVersion};
+             url    = "https://github.com/graalvm/graalpython/releases/download/vm-${version}/python-installable-svm-java${javaVersion}-linux-amd64-${version}.jar";
+          })
+          (fetchurl {
+             sha256 = {  "8" = "1br7camk7y8ych43ws57096100f9kzjvqznh2flmws78ipcrrb66";
+                        "11" = "10swxspjvzh0j82lbpy38dckk69lw1pawqkhnj1hxd05ls36fwq5";
+                      }.${javaVersion};
+             url    = "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/wasm-installable-svm-java${javaVersion}-linux-amd64-${version}.jar";
+          })
+        ];
+        nativeBuildInputs = [ unzip perl ];
+        unpackPhase = ''
+           unpack_jar() {
+             jar=$1
+             unzip -o $jar -d $out
+             perl -ne 'use File::Path qw(make_path);
+                       use File::Basename qw(dirname);
+                       if (/^(.+) = (.+)$/) {
+                         make_path dirname("$ENV{out}/$1");
+                         system "ln -s $2 $ENV{out}/$1";
+                       }' $out/META-INF/symlinks
+             perl -ne 'if (/^(.+) = ([r-])([w-])([x-])([r-])([w-])([x-])([r-])([w-])([x-])$/) {
+                         my $mode = ($2 eq 'r' ? 0400 : 0) + ($3 eq 'w' ? 0200 : 0) + ($4  eq 'x' ? 0100 : 0) +
+                                    ($5 eq 'r' ? 0040 : 0) + ($6 eq 'w' ? 0020 : 0) + ($7  eq 'x' ? 0010 : 0) +
+                                    ($8 eq 'r' ? 0004 : 0) + ($9 eq 'w' ? 0002 : 0) + ($10 eq 'x' ? 0001 : 0);
+                         chmod $mode, "$ENV{out}/$1";
+                       }' $out/META-INF/permissions
+             rm -rf $out/META-INF
+           }
+
+           mkdir -p $out
+           arr=($srcs)
+           tar xf ''${arr[0]} -C $out --strip-components=1
+           unpack_jar ''${arr[1]}
+           unpack_jar ''${arr[2]}
+           unpack_jar ''${arr[3]}
+           unpack_jar ''${arr[4]}
+        '';
+
+        installPhase = {
+          "8" = ''
+            # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html
+            substituteInPlace $out/jre/lib/security/java.security \
+              --replace file:/dev/random    file:/dev/./urandom \
+              --replace NativePRNGBlocking  SHA1PRNG
+
+            # provide libraries needed for static compilation
+            for f in ${glibc}/lib/* ${glibc.static}/lib/* ${zlib.static}/lib/*; do
+              ln -s $f $out/jre/lib/svm/clibraries/linux-amd64/$(basename $f)
+            done
+
+            # allow using external truffle-api.jar and languages not included in the distrubution
+            rm $out/jre/lib/jvmci/parentClassLoader.classpath
+          '';
+          "11" = ''
+            # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html
+            substituteInPlace $out/conf/security/java.security \
+              --replace file:/dev/random    file:/dev/./urandom \
+              --replace NativePRNGBlocking  SHA1PRNG
+
+            # provide libraries needed for static compilation
+            for f in ${glibc}/lib/* ${glibc.static}/lib/* ${zlib.static}/lib/*; do
+              ln -s $f $out/lib/svm/clibraries/linux-amd64/$(basename $f)
+            done
+           '';
+        }.${javaVersion};
+
+        dontStrip = true;
+
+        # copy-paste openjdk's preFixup
+        preFixup = ''
+          # Set JAVA_HOME automatically.
+          mkdir -p $out/nix-support
+          cat <<EOF > $out/nix-support/setup-hook
+            if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+          EOF
+        '';
+
+        postFixup = ''
+          rpath="${ {  "8" = "$out/jre/lib/amd64/jli:$out/jre/lib/amd64/server:$out/jre/lib/amd64";
+                      "11" = "$out/lib/jli:$out/lib/server:$out/lib";
+                    }.${javaVersion}
+                 }:${
+            stdenv.lib.makeLibraryPath [
+              stdenv.cc.cc.lib # libstdc++.so.6
+              zlib             # libz.so.1
+            ]}"
+
+          for f in $(find $out -type f -perm -0100); do
+            patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$f" || true
+            patchelf --set-rpath   "$rpath"                                    "$f" || true
+
+            if ldd "$f" | fgrep 'not found'; then echo "in file $f"; fi
+          done
+        '';
+
+        propagatedBuildInputs = [ setJavaClassPath zlib ]; # $out/bin/native-image needs zlib to build native executables
+
+        doInstallCheck = true;
+        installCheckPhase = ''
+          echo ${stdenv.lib.escapeShellArg ''
+                   public class HelloWorld {
+                     public static void main(String[] args) {
+                       System.out.println("Hello World");
+                     }
+                   }
+                 ''} > HelloWorld.java
+          $out/bin/javac HelloWorld.java
+
+          # run on JVM with Graal Compiler
+          $out/bin/java -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:+UseJVMCICompiler HelloWorld | fgrep 'Hello World'
+
+          # Ahead-Of-Time compilation
+          $out/bin/native-image --no-server HelloWorld
+          ./helloworld | fgrep 'Hello World'
+
+          # Ahead-Of-Time compilation with --static
+          $out/bin/native-image --no-server --static HelloWorld
+          ./helloworld | fgrep 'Hello World'
+        '';
+
+        passthru.home = graalvmXXX-ce;
+
+        meta = with stdenv.lib; {
+          homepage = "https://www.graalvm.org/";
+          description = "High-Performance Polyglot VM";
+          license = with licenses; [ upl gpl2Classpath bsd3 ];
+          maintainers = with maintainers; [ bandresen volth hlolli glittershark ];
+          platforms = [ "x86_64-linux" ];
+        };
+      };
+    in
+      graalvmXXX-ce;
+in {
+  graalvm8-ce  = common  "8";
+  graalvm11-ce = common "11";
+}

--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -1,25 +1,25 @@
-{ stdenv, fetchurl, graalvm8-ce, glibcLocales }:
+{ stdenv, fetchurl, graalvm11-ce, glibcLocales }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "babashka";
-  version = "0.0.97";
+  version = "0.2.3";
 
   reflectionJson = fetchurl {
     name = "reflection.json";
     url = "https://github.com/borkdude/${pname}/releases/download/v${version}/${pname}-${version}-reflection.json";
-    sha256 = "1gd9ih9l02n1j9qkbxb36d3cb5sddwvxiw8kkicgc4xig77lsa7z";
+    sha256 = "0lbdh3v3g3j00bn99bjhjj3gk1q9ks2alpvl9bxc00xpyw86f7z8";
   };
 
   src = fetchurl {
     url = "https://github.com/borkdude/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
-    sha256 = "08py6bawfrhg90fbcnv2mq4c91g5wa1q2q6zdjy2i1b9q4x1654r";
+    sha256 = "0vh6k3dkzyk346jjzg6n4mdi65iybrmhb3js9lm73yc3ay2c5dyi";
   };
 
   dontUnpack = true;
 
   LC_ALL = "en_US.UTF-8";
-  nativeBuildInputs = [ graalvm8-ce glibcLocales ];
+  nativeBuildInputs = [ graalvm11-ce glibcLocales ];
 
   buildPhase = ''
     native-image \
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/borkdude/babashka";
     license = licenses.epl10;
-    platforms = graalvm8-ce.meta.platforms;
+    platforms = graalvm11-ce.meta.platforms;
     maintainers = with maintainers; [ bandresen bhougland DerGuteMoritz jlesquembre ];
   };
 }

--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, graalvm8, glibcLocales }:
+{ stdenv, fetchurl, graalvm8-ce, glibcLocales }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   dontUnpack = true;
 
   LC_ALL = "en_US.UTF-8";
-  nativeBuildInputs = [ graalvm8 glibcLocales ];
+  nativeBuildInputs = [ graalvm8-ce glibcLocales ];
 
   buildPhase = ''
     native-image \
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/borkdude/babashka";
     license = licenses.epl10;
-    platforms = graalvm8.meta.platforms;
+    platforms = graalvm8-ce.meta.platforms;
     maintainers = with maintainers; [ bandresen bhougland DerGuteMoritz jlesquembre ];
   };
 }

--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, graalvm8, fetchurl }:
+{ stdenv, lib, graalvm8-ce, fetchurl }:
 
 stdenv.mkDerivation rec {
   pname = "clj-kondo";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  buildInputs = [ graalvm8 ];
+  buildInputs = [ graalvm8-ce ];
 
   buildPhase = ''
     native-image  \
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     description = "A linter for Clojure code that sparks joy.";
     homepage = "https://github.com/borkdude/clj-kondo";
     license = licenses.epl10;
-    platforms = graalvm8.meta.platforms;
+    platforms = graalvm8-ce.meta.platforms;
     maintainers = with maintainers; [ jlesquembre bandresen ];
   };
 }

--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -1,23 +1,23 @@
-{ stdenv, lib, graalvm8-ce, fetchurl }:
+{ stdenv, lib, graalvm11-ce, fetchurl }:
 
 stdenv.mkDerivation rec {
   pname = "clj-kondo";
-  version = "2020.04.05";
+  version = "2020.11.07";
 
   reflectionJson = fetchurl {
     name = "reflection.json";
     url = "https://raw.githubusercontent.com/borkdude/${pname}/v${version}/reflection.json";
-    sha256 = "1m6kja38p6aypawbynkyq8bdh8wpdjmyqrhslinqid9r8cl25rcq";
+    sha256 = "0mwclqjh38alkddr5r7bfqn5lplx06h9gladi89kp06qdxc1hp7a";
   };
 
   src = fetchurl {
     url = "https://github.com/borkdude/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
-    sha256 = "0k9samcqkpkdgzbzr2bpixf75987lsabh97101v1fg12qvjhf187";
+    sha256 = "1xqryfcn82bp8wasqnllfgvhl5w9zm63yw8c2kgxz18dayhq4i31";
   };
 
   dontUnpack = true;
 
-  buildInputs = [ graalvm8-ce ];
+  buildInputs = [ graalvm11-ce ];
 
   buildPhase = ''
     native-image  \
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     description = "A linter for Clojure code that sparks joy.";
     homepage = "https://github.com/borkdude/clj-kondo";
     license = licenses.epl10;
-    platforms = graalvm8-ce.meta.platforms;
+    platforms = graalvm11-ce.meta.platforms;
     maintainers = with maintainers; [ jlesquembre bandresen ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9203,6 +9203,10 @@ in
     inherit (darwin) libiconv libobjc libresolv;
   }) mx jvmci8 graalvm8;
 
+  inherit (callPackages ../development/compilers/graalvm/community-edition.nix { })
+    graalvm8-ce
+    graalvm11-ce;
+
   inherit (callPackages ../development/compilers/graalvm/enterprise-edition.nix { })
     graalvm8-ee
     graalvm11-ee;


### PR DESCRIPTION
###### Motivation for this change
clj-kondo and babashka is currently broken on 20.09 and this fixed it

cherry-picked from, PR and message
76807acbcbeb57f457ad71f957638c5db05f3db2 #103096 clj-kondo: 2020.04.05 -> 2020.11.07 
43ae9045f85c2f4210b5b7df32ea17d821d7988a  #102867 babashka: 0.0.97 -> 0.2.3
bb885bc8832f57786cb059ea6947bc5e6ac30811 #102693 babashka,clj-kondo: Depend on graalvm-ce
569c825242a96a7dc713ce8b8ed000b5f3e6b432 #99631 graalvm{8,11}-ce: init at 20.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/marvin opt-in
/status needs_merger