### PR TITLE
fuse-overlayfs: Propagate fuse3

### DIFF
--- a/pkgs/tools/filesystems/fuse-overlayfs/default.nix
+++ b/pkgs/tools/filesystems/fuse-overlayfs/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ fuse3 ];
 
+  propagateBuildInputs = [ fuse3 ];
+
   passthru.tests = { inherit (nixosTests) podman; };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Fix a dependency issue where a runtime dependency was added only as a build dependency.

`fusermount3` is required at runtime for the package. Some non-NixOS systems such as Ubuntu 18.04 LTS have fuse2 and not fuse3, so you have to add fuse3 as a runtime dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
