### PR TITLE
xmountains: init at 2.1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -392,6 +392,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "Historic Permission Notice and Disclaimer";
   };
 
+  hpndSellVariant = spdx {
+    fullName = "Historical Permission Notice and Disclaimer - sell variant";
+    spdxId = "HPND-sell-variant";
+  };
+
   # Intel's license, seems free
   iasl = {
     fullName = "iASL";

--- a/pkgs/applications/graphics/xmountains/default.nix
+++ b/pkgs/applications/graphics/xmountains/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, xlibsWrapper, xorg }:
+
+stdenv.mkDerivation rec {
+  pname = "xmountains";
+  version = "2.10";
+
+  src = fetchFromGitHub {
+    owner = "spbooth";
+    repo = pname;
+    rev = "aa3bcbfed228adf3fff0fe4295589f13fc194f0b";
+    sha256 = "0dx4n2y736lv04sj41cp1dw8n5zkw5gyd946a6zsiv0k796s9ra9";
+  };
+
+  buildInputs = [ xlibsWrapper xorg.xbitmaps ];
+  nativeBuildInputs = with xorg; [ imake gccmakedep ];
+
+  installPhase = "install -Dm755 xmountains -t $out/bin";
+
+  meta = with lib; {
+    description = "X11 based fractal landscape generator";
+    homepage = "https://spbooth.github.io/xmountains";
+    license = licenses.hpndSellVariant;
+    maintainers = with maintainers; [ djanatyn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24688,6 +24688,8 @@ in
     desktopSupport = "xfce4";
   };
 
+  xmountains = callPackage ../applications/graphics/xmountains { };
+
   xmpp-client = callPackage ../applications/networking/instant-messengers/xmpp-client { };
 
   libxpdf = callPackage ../applications/misc/xpdf/libxpdf.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
This is a fractal image generator for X11. The algorithms it uses are well documented.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I added a new license, `hpndSellVariant`, after identifying `copyright.h`.

There are no tags in the repository. The version (`2.10`) is taken from the latest commit:
```
$ git show --no-patch aa3bcbfed228adf3fff0fe4295589f13fc194f0b
commit aa3bcbfed228adf3fff0fe4295589f13fc194f0b (HEAD -> master, origin/master, origin/HEAD)
Author: Stephen Booth <s.booth@epcc.ed.ac.uk>
Date:   Fri Jul 24 11:12:21 2020 +0100

    Version 2.10
```