### PR TITLE
batik: 1.6 -> 1.13

### DIFF
--- a/pkgs/applications/graphics/batik/builder.sh
+++ b/pkgs/applications/graphics/batik/builder.sh
@@ -1,7 +1,0 @@
-set -e
-
-source $stdenv/setup
-
-tar xzvf $src
-mkdir $out
-mv batik-* $out/batik

--- a/pkgs/applications/graphics/batik/builder.sh
+++ b/pkgs/applications/graphics/batik/builder.sh
@@ -2,6 +2,6 @@ set -e
 
 source $stdenv/setup
 
-unzip $src
+tar xzvf $src
 mkdir $out
 mv batik-* $out/batik

--- a/pkgs/applications/graphics/batik/default.nix
+++ b/pkgs/applications/graphics/batik/default.nix
@@ -1,10 +1,9 @@
-{stdenv, fetchurl, unzip}:
+{stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
   pname = "batik";
   version = "1.13";
 
-  builder = ./builder.sh;
   src = fetchurl {
     url = "mirror://apache/xmlgraphics/batik/binaries/batik-bin-${version}.tar.gz";
     sha256 = "16sq90nbs6psgm3xz30sbs6r5dnpd3qzsvr1xvnp4yipwjcmhmkw";
@@ -16,4 +15,9 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     platforms = platforms.unix;
   };
+
+  installPhase = ''
+    mkdir $out
+    cp -r * $out/
+  '';
 }

--- a/pkgs/applications/graphics/batik/default.nix
+++ b/pkgs/applications/graphics/batik/default.nix
@@ -1,25 +1,19 @@
 {stdenv, fetchurl, unzip}:
 
-stdenv.mkDerivation {
-  name = "batik-1.6";
+stdenv.mkDerivation rec {
+  pname = "batik";
+  version = "1.13";
+
   builder = ./builder.sh;
   src = fetchurl {
-    url = "http://tarballs.nixos.org/batik-1.6.zip";
-    sha256 = "0cf15dspmzcnfda8w5lbsdx28m4v2rpq1dv5zx0r0n99ihqd1sh6";
+    url = "mirror://apache/xmlgraphics/batik/binaries/batik-bin-${version}.tar.gz";
+    sha256 = "16sq90nbs6psgm3xz30sbs6r5dnpd3qzsvr1xvnp4yipwjcmhmkw";
   };
-
-  buildInputs = [unzip];
 
   meta = with stdenv.lib; {
     description = "Java based toolkit for handling SVG";
     homepage = "https://xmlgraphics.apache.org/batik";
     license = licenses.asl20;
     platforms = platforms.unix;
-    knownVulnerabilities = [
-      # vulnerabilities as of 16th October 2018 from https://xmlgraphics.apache.org/security.html:
-      "CVE-2018-8013"
-      "CVE-2017-5662"
-      "CVE-2015-0250"
-    ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes vulnerabilities:
 * [CVE-2018-8013](https://nvd.nist.gov/vuln/detail/CVE-2018-8013)
 * [CVE-2017-5662](https://nvd.nist.gov/vuln/detail/CVE-2017-5662)
 * [CVE-2015-0250](https://nvd.nist.gov/vuln/detail/CVE-2015-0250)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
