### PR TITLE
ocamlPackages.ppx_blob: 0.4.0 → 0.7.1

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_blob/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_blob/default.nix
@@ -2,16 +2,18 @@
 
 buildDunePackage rec {
   pname = "ppx_blob";
-  version = "0.4.0";
+  version = "0.7.1";
+
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/johnwhitington/${pname}/releases/download/${version}/ppx_blob-${version}.tbz";
-    sha256 = "1xmslk1mwdzhy1bydgsjlcb7h544c39hvxa8lywp8w72gaggjl16";
+    sha256 = "0m616ri6kmawflphiwm6j4djds27v0fjvi8xjz1fq5ydc1sq8d0l";
   };
 
-  checkInputs = lib.optional doCheck alcotest;
+  checkInputs = [ alcotest ];
   buildInputs = [ ocaml-migrate-parsetree ];
-  doCheck = lib.versionAtLeast ocaml.version "4.03";
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
 
   meta = with lib; {
     homepage = "https://github.com/johnwhitington/ppx_blob";


### PR DESCRIPTION
###### Motivation for this change

Compatibility with new syntax: https://github.com/johnwhitington/ppx_blob/blob/0.7.1/CHANGES.md

Use Dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
