### PR TITLE
ulogd: init at 2.0.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9522,6 +9522,12 @@
     githubId = 11824817;
     name = "Marti Serra";
   };
+  xvuko = {
+    email = "nix@vuko.pl";
+    github = "xvuko";
+    githubId = 28767436;
+    name = "Jan Wiśniewski";
+  };
   xwvvvvwx = {
     email = "davidterry@posteo.de";
     github = "xwvvvvwx";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -396,6 +396,7 @@
   ./services/logging/rsyslogd.nix
   ./services/logging/syslog-ng.nix
   ./services/logging/syslogd.nix
+  ./services/logging/ulogd.nix
   ./services/mail/clamsmtp.nix
   ./services/mail/davmail.nix
   ./services/mail/dkimproxy-out.nix

--- a/nixos/modules/services/logging/ulogd.nix
+++ b/nixos/modules/services/logging/ulogd.nix
@@ -1,0 +1,48 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.ulogd;
+  settingsFormat = pkgs.formats.ini { };
+  settingsFile = settingsFormat.generate "ulogd.conf" cfg.settings;
+in {
+  options = {
+    services.ulogd = {
+      enable = mkEnableOption "ulogd";
+
+      settings = mkOption {
+        example = {
+          global.stack = "stack=log1:NFLOG,base1:BASE,pcap1:PCAP";
+          log1.group = 2;
+          pcap1 = {
+            file = "/var/log/ulogd.pcap";
+            sync = 1;
+          };
+        };
+        type = settingsFormat.type;
+        default = {};
+        description = "Configuration for ulogd. See <literal>./share/doc/ulogd/</literal> in <literal>pkgs.ulogd.doc</literal>.";
+      };
+
+      logLevel = mkOption {
+        type = types.enum [ 1 3 5 7 8 ];
+        default = 5;
+        description = "Log level (1 = debug, 3 = info, 5 = notice, 7 = error, 8 = fatal)";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.ulogd = with pkgs; {
+      description = "Ulogd Daemon";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-pre.target" ];
+      before = [ "network-pre.target" ];
+
+      serviceConfig = {
+        ExecStart = "${pkgs.ulogd}/bin/ulogd -c ${settingsFile} --verbose --loglevel ${toString cfg.logLevel}";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+      };
+    };
+  };
+}

--- a/nixos/tests/ulogd.nix
+++ b/nixos/tests/ulogd.nix
@@ -1,0 +1,75 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "ulogd";
+
+  meta = with pkgs.stdenv.lib; {
+    maintainers = with maintainers; [ xvuko ];
+  };
+
+  machine = { ... }: {
+    networking.firewall.enable = false;
+    networking.nftables.enable = true;
+    networking.nftables.ruleset = ''
+      table inet filter {
+        chain input {
+          type filter hook input priority 0;
+          log group 2 accept
+        }
+
+        chain output {
+          type filter hook output priority 0; policy accept;
+          log group 2 accept
+        }
+
+        chain forward {
+          type filter hook forward priority 0; policy drop;
+          log group 2 accept
+        }
+
+      }
+    '';
+    services.ulogd = {
+      enable = true;
+      settings = {
+        global = {
+          logfile = "/var/log/ulogd.log";
+          stack = "log1:NFLOG,base1:BASE,pcap1:PCAP";
+        };
+
+        log1.group = 2;
+
+        pcap1 = {
+          file = "/var/log/ulogd.pcap";
+          sync = 1;
+        };
+      };
+    };
+
+    environment.systemPackages = with pkgs; [
+      tcpdump
+    ];
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("ulogd.service")
+    machine.wait_for_unit("network-online.target")
+
+    with subtest("Ulogd is running"):
+        machine.succeed("pgrep ulogd >&2")
+
+    with subtest("Logs are collected"):
+        machine.succeed("ping -f localhost -c 5 >&2")
+        machine.wait_until_succeeds("du /var/log/ulogd.pcap >&2")
+        _, packets = machine.execute("tcpdump -r /var/log/ulogd.pcap")
+        assert len(packets.splitlines()) > 10
+        print(packets)
+
+    with subtest("Reloading service reopens log file"):
+        machine.succeed("mv /var/log/ulogd.pcap /var/log/old_ulogd.pcap")
+        machine.succeed("systemctl reload ulogd.service")
+        machine.succeed("ping -f localhost -c 5 >&2")
+        _, packets = machine.execute("tcpdump -r /var/log/ulogd.pcap")
+        assert len(packets.splitlines()) > 10
+        print(packets)
+  '';
+})

--- a/pkgs/os-specific/linux/ulogd/default.nix
+++ b/pkgs/os-specific/linux/ulogd/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchurl, gnumake, libnetfilter_acct, libnetfilter_conntrack,
+libnetfilter_log, libmnl, libnfnetlink, automake, autoconf, autogen, libtool,
+pkg-config, libpcap, linuxdoc-tools, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  version = "2.0.7";
+  pname = "ulogd";
+
+  src = fetchurl {
+    url = "https://netfilter.org/projects/${pname}/files/${pname}-${version}.tar.bz2";
+    sha256 = "0ax9959c4bapq78n13bbaibcf1gwjir3ngx8l2dh45lw9m4ha2lr";
+  };
+
+  outputs = [ "out" "doc" "man"];
+
+  prePath = ''
+    substituteInPlace ulogd.8 --replace "/usr/share/doc" "$doc/share/doc"
+  '';
+
+  postBuild = ''
+    pushd doc/
+    linuxdoc --backend=txt --filter ulogd.sgml
+    linuxdoc --backend=html --split=0 ulogd.sgml
+    popd
+  '';
+
+  postInstall = ''
+    install -Dm444 -t $out/share/doc/${pname} ulogd.conf doc/ulogd.txt doc/ulogd.html README doc/*table
+    install -Dm444 -t $out/share/doc/${pname}-mysql doc/mysql*.sql
+    install -Dm444 -t $out/share/doc/${pname}-pgsql doc/pgsql*.sql
+  '';
+
+  buildInputs = [
+    libnetfilter_acct libnetfilter_conntrack libnetfilter_log libmnl
+    libnfnetlink libpcap
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook gnumake pkg-config automake autoconf autogen libtool
+    linuxdoc-tools
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Userspace logging daemon for netfilter/iptables";
+
+    longDescription =
+    '' Logging daemon that reads event messages coming from the Netfilter
+       connection tracking, the Netfilter packet logging subsystem and from the
+       Netfilter accounting subsystem. You have to enable support for connection
+       tracking event delivery; ctnetlink and the NFLOG target in your Linux
+       kernel 2.6.x or load their respective modules. The deprecated ULOG target
+       (which has been superseded by NFLOG) is also supported.
+
+       The received messages can be logged into files or into a mySQL, sqlite3
+       or PostgreSQL database. IPFIX and Graphite output are also supported.
+    '';
+
+    homepage = "https://www.netfilter.org/projects/ulogd/index.html";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ xvuko ];
+  };
+}

--- a/pkgs/tools/text/sgml/linuxdoc-tools/default.nix
+++ b/pkgs/tools/text/sgml/linuxdoc-tools/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, lib, makeWrapper, fetchFromGitLab, openjade, gnumake, perl, flex,
+gnused, coreutils, which, opensp, groff, texlive, texinfo, withLatex ? false }:
+
+stdenv.mkDerivation rec {
+  version = "0.9.82";
+  pname = "linuxdoc-tools";
+
+  src = fetchFromGitLab {
+    rev = version;
+    owner = "agmartin";
+    repo = "linuxdoc-tools";
+    sha256 = "17v9ilh79av4n94vk4m52aq57ykb9myffxd2qr8kb8b3xnq5d36z";
+  };
+
+  outputs = [ "out" "man" "doc" ];
+
+  configureFlagsArray = [
+    ("--enable-docs=txt info lyx html rtf" + lib.optionalString withLatex " pdf")
+  ];
+
+  LEX="flex";
+
+  postInstall = ''
+    wrapProgram $out/bin/linuxdoc \
+      --prefix PATH : "${stdenv.lib.makeBinPath buildInputs}:$out/bin" \
+      --prefix PERL5LIB : "$out/share/linuxdoc-tools/"
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    pushd doc/example
+    substituteInPlace Makefile \
+      --replace "COMMAND=linuxdoc" "COMMAND=$out/bin/linuxdoc" \
+      ${ lib.optionalString (!withLatex) "--replace '.tex .dvi .ps .pdf' ''"}
+    make
+    popd
+  '';
+
+  nativeBuildInputs = [ gnumake flex which makeWrapper ];
+
+  buildInputs = [ opensp groff texinfo perl gnused coreutils]
+    ++ lib.optionals withLatex [ texlive.combined.scheme-medium ];
+
+  meta = with stdenv.lib; {
+    description = "Toolset for processing LinuxDoc DTD SGML files";
+
+    longDescription =
+    ''A collection of text formatters which understands a LinuxDoc DTD SGML
+      source file. Each formatter (or "back-end") renders the source file into
+      a variety of output formats, including HTML, TeX, DVI, PostScript, plain
+      text, and groff source in manual-page format. The linuxdoc suite is
+      provided for backward compatibility, because there are still many useful
+      documents written in LinuxDoc DTD sgml source.
+    '';
+
+    homepage = "https://gitlab.com/agmartin/linuxdoc-tools";
+    license = licenses.gpl3Plus; # and some more permisive licenses
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ xvuko ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8179,6 +8179,8 @@ in
     inherit (chickenPackages_4) eggDerivation fetchegg;
   };
 
+  ulogd = callPackage ../os-specific/linux/ulogd { };
+
   unar = callPackage ../tools/archivers/unar { stdenv = clangStdenv; };
 
   unp = callPackage ../tools/archivers/unp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2318,6 +2318,8 @@ in
 
   linuxptp = callPackage ../os-specific/linux/linuxptp { };
 
+  linuxdoc-tools = callPackage ../tools/text/sgml/linuxdoc-tools { };
+
   lite = callPackage ../applications/editors/lite { };
 
   loadwatch = callPackage ../tools/system/loadwatch { };


### PR DESCRIPTION
###### Motivation for this change
> ulogd is a userspace logging daemon for netfilter/iptables related logging. This includes per-packet logging of security violations, per-packet logging for accounting, per-flow logging and flexible user-defined accounting. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
