### PR TITLE
terraform-providers: build automated providers with Go module

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -136,14 +136,6 @@ let
       '';
     });
 
-    # https://github.com/hashicorp/terraform-provider-tls/pull/71
-    tls = automated-providers.tls.overrideAttrs (attrs: {
-      prePatch = attrs.prePatch or "" + ''
-        substituteInPlace go.mod --replace terraform-providers/terraform-provider-tls hashicorp/terraform-provider-tls
-        substituteInPlace main.go --replace terraform-providers/terraform-provider-tls hashicorp/terraform-provider-tls
-      '';
-    });
-
     # Packages that don't fit the default model
     ansible = callPackage ./ansible {};
     cloudfoundry = callPackage ./cloudfoundry {};

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -76,7 +76,6 @@ let
     # Override providers that use Go modules + vendor/ folder
     google = patchGoModVendor automated-providers.google;
     google-beta = patchGoModVendor automated-providers.google-beta;
-    ibm = patchGoModVendor automated-providers.ibm;
 
     acme = automated-providers.acme.overrideAttrs (attrs: {
       prePatch = attrs.prePatch or "" + ''

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -136,14 +136,6 @@ let
       '';
     });
 
-    # https://github.com/hashicorp/terraform-provider-random/pull/107
-    random = automated-providers.random.overrideAttrs (attrs: {
-      prePatch = attrs.prePatch or "" + ''
-        substituteInPlace go.mod --replace terraform-providers/terraform-provider-random hashicorp/terraform-provider-random
-        substituteInPlace main.go --replace terraform-providers/terraform-provider-random hashicorp/terraform-provider-random
-      '';
-    });
-
     # https://github.com/hashicorp/terraform-provider-template/pull/79
     template = automated-providers.template.overrideAttrs (attrs: {
       prePatch = attrs.prePatch or "" + ''

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -85,17 +85,6 @@ let
       '';
     });
 
-    # providers that were moved to the `hashicorp` organization,
-    # but haven't updated their references yet:
-
-    # https://github.com/hashicorp/terraform-provider-helm/pull/522
-    helm = automated-providers.helm.overrideAttrs (attrs: {
-      prePatch = attrs.prePatch or "" + ''
-        substituteInPlace go.mod --replace terraform-providers/terraform-provider-helm hashicorp/terraform-provider-helm
-        substituteInPlace main.go --replace terraform-providers/terraform-provider-helm hashicorp/terraform-provider-helm
-      '';
-    });
-
     # Packages that don't fit the default model
     ansible = callPackage ./ansible {};
     cloudfoundry = callPackage ./cloudfoundry {};

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -88,14 +88,6 @@ let
     # providers that were moved to the `hashicorp` organization,
     # but haven't updated their references yet:
 
-    # https://github.com/hashicorp/terraform-provider-external/pull/41
-    external = automated-providers.external.overrideAttrs (attrs: {
-      prePatch = attrs.prePatch or "" + ''
-        substituteInPlace go.mod --replace terraform-providers/terraform-provider-external hashicorp/terraform-provider-external
-        substituteInPlace main.go --replace terraform-providers/terraform-provider-external hashicorp/terraform-provider-external
-      '';
-    });
-
     # https://github.com/hashicorp/terraform-provider-helm/pull/522
     helm = automated-providers.helm.overrideAttrs (attrs: {
       prePatch = attrs.prePatch or "" + ''

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -128,14 +128,6 @@ let
       '';
     });
 
-    # https://github.com/hashicorp/terraform-provider-template/pull/79
-    template = automated-providers.template.overrideAttrs (attrs: {
-      prePatch = attrs.prePatch or "" + ''
-        substituteInPlace go.mod --replace terraform-providers/terraform-provider-template hashicorp/terraform-provider-template
-        substituteInPlace main.go --replace terraform-providers/terraform-provider-template hashicorp/terraform-provider-template
-      '';
-    });
-
     # Packages that don't fit the default model
     ansible = callPackage ./ansible {};
     cloudfoundry = callPackage ./cloudfoundry {};

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -120,14 +120,6 @@ let
       '';
     });
 
