### PR TITLE
ocamlPackages.httpaf: 0.4.1 → 0.6.6

### DIFF
--- a/pkgs/development/ocaml-modules/httpaf/default.nix
+++ b/pkgs/development/ocaml-modules/httpaf/default.nix
@@ -1,19 +1,31 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml, angstrom, faraday, alcotest }:
+{ lib, fetchFromGitHub, fetchpatch, buildDunePackage
+, angstrom, faraday, alcotest
+}:
 
 buildDunePackage rec {
   pname = "httpaf";
-  version = "0.4.1";
+  version = "0.6.6";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "inhabitedtype";
     repo = pname;
     rev = version;
-    sha256 = "0i2r004ihj00hd97475y8nhjqjln58xx087zcjl0dfp0n7q80517";
+    sha256 = "065ikryv8zw9cbk6ddcjcind88ckk0inz9m3sqj9nwyfw4v4scm6";
   };
 
-  checkInputs = lib.optional doCheck alcotest;
+  patches = [
+    # Fix tests with angstrom ≥ 0.14
+    (fetchpatch {
+      url = "https://github.com/inhabitedtype/httpaf/commit/fc0de5f2f1bd8df953ae4d4c9a61032392436c84.patch";
+      sha256 = "1a8ca76ifbgyaq1bqfyq18mmxinjjparzkrr7ljbj0y1z1rl748z";
+    })
+  ];
+
+  checkInputs = [ alcotest ];
   propagatedBuildInputs = [ angstrom faraday ];
-  doCheck = lib.versions.majorMinor ocaml.version != "4.07";
+  doCheck = true;
 
   meta = {
     description = "A high-performance, memory-efficient, and scalable web server for OCaml";


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/inhabitedtype/httpaf/releases

Use Dune 2

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
