### PR TITLE
tts: init at unstable-2020-06-17

### DIFF
--- a/pkgs/development/python-modules/pysbd/default.nix
+++ b/pkgs/development/python-modules/pysbd/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, tqdm
+, spacy
+}:
+
+buildPythonPackage rec {
+  pname = "pysbd";
+  version = "0.3.3";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "56ab48a28a8470f0042a4cb7c9da8a6dde8621ecf87a86d75f201cbf1837e77f";
+  };
+
+  checkInputs = [ tqdm spacy ];
+
+  doCheck = false; # requires pyconll and blingfire
+
+  pythonImportsCheck = [ "pysbd" ];
+
+  meta = with lib; {
+    description = "Pysbd (Python Sentence Boundary Disambiguation) is a rule-based sentence boundary detection that works out-of-the-box across many languages";
+    homepage = "https://github.com/nipunsadvilkar/pySBD";
+    license = licenses.mit;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/tools/audio/tts/default.nix
+++ b/pkgs/tools/audio/tts/default.nix
@@ -1,0 +1,123 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, fetchpatch
+, python3
+}:
+
+#
+# Tested in the following setup:
+#
+# TTS model:
+#   Tacotron2 DDC
+#   https://drive.google.com/drive/folders/1Y_0PcB7W6apQChXtbt6v3fAiNwVf4ER5
+# Vocoder model:
+#   Multi-Band MelGAN
+#   https://drive.google.com/drive/folders/1XeRT0q4zm5gjERJqwmX5w84pMrD00cKD
+#
+# Arrange /tmp/tts like this:
+#   scale_stats.npy
+#   tts
+#   tts/checkpoint_130000.pth.tar
+#   tts/checkpoint_130000_tf.pkl
+#   tts/checkpoint_130000_tf_2.3rc0.tflite
+#   tts/config.json
+#   tts/scale_stats.npy
+#   vocoder
+#   vocoder/checkpoint_1450000.pth.tar
+#   vocoder/checkpoint_2750000_tf.pkl
+#   vocoder/checkpoint_2750000_tf_v2.3rc.tflite
+#   vocoder/config.json
+#   vocoder/scale_stats.npy
+#
+# Start like this:
+#   cd /tmp/tts
+#   tts-server \
+#     --vocoder_config ./tts/vocoder/config.json \
+#     --vocoder_checkpoint ./tts/vocoder/checkpoint_1450000.pth.tar \
+#     --tts_config ./tts/config.json \
+#     --tts_checkpoint ./tts/checkpoint_130000.pth.tar
+#
+# For now, for deployment check the systemd unit in the pull request:
+#   https://github.com/NixOS/nixpkgs/pull/103851#issue-521121136
+#
+
+python3Packages.buildPythonApplication rec {
+  pname = "tts";
+  # until https://github.com/mozilla/TTS/issues/424 is resolved
+  # we treat released models as released versions:
+  # https://github.com/mozilla/TTS/wiki/Released-Models
+  version = "unstable-2020-06-17";
+
+  src = fetchFromGitHub {
+    owner = "mozilla";
+    repo = "TTS";
+    rev = "72a6ac54c8cfaa407fc64b660248c6a788bdd381";
+    sha256 = "1wvs264if9n5xzwi7ryxvwj1j513szp6sfj6n587xk1fphi0921f";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/mozilla/TTS/commit/36fee428b9f3f4ec1914b090a2ec9d785314d9aa.patch";
+      sha256 = "sha256-pP0NxiyrsvQ0A7GEleTdT87XO08o7WxPEpb6Bmj66dc=";
+    })
+  ];
+
+  preBuild = ''
+    # numba jit tries to write to its cache directory
+    export HOME=$TMPDIR
+    sed -i -e 's!tensorflow==.*!tensorflow!' requirements.txt
+    sed -i -e 's!librosa==[^"]*!librosa!' requirements.txt setup.py
+    sed -i -e 's!unidecode==[^"]*!unidecode!' requirements.txt setup.py
+    sed -i -e 's!bokeh==[^"]*!bokeh!' requirements.txt setup.py
+    sed -i -e 's!numba==[^"]*!numba!' requirements.txt setup.py
+    # Not required for building/installation but for their development/ci workflow
+    sed -i -e '/pylint/d' requirements.txt setup.py
+    sed -i -e '/cardboardlint/d' requirements.txt setup.py
+  '';
+
+
+  propagatedBuildInputs = with python3Packages; [
+    matplotlib
+    scipy
+    pytorch
+    flask
+    attrdict
+    bokeh
+    soundfile
+    tqdm
+    librosa
+    unidecode
+    phonemizer
+    tensorboardx
+    fuzzywuzzy
+    tensorflow_2
+    inflect
+    gdown
+    pysbd
+  ];
+
+  postInstall = ''
+    cp -r TTS/server/templates/ $out/${python3.sitePackages}/TTS/server
+  '';
+
+  checkInputs = with python3Packages; [ pytestCheckHook ];
+
+  disabledTests = [
+    # RuntimeError: fft: ATen not compiled with MKL support
+    "test_torch_stft"
+    "test_stft_loss"
+    "test_multiscale_stft_loss"
+    # AssertionErrors that I feel incapable of debugging
+    "test_phoneme_to_sequence"
+    "test_text2phone"
+    "test_parametrized_gan_dataset"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mozilla/TTS";
+    description = "Deep learning for Text to Speech";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ hexa mic92 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25840,6 +25840,8 @@ julia_15 = callPackage ../development/compilers/julia/1.5.nix {
 
   tremulous = callPackage ../games/tremulous { };
 
+  tts = callPackage ../tools/audio/tts { };
+
   tuxpaint = callPackage ../games/tuxpaint { };
 
   tuxtype = callPackage ../games/tuxtype { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4568,6 +4568,8 @@ in {
 
   pkuseg = callPackage ../development/python-modules/pkuseg { };
 
+  pysbd = callPackage ../development/python-modules/pysbd { };
+
   python-csxcad = callPackage ../development/python-modules/python-csxcad { };
 
   python-openems = callPackage ../development/python-modules/python-openems { };


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Mozilla TTS is a text to speech engine based on pytorch and tensorflow. @Mic92 and I have been successfully using it for the last few days in combination with https://rhasspy.readthedocs.io, which we might eventually package, not sure yet.

Demo: https://shells.darmstadt.ccc.de/~hexa/nixpkgs.wav

To get this running one needs to download a TTS and Vocoder model, check out https://github.com/mozilla/TTS/wiki/Released-Models, from where we pulled a commit, that matched a given version.

```
  systemd.services.tts = {
    after = [ "network.target" ];
    wantedBy = [ "multi-user.target" ];
    script = ''
      ${pkgs.tts}/bin/tts-server \
        --vocoder_config ./vocoder/config.json \
        --vocoder_checkpoint ./vocoder/checkpoint_1450000.pth.tar \
        --tts_config ./tts/config.json \
        --tts_checkpoint ./tts/checkpoint_130000.pth.tar
    '';
    serviceConfig = {
      User = "youruser";
      # needed for pulseaudio
      Environment = "XDG_RUNTIME_DIR=/run/user/1000";
      WorkingDirectory = "/path/to/models";
    };
  };
```

Then reproduce the demo like this:

```
curl http://localhost:5002/api/tts\\?text\\=Dear%20NixOS%20Maintainer,%20I%20am%20Mozilla%20TTS.%20I%20am%20ready%20to%20be%20merged,%20please%20review%20me\\. > /tmp/nixpkgs.wav
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
