### PR TITLE
fix some dead meta.homepage entries

### DIFF
--- a/pkgs/applications/audio/muse/default.nix
+++ b/pkgs/applications/audio/muse/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    homepage = "https://www.muse-sequencer.org/";
+    homepage = "https://muse-sequencer.github.io/";
     description = "MIDI/Audio sequencer with recording and editing capabilities";
     longDescription = ''
       MusE is a MIDI/Audio sequencer with recording and editing capabilities

--- a/pkgs/applications/editors/elvis/default.nix
+++ b/pkgs/applications/editors/elvis/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
   configureFlags = [ "--ioctl=termios" ];
 
   meta = {
-    homepage = "http://elvis.vi-editor.org/";
+    homepage = "http://elvis.the-little-red-haired-girl.org/";
     description = "A vi clone for Unix and other operating systems";
     license = stdenv.lib.licenses.free;
   };

--- a/pkgs/development/libraries/audio/lvtk/default.nix
+++ b/pkgs/development/libraries/audio/lvtk/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A set C++ wrappers around the LV2 C API";
-    homepage = "http://lvtoolkit.org";
+    homepage = "https://lvtk.org/";
     license = licenses.gpl3;
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/phonon/default.nix
+++ b/pkgs/development/libraries/phonon/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   version = "4.11.1";
 
   meta = {
-    homepage = "https://phonon.kde.org/";
+    homepage = "https://community.kde.org/Phonon";
     description = "Multimedia API for Qt";
     license = stdenv.lib.licenses.lgpl2;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/psqlodbc/default.nix
+++ b/pkgs/development/libraries/psqlodbc/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-iodbc=${libiodbc}" ];
 
   meta = with stdenv.lib; {
-    homepage = "http://psqlodbc.projects.postgresql.org/";
+    homepage = "https://odbc.postgresql.org/";
     description = "ODBC driver for PostgreSQL";
     license = licenses.lgpl2;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/science/math/openlibm/default.nix
+++ b/pkgs/development/libraries/science/math/openlibm/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "High quality system independent, portable, open source libm implementation";
-    homepage = "https://www.openlibm.org/";
+    homepage = "https://openlibm.org/";
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.ttuegel ];
     platforms = stdenv.lib.platforms.all;


### PR DESCRIPTION
###### Motivation for this change
i spotted `pkgs.elvis.meta.homepage` was broken on https://repology.org/repository/nix_unstable/problems
i fixed that and had a quick look through other domain issues on that page

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


###### Notes
`pg_top` gets its source from the same domain as its homepage, and that domain seems to have been recycled by now, it does not have a listed maintainer
i feel like updating its `meta.homepage` would oblige me to also fix the source and complicate this PR, so i leave that to a future interested party...
`openlibm` could (should?) be changed to use `fetchFromGitHub` and the newer repo owner name.

tag @ttuegel, @orivej and @cillianderoiste as they're listed as maintainers for some of the affected packages