### PR TITLE
Provide libwpe for webkitgtk in Wayland

### DIFF
--- a/pkgs/development/libraries/libwpe/default.nix
+++ b/pkgs/development/libraries/libwpe/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchurl
+, meson
+, pkg-config
+, libxkbcommon
+, libGL
+, ninja
+, libX11 }:
+
+stdenv.mkDerivation rec {
+  pname = "libwpe";
+  version = "1.7.1";
+
+  src = fetchurl {
+    url = "https://wpewebkit.org/releases/${pname}-${version}.tar.xz";
+    sha256 = "0h6kh8wy2b370y705pl2vp6vp18dkdsgdxh0243ji2v51kxbg157";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    libxkbcommon
+    libGL
+    libX11
+  ];
+
+  meta = with stdenv.lib; {
+    description = "General-purpose library for WPE WebKit";
+    license = licenses.bsd2;
+    homepage = "https://wpewebkit.org";
+    maintainers = with maintainers; [ matthewbauer ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libwpe/fdo.nix
+++ b/pkgs/development/libraries/libwpe/fdo.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, fetchurl
+, meson
+, pkg-config
+, ninja
+, wayland
+, epoxy
+, glib
+, libwpe
+, libxkbcommon
+, libGL
+, libX11 }:
+
+stdenv.mkDerivation rec {
+  pname = "wpebackend-fdo";
+  version = "1.7.1";
+
+  src = fetchurl {
+    url = "https://wpewebkit.org/releases/${pname}-${version}.tar.xz";
+    sha256 = "1xf6akagvpyh0nyxkfijrx5avp6ravnivy28dhk64dsfx9rhm64v";
+  };
+
+  depsBuildBuild = [
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    meson
+    ninja
+    wayland
+  ];
+
+  buildInputs = [
+    wayland
+    epoxy
+    glib
+    libwpe
+    libxkbcommon
+    libGL
+    libX11
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Freedesktop.org backend for WPE WebKit";
+    license = licenses.bsd2;
+    homepage = "https://wpewebkit.org";
+    maintainers = with maintainers; [ matthewbauer ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -51,6 +51,8 @@
 , xdg-dbus-proxy
 , substituteAll
 , glib
+, libwpe
+, libwpe-fdo
 }:
 
 assert enableGeoLocation -> geoclue2 != null;
@@ -119,6 +121,8 @@ stdenv.mkDerivation rec {
     libsecret
     libtasn1
     libwebp
+    libwpe
+    libwpe-fdo
     libxkbcommon
     libxml2
     libxslt
@@ -153,7 +157,6 @@ stdenv.mkDerivation rec {
     "-DENABLE_INTROSPECTION=ON"
     "-DPORT=GTK"
     "-DUSE_LIBHYPHEN=OFF"
-    "-DUSE_WPE_RENDERER=OFF"
   ] ++ optionals stdenv.isDarwin [
     "-DENABLE_GRAPHICS_CONTEXT_3D=OFF"
     "-DENABLE_GTKDOC=OFF"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14608,6 +14608,8 @@ in
 
   libwpe = callPackage ../development/libraries/libwpe { };
 
+  libwpe-fdo = callPackage ../development/libraries/libwpe/fdo.nix { };
+
   libyaml = callPackage ../development/libraries/libyaml { };
 
   libyamlcpp = callPackage ../development/libraries/libyaml-cpp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14606,6 +14606,8 @@ in
 
   libixp_hg = callPackage ../development/libraries/libixp-hg { };
 
+  libwpe = callPackage ../development/libraries/libwpe { };
+
   libyaml = callPackage ../development/libraries/libyaml { };
 
   libyamlcpp = callPackage ../development/libraries/libyaml-cpp { };


### PR DESCRIPTION
When running in a Wayland environment, webkitgtk needs the libwpe backend to implement accelerated compositing on Wayland. Without this, you can get errors like:

>  Cannot get default EGL display: EGL_BAD_PARAMETER

Webkitgtk is supposed to gracefully disable AC when this happens, but this doesn't appear to be working for me. You can manually disable AC with WEBKIT_DISABLE_COMPOSITING_MODE=1.

See https://gitweb.gentoo.org/repo/gentoo.git/tree/net-libs/webkit-gtk/webkit-gtk-2.28.4.ebuild#n222 for some idea of how Gentoo handles this. In nixpkgs, I think it's a good idea to just provide libwpe everywhere, regardless of whether the user has configured "wayland" or not.

Other discussions:

- https://github.com/reflex-frp/reflex-platform/issues/691
- https://bugs.webkit.org/show_bug.cgi?id=202362
- https://discourse.nixos.org/t/install-nixos-on-laptop-im-failing-hard/6955