### PR TITLE
zathura: 0.4.5 -> 0.4.7

### DIFF
--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -10,11 +10,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "zathura";
-  version = "0.4.5";
+  version = "0.4.7";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
-    sha256 = "0b3nrcvykkpv2vm99kijnic2gpfzva520bsjlihaxandzfm9ff8c";
+    sha256 = "1rx1fk9s556fk59lmqgvhwrmv71ashh89bx9adjq46wq5gzdn4p0";
   };
 
   outputs = [ "bin" "man" "dev" "out" ];

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -1,28 +1,44 @@
 { stdenv, lib, meson, ninja, fetchurl, fetchpatch
-, pkgconfig, zathura_core, cairo , gtk-mac-integration, girara, mupdf }:
+, cairo
+, girara
+, gtk-mac-integration
+, gumbo
+, jbig2dec
+, libjpeg
+, mupdf
+, openjpeg_2
+, pkgconfig
+, zathura_core
+}:
 
 stdenv.mkDerivation rec {
-  version = "0.3.5";
+  version = "0.3.6";
   pname = "zathura-pdf-mupdf";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
-    sha256 = "1pjwsb7zwclxsvz229fl7y2saf1pv3ifwv3ay8viqxgrp9x3z9hq";
+    sha256 = "1r3v37k9fl2rxipvacgxr36llywvy7n20a25h3ajlyk70697sa66";
   };
-
-  patches = [
-    # compatibility with MuPDF 1.17
-    (fetchpatch {
-      url = "https://git.pwmt.org/pwmt/zathura-pdf-mupdf/-/commit/c7f341addb76d5e6fd8c24c666d8fe97c451a4cb.patch";
-      sha256 = "12rikx2j7dpngfma9x4i504w58a8xx3rc0gmyz183v19hn54c075";
-    })
-  ];
 
   nativeBuildInputs = [ meson ninja pkgconfig ];
 
   buildInputs = [
-    zathura_core girara mupdf cairo
+    cairo
+    girara
+    gumbo
+    jbig2dec
+    libjpeg
+    mupdf
+    openjpeg_2
+    zathura_core
   ] ++ lib.optional stdenv.isDarwin gtk-mac-integration;
+
+  mesonFlags = [
+    "-Dlink-external=true"
+  ];
+
+  # avoid: undefined symbol: gumbo_destroy_output
+  NIX_LDFLAGS = [ "-lgumbo" ];
 
   PKG_CONFIG_ZATHURA_PLUGINDIR= "lib/zathura";
 


### PR DESCRIPTION
###### Motivation for this change
fix https://github.com/NixOS/nixpkgs/pull/100441#issuecomment-726762347

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
