### PR TITLE
nixos/xidlehook: new service

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2613,6 +2613,12 @@
     githubId = 231483;
     name = "Jack Kelly";
   };
+  enolan = {
+    name = "Echo Nolan";
+    email = "echo@echonolan.net";
+    github = "enolan";
+    githubId = 61517;
+  };
   enorris = {
     name = "Eric Norris";
     email = "erictnorris@gmail.com";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -952,6 +952,7 @@
   ./services/x11/xautolock.nix
   ./services/x11/xbanish.nix
   ./services/x11/xfs.nix
+  ./services/x11/xidlehook.nix
   ./services/x11/xserver.nix
   ./system/activation/activation-script.nix
   ./system/activation/top-level.nix

--- a/nixos/modules/services/x11/xidlehook.nix
+++ b/nixos/modules/services/x11/xidlehook.nix
@@ -1,0 +1,145 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.xidlehook;
+in
+  {
+    options = {
+      services.xserver.xidlehook = {
+        enable = mkEnableOption "xidlehook";
+
+        notWhenFullscreen = mkOption {
+          default = true;
+          description = "Whether to lock the screen when an application is fullscreened.";
+          type = types.bool;
+        };
+
+        notWhenAudio = mkOption {
+          default = false;
+          description = "Whether to lock the screen when audio is playing.";
+          type = types.bool;
+        };
+
+        socket = mkOption {
+          default = ".local/xidlehook.socket";
+          description = ''
+            Socket file for controlling the daemon. The path is relative to the
+            user's home directory. Set to null to not have one.
+          '';
+          type = types.nullOr types.str;
+        };
+
+        timerPkgs = mkOption {
+          default = with pkgs; [xorg.xrandr gawk i3lock-fancy-rapid];
+          description = "Packages added to PATH for the timer commands.";
+        };
+
+        timers = mkOption {
+          default = let brightnessCmd = tgt:
+            "xrandr --output $(xrandr | awk '/ connected/{print $1}') --brightness ${toString tgt} ; " +
+            "echo brightness ${toString tgt}"; in
+          [
+            {
+              seconds = 5*60-5;
+              command = brightnessCmd 0.5;
+              canceller = brightnessCmd 1;
+            }
+            {
+              seconds = 5;
+              command = brightnessCmd 1 + " ; i3lock-fancy-rapid 10 5";
+            }
+          ];
+          description = ''
+            List of commands to run after the screen has been idle for a given \
+            amount of time. N.B. times are cumulative here - in the example \
+            below the first command runs after the screen is idle for 60 \
+            seconds and the second command runs after the screen has been idle \
+            for 70 seconds.
+          '';
+
+          type = with types; listOf (
+            submodule {
+              options = {
+                seconds = mkOption {
+                  type = ints.unsigned;
+                  description = ''
+                    How long to wait while the screen is idle before running \
+                    the command.
+                  '';
+                };
+
+                command = mkOption {
+                  type = str;
+                  description = "Command to run. Passed through sh -c.";
+                };
+
+                canceller = mkOption {
+                  type = str;
+                  description = ''
+                    The canceller is what is invoked when the user becomes \
+                    active after the timer has gone off, but before the next \
+                    timer (if any). Pass an empty string to not have one.
+                  '';
+                  default = "";
+                };
+              };
+            }
+          );
+
+          example = [
+            { seconds = 60;
+              command = "${pkgs.libnotify}/bin/notify-send \"Locking soon\"";
+            }
+            { seconds = 10;
+              command = "{pkgs.i3lock}/bin/i3lock";
+            }
+          ];
+        };
+
+
+        extraOptions = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          description = ''
+            Additional command-line arguments to pass to
+            <command>xidlehook</command>.
+          '';
+        };
+      };
+    };
+
+    config = mkIf cfg.enable {
+      environment.systemPackages = with pkgs; [ xidlehook ];
+      systemd.user.services.xidlehook = with lib;
+        let socketEscaped = "\${HOME}/" + strings.escapeShellArg cfg.socket; in {
+        description = "xidlehook service";
+        wantedBy = [ "graphical-session.target" ];
+        partOf = [ "graphical-session.target" ];
+        path = cfg.timerPkgs;
+        preStart = optionalString (!(isNull cfg.socket))
+          "mkdir -p $(dirname ${socketEscaped}) ; rm -f ${socketEscaped}";
+        serviceConfig = {
+          ExecStart = strings.concatStringsSep " " ([
+            "${pkgs.xidlehook}/bin/xidlehook"
+          ] ++ optional cfg.notWhenFullscreen
+            "--not-when-fullscreen"
+          ++ optional cfg.notWhenAudio
+            "--not-when-audio"
+          ++ [(strings.escapeShellArgs (lists.concatMap (timer:
+            ["--timer" (toString timer.seconds) timer.command timer.canceller])
+            cfg.timers))]
+          ++ optional (!(isNull cfg.socket)) "--socket ${socketEscaped}"
+          ++ cfg.extraOptions);
+          Restart = "always";
+        };
+      };
+      assertions = [
+        {
+          assertion = lib.lists.length cfg.timers != 0;
+          message = "You must specify at least one timer for xidlehook.";
+        }
+      ];
+    };
+  }

