### PR TITLE
cataclysmDDA: add utility function `attachPkgs`

### DIFF
--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -33,7 +33,8 @@ let
     buildMod
     buildSoundPack
     buildTileSet
-    wrapCDDA;
+    wrapCDDA
+    attachPkgs;
 
     inherit pkgs;
   };

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, CoreFoundation, fetchFromGitHub, pkgs, wrapCDDA
+{ lib, callPackage, CoreFoundation, fetchFromGitHub, pkgs, wrapCDDA, attachPkgs
 , tiles ? true, Cocoa
 , debug ? false
 , useXdgDir ? false
@@ -26,11 +26,6 @@ let
       "VERSION=git-${version}-${lib.substring 0 8 src.rev}"
     ];
 
-    passthru = common.passthru // {
-      pkgs = pkgs.override { build = self; };
-      withMods = wrapCDDA self;
-    };
-
     meta = common.meta // {
       maintainers = with lib.maintainers;
       common.meta.maintainers ++ [ rardiol ];
@@ -38,4 +33,4 @@ let
   });
 in
 
-self
+attachPkgs pkgs self

--- a/pkgs/games/cataclysm-dda/lib.nix
+++ b/pkgs/games/cataclysm-dda/lib.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
-{
+rec {
   buildMod = callPackage ./builder.nix {
     type = "mod";
   };
@@ -14,4 +14,33 @@
   };
 
   wrapCDDA = callPackage ./wrapper.nix {};
+
+  # Required to fix `pkgs` and `withMods` attrs after applying `overrideAttrs`.
+  #
+  # Example:
+  #     let
+  #       myBuild = cataclysmDDA.jenkins.latest.tiles.overrideAttrs (_: {
+  #         x = "hello";
+  #       });
+  #
+  #       # This refers to the derivation before overriding! So, `badExample.x` is not accessible.
+  #       badExample = myBuild.withMods (_: []);
+  #
+  #       # `myBuild` is correctly referred by `withMods` and `goodExample.x` is accessible.
+  #       goodExample = let
+  #         inherit (cataclysmDDA) attachPkgs pkgs;
+  #       in
+  #       (attachPkgs pkgs myBuild).withMods (_: []);
+  #     in
+  #     goodExample.x  # returns "hello"
+  attachPkgs = pkgs: super:
+  let
+    self = super.overrideAttrs (old: {
+      passthru = old.passthru // {
+        pkgs = pkgs.override { build = self; };
+        withMods = wrapCDDA self;
+      };
+    });
+  in
+  self;
 }

--- a/pkgs/games/cataclysm-dda/pkgs/default.nix
+++ b/pkgs/games/cataclysm-dda/pkgs/default.nix
@@ -13,9 +13,9 @@ let
     };
   };
 
-  pkgs' = lib.mapAttrs (_: mod: lib.filterAttrs availableForBuild mod) pkgs;
+  pkgs' = lib.mapAttrs (_: mods: lib.filterAttrs isAvailable mods) pkgs;
 
-  availableForBuild = _: mod:
+  isAvailable = _: mod:
   if isNull build then
     true
   else if build.isTiles then

--- a/pkgs/games/cataclysm-dda/pkgs/default.nix
+++ b/pkgs/games/cataclysm-dda/pkgs/default.nix
@@ -19,9 +19,11 @@ let
   if isNull build then
     true
   else if build.isTiles then
-    mod.forTiles
+    mod.forTiles or false
+  else if build.isCurses then
+    mod.forCurses or false
   else
-    mod.forCurses;
+    false;
 in
 
 lib.makeExtensible (_: pkgs')

--- a/pkgs/games/cataclysm-dda/stable.nix
+++ b/pkgs/games/cataclysm-dda/stable.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, CoreFoundation, fetchFromGitHub, pkgs, wrapCDDA
+{ lib, callPackage, CoreFoundation, fetchFromGitHub, pkgs, wrapCDDA, attachPkgs
 , tiles ? true, Cocoa
 , debug ? false
 , useXdgDir ? false
@@ -19,11 +19,6 @@ let
       sha256 = "15l6w6lxays7qmsv0ci2ry53asb9an9dh7l7fc13256k085qcg68";
     };
 
-    passthru = common.passthru // {
-      pkgs = pkgs.override { build = self; };
-      withMods = wrapCDDA self;
-    };
-
     meta = common.meta // {
       maintainers = with lib.maintainers;
       common.meta.maintainers ++ [ skeidel ];
@@ -31,4 +26,4 @@ let
   });
 in
 
-self
+attachPkgs pkgs self


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Add a helper function `attachPkgs` to override packages correctly
- Fix some minor bugs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
