### PR TITLE
tor-browser-bundle-mutable: init

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -410,5 +410,6 @@ stdenv.mkDerivation rec {
     # the compound is "libre" in a strict sense (some components place certain
     # restrictions on redistribution), it's free enough for our purposes.
     license = licenses.free;
+    passthru = { inherit src srcs version; };
   };
 }

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/mutable.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/mutable.nix
@@ -1,0 +1,124 @@
+{ lib
+, buildFHSUserEnv
+, fetchurl
+, writers
+, tor-browser-bundle-bin
+
+# For XDG_DATA_DIRS
+, gnome3 # .adwaita-icon-theme
+, shared-mime-info
+, glib
+, gsettings-desktop-schemas
+, gtk3
+
+# override the bootstrapping script, useful for debugging
+, runScript ? null
+
+, audioSupport ? mediaSupport
+, pulseaudioSupport ? false
+# Media support (implies audio support)
+, mediaSupport ? true
+
+# Hardening
+, graphene-hardened-malloc
+# crashes with intel driver
+, useHardenedMalloc ? false
+
+}:
+
+let
+  lang = "en-US";
+  inherit (tor-browser-bundle-bin.meta.passthru) src srcs version;
+
+  # Bootstrapping script
+  tor-browser-bootstrap = writers.writeBash "tor-browser-bootstrap" ''
+    set -o errexit -o pipefail
+
+    if ! [[ -v XDG_DATA_HOME || -v HOME ]]; then
+      echo "Could not determine tor-browser home!"
+      exit 1
+    fi
+
+    TBB_HOME=''${XDG_DATA_HOME:-"$HOME/.local/share"}/tor-browser-mutable
+
+    # Copy the runtime if not present
+    if ! [[ -f "$TBB_HOME/start-tor-browser" ]]; then
+      mkdir -p "$TBB_HOME"
+      tar xf "${src}" --strip-components=2 -C "$TBB_HOME"
+    fi
+
+    # Set up the environment
+    ${lib.optionalString useHardenedMalloc ''
+      export LD_PRELOAD="${graphene-hardened-malloc}/lib/libhardened_malloc.so"
+    ''}
+
+    XDG_DATA_DIRS=${lib.concatMapStringsSep ":" (x: "${x}/share") [
+      gnome3.adwaita-icon-theme
+      shared-mime-info
+    ]}
+
+    XDG_DATA_DIRS+=":"${lib.concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [
+      glib
+      gsettings-desktop-schemas
+      gtk3
+    ]}
+
+    exec -- "$TBB_HOME/start-tor-browser"
+
+  '';
+
+in buildFHSUserEnv {
+  name = "tor-browser";
+  targetPkgs = (pkgs: with pkgs; [
+      # libxul run-time dependencies
+      zlib
+      udev
+      atk
+      cairo
+      dbus
+      dbus-glib
+      fontconfig
+      freetype
+      gdk-pixbuf
+      glib
+      gtk3
+      xorg.libxcb
+      xorg.libX11
+      xorg.libXext
+      xorg.libXrender
+      xorg.libXt
+      pango
+    ] ++ lib.optionals pulseaudioSupport [
+      libpulseaudio
+      apulse
+    ]
+    # Media support (implies audio support)
+    ++ lib.optionals mediaSupport [
+      ffmpeg_3
+    ]);
+
+  runScript = if runScript != null then runScript else tor-browser-bootstrap;
+
+  meta = {
+    description = "Tor Browser Bundle built by torproject.org (self updating version)";
+    longDescription = ''
+      Tor Browser Bundle is a bundle of the Tor daemon, Tor Browser (heavily patched version of
+      Firefox), several essential extensions for Tor Browser, and some tools that glue those
+      together with a convenient UI.
+
+      `tor-browser-bundle-mutable` package is a wrapper for the official version built by torproject.org.
+      It will install the tor-browser bundle in a local prefix on first run, and set up a FHS compatible environment,
+      which allows the browser to work on nix based systems.
+    '';
+    homepage = "https://www.torproject.org/";
+    changelog = "https://gitweb.torproject.org/builders/tor-browser-build.git/plain/projects/tor-browser/Bundle-Data/Docs/ChangeLog.txt?h=maint-${version}";
+    platforms = lib.attrNames srcs;
+    maintainers = with lib.maintainers; [ xaverdh ];
+    hydraPlatforms = [];
+    # MPL2.0+, GPL+, &c.  While it's not entirely clear whether
+    # the compound is "libre" in a strict sense (some components place certain
+    # restrictions on redistribution), it's free enough for our purposes.
+    license = lib.licenses.free;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7649,6 +7649,10 @@ in
 
   tor-browser-bundle-bin = callPackage ../applications/networking/browsers/tor-browser-bundle-bin { };
 
+  tor-browser-bundle-mutable = callPackage ../applications/networking/browsers/tor-browser-bundle-bin/mutable.nix {
+    buildFHSUserEnv = buildFHSUserEnvBubblewrap;
+  };
+
   touchegg = callPackage ../tools/inputmethods/touchegg { };
 
   torsocks = callPackage ../tools/security/tor/torsocks.nix { };


### PR DESCRIPTION
###### Motivation for this change

Spin off from #103156

This offers an alternative FHS based packaging for the tor browser. This may be useful for some people (due to faster updates, or perhaps less chance of breakage, due to being closer to upstream), but obviously has its drawbacks. It is not as close to the spirit of Nix /  NixOS and will waste disk space, by keeping a separate copy of the (compressed) source in the store, in addition to the one in the local prefix.
Another rationale for writing this may be that mozilla is known for increasingly trying to lock down the browser, thereby sadly making the kind of packaging as required in `nixpkgs` more difficult to do properly.

###### Implementation details
* It uses `.local/share/tor-browser-mutable/` as prefix (separate from the prefix of tor-browser-bundle-bin), so they should not collide.
* It adds some things to the `passthru` attribute of tor-browser-bundle-bin, to keep versions in sync; hope that's a valid thing to do.

###### Things done

* running works and NoScript / addons as well
* checked that the tor browsers self update mechanism works

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
