### PR TITLE
ubootRockPi4: init

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -394,4 +394,11 @@ in {
     extraMeta.platforms = ["armv7l-linux"];
     filesToInstall = ["u-boot.img" "SPL"];
   };
+
+  ubootRockPi4 = buildUBoot {
+    defconfig = "rock-pi-4-rk3399_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    BL31 = "${armTrustedFirmwareRK3399}/bl31.elf";
+    filesToInstall = [ "u-boot.itb" "idbloader.img"];
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18988,6 +18988,7 @@ in
     ubootRaspberryPi3_64bit
     ubootRaspberryPiZero
     ubootRock64
+    ubootRockPi4
     ubootRockPro64
     ubootROCPCRK3399
     ubootSheevaplug


### PR DESCRIPTION
###### Motivation for this change

This adds support for the Radxa Rock Pi 4 board which is based on
RK3399. The u-boot outputs from the introduced build are suitable to
build a generic image for the Rock Pi 4 by setting the following in a
custom build of $nixpkgs/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix:

```
  sdImage.postBuildCommands = ''
    dd if=${pkgs.ubootRockPi4}/idbloader.img of=$img seek=64 conv=notrunc
    dd if=${pkgs.ubootROckPi4}/u-boot.itb of=$img seek=16384 conv=notrunc
  '';
```
cc @samueldr 

###### Things done

- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
