### PR TITLE
[staging] python3: Fix clang / llvm build with optimizations

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -64,9 +64,6 @@ assert bluezSupport -> bluez != null;
 
 assert mimetypesSupport -> mime-types != null;
 
-assert lib.assertMsg (enableOptimizations -> (!stdenv.cc.isClang))
-  "Optimizations with clang are not supported. configure: error: llvm-profdata is required for a --enable-optimizations build but could not be found.";
-
 assert lib.assertMsg (reproducibleBuild -> stripBytecode)
   "Deterministic builds require stripping bytecode.";
 
@@ -109,11 +106,14 @@ let
     autoconf-archive # needed for AX_CHECK_COMPILE_FLAG
   ] ++ [
     nukeReferences
+    buildPackages.which
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     buildPackages.stdenv.cc
     pythonForBuild
   ] ++ optionals (stdenv.cc.isClang && enableLTO) [
     stdenv.cc.cc.libllvm.out
+  ] ++ optionals (stdenv.cc.isClang && enableOptimizations) [
+    stdenv.cc.cc.libllvm
   ];
 
   buildInputs = filter (p: p != null) ([


### PR DESCRIPTION
###### Motivation for this change

When building python3 with clang, the build errors out because optimizations are enabled (disabled by default on Darwin for I assume the very same reason) because python requires `llvm-profdata` to be available to build in that case. 

I am not sure if the way I figure out how to choose the matching version of `llvm` to the `clang` version provided by the `stdenv` is ideal. Please feel free to suggest a better approach.

@NixOS/darwin-maintainers maybe you could verify if this also applies to Darwin builds? Then we can get rid of the `enableOptimizations` flag I think.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
