### PR TITLE
doc/contributing: remove label instructions

### DIFF
--- a/doc/contributing/reviewing-contributions.xml
+++ b/doc/contributing/reviewing-contributions.xml
@@ -49,18 +49,6 @@
   <itemizedlist>
    <listitem>
     <para>
-     Add labels to the pull request. (Requires commit rights)
-    </para>
-    <itemizedlist>
-     <listitem>
-      <para>
-       <literal>8.has: package (update)</literal> and any topic label that fit the updated package.
-      </para>
-     </listitem>
-    </itemizedlist>
-   </listitem>
-   <listitem>
-    <para>
      Ensure that the package versioning fits the guidelines.
     </para>
    </listitem>
@@ -188,18 +176,6 @@
   <itemizedlist>
    <listitem>
     <para>
-     Add labels to the pull request. (Requires commit rights)
-    </para>
-    <itemizedlist>
-     <listitem>
-      <para>
-       <literal>8.has: package (new)</literal> and any topic label that fit the new package.
-      </para>
-     </listitem>
-    </itemizedlist>
-   </listitem>
-   <listitem>
-    <para>
      Ensure that the package versioning is fitting the guidelines.
     </para>
    </listitem>
@@ -304,18 +280,6 @@
   <itemizedlist>
    <listitem>
     <para>
-     Add labels to the pull request. (Requires commit rights)
-    </para>
-    <itemizedlist>
-     <listitem>
-      <para>
-       <literal>8.has: module (update)</literal> and any topic label that fit the module.
-      </para>
-     </listitem>
-    </itemizedlist>
-   </listitem>
-   <listitem>
-    <para>
      Ensure that the module maintainers are notified.
     </para>
     <itemizedlist>
@@ -406,18 +370,6 @@
   </para>
 
   <itemizedlist>
-   <listitem>
-    <para>
-     Add labels to the pull request. (Requires commit rights)
-    </para>
-    <itemizedlist>
-     <listitem>
-      <para>
-       <literal>8.has: module (new)</literal> and any topic label that fit the module.
-      </para>
-     </listitem>
-    </itemizedlist>
-   </listitem>
    <listitem>
     <para>
      Ensure that the module tests, if any, are succeeding.


### PR DESCRIPTION
###### Motivation for this change
ofborg largely does this for us, now

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
