### PR TITLE
jstest-gtk: init at master

### DIFF
--- a/pkgs/tools/misc/jstest-gtk/default.nix
+++ b/pkgs/tools/misc/jstest-gtk/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitLab, cmake, pkg-config, gtkmm3, libsigcxx, xorg }:
+
+stdenv.mkDerivation rec {
+  pname = "jstest-gtk";
+  version = "2018-07-10";
+
+  src = fetchFromGitLab {
+    owner = pname;
+    repo = pname;
+    rev = "62f6e2d7d44620e503149510c428df9e004c9f3b";
+    sha256 = "0icbbhrj5aqljhiavdy3hic60vp0zzfzyg0d6vpjaqkbzd5pv9d8";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ gtkmm3 libsigcxx xorg.libX11 ];
+
+  meta = with lib; {
+    description = "A simple joystick tester based on Gtk+";
+    longDescription = ''
+      It provides you with a list of attached joysticks, a way to display which
+      buttons and axis are pressed, a way to remap axis and buttons and a way
+      to calibrate your joystick.
+    '';
+    homepage = "https://jstest-gtk.gitlab.io/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ wucke13 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28704,6 +28704,8 @@ in
   libjack2 = jack2.override { prefix = "lib"; };
   jack2Full = jack2; # TODO: move to aliases.nix
 
+  jstest-gtk = callPackage ../tools/misc/jstest-gtk { };
+
   keynav = callPackage ../tools/X11/keynav { };
 
   kmon = callPackage ../tools/system/kmon { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change
I contributed to a joystick firmware and wanted to test the new joystick. This tool allows easy calibration, which is sweet!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
