### PR TITLE
 nixos/tests: add integration tests for terminal emulators

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -521,6 +521,7 @@ in
   telegraf = handleTest ./telegraf.nix {};
   teleport = handleTest ./teleport.nix {};
   thelounge = handleTest ./thelounge.nix {};
+  terminal-emulators = handleTest ./terminal-emulators.nix {};
   tiddlywiki = handleTest ./tiddlywiki.nix {};
   tigervnc = handleTest ./tigervnc.nix {};
   timezone = handleTest ./timezone.nix {};

--- a/nixos/tests/terminal-emulators.nix
+++ b/nixos/tests/terminal-emulators.nix
@@ -1,0 +1,206 @@
+# Terminal emulators all present a pretty similar interface.
+# That gives us an opportunity to easily test their basic functionality with a single codebase.
+#
+# There are two tests run on each terminal emulator
+# - can it successfully execute a command passed on the cmdline?
+# - can it successfully display a colour?
+# the latter is used as a proxy for "can it display text?", without going through all the intricacies of OCR.
+#
+# 256-colour terminal mode is used to display the test colour, since it has a universally-applicable palette (unlike 8- and 16- colour, where the colours are implementation-defined), and it is widely supported (unlike 24-bit colour).
+#
+# Future work:
+# - Wayland support (both for testing the existing terminals, and for testing wayland-only terminals like foot and havoc)
+# - Test keyboard input? (skipped for now, to eliminate the possibility of race conditions and focus issues)
+
+{ system ? builtins.currentSystem,
+  config ? {},
+  pkgs ? import ../.. { inherit system config; }
+}:
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+with pkgs.lib;
+
+let tests = {
+      alacritty.pkg = p: p.alacritty;
+
+      contour.pkg = p: p.contour;
+      contour.cmd = "contour $command";
+
+      cool-retro-term.pkg = p: p.cool-retro-term;
+      cool-retro-term.colourTest = false; # broken by gloss effect
+
+      ctx.pkg = p: p.ctx;
+      ctx.pinkValue = "#FE0065";
+
+      darktile.pkg = p: p.darktile;
+
+      eterm.pkg = p: p.eterm;
+      eterm.executable = "Eterm";
+      eterm.pinkValue = "#D40055";
+
+      germinal.pkg = p: p.germinal;
+
+      gnome-terminal.pkg = p: p.gnome.gnome-terminal;
+
+      guake.pkg = p: p.guake;
+      guake.cmd = "SHELL=$command guake --show";
+      guake.kill = true;
+
+      hyper.pkg = p: p.hyper;
+
+      kermit.pkg = p: p.kermit-terminal;
+
+      kgx.pkg = p: p.kgx;
+      kgx.cmd = "kgx -e $command";
+      kgx.kill = true;
+
+      kitty.pkg = p: p.kitty;
+      kitty.cmd = "kitty $command";
+
+      konsole.pkg = p: p.plasma5Packages.konsole;
+
+      lxterminal.pkg = p: p.lxterminal;
+
+      mate-terminal.pkg = p: p.mate.mate-terminal;
+      mate-terminal.cmd = "SHELL=$command mate-terminal --disable-factory"; # factory mode uses dbus, and we don't have a proper dbus session set up
+
+      mlterm.pkg = p: p.mlterm;
+
+      mrxvt.pkg = p: p.mrxvt;
+
+      qterminal.pkg = p: p.lxqt.qterminal;
+      qterminal.kill = true;
+
+      roxterm.pkg = p: p.roxterm;
+      roxterm.cmd = "roxterm -e $command";
+
+      sakura.pkg = p: p.sakura;
+
+      st.pkg = p: p.st;
+
+      stupidterm.pkg = p: p.stupidterm;
+      stupidterm.cmd = "stupidterm -- $command";
+
+      terminator.pkg = p: p.terminator;
+      terminator.cmd = "terminator -e $command";
+
+      terminology.pkg = p: p.enlightenment.terminology;
+      terminology.cmd = "SHELL=$command terminology --no-wizard=true";
+      terminology.colourTest = false; # broken by gloss effect
+
+      termite.pkg = p: p.termite;
+
+      termonad.pkg = p: p.termonad;
+
+      tilda.pkg = p: p.tilda;
+
+      tilix.pkg = p: p.tilix;
+      tilix.cmd = "tilix -e $command";
+
+      urxvt.pkg = p: p.rxvt-unicode;
+
+      wayst.pkg = p: p.wayst;
+      wayst.pinkValue = "#FF0066";
+
+      wezterm.pkg = p: p.wezterm;
+
+      xfce4-terminal.pkg = p: p.xfce.xfce4-terminal;
+
+      xterm.pkg = p: p.xterm;
+    };
+in mapAttrs (name: { pkg, executable ? name, cmd ? "SHELL=$command ${executable}", colourTest ? true, pinkValue ? "#FF0087", kill ? false }: makeTest
+{
+  name = "terminal-emulator-${name}";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ jjjollyjim ];
+  };
+
+  machine = { pkgsInner, ... }:
+
+  {
+    imports = [ ./common/x11.nix ./common/user-account.nix ];
+
+    # Hyper (and any other electron-based terminals) won't run as root
+    test-support.displayManager.auto.user = "alice";
+
+    environment.systemPackages = [
+      (pkg pkgs)
+      (pkgs.writeShellScriptBin "report-success" ''
+        echo 1 > /tmp/term-ran-successfully
+        ${optionalString kill "pkill ${executable}"}
+      '')
+      (pkgs.writeShellScriptBin "display-colour" ''
+        # A 256-colour background colour code for pink, then spaces.
+        #
+        # Background is used rather than foreground to minimize the effect of anti-aliasing.
+        #
+        # Keep adding more in case the window is partially offscreen to the left or requires
+        # a change to correctly redraw after initialising the window (as with ctx).
+
+        while :
+        do
+            echo -ne "\e[48;5;198m                   "
+            sleep 0.5
+        done
+        sleep infinity
+      '')
+      (pkgs.writeShellScriptBin "run-in-this-term" "sudo -u alice run-in-this-term-wrapped $1")
+
+      (pkgs.writeShellScriptBin "run-in-this-term-wrapped" "command=\"$(which \"$1\")\"; ${cmd}")
+    ];
+
+    # Helpful reminder to add this test to passthru.tests
+    warnings = if !((pkg pkgs) ? "passthru" && (pkg pkgs).passthru ? "tests") then [ "The package for ${name} doesn't have a passthru.tests" ] else [ ];
+  };
+
+  # We need imagemagick, though not tesseract
+  enableOCR = true;
+
+  testScript = { nodes, ... }: let
+  in ''
+    with subtest("wait for x"):
+        start_all()
+        machine.wait_for_x()
+
+    with subtest("have the terminal run a command"):
+        # We run this command synchronously, so we can be certain the exit codes are happy
+        machine.${if kill then "execute" else "succeed"}("run-in-this-term report-success")
+        machine.wait_for_file("/tmp/term-ran-successfully")
+    ${optionalString colourTest ''
+
+    import tempfile
+    import subprocess
+
+
+    def check_for_pink(final=False) -> bool:
+        with tempfile.NamedTemporaryFile() as tmpin:
+            machine.send_monitor_command("screendump {}".format(tmpin.name))
+
+            cmd = 'convert {} -define histogram:unique-colors=true -format "%c" histogram:info:'.format(
+                tmpin.name
+            )
+            ret = subprocess.run(cmd, shell=True, capture_output=True)
+            if ret.returncode != 0:
+                raise Exception(
+                    "image analysis failed with exit code {}".format(ret.returncode)
+                )
+
+            text = ret.stdout.decode("utf-8")
+            return "${pinkValue}" in text
+
+
+    with subtest("ensuring no pink is present without the terminal"):
+        assert (
+            check_for_pink() == False
+        ), "Pink was present on the screen before we even launched a terminal!"
+
+    with subtest("have the terminal display a colour"):
+        # We run this command in the background
+        machine.shell.send(b"(run-in-this-term display-colour |& systemd-cat -t terminal) &\n")
+
+        with machine.nested("Waiting for the screen to have pink on it:"):
+            retry(check_for_pink)
+  ''}'';
+}
+
+  ) tests

