### PR TITLE
fedora-backgrounds.f33: init at 33.0.7

### DIFF
--- a/pkgs/data/misc/fedora-backgrounds/default.nix
+++ b/pkgs/data/misc/fedora-backgrounds/default.nix
@@ -1,0 +1,23 @@
+{ callPackage, lib, fetchurl }:
+
+let
+  fedoraBackground = callPackage ./generic.nix { };
+in {
+  f32 = fedoraBackground rec {
+    version = "32.2.2";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-1F75aae7Jj7M2IPn/vWKcUF+O5mZ0Yey7hWuFj/4Fhg=";
+    };
+  };
+
+  f33 = fedoraBackground rec {
+    version = "33.0.7";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-lAn5diEYebCo2ZJCOn9rD87rOasUU0qnSOr0EnZKW4o=";
+    };
+    # Fix broken symlinks in the Xfce background directory.
+    patches = [ ./f33-fix-xfce-path.patch ];
+  };
+}

--- a/pkgs/data/misc/fedora-backgrounds/f33-fix-xfce-path.patch
+++ b/pkgs/data/misc/fedora-backgrounds/f33-fix-xfce-path.patch
@@ -1,0 +1,15 @@
+diff --git a/default/Makefile b/default/Makefile
+index ec8095a..9391f8f 100644
+--- a/default/Makefile
++++ b/default/Makefile
+@@ -48,8 +48,8 @@ install:
+ 	
+ 	#~ XFCE background
+ 	$(MKDIR) $(XFCE_BG_DIR)
+-	$(LN_S) ../default/$(WP_NAME)-02-day.png \
++	$(LN_S) ../../backgrounds/$(WP_NAME)/default/$(WP_NAME)-02-day.png \
+ 			$(XFCE_BG_DIR)/$(WP_NAME).png
+ 	for tod in 01-dawn 03-dusk 04-night; do \
+-	   $(LN_S) ../default/$(WP_NAME)-$${tod}.png $(XFCE_BG_DIR)/$(WP_NAME)-$${tod}.png; \
++	   $(LN_S) ../../backgrounds/$(WP_NAME)/default/$(WP_NAME)-$${tod}.png $(XFCE_BG_DIR)/$(WP_NAME)-$${tod}.png; \
+ 	done;

--- a/pkgs/data/misc/fedora-backgrounds/generic.nix
+++ b/pkgs/data/misc/fedora-backgrounds/generic.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, coreutils
+}:
+
+{ version
+, src
+, patches ? [ ]
+}:
+
+stdenv.mkDerivation {
+  inherit patches src version;
+
+  pname = "fedora${stdenv.lib.versions.major version}-backgrounds";
+
+  dontBuild = true;
+
+  postPatch = ''
+    for f in default/Makefile extras/Makefile; do
+      substituteInPlace $f \
+        --replace "usr/share" "share" \
+        --replace "/usr/bin/" "" \
+        --replace "/bin/" ""
+    done
+
+    for f in $(find . -name '*.xml'); do
+      substituteInPlace $f \
+        --replace "/usr/share" "$out/share"
+    done;
+  '';
+
+  installFlags = [
+    "DESTDIR=$(out)"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/fedoradesign/backgrounds";
+    description = "A set of default and supplemental wallpapers for Fedora";
+    license = licenses.cc-by-sa-40;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1049,6 +1049,8 @@ in
 
   container-linux-config-transpiler = callPackage ../development/tools/container-linux-config-transpiler { };
 
+  fedora-backgrounds = callPackage ../data/misc/fedora-backgrounds { };
+
   fedora-coreos-config-transpiler = callPackage ../development/tools/fedora-coreos-config-transpiler { };
 
   ccextractor = callPackage ../applications/video/ccextractor { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

I am envious of Fedora's backgrounds (especially the animated backgrounds),
so let's package them.

Throw in Fedora 32 backgrounds for good measure.

Tested with GNOME. I am not using any of the other environments.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
