### PR TITLE
 thunderbird,  thunderbird-bin: 78.4.2 -> 78.4.3 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.4.2";
+  version = "78.4.3";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/af/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/af/thunderbird-78.4.3.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "8b1c2e12bd1de45251131d9fe444b06681577cafc019219dac4aa13b3abf989b";
+      sha256 = "03d4e32b23408b003de5347b2a26d9e3e734f7c3e811510ba81114eff80e6fa3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ar/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ar/thunderbird-78.4.3.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "708ce9ae434ae78bd21d2c8a608a732d6ebdc88c2cc3c91c748d2b6a4eab24bd";
+      sha256 = "5aefbc61f46d59de19061a0e76949642e254a13867881b40b6bac289791c281e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ast/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ast/thunderbird-78.4.3.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "46aadaa73a4e214c016f05eb9e0dc0a3daa6a87fc72988c696bf243d475d0285";
+      sha256 = "1e328339808efed1db23ed372841ff65f64e1bda8e1d4be81fd00039468bbb1f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/be/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/be/thunderbird-78.4.3.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "06abeef2331df228ad303d9280d077ef4a74af8658c4ac0147ae59e181dfc42e";
+      sha256 = "f42230768f2907fb3d23a03a56fc20f14ff5ded7b4418debb3e77c4942eb7db8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/bg/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/bg/thunderbird-78.4.3.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "3aa13c52a514f5331bf626f9e3138bfe995c6a223559a9fbd6d590858484d9c1";
+      sha256 = "27a72288cbaaaaee6a24a36bb2e463a0426810e97938cbfe012dceb1a3800fd0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/br/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/br/thunderbird-78.4.3.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "1f2d9ee7090e96e3e5611011c9fef8389b514dda4edbf47e889019312df6ab5f";
+      sha256 = "fa1b6c891e3d9d097857a08181030e1df2201240ae466c4adc6fc0be0982d002";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ca/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ca/thunderbird-78.4.3.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "f48d5d02a04212ca14cd4c175102a0e45483299d8a4615ff96232431c4ffa4a5";
+      sha256 = "6bcc123c7ecccbf42022e302b63683cdf77f6f6f2a615b12c5ea9e6a081fb900";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/cak/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/cak/thunderbird-78.4.3.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "28b541daeac6aa6274f4185f9471ce8b2a46e18fe55ae1e373246d9f23d78ec6";
+      sha256 = "392cc166ee9be6c5cf8294f727f97cb21b6ad7ebb77d263bba273f02cb15e661";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/cs/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/cs/thunderbird-78.4.3.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "d4f061ac86da0b6279b81b30c8949cca93aca5b2f90d0e5dafc5cdecc2868e05";
+      sha256 = "60f5ea97e75f965ac0947e51c8cb8e709e5fa8f67ea478babe936032dee5a912";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/cy/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/cy/thunderbird-78.4.3.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "824c703a570ae23d8e7b86d93baabb193842ac36fbc9d4ec65ae686e3d540de1";
+      sha256 = "93aa92633d2414ad59aedea8b1a820b158a21c042cbfaedd8abd2b5a41e31c5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/da/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/da/thunderbird-78.4.3.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "8dd27d2596346853e3fddab12ad0dabd700c5216310922e768faacb019b5b3d9";
+      sha256 = "dc263e9d186f4ca8cd404b6e5bd13f9d2874e0e2507eaa55e99a6b5ab3b05179";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/de/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/de/thunderbird-78.4.3.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "3920c60073ee3066fbe35a1d2c34ab03a7b7e2dfbbe22af97fa32814000f6942";
+      sha256 = "d9dbf07f3c57f688b08f75673074562ad9d4a9b138159f353415d63f9ccac80b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/dsb/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/dsb/thunderbird-78.4.3.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "fd09bbf80996e3aaf12dba79c366c4cfff41a0db0cdf7f6ed4d9722fd2623ff1";
+      sha256 = "084ef3ef3628d003c75dea9a9fa5897424e6e564cb18fb5bca33b341c8c511cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/el/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/el/thunderbird-78.4.3.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "a9df959b2df9c381b9881fe3015e654ac82ca441a3cfc25036c1e658401bf810";
+      sha256 = "4e91e7d21d0a3d524de7e41201ce8af58518a7e0292c11fc2961a84e9b7d04fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/en-CA/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/en-CA/thunderbird-78.4.3.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "126e6fffa28b9c2a7eb7bb49254786fd0884aba62524dcf7d8352d6542903f77";
+      sha256 = "922220811fb0083e8dc51c7cbd703530acdfeb0e9403d1a0909ba1618db020bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/en-GB/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/en-GB/thunderbird-78.4.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "099ef4c54072c6a4a134badd02a51255573e876c8b630c3b9eaecfde997f9e03";
+      sha256 = "090806f6ebf12efbc5c20a920451feeb0d88d1e7366a074553b79080869687c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/en-US/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/en-US/thunderbird-78.4.3.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "e6041bd8ad2a21f0a8f8d78fd395239f1f41e2948584770673aaa0f3a9978b3e";
+      sha256 = "7fa3769297600c47c54902bac696e718053c48fc02e54698cb05ef81a4eec873";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/es-AR/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/es-AR/thunderbird-78.4.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "d4055f3134cd255f8e91ee2ef012bd4e4443e6db519cb7bf2543d4e193f59f61";
+      sha256 = "51be3a453bb3e3f1353b88ab31fffa3fc0c135cb91facb7807c967a9d4afa659";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/es-ES/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/es-ES/thunderbird-78.4.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "39f3c8e5262b1125f21e2bc0e51d53b09283ef4922a7bbec6146605ea0bd1d51";
+      sha256 = "8828e5ff82e84c5f69afd60ae5dbba445d766e2a2d7fbbcd8f0dc8f255d8fc02";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/et/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/et/thunderbird-78.4.3.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "60331d65f98b68397a0d53a08a169b97654aae3d26efe48f494f575e1a51fe13";
+      sha256 = "d58404701341bcd9b859f1afb87cb3340fc4b8334cc9490e8ea21446e3f308eb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/eu/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/eu/thunderbird-78.4.3.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "206026522eb361b599dccf433887b1314b554adfea90ee558f36d116ae6c8f70";
+      sha256 = "5570472164329f23d3f0be51911402c2b454ea704419ef16b46b359a2c93e821";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/fa/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fa/thunderbird-78.4.3.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "88f1421d251e0bc5288f2c8ca333345ec97ca0a86d491b242471d1af82c04776";
+      sha256 = "cc56e14f1fa17e8b4ec9431ae9ada10159bd90bcade39432c647ba401791e3fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/fi/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fi/thunderbird-78.4.3.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "4abbc607c3d6ec03a8416636e88ffdfd61fc0b062aa135d14fb3918c284f9ebd";
+      sha256 = "5175e312e8957490b013dd515b84fe4dfcdf57d30c6806f8bdee67caf39659f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/fr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fr/thunderbird-78.4.3.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "406437d8cf7a695b636c3c1005df5a65f174bbb10d0d961ddda08833ee2c808d";
+      sha256 = "5239f8a07f0f6bc4f69b3d4315570dab33c331ab775479a9df39479b71542cc7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/fy-NL/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fy-NL/thunderbird-78.4.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "456f51fbef14e1de16fdb3d7c31b6736e0e7b43c509ac38bdb8a88cb4a2de0d9";
+      sha256 = "5747be2c7f9d5463f9c14fd02fd5e66a8f6c4c8adca3a1bf8c3b4333f1ea2adf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ga-IE/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ga-IE/thunderbird-78.4.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "0f1ab856deed39280ab9d6a43afd6f719470d4aafc4404e0662da0e14b64308a";
+      sha256 = "8e15ffc9235742ad88a1ecaf587a178f5aeb0bc57e075b33f792e2d458362ab9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/gd/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/gd/thunderbird-78.4.3.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "07f2fc13f34a70d4e6ecc65d465e33f5bcff63196996fe057f8584ef2e7e595c";
+      sha256 = "72f53918cd04e587319d59100da05657a3084f97d70acba7d1ef7b7321add6ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/gl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/gl/thunderbird-78.4.3.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "f4cb60a537ffba88823c8c8a60f2c164e62fbba13d448f2931c71e7d98d6abe0";
+      sha256 = "28beb85fe0ea27a659e5063f7094877e906729602ef2e155f0e55e9e9f6d56ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/he/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/he/thunderbird-78.4.3.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "425a0bd38d231308fa5cac5d362b7818ccfb6b5fc06924ce312433ba4d5bf2b0";
+      sha256 = "718f8605fc8d418c645a0485ce86d97ae1eeded8b776a990e137ced78eb91a68";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/hr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hr/thunderbird-78.4.3.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "37d3f14aeed404bad5cab35c256473a5927787f889afee3da112e510999373f9";
+      sha256 = "febadac023152dc30e72026f6df203c8051b65ad4da0c4e7059a14ab0b4b5f37";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/hsb/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hsb/thunderbird-78.4.3.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "3249467db25d25866a4d1e0acd9a18a26bad13e2ca683df04ca5f8ca19affac3";
+      sha256 = "faaaf4606fde4baca3216ed5801209f13cd1bbf34c9671cfc7a7648bb0ac7351";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/hu/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hu/thunderbird-78.4.3.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "f3a82c5917757f221ca59c4b6a950991b52b10f2782b1dffe21c7a7ca6a26272";
+      sha256 = "353633956336852193510c8e77251834355c92ec503ab827a389a0dbc21c05bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/hy-AM/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hy-AM/thunderbird-78.4.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "cb917c1ff3fa342a8ad3253a03a1dbb4a417c0bc3cdfd1422ef5ff06dcfcca74";
+      sha256 = "1b5dba6f05ecc8449522d8a54c1d4e7aa5ec7a2e26fafbaefbd754ee3ea5780f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/id/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/id/thunderbird-78.4.3.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "1599ddf22093c6a99ccd3ec3e1492e65ce0b5ebdc3a69aafb321ec26f22b6a13";
+      sha256 = "470151868d745ce829f0f38c6377f4ead87be829d43f4383d2e5c3541b93e8d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/is/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/is/thunderbird-78.4.3.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "8cb02ca7ce8c28c10aa1f16ed08417342e93da2dd00f15c5a89fd71306f9afb3";
+      sha256 = "e9d6b36beb61445c3f96ffe6e11b238a8539b398d5f3911f2ded7ee96ec0766c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/it/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/it/thunderbird-78.4.3.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "16f3c54980e614b20ef6a8c0a09ebe7707e298d753d373da79bb2d52d1cc43b6";
+      sha256 = "95a02afcebb834b14986b8ccd92d5381a8ac64d3ebbba13860ffbd0313a594e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ja/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ja/thunderbird-78.4.3.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "e4ec88dd86b46d814232662a4d558361043ac97b348a8fbb2076ec856087be6e";
+      sha256 = "d1c4e2a551a5266839da96b843372e71616346ea00361dccc8e1a62628e6315f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ka/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ka/thunderbird-78.4.3.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "9c2a110ed4df58c334b533255c0f3bf46d777960967e46e74f7f376203bf467b";
+      sha256 = "9eb37a69a370b2619724c91c6789471b9ef579190c08363f633f320563dc4df1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/kab/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/kab/thunderbird-78.4.3.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "1f5cf7b8a03fb4273d9ce4d657c3a77ac4a26b7716e3bed700e14f05a398163d";
+      sha256 = "bce07886dc5251ef401141d387c926f27f61d13450f35cb9a9cbc8403b43260a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/kk/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/kk/thunderbird-78.4.3.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "002ac92fee28c3ec9c05587025eddb4065a842df0430ace7f468ed8f3ec2df27";
+      sha256 = "222647dd8106134d46bbad6dad8638090e5441a64aa2a6725aa5b1d959a2832a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ko/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ko/thunderbird-78.4.3.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "277f0fdfbda0d215a03ccd663f0986cf1b0a1c4e68e3ef36e81c8505d6eb7d09";
+      sha256 = "be2346d5a48e5323d5cc8c1077adf054927d8aececd2fb45fc2f5c0a9f0b8dc2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/lt/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/lt/thunderbird-78.4.3.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "65b6737b4ff528453bdaf57cc525a74c79899a9563d189123f87db729aa0f529";
+      sha256 = "da5cde252d5e167025fb06861a32b67a2d0f7171c767bdd8c5d2ba9fc90d7739";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ms/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ms/thunderbird-78.4.3.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "cd40e14d4dbcf03ea7e5ab672678abc9b3b46c5b67fdbb961928a860c2f3218b";
+      sha256 = "d6ab0652184cbbfe9126a49f61c25fe8852725b88460ad92c37dc1c4d969368f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/nb-NO/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/nb-NO/thunderbird-78.4.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "49c9633a0552a704b06df87ea91991017be920684d12f66c72f6795dafd1cd5d";
+      sha256 = "2485cc4df1b1dafd0c5fb7d7723e923e7fea10af1dbf9764d5d7447f38825e49";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/nl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/nl/thunderbird-78.4.3.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "4514d79caa1e2b44cafdc9ef06aa54c4708763c888a489d6bdf4473597221316";
+      sha256 = "0795d2ae4364def43056e77106ea19053c3111e2f95758dbb41875071655ba47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/nn-NO/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/nn-NO/thunderbird-78.4.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "f6aab88e4708659658be8cfb457c40533969a261af489a976f4010439a833458";
+      sha256 = "b774035d8bff615646d3b3d73228277531d50309fb5dbf3978346e2b988b2491";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/pa-IN/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pa-IN/thunderbird-78.4.3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "10f5a885550f2cbee158fedc7111b96a0f07764b5d6d60004d17c233153f304b";
+      sha256 = "2a38813c8aa0eaef3d2ec0ac379ab5c85d0b8c2df1f6a2d36ae066f7b0445447";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/pl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pl/thunderbird-78.4.3.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "1a192c0a9b8ac2f9b18445e69024462b8e95b78bff48014b55dd451e260aaf73";
+      sha256 = "21cdb977bff1f0c07bf913b4feab2075a429b4594760de52ac358538179d9c66";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/pt-BR/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pt-BR/thunderbird-78.4.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "b9dc3db4d8cf4fc2b958695f9077c50d48d355e850618320adff179d33a116d0";
+      sha256 = "d903ccd23367c39779ac2cdd3abe636a0f9e72f8d133a567bead8a739e651589";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/pt-PT/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pt-PT/thunderbird-78.4.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "0a3887ff46f9ecc1576bda76e1469eed8ef43813ccec25536e2dbae289196bd5";
+      sha256 = "f220a8bc90b05dd796c402aa5e79c62a8aa91a4d80dacbdf57abf77ec51d73b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/rm/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/rm/thunderbird-78.4.3.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "1a13d443c00da4300aaf58d0af0620541de04e02e87218fa0774cad4b2aaa34f";
+      sha256 = "805d08f629e9dda7d6db36bd41dbcc128defe59b4610e4b7d5d47408a07e47b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ro/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ro/thunderbird-78.4.3.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "62bd15566895dc9462b985f2f5e1afcc7057ef4e93f69005b9ebe89821a2a73a";
+      sha256 = "3b09b2c59f32a09938a45270e04740616b2a13f8b8a6f40503650d9b0f72fc35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ru/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ru/thunderbird-78.4.3.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "e0624e745da31cafe1b885393e11622bac6ddd2e3e4c0cd35432eb5e0e57a47c";
+      sha256 = "2022473752da127d2ebe4eef7f834ac5feafe38dedbe64ad30defb8ae69c6ebd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/si/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/si/thunderbird-78.4.3.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "46e286fd0913b07ede577514b8e64ce279afd7bda3054b7cba4ec1f9981eef03";
+      sha256 = "dc5166b0b24bd0a9e98f7dfc483a6bff184a4bfffb0eff8a4007b96fe8205254";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sk/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sk/thunderbird-78.4.3.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "3ab838c25d5e10d318705bed69e690d287e6b988412a3f9d5d94f2b7c8cd831b";
+      sha256 = "d30e4d3218fbf13a5c531d45f55f0f366aac10aa2d180886ced778c7459c0610";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sl/thunderbird-78.4.3.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "c04e1a339c4fb2ca8748da6bbc0f5a4dc9eb032b565d6f2333c7d1751eaaaa9a";
+      sha256 = "f968618f7b13b6dc4441a09882ac5c826017a5b0ca3887b7cdca8ef6a3b3c266";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sq/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sq/thunderbird-78.4.3.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "ae9052f081baf3f25c43b2b1e109ce50abeacb5b2322ef38f8d42fb070417908";
+      sha256 = "f4400c6e55859e07705b353cbf211e863e8c3f373490f3fff6bd3e6d360d5b7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sr/thunderbird-78.4.3.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "c4eec55d9be21e02158e8266b9b7b424aa1f5d1078d9de2f0dfce4fef5f801d2";
+      sha256 = "f6437ffb64b1a98b5c5630f3b386b12866a514467c641fb02c8e86560e4b62d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sv-SE/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sv-SE/thunderbird-78.4.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "c7c01c580e1201e2948d0bfe3e029b6bd3a98e9845e6ff648d8bd4fbc8189d37";
+      sha256 = "f1af8019698347ac94bad5c33b5e094b65e8ebed9181f5fed5e740cf2029bcef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/th/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/th/thunderbird-78.4.3.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "f09079980e41c156e62f8d008d600850ca8a62fc88917f3cc06d10321bb3e500";
+      sha256 = "75830b637302032bbc70342b71012f391b333a2645d8fefb8f4232d432c9dde1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/tr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/tr/thunderbird-78.4.3.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "2b99f6fcf904c7cdf67de2ed957167b6e1fe7d997c5a422641bba0af8a22b7f4";
+      sha256 = "3691e5aca6b9713fab9c8a15952d1ceae50d67cc60e362eacc9513a362875dfd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/uk/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/uk/thunderbird-78.4.3.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "d502f4447e1e0c02e9384435e1b552c4da6d083225555b03f90d71ed04314324";
+      sha256 = "c4aca974c3a541c312029eb66fb8fdb1c5ecd787deb67a10bda3195f0ca06263";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/uz/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/uz/thunderbird-78.4.3.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "7b9548f91dcf0ee6bfaed9d735baf9254842a633e3f06986d00d9d86b0f645d6";
+      sha256 = "2052c0a9a41c81a37aa23fbf28775e286b8350594b01aff629604ccbd74ae90d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/vi/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/vi/thunderbird-78.4.3.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "32f78b425fd56900d1b3319e571af151214edee83a22321a449556e8ddebea69";
+      sha256 = "b142f463cd953bfc423be210eb891f66e948308129de74cdfd415409d4b0cb03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/zh-CN/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/zh-CN/thunderbird-78.4.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "a6252fdd66dbfbd33444a3ebdacef38f8b600891af324d31f22f2fcf59b1e7fb";
+      sha256 = "0664f379ce4e464e2e6dcc3cfa749bd6ae4a597b008b7fd1c97bb6219727da6d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/zh-TW/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/zh-TW/thunderbird-78.4.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "b97a176fc12f156d8503e07819e9a0536b338850b8527c3896d93a36d64083aa";
+      sha256 = "2ba4d49b52e6cd699f7bb1fa8f024c330f67d6b9df543a77fea7c3dc87985cc4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/af/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/af/thunderbird-78.4.3.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "e1f0a03f540da701f9e742cf7a05e21a1216ba5c60c402968799ff494ffb1fcc";
+      sha256 = "60f62dc28a8433e571b894d33c0d9670c3aebc6a8c556c65f12d8d574e5edceb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ar/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ar/thunderbird-78.4.3.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "5bbee34fe9c5cf02f2f3c8160264f3a0ca3ad880bd75fd1ede87f906b886c7fd";
+      sha256 = "cf0fc7d7af09b20dbb35364ac0e47615919ae1627a0b729acf2f13dd99198400";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ast/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ast/thunderbird-78.4.3.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "8a5e481e9aa16619513260d532ec6f7e2c6338b41a0a44468950ec26287b2a26";
+      sha256 = "cb7ed53eedb55858fa5a5aadab1ed0ae4f2f9e2714406488b211660e56785d21";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/be/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/be/thunderbird-78.4.3.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "27f600f0d4b977cde9ede5bd39efd97bfa1abc04f3d1c7a3290339e7eedaef47";
+      sha256 = "b04239a6caf488d3fcb5be0373ddf83554643897d41bd197edb6dbaee15b9a4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/bg/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/bg/thunderbird-78.4.3.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "a9a6c127461ca7da6b5fca5e2d2ca8b1eecbbe78b42a9e18e16bc7a343c761ec";
+      sha256 = "fabd2c79cee02328166954d6b793b70bb94cb41162b904ecb124cdf91e5cff0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/br/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/br/thunderbird-78.4.3.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "b8f363ca9ada5b2ed80a9526d1f775d9c17bfecd6b84113391fd6a5b1966bd90";
+      sha256 = "66584e5c63c58c10cb4f2f8fb81048c4201046adbad03d58faf8f36e405a8e40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ca/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ca/thunderbird-78.4.3.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "e1c5035ab818ce7525c2bd659622b14b3fe544b7f4c8432bca2b018c7ba1bfa5";
+      sha256 = "eca54850e9ed41a19bb4cd23de9c11d9d2851ac1573507b32b4fd33431ad7889";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/cak/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/cak/thunderbird-78.4.3.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "f42d03442c8ab4bd844b0414e6d6c8ee168230714b55bbff1704117315f26a0d";
+      sha256 = "ff8e285bf3198c225c2b5b216678bde7f978443c1f354193e39c0c5d3d7237bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/cs/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/cs/thunderbird-78.4.3.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "c45a3b75c5106377d73f72b905814972a58604b4f2bfe49f05f5177584f2e0d6";
+      sha256 = "72a18f3ac0168478c7b9c8d2641922ba7be5d129b63b711b7f7f133ba3cb1d75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/cy/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/cy/thunderbird-78.4.3.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "e8e1f70703c9c22fceb2efe10f55a2f25da4085822ada1a3a3a3736ae41c0503";
+      sha256 = "16fecfef3f81870befcadf833db5ecf54b7b83d587f2a211c5eaceeaf7a5796f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/da/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/da/thunderbird-78.4.3.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "d8fb3be7bc41ae6ae0d064bdf9ab9cc569f65dc18f720de960ace84bb2514b68";
+      sha256 = "7aac88184c6e2539003905b3a7609116cb2180943a8df219449354297b323455";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/de/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/de/thunderbird-78.4.3.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "373f50cb99608779e502d76af0e4a301ef0b8b75a6ec235f64da7626188157c6";
+      sha256 = "f3f487f8852b7f50ed49b5375ae97376470282a0f5639c8fc4cb7040da30f946";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/dsb/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/dsb/thunderbird-78.4.3.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "07518d32b488fb805adceea1126ca104f2e86e3a1245f6cc4fe108b70335c995";
+      sha256 = "842a084fc74c29d3c7573e473666cfa01f205b75fe6c1ee83acc25cca68d3666";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/el/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/el/thunderbird-78.4.3.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "97699a80d96422dad4c95658c9c4d472bd1d69e1823f5a5f7dce5fdaddf1211f";
+      sha256 = "8df4c2a688b435f60fe0d5646ac5172dad33d254fdd68e35a29a6a83c4bda905";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/en-CA/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/en-CA/thunderbird-78.4.3.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "0b2dc377399c4f27acb717c7f0e59e9e735ad3d2ba1e617a93a3fa337b6dd2c0";
+      sha256 = "8eab7a0b08e3c65eb5c373eb018d5e1df519b28f8774b06203a5b7743b146cd5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/en-GB/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/en-GB/thunderbird-78.4.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "679fd1138a8795b0e7d64a4b8d8a2821deb8b30d40092e9df98b0a08d6cc6539";
+      sha256 = "23c819e15ca0ff1ad366f2d5fb76e934dcea0fae9cec6674b39339e14a3c4254";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/en-US/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/en-US/thunderbird-78.4.3.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "a86f2780353dff8a449f323d5f54d83ce70b724db1a2d77dc3cecf6d1e849ada";
+      sha256 = "5cdf4b40f337352a8e966046a2eb1a368c0feef4fb069fd4c22d4f986ea1ed3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/es-AR/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/es-AR/thunderbird-78.4.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "1fbd2312a971f658243dd6733067157fe3de509a88b2cce766ee8e45c243d23d";
+      sha256 = "e7947542ef45cb432991ac5435523987c79811889e9bd5cb6fe4c698897a241e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/es-ES/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/es-ES/thunderbird-78.4.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "e51217ca711a307c67f538d487eb836d49e4ccd6b8ff9b1a1926bd481322d46f";
+      sha256 = "95121f74bc1389e62dfe7acb286d2a4cd60a536f28054c8e367cdfd867babde1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/et/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/et/thunderbird-78.4.3.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "345ccfa0e703893795d226aacf95645cc2cdc7dc99f5f9fba108466f74af19fe";
+      sha256 = "87aedd276bc54360887e81bf2e3b07c54a365b78814d7e478f7ad5ec15c1d451";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/eu/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/eu/thunderbird-78.4.3.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "47e95ce28a229dbd01d8598d3a5b7f00d8e2c1934f8da4ff92052693dbb0c7c9";
+      sha256 = "66168f09ed77b7f31faaf21daff48e9a8bf75314fcab585fad67160db52471b9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/fa/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fa/thunderbird-78.4.3.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "6c05b6a34a1ae3232b417e37c6c71bb05e46a296019b55192331cd441f212e1b";
+      sha256 = "2848f0277f75dc58f371e2025bebdeca1c37d543055fa78258df67d05c67f5bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/fi/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fi/thunderbird-78.4.3.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "fe043a86dd6679dc20ed17920e008894d78562d099861c0cda598c74aff3b176";
+      sha256 = "725f0dcd456245e188e32a32401ecd40400b7786da3a39d9f6965c1f674ee954";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/fr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fr/thunderbird-78.4.3.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "950fa73e6f5fcf2fd66da9af7b79e43420e3ce75c9227fee095ea65ce2769a7f";
+      sha256 = "d24ab35a8db7cb32d6098defb9f7b6b007b5c993a070c1a3a5c8991451165e37";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/fy-NL/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fy-NL/thunderbird-78.4.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "e01f59e5b7abde309421515240229d16cc0ec6ad4ea52ef1a54fb65f0bc49091";
+      sha256 = "ea3a88b57166b3b8f04922a5c2f6d8d9f94f1a7bb5f3a9e2d6b5f11a13528c18";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ga-IE/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ga-IE/thunderbird-78.4.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "53a7b0b5a2046525701120101fbab5c581b99de56caadf3aed4732f444c35569";
+      sha256 = "763bc901967ec61e1f7f543bbf248bb03ea68b01c000677505408ec8e8c3cbb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/gd/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/gd/thunderbird-78.4.3.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "eaea6b3770d5bc51a00e25fee02110f5614d9ef52049fc092d90dc1e8de4c210";
+      sha256 = "7394f43ae2ff5816dcf9b37255fd9770dc48dd7309d685ab378bc2de8a5a39b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/gl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/gl/thunderbird-78.4.3.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "b0c5d871785d1efa23bdbe341d8186b96394375ac56bb541d5d9a75bc784b471";
+      sha256 = "7daaacf6af75b34d37d440e2c0b252ef03c3b432523f5acb8ef71f83b5d7b6cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/he/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/he/thunderbird-78.4.3.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "cef410178a3cf310c7bf158eba5c12093385dfda1de334d6d6e0c28ada16c7ca";
+      sha256 = "4831ef263de0a08df6494b13a280475642c3eed7f34c7415fd7b59af192398dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/hr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hr/thunderbird-78.4.3.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "9040e2235a752a50cbe09207684df928b84787629d21c8d53e6b9bfc708b09a3";
+      sha256 = "6860b40fc2ba7f9b8ddedcaf50acca8ac01b6451c0895c325b36485f188b5dda";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/hsb/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hsb/thunderbird-78.4.3.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "b0bb84d18c588abf2f05abc8ecb1f3a169221fcdf4117e48b3169362cfc69aa6";
+      sha256 = "681fc8200f6f9346e911c21d6a1c8206e5ee5ad1adfaa56ddfbc5088225fc561";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/hu/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hu/thunderbird-78.4.3.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "6d5d0ded325cf7852ef638d7f5d8dd4d7ce127ad7f4eace22ce696541f9485a5";
+      sha256 = "8909d02e58f5b333fa51b15e4ddb5df162d01e36a8052827482c479949da2cb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/hy-AM/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hy-AM/thunderbird-78.4.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "cbb8de1462385ef9bdb42cec5e8c81664347dc9e7573f602f41ff586c217d8ea";
+      sha256 = "12dee2dbe126d2243b674bed4617ffcec7c93f850d266f6253d802c6af5b6d6d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/id/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/id/thunderbird-78.4.3.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "358a95d7d87adc85cd39bf6da1373026de5b8631139ee1ec44e9410b027e00cd";
+      sha256 = "5564c24b01f9a952def885a4fb56e3246643ca30bc5066d6ffa4ed6c6982b33b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/is/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/is/thunderbird-78.4.3.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "c7b27e5311737cd5f3d314830aba0ec165669d8c949edb37482fb4df3b460f9e";
+      sha256 = "fedea70297479b2c828aa19a9a4aa3090597c5490ee842a0f521d0096615d6db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/it/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/it/thunderbird-78.4.3.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "a302c50190fb992fcdaa66a8de9c5f5d177a5563fcec55e5f433761646ccfcbd";
+      sha256 = "8466f3dc9988270d4a9166b82dba764d8dbfa14e8c26a1931d35abe011c3160a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ja/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ja/thunderbird-78.4.3.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "d2357cc5bb5b5493035a79b504db8db2750f5880705b693554e2170d8d840cb0";
+      sha256 = "3ffe4ae508896ac961a27940a93f5955bb8b29640c88e5378a8251827b4e9ab8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ka/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ka/thunderbird-78.4.3.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "2d150d1160d92499fd9dc4d632e006170a27929f88909715c0d0210005516ff7";
+      sha256 = "7c099596fbc4666e053bd1079f6b7c45511b2b44db73cd5c099fd392bec8e3e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/kab/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/kab/thunderbird-78.4.3.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "4f9879d5a106ec9fc3bd423fdb5df25a3e0d47690cfec652654472addd21a2c2";
+      sha256 = "5e64e5a276a6e77250ad7647f9b4ecc2b8c9dc360c486f9504b3b17b8da3e467";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/kk/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/kk/thunderbird-78.4.3.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "f8d7fe1f39af2019bb37e117545e8cb2901feb0d31a92287eb4b30da2e431a6b";
+      sha256 = "4562bced5900bc447a79c53d381b250a1e13b9f076979cb9760f9adaa89c54b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ko/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ko/thunderbird-78.4.3.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "bd9abd627205fe33430717a60eea8b54498325a8fe4d92fb5572a2719ba50341";
+      sha256 = "b6cb53893d67bedb077547f1262a833a5487e49395187a49eb977659d019e7f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/lt/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/lt/thunderbird-78.4.3.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "69ab343eb79c42c4a1a9ea480aa2ac50d95e9140968690fd99b3d13824be17ef";
+      sha256 = "6291d36e9347729920f89a28b949c943d8c92863cba1a03624801c7136eff997";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ms/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ms/thunderbird-78.4.3.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "fb1246094e22ff59f8671a6aa0827c8e51a7fa8dc2bb565a3cb446d35c098f16";
+      sha256 = "5dee2e40dbceea93fbe3b35b744d00472b89b88e745025127a1d07afc79d7df8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/nb-NO/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/nb-NO/thunderbird-78.4.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "0ffcd2db855686c4b7e8751884aa4a8729b0fc8da597d256d37d6c73a50c7585";
+      sha256 = "491115e7ad1c4245da34dc328e179de3916291d4e42a85ee5fd4fadeae1fcdcd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/nl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/nl/thunderbird-78.4.3.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "615205a37248619a664b4649f808ddce9b019aae60a900fe4d2ca2dfdd717fe2";
+      sha256 = "c4631681eb3354a3093acd5a76d5c7ca5ef3e76ac2cef9f1fa4007c40c1e282d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/nn-NO/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/nn-NO/thunderbird-78.4.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "8813d2b40da457d5d7c0da88d54b8b0c13d2ea0215b9bee2966215d366d79a81";
+      sha256 = "aa4d383b90b7cd48ff18f098c9bba429f09fcfb72a2f2a086a992778718a3b1d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/pa-IN/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pa-IN/thunderbird-78.4.3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "31feb987ff8493d96e15395deb93506b13089db28d91c0bf6ee4da271db8a0d2";
+      sha256 = "c5fb66455a59383494890e06559d4529c0762ecf76d17e5ad784eb413277438d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/pl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pl/thunderbird-78.4.3.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "a9c30450e918ec4c0a95da51c071f8c4ec4f870976ac494ae6042aa3fdbc4a56";
+      sha256 = "720eea0998d9934960a5dc97466f57c7e68b2048f88125a987569539a8a00579";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/pt-BR/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pt-BR/thunderbird-78.4.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "157d64059b2a7a1082f233c05fdc0302f92dfa496c0075761bd54327b439594c";
+      sha256 = "d27ab836f5d8753d740e980291a4403656735c206cedbaf7d5c13df26d327150";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/pt-PT/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pt-PT/thunderbird-78.4.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "d8a403996d56e22809e9124fc4c9dec98cda19a5fad7144fa87e452ae75a990e";
+      sha256 = "2b996d07174c24df1b066c41bd92c8b24ebab82767c47d8c658f2205eeff9cb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/rm/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/rm/thunderbird-78.4.3.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "97524948b2f9259d1b08b9bbc6533b79fd5e592b08fb5fc5cc63bdb749d5866c";
+      sha256 = "206b2bf82b88ab733bf585e11a3eba49a779c8b8fb7bb249716022fc7ee1a18a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ro/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ro/thunderbird-78.4.3.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "99e2c94054fd01001555fdcf4e9ee8a04fbae77e5ff9d34ebc42a6415b939bbd";
+      sha256 = "2d06d671114d70ba4e39b2c639eab1debe7ad33de11795113f30f27708d13ae4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ru/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ru/thunderbird-78.4.3.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "f1996c3f3b6b5371f853f6854edd15ee030b6238f396870a2cff39320eac111a";
+      sha256 = "08e71802964c340dfbcddf963382d1ccc5b8fd2e262daa1316488cffd04f449f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/si/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/si/thunderbird-78.4.3.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "10df360a1d5a94ccd218a265024fb3f3d9d9a72b8c749ab93d797a3879cbad03";
+      sha256 = "0f59d187fa15bd08ffe0e08e643bb76954f7eb7730c3768079514385c53df5d3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sk/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sk/thunderbird-78.4.3.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "a5f9e0b983961cc4e4ff7cb6f03c197cd8729eead74d6c0b657b441a91635326";
+      sha256 = "5109939226907517fac9ae9c4e6ee96d732de9a67b9139e390d32cbdea892ef7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sl/thunderbird-78.4.3.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "10526684f3066322066f204a2cf978c779bb895d5c7ba73880ee32caf63d62a7";
+      sha256 = "c56fb54ad65dd453b487813b1f0dde8d83ed6a2f7e428af55c40a80d1c9a35ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sq/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sq/thunderbird-78.4.3.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "d422e42397d2012efaeeb37101a5b1b29feb34e9e9dbaf87a85f9e2f881511ea";
+      sha256 = "0b3814c80014108032c9f0376a62c09864704441f36a084accba1c7c0f8156de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sr/thunderbird-78.4.3.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "1e9b5637581c2c4973efcc5b0844ca228f66c4fbb0a44e88201973623aad0b83";
+      sha256 = "80b01424fae7d18c98a77a0026dd4b50f1913f5f3cce2d3f85d9e56da633a537";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sv-SE/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sv-SE/thunderbird-78.4.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "592daeeebdb5f56f486a4e6efa1c51e709d834a65c861e76e5b6fd86f8a4bb09";
+      sha256 = "ef0154595d85c13d0eac381a907a51da19e9d93d2758c7dc0f052b7b76a7f31f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/th/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/th/thunderbird-78.4.3.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "00f883ed3d542d0bf3da3e744523cfd1b3405ae0b928dd83c42e55e5f1bab4e1";
+      sha256 = "939f56c4951e8dbfdff257efe7f0212e93c1bb55547ce1e934f7d908932d3116";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/tr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/tr/thunderbird-78.4.3.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "ab69a35eebbd1cdef80b22a398c4d570c17e13a8a36e5399b892974d7ed29b10";
+      sha256 = "66f4f2cb06f20fca47e59b37d52f07a9e1215b03f0bbf9320cd1436e1d1a7c35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/uk/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/uk/thunderbird-78.4.3.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "efbd5bf9552333d78c68191265b3ecccb2a59ae19f2bfe7a1d8b096a44c9fcdc";
+      sha256 = "33f3b9812b442184c075056cbe7da924655729865d849856093bdaa2d7d84660";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/uz/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/uz/thunderbird-78.4.3.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "db90d47b59efeb5c847ecdf8b7438a4f99d0954283f1deda39a0ee08f54fdfd1";
+      sha256 = "5abbc17bb66700093eeef5eb97bcab0a5d040ffe20ecf79d8239123248b1affb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/vi/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/vi/thunderbird-78.4.3.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "1d616c682f04f7c0ec976d41eb71d3ac929eaa3199b4af749a80c906a3f2a212";
+      sha256 = "de5071c3b4a5cf7494f91c69f4a7cf4678bcf57227115e1b6e50cc65a3e716dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/zh-CN/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/zh-CN/thunderbird-78.4.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "490e4e310606846836d93ca9704b7de11bf307b918933fd0187aa5d3795a82bf";
+      sha256 = "07afc2b794439475d0d4db82c7b694728aa5b8e6e80ac79789bae662757ae8d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/zh-TW/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/zh-TW/thunderbird-78.4.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "c62476ac43d302ad9895524f6f66350122edfdf393697111d5868cf25b996c1a";
+      sha256 = "70a71d0c26fd2cd18dd599374cc6f1c39d22246f3b3c8e8d17659cb7c33a5a77";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -70,13 +70,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.4.2";
+  version = "78.4.3";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "1bd8z6fm2nky4p3qxc5jh9dca7v7g77i6kdn6p5dzzm4gyadqvk00bfa4nzglzi9nwwyld14r3ydjd6ms012yk07q4aqdsrf51b9k4y";
+      "0h5ddqp1z2dphyy4mjcb7v9mrrxlnjw8rwklm0yqsbvs9m96pc1yyp4clb3wmgs7kzh3wxdwi450842m3b13wdg5h0ls7rhamd1yi0c";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

- Bug fixes

https://www.thunderbird.net/en-US/thunderbird/78.4.3/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
