### PR TITLE
eduke32: 20190330 -> 20200907

### DIFF
--- a/pkgs/games/eduke32/default.nix
+++ b/pkgs/games/eduke32/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, makeWrapper, pkgconfig, nasm, makeDesktopItem
-, flac, gtk2, libvorbis, libvpx, libGLU, libGL
+, alsaLib, flac, gtk2, libvorbis, libvpx, libGLU, libGL
 , SDL2, SDL2_mixer }:
 
 let
-  version = "20190330";
-  rev = "7470";
+  version = "20200907";
+  rev = "9527";
+  revExtra = "93f62bbad";
 
   desktopItem = makeDesktopItem {
     name = "eduke32";
@@ -22,11 +23,12 @@ in stdenv.mkDerivation {
   inherit version;
 
   src = fetchurl {
-    url = "http://dukeworld.duke4.net/eduke32/synthesis/latest/eduke32_src_${version}-${rev}.tar.xz";
-    sha256 = "09a7l23i6sygicc82w1in9hjw0jvivlf7q0vw8kcx9j98lm23mkn";
+    url = "http://dukeworld.duke4.net/eduke32/synthesis/latest/eduke32_src_20200907-9257-93f62bbad.tar.xz"; # Good
+    # url = "http://dukeworld.duke4.net/eduke32/synthesis/latest/eduke32_src_${version}-${rev}-${revExtra}.tar.xz";
+    sha256 = "972630059be61ef9564a241b84ef2ee4f69fc85c19ee36ce46052ff2f1ce3bf9";
   };
 
-  buildInputs = [ flac gtk2 libvorbis libvpx libGL libGLU SDL2 SDL2_mixer ];
+  buildInputs = [ alsaLib flac gtk2 libvorbis libvpx libGL libGLU SDL2 SDL2_mixer ];
 
   nativeBuildInputs = [ makeWrapper pkgconfig ]
     ++ stdenv.lib.optional (stdenv.hostPlatform.system == "i686-linux") nasm;


### PR DESCRIPTION
Update eduke32 to latest version.  I've had to add alsaLib to
buildInputs, but I assume the system provides it at runtime, so
there's no need to make it a full runtime dependency.  To make sure,
I've tried to run the game after nix-collect-garbage, and it worked.