### PR TITLE
gnomeExtensions.material-shell: 9 -> 10

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/material-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/material-shell/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-material-shell";
-  version = "9";
+  version = "10";
 
   src = fetchFromGitHub {
     owner = "material-shell";
     repo = "material-shell";
     rev = version;
-    sha256 = "154ids72hkkvibqpq3522wf6h9qw7zkjnf8dgz50vxbkiiy015xn";
+    sha256 = "18d813n8s7ns8xp75zmlna7a8mi23rn9yqps51xvdd0sdgn72a1c";
   };
 
   # This package has a Makefile, but it's used for building a zip for


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Updating to the version released today.
https://github.com/material-shell/material-shell/releases/tag/10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Since I can't really mark that I've tested the binary, here's a screenshot showing version 10 after I rebuilt against my local branch with `sudo nixos-rebuild switch -I nixpkgs=~/dev/nixpkgs`:

![image](https://user-images.githubusercontent.com/7545665/98974974-83106d00-24e3-11eb-9eb6-bf6c98b4aded.png)
