### PR TITLE
wlsunset: init at 0.1.0

### DIFF
--- a/pkgs/tools/wayland/wlsunset/default.nix
+++ b/pkgs/tools/wayland/wlsunset/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, meson, pkg-config, ninja, wayland
+, wayland-protocols
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wlsunset";
+  version = "0.1.0";
+
+  src = fetchurl {
+    url = "https://git.sr.ht/~kennylevinsen/wlsunset/archive/${version}.tar.gz";
+    sha256 = "0g7mk14hlbwbhq6nqr84452sbgcja3hdxsqf0vws4njhfjgqiv3q";
+  };
+
+  nativeBuildInputs = [ meson pkg-config ninja wayland ];
+  buildInputs = [ wayland wayland-protocols ];
+
+  meta = with stdenv.lib; {
+    description = "Day/night gamma adjustments for Wayland";
+    longDescription = ''
+      Day/night gamma adjustments for Wayland compositors supporting
+      wlr-gamma-control-unstable-v1.
+    '';
+    homepage = "https://sr.ht/~kennylevinsen/wlsunset/";
+    changelog = "https://git.sr.ht/~kennylevinsen/wlsunset/refs/${version}";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3566,6 +3566,8 @@ in
 
   wl-clipboard = callPackage ../tools/misc/wl-clipboard { };
 
+  wlsunset = callPackage ../tools/wayland/wlsunset { };
+
   wob = callPackage ../tools/misc/wob { };
 
   wtype = callPackage ../tools/wayland/wtype { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add a much simpler (codewise) alternative to `gammastep` (`redshift-wlr`), etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