--- a/nixos/tests/terminal-emulators.nix
+++ b/nixos/tests/terminal-emulators.nix
@@ -77,6 +77,7 @@ let tests = {
       sakura.pkg = p: p.sakura;
 
       st.pkg = p: p.st;
+      st.kill = true;
 
       stupidterm.pkg = p: p.stupidterm;
       stupidterm.cmd = "stupidterm -- $command";

--- a/pkgs/applications/kde/konsole.nix
+++ b/pkgs/applications/kde/konsole.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib,
+  mkDerivation, lib, nixosTests,
   extra-cmake-modules, kdoctools,
   kbookmarks, kcompletion, kconfig, kconfigwidgets, kcoreaddons, kguiaddons,
   ki18n, kiconthemes, kinit, kio, knotifications,
@@ -21,6 +21,8 @@ mkDerivation {
     kguiaddons ki18n kiconthemes kinit kio knotifications knotifyconfig kparts kpty
     kservice ktextwidgets kwidgetsaddons kwindowsystem kxmlgui qtscript knewstuff
   ];
+
+  passthru.tests.test = nixosTests.terminal-emulators.konsole;
 
   propagatedUserEnvPkgs = [ (lib.getBin kinit) ];
 }

--- a/pkgs/applications/terminal-emulators/alacritty/default.nix
+++ b/pkgs/applications/terminal-emulators/alacritty/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , fetchpatch
 , rustPlatform
