### PR TITLE
[20.09] fastd: 19 -> 21

### DIFF
--- a/pkgs/tools/networking/fastd/default.nix
+++ b/pkgs/tools/networking/fastd/default.nix
@@ -1,28 +1,19 @@
-{ stdenv, fetchFromGitHub, cmake, bison, pkgconfig
+{ stdenv, fetchFromGitHub, bison, meson, ninja, pkgconfig
 , libuecc, libsodium, libcap, json_c, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "fastd";
-  version = "19";
+  version = "21";
 
   src = fetchFromGitHub {
     owner  = "Neoraider";
     repo = "fastd";
     rev = "v${version}";
-    sha256 = "1h3whjvy2n2cyvbkbg4y1z9vlrn790spzbdhj4glwp93xcykhz5i";
+    sha256 = "1p4k50dk8byrghbr0fwmgwps8df6rlkgcd603r14i71m5g27z5gw";
   };
 
-  postPatch = ''
-    substituteInPlace src/crypto/cipher/CMakeLists.txt \
-      --replace 'add_subdirectory(aes128_ctr)' ""
-  '';
-
-  nativeBuildInputs = [ pkgconfig bison cmake ];
+  nativeBuildInputs = [ pkgconfig bison meson ninja ];
   buildInputs = [ libuecc libsodium libcap json_c openssl ];
-
-  cmakeFlags = [
-    "-DENABLE_OPENSSL=true"
-  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
(cherry picked from commit 5a4385d4a9c68dde8573e25a33951cc6180a79ea)


###### Motivation for this change

Addresses: #102785 - CVE-2020-27638

I have reviewed the release notes for v20 and v21. 
* The one operational change is specific to their openWRT implementation. (v20)
* Rest are benign bugfixes. (v20)

v21 is listed as a critical update that all v20 users MUST update to.

https://fastd.readthedocs.io/en/stable/releases/v20.html
https://fastd.readthedocs.io/en/stable/releases/v21.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