-    # https://github.com/hashicorp/terraform-provider-local/pull/40
-    local = automated-providers.local.overrideAttrs (attrs: {
-      prePatch = attrs.prePatch or "" + ''
-        substituteInPlace go.mod --replace terraform-providers/terraform-provider-local hashicorp/terraform-provider-local
-        substituteInPlace main.go --replace terraform-providers/terraform-provider-local hashicorp/terraform-provider-local
-      '';
-    });
-
     # Packages that don't fit the default model
     ansible = callPackage ./ansible {};
     cloudfoundry = callPackage ./cloudfoundry {};

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -88,14 +88,6 @@ let
     # providers that were moved to the `hashicorp` organization,
     # but haven't updated their references yet:
 
-    # https://github.com/hashicorp/terraform-provider-archive/pull/67
-    archive = automated-providers.archive.overrideAttrs (attrs: {
-      prePatch = attrs.prePatch or "" + ''
-        substituteInPlace go.mod --replace terraform-providers/terraform-provider-archive hashicorp/terraform-provider-archive
-        substituteInPlace main.go --replace terraform-providers/terraform-provider-archive hashicorp/terraform-provider-archive
-      '';
-    });
-
     # https://github.com/hashicorp/terraform-provider-external/pull/41
     external = automated-providers.external.overrideAttrs (attrs: {
       prePatch = attrs.prePatch or "" + ''

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -96,14 +96,6 @@ let
       '';
     });
 