--- a/nixos/modules/services/x11/xidlehook.nix
+++ b/nixos/modules/services/x11/xidlehook.nix
@@ -32,14 +32,16 @@ in
         };
 
         timerPkgs = mkOption {
-          default = with pkgs; [xorg.xrandr gawk i3lock-fancy-rapid];
+          default = with pkgs; [ xorg.xrandr gawk i3lock-fancy-rapid ];
           description = "Packages added to PATH for the timer commands.";
         };
 
         timers = mkOption {
-          default = let brightnessCmd = tgt:
-            "xrandr --output $(xrandr | awk '/ connected/{print $1}') --brightness ${toString tgt} ; " +
-            "echo brightness ${toString tgt}"; in
+          default = let 
+             brightnessCmd = tgt:
+               "xrandr --output $(xrandr | awk '/ connected/{print $1}') --brightness ${toString tgt} ; " +
+               "echo brightness ${toString tgt}";
+          in
           [
             {
               seconds = 5*60-5;
@@ -52,10 +54,10 @@ in
             }
           ];
           description = ''
-            List of commands to run after the screen has been idle for a given \
-            amount of time. N.B. times are cumulative here - in the example \
-            below the first command runs after the screen is idle for 60 \
-            seconds and the second command runs after the screen has been idle \
+            List of commands to run after the screen has been idle for a given
+            amount of time. N.B. times are cumulative here - in the example
+            below the first command runs after the screen is idle for 60
+            seconds and the second command runs after the screen has been idle
             for 70 seconds.
           '';
 
@@ -78,8 +80,8 @@ in
                 canceller = mkOption {
                   type = str;
                   description = ''
-                    The canceller is what is invoked when the user becomes \
-                    active after the timer has gone off, but before the next \
+                    The canceller is what is invoked when the user becomes
+                    active after the timer has gone off, but before the next
                     timer (if any). Pass an empty string to not have one.
                   '';
                   default = "";

--- a/nixos/modules/services/x11/xidlehook.nix
+++ b/nixos/modules/services/x11/xidlehook.nix
@@ -37,7 +37,7 @@ in
         };
 
         timers = mkOption {
-          default = let 
+          default = let
              brightnessCmd = tgt:
                "xrandr --output $(xrandr | awk '/ connected/{print $1}') --brightness ${toString tgt} ; " +
                "echo brightness ${toString tgt}";

--- a/nixos/modules/services/x11/xidlehook.nix
+++ b/nixos/modules/services/x11/xidlehook.nix
@@ -55,7 +55,7 @@ in
           ];
           description = ''
             List of commands to run after the screen has been idle for a given
-            amount of time. N.B. times are cumulative here - in the example
+            amount of time. Note that times are cumulative here - in the example
             below the first command runs after the screen is idle for 60
             seconds and the second command runs after the screen has been idle
             for 70 seconds.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -385,6 +385,7 @@ in
   xandikos = handleTest ./xandikos.nix {};
   xautolock = handleTest ./xautolock.nix {};
   xfce = handleTest ./xfce.nix {};
+  xidlehook = handleTest ./xidlehook.nix {};
   xmonad = handleTest ./xmonad.nix {};
   xrdp = handleTest ./xrdp.nix {};
   xss-lock = handleTest ./xss-lock.nix {};

--- a/nixos/tests/xidlehook.nix
+++ b/nixos/tests/xidlehook.nix
@@ -1,0 +1,37 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+
+with lib;
+
+{
+  name = "xidlehook";
+  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ enolan ];
+
+  machine = {
+    imports = [ ./common/x11.nix ./common/user-account.nix ];
+
+    test-support.displayManager.auto.user = "bob";
+    services.xserver.xidlehook = {
+      enable = true;
+      timers = [
+        { seconds = 10;
+          command = "touch ~/timer1";
+        }
+        { seconds = 15;
+          command = "touch ~/timer2";
+        }
+      ];
+    };
+
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_x()
+    machine.fail("cat ~bob/timer1 && ~bob/timer2")
+    machine.sleep(15)
+    machine.succeed("cat ~bob/timer1")
+    machine.fail("cat ~bob/timer2")
+    machine.sleep(15)
+    machine.succeed("cat ~bob/timer1 && cat ~bob/timer2")
+  '';
+})


### PR DESCRIPTION
I added a service for xidlehook so it can be automatically managed by systemd like xautolock is. We already had a package for it.

###### Motivation for this change

It's really annoying when the screen locks while I'm watching DS9 because I haven't moved the mouse.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
