### PR TITLE
lcms: Fix fetch URL

### DIFF
--- a/pkgs/development/libraries/lcms/default.nix
+++ b/pkgs/development/libraries/lcms/default.nix
@@ -1,10 +1,11 @@
 {stdenv, fetchurl}:
 
-stdenv.mkDerivation {
-  name = "lcms-1.19";
+stdenv.mkDerivation rec {
+  pname = "lcms";
+  version = "1.19";
 
   src = fetchurl {
-    url = "http://www.littlecms.com/lcms-1.19.tar.gz";
+    url = "mirror://sourceforge/lcms/${pname}-${version}.tar.gz";
     sha256 = "1abkf8iphwyfs3z305z3qczm3z1i9idc1lz4gvfg92jnkz5k5bl0";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->
Continuation of #103542

###### Motivation for this change
Make this package fetchable. Currently, this build is only working because these sources are cached in tarballs.nixos.org.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

FYI @svanderburg , last person to version bump this package.