### PR TITLE
glibc: fix darwin -> linux cross compilation

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -206,6 +206,8 @@ stdenv.mkDerivation ({
 
 
   '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    unset NIX_COREFOUNDATION_RPATH
+
     sed -i s/-lgcc_eh//g "../$sourceRoot/Makeconfig"
 
     cat > config.cache << "EOF"

--- a/pkgs/development/libraries/glibc/darwin-cross-build.patch
+++ b/pkgs/development/libraries/glibc/darwin-cross-build.patch
@@ -3,7 +3,6 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
 * use host version of ar, which is given by environment variable
 * build system uses stamp.os and stamp.oS files, which only differ in case;
   this fails on macOS, so replace .oS with .o_S
-* libintl.h does not exist (and is not needed) on macOS
 
 --- glibc-2.27/Makefile.in	2018-02-01 17:17:18.000000000 +0100
 +++ glibc-2.27/Makefile.in	2019-02-15 17:38:27.022965553 +0100
@@ -77,27 +76,3 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
  endef
  
  # Also remove the dependencies and generated source files.
---- glibc-2.27/sunrpc/rpc_main.c	2019-02-15 17:32:43.710244513 +0100
-+++ glibc-2.27/sunrpc/rpc_main.c	2019-02-15 17:23:57.139617796 +0100
-@@ -38,7 +38,9 @@
- #include <stdio.h>
- #include <string.h>
- #include <unistd.h>
-+#ifndef __APPLE__
- #include <libintl.h>
-+#endif
- #include <locale.h>
- #include <ctype.h>
- #include <sys/types.h>
---- glibc-2.27/sunrpc/rpc_scan.c	2019-02-15 17:32:54.845490606 +0100
-+++ glibc-2.27/sunrpc/rpc_scan.c	2019-02-15 17:24:54.288066644 +0100
-@@ -37,7 +37,9 @@
- #include <stdio.h>
- #include <ctype.h>
- #include <string.h>
-+#ifndef __APPLE__
- #include <libintl.h>
-+#endif
- #include "rpc_scan.h"
- #include "rpc_parse.h"
- #include "rpc_util.h"


### PR DESCRIPTION
###### Motivation for this change
darwin -> linux cross-compilation of glibc was broken for two reasons. This fixes both of them:

* A recent glibc update removed some code we were patching. I fixed this by removing the relevant part of the patch.
* When `NIX_COREFOUNDATION_RPATH` is set, we create a ld.so binary with an RPATH of [], but ld.so expects not to have an RPATH set at all. I fix this by unsetting the variable in the `glibc` derivation, as [suggested by](https://github.com/NixOS/nixpkgs/issues/88213#issuecomment-644881990) @parthy, but I'm not sure this is the best solution (in particular, I'm not convinced we should be setting NIX_COREFOUNDATION_RPATH at all when host != darwin). However, this does get cross-compilation working for now.

Tested by doing `nix-build . --arg crossSystem '(import ./. {}).lib.systems.examples.gnu64' -A hello` on Darwin, copying the resulting closure onto a Linux box, and running `hello`.

This should only change code on the cross-compilation path, so it shouldn't cause any mass rebuilds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).