+, nixosTests
 
 , cmake
 , gzip
@@ -131,6 +132,8 @@ rustPlatform.buildRustPackage rec {
   '';
 
   dontPatchELF = true;
+
+  passthru.tests.test = nixosTests.terminal-emulators.alacritty;
 
   meta = with lib; {
     description = "A cross-platform, GPU-accelerated terminal emulator";

--- a/pkgs/applications/terminal-emulators/contour/default.nix
+++ b/pkgs/applications/terminal-emulators/contour/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, mkDerivation, fetchFromGitHub, cmake, pkg-config, freetype, libGL, pcre }:
+{ lib, stdenv, mkDerivation, fetchFromGitHub, cmake, pkg-config, freetype, libGL, pcre, nixosTests }:
 
 mkDerivation rec {
   pname = "contour";
@@ -15,6 +15,8 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [ freetype libGL pcre ];
+
+  passthru.tests.test = nixosTests.terminal-emulators.contour;
 
   meta = with lib; {
     description = "Modern C++ Terminal Emulator";

--- a/pkgs/applications/terminal-emulators/cool-retro-term/default.nix
+++ b/pkgs/applications/terminal-emulators/cool-retro-term/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, mkDerivation, qtbase, qtquick1, qmltermwidget
-, qtquickcontrols, qtgraphicaleffects, qmake }:
+, qtquickcontrols, qtgraphicaleffects, qmake, nixosTests }:
 
 mkDerivation rec {
   version = "1.1.1";
@@ -28,6 +28,8 @@ mkDerivation rec {
   '' + lib.optionalString stdenv.isDarwin ''
     ln -s $out/bin/cool-retro-term.app/Contents/MacOS/cool-retro-term $out/bin/cool-retro-term
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.cool-retro-term;
 
   meta = {
     description = "Terminal emulator which mimics the old cathode display";

--- a/pkgs/applications/terminal-emulators/ctx/default.nix
+++ b/pkgs/applications/terminal-emulators/ctx/default.nix
@@ -8,6 +8,7 @@
 , libdrm # Not documented
 , pkg-config
 , enableFb ? false
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -42,6 +43,8 @@ stdenv.mkDerivation rec {
   installFlags = [
     "PREFIX=${placeholder "out"}"
   ];
+
+  passthru.tests.test = nixosTests.terminal-emulators.ctx;
 
   meta = with lib; {
     homepage = "https://ctx.graphics/";

--- a/pkgs/applications/terminal-emulators/darktile/default.nix
+++ b/pkgs/applications/terminal-emulators/darktile/default.nix
@@ -12,6 +12,7 @@
 , libXext
 , libXxf86vm
 , libGL
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -56,6 +57,8 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.darktile;
 
   meta = with lib; {
     description = "A GPU rendered terminal emulator designed for tiling window managers";

--- a/pkgs/applications/terminal-emulators/eterm/default.nix
+++ b/pkgs/applications/terminal-emulators/eterm/default.nix
@@ -8,6 +8,7 @@
 , libXext
 , libast
 , pkg-config
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -32,6 +33,8 @@ stdenv.mkDerivation rec {
     libXext
     libast
   ];
+
+  passthru.tests.test = nixosTests.terminal-emulators.eterm;
 
   meta = with lib; {
     homepage = "https://github.com/mej/Eterm"; # http://www.eterm.org is gone

--- a/pkgs/applications/terminal-emulators/germinal/default.nix
+++ b/pkgs/applications/terminal-emulators/germinal/default.nix
@@ -9,6 +9,7 @@
 , tmux
 , vte
 , wrapGAppsHook
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -44,6 +45,8 @@ stdenv.mkDerivation rec {
       "''${gappsWrapperArgs[@]}"
     runHook postFixup
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.germinal;
 
   meta = with lib; {
     description = "A minimal terminal emulator";

--- a/pkgs/applications/terminal-emulators/guake/default.nix
+++ b/pkgs/applications/terminal-emulators/guake/default.nix
@@ -10,6 +10,7 @@
 , libutempter
 , vte
 , libwnck
+, nixosTests
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -65,6 +66,8 @@ python3.pkgs.buildPythonApplication rec {
   preFixup = ''
     gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libutempter ]}")
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.guake;
 
   meta = with lib; {
     description = "Drop-down terminal for GNOME";

--- a/pkgs/applications/terminal-emulators/hyper/default.nix
+++ b/pkgs/applications/terminal-emulators/hyper/default.nix
@@ -2,7 +2,7 @@
 , freetype, fontconfig, dbus, libXi, libXcursor, libXdamage, libXrandr, libXcomposite
 , libXext, libXfixes, libXrender, libX11, libXtst, libXScrnSaver, libxcb, nss, nspr
 , alsa-lib, cups, expat, udev, libpulseaudio, at-spi2-atk, at-spi2-core, libxshmfence
-, libdrm, libxkbcommon, mesa }:
+, libdrm, libxkbcommon, mesa, nixosTests}:
 
 let
   libPath = lib.makeLibraryPath [
@@ -42,6 +42,8 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/share/applications/hyper.desktop \
       --replace "/opt/Hyper/hyper" "hyper"
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.hyper;
 
   dontPatchELF = true;
   meta = with lib; {

--- a/pkgs/applications/terminal-emulators/kermit-terminal/default.nix
+++ b/pkgs/applications/terminal-emulators/kermit-terminal/default.nix
@@ -6,6 +6,7 @@
 , pcre
 , pkg-config
 , vte
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -30,6 +31,8 @@ stdenv.mkDerivation rec {
     pcre
     vte
   ];
+
+  passthru.tests.test = nixosTests.terminal-emulators.kermit;
 
   meta = with lib; {
     homepage = "https://github.com/orhun/kermit";

--- a/pkgs/applications/terminal-emulators/kgx/default.nix
+++ b/pkgs/applications/terminal-emulators/kgx/default.nix
@@ -18,6 +18,7 @@
 , python3
 , sassc
 , wrapGAppsHook
+, nixosTests
 }:
 
 stdenv.mkDerivation {
@@ -65,6 +66,8 @@ stdenv.mkDerivation {
     substituteInPlace $out/share/applications/org.gnome.zbrown.KingsCross.desktop \
       --replace "Exec=kgx" "Exec=$out/bin/kgx"
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.kgx;
 
   meta = with lib; {
     description = "Simple user-friendly terminal emulator for the GNOME desktop";

--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -22,6 +22,7 @@
 , zsh
 , fish
 , fetchpatch
+, nixosTests
 }:
 
 with python3Packages;
@@ -175,6 +176,8 @@ buildPythonApplication rec {
 
     runHook postInstall
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.kitty;
 
   meta = with lib; {
     homepage = "https://github.com/kovidgoyal/kitty";

--- a/pkgs/applications/terminal-emulators/lxterminal/default.nix
+++ b/pkgs/applications/terminal-emulators/lxterminal/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, automake, autoconf, intltool, pkg-config, gtk3, vte, wrapGAppsHook
-, libxslt, docbook_xml_dtd_412, docbook_xsl, libxml2, findXMLCatalogs
+, libxslt, docbook_xml_dtd_412, docbook_xsl, libxml2, findXMLCatalogs, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = true;
+
+  passthru.tests.test = nixosTests.terminal-emulators.lxterminal;
 
   meta = {
     description = "The standard terminal emulator of LXDE";

--- a/pkgs/applications/terminal-emulators/mlterm/default.nix
+++ b/pkgs/applications/terminal-emulators/mlterm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, pkg-config, autoconf, makeDesktopItem
+{ stdenv, lib, fetchFromGitHub, pkg-config, autoconf, makeDesktopItem, nixosTests
 , libX11, gdk-pixbuf, cairo, libXft, gtk3, vte
 , harfbuzz #substituting glyphs with opentype fonts
 , fribidi, m17n_lib #bidi and encoding
@@ -109,6 +109,8 @@ stdenv.mkDerivation rec {
     categories = [ "Application" "System" "TerminalEmulator" ];
     startupNotify = false;
   };
+
+  passthru.tests.test = nixosTests.terminal-emulators.mlterm;
 
   meta = with lib; {
     description = "Multi Lingual TERMinal emulator";

--- a/pkgs/applications/terminal-emulators/mrxvt/default.nix
+++ b/pkgs/applications/terminal-emulators/mrxvt/default.nix
@@ -10,6 +10,7 @@
 , freetype
 , pkg-config
 , which
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -37,6 +38,8 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${freetype.dev}/include/freetype2";
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.mrxvt;
 
   meta = with lib; {
     description = "Lightweight multitabbed feature-rich X11 terminal emulator";

--- a/pkgs/applications/terminal-emulators/roxterm/default.nix
+++ b/pkgs/applications/terminal-emulators/roxterm/default.nix
@@ -1,7 +1,7 @@
 { at-spi2-core, cmake, dbus, dbus-glib, docbook_xsl, libepoxy, fetchFromGitHub
 , glib, gtk3, harfbuzz, libXdmcp, libXtst, libpthreadstubs
 , libselinux, libsepol, libtasn1, libxkbcommon, libxslt, p11-kit, pcre2
-, pkg-config, lib, stdenv, util-linuxMinimal, vte, wrapGAppsHook, xmlto
+, pkg-config, lib, stdenv, util-linuxMinimal, vte, wrapGAppsHook, xmlto, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
       util-linuxMinimal glib docbook_xsl xmlto libselinux
       libsepol libxkbcommon libepoxy at-spi2-core libXtst libtasn1 p11-kit
     ];
+
+  passthru.tests.test = nixosTests.terminal-emulators.roxterm;
 
   meta = with lib; {
     homepage = "https://github.com/realh/roxterm";

--- a/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
@@ -7,6 +7,7 @@
 , gdkPixbufSupport ? true
 , unicode3Support  ? true
 , emojiSupport     ? false
+, nixosTests
 }:
 
 let
@@ -101,6 +102,8 @@ stdenv.mkDerivation {
     echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
     cp -r ${desktopItem}/share/applications/ $out/share/
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.urxvt;
 
   meta = {
     inherit description;

--- a/pkgs/applications/terminal-emulators/rxvt-unicode/wrapper.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode/wrapper.nix
@@ -5,6 +5,7 @@
 , rxvt-unicode-unwrapped
 , rxvt-unicode-plugins
 , perlPackages
+, nixosTests
 , configure ? { availablePlugins, ... }:
   { plugins = builtins.attrValues availablePlugins;
     extraDeps = [ ];
@@ -51,7 +52,10 @@ let
             --suffix-each URXVT_PERL_LIB ':' "$out/lib/urxvt/perl"
         '';
 
-        passthru.plugins = plugins;
+        passthru = {
+          plugins = plugins;
+          tests.test = nixosTests.terminal-emulators.urxvt;
+        };
       };
 
 in

--- a/pkgs/applications/terminal-emulators/sakura/default.nix
+++ b/pkgs/applications/terminal-emulators/sakura/default.nix
@@ -9,6 +9,7 @@
 , perl
 , pkg-config
 , vte
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -42,6 +43,8 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/sakura \
       --suffix XDG_DATA_DIRS : ${gtk3}/share/gsettings-schemas/${gtk3.name}/
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.sakura;
 
   meta = with lib; {
     homepage = "https://www.pleyades.net/david/projects/sakura";

--- a/pkgs/applications/terminal-emulators/st/default.nix
+++ b/pkgs/applications/terminal-emulators/st/default.nix
@@ -11,6 +11,7 @@
 , conf ? null
 , patches ? [ ]
 , extraLibs ? [ ]
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -54,6 +55,8 @@ stdenv.mkDerivation rec {
   '';
 
   installFlags = [ "PREFIX=$(out)" ];
+
+  passthru.tests.test = nixosTests.terminal-emulators.st;
 
   meta = with lib; {
     homepage = "https://st.suckless.org/";

--- a/pkgs/applications/terminal-emulators/stupidterm/default.nix
+++ b/pkgs/applications/terminal-emulators/stupidterm/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, vte, gtk, pcre2 }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, vte, gtk, pcre2, nixosTests }:
 
 stdenv.mkDerivation {
   pname = "stupidterm";
@@ -25,6 +25,8 @@ stdenv.mkDerivation {
     substituteInPlace $out/share/applications/stupidterm.desktop \
       --replace "Exec=st" "Exec=$out/bin/stupidterm"
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.stupidterm;
 
   meta = with lib; {
     description = "Simple wrapper around the VTE terminal emulator widget for GTK";

--- a/pkgs/applications/terminal-emulators/terminator/default.nix
+++ b/pkgs/applications/terminal-emulators/terminator/default.nix
@@ -9,6 +9,7 @@
 , libnotify
 , wrapGAppsHook
 , vte
+, nixosTests
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -61,6 +62,8 @@ python3.pkgs.buildPythonApplication rec {
   preFixup = ''
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.terminator;
 
   meta = with lib; {
     description = "Terminal emulator with support for tiling and tabs";

--- a/pkgs/applications/terminal-emulators/termite/default.nix
+++ b/pkgs/applications/terminal-emulators/termite/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, pkg-config, vte, gtk3, ncurses, pcre2, wrapGAppsHook }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, pkg-config, vte, gtk3, ncurses, pcre2, wrapGAppsHook, nixosTests }:
 
 let
 
@@ -57,7 +57,10 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "terminfo" ];
 
-  passthru = { inherit vte-ng; };
+  passthru = {
+    inherit vte-ng;
+    tests = nixosTests.terminal-emulators.termite;
+  };
 
   postInstall = ''
     mkdir -p $terminfo/share

--- a/pkgs/applications/terminal-emulators/termonad/default.nix
+++ b/pkgs/applications/terminal-emulators/termonad/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, haskellPackages, makeWrapper, packages ? (pkgSet: []) }:
+{ stdenv, haskellPackages, makeWrapper, packages ? (pkgSet: []), nixosTests }:
 
 let
   termonadEnv = haskellPackages.ghcWithPackages (self: [ self.termonad ] ++ packages self);
@@ -16,6 +16,8 @@ in stdenv.mkDerivation {
   # trivial derivation
   preferLocalBuild = true;
   allowSubstitutes = false;
+
+  passthru.tests.test = nixosTests.terminal-emulators.termonad;
 
   meta = haskellPackages.termonad.meta // {
     mainProgram = "termonad";

--- a/pkgs/applications/terminal-emulators/tilda/default.nix
+++ b/pkgs/applications/terminal-emulators/tilda/default.nix
@@ -9,6 +9,7 @@
 , pcre2
 , vte
 , makeWrapper
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -41,6 +42,8 @@ stdenv.mkDerivation rec {
     makeWrapper "$out/bin/wrapped/tilda" "$out/bin/tilda" \
         --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.tilda;
 
   meta = with lib; {
     description = "A Gtk based drop down terminal for Linux and Unix";

--- a/pkgs/applications/terminal-emulators/tilix/default.nix
+++ b/pkgs/applications/terminal-emulators/tilix/default.nix
@@ -17,6 +17,7 @@
 , wrapGAppsHook
 , libunwind
 , appstream
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -65,6 +66,8 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/share/applications/com.gexperts.Tilix.desktop \
       --replace "Exec=tilix" "Exec=$out/bin/tilix"
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.tilix;
 
   meta = with lib; {
     description = "Tiling terminal emulator following the Gnome Human Interface Guidelines";

--- a/pkgs/applications/terminal-emulators/wayst/default.nix
+++ b/pkgs/applications/terminal-emulators/wayst/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitHub
 , pkg-config
+, nixosTests
 , freetype
 , fontconfig
 , libGL
@@ -77,6 +78,8 @@ stdenv.mkDerivation rec {
     ln -s ${desktopItem}/share/applications/* $out/share/applications
     install -D icons/wayst.svg $out/share/icons/hicolor/scalable/apps/wayst.svg
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.wayst;
 
   meta = with lib; {
     description = "A simple terminal emulator";

--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -22,6 +22,7 @@
 , Cocoa
 , Foundation
 , libiconv
+, nixosTests
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -98,6 +99,8 @@ rustPlatform.buildRustPackage rec {
     cp -r assets/shell-integration/* "$OUT_APP"
     ln -s $out/bin/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$OUT_APP"
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.wezterm;
 
   meta = with lib; {
     description = "A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust";

--- a/pkgs/applications/terminal-emulators/xterm/default.nix
+++ b/pkgs/applications/terminal-emulators/xterm/default.nix
@@ -76,7 +76,10 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    tests = { inherit (nixosTests) xterm; };
+    tests = {
+      customTest = nixosTests.xterm;
+      standardTest = nixosTests.terminal-emulators.xterm;
+    };
 
     updateScript = let
       # Tags that end in letters are unstable

--- a/pkgs/desktops/enlightenment/terminology/default.nix
+++ b/pkgs/desktops/enlightenment/terminology/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config, python3, efl }:
+{ lib, stdenv, fetchurl, meson, ninja, pkg-config, python3, efl, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "terminology";
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs data/colorschemes/*.py
   '';
+
+  passthru.tests.test = nixosTests.terminal-emulators.terminology;
 
   meta = with lib; {
     description = "Powerful terminal emulator based on EFL";

--- a/pkgs/desktops/gnome/core/gnome-terminal/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-terminal/default.nix
@@ -23,6 +23,7 @@
 , pcre2
 , libxslt
 , docbook-xsl-nons
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -81,6 +82,8 @@ stdenv.mkDerivation rec {
       attrPath = "gnome.gnome-terminal";
     };
   };
+
+  passthru.tests.test = nixosTests.terminal-emulators.gnome-terminal;
 
   meta = with lib; {
     description = "The GNOME Terminal Emulator";

--- a/pkgs/desktops/lxqt/qterminal/default.nix
+++ b/pkgs/desktops/lxqt/qterminal/default.nix
@@ -8,6 +8,7 @@
 , qttools
 , qtx11extras
 , lxqtUpdateScript
+, nixosTests
 }:
 
 mkDerivation rec {
@@ -34,6 +35,8 @@ mkDerivation rec {
   ];
 
   passthru.updateScript = lxqtUpdateScript { inherit pname version src; };
+
+  passthru.tests.test = nixosTests.terminal-emulators.qterminal;
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/qterminal";

--- a/pkgs/desktops/mate/mate-terminal/default.nix
+++ b/pkgs/desktops/mate/mate-terminal/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, gettext, itstool, libxml2, mate-desktop, dconf, vte, pcre2, wrapGAppsHook, mateUpdateScript }:
+{ lib, stdenv, fetchurl, pkg-config, gettext, itstool, libxml2, mate-desktop, dconf, vte, pcre2, wrapGAppsHook, mateUpdateScript, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "mate-terminal";
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   passthru.updateScript = mateUpdateScript { inherit pname version; };
+
+  passthru.tests.test = nixosTests.terminal-emulators.mate-terminal;
 
   meta = with lib; {
     description = "MATE desktop terminal emulator";

--- a/pkgs/desktops/xfce/applications/xfce4-terminal/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-terminal/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkXfceDerivation, gtk3, libxfce4ui, vte, xfconf, pcre2, libxslt, docbook_xml_dtd_45, docbook_xsl }:
+{ lib, mkXfceDerivation, gtk3, libxfce4ui, vte, xfconf, pcre2, libxslt, docbook_xml_dtd_45, docbook_xsl, nixosTests }:
 
 mkXfceDerivation {
   category = "apps";
@@ -10,6 +10,8 @@ mkXfceDerivation {
   nativeBuildInputs = [ libxslt docbook_xml_dtd_45 docbook_xsl ];
 
   buildInputs = [ gtk3 libxfce4ui vte xfconf pcre2 ];
+
+  passthru.tests.test = nixosTests.terminal-emulators.xfce4-terminal;
 
   meta = with lib; {
     description = "A modern terminal emulator";

--- a/pkgs/development/libraries/vte/default.nix
+++ b/pkgs/development/libraries/vte/default.nix
@@ -22,6 +22,7 @@
 , icu
 , systemd
 , systemdSupport ? stdenv.hostPlatform.isLinux
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -90,6 +91,9 @@ stdenv.mkDerivation rec {
     updateScript = gnome.updateScript {
       packageName = pname;
       versionPolicy = "odd-unstable";
+    };
+    tests = {
+      inherit (nixosTests.terminal-emulators) gnome-terminal lxterminal mlterm roxterm sakura stupidterm terminator termite xfce4-terminal;
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

The terminal emulator is a pretty key program for a lot of (most?) desktop users, so it seems nice to have some certainty that they work before updating your system.

Terminal emulators all present a pretty similar interface, which gives us an opportunity to easily test their basic functionality with a single codebase.

My goal here was consistency -- I believe these tests should strike a good balance of thoroughness and simplicity, by not doing text input to the terminals, thereby avoiding much possibility of race conditions or focus issues.

There are two tests run on each terminal emulator
 - can it successfully execute a command passed on the cmdline?
 - can it successfully display a colour?

The latter is used as a proxy for "can it display text?", without going through all the intricacies of OCR.

256-colour terminal mode is used to display the test colour, since it has a universally-applicable palette (unlike 8- and 16- colour, where the colours are implementation-defined), and it is widely supported (unlike 24-bit colour).

I definitely don't have coverage of every terminal emulator -- I will address these in future PRs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

~~(note: termite fails to build pending #103704)~~ fixed :+1: 