### PR TITLE
ocamlPackages.containers: 3.0 → 3.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/containers/data.nix
+++ b/pkgs/development/ocaml-modules/containers/data.nix
@@ -1,12 +1,14 @@
 { buildDunePackage, containers
+, dune-configurator
 , gen, iter, qcheck
 }:
 
 buildDunePackage {
   pname = "containers-data";
 
-  inherit (containers) src version;
+  inherit (containers) src version useDune2;
 
+  buildInputs = [ dune-configurator ];
   doCheck = true;
   checkInputs = [ gen iter qcheck ];
 

--- a/pkgs/development/ocaml-modules/containers/default.nix
+++ b/pkgs/development/ocaml-modules/containers/default.nix
@@ -1,19 +1,23 @@
 { lib, fetchFromGitHub, buildDunePackage, ocaml
+, dune-configurator
 , seq
 , gen, iter, ounit, qcheck, uutf
 }:
 
 buildDunePackage rec {
-  version = "3.0";
+  version = "3.0.1";
   pname = "containers";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "ocaml-containers";
     rev = "v${version}";
-    sha256 = "0c75d5csgc68qqbsdz4279nlin111zrjbg4d47k32ska28myvpqn";
+    sha256 = "1m19cfcwks3xcj16nqldfb49dg0vdc7by1q1j8bpac3z2mjvks0l";
   };
 
+  buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ seq ];
 
   checkInputs = [ gen iter ounit qcheck uutf ];

--- a/pkgs/development/ocaml-modules/tsort/default.nix
+++ b/pkgs/development/ocaml-modules/tsort/default.nix
@@ -2,6 +2,7 @@
 
 buildDunePackage rec {
   pname = "tsort";
+  useDune2 = true;
   version = "2.0.0";
   src = fetchFromGitHub {
     owner = "dmbaturin";


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2.
Fix: https://github.com/c-cube/ocaml-containers/blob/v3.0.1/CHANGELOG.md

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
