### PR TITLE
chicken: support darwin platform

### DIFF
--- a/pkgs/development/compilers/chicken/4/chicken.nix
+++ b/pkgs/development/compilers/chicken/4/chicken.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, bootstrap-chicken ? null }:
+{ stdenv, fetchurl, makeWrapper, darwin, bootstrap-chicken ? null }:
 
 let
   version = "4.13.0";
@@ -21,31 +21,39 @@ stdenv.mkDerivation {
     sha256 = "0hvckhi5gfny3mlva6d7y9pmx7cbwvq0r7mk11k3sdiik9hlkmdd";
   };
 
-  setupHook = lib.ifEnable (bootstrap-chicken != null) ./setup-hook.sh;
+  setupHook = lib.optional (bootstrap-chicken != null) ./setup-hook.sh;
 
-  buildFlags = [ "PLATFORM=${platform}" "PREFIX=$(out)" "VARDIR=$(out)/var/lib" ];
-  installFlags = [ "PLATFORM=${platform}" "PREFIX=$(out)" "VARDIR=$(out)/var/lib" ];
+  # -fno-strict-overflow is not a supported argument in clang on darwin
+  hardeningDisable = lib.optionals stdenv.isDarwin ["strictoverflow"];
+
+  makeFlags = [
+    "PLATFORM=${platform}" "PREFIX=$(out)"
+    "VARDIR=$(out)/var/lib"
+  ] ++ (lib.optionals stdenv.isDarwin [
+    "XCODE_TOOL_PATH=${darwin.binutils.bintools}/bin"
+    "C_COMPILER=$(CC)"
+  ]);
 
   # We need a bootstrap-chicken to regenerate the c-files after
   # applying a patch to add support for CHICKEN_REPOSITORY_EXTRA
-  patches = lib.ifEnable (bootstrap-chicken != null) [
+  patches = lib.optionals (bootstrap-chicken != null) [
     ./0001-Introduce-CHICKEN_REPOSITORY_EXTRA.patch
   ];
 
   buildInputs = [
     makeWrapper
-  ] ++ (lib.ifEnable (bootstrap-chicken != null) [
+  ] ++ (lib.optionals (bootstrap-chicken != null) [
     bootstrap-chicken
   ]);
 
-  preBuild = lib.ifEnable (bootstrap-chicken != null) ''
+  preBuild = lib.optionalString (bootstrap-chicken != null) ''
     # Backup the build* files - those are generated from hostname,
     # git-tag, etc. and we don't need/want that
     mkdir -p build-backup
     mv buildid buildbranch buildtag.h build-backup
 
     # Regenerate eval.c after the patch
-    make spotless $buildFlags
+    make spotless $makeFlags
 
     mv build-backup/* .
   '';
@@ -64,7 +72,7 @@ stdenv.mkDerivation {
     homepage = "http://www.call-cc.org/";
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ corngood ];
-    platforms = stdenv.lib.platforms.linux; # Maybe other non-darwin Unix
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin; # Maybe other Unix
     description = "A portable compiler for the Scheme programming language";
     longDescription = ''
       CHICKEN is a compiler for the Scheme programming language.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Darwin was not included as a supported platform for chicken. However, it compiled and
worked fine after bypassing unsupported platforms.

###### Things done

We make two changes to chicken's derivation. First, we add darwin as a supported
platform.

Second, we set some envvars that force the build to use nix-supplied build
tools. Chicken's Makefile for macOS hardcodes paths to gcc and other build tools
(see [here](https://code.call-cc.org/cgi-bin/gitweb.cgi?p=chicken-core.git;a=blob;f=Makefile.macosx;h=5d4d9b0aa1bb4c95e1ba7a55f9586fa86ee5034f;hb=317468e4994e6245d787400359726a9fb97d5d60#l31)). We override these envvars to use the wrapped $CC and bintools provided by 
nix to make the build pure.

Fixes https://github.com/NixOS/nixpkgs/issues/12686

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
