### PR TITLE
sc-controller: unbreak by restoring pygobject3 for python2

### DIFF
--- a/pkgs/development/python-modules/pygobject/3.36.nix
+++ b/pkgs/development/python-modules/pygobject/3.36.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, buildPythonPackage, pkgconfig, glib, gobject-introspection,
+pycairo, cairo, which, ncurses, meson, ninja, isPy3k, gnome3 }:
+
+buildPythonPackage rec {
+  pname = "pygobject";
+  version = "3.36.1";
+
+  format = "other";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0b9CgC0c7BE7Wtqg579/N0W0RSHcIWNYjSdtXNYdcY8=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  mesonFlags = [
+    "-Dpython=python${if isPy3k then "3" else "2" }"
+  ];
+
+  nativeBuildInputs = [ pkgconfig meson ninja gobject-introspection ];
+  buildInputs = [ glib gobject-introspection ]
+                 ++ stdenv.lib.optionals stdenv.isDarwin [ which ncurses ];
+  propagatedBuildInputs = [ pycairo cairo ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "python3.pkgs.${pname}3";
+    };
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://pygobject.readthedocs.io/";
+    description = "Python bindings for Glib";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/pylibacl/0.5.nix
+++ b/pkgs/development/python-modules/pylibacl/0.5.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pkgs
+}:
+
+buildPythonPackage rec {
+  pname = "pylibacl";
+  version = "0.5.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0drvxb21y7p0aikcv3jx90vdcjk96kibf9x8qgxic2prxxd3f3q6";
+  };
+
+  # ERROR: testExtended (tests.test_acls.AclExtensions)
+  # IOError: [Errno 0] Error
+  doCheck = false;
+
+  buildInputs = with pkgs; [ acl ];
+
+  meta = {
+    description = "A Python extension module for POSIX ACLs, it can be used to query, list, add, and remove ACLs from files and directories under operating systems that support them";
+    license = lib.licenses.lgpl21Plus;
+  };
+}

--- a/pkgs/misc/drivers/sc-controller/default.nix
+++ b/pkgs/misc/drivers/sc-controller/default.nix
@@ -55,7 +55,6 @@ buildPythonApplication rec {
   meta = with lib; {
     homepage    = "https://github.com/kozec/sc-controller";
     # donations: https://www.patreon.com/kozec
-    broken = true;
     description = "User-mode driver and GUI for Steam Controller and other controllers";
     license     = licenses.gpl2;
     platforms   = platforms.linux;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5154,7 +5154,10 @@ in {
 
   pygobject2 = callPackage ../development/python-modules/pygobject { inherit (pkgs) pkgconfig; };
 
-  pygobject3 = callPackage ../development/python-modules/pygobject/3.nix { inherit (pkgs) meson pkgconfig; };
+  pygobject3 = if isPy3k then
+    callPackage ../development/python-modules/pygobject/3.nix { inherit (pkgs) meson pkgconfig; }
+  else
+    callPackage ../development/python-modules/pygobject/3.36.nix { inherit (pkgs) meson pkgconfig; };
 
   pygogo = callPackage ../development/python-modules/pygogo { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5245,7 +5245,10 @@ in {
 
   pylev = callPackage ../development/python-modules/pylev { };
 
-  pylibacl = callPackage ../development/python-modules/pylibacl { };
+  pylibacl = if isPy3k then
+    callPackage ../development/python-modules/pylibacl { }
+  else
+    callPackage ../development/python-modules/pylibacl/0.5.nix { };
 
   pylibconfig2 = callPackage ../development/python-modules/pylibconfig2 { };
 


### PR DESCRIPTION
###### Motivation for this change

Unbreak sc-controller.

Upstream issue re. python3: https://github.com/kozec/sc-controller/issues/498.
pygobject maintainers recommend keeping 3.36 for python2: https://github.com/GNOME/pygobject/blob/3.38.0/NEWS#L7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
