### PR TITLE
plik: init at 1.3.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -509,6 +509,7 @@
   ./services/misc/paperless.nix
   ./services/misc/parsoid.nix
   ./services/misc/plex.nix
+  ./services/misc/plikd.nix
   ./services/misc/tautulli.nix
   ./services/misc/pinnwand.nix
   ./services/misc/pykms.nix

--- a/nixos/modules/services/misc/plikd.nix
+++ b/nixos/modules/services/misc/plikd.nix
@@ -1,0 +1,82 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.plikd;
+
+  format = pkgs.formats.toml {};
+  plikdCfg = format.generate "plikd.cfg" cfg.settings;
+in
+{
+  options = {
+    services.plikd = {
+      enable = mkEnableOption "the plikd server";
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Open ports in the firewall for the plikd.";
+      };
+
+      settings = mkOption {
+        type = format.type;
+        default = {};
+        description = ''
+          Configuration for plikd, see <link xlink:href="https://github.com/root-gg/plik/blob/master/server/plikd.cfg"/>
+          for supported values.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.plikd.settings = mapAttrs (name: mkDefault) {
+      ListenPort = 8080;
+      ListenAddress = "localhost";
+      DataBackend = "file";
+      DataBackendConfig = {
+         Directory = "/var/lib/plikd";
+      };
+      MetadataBackendConfig = {
+        Driver = "sqlite3";
+        ConnectionString = "/var/lib/plikd/plik.db";
+      };
+    };
+
+    systemd.services.plikd = {
+      description = "Plikd file sharing server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.plikd}/bin/plikd --config ${plikdCfg}";
+        Restart = "on-failure";
+        StateDirectory = "plikd";
+        LogsDirectory = "plikd";
+        DynamicUser = true;
+
+        # Basic hardening
+        NoNewPrivileges = "yes";
+        PrivateTmp = "yes";
+        PrivateDevices = "yes";
+        DevicePolicy = "closed";
+        ProtectSystem = "strict";
+        ProtectHome = "read-only";
+        ProtectControlGroups = "yes";
+        ProtectKernelModules = "yes";
+        ProtectKernelTunables = "yes";
+        RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6 AF_NETLINK";
+        RestrictNamespaces = "yes";
+        RestrictRealtime = "yes";
+        RestrictSUIDSGID = "yes";
+        MemoryDenyWriteExecute = "yes";
+        LockPersonality = "yes";
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.settings.ListenPort ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -306,6 +306,7 @@ in
   pinnwand = handleTest ./pinnwand.nix {};
   plasma5 = handleTest ./plasma5.nix {};
   pleroma = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./pleroma.nix {};
+  plikd = handleTest ./plikd.nix {};
   plotinus = handleTest ./plotinus.nix {};
   podman = handleTestOn ["x86_64-linux"] ./podman.nix {};
   postfix = handleTest ./postfix.nix {};

--- a/nixos/tests/plikd.nix
+++ b/nixos/tests/plikd.nix
@@ -1,0 +1,27 @@
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "plikd";
+  meta = with lib.maintainers; {
+    maintainers = [ freezeboy ];
+  };
+
+  machine = { pkgs, ... }: let
+  in {
+    services.plikd.enable = true;
+    environment.systemPackages = [ pkgs.plik ];
+  };
+
+  testScript = ''
+    # Service basic test
+    machine.wait_for_unit("plikd")
+
+    # Network test
+    machine.wait_for_open_port("8080")
+    machine.succeed("curl --fail -v http://localhost:8080")
+
+    # Application test
+    machine.execute("echo test > /tmp/data.txt")
+    machine.succeed("plik --server http://localhost:8080 /tmp/data.txt | grep curl")
+
+    machine.succeed("diff data.txt /tmp/data.txt")
+  '';
+})

--- a/pkgs/servers/plik/default.nix
+++ b/pkgs/servers/plik/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchurl, makeWrapper, runCommand, callPackage }:
+
+let
+  version = "1.3.1";
+
+  programs = callPackage ./programs.nix {};
+
+  webapp = fetchurl {
+    url = "https://github.com/root-gg/plik/releases/download/${version}/plik-${version}-linux-amd64.tar.gz";
+    sha256 = "KN6cp29KKdGamYnfL3jYltx0EDx6syDPfV0jShOk7Zw=";
+  };
+
+in {
+
+  inherit (programs) plik plikd-unwrapped;
+
+  plikd = runCommand "plikd-${version}" { nativeBuildInputs = [ makeWrapper ]; } ''
+    mkdir -p $out/libexec/plikd/{bin,webapp} $out/bin
+    tar xf ${webapp} plik-${version}-linux-amd64/webapp/dist/
+    mv plik-*/webapp/dist $out/libexec/plikd/webapp
+    cp ${programs.plikd-unwrapped}/bin/plikd $out/libexec/plikd/bin/plikd
+    makeWrapper $out/libexec/plikd/bin/plikd $out/bin/plikd \
+      --run "cd $out/libexec/plikd/bin"
+  '';
+}

--- a/pkgs/servers/plik/programs.nix
+++ b/pkgs/servers/plik/programs.nix
@@ -1,0 +1,42 @@
+{ lib, buildGoModule, fetchFromGitHub, fetchurl, makeWrapper, runCommand }:
+
+let
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "root-gg";
+    repo = "plik";
+    rev = version;
+    sha256 = "C/1Uwjsqd9n3WSXlnlq9K3EJHkLOSavS9cPqF2UqmGo=";
+  };
+
+  vendorSha256 = "klmWXC3tkoOcQHhiQZjR2C5jqaRJqMQOLtVxZ0cFq/Y=";
+
+  meta = with lib; {
+    homepage = "https://plik.root.gg/";
+    description = "Scalable & friendly temporary file upload system";
+    maintainers = with maintainers; [ freezeboy ];
+    license = licenses.mit;
+  };
+in {
+
+  plik = buildGoModule {
+    pname = "plik";
+    inherit version meta src vendorSha256;
+
+    subPackages = [ "client" ];
+    postInstall = ''
+      mv $out/bin/client $out/bin/plik
+    '';
+  };
+
+  plikd-unwrapped = buildGoModule {
+    pname = "plikd-unwrapped";
+    inherit version src vendorSha256;
+
+    subPackages = [ "server" ];
+    postFixup = ''
+      mv $out/bin/server $out/bin/plikd
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7176,6 +7176,9 @@ in
 
   plujain-ramp = callPackage ../applications/audio/plujain-ramp { };
 
+  inherit (callPackage ../servers/plik { })
+    plik plikd;
+
   plex = callPackage ../servers/plex { };
   plexRaw = callPackage ../servers/plex/raw.nix { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Add package, module and test for [plik](https://plik.root.gg)

Currently, the web frontend is extracted from the release from upstream due to problems to
build it. I hope to fix this in a future update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
