### PR TITLE
xorg.xkbcomp: 1.4.2 -> 1.4.4

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2471,11 +2471,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xkbcomp = callPackage ({ stdenv, pkgconfig, fetchurl, libX11, libxkbfile, xorgproto }: stdenv.mkDerivation {
-    name = "xkbcomp-1.4.2";
+    name = "xkbcomp-1.4.4";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/app/xkbcomp-1.4.2.tar.bz2";
-      sha256 = "0944rrkkf0dxp07vhh9yr4prslxhqyw63qmbjirbv1bypswvrn3d";
+      url = "mirror://xorg/individual/app/xkbcomp-1.4.4.tar.bz2";
+      sha256 = "0zpjkbap9160pdd6jpgb5f0yg5281w0rkkx1l0i7g887lq1ydk2r";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -46,7 +46,7 @@ mirror://xorg/individual/app/xgc-1.0.5.tar.bz2
 mirror://xorg/individual/app/xhost-1.0.8.tar.bz2
 mirror://xorg/individual/app/xinit-1.4.1.tar.bz2
 mirror://xorg/individual/app/xinput-1.6.3.tar.bz2
-mirror://xorg/individual/app/xkbcomp-1.4.2.tar.bz2
+mirror://xorg/individual/app/xkbcomp-1.4.4.tar.bz2
 mirror://xorg/individual/app/xkbevd-1.1.4.tar.bz2
 mirror://xorg/individual/app/xkbprint-1.0.4.tar.bz2
 mirror://xorg/individual/app/xkbutils-1.0.4.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2020-February/003037.html
https://lists.x.org/archives/xorg-announce/2020-November/003063.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).