### PR TITLE
open-policy-agent: move to go modules

### DIFF
--- a/pkgs/development/tools/open-policy-agent/default.nix
+++ b/pkgs/development/tools/open-policy-agent/default.nix
@@ -22,6 +22,12 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "General-purpose policy engine";
+    longDescription = ''
+      The Open Policy Agent (OPA, pronounced "oh-pa") is an open source, general-purpose policy engine that unifies
+      policy enforcement across the stack. OPA provides a high-level declarative language that let’s you specify policy
+      as code and simple APIs to offload policy decision-making from your software. You can use OPA to enforce policies
+      in microservices, Kubernetes, CI/CD pipelines, API gateways, and more.
+    '';
     homepage = "https://www.openpolicyagent.org";
     license = licenses.asl20;
     maintainers = with maintainers; [ lewo ];

--- a/pkgs/development/tools/open-policy-agent/default.nix
+++ b/pkgs/development/tools/open-policy-agent/default.nix
@@ -1,10 +1,9 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "open-policy-agent";
   version = "0.24.0";
 
-  goPackagePath = "github.com/open-policy-agent/opa";
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "opa";
@@ -12,12 +11,14 @@ buildGoPackage rec {
     sha256 = "0fv2rq8a01hapcpgfqp71v113iyyzs5w1sam14h9clyr1vqrbcf2";
   };
 
+  vendorSha256 = null;
+
   subPackages = [ "." ];
 
-  buildFlagsArray = ''
-    -ldflags=
-      -X ${goPackagePath}/version.Version=${version}
-  '';
+  buildFlagsArray = [
+    "-ldflags="
+    "-X github.com/open-policy-agent/opa/version.Version=${version}"
+  ];
 
   meta = with lib; {
     description = "General-purpose policy engine";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Move to `buildGoModule`, use an array for `buildFlagsArray`, and add a `longDescription`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
