### PR TITLE
lombok: add bin output with lombok wrapper script

### DIFF
--- a/pkgs/development/libraries/java/lombok/default.nix
+++ b/pkgs/development/libraries/java/lombok/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, makeWrapper, jdk }:
 
 stdenv.mkDerivation rec {
   name = "lombok-1.18.16";
@@ -8,9 +8,17 @@ stdenv.mkDerivation rec {
     sha256 = "1msys7xkaj0d7fi112fmb2z50mk46db58agzrrdyimggsszwn1kj";
   };
 
+  buildInputs = [ makeWrapper ];
+
+  outputs = [ "out" "bin" ];
+
   buildCommand = ''
     mkdir -p $out/share/java
     cp $src $out/share/java/lombok.jar
+
+    makeWrapper ${jdk}/bin/java $bin/bin/lombok \
+      --add-flags "-cp ${jdk}/lib/openjdk/lib/tools.jar:$out/share/java/lombok.jar" \
+      --add-flags lombok.launch.Main
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

To provide a convenient way to run delombok.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
