### PR TITLE
pytest-testmon: skip broken tests

### DIFF
--- a/pkgs/development/python-modules/pytest-testmon/default.nix
+++ b/pkgs/development/python-modules/pytest-testmon/default.nix
@@ -24,7 +24,10 @@ buildPythonPackage rec {
   # unittest_mixins doesn't seem to be very active
   checkPhase = ''
     cd test
-    pytest test_{core,process_code,pytest_assumptions}.py
+    # test_core.py and test_process_code.py should also be tested here, but tests
+    # were broken on version 1.0.3
+    # https://github.com/tarpas/pytest-testmon/issues/158
+    pytest test_pytest_assumptions.py
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

For some reason the v1.0.3 PyPI tarball ships with tests that expect pytest-testmon master instead of the v1.0.3 code (tarpas/pytest-testmon#158), causing these tests to fail against 1.0.3 itself.

`nixpkgs-review` on unrelated PR's to staging currently fail because the tests for this package fail.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
