### PR TITLE
bluespec unstable-2020.02.09 -> unstable-2020.11.04

### DIFF
--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -4,40 +4,45 @@
 , autoconf
 , automake
 , fontconfig
-, gmp
+, gmp-static
 , gperf
 , libX11
 , libpoly
 , perl
+, flex
+, bison
 , pkgconfig
+, itktcl
+, incrtcl
+, tcl
+, tk
 , verilog
 , xorg
+, yices
 , zlib
 , ghc
 }:
 
 let
-  # yices wants a libgmp.a and fails otherwise
-  gmpStatic = gmp.override { withStatic = true; };
-
-  ghcWithPackages = ghc.withPackages (g: (with g; [old-time regex-compat syb]));
+  ghcWithPackages = ghc.withPackages (g: (with g; [old-time regex-compat syb split ]));
 in stdenv.mkDerivation rec {
   pname = "bluespec";
-  version = "unstable-2020.02.09";
+  version = "unstable-2020.11.04";
 
   src = fetchFromGitHub {
-    owner  = "B-Lang-org";
-    repo   = "bsc";
-    rev    = "05c8afb08078e437c635b9c708124b428ac51b3d";
-    sha256 = "06yhpkz7wga1a0p9031cfjqbzw7205bj2jxgdghhfzmllaiphniy";
-    fetchSubmodules = true;
-  };
+      owner  = "B-Lang-org";
+      repo   = "bsc";
+      rev    = "103357f32cf63f2ca2b16ebc8e2c675ec5562464";
+      sha256 = "sha256:1nynlnrdjgx9alr816spn3s1rvcsgcx56bqvvzklfgrh009rz95h";
+    }; 
 
   enableParallelBuilding = true;
 
