### PR TITLE
onionshare: 2.2 -> 2.3.1

### DIFF
--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -56,7 +56,7 @@ let
 
 in rec {
   onionshare = buildPythonApplication {
-    pname = "onionshare";
+    pname = "onionshare-cli";
     inherit version meta;
     src = "${src}/cli";
     patches = [
@@ -95,7 +95,7 @@ in rec {
   };
 
   onionshare-gui = buildPythonApplication {
-    pname = "onionshare-gui";
+    pname = "onionshare";
     inherit version meta;
     src = "${src}/desktop/src";
     patches = [

--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -22,12 +22,12 @@
 }:
 
 let
-  version = "2.3";
+  version = "2.3.1";
   src = fetchFromGitHub {
     owner = "micahflee";
     repo = "onionshare";
     rev = "v${version}";
-    sha256 = "sha256-CyL9J3ADxs1QAVaWz9HepwSwgZ98Z5uO2fdplOvnU1E=";
+    sha256 = "sha256-H09x3OF6l1HLHukGPvV2rZUjW9fxeKKMZkKbY9a2m9I=";
   };
   meta = with lib; {
     description = "Securely and anonymously send and receive files";

--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -1,30 +1,33 @@
 {
   lib,
   buildPythonApplication,
-  stdenv,
   substituteAll,
   fetchFromGitHub,
   isPy3k,
   flask,
   flask-httpauth,
+  flask-socketio,
   stem,
+  psutil,
   pyqt5,
   pycrypto,
-  pysocks,
-  pytest,
+  pyside2,
+  pytestCheckHook,
+  qrcode,
   qt5,
   requests,
+  unidecode,
   tor,
   obfs4,
 }:
 
 let
-  version = "2.2";
+  version = "2.3";
   src = fetchFromGitHub {
     owner = "micahflee";
     repo = "onionshare";
     rev = "v${version}";
-    sha256 = "0m8ygxcyp3nfzzhxs2dfnpqwh1vx0aws44lszpnnczz4fks3a5j4";
+    sha256 = "sha256-CyL9J3ADxs1QAVaWz9HepwSwgZ98Z5uO2fdplOvnU1E=";
   };
   meta = with lib; {
     description = "Securely and anonymously send and receive files";
@@ -51,63 +54,76 @@ let
     maintainers = with maintainers; [ lourkeur ];
   };
 
-  common = buildPythonApplication {
-    pname = "onionshare-common";
-    inherit version meta src;
-
-    disable = !isPy3k;
-    propagatedBuildInputs = [
-      flask
-      flask-httpauth
-      stem
-      pyqt5
-      pycrypto
-      pysocks
-      requests
-    ];
-    buildInputs = [
-      tor
-      obfs4
-    ];
-
+in rec {
+  onionshare = buildPythonApplication {
+    pname = "onionshare";
+    inherit version meta;
+    src = "${src}/cli";
     patches = [
+      # hardcode store paths of dependencies
       (substituteAll {
         src = ./fix-paths.patch;
         inherit tor obfs4;
         inherit (tor) geoip;
       })
     ];
-    postPatch = "substituteInPlace onionshare/common.py --subst-var-by common $out";
+    disable = !isPy3k;
+    propagatedBuildInputs = [
+      flask
+      flask-httpauth
+      flask-socketio
+      stem
+      psutil
+      pycrypto
+      requests
+      unidecode
+    ];
 
-    doCheck = false;
-  };
-in
-{
-  onionshare = stdenv.mkDerivation {
-    pname = "onionshare";
-    inherit version meta;
+    buildInputs = [
+      tor
+      obfs4
+    ];
 
-    dontUnpack = true;
+    checkInputs = [
+      pytestCheckHook
+    ];
 
-    inherit common;
-    installPhase = ''
-      mkdir -p $out/bin
-      cp $common/bin/onionshare -t $out/bin
+    preCheck = ''
+      # Tests use the home directory
+      export HOME="$(mktemp -d)"
     '';
   };
-  onionshare-gui = stdenv.mkDerivation {
+
+  onionshare-gui = buildPythonApplication {
     pname = "onionshare-gui";
     inherit version meta;
+    src = "${src}/desktop/src";
+    patches = [
+      # hardcode store paths of dependencies
+      (substituteAll {
+        src = ./fix-paths-gui.patch;
+        inherit tor obfs4;
+        inherit (tor) geoip;
+      })
+    ];
+
+    disable = !isPy3k;
+    propagatedBuildInputs = [
+      onionshare
+      pyqt5
+      pyside2
+      psutil
+      qrcode
+    ];
 
     nativeBuildInputs = [ qt5.wrapQtAppsHook ];
 
-    dontUnpack = true;
-
-    inherit common;
-    installPhase = ''
-      mkdir -p $out/bin
-      cp $common/bin/onionshare-gui -t $out/bin
-      wrapQtApp $out/bin/onionshare-gui
+    preFixup = ''
+      wrapQtApp $out/bin/onionshare
     '';
+
+    doCheck = false;
+
+    pythonImportsCheck = [ "onionshare" ];
   };
 }

--- a/pkgs/applications/networking/onionshare/fix-paths-gui.patch
+++ b/pkgs/applications/networking/onionshare/fix-paths-gui.patch
@@ -1,32 +1,29 @@
---- a/onionshare_cli/common.py
-+++ b/onionshare_cli/common.py
-@@ -86,33 +86,10 @@ class Common:
-         return path
+
+--- a/onionshare/gui_common.py
++++ b/onionshare/gui_common.py
+@@ -376,29 +376,10 @@ class GuiCommon:
+         }
  
      def get_tor_paths(self):
--        if self.platform == "Linux":
+-        if self.common.platform == "Linux":
 -            tor_path = shutil.which("tor")
--            if not tor_path:
--                raise CannotFindTor()
 -            obfs4proxy_file_path = shutil.which("obfs4proxy")
 -            prefix = os.path.dirname(os.path.dirname(tor_path))
 -            tor_geo_ip_file_path = os.path.join(prefix, "share/tor/geoip")
 -            tor_geo_ipv6_file_path = os.path.join(prefix, "share/tor/geoip6")
--        elif self.platform == "Windows":
+-        elif self.common.platform == "Windows":
 -            base_path = self.get_resource_path("tor")
 -            tor_path = os.path.join(base_path, "Tor", "tor.exe")
 -            obfs4proxy_file_path = os.path.join(base_path, "Tor", "obfs4proxy.exe")
 -            tor_geo_ip_file_path = os.path.join(base_path, "Data", "Tor", "geoip")
 -            tor_geo_ipv6_file_path = os.path.join(base_path, "Data", "Tor", "geoip6")
--        elif self.platform == "Darwin":
--            tor_path = shutil.which("tor")
--            if not tor_path:
--                raise CannotFindTor()
--            obfs4proxy_file_path = shutil.which("obfs4proxy")
--            prefix = os.path.dirname(os.path.dirname(tor_path))
--            tor_geo_ip_file_path = os.path.join(prefix, "share/tor/geoip")
--            tor_geo_ipv6_file_path = os.path.join(prefix, "share/tor/geoip6")
--        elif self.platform == "BSD":
+-        elif self.common.platform == "Darwin":
+-            base_path = self.get_resource_path("tor")
+-            tor_path = os.path.join(base_path, "tor")
+-            obfs4proxy_file_path = os.path.join(base_path, "obfs4proxy.exe")
+-            tor_geo_ip_file_path = os.path.join(base_path, "geoip")
+-            tor_geo_ipv6_file_path = os.path.join(base_path, "geoip6")
+-        elif self.common.platform == "BSD":
 -            tor_path = "/usr/local/bin/tor"
 -            tor_geo_ip_file_path = "/usr/local/share/tor/geoip"
 -            tor_geo_ipv6_file_path = "/usr/local/share/tor/geoip6"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
  Upstream release. [Changelog](https://github.com/micahflee/onionshare/releases/tag/v2.3)

The structure of the nix expression changed quite a bit, but that's because the structure of upstream did too, and for the better. They introduced Flatpak and Snap as their main method of distribution. Since those are declarative, this makes our job easier.

###### Things done

- [x] Wait for final release
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
