### PR TITLE
vendor-reset: init at unstable-2021-02-16

### DIFF
--- a/pkgs/os-specific/linux/vendor-reset/default.nix
+++ b/pkgs/os-specific/linux/vendor-reset/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, kernel, lib }:
+
+stdenv.mkDerivation rec {
+  name = "vendor-reset-${version}-${kernel.version}";
+  version = "unstable-2021-02-16";
+
+  src = fetchFromGitHub {
+    owner = "gnif";
+    repo = "vendor-reset";
+    rev = "225a49a40941e350899e456366265cf82b87ad25";
+    sha256 = "sha256-xa7P7+mRk4FVgi+YYCcsFLfyNqPmXvy3xhGoTDVqPxw=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  hardeningDisable = [ "pic" ];
+
+  makeFlags = [
+    "KVER=${kernel.modDirVersion}"
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    install -D vendor-reset.ko -t "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/misc/"
+  '';
+
+  meta = with lib; {
+    description = "Linux kernel vendor specific hardware reset module";
+    homepage = "https://github.com/gnif/vendor-reset";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ wedens ];
+    platforms = [ "x86_64-linux" ];
+    broken = kernel.kernelOlder "4.19";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19639,6 +19639,8 @@ in
 
     v86d = callPackage ../os-specific/linux/v86d { };
 
+    vendor-reset = callPackage ../os-specific/linux/vendor-reset { };
+
     vhba = callPackage ../misc/emulators/cdemu/vhba.nix { };
 
     virtualbox = callPackage ../os-specific/linux/virtualbox {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

> The goal of this project is to provide a kernel module that is capable of resetting hardware devices into a state where they can be re-initialized or passed through into a virtual machine (VFIO). While it would be great to have these in the kernel as PCI quirks, some of the reset procedures are very complex and would never be accepted as a quirk (ie AMD Vega 10).

> By providing this as an out of tree kernel module, vendors will be able to easily create pull requests to add functionality to this module, and users will be able to easily update this module without requiring a complete kernel rebuild.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
