### PR TITLE
nix-prefetch-github: 4.0.1 -> 4.0.2

### DIFF
--- a/pkgs/development/python-modules/nix-prefetch-github/default.nix
+++ b/pkgs/development/python-modules/nix-prefetch-github/default.nix
@@ -8,18 +8,17 @@
 , jinja2
 , git
 , pytestCheckHook
-, pytest-black
 , pytestcov
 , pytest-isort
 }:
 
 buildPythonPackage rec {
   pname = "nix-prefetch-github";
-  version = "4.0.1";
+  version = "4.0.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "asfRohjOgYxMV/wprKvxUD328GVJQkAYnuAkE09kKgs=";
+    sha256 = "ZdaWIkpJk8AvTZmA76VMTXeOUTrWLe+W3vh/e0zwWB4=";
   };
 
   propagatedBuildInputs = [
@@ -29,7 +28,7 @@ buildPythonPackage rec {
     jinja2
   ];
 
-  checkInputs = [ pytestCheckHook pytest-black pytestcov pytest-isort git ];
+  checkInputs = [ pytestCheckHook pytestcov pytest-isort git ];
   checkPhase = ''
     pytest -m 'not network'
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
Package Update. New version no longer uses `pytest-black`. 

https://github.com/seppeljordan/nix-prefetch-github/commit/3e1f3f9fd213a71389b32ba5adf46f1614ddffdb


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
