### PR TITLE
python3Packages.phonemizer: init at 2.2.1

### DIFF
--- a/pkgs/development/python-modules/phonemizer/backend-paths.patch
+++ b/pkgs/development/python-modules/phonemizer/backend-paths.patch
@@ -1,0 +1,29 @@
+diff --git a/phonemizer/backend/espeak.py b/phonemizer/backend/espeak.py
+index 387c11c..ceb5e7e 100644
+--- a/phonemizer/backend/espeak.py
++++ b/phonemizer/backend/espeak.py
+@@ -81,10 +81,7 @@ class BaseEspeakBackend(BaseBackend):
+         if _ESPEAK_DEFAULT_PATH:
+             return _ESPEAK_DEFAULT_PATH
+ 
+-        espeak = distutils.spawn.find_executable('espeak-ng')
+-        if not espeak:  # pragma: nocover
+-            espeak = distutils.spawn.find_executable('espeak')
+-        return espeak
++        return "@espeak@"
+ 
+     @classmethod
+     def is_available(cls):
+diff --git a/phonemizer/backend/festival.py b/phonemizer/backend/festival.py
+index b5bc56d..0833160 100644
+--- a/phonemizer/backend/festival.py
++++ b/phonemizer/backend/festival.py
+@@ -78,7 +78,7 @@ class FestivalBackend(BaseBackend):
+         if _FESTIVAL_DEFAULT_PATH:
+             return _FESTIVAL_DEFAULT_PATH
+ 
+-        return distutils.spawn.find_executable('festival')
++        return "@festival@"
+ 
+     @classmethod
+     def is_available(cls):

--- a/pkgs/development/python-modules/phonemizer/default.nix
+++ b/pkgs/development/python-modules/phonemizer/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, substituteAll
+, buildPythonApplication
+, fetchPypi
+, python3Packages
+, pkgs
+, joblib
+, segments
+, attrs
+, espeak-ng
+, pytestCheckHook
+, pytestrunner
+, pytestcov
+}:
+
+buildPythonApplication rec {
+  pname = "phonemizer";
+  version = "2.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "127n4f10zxq60qd8xvlc1amji4wbghqb90rfp25rzdk716kvgwab";
+  };
+
+  postPatch = ''
+    sed -i -e '/\'pytest-runner\'/d setup.py
+  '';
+
+  patches = [
+    (substituteAll {
+      src = ./backend-paths.patch;
+      espeak = "${lib.getBin espeak-ng}/bin/espeak";
+      # override festival path should you try to integrate it
+      festival = "";
+    })
+    ./remove-intertwined-festival-test.patch
+  ];
+
+  propagatedBuildInputs = [
+    joblib
+    segments
+    attrs
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+    pytestcov
+  ];
+
+  # We tried to package festvial, but were unable to get the backend running,
+  # so let's disable related tests.
+  pytestFlagsArray = [
+    "--ignore=test/test_festival.py"
+  ];
+
+  disabledTests = [
+    "test_festival"
+    "test_relative"
+    "test_absolute"
+    "test_readme_festival_syll"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/bootphon/phonemizer";
+    description = "Simple text to phones converter for multiple languages";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/phonemizer/drop-readme-festival-test.patch
+++ b/pkgs/development/python-modules/phonemizer/drop-readme-festival-test.patch
@@ -1,0 +1,12 @@
+diff --git a/test/test_main.py b/test/test_main.py
+index 71d605a..d137cd7 100644
+--- a/test/test_main.py
++++ b/test/test_main.py
+@@ -63,7 +63,6 @@ def test_readme():
+     _test(u'hello world', u'həloʊ wɜːld ')
+     _test(u'hello world', u'həloʊ wɜːld ', '--verbose')
+     _test(u'hello world', u'həloʊ wɜːld ', '--quiet')
+-    _test(u'hello world', u'hhaxlow werld', '-b festival --strip')
+     _test(u'hello world', u'həloʊ wɜːld ', '-l en-us')
+     _test(u'bonjour le monde', u'bɔ̃ʒuʁ lə mɔ̃d ', '-l fr-fr')
+     _test(u'bonjour le monde', u'b ɔ̃ ʒ u ʁ ;eword l ə ;eword m ɔ̃ d ;eword ',

--- a/pkgs/development/python-modules/phonemizer/remove-intertwined-festival-test.patch
+++ b/pkgs/development/python-modules/phonemizer/remove-intertwined-festival-test.patch
@@ -1,0 +1,22 @@
+diff --git a/test/test_main.py b/test/test_main.py
+index 71d605a..0ea3c74 100644
+--- a/test/test_main.py
++++ b/test/test_main.py
+@@ -63,17 +63,12 @@ def test_readme():
+     _test(u'hello world', u'həloʊ wɜːld ')
+     _test(u'hello world', u'həloʊ wɜːld ', '--verbose')
+     _test(u'hello world', u'həloʊ wɜːld ', '--quiet')
+-    _test(u'hello world', u'hhaxlow werld', '-b festival --strip')
+     _test(u'hello world', u'həloʊ wɜːld ', '-l en-us')
+     _test(u'bonjour le monde', u'bɔ̃ʒuʁ lə mɔ̃d ', '-l fr-fr')
+     _test(u'bonjour le monde', u'b ɔ̃ ʒ u ʁ ;eword l ə ;eword m ɔ̃ d ;eword ',
+           '-l fr-fr -p " " -w ";eword "')
+ 
+ 
+-@pytest.mark.skipif(
+-    '2.1' in backend.FestivalBackend.version(),
+-    reason='festival-2.1 gives different results than further versions '
+-    'for syllable boundaries')
+ def test_readme_festival_syll():
+     _test(u'hello world',
+           u'hh ax ;esyll l ow ;esyll ;eword w er l d ;esyll ;eword ',

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5290,6 +5290,8 @@ in {
 
   pyomo = callPackage ../development/python-modules/pyomo { };
 
+  phonemizer = callPackage ../development/python-modules/phonemizer { };
+
   pyopencl = callPackage ../development/python-modules/pyopencl { };
 
   pyopengl = callPackage ../development/python-modules/pyopengl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Part of @Mic92 and my plan to package Mozilla TTS.

This step includes phonemizer, a library to convert text to phonemes.

It supports multiple backends, like espeak and festival. Unfortunately we couldn't get the festival backend to work, so we didn't include it.

```
E           RuntimeError: Command "/nix/store/3jb8rhr9ls6lwmrsahnwcq4v53kv3aw3-festival-2.5.0/bin/festival -b /build/tmpyi73uuuh" returned exit status 255, output is:
E           -=-=-=-=-=- EST Error -=-=-=-=-=-
E           {FND} Feature Token_Method not defined
E
E           -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
E           closing a file left open: /build/tmpyi73uuuh
```

According to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=687822 we are likely missing two folders, `voices` and `dict`. But for us the festival integration is out of scope for now. The espeak backend works and it's what we are using.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
