### PR TITLE
yq: fix path to jq

### DIFF
--- a/pkgs/development/python-modules/yq/default.nix
+++ b/pkgs/development/python-modules/yq/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, substituteAll
 , pkgs
 , argcomplete
 , pyyaml
@@ -22,6 +23,13 @@ buildPythonPackage rec {
     sha256 = "1q4rky0a6n4izmq7slb91a54g8swry1xrbfqxwc8lkd3hhvlxxkl";
   };
 
+  patches = [
+    (substituteAll {
+      src = ./jq-path.patch;
+      jq = "${lib.getBin pkgs.jq}/bin/jq";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace test/test.py --replace "expect_exit_codes={0} if sys.stdin.isatty() else {2}" "expect_exit_codes={0}"
   '';
@@ -38,7 +46,6 @@ buildPythonPackage rec {
    pytest
    coverage
    flake8
-   pkgs.jq
    toml
   ];
 

--- a/pkgs/development/python-modules/yq/jq-path.patch
+++ b/pkgs/development/python-modules/yq/jq-path.patch
@@ -1,0 +1,26 @@
+diff --git a/test/test.py b/test/test.py
+index a81f41b..9e80f04 100755
+--- a/test/test.py
++++ b/test/test.py
+@@ -112,7 +112,7 @@ class TestYq(unittest.TestCase):
+                 tf2.seek(0)
+                 self.assertEqual(self.run_yq("", ["-y", arg, tf.name, self.fd_path(tf2)]), '1\n...\n')
+ 
+-    @unittest.skipIf(subprocess.check_output(["jq", "--version"]) < b"jq-1.6", "Test options introduced in jq 1.6")
++    @unittest.skipIf(subprocess.check_output(["@jq@", "--version"]) < b"jq-1.6", "Test options introduced in jq 1.6")
+     def test_jq16_arg_passthrough(self):
+         self.assertEqual(self.run_yq("{}", ["--indentless", "-y", ".a=$ARGS.positional", "--args", "a", "b"]),
+                          "a:\n- a\n- b\n")
+diff --git a/yq/__init__.py b/yq/__init__.py
+index afeb42c..a0d7970 100755
+--- a/yq/__init__.py
++++ b/yq/__init__.py
+@@ -146,7 +146,7 @@ def yq(input_streams=None, output_stream=None, input_format="yaml", output_forma
+ 
+     try:
+         # Note: universal_newlines is just a way to induce subprocess to make stdin a text buffer and encode it for us
+-        jq = subprocess.Popen(["jq"] + list(jq_args),
++        jq = subprocess.Popen(["@jq@"] + list(jq_args),
+                               stdin=subprocess.PIPE,
+                               stdout=subprocess.PIPE if converting_output else None,
+                               universal_newlines=True)


### PR DESCRIPTION
yq requires jq at runtime, so that the package is broken without patching in the path to jq.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
