### PR TITLE
openocd: unstable-2020-09-02 -> unstable-2020-11-11

### DIFF
--- a/pkgs/development/tools/misc/openocd/default.nix
+++ b/pkgs/development/tools/misc/openocd/default.nix
@@ -1,18 +1,27 @@
-{ stdenv, lib, fetchgit, libftdi1, libusb1, pkgconfig, hidapi, autoreconfHook }:
+{ stdenv
+, lib
+, fetchgit
+, autoreconfHook
+, pkg-config
+, hidapi
+, libftdi1
+, libusb1
+}:
 
 stdenv.mkDerivation rec {
   pname = "openocd";
-  version = "2020-09-02";
+  version = "unstable-2020-11-11";
 
   src = fetchgit {
     url = "https://git.code.sf.net/p/openocd/code";
-    rev = "d46f28c2ea2611f5fbbc679a5eed253d3dcd2fe3";
-    sha256 = "1256qqhn3pxmijfk1x0y5b5kc5ar88ivykkvx0h1m7pdwqfs6zm9";
+    rev = "06c7a53f1fff20bcc4be9e63f83ae98664777f34";
+    sha256 = "0g0w7g94r88ylfpwswnhh8czlf5iqvd991ssn4gfcfd725lpdb01";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook ];
-  buildInputs = [ libftdi1 libusb1 hidapi ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  buildInputs = [ hidapi libftdi1 libusb1 ];
 
   configureFlags = [
     "--enable-jtag_vpi"
@@ -29,6 +38,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [
     "-Wno-error=cpp"
+    "-Wno-error=strict-prototypes" # fixes build failure with hidapi 0.10.0
   ];
 
   postInstall = lib.optionalString stdenv.isLinux ''


### PR DESCRIPTION
fix build failure with hidapi 0.10.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest HEAD + fix build failure with hidapi 0.10.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
