### PR TITLE
xlife: init at 6.7.5

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -392,6 +392,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "Historic Permission Notice and Disclaimer";
   };
 
+  hpndSellVariant = spdx {
+    fullName = "Historical Permission Notice and Disclaimer - sell variant";
+    spdxId = "HPND-sell-variant";
+  };
+
   # Intel's license, seems free
   iasl = {
     fullName = "iASL";

--- a/pkgs/applications/graphics/xlife/default.nix
+++ b/pkgs/applications/graphics/xlife/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchsvn, xorg }:
+
+stdenv.mkDerivation {
+  pname = "xlife";
+  version = "6.7.5";
+
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/xlife-cal/xlife/trunk";
+    rev = "365";
+    sha256 = "1gadlcp32s179kd7ypxr8cymd6s060p6z4c2vnx94i8bmiw3nn8h";
+  };
+
+  nativeBuildInputs = with xorg; [ imake gccmakedep ];
+  buildInputs = [ xorg.libX11 ];
+
+  hardeningDisable = [ "format" ];
+  installPhase = ''
+    install -Dm755 xlife -t $out/bin
+    install -Dm755 lifeconv -t $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://litwr2.atspace.eu/xlife.php";
+    description = "Conway's Game of Life and other cellular automata, for X";
+    license = licenses.hpndSellVariant;
+    maintainers = with maintainers; [ djanatyn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24738,6 +24738,8 @@ in
 
   xkblayout-state = callPackage ../applications/misc/xkblayout-state { };
 
+  xlife = callPackage ../applications/graphics/xlife { };
+
   xmobar = haskellPackages.xmobar;
 
   xmonad-log = callPackage ../tools/misc/xmonad-log { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
There are a few different branches of `xlife` development. This is the `6.7 (2013)` branch, documented in the development history on the homepage:
* http://litwr2.atspace.eu/xlife/XLIFE-DEVELOPMENT.html

It appears to be the most recent development branch available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I've also added the `hpndSellVariant` license that this application uses. I've done the same in a previous PR: #103518