### PR TITLE
libsndfile: 1.0.28 -> 1.0.30

### DIFF
--- a/pkgs/development/libraries/libsndfile/default.nix
+++ b/pkgs/development/libraries/libsndfile/default.nix
@@ -1,50 +1,20 @@
-{ stdenv, fetchurl, flac, libogg, libvorbis, pkgconfig
+{ stdenv, fetchFromGitHub, autoreconfHook, autogen, flac, libogg, libopus, libvorbis, pkgconfig, python3
 , Carbon, AudioToolbox
 }:
 
 stdenv.mkDerivation rec {
-  name = "libsndfile-1.0.28";
+  pname = "libsndfile";
+  version = "1.0.30";
 
-  src = fetchurl {
-    url = "http://www.mega-nerd.com/libsndfile/files/${name}.tar.gz";
-    sha256 = "1afzm7jx34jhqn32clc5xghyjglccam2728yxlx37yj2y0lkkwqz";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1rh79y4s4m2wcm2kahmzs2kijpdpayif2gyca6m71f3k7jbhgcwa";
   };
 
-  patches = [
-    (fetchurl {
-      name = "CVE-2017-12562.patch";
-      url = "https://github.com/erikd/libsndfile/commit/cf7a8182c2642c50f1cf90dddea9ce96a8bad2e8.patch";
-      sha256 = "1jg3wq30wdn9nv52mcyv6jyi4d80h4r1h9p96czcria7l91yh4sy";
-    })
-    (fetchurl {
-      name = "CVE-2017-6892.patch";
-      url = "https://github.com/erikd/libsndfile/commit/f833c53cb596e9e1792949f762e0b33661822748.patch";
-      sha256 = "05xkmz2ihc1zcj73sbmj1ikrv9qlcym2bkp1v6ak7w53ky619mwq";
-    })
-    (fetchurl {
-      name = "CVE-2017-8361+CVE-2017-8363+CVE-2017-8365.patch";
-      url = "https://github.com/erikd/libsndfile/commit/fd0484aba8e51d16af1e3a880f9b8b857b385eb3.patch";
-      sha256 = "0ccndnvjzx5fw18zvy03vnb29rr81h5vsh1m16msqbxk8ibndln2";
-    })
-    (fetchurl {
-      name = "CVE-2017-8362.patch";
-      url = "https://github.com/erikd/libsndfile/commit/ef1dbb2df1c0e741486646de40bd638a9c4cd808.patch";
-      sha256 = "1xyv30ga71cpy4wx5f76sc4dma91la2lcc6s9f3pk9rndyi7gj9x";
-    })
-    (fetchurl {
-      name = "CVE-2017-14634.patch";
-      url = "https://github.com/erikd/libsndfile/commit/85c877d5072866aadbe8ed0c3e0590fbb5e16788.patch";
-      sha256 = "0kc7vp22qsxidhvmlc6nfamw7k92n0hcfpmwhb3gaksjamwhb2df";
-    })
-    (fetchurl {
-      name = "CVE-2018-13139.patch";
-      url = "https://github.com/erikd/libsndfile/commit/aaea680337267bfb6d2544da878890ee7f1c5077.patch";
-      sha256 = "01q3m7pa3xqkh05ijmfgv064v8flkg4p24bgy9wxnc6wfcdifggx";
-    })
-  ];
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ flac libogg libvorbis ]
+  nativeBuildInputs = [ autoreconfHook autogen pkgconfig python3 ];
+  buildInputs = [ flac libogg libopus libvorbis ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ Carbon AudioToolbox ];
 
   enableParallelBuilding = true;
@@ -63,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A C library for reading and writing files containing sampled sound";
-    homepage    = "http://www.mega-nerd.com/libsndfile/";
+    homepage    = "https://libsndfile.github.io/libsndfile/";
     license     = licenses.lgpl2Plus;
     maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/libsndfile/libsndfile/releases/tag/v1.0.29
https://github.com/libsndfile/libsndfile/releases/tag/v1.0.30

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).