-    # https://github.com/hashicorp/terraform-provider-dns/pull/101
-    dns = automated-providers.dns.overrideAttrs (attrs: {
-      prePatch = attrs.prePatch or "" + ''
-        substituteInPlace go.mod --replace terraform-providers/terraform-provider-dns hashicorp/terraform-provider-dns
-        substituteInPlace main.go --replace terraform-providers/terraform-provider-dns hashicorp/terraform-provider-dns
-      '';
-    });
-
     # https://github.com/hashicorp/terraform-provider-external/pull/41
     external = automated-providers.external.overrideAttrs (attrs: {
       prePatch = attrs.prePatch or "" + ''

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -74,7 +74,6 @@ let
   # These are the providers that don't fall in line with the default model
   special-providers = {
     # Override providers that use Go modules + vendor/ folder
-    google = patchGoModVendor automated-providers.google;
     google-beta = patchGoModVendor automated-providers.google-beta;
 
     acme = automated-providers.acme.overrideAttrs (attrs: {

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -112,14 +112,6 @@ let
       '';
     });
 
-    # https://github.com/hashicorp/terraform-provider-http/pull/40
-    http = automated-providers.http.overrideAttrs (attrs: {
-      prePatch = attrs.prePatch or "" + ''
-        substituteInPlace go.mod --replace terraform-providers/terraform-provider-http hashicorp/terraform-provider-http
-        substituteInPlace main.go --replace terraform-providers/terraform-provider-http hashicorp/terraform-provider-http
-      '';
-    });
-
     # Packages that don't fit the default model
     ansible = callPackage ./ansible {};
     cloudfoundry = callPackage ./cloudfoundry {};

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -128,14 +128,6 @@ let
       '';
     });
 
-    # https://github.com/hashicorp/terraform-provider-null/pull/43
-    null = automated-providers.null.overrideAttrs (attrs: {
-      prePatch = attrs.prePatch or "" + ''
-        substituteInPlace go.mod --replace terraform-providers/terraform-provider-null hashicorp/terraform-provider-null
-        substituteInPlace main.go --replace terraform-providers/terraform-provider-null hashicorp/terraform-provider-null
-      '';
-    });
-
     # https://github.com/hashicorp/terraform-provider-template/pull/79
     template = automated-providers.template.overrideAttrs (attrs: {
       prePatch = attrs.prePatch or "" + ''

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -346,11 +346,13 @@
     "version": "2.9.0"
   },
   "google": {
-    "owner": "terraform-providers",
+    "owner": "hashicorp",
+    "provider-source-address": "registry.terraform.io/hashicorp/google",
     "repo": "terraform-provider-google",
-    "rev": "v3.18.0",
-    "sha256": "18cxl1qw1wyvzvhgjm1s3c19hbi5z9s6mipgazhrac70myw8dmy7",
-    "version": "3.18.0"
+    "rev": "v3.47.0",
+    "sha256": "05xb0q56y9088qbyaf3vzjm9im1s2azxffhjffjpzi0i79k0g2p0",
+    "vendorSha256": "1h83p7ncv7b4ci7qdig7hb81zk9458fq9aqqbkryawf1w7wbaq2a",
+    "version": "3.47.0"
   },
   "google-beta": {
     "owner": "terraform-providers",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -908,6 +908,7 @@
     "repo": "terraform-provider-template",
     "rev": "v2.2.0",
     "sha256": "12pn1i06jz4xl50md94yfdggg3pg5bv1viwf35izizm5rnyksyv2",
+    "vendorSha256": null,
     "version": "2.2.0"
   },
   "tencentcloud": {

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -616,6 +616,7 @@
     "repo": "terraform-provider-null",
     "rev": "v3.0.0",
     "sha256": "0r1kvsc96922i85hdvf1pk8aicxjr6bc69gc63qi21hrl0jpvr7r",
+    "vendorSha256": null,
     "version": "3.0.0"
   },
   "nutanix": {

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -235,11 +235,13 @@
     "version": "2.7.0"
   },
   "digitalocean": {
-    "owner": "terraform-providers",
+    "owner": "digitalocean",
+    "provider-source-address": "registry.terraform.io/digitalocean/digitalocean",
     "repo": "terraform-provider-digitalocean",
-    "rev": "v1.19.0",
-    "sha256": "0plfkwkfb19f7bzky4jfa2kmkqvbah02c6j6applsd3jyiawpbgy",
-    "version": "1.19.0"
+    "rev": "v2.2.0",
+    "sha256": "14v9sh2qqdflzzp5mvkr7hd5c21hch8b8shxiwm0ar4qgdxq3wfy",
+    "vendorSha256": null,
+    "version": "2.2.0"
   },
   "dme": {
     "owner": "terraform-providers",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -786,6 +786,7 @@
     "repo": "terraform-provider-random",
     "rev": "v3.0.0",
     "sha256": "00dkpcri9ckp0kxwgh3p8175cyd44m8z13cb013pm4mrr61n4wq9",
+    "vendorSha256": null,
     "version": "3.0.0"
   },
   "rightscale": {

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -355,11 +355,13 @@
     "version": "3.47.0"
   },
   "google-beta": {
-    "owner": "terraform-providers",
+    "owner": "hashicorp",
+    "provider-source-address": "registry.terraform.io/hashicorp/google-beta",
     "repo": "terraform-provider-google-beta",
-    "rev": "v3.18.0",
-    "sha256": "1rsaqrgr6ddgx1pala83y70dk32s0mvf6vi877awmimxjzsa1l4r",
-    "version": "3.18.0"
+    "rev": "v3.47.0",
+    "sha256": "1nk0bg2q7dg65rn3j5pkdjv07x0gs7bkv1bpfvlhi9p4fzx9g4by",
+    "vendorSha256": "0c2q4d2khsi3v9b659q1kmncnlshv4px6ch99jpcymwqg3xrxda2",
+    "version": "3.47.0"
   },
   "grafana": {
     "owner": "terraform-providers",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -251,9 +251,10 @@
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/dns",
     "repo": "terraform-provider-dns",
-    "rev": "v2.2.0",
-    "sha256": "11xdxj6hfclaq9glbh14nihmrsk220crm9ld8bdv77w0bppmrrch",
-    "version": "2.2.0"
+    "rev": "v3.0.0",
+    "sha256": "160dbmg7xg7iyc70f66dphyiysrdbscwya2n28idi8wp5rjx8bid",
+    "vendorSha256": null,
+    "version": "3.0.0"
   },
   "dnsimple": {
     "owner": "terraform-providers",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -395,9 +395,10 @@
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/http",
     "repo": "terraform-provider-http",
-    "rev": "v1.2.0",
-    "sha256": "0q8ichbqrq62q1j0rc7sdz1jzfwg2l9v4ac9jqf6y485dblhmwqd",
-    "version": "1.2.0"
+    "rev": "v2.0.0",
+    "sha256": "0x6a9qf819g16dj9inyvhwff67xy0ixyy70ck56lkidrldara444",
+    "vendorSha256": null,
+    "version": "2.0.0"
   },
   "huaweicloud": {
     "owner": "terraform-providers",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -382,9 +382,10 @@
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/helm",
     "repo": "terraform-provider-helm",
-    "rev": "v1.2.2",
-    "sha256": "1hjlf0pzc9jkcvqi52kvqwmd8v0cvnhhcbahzxmv0zkdwh310c12",
-    "version": "1.2.2"
+    "rev": "v1.3.2",
+    "sha256": "0mpbf03483jqrwd9cx4pdn2pcv4swfs5nbp021gaqr0jf1w970x6",
+    "vendorSha256": null,
+    "version": "1.3.2"
   },
   "heroku": {
     "owner": "terraform-providers",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -35,6 +35,7 @@
     "repo": "terraform-provider-archive",
     "rev": "v2.0.0",
     "sha256": "1d5n379zyjp2srg43g78a8h33qwcpkfkj7c35idvbyydi35vzlpl",
+    "vendorSha256": null,
     "version": "2.0.0"
   },
   "arukas": {

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -945,6 +945,7 @@
     "repo": "terraform-provider-tls",
     "rev": "v3.0.0",
     "sha256": "1p9d5wrr4xwf2i930zlcarm1zl8ysj3nyc6rrbhpxk04kr6ap0wz",
+    "vendorSha256": null,
     "version": "3.0.0"
   },
   "triton": {

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -298,6 +298,7 @@
     "repo": "terraform-provider-external",
     "rev": "v2.0.0",
     "sha256": "16wciz08gicicsirij2ql0gy8dg0372jjsqmaigkl2n07mqz2b6a",
+    "vendorSha256": null,
     "version": "2.0.0"
   },
   "fastly": {

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -66,12 +66,13 @@
     "version": "2.14.1"
   },
   "aws": {
-    "owner": "terraform-providers",
+    "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/aws",
     "repo": "terraform-provider-aws",
-    "rev": "v2.65.0",
-    "sha256": "005vs1qd6payicxldc9lr4w6kzr58xw9b930j52g1q7hlddl5mbb",
-    "version": "2.65.0"
+    "rev": "v3.15.0",
+    "sha256": "0rxpdxg5p478sipbhq2x347gs5wrlwz4ggy9z007cbp34yhb2wka",
+    "vendorSha256": "0vapfnd4c8jb15pdjnnb97vgsvfakjvl1czccbfy0znhdk2ynz02",
+    "version": "3.15.0"
   },
   "azuread": {
     "owner": "terraform-providers",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -510,6 +510,7 @@
     "repo": "terraform-provider-local",
     "rev": "v2.0.0",
     "sha256": "0c1mk63lh3qmj8pl80lyvvsgyg4gg7673abr8cfxrj45635h74z5",
+    "vendorSha256": null,
     "version": "2.0.0"
   },
   "logentries": {

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -419,10 +419,12 @@
   },
   "ibm": {
     "owner": "IBM-Cloud",
+    "provider-source-address": "registry.terraform.io/IBM-Cloud/ibm",
     "repo": "terraform-provider-ibm",
-    "rev": "v1.7.0",
-    "sha256": "1kb2dxdygvph65hh7qiba9kl9k5aygxxvx3x1qi28jwny594j82a",
-    "version": "1.7.0"
+    "rev": "v1.14.0",
+    "sha256": "1r3y7r0mnbzd7xk6d5f7pvysl3p8vl5i5phya89dfwrk2x9xyw21",
+    "vendorSha256": null,
+    "version": "1.14.0"
   },
   "icinga2": {
     "owner": "terraform-providers",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

With more providers adopting Go module, nixpkgs needs to follow suit. This work adds a `vendorSha256` key to providers that use Go module. When the key is present the provider will be built with Go module, else with Go package.

The `update-provider` script has been updated to handle `vendorSha256` and will be made available in a subsequent PR.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
