### PR TITLE
mailutils: 3.9 -> 3.10, fix cross-compilation

### DIFF
--- a/pkgs/tools/networking/mailutils/default.nix
+++ b/pkgs/tools/networking/mailutils/default.nix
@@ -37,6 +37,12 @@ stdenv.mkDerivation rec {
       url = "http://git.savannah.gnu.org/cgit/mailutils.git/patch/?id=37713b42a501892469234b90454731d8d8b7a3e6";
       sha256 = "1mwj77nxvf4xvqf26yjs59jyksnizj0lmbymbzg4kmqynzq3zjny";
     })
+    # Fix cross-compilation
+    # https://lists.gnu.org/archive/html/bug-mailutils/2020-11/msg00038.html
+    (fetchpatch {
+      url = "https://lists.gnu.org/archive/html/bug-mailutils/2020-11/txtiNjqcNpqOk.txt";
+      sha256 = "0ghzqb8qx2q8cffbvqzw19mivv7r5f16whplzhm7hdj0j2i6xf6s";
+    })
   ];
 
   enableParallelBuilding = false;

--- a/pkgs/tools/networking/mailutils/default.nix
+++ b/pkgs/tools/networking/mailutils/default.nix
@@ -3,13 +3,12 @@
 , python3, gss, libmysqlclient, system-sendmail }:
 
 stdenv.mkDerivation rec {
-  name = "${project}-${version}";
-  project = "mailutils";
-  version = "3.9";
+  pname = "mailutils";
+  version = "3.10";
 
   src = fetchurl {
-    url = "mirror://gnu/${project}/${name}.tar.xz";
-    sha256 = "1g1xf2lal04nsnf1iym9n9n0wxjpqbcr9nysxpm98v4pniinqwsz";
+    url = "mirror://gnu/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "17smrxjdgbbzbzakik30vj46q4iib85ksqhb82jr4vjp57akszh9";
   };
 
   postPatch = ''
@@ -32,6 +31,12 @@ stdenv.mkDerivation rec {
   patches = [
     ./fix-build-mb-len-max.patch
     ./path-to-cat.patch
+    # mailquota.c:277: undefined reference to `get_size'
+    # https://lists.gnu.org/archive/html/bug-mailutils/2020-08/msg00002.html
+    (fetchpatch {
+      url = "http://git.savannah.gnu.org/cgit/mailutils.git/patch/?id=37713b42a501892469234b90454731d8d8b7a3e6";
+      sha256 = "1mwj77nxvf4xvqf26yjs59jyksnizj0lmbymbzg4kmqynzq3zjny";
+    })
   ];
 
   enableParallelBuilding = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates mailutils to the latest version and fixes cross-compilation using a patch that has been submitted upstream.

Mailutils is now in the dependency chain for ZFS, so this allows ZFS to cross-compile again.

cc @orivej @vrthra

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
