### PR TITLE
pythonPackages.fonttools: 4.14.0 → 4.18.2

### DIFF
--- a/pkgs/development/python-modules/fonttools/default.nix
+++ b/pkgs/development/python-modules/fonttools/default.nix
@@ -12,6 +12,7 @@
 , sympy
 , matplotlib
 , reportlab
+, sphinx
 , pytest
 , pytest-randomly
 , glibcLocales
@@ -19,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "fonttools";
-  version = "4.14.0";
+  version = "4.18.2";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner  = pname;
     repo   = pname;
     rev    = version;
-    sha256 = "0aiaxjg2v2391gxnhp4nvmgfb3ygm6x7n080s5mnkfjq2bq319in";
+    sha256 = "0h750gvwpsp7fpmgfwkx93gkaf0m1s698g6r7n4xlaji563nlkiv";
   };
 
   # all dependencies are optional, but
@@ -53,6 +54,7 @@ buildPythonPackage rec {
     matplotlib
     # pens
     reportlab
+    sphinx
   ];
 
   preCheck = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* <https://github.com/fonttools/fonttools/releases/tag/4.18.2>
* <https://github.com/fonttools/fonttools/releases/tag/4.18.1>
* <https://github.com/fonttools/fonttools/releases/tag/4.18.0>
* <https://github.com/fonttools/fonttools/releases/tag/4.17.1>
* <https://github.com/fonttools/fonttools/releases/tag/4.17.0>
* <https://github.com/fonttools/fonttools/releases/tag/4.16.1>
* <https://github.com/fonttools/fonttools/releases/tag/4.16.0>
* <https://github.com/fonttools/fonttools/releases/tag/4.15.0>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
