### PR TITLE
f2fs-tools: 1.13.0 -> 1.14.0 [20.09]

### DIFF
--- a/pkgs/tools/filesystems/f2fs-tools/default.nix
+++ b/pkgs/tools/filesystems/f2fs-tools/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "f2fs-tools";
-  version = "1.13.0";
+  version = "1.14.0";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git";
     rev = "refs/tags/v${version}";
-    sha256 = "0h6wincsvg6s232ajxblg66r5nx87v00a4w7xkbxgbl1qyny477j";
+    sha256 = "06ss05n87i1c3149qb3n7j1qp2scv3g2adx0v6ljkl59ab9b5saj";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Allow use of 'compression' option on volume creation, supported at
mount-time in kernels 5.6+

(cherry picked from commit b467630062f6dac3cebc205b8e1b42566ba218cb)

###### Motivation for this change

Addresses 5 CVEs: Issue roundup: #101150

```Report for f2fs-tools
     nixos-20.09: f2fs-tools-1.13.0 (1.13.0): pkgs/tools/filesystems/f2fs-tools/default.nix:20
       Issues: 101150 (Containing 5 CVE(s)) Hash:NwPunTqpedk5yfSaIEOgMg==
nixpkgs-unstable: f2fs-tools-1.14.0 (1.14.0): pkgs/tools/filesystems/f2fs-tools/default.nix:20
       Issues: 
  CVE Block
  NwPunTqpedk5yfSaIEOgMg== => CVE-2020-6104,CVE-2020-6105,CVE-2020-6106
                              CVE-2020-6107,CVE-2020-6108
```

Review of changelog doesn't show any differences in existing usage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
