### PR TITLE
simh: init at 3.11-1

### DIFF
--- a/pkgs/misc/emulators/simh/default.nix
+++ b/pkgs/misc/emulators/simh/default.nix
@@ -1,0 +1,62 @@
+{ stdenv
+, fetchFromGitHub
+, SDL2
+, SDL2_ttf
+, libpcap
+, vde2
+, pcre
+}:
+
+stdenv.mkDerivation rec {
+  pname = "simh";
+  version = "3.11-1";
+
+  src = fetchFromGitHub {
+    owner = "simh";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-65+YfOWpVXPeT64TZcSaWJY+ODQ0q/pwF9jb8xGdpIs=";
+  };
+
+  buildInputs = [ SDL2 SDL2_ttf libpcap vde2 pcre ];
+
+  dontConfigure = true;
+
+  makeFlags = [ "GCC=cc" "CC_STD=-std=c99" "LDFLAGS=-lm" ];
+
+  preInstall = ''
+    install -d ${placeholder "out"}/bin
+    install -d ${placeholder "out"}/share/simh
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    for i in BIN/*; do
+      install -D $i ${placeholder "out"}/bin
+    done
+    for i in VAX/*bin; do
+      install -D $i ${placeholder "out"}/share/simh
+    done
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    (cd $out/bin; for i in *; do ln -s $i simh-$i; done)
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://simh.trailing-edge.com/";
+    description = "A collection of simulators of historic hardware";
+    longDescription = ''
+      SimH (History Simulator) is a collection of simulators for historically
+      significant or just plain interesting computer hardware and software from
+      the past. The goal of the project is to create highly portable system
+      simulators and to publish them as freeware on the Internet, with freely
+      available copies of significant or representative software.
+    '';
+    license = with licenses; mit;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; unix;
+  };
+}
+# TODO: install documentation

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1589,6 +1589,8 @@ in
 
   bsod = callPackage ../misc/emulators/bsod { };
 
+  simh = callPackage ../misc/emulators/simh { };
+
   btrfs-progs = callPackage ../tools/filesystems/btrfs-progs { };
 
   btrbk = callPackage ../tools/backup/btrbk {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
