### PR TITLE
qvge: init at 0.6.1

### DIFF
--- a/pkgs/applications/graphics/qvge/default.nix
+++ b/pkgs/applications/graphics/qvge/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, substituteAll
+, qmake
+, qtx11extras
+, graphviz
+}:
+
+mkDerivation rec {
+  pname = "qvge";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "ArsMasiuk";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0j4ih03nl6iihhnxrfldkarg9hvxb62lpr58xspn417d3gj6xjll";
+  };
+
+  prePatch = "cd src";
+
+  patches = (substituteAll {
+    src = ./set-graphviz-path.patch;
+    inherit graphviz;
+  });
+
+  nativeBuildInputs = [ qmake ];
+
+  buildInputs = [ qtx11extras ];
+
+  meta = with lib; {
+    description = "Qt Visual Graph Editor";
+    homepage = "https://github.com/ArsMasiuk/qvge";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/applications/graphics/qvge/set-graphviz-path.patch
+++ b/pkgs/applications/graphics/qvge/set-graphviz-path.patch
@@ -1,0 +1,13 @@
+diff --git i/commonui/CNodeEditorUIController.cpp w/commonui/CNodeEditorUIController.cpp
+index 7dacd48..64983e4 100644
+--- i/commonui/CNodeEditorUIController.cpp
++++ w/commonui/CNodeEditorUIController.cpp
+@@ -123,7 +123,7 @@ CNodeEditorUIController::CNodeEditorUIController(CMainWindow *parent) :
+ 	QString pathToGraphviz = QCoreApplication::applicationDirPath() + "/../tools/graphviz";
+ 	m_optionsData.graphvizPath = QFileInfo(pathToGraphviz).absoluteFilePath();
+ #else
+-	m_optionsData.graphvizPath = "";
++	m_optionsData.graphvizPath = "@graphviz@/bin";
+ #endif
+ 	m_gvController->setPathToGraphviz(m_optionsData.graphvizPath);
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6723,6 +6723,8 @@ in
 
   quota = if stdenv.isLinux then linuxquota else unixtools.quota;
 
+  qvge = libsForQt5.callPackage ../applications/graphics/qvge { };
+
   qview = libsForQt5.callPackage ../applications/graphics/qview {};
 
   wayback_machine_downloader = callPackage ../applications/networking/wayback_machine_downloader { };


### PR DESCRIPTION
###### Motivation for this change
> **[QVGE](https://github.com/ArsMasiuk/qvge)** is a multiplatform graph editor written in C++/Qt. Its main goal is to make possible visually edit two-dimensional graphs in a simple and intuitive way.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
