### PR TITLE
python3Packages.pytorch-metric-learning: 0.9.81 -> 0.9.94

### DIFF
--- a/pkgs/development/python-modules/pytorch-metric-learning/default.nix
+++ b/pkgs/development/python-modules/pytorch-metric-learning/default.nix
@@ -4,6 +4,7 @@
 , isPy27
 , numpy
 , scikitlearn
+, pytestCheckHook
 , pytorch
 , torchvision
 , tqdm
@@ -11,15 +12,15 @@
 
 buildPythonPackage rec {
   pname   = "pytorch-metric-learning";
-  version = "0.9.81";
+  version = "0.9.94";
 
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "KevinMusgrave";
     repo = pname;
-    rev = "cb23328aba64f7f4658374cc2920ef5d56cda5c8";  # no version tag
-    sha256 = "0c2dyi4qi7clln43481xq66f6r4fadrz84jphjc5phz97bp33ds8";
+    rev = "v${version}";
+    sha256 = "1i2m651isa6xk3zj8dhzdbmd1bdzl51bh6rxifx6gg22hfa5dj9a";
   };
 
   propagatedBuildInputs = [
@@ -28,6 +29,22 @@ buildPythonPackage rec {
     scikitlearn
     torchvision
     tqdm
+  ];
+
+  preCheck = ''
+    export HOME=$TMP
+    export TEST_DEVICE=cpu
+    export TEST_DTYPES=float32,float64  # half-precision tests fail on CPU
+  '';
+  # package only requires `unittest`, but use `pytest` to exclude tests
+  checkInputs = [ pytestCheckHook ];
+  disabledTests = [
+    # requires FAISS (not in Nixpkgs)
+    "test_accuracy_calculator_and_faiss"
+    # require network access:
+    "test_get_nearest_neighbors"
+    "test_tuplestoweights_sampler"
+    "test_untrained_indexer"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
