### PR TITLE
terraform-providers.gitlab: 2.9.0 -> 3.1.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -333,11 +333,12 @@
     "version": "3.1.0"
   },
   "gitlab": {
-    "owner": "terraform-providers",
+    "owner": "gitlabhq",
+    "provider-source-address": "registry.terraform.io/gitlabhq/gitlab",
     "repo": "terraform-provider-gitlab",
-    "rev": "v2.9.0",
-    "sha256": "0l0b69nxxskpsylcgli2sm9qq7p4hw96dsri24w38shhnxmpysbb",
-    "version": "2.9.0"
+    "rev": "v3.1.0",
+    "sha256": "1an34ckz7lz1k25lkjpbmls55zp9pacr46vjnjjpqx6bx5s95f5g",
+    "version": "3.1.0"
   },
   "google": {
     "owner": "terraform-providers",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
terraform-provider: gitlab version update to v3.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Guys, I'm fairly new to NixOS and to that terraform packaging as well, how would I get new sha256 for new gitlab provider version? Thanks.

update: i think i figured that ^ out.