-  buildInputs = [
+  patches = [ ./libstp_stub_makefile.patch ];
+
+  buildInputs = yices.buildInputs ++ [
     zlib
-    gmpStatic gperf libpoly # yices
+    tcl tk
     libX11 # tcltk
     xorg.libXft
     fontconfig
@@ -46,6 +51,8 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [
     automake autoconf
     perl
+    flex
+    bison
     pkgconfig
     ghcWithPackages
   ];
@@ -54,13 +61,13 @@ in stdenv.mkDerivation rec {
     verilog
   ];
 
-  patches = [
-    # drop stp support https://github.com/B-Lang-org/bsc/pull/31
-    (fetchpatch {
-      url = "https://github.com/flokli/bsc/commit/0bd48ecc2561541dc1368918863c0b2f4915006f.patch";
-      sha256 = "0bam9anld33zfi9d4gs502g94w49zhl5iqmbs2d1p5i19aqpy38l";
-    })
-  ];
+
+  postUnpack = ''
+    mkdir -p $sourceRoot/src/vendor/yices/v2.6/yices2
+    # XXX: only works because yices.src isn't a tarball.
+    cp -av ${yices.src}/* $sourceRoot/src/vendor/yices/v2.6/yices2
+    chmod -R +rwX $sourceRoot/src/vendor/yices/v2.6/yices2
+  '';
 
   preBuild = ''
     patchShebangs \
@@ -72,11 +79,15 @@ in stdenv.mkDerivation rec {
     substituteInPlace src/comp/Makefile \
       --replace 'BINDDIR' 'BINDIR' \
       --replace 'install-bsc install-bluetcl' 'install-bsc install-bluetcl $(UTILEXES) install-utils'
+    # allow running bsc to bootstrap
+    export LD_LIBRARY_PATH=/build/source/inst/lib/SAT
   '';
 
   makeFlags = [
+    "NO_DEPS_CHECKS=1" # skip the subrepo check (this deriviation uses yices.src instead of the subrepo)
     "NOGIT=1" # https://github.com/B-Lang-org/bsc/issues/12
     "LDCONFIG=ldconfig" # https://github.com/B-Lang-org/bsc/pull/43
+    "STP_STUB=1"
   ];
 
   installPhase = "mv inst $out";

--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -34,7 +34,7 @@ in stdenv.mkDerivation rec {
       repo   = "bsc";
       rev    = "103357f32cf63f2ca2b16ebc8e2c675ec5562464";
       sha256 = "sha256:1nynlnrdjgx9alr816spn3s1rvcsgcx56bqvvzklfgrh009rz95h";
-    }; 
+    };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/bluespec/libstp_stub_makefile.patch
+++ b/pkgs/development/compilers/bluespec/libstp_stub_makefile.patch
@@ -1,0 +1,28 @@
+diff -ru bsc-orig/src/vendor/stp/Makefile bsc-new/src/vendor/stp/Makefile
+--- bsc-orig/src/vendor/stp/Makefile	1969-12-31 16:00:01.000000000 -0800
++++ bsc-new/src/vendor/stp/Makefile	2020-11-12 17:42:40.115143035 -0800
+@@ -9,12 +9,13 @@
+ SRC = src
+ else
+ SRC = src_stub
++SNAME += lib/libstp_stub.so
+ endif
+ 
+ ifeq ($(OSTYPE), Darwin)
+-SNAME=libstp.dylib
++SNAME = lib/libstp.dylib
+ else
+-SNAME=libstp.so.1
++SNAME += lib/libstp.so.1
+ endif
+ 
+ all: install
+@@ -23,7 +24,7 @@
+ 	$(MAKE) -C $(SRC) install
+ 	ln -fsn HaskellIfc include_hs
+ 	install -m 755 -d $(PREFIX)/lib/SAT
+-	install -m 644 lib/$(SNAME) $(PREFIX)/lib/SAT
++	install -m 644 $(SNAME) $(PREFIX)/lib/SAT
+ 
+ clean:
+ 	$(MAKE) -C $(SRC) clean

--- a/pkgs/development/libraries/incrtcl/default.nix
+++ b/pkgs/development/libraries/incrtcl/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     rmdir $out/bin
     mv $out/lib/itcl${version}/* $out/lib
+    ln -s libitcl${version}${stdenv.hostPlatform.extensions.sharedLibrary} \
+      $out/lib/libitcl${stdenv.lib.versions.major version}${stdenv.hostPlatform.extensions.sharedLibrary}
     rmdir $out/lib/itcl${version}
   '';
 

--- a/pkgs/development/libraries/itktcl/default.nix
+++ b/pkgs/development/libraries/itktcl/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     rmdir $out/bin
     mv $out/lib/itk${version}/* $out/lib
+    ln -s libitk${version}${stdenv.hostPlatform.extensions.sharedLibrary} \
+      $out/lib/libitk${stdenv.lib.versions.major version}${stdenv.hostPlatform.extensions.sharedLibrary}
     rmdir $out/lib/itk${version}
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8676,7 +8676,7 @@ in
 
   binaryen = callPackage ../development/compilers/binaryen { };
 
-  bluespec = callPackage ../development/compilers/bluespec { 
+  bluespec = callPackage ../development/compilers/bluespec {
     gmp-static = gmp.override { withStatic = true; };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8676,7 +8676,9 @@ in
 
   binaryen = callPackage ../development/compilers/binaryen { };
 
-  bluespec = callPackage ../development/compilers/bluespec { };
+  bluespec = callPackage ../development/compilers/bluespec { 
+    gmp-static = gmp.override { withStatic = true; };
+  };
 
   ciao = callPackage ../development/compilers/ciao { };
 


### PR DESCRIPTION
#  Continue on with #84142 
  - (thanks @flokli).
  - a small patch to install the STP stub (upstream PR: https://github.com/B-Lang-org/bsc/pull/278)
  - set LD_LIBRARY_PATH during build so that bsc finishes bootstrapping
  - use nixpkgs yices.src instead of a subrepo
  - match yices gmp-static idiom

I ran this through https://github.com/jcumming/bsc-testsuite, and the 13 failures appear to mostly be nixos-isms.

I'm waiting on to see if upstream takes the patch, so I can drop it from this PR. 

###### Motivation for this change

Update bluespec to latest version.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] ran bsc-testsuite