### PR TITLE
llvm_11: Disable checks on musl libc hosts

### DIFF
--- a/pkgs/development/compilers/llvm/11/llvm.nix
+++ b/pkgs/development/compilers/llvm/11/llvm.nix
@@ -152,7 +152,7 @@ in stdenv.mkDerivation (rec {
     ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${release_version}.dylib
   '';
 
-  doCheck = stdenv.isLinux && (!stdenv.isx86_32);
+  doCheck = stdenv.isLinux && (!stdenv.isx86_32) && (!stdenv.hostPlatform.isMusl);
 
   checkTarget = "check-all";
 


### PR DESCRIPTION
###### Motivation for this change

When building `llvm_11` with musl libc, the checks fail.
```
llvm> Failed Tests (8):                                                                         
llvm>   LLVM :: CodeGen/Hexagon/csr-stubs-spill-threshold.ll                                    
llvm>   LLVM :: CodeGen/Hexagon/long-calls.ll                                                   
llvm>   LLVM :: CodeGen/Hexagon/mlong-calls.ll                                                  
llvm>   LLVM :: CodeGen/Hexagon/pic-regusage.ll                                                 
llvm>   LLVM :: CodeGen/Hexagon/runtime-stkchk.ll                                               
llvm>   LLVM :: CodeGen/Hexagon/swp-memrefs-epilog.ll                                     
llvm>   LLVM :: CodeGen/Hexagon/vararg-formal.ll                                          
llvm>   LLVM :: ExecutionEngine/Interpreter/intrinsics.ll                                 
llvm> Testing Time: 507.14s                                                                     
llvm>   Unsupported      :   995                                                                
llvm>   Passed           : 37262                                                                
llvm>   Expectedly Failed:   149                                                                
llvm>   Failed           :     8                                                                
llvm> 1 warning(s) in tests  
```

Hence, I propose disabling the checks on musl hosts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
