### PR TITLE
pastebinit: fix basic usage

### DIFF
--- a/pkgs/tools/misc/pastebinit/default.nix
+++ b/pkgs/tools/misc/pastebinit/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, python3 }:
+{ stdenv
+, fetchurl
+, fetchpatch
+, python3
+}:
 
 stdenv.mkDerivation rec {
   version = "1.5";
@@ -9,7 +13,26 @@ stdenv.mkDerivation rec {
     sha256 = "0mw48fgm9lyh9d3pw997fccmglzsjccf2y347gxjas74wx6aira2";
   };
 
-  buildInputs = [ python3 ];
+  buildInputs = [
+    (python3.withPackages (p: [ p.distro ]))
+  ];
+
+  patchFlags = [ "-p0" ];
+
+  patches = [
+    # Required to allow pastebinit 1.5 to run on Python 3.8
+    (fetchpatch {
+      name = "use-distro-module.patch";
+      url = "https://bazaar.launchpad.net/~arnouten/pastebinit/python38/diff/264?context=3";
+      sha256 = "1gp5inp4xald65xbb7fc5aqq5s2fhw464niwjjja9anqyp3zhawj";
+    })
+    # Required because pastebin.com now redirects http requests to https
+    (fetchpatch {
+      name = "pastebin-com-https.patch";
+      url = "https://bazaar.launchpad.net/~arnouten/pastebinit/pastebin-com-https/diff/264?context=3";
+      sha256 = "0hxhhfcai0mll8qfyhdl3slmbf34ynb759b648x63274m9nd2kji";
+    })
+  ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -22,7 +45,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://launchpad.net/pastebinit";
     description = "A software that lets you send anything you want directly to a pastebin from the command line";
-    maintainers = with maintainers; [ lethalman ];
+    maintainers = with maintainers; [ lethalman raboof ];
     license = licenses.gpl2;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change

I like piping things from the commandline to a URL for sharing online

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).