### PR TITLE
[20.09] haskellPackages.taffybar: overrides to fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1470,6 +1470,20 @@ self: super: {
   pandoc-types = self.pandoc-types_1_21;
   rfc5051 = self.rfc5051_0_2;
 
+  # 2020-11-15: Taffybar and gi-* dependencies need these overrides to
+  # be compatible with haskell-gi-base 0.24.
+  # Note: Some generated dependencies in hackage-packages.nix have
+  # been edited to remove the broken flag.
+  taffybar = appendPatch super.taffybar (pkgs.fetchpatch {
+    # Compatibility fix for haskell-gi-base 0.24
+    url = "https://github.com/taffybar/taffybar/pull/494/commits/a7443324a549617f04d49c6dfeaf53f945dc2b98.patch";
+    sha256 = "0prskimfpapgncwc8si51lf0zxkkdghn33y3ysjky9a82dsbhcqi";
+  });
+  gi-dbusmenu = assert super.gi-dbusmenu.version == "0.4.7"; self.gi-dbusmenu_0_4_8;
+  gi-dbusmenugtk3 = assert super.gi-dbusmenugtk3.version == "0.4.8"; self.gi-dbusmenugtk3_0_4_9;
+  gi-gtk-hs = assert super.gi-gtk-hs.version == "0.3.8.1"; self.gi-gtk-hs_0_3_9;
+  gi-xlib = assert super.gi-xlib.version == "2.0.8"; self.gi-xlib_2_0_9;
+
   # INSERT NEW OVERRIDES ABOVE THIS LINE
 
 } // (let

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -925,13 +925,13 @@ default-package-overrides:
   - ghost-buster ==0.1.1.0
   - gi-atk ==2.0.21
   - gi-cairo ==1.0.23
-  - gi-cairo-connector ==0.0.1
-  - gi-cairo-render ==0.0.1
+  - gi-cairo-connector ==0.1.0
+  - gi-cairo-render ==0.1.0
   - gi-dbusmenu ==0.4.7
   - gi-dbusmenugtk3 ==0.4.8
   - gi-gdk ==3.0.22
   - gi-gdkpixbuf ==2.0.23
-  - gi-gdkx11 ==3.0.9
+  - gi-gdkx11 ==3.0.10
   - gi-gio ==2.0.26
   - gi-glib ==2.0.23
   - gi-gobject ==2.0.22
@@ -5354,23 +5354,16 @@ broken-packages:
   - ghcprofview
   - ght
   - gi-cairo-again
-  - gi-cairo-connector
-  - gi-cairo-render
-  - gi-dbusmenu
-  - gi-dbusmenugtk3
-  - gi-gdkx11
   - gi-graphene
   - gi-gsk
   - gi-gstpbutils
   - gi-gsttag
   - gi-gtk-declarative
   - gi-gtk-declarative-app-simple
-  - gi-gtk-hs
   - gi-gtkosxapplication
   - gi-handy
   - gi-poppler
   - gi-wnck
-  - gi-xlib
   - giak
   - Gifcurry
   - ginsu
@@ -5587,8 +5580,6 @@ broken-packages:
   - gtfs
   - gtfs-realtime
   - gtk-serialized-event
-  - gtk-sni-tray
-  - gtk-strut
   - gtk-toy
   - gtk2hs-hello
   - gtk2hs-rpn
@@ -10210,7 +10201,6 @@ broken-packages:
   - Tablify
   - tabloid
   - tabs
-  - taffybar
   - tag-bits
   - tag-stream
   - tagged-exception-core


### PR DESCRIPTION
###### Motivation for this change

Apply patches to make Taffybar work with haskell-gi-base 0.24. Select versions of dependencies which are compatible with haskell-gi-base 0.24 and clear their broken flag.

Resolves #63500 on the **20.09** branch.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
