### PR TITLE
terragrunt: removing terraform dependency

### DIFF
--- a/pkgs/applications/networking/cluster/terragrunt/default.nix
+++ b/pkgs/applications/networking/cluster/terragrunt/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, makeWrapper, terraform }:
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper }:
 
 buildGoModule rec {
   pname = "terragrunt";
@@ -18,11 +18,6 @@ buildGoModule rec {
   buildInputs = [ makeWrapper ];
 
   buildFlagsArray = [ "-ldflags=" "-X main.VERSION=v${version}" ];
-
-  postInstall = ''
-    wrapProgram $out/bin/terragrunt \
-      --set TERRAGRUNT_TFPATH ${lib.getBin terraform.full}/bin/terraform
-  '';
 
   meta = with lib; {
     description = "A thin wrapper for Terraform that supports locking for Terraform state and enforces best practices";


### PR DESCRIPTION
Since terragrunt would trigger downloading all the plugins and basing on terraform 0.12 branch whereas people could use it against 0.11 or 0.13 terraform.

fixes #103631

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
it is very frustrating when you download a statically linked binary and a vast amount of software is downloaded with it. i understand that from a user perspective it might be convenient and make sense to have terraform (not sure though about ALL the providers) along side it.

but terragrunt itself is very niche software, and people would want to have different terraform versions with it.

PS: i'm new to NixOS, and to that packaging as well. i could miss some things, please correct me where applicable, thanks.

i've used to use tgenv/tfenv myself, but downloading providers every time in `.terraform` directory within your code is a nightmare. NixOS packaging did it very cool i must say with linking provider binaries to `.terraform/plugins`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
