### PR TITLE
gdbm: Fix multiple definitions error when building with clang

### DIFF
--- a/pkgs/development/libraries/gdbm/0001-Remove-duplicate-assignments.patch
+++ b/pkgs/development/libraries/gdbm/0001-Remove-duplicate-assignments.patch
@@ -1,0 +1,25 @@
+From 2c31a95d9e57a4308c5159c50e69b5c9178dee72 Mon Sep 17 00:00:00 2001
+From: Christian Kampka <christian@kampka.net>
+Date: Fri, 13 Nov 2020 16:52:12 +0100
+Subject: [PATCH] Remove duplicate assignments
+
+---
+ src/parseopt.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/parseopt.c b/src/parseopt.c
+index 268e080..a4c8576 100644
+--- a/src/parseopt.c
++++ b/src/parseopt.c
+@@ -255,8 +255,6 @@ print_option_descr (const char *descr, size_t lmargin, size_t rmargin)
+ }
+ 
+ char *parseopt_program_name;
+-char *parseopt_program_doc;
+-char *parseopt_program_args;
+ const char *program_bug_address = "<" PACKAGE_BUGREPORT ">";
+ void (*parseopt_help_hook) (FILE *stream);
+ 
+-- 
+2.25.4
+

--- a/pkgs/development/libraries/gdbm/default.nix
+++ b/pkgs/development/libraries/gdbm/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   doCheck = true; # not cross;
 
+  patches = [ ./0001-Remove-duplicate-assignments.patch ];
+
   # Linking static stubs on cygwin requires correct ordering.
   # Consider upstreaming this.
 


### PR DESCRIPTION
###### Motivation for this change

Building gdbm with clang fails with 
```
/nix/store/0zjjw5q49symj3s4g4axqgrq7jil1hk0-binutils-2.31.1/bin/ld: ./libgdbmapp.a(parseopt.o):/build/gdbm-1.18.1/src/parseopt.c:259: multiple definition of `parseopt_program_args'; gdbmtool.o
:/build/gdbm-1.18.1/src/gdbmtool.c:1539: first defined here                                     
/nix/store/0zjjw5q49symj3s4g4axqgrq7jil1hk0-binutils-2.31.1/bin/ld: ./libgdbmapp.a(parseopt.o):/build/gdbm-1.18.1/src/parseopt.c:258: multiple definition of `parseopt_program_doc'; gdbmtool.o:
/build/gdbm-1.18.1/src/gdbmtool.c:1538: first defined here    
```

This patch fixes that by removing the unnecessary definitions.
The patch has also been send upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
