### PR TITLE
kenlm: init at unstable-2020-11-14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9740,6 +9740,12 @@
     githubId = 1108325;
     name = "Théo Zimmermann";
   };
+  znewman01 = {
+    name = "Zachary Newman";
+    email = "nixpkgs@z.znewman.net";
+    github = "znewman01";
+    githubId = 873857;
+  };
   zohl = {
     email = "zohl@fmap.me";
     github = "zohl";

--- a/pkgs/tools/text/kenlm/default.nix
+++ b/pkgs/tools/text/kenlm/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, cmake, boost, eigen, xz, zlib, bzip2 }:
+
+stdenv.mkDerivation rec {
+  pname = "kenlm-unstable";
+  version = "2020-11-03";
+
+  src = fetchFromGitHub {
+    owner = "kpu";
+    repo = "kenlm";
+    rev = "d70e28403f07e88b276c6bd9f162d2a428530f2e";
+    sha256 = "1ia9mj1cqd4bg6311fpay05awnx8kmmqb53jwq9yhv7kcvsa6yay";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost eigen xz zlib bzip2 ];
+
+  meta = with stdenv.lib; {
+    description = "Faster and Smaller Language Model Queries";
+    longDescription = ''
+      KenLM estimates, filters, and queries language models.
+
+      Estimation is fast and scalable due to streaming algorithms explained in the paper:
+
+      Scalable Modified Kneser-Ney Language Model Estimation
+      Kenneth Heafield, Ivan Pouzyrevsky, Jonathan H. Clark, and Philipp Koehn. ACL, Sofia, Bulgaria, 4—9 August, 2013.
+
+      Querying is fast and low-memory, as shown in the paper:
+
+      KenLM: Faster and Smaller Language Model Queries
+      Kenneth Heafield. WMT at EMNLP, Edinburgh, Scotland, United Kingdom, 30—31 July, 2011.
+    '';
+    homepage = "https://kheafield.com/code/kenlm/";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ znewman01 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2294,6 +2294,8 @@ in
 
   kapacitor = callPackage ../servers/monitoring/kapacitor { };
 
+  kenlm = callPackage ../tools/text/kenlm { };
+
   kisslicer = callPackage ../tools/misc/kisslicer { };
 
   klaus = with python3Packages; toPythonApplication klaus;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`kenlm` is a natural language processing tool for dealing with language models: estimating, filtering, and querying.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
