### PR TITLE
sof-firmware: 1.5.1 -> 1.6

### DIFF
--- a/pkgs/os-specific/linux/firmware/sof-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/sof-firmware/default.nix
@@ -3,24 +3,22 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "sof-firmware";
-  version = "1.5.1";
+  version = "1.6";
 
   src = fetchFromGitHub {
     owner = "thesofproject";
     repo = "sof-bin";
-    rev = "ae61d2778b0a0f47461a52da0d1f191f651e0763";
-    sha256 = "0j6bpwz49skvdvian46valjw4anwlrnkq703n0snkbngmq78prba";
+    rev = "cbdec6963b2c2d58b0080955d3c11b96ff4c92f0";
+    sha256 = "0la2pw1zpv50cywiqcfb00cxqvjc73drxwjchyzi54l508817nxh";
   };
 
   phases = [ "unpackPhase" "installPhase" ];
 
   installPhase = ''
-    mkdir -p $out/lib/firmware/intel
+    mkdir -p $out/lib/firmware
 
-    sed -i 's/ROOT=.*$/ROOT=$out/g' go.sh
-    sed -i 's/VERSION=.*$/VERSION=v${version}/g' go.sh
-
-    ./go.sh
+    patchShebangs go.sh
+    ROOT=$out SOF_VERSION=v${version} ./go.sh
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Bump to latest stable, hopefully more stable than version before. Testing it on X1 carbon gen7.

cc @zuigon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
