### PR TITLE
elisa: backporting Qt < 5.14 fix

### DIFF
--- a/pkgs/applications/kde/elisa.nix
+++ b/pkgs/applications/kde/elisa.nix
@@ -1,5 +1,6 @@
 { mkDerivation
 , fetchFromGitHub
+, fetchpatch
 , lib
 , extra-cmake-modules
 , kdoctools
@@ -20,6 +21,14 @@
 
 mkDerivation rec {
   name = "elisa";
+
+  patches = [
+    # Backporting build fix for QT < 5.14
+    (fetchpatch {
+      url = "https://invent.kde.org/multimedia/elisa/-/commit/159134b4716f07eb1d4ecbaeaae6e1c342088ef0.patch";
+      sha256 = "1ijlmmlfzwvmpkb5dnpmg552zz5y5b02spmfd7kz0z1g08cfxdhi";
+    })
+  ];
 
   buildInputs = [ libvlc ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://hydra.nixos.org/build/130350392#tabs-summary

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
