### PR TITLE
doc/manual/stdenv: improve cmake documentation

### DIFF
--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -2113,8 +2113,7 @@ postInstall = ''
     </varlistentry>
 
     <varlistentry>
-     <term>
-      <anchor xml:id="cmake"/>
+     <term xml:id="cmake">
        cmake
      </term>
      <listitem>
@@ -2129,7 +2128,7 @@ cmake ..</programlisting>
        <title>Variables controlling CMake</title>
        <varlistentry>
         <term>
-         <varname>cmakeFlags</varname>
+         <varname xml:id="cmake-cmakeflags">cmakeFlags</varname>
         </term>
         <listitem>
          <para>
@@ -2139,7 +2138,7 @@ cmake ..</programlisting>
        </varlistentry>
        <varlistentry>
         <term>
-         <varname>cmakeFlagsArray</varname>
+         <varname xml:id="cmake-cmakeflagsarray">cmakeFlagsArray</varname>
         </term>
         <listitem>
          <para>
@@ -2149,7 +2148,7 @@ cmake ..</programlisting>
        </varlistentry>
        <varlistentry>
         <term>
-         <varname>dontUseCmakeBuildDir</varname>
+         <varname xml:id="cmake-dontusecmakebuilddir">dontUseCmakeBuildDir</varname>
         </term>
         <listitem>
          <para>
@@ -2159,7 +2158,7 @@ cmake ..</programlisting>
        </varlistentry>
        <varlistentry>
         <term>
-         <varname>cmakeDir</varname>
+         <varname xml:id="cmake-cmakedir">cmakeDir</varname>
         </term>
         <listitem>
          <para>
@@ -2169,7 +2168,7 @@ cmake ..</programlisting>
        </varlistentry>
        <varlistentry>
         <term>
-         <varname>dontFixCmake</varname>
+         <varname xml:id="cmake-dontfixcmake">dontFixCmake</varname>
         </term>
         <listitem>
          <para>
@@ -2179,7 +2178,7 @@ cmake ..</programlisting>
        </varlistentry>
        <varlistentry>
         <term>
-         <varname>dontAddPrefix</varname>
+         <varname xml:id="cmake-dontaddprefix">dontAddPrefix</varname>
         </term>
         <listitem>
          <para>
@@ -2189,7 +2188,7 @@ cmake ..</programlisting>
        </varlistentry>
        <varlistentry>
         <term>
-         <varname>doCheck</varname>
+         <varname xml:id="cmake-docheck">doCheck</varname>
         </term>
         <listitem>
          <para>
@@ -2199,7 +2198,7 @@ cmake ..</programlisting>
        </varlistentry>
        <varlistentry>
         <term>
-         <varname>dontUseCmakeConfigure</varname>
+         <varname xml:id="cmake-dontusecmakeconfigure">dontUseCmakeConfigure</varname>
         </term>
         <listitem>
          <para>

--- a/doc/stdenv/stdenv.xml
+++ b/doc/stdenv/stdenv.xml
@@ -2111,16 +2111,106 @@ postInstall = ''
       </para>
      </listitem>
     </varlistentry>
+
     <varlistentry>
      <term>
-      cmake
+      <anchor xml:id="cmake"/>
+       cmake
      </term>
      <listitem>
       <para>
-       Overrides the default configure phase to run the CMake command. By default, we use the Make generator of CMake. In addition, dependencies are added automatically to CMAKE_PREFIX_PATH so that packages are correctly detected by CMake. Some additional flags are passed in to give similar behavior to configure-based packages. You can disable this hook’s behavior by setting configurePhase to a custom value, or by setting dontUseCmakeConfigure. cmakeFlags controls flags passed only to CMake. By default, parallel building is enabled as CMake supports parallel building almost everywhere. When Ninja is also in use, CMake will detect that and use the ninja generator.
+       Overrides the default configure phase to run the CMake command. By default, we use the Make generator of CMake, however, if ninja is present, then the ninja generator will be used instead. In addition, dependencies are added automatically to CMAKE_PREFIX_PATH so that packages are correctly detected by CMake. By default, the cmake configurePhase can be thought of as:
+       <programlisting>
+mkdir build
+cd build
+cmake ..</programlisting>
       </para>
+      <variablelist>
+       <title>Variables controlling CMake</title>
+       <varlistentry>
+        <term>
+         <varname>cmakeFlags</varname>
+        </term>
+        <listitem>
+         <para>
+          Flags passed to cmake. <literal>cmakeFlags = "-DBUILD_SHARED_LIB=ON -DENABLE_LTO=ON";</literal>
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         <varname>cmakeFlagsArray</varname>
+        </term>
+        <listitem>
+         <para>
+          Flag array passed to cmake. <literal>cmakeFlagsArray = [ "-DBUILD_SHARED_LIB=ON" "-DENABLE_LTO=ON" ];</literal>
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         <varname>dontUseCmakeBuildDir</varname>
+        </term>
+        <listitem>
+         <para>
+          Avoid creating and changing directory to <literal>build</literal>.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         <varname>cmakeDir</varname>
+        </term>
+        <listitem>
+         <para>
+          Set directory which contains the top-level CMakeLists.txt file. Defaults to the parent directory <literal>".."</literal>, otherwise the current directory <literal>"."</literal> if <literal>dontUseCmakeBuildDir</literal> is set to true. For example, if a project has the cmake files located in a top-level source directory called <literal>cmake/</literal>, then you will want to set the value to <literal>../cmake</literal> so that cmake can reference CMakeLists.txt from the build directory.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         <varname>dontFixCmake</varname>
+        </term>
+        <listitem>
+         <para>
+          Avoid replacing instances of <literal>/usr</literal> and <literal>/opt</literal> with <literal>/var/empty</literal> in cmake files.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         <varname>dontAddPrefix</varname>
+        </term>
+        <listitem>
+         <para>
+          Avoid setting <literal>-DCMAKE_INSTALL_PREFIX</literal> to <literal>$prefix</literal>.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         <varname>doCheck</varname>
+        </term>
+        <listitem>
+         <para>
+          Whether or not to also build ctest project.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         <varname>dontUseCmakeConfigure</varname>
+        </term>
+        <listitem>
+         <para>
+          Avoid the cmake configure step altogether.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
      </listitem>
     </varlistentry>
+
     <varlistentry>
      <term>
       xcbuildHook


### PR DESCRIPTION
###### Motivation for this change
closes: #102104 

Changes:
- list attrs which affects cmake builds
- add anchor E.g. manual#cmake (although there's probably a better way)
- add some examples

modeled it after the meson section

since stable manual is the default one on the website, this should also be backported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
