### PR TITLE
fetchMavenArtifact: support artifact classifier syntax

### DIFF
--- a/pkgs/build-support/fetchmavenartifact/default.nix
+++ b/pkgs/build-support/fetchmavenartifact/default.nix
@@ -17,6 +17,8 @@ args@
   artifactId
 , # Example: "4.3.6"
   version
+, # Example: "jdk11"
+  classifier ? null
 , # List of maven repositories from where to fetch the artifact.
   # Example: [ http://oss.sonatype.org/content/repositories/public ].
   repos ? defaultRepos
@@ -36,28 +38,19 @@ assert (repos != []) || (url != "") || (urls != []);
 
 
 let
-  classifierSplit =
-    with stdenv.lib.strings;
-      splitString "$" artifactId;
-  artifactId_ = builtins.head classifierSplit;
-  classifier =
-    with stdenv.lib;
-      if builtins.length classifierSplit > 1
-      then concatStrings ["-" (builtins.elemAt classifierSplit 1)]
-      else "";
   name_ =
     with stdenv.lib; concatStrings [
       (replaceChars ["."] ["_"] groupId) "_"
-      (replaceChars ["."] ["_"] artifactId_) "-"
+      (replaceChars ["."] ["_"] artifactId) "-"
       version
     ];
   mkJarUrl = repoUrl:
     with stdenv.lib; concatStringsSep "/" [
       (removeSuffix "/" repoUrl)
       (replaceChars ["."] ["/"] groupId)
-      artifactId_
+      artifactId
       version
-      "${artifactId_}-${version}${classifier}.jar"
+      "${artifactId}-${version}-${optionalString (!isNull classifier) "-${classifier}"}.jar"
     ];
   urls_ =
     if url != "" then [url]
@@ -65,8 +58,8 @@ let
     else map mkJarUrl repos;
   jar =
     fetchurl (
-      builtins.removeAttrs args ["groupId" "artifactId" "version" "repos" "url" ]
-        // { urls = urls_; name = "${name_}${classifier}.jar"; }
+      builtins.removeAttrs args ["groupId" "artifactId" "version" "classifier" "repos" "url" ]
+        // { urls = urls_; name = "${name_}.jar"; }
     );
 in
   stdenv.mkDerivation {
@@ -76,7 +69,7 @@ in
     # packages packages that mention this derivation in their buildInputs.
     installPhase = ''
       mkdir -p $out/share/java
-      ln -s ${jar} $out/share/java/${artifactId_}-${version}${classifier}.jar
+      ln -s ${jar} $out/share/java/${artifactId}-${version}.jar
     '';
     # We also add a `jar` attribute that can be used to easily obtain the path
     # to the downloaded jar file.


### PR DESCRIPTION
###### Motivation for this change

On several occasions, users of clj2nix have reported problems with maven artifacts which include classifiers.
Outside of POM/xml, at least in clojure (altough I failed to find much information around this topic), classifiers
are specified by artifact name with dollar and the classifier name appended.

This will solve problems for clojure users using the official clojure cli tool with deps.edn, as well as java users who wish to
specify maven artifacts with specifiers.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
