### PR TITLE
ghidra: 9.1.2 -> 9.2

### DIFF
--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -14,13 +14,15 @@
   };
 
 
-in stdenv.mkDerivation {
+in stdenv.mkDerivation rec {
 
-  name = "ghidra-9.1.2";
+  pname = "ghidra";
+  version = "9.2";
+  versiondate = "20201113";
 
   src = fetchzip {
-    url = "https://ghidra-sre.org/ghidra_9.1.2_PUBLIC_20200212.zip";
-    sha256 = "0j48pijypg44bw06azbrgfqjkigb13ljfdxib70sxwyqia3vkbbm";
+    url = "https://www.ghidra-sre.org/ghidra_${version}_PUBLIC_${versiondate}.zip";
+    sha256 = "0lcvmbq04qkdsf0bz509frgw79bhyxyixkqg1k712p3576ng3nby";
   };
 
   nativeBuildInputs = [
@@ -62,7 +64,7 @@ in stdenv.mkDerivation {
     homepage = "https://ghidra-sre.org/";
     platforms = [ "x86_64-linux" ];
     license = licenses.asl20;
-    maintainers = [ maintainers.ck3d ];
+    maintainers = with maintainers; [ ck3d govanify ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Version bump, also added myself as a maintainer. ~~Depends on https://github.com/NixOS/nixpkgs/pull/103461 as I added myself to the maintainers-nix in the linked PR but it will probably be merged in the next few hours. Ofborg will fail until this PR is merged.~~
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
