### PR TITLE
pdsh: enable optional slurm support

### DIFF
--- a/pkgs/tools/networking/pdsh/default.nix
+++ b/pkgs/tools/networking/pdsh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, readline, rsh, ssh }:
+{ stdenv, fetchurl, perl, readline, rsh, ssh, slurm, slurmSupport ? false }:
 
 stdenv.mkDerivation rec {
   name = "pdsh-2.34";
@@ -8,7 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1s91hmhrz7rfb6h3l5k97s393rcm1ww3svp8dx5z8vkkc933wyxl";
   };
 
-  buildInputs = [ perl readline ssh ];
+  buildInputs = [ perl readline ssh ]
+    ++ (stdenv.lib.optional slurmSupport slurm);
 
   preConfigure = ''
     configureFlagsArray=(
@@ -18,6 +19,7 @@ stdenv.mkDerivation rec {
       ${if readline == null then "--without-readline" else "--with-readline"}
       ${if ssh == null then "--without-ssh" else "--with-ssh"}
       ${if rsh == false then "--without-rsh" else "--with-rsh"}
+      ${if slurmSupport then "--with-slurm" else "--without-slurm"}
       "--with-dshgroups"
       "--with-xcpu"
       "--disable-debug"


### PR DESCRIPTION
##### Motivation for this change

pdsh provides a number of optional modules with additional functionality. One such is the slurm module. This adds a slurmSupport option (default false) to enable it.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
