### PR TITLE
python3Packages.reedsolo: init at 1.5.4

### DIFF
--- a/pkgs/development/python-modules/reedsolo/default.nix
+++ b/pkgs/development/python-modules/reedsolo/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, cython, nose }:
+
+buildPythonPackage rec {
+  pname = "reedsolo";
+  version = "1.5.4";
+
+  # Pypi does not have the tests
+  src = fetchFromGitHub {
+    owner = "tomerfiliba";
+    repo = "reedsolomon";
+    # https://github.com/tomerfiliba/reedsolomon/issues/28
+    rev = "73926cdf81b39009bd6e46c8d49f3bbc0eaad4e4";
+    sha256 = "03wrr0c32dsl7h9k794b8fwnyzklvmxgriy49mjvvd3val829cc1";
+  };
+
+  nativeBuildInputs = [ cython ];
+
+  checkInputs = [ nose ];
+  checkPhase = "nosetests";
+
+  meta = with stdenv.lib; {
+    description = "Pure-python universal errors-and-erasures Reed-Solomon Codec";
+    homepage = "https://github.com/tomerfiliba/reedsolomon";
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ yorickvp ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6170,6 +6170,8 @@ in {
 
   rednose = callPackage ../development/python-modules/rednose { };
 
+  reedsolo = callPackage ../development/python-modules/reedsolo { };
+
   regex = callPackage ../development/python-modules/regex { };
 
   regional = callPackage ../development/python-modules/regional { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Required for esptool update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
