### PR TITLE
augustus: 1.4.1a -> 2.0.1

### DIFF
--- a/pkgs/games/augustus/default.nix
+++ b/pkgs/games/augustus/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "augustus";
-  version = "1.4.1a";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "Keriew";
     repo = "augustus";
     rev = "v${version}";
-    sha256 = "1xqv8j8jh3f13fjhyf7hk1anrn799cwwsvsd75kpl9n5yh5s1j5y";
+    sha256 = "0czazw8mc3fbvdazs2nzvgxd1dpzjc8z5fwiv89vv4nd7laz3jkj";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -17,8 +17,9 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "An open source re-implementation of Caesar III. Fork of Julius incorporating gameplay changes";
     homepage = "https://github.com/Keriew/augustus";
-    license = licenses.agpl3;
+    license = licenses.agpl3Only;
     platforms = platforms.all;
+    broken = stdenv.isDarwin;
     maintainers = with maintainers; [ Thra11 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Version update.

Almost certainly broken on darwin in the same way as #102263 (needs a program called sips to do something icon related). Not a new failure. Would be nice to fix it if possible, but could be a separate PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
