### PR TITLE
cmark-gfm: init at 0.29.0.gfm.0

### DIFF
--- a/pkgs/development/libraries/cmark-gfm/default.nix
+++ b/pkgs/development/libraries/cmark-gfm/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake }:
+stdenv.mkDerivation rec {
+  pname = "cmark-gfm";
+  version = "0.29.0.gfm.0";
+
+  src = fetchFromGitHub {
+    owner = "github";
+    repo = "cmark-gfm";
+    rev = version;
+    sha256 = "0wfr3xwl4wria8vld71flv6vpsdj9aj81yqvj0azidyb8p229a1l";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  # tests load the library dynamically which for unknown reason failed
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "GitHub's fork of cmark, a CommonMark parsing and rendering library and program in C";
+    homepage = "https://github.com/github/cmark-gfm";
+    maintainers = with maintainers; [ cyplo ];
+    platforms = platforms.unix;
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -182,6 +182,8 @@ in
 
   cmark = callPackage ../development/libraries/cmark { };
 
+  cmark-gfm = callPackage ../development/libraries/cmark-gfm { };
+
   cm256cc = callPackage ../development/libraries/cm256cc {  };
 
   conftest = callPackage ../development/tools/conftest { };


### PR DESCRIPTION
It seems to be working when included as a library in other programs, tested with new version of `mindforger` locally.
I also tested the binary locally, parsed some simple markdown and got html back.

I had hard time enabling unit tests as they seem to be loading the library dynamically.
Would probably like to issue a second PR later when I figure out how to run them, but imho the inclusion of the library, even without the tests provides some benefit already.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I wanted to update `mindforger` and the new version requires `cmark-gfm`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

