### PR TITLE
vte-ng: update patches to apply on vte 0.62

### DIFF
--- a/pkgs/applications/terminal-emulators/termite/default.nix
+++ b/pkgs/applications/terminal-emulators/termite/default.nix
@@ -4,6 +4,8 @@ let
 
   # termite requires VTE with some internals exposed
   # https://github.com/thestinger/vte-ng
+  #
+  # three of the patches have been locally modified to cleanly apply on 0.62
   vte-ng =  vte.overrideAttrs (attrs: {
     patches = attrs.patches or [] ++ [
       (fetchpatch {
@@ -11,26 +13,17 @@ let
         url = "https://github.com/thestinger/vte-ng/commit/342e26574f50dcd40bbeaad9e839c2a6144d0c1c.patch";
         sha256 = "1b0k9ys545q85vfki417p21kis9f36yd0hyp12phayynss6fn715";
       })
-      (fetchpatch {
-        name = "0002-expose-function-for-setting-cursor-position.patch";
-        url = "https://github.com/thestinger/vte-ng/commit/5ae3acb69474fe5bc43767a4a3625e9ed23607a1.patch";
-        sha256 = "091sb44g2pl0zbxnxidpfmsqqc65dmkakhjb0wvlnsjckqalhs89";
-      })
-      (fetchpatch {
-        name = "0003-add-function-for-setting-the-text-selections.patch";
-        url = "https://github.com/thestinger/vte-ng/commit/742d57ecf15e24f6a5f2133a81b6c70acc8ff03c.patch";
-        sha256 = "12rq3svbj1nzridbssxsvmmb8njky3w8qdnkymz7850b3kqg277x";
-      })
+      # Derived from https://github.com/thestinger/vte-ng/commit/5ae3acb69474fe5bc43767a4a3625e9ed23607a1.patch
+      ./vte-ng-modified-patches/vte-0002-expose-function-for-setting-cursor-position.patch
+      # Derived from https://github.com/thestinger/vte-ng/commit/742d57ecf15e24f6a5f2133a81b6c70acc8ff03c.patch
+      ./vte-ng-modified-patches/vte-0003-add-function-for-setting-the-text-selections.patch
       (fetchpatch {
         name = "0004-add-functions-to-get-set-block-selection-mode.patch";
         url = "https://github.com/thestinger/vte-ng/commit/08748fd9cb82bd191e5c476b1682ca71f7732572.patch";
         sha256 = "1cnhd8f7ywdgcyd6xmcd2nn39jjxzkxp4d0zsj2k7m5v74nhcs1g";
       })
-      (fetchpatch {
-        name = "0005-expose-function-for-getting-the-selected-text.patch";
-        url = "https://github.com/thestinger/vte-ng/commit/dd74ae7c06e8888af2fc090ac6f8920a9d8227fb.patch";
-        sha256 = "0pbnbkwqxm4p9xsgvqwayvh8srk5z1kyjnigmahf9mlqn7hi6v27";
-      })
+      # Derived from "https://github.com/thestinger/vte-ng/commit/dd74ae7c06e8888af2fc090ac6f8920a9d8227fb.patch";
+      ./vte-ng-modified-patches/vte-0005-expose-function-for-getting-the-selected-text.patch
     ];
   });
 

