### PR TITLE
Separate AdobeBlank-Regular.ttf from google-fonts package, moved to google-fonts.adobeBlank

### DIFF
--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -4,6 +4,8 @@ stdenv.mkDerivation {
   pname = "google-fonts";
   version = "2019-07-14";
 
+  outputs = [ "out" "adobeBlank" ];
+
   src = fetchFromGitHub {
     owner = "google";
     repo = "fonts";
@@ -30,11 +32,7 @@ stdenv.mkDerivation {
     rm -rv ofl/comfortaa/*.ttf \
       ofl/mavenpro/*.ttf \
       ofl/muli/*.ttf \
-      ofl/oswald/*.ttf \
-
-    # This abomination of a font causes crashes with `libfontconfig',
-    # It has an absurd number of symbols
-    rm -r ofl/adobeblank/
+      ofl/oswald/*.ttf
 
     if find . -name "*.ttf" | sed 's|.*/||' | sort | uniq -c | sort -n | grep -v '^.*1 '; then
       echo "error: duplicate font names"
@@ -43,6 +41,9 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
+    adobeBlankDest=$adobeBlank/share/fonts/truetype
+    install -m 444 -Dt $adobeBlankDest ofl/adobeblank/AdobeBlank-Regular.ttf
+    rm -r ofl/adobeblank
     dest=$out/share/fonts/truetype
     find . -name '*.ttf' -exec install -m 444 -Dt $dest '{}' +
   '';

--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -30,7 +30,11 @@ stdenv.mkDerivation {
     rm -rv ofl/comfortaa/*.ttf \
       ofl/mavenpro/*.ttf \
       ofl/muli/*.ttf \
-      ofl/oswald/*.ttf
+      ofl/oswald/*.ttf \
+
+    # This abomination of a font causes crashes with `libfontconfig',
+    # It has an absurd number of symbols
+    rm -r ofl/adobeblank/
 
     if find . -name "*.ttf" | sed 's|.*/||' | sort | uniq -c | sort -n | grep -v '^.*1 '; then
       echo "error: duplicate font names"


### PR DESCRIPTION
	modified:   default.nix

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This absurdly large font causes `libfontconfig` to get trapped processing for hours. It managed to break my `emacs` and `thunderbird` packages. ( `emacs` did manage to respond after 40+ hours of me leaving it to run, `thunderbird` died immediately at startup ).

Frankly I don't know what Adobe was aiming to do with this font, but it has over 550,000 symbols, which is enough to murder `fontconfig`. Some ["ancient wisdom"](https://xkcd.com/979/) left in a log from a Google dev back in 2014 was helpful, as well as some discussions about a related issue with `fontconfig` #101813 and #73795

I tested the build by itself, as well as across my usual NixOS system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
