### PR TITLE
scribusUnstable: 1.5.5 -> 1.5.6.1

### DIFF
--- a/pkgs/applications/office/scribus/unstable.nix
+++ b/pkgs/applications/office/scribus/unstable.nix
@@ -18,7 +18,7 @@
 , podofo
 , poppler
 , poppler_data
-, python2
+, python3
 , qtbase
 , qtimageformats
 , qttools
@@ -26,7 +26,7 @@
 }:
 
 let
-  pythonEnv = python2.withPackages (
+  pythonEnv = python3.withPackages (
     ps: [
       ps.pillow
       ps.tkinter
@@ -36,49 +36,12 @@ in
 mkDerivation rec {
   pname = "scribus";
 
-  version = "1.5.5";
+  version = "1.5.6.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/${pname}-devel/${pname}-${version}.tar.xz";
-    sha256 = "0w9zzsiaq3f7vpxybk01c9z2b4qqg67mzpyfb2gjchz8dhdb423r";
+    sha256 = "sha256-1CV2lVOc+kDerYq9rwTFHjTU10vK1aLJNNCObp1Dt6s=";
   };
-
-  patches = [
-    # Poppler patches from
-    # https://github.com/scribusproject/scribus/commits/master/scribus/plugins/import/pdf
-
-    # fix build with Poppler 0.82
-    (fetchpatch {
-      url = "https://github.com/scribusproject/scribus/commit/6db15ec1af791377b28981601f8c296006de3c6f.patch";
-      sha256 = "1y6g3avmsmiyaj8xry1syaz8sfznsavh6l2rp13pj2bwsxfcf939";
-    })
-    # fix build with Poppler 0.83
-    (fetchpatch {
-      url = "https://github.com/scribusproject/scribus/commit/b51c2bab4d57d685f96d427d6816bdd4ecfb4674.patch";
-      sha256 = "031yy9ylzksczfnpcc4glfccz025sn47zg6fqqzjnqqrc16bgdlx";
-    })
-    # fix build with Poppler 0.84
-    # TODO: Remove patches with scribus version > 1.5.5 as it should be fixed upstream in next version
-    (fetchpatch {
-      url = "https://github.com/scribusproject/scribus/commit/3742559924136c2471ab15081c5b600dd5feaeb0.patch";
-      sha256 = "1d72h7jbajy9w83bnxmhn1ca947hpfxnfbmq30g5ljlj824c7y9y";
-    })
-    # Formating changes needed for the Poppler 0.86 patch to apply
-    (fetchpatch {
-      url = "https://github.com/scribusproject/scribus/commit/58613b5ce44335f202a55ab15ed303d97fe274cb.patch";
-      sha256 = "16n3wch2mkabgkb06iywggdkckr4idrw4in56k5jh2jqjl0ra2db";
-    })
-    (fetchpatch {
-      url = "https://github.com/scribusproject/scribus/commit/24aba508aac3f672f5f8cd629744a3b71e58ec37.patch";
-      sha256 = "0g6l3qc75wiykh59059ajraxjczh11wkm68942d0skl144i893rr";
-      includes = [ "scribus/plugins/import/pdf/*" ];
-    })
-    # fix build with Poppler 0.86
-    (fetchpatch {
-      url = "https://github.com/scribusproject/scribus/commit/67f8771aaff2f55d61b8246f420e762f4b526944.patch";
-      sha256 = "1lszpzlpgdhm79nywvqji25aklfhzb2qfsfiyld7yv51h82zwp77";
-    })
-  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION


###### Motivation for this change

Release notes: https://wiki.scribus.net/canvas/1.5.6_Release

Currently keeping this as draft as Scribus shows a nasty startup error, reported [here](https://bugs.scribus.net/view.php?id=16327). It doesn't compromise functionality but is bad UX.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
