### PR TITLE
ocamlPackages.metrics: 0.1.0 → 0.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/dns/default.nix
+++ b/pkgs/development/ocaml-modules/dns/default.nix
@@ -6,6 +6,7 @@ buildDunePackage rec {
   pname = "dns";
   version = "4.6.2";
 
+  useDune2 = true;
   minimumOCamlVersion = "4.07";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/metrics/default.nix
+++ b/pkgs/development/ocaml-modules/metrics/default.nix
@@ -2,18 +2,20 @@
 
 buildDunePackage rec {
   pname = "metrics";
-  version = "0.1.0";
+  version = "0.2.0";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.04";
 
   src = fetchurl {
     url = "https://github.com/mirage/metrics/releases/download/${version}/metrics-${version}.tbz";
-    sha256 = "0jy88anrx3rh19046rrbrjmx922zvz3wlqkk8asilqv9pbvpnp1a";
+    sha256 = "0j215cji3n78lghzi9m6kgr3r1s91v681hfnn7cgybb31d7gjkqg";
   };
 
   propagatedBuildInputs = [ fmt ];
 
-  checkInputs = lib.optional doCheck alcotest;
+  checkInputs = [ alcotest ];
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/metrics/influx.nix
+++ b/pkgs/development/ocaml-modules/metrics/influx.nix
@@ -1,0 +1,14 @@
+{ buildDunePackage, metrics
+, astring, duration, fmt, lwt
+}:
+
+buildDunePackage rec {
+  pname = "metrics-influx";
+  inherit (metrics) version useDune2 src;
+
+  propagatedBuildInputs = [ astring duration fmt lwt metrics ];
+
+  meta = metrics.meta // {
+    description = "Influx reporter for the Metrics library";
+  };
+}

--- a/pkgs/development/ocaml-modules/metrics/lwt.nix
+++ b/pkgs/development/ocaml-modules/metrics/lwt.nix
@@ -1,11 +1,11 @@
-{ buildDunePackage, ocaml_lwt, metrics }:
+{ buildDunePackage, logs, ocaml_lwt, metrics }:
 
 buildDunePackage {
   pname = "metrics-lwt";
 
-  inherit (metrics) version src;
+  inherit (metrics) version useDune2 src;
 
-  propagatedBuildInputs = [ ocaml_lwt metrics ];
+  propagatedBuildInputs = [ logs ocaml_lwt metrics ];
 
   meta = metrics.meta // {
     description = "Lwt backend for the Metrics library";

--- a/pkgs/development/ocaml-modules/metrics/mirage.nix
+++ b/pkgs/development/ocaml-modules/metrics/mirage.nix
@@ -1,0 +1,14 @@
+{ buildDunePackage, metrics, metrics-influx
+, cstruct, ipaddr, logs, lwt, mirage-clock, mirage-stack
+}:
+
+buildDunePackage {
+  pname = "metrics-mirage";
+  inherit (metrics) version useDune2 src;
+
+  propagatedBuildInputs = [ cstruct ipaddr logs lwt metrics metrics-influx mirage-clock mirage-stack ];
+
+  meta = metrics.meta // {
+    description = "Mirage backend for the Metrics library";
+  };
+}

--- a/pkgs/development/ocaml-modules/metrics/unix.nix
+++ b/pkgs/development/ocaml-modules/metrics/unix.nix
@@ -1,14 +1,14 @@
-{ lib, buildDunePackage, gnuplot, ocaml_lwt, metrics, metrics-lwt, mtime, uuidm }:
+{ buildDunePackage, gnuplot, ocaml_lwt, metrics, metrics-lwt, mtime, uuidm }:
 
 buildDunePackage rec {
 
   pname = "metrics-unix";
 
-  inherit (metrics) version src;
+  inherit (metrics) version useDune2 src;
 
   propagatedBuildInputs = [ gnuplot ocaml_lwt metrics mtime uuidm ];
 
-  checkInputs = lib.optional doCheck metrics-lwt;
+  checkInputs = [ metrics-lwt ];
 
   doCheck = true;
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -533,6 +533,8 @@ let
 
     metrics-lwt = callPackage ../development/ocaml-modules/metrics/lwt.nix { };
 
+    metrics-mirage = callPackage ../development/ocaml-modules/metrics/mirage.nix { };
+
     metrics-unix = callPackage ../development/ocaml-modules/metrics/unix.nix {
       inherit (pkgs) gnuplot;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -529,6 +529,8 @@ let
 
     metrics = callPackage ../development/ocaml-modules/metrics { };
 
+    metrics-influx = callPackage ../development/ocaml-modules/metrics/influx.nix { };
+
     metrics-lwt = callPackage ../development/ocaml-modules/metrics/lwt.nix { };
 
     metrics-unix = callPackage ../development/ocaml-modules/metrics/unix.nix {


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/mirage/metrics/blob/master/CHANGES.md

Use Dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