--- a/pkgs/applications/terminal-emulators/termite/vte-ng-modified-patches/vte-0002-expose-function-for-setting-cursor-position.patch
+++ b/pkgs/applications/terminal-emulators/termite/vte-ng-modified-patches/vte-0002-expose-function-for-setting-cursor-position.patch
@@ -1,0 +1,61 @@
+From 5ae3acb69474fe5bc43767a4a3625e9ed23607a1 Mon Sep 17 00:00:00 2001
+From: Jelle van der Waa <jelle@vdwaa.nl>
+Date: Sat, 13 Feb 2016 22:18:01 +0100
+Subject: [PATCH] expose function for setting cursor position
+
+---
+ src/vte/vteterminal.h |  5 +++++
+ src/vtegtk.cc         | 24 ++++++++++++++++++++++++
+ 2 files changed, 29 insertions(+)
+
+diff --git a/src/vte/vteterminal.h b/src/vte/vteterminal.h
+index a607e5da..9701320d 100644
+--- a/src/vte/vteterminal.h
++++ b/src/vte/vteterminal.h
+@@ -378,6 +378,11 @@ _VTE_PUBLIC
+ void vte_terminal_get_cursor_position(VteTerminal *terminal,
+ 				      glong *column,
+                                       glong *row) _VTE_CXX_NOEXCEPT _VTE_GNUC_NONNULL(1);
++_VTE_PUBLIC
++void vte_terminal_set_cursor_position(VteTerminal *terminal,
++                                      glong column,
++                                      glong row) _VTE_CXX_NOEXCEPT _VTE_GNUC_NONNULL(1);
++
+ 
+ _VTE_PUBLIC
+ char *vte_terminal_hyperlink_check_event(VteTerminal *terminal,
+diff --git a/src/vtegtk.cc b/src/vtegtk.cc
+index b11b780b..bdf36eac 100644
+--- a/src/vtegtk.cc
++++ b/src/vtegtk.cc
+@@ -2415,6 +2415,30 @@ vte_terminal_get_cursor_position(VteTerminal *terminal,
+ 	}
+ }
+ 
++/**
++ * vte_terminal_set_cursor_position
++ * @terminal: a #VteTerminal
++ * @column: the new cursor column
++ * @row: the new cursor row
++ *
++ * Set the location of the cursor.
++ */
++void
++vte_terminal_set_cursor_position(VteTerminal *terminal,
++		                 long column, long row) noexcept
++{
++	g_return_if_fail(VTE_IS_TERMINAL(terminal));
++
++        auto impl = IMPL(terminal);
++	impl->invalidate_cursor_once(FALSE);
++	impl->m_screen->cursor.col = column;
++	impl->m_screen->cursor.row = row;
++	impl->invalidate_cursor_once(FALSE);
++	impl->check_cursor_blink();
++	impl->queue_cursor_moved();
++
++}
++
+ /**
+  * vte_terminal_pty_new_sync:
+  * @terminal: a #VteTerminal

--- a/pkgs/applications/terminal-emulators/termite/vte-ng-modified-patches/vte-0003-add-function-for-setting-the-text-selections.patch
+++ b/pkgs/applications/terminal-emulators/termite/vte-ng-modified-patches/vte-0003-add-function-for-setting-the-text-selections.patch
@@ -1,0 +1,56 @@
+From 742d57ecf15e24f6a5f2133a81b6c70acc8ff03c Mon Sep 17 00:00:00 2001
+From: Jelle van der Waa <jelle@vdwaa.nl>
+Date: Sat, 13 Feb 2016 22:25:19 +0100
+Subject: [PATCH] add function for setting the text selections
+
+---
+ src/vte/vteterminal.h |  4 ++++
+ src/vtegtk.cc         | 20 ++++++++++++++++++++
+ 2 files changed, 24 insertions(+)
+
+diff --git a/src/vte/vteterminal.h b/src/vte/vteterminal.h
+index 9701320d..a11b4cb7 100644
+--- a/src/vte/vteterminal.h
++++ b/src/vte/vteterminal.h
+@@ -196,6 +196,10 @@ _VTE_PUBLIC
+ void vte_terminal_select_all(VteTerminal *terminal) _VTE_CXX_NOEXCEPT _VTE_GNUC_NONNULL(1);
+ _VTE_PUBLIC
+ void vte_terminal_unselect_all(VteTerminal *terminal) _VTE_CXX_NOEXCEPT _VTE_GNUC_NONNULL(1);
++_VTE_PUBLIC
++void vte_terminal_select_text(VteTerminal *terminal, long start_col, long start_row,
++			      long end_col, long end_row) _VTE_CXX_NOEXCEPT _VTE_GNUC_NONNULL(1);
++
+ 
+ /* By-word selection */
+ _VTE_PUBLIC
+diff --git a/src/vtegtk.cc b/src/vtegtk.cc
+index bdf36eac..d9e9f2ed 100644
+--- a/src/vtegtk.cc
++++ b/src/vtegtk.cc
+@@ -2390,6 +2390,26 @@ vte_terminal_unselect_all(VteTerminal *terminal)
+         IMPL(terminal)->deselect_all();
+ }
+ 
++/**
++ * vte_terminal_select_text:
++ * @terminal: a #VteTerminal
++ * @start_col: the starting column for the selection
++ * @start_row: the starting row for the selection
++ * @end_col: the end column for the selection
++ * @end_row: the end row for the selection
++ *
++ * Sets the current selection region.
++ */
++void
++vte_terminal_select_text(VteTerminal *terminal,
++		         long start_col, long start_row,
++			 long end_col, long end_row) noexcept
++{
++	g_return_if_fail (VTE_IS_TERMINAL (terminal));
++
++        IMPL(terminal)->select_text(start_col, start_row, end_col, end_row);
++}
++
+ /**
+  * vte_terminal_get_cursor_position:
+  * @terminal: a #VteTerminal

--- a/pkgs/applications/terminal-emulators/termite/vte-ng-modified-patches/vte-0005-expose-function-for-getting-the-selected-text.patch
+++ b/pkgs/applications/terminal-emulators/termite/vte-ng-modified-patches/vte-0005-expose-function-for-getting-the-selected-text.patch
@@ -1,0 +1,29 @@
+--- a/src/vte/vteterminal.h
++++ b/src/vte/vteterminal.h
+@@ -204,7 +204,9 @@
+ _VTE_PUBLIC
+ void vte_terminal_select_text(VteTerminal *terminal, long start_col, long start_row,
+ 			      long end_col, long end_row) _VTE_CXX_NOEXCEPT _VTE_GNUC_NONNULL(1);
+-
++_VTE_PUBLIC
++char *
++vte_terminal_get_selection(VteTerminal *terminal) _VTE_CXX_NOEXCEPT _VTE_GNUC_NONNULL(1);
+ 
+ /* By-word selection */
+ _VTE_PUBLIC
+--- a/src/vtegtk.cc
++++ b/src/vtegtk.cc
+@@ -2435,6 +2435,13 @@
+         IMPL(terminal)->select_text(start_col, start_row, end_col, end_row);
+ }
+ 
++char *
++vte_terminal_get_selection(VteTerminal *terminal) noexcept
++{
++	g_return_val_if_fail(VTE_IS_TERMINAL(terminal), NULL);
++	return g_strdup (IMPL(terminal)->m_selection[VTE_SELECTION_PRIMARY]->str);
++}
++
+ /**
+  * vte_terminal_get_cursor_position:
+  * @terminal: a #VteTerminal


### PR DESCRIPTION
###### Motivation for this change

Closes #103643

The upstream vte-ng patches from 0.56 have applied cleanly up until now, 0.62 added `noexcept` modifiers everywhere so a modification was necessary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
