### PR TITLE
xorg.xorgserver: 1.20.8 -> 1.20.10 [20.09]

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2692,11 +2692,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xorgserver = callPackage ({ stdenv, pkgconfig, fetchurl, xorgproto, openssl, libX11, libXau, libXaw, libxcb, xcbutil, xcbutilwm, xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, libXdmcp, libXfixes, libxkbfile, libXmu, libXpm, libXrender, libXres, libXt }: stdenv.mkDerivation {
-    name = "xorg-server-1.20.8";
+    name = "xorg-server-1.20.9";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/xserver/xorg-server-1.20.8.tar.bz2";
-      sha256 = "0ih15m7gh1z1ly6z7g82bkni719yisqmbk61a1wgp82bxrmn8yyi";
+      url = "mirror://xorg/individual/xserver/xorg-server-1.20.9.tar.bz2";
+      sha256 = "0w9mrnffvjgmwi50kln15i8rpdskxv97r78l75wlcmg4vzhg46g2";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2692,11 +2692,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xorgserver = callPackage ({ stdenv, pkgconfig, fetchurl, xorgproto, openssl, libX11, libXau, libXaw, libxcb, xcbutil, xcbutilwm, xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, libXdmcp, libXfixes, libxkbfile, libXmu, libXpm, libXrender, libXres, libXt }: stdenv.mkDerivation {
-    name = "xorg-server-1.20.9";
+    name = "xorg-server-1.20.10";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/xserver/xorg-server-1.20.9.tar.bz2";
-      sha256 = "0w9mrnffvjgmwi50kln15i8rpdskxv97r78l75wlcmg4vzhg46g2";
+      url = "mirror://xorg/individual/xserver/xorg-server-1.20.10.tar.bz2";
+      sha256 = "16bwrf0ag41l7jbrllbix8z6avc5yimga7ihvq4ch3a5hb020x4p";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -639,6 +639,16 @@ self: super:
         propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ libpciaccess epoxy ] ++ commonPropagatedBuildInputs ++ lib.optionals stdenv.isLinux [
           udev
         ];
+        # patchPhase is not working, this is a hack but we can remove it in the next xorg-server release
+        preConfigure = let
+          # https://gitlab.freedesktop.org/xorg/xserver/-/issues/1067
+          headerFix = fetchpatch {
+            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/919f1f46fc67dae93b2b3f278fcbfc77af34ec58.patch";
+            sha256 = "0w48rdpl01v0c97n9zdxhf929y76r1f6rqkfs9mfygkz3xcmrfsq";
+          };
+        in ''
+          patch -p1 < ${headerFix}
+        '';
         prePatch = stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
           export CFLAGS+=" -D__uid_t=uid_t -D__gid_t=gid_t"
         '';

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -639,16 +639,6 @@ self: super:
         propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ libpciaccess epoxy ] ++ commonPropagatedBuildInputs ++ lib.optionals stdenv.isLinux [
           udev
         ];
-        # patchPhase is not working, this is a hack but we can remove it in the next xorg-server release
-        preConfigure = let
-          # https://gitlab.freedesktop.org/xorg/xserver/-/issues/1067
-          headerFix = fetchpatch {
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/919f1f46fc67dae93b2b3f278fcbfc77af34ec58.patch";
-            sha256 = "0w48rdpl01v0c97n9zdxhf929y76r1f6rqkfs9mfygkz3xcmrfsq";
-          };
-        in ''
-          patch -p1 < ${headerFix}
-        '';
         prePatch = stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
           export CFLAGS+=" -D__uid_t=uid_t -D__gid_t=gid_t"
         '';

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -218,4 +218,4 @@ mirror://xorg/individual/util/lndir-1.0.3.tar.bz2
 mirror://xorg/individual/util/makedepend-1.0.6.tar.bz2
 mirror://xorg/individual/util/util-macros-1.19.2.tar.bz2
 mirror://xorg/individual/util/xorg-cf-files-1.0.6.tar.bz2
-mirror://xorg/individual/xserver/xorg-server-1.20.8.tar.bz2
+mirror://xorg/individual/xserver/xorg-server-1.20.9.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -218,4 +218,4 @@ mirror://xorg/individual/util/lndir-1.0.3.tar.bz2
 mirror://xorg/individual/util/makedepend-1.0.6.tar.bz2
 mirror://xorg/individual/util/util-macros-1.19.2.tar.bz2
 mirror://xorg/individual/util/xorg-cf-files-1.0.6.tar.bz2
-mirror://xorg/individual/xserver/xorg-server-1.20.9.tar.bz2
+mirror://xorg/individual/xserver/xorg-server-1.20.10.tar.bz2


### PR DESCRIPTION
Cherry-picked two separate commits:

* 1.20.8 ->1.20.9 to address vuln issue.
* 1.20.9 -> 1.20.10 to address CVE-2020-14360 and CVE-2020-25712

xorg.xorgserver: 1.20.8 -> 1.20.9
https://lists.x.org/archives/xorg-announce/2020-August/003059.html
https://lists.x.org/archives/xorg-announce/2020-August/003058.html
(cherry picked from commit 4ebe8eeb50c732756305283980ebbb534c20944e)

xorg.xorgserver: 1.20.9 -> 1.20.10
https://lists.x.org/archives/xorg-announce/2020-December/003067.html
https://lists.x.org/archives/xorg-announce/2020-December/003066.html
(cherry picked from commit 0309973b82e43873ca2bdeab5f525ca86525c734)

###### Motivation for this change
```
Report for xorg.xorgserver
     nixos-20.09: xorg-server-1.20.8 (1.20.8): pkgs/servers/x11/xorg/default.nix:2695
       Issues: 99870 (Containing 4 CVE(s)) Hash:gvrfnDj1eXL0G4YrHLZCsQ==
nixpkgs-unstable: xorg-server-1.20.9 (1.20.9): pkgs/servers/x11/xorg/default.nix:2695
       Issues: 
  CVE Block
  gvrfnDj1eXL0G4YrHLZCsQ== => CVE-2020-14346,CVE-2020-14347,CVE-2020-14361
                              CVE-2020-14362
```

Addresses #99870

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
