### PR TITLE
musescore: fix unpack on darwin

### DIFF
--- a/pkgs/applications/audio/musescore/darwin.nix
+++ b/pkgs/applications/audio/musescore/darwin.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   version = concatStringsSep "." versionComponents;
 
   # The disk image contains the .app and a symlink to /Applications.
-  sourceRoot="${appName}.app";
+  sourceRoot = "${appName}.app";
 
   src = fetchurl {
     url =  "ftp://ftp.osuosl.org/pub/musescore/releases/MuseScore-${concatStringsSep "." (take 3 versionComponents)}/MuseScore-${version}.dmg";

--- a/pkgs/applications/audio/musescore/darwin.nix
+++ b/pkgs/applications/audio/musescore/darwin.nix
@@ -11,6 +11,9 @@ stdenv.mkDerivation rec {
   pname = "musescore-darwin";
   version = concatStringsSep "." versionComponents;
 
+  # The disk image contains the .app and a symlink to /Applications.
+  sourceRoot="${appName}.app";
+
   src = fetchurl {
     url =  "ftp://ftp.osuosl.org/pub/musescore/releases/MuseScore-${concatStringsSep "." (take 3 versionComponents)}/MuseScore-${version}.dmg";
     sha256 = "19xkaxlkbrhvfip6n3iw6q7463ngr6y5gfisrpjqg2xl2igyl795";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Fix build error:

```
building '/nix/store/fkpnbjbyccyrjkqkg3jhv2s491r78ny6-musescore-darwin-2.1.drv'...
unpacking sources
unpacking source archive /nix/store/bgy2npvf9wcgwzq40mazjl6hwpfg1cf0-MuseScore-2.1.dmg
unpacker produced multiple directories
builder for '/nix/store/fkpnbjbyccyrjkqkg3jhv2s491r78ny6-musescore-darwin-2.1.drv' failed with exit code 1
error: build of '/nix/store/fkpnbjbyccyrjkqkg3jhv2s491r78ny6-musescore-darwin-2.1.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
