### PR TITLE
quisk: 4.1.72 -> 4.1.73

### DIFF
--- a/pkgs/applications/radio/quisk/default.nix
+++ b/pkgs/applications/radio/quisk/default.nix
@@ -3,11 +3,11 @@
 
 python38Packages.buildPythonApplication rec {
   pname = "quisk";
-  version = "4.1.72";
+  version = "4.1.73";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0qw00b9d0l3ysdrmd3nr5a2zlwg9ygdil7krnk2gjp5g8bb778k7";
+    sha256 = "37dfb02a32341025c086b07d66ddf1608d4ee1ae1c62fb51f87c97662f13e0d8";
   };
 
   buildInputs = [ fftw alsaLib pulseaudio ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Quoting James Ahlstrom, http://james.ahlstrom.name/quisk/CHANGELOG.txt :

> Quisk Version 4.1.73  November 2020
> ===================================
> I rewrote the logic for SoftRock I/Q amplitude and phase corrections. The new logic will enable much better
> image suppression because it can correct I/Q based on both the VFO and the tuning offset. If you do nothing,
> there is no change in the corrections. To use the new logic, enter new correction data. Use the Help button
> on the Config/radio/Config correction screens. Corrections are in the file quisk_init.json, and you should
> make a copy of this file to save your current corrections.
> 
> I added a missing version.h file to SoapySDR. It is not clear that this fixes the version check for the
> change in the Soapy API. Please test.
> 
> When using the Split button, Quisk now leaves the Rx frequency unchanged and splits the Tx frequency.
> 
> I added a new band "Aux1" that can be checked on the Config/radio/Bands screen. It can be used as a special
> band for a panadapter or when Quisk is used as a 10.7 MHz IF.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
