### PR TITLE
timescaledb: Move unfree library to separate package to fix the license

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -235,6 +235,12 @@
      <literal>unbound-control</literal> without passing a custom configuration location.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <package>timescaledb</package>'s non-free <literal>tsl</literal> library has been moved to
+     <package>timescaledb-tsl</package>.  This does not affect the Postgresql extension.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/tests/timescaledb.nix
+++ b/nixos/tests/timescaledb.nix
@@ -1,0 +1,41 @@
+{ system ? builtins.currentSystem, config ? { }
+, pkgs ? import ../.. { inherit system config; } }:
+
+let
+  inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
+
+  # Test script from https://docs.timescale.com/latest/getting-started/creating-hypertables
+  test-sql = pkgs.writeText "timescaledb-test" ''
+    CREATE EXTENSION IF NOT EXISTS timescaledb;
+    CREATE TABLE conditions (
+      time        TIMESTAMPTZ       NOT NULL,
+      location    TEXT              NOT NULL,
+      temperature DOUBLE PRECISION  NULL,
+      humidity    DOUBLE PRECISION  NULL
+    );
+    SELECT create_hypertable('conditions', 'time');
+    INSERT INTO conditions(time, location, temperature, humidity)
+      VALUES (NOW(), 'office', 70.0, 50.0);
+    SELECT * FROM conditions ORDER BY time DESC LIMIT 100;
+  '';
+in makeTest {
+  name = "timescaledb-test";
+  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ chkno ]; };
+
+  machine = {
+    services.postgresql = {
+      enable = true;
+      extraPlugins = [ pkgs.timescaledb ];
+      settings.shared_preload_libraries = "timescaledb";
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("postgresql")
+    machine.succeed(
+        "cat ${test-sql} | sudo -u postgres psql",
+        '[[ "$(sudo -u postgres psql postgres -tAc "SELECT * FROM conditions ORDER BY time DESC LIMIT 100")" == *"|office|70|50" ]]',
+    )
+  '';
+
+}

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, postgresql, openssl }:
+{ stdenv, fetchFromGitHub, cmake, postgresql, openssl, build-unfree-tsl }:
 
 # # To enable on NixOS:
 # config.services.postgresql = {
@@ -20,7 +20,8 @@ stdenv.mkDerivation rec {
     sha256 = "0w0sl5izwic3j1k94xhky2y4wkd8l18m5hcknj5vqxq3ryhxaszc";
   };
 
-  cmakeFlags = [ "-DSEND_TELEMETRY_DEFAULT=OFF" "-DREGRESS_CHECKS=OFF" ];
+  cmakeFlags = [ "-DSEND_TELEMETRY_DEFAULT=OFF" "-DREGRESS_CHECKS=OFF" ]
+    ++ stdenv.lib.optional (!build-unfree-tsl) [ "-DAPACHE_ONLY=1" ];
 
   # Fix the install phase which tries to install into the pgsql extension dir,
   # and cannot be manually overridden. This is rather fragile but works OK.
@@ -41,6 +42,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://www.timescale.com/";
     maintainers = with maintainers; [ volth marsam ];
     platforms   = postgresql.meta.platforms;
-    license     = licenses.asl20;
+    license = if build-unfree-tsl then licenses.unfree else licenses.asl20;
   };
 }

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -51,7 +51,11 @@ self: super: {
 
     temporal_tables = super.callPackage ./ext/temporal_tables.nix { };
 
-    timescaledb = super.callPackage ./ext/timescaledb.nix { };
+    timescaledb =
+      super.callPackage ./ext/timescaledb.nix { build-unfree-tsl = false; };
+
+    timescaledb-tsl =
+      super.callPackage ./ext/timescaledb.nix { build-unfree-tsl = true; };
 
     tsearch_extras = super.callPackage ./ext/tsearch_extras.nix { };
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -447,6 +447,7 @@ mapAliases ({
   pgtap = postgresqlPackages.pgtap;
   plv8 = postgresqlPackages.plv8;
   timescaledb = postgresqlPackages.timescaledb;
+  timescaledb-tsl = postgresqlPackages.timescaledb-tsl;
   tsearch_extras = postgresqlPackages.tsearch_extras;
   cstore_fdw = postgresqlPackages.cstore_fdw;
   pg_hll = postgresqlPackages.pg_hll;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Fix the timescaledb license.
Make the Free/Libre/Open Source timescaledb build available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    43361488 → 43005136
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

timescaledb maintainers: @volth @marsam