### PR TITLE
[20.09] go_1_14: 1.14.9 -> 1.14.12, go_1_15: 1.15.2 -> 1.15.5

### DIFF
--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -31,11 +31,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.14.10";
+  version = "1.14.11";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "0rfnjl582cm5klv8c2qyyvn26807zn89m5mk282gkc7awfkrjxmk";
+    sha256 = "05hgnyda5bpm29gnx1956syq54jmpk4k9cf976vypw8ckg9g6w8q";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -31,11 +31,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.14.11";
+  version = "1.14.12";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "05hgnyda5bpm29gnx1956syq54jmpk4k9cf976vypw8ckg9g6w8q";
+    sha256 = "0wdr85l3rr6w50dmlbsib895gs9cc19z5piblp0v9slrsxx4nkxk";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -31,11 +31,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.14.9";
+  version = "1.14.10";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "0m2581pi1iid39dd0k81r6zypasr8byc6d75nprapg09ri4ci1y6";
+    sha256 = "0rfnjl582cm5klv8c2qyyvn26807zn89m5mk282gkc7awfkrjxmk";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.15.nix
+++ b/pkgs/development/compilers/go/1.15.nix
@@ -31,11 +31,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.15.4";
+  version = "1.15.5";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "0rr3gp99bmdzg381x5fdwa15brllihn57175l0c82sqqljlscg86";
+    sha256 = "1wc43h3pmi92r6ypmh58vq13vm44rl1di09assz3xdwlry86n1y1";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.15.nix
+++ b/pkgs/development/compilers/go/1.15.nix
@@ -31,11 +31,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.15.2";
+  version = "1.15.3";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "0kabkmc3759g5hpsdwh3l8p1fywibnha8c72m8f02lg2rl5rvgr8";
+    sha256 = "1228nv4vyzbqv768dl0bimsic47x9yyqld61qbgqqk75f0jn0sl9";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.15.nix
+++ b/pkgs/development/compilers/go/1.15.nix
@@ -31,11 +31,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.15.3";
+  version = "1.15.4";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "1228nv4vyzbqv768dl0bimsic47x9yyqld61qbgqqk75f0jn0sl9";
+    sha256 = "0rr3gp99bmdzg381x5fdwa15brllihn57175l0c82sqqljlscg86";
   };
 
   # perl is used for testing go vet


### PR DESCRIPTION
(cherry picked from commit 1692a8a584c6fd1f3755eeaff897d0c4916cbcd7)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Backports #103649

Go 1.14.12 and 1.15.5 contain a fix for CVE-2020-28362.

Backporting this is a prerequisite for updating vulnerable go packages, such as go-ethereum.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
