### PR TITLE
waypoint: init at 0.1.5

### DIFF
--- a/pkgs/applications/networking/cluster/waypoint/default.nix
+++ b/pkgs/applications/networking/cluster/waypoint/default.nix
@@ -1,0 +1,46 @@
+{ lib, buildGoModule, fetchFromGitHub, go-bindata }:
+
+buildGoModule rec {
+  pname = "waypoint";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "115cak87kpfjckqgn8ws09z1w8x8l9bch9xrm29k4r0zi71xparn";
+  };
+
+  deleteVendor = true;
+  vendorSha256 = "1xdari6841jp6lpjwydv19v3wafj17hmnwsa2b55iw6dysm4yxdr";
+
+  subPackages = ["."];
+
+  nativeBuildInputs = [ go-bindata ];
+
+  buildPhase = ''
+    CGO_ENABLED=0 go build -ldflags '-s -w -extldflags "-static"' -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
+    cd internal/assets
+    go-bindata -pkg assets -o prod.go -tags assetsembedded ./ceb
+    cd ../../
+    CGO_ENABLED=0 go build -ldflags '-s -w -X github.com/hashicorp/waypoint/version.GitDescribe=v${version}' -tags assetsembedded -o ./waypoint ./cmd/waypoint
+    CGO_ENABLED=0 go build -ldflags '-s -w' -tags assetsembedded -o ./waypoint-entrypoint ./cmd/waypoint-entrypoint
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv waypoint{,-entrypoint} $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "A tool to build, deploy, and release any application on any platform";
+    longDescription = ''
+      Waypoint allows developers to define their application build, deploy, and release lifecycle as code, reducing the
+      time to deliver deployments through a consistent and repeatable workflow.
+    '';
+    homepage = "https://waypointproject.io";
+    platforms = platforms.linux;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ winpat jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1347,6 +1347,8 @@ in
 
   wiimms-iso-tools = callPackage ../tools/filesystems/wiimms-iso-tools { };
 
+  waypoint = callPackage ../applications/networking/cluster/waypoint { };
+
   xcodeenv = callPackage ../development/mobile/xcodeenv { };
 
   ssh-agents = callPackage ../tools/networking/ssh-agents { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

Init waypoint at `0.1.5`
Based on @winpat's pr #100994
I'm happy for any of my modifications to be coppied over & delete this branch. I'll put a PR in upstream so we can probably use `make bin` as is.

Resolves the injection issue issue

![nixpkgs_waypoint](https://user-images.githubusercontent.com/9866621/99130373-0a570100-2608-11eb-9afb-979330670af5.png)

Removed the dontPatchELF stuff because none of it seems to actually be passed through by `buildGoModule` and I'm not comfortable changing it.


###### Things done

I ran the init and the build but it could do with more testing.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
