### PR TITLE
nixos/spamassassin: Avoid network dependency on boot

### DIFF
--- a/nixos/modules/services/mail/spamassassin.nix
+++ b/nixos/modules/services/mail/spamassassin.nix
@@ -135,7 +135,10 @@ in
         User = "spamd";
         Group = "spamd";
         StateDirectory = "spamassassin";
-        ExecStart = "${pkgs.spamassassin}/bin/sa-update --verbose --gpghomedir=%S/spamassassin/sa-update-keys/";
+        ExecStart = [
+          "${pkgs.spamassassin}/bin/sa-update --verbose --gpghomedir=%S/spamassassin/sa-update-keys/"
+          "${pkgs.spamassassin}/bin/sa-compile"
+        ];
         ExecStartPost = "+${pkgs.systemd}/bin/systemctl -q --no-block try-reload-or-restart spamd.service";
         SuccessExitStatus = "1";
       };

--- a/nixos/modules/services/mail/spamassassin.nix
+++ b/nixos/modules/services/mail/spamassassin.nix
@@ -126,6 +126,8 @@ in
     };
 
     systemd.services.sa-update = {
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
       script = ''
         set +e
         ${pkgs.su}/bin/su -s "${pkgs.bash}/bin/bash" -c "${pkgs.spamassassin}/bin/sa-update --gpghomedir=/var/lib/spamassassin/sa-update-keys/" spamd
@@ -152,33 +154,44 @@ in
       };
     };
 
+    systemd.services.spamd-init = {
+      serviceConfig = {
+        Type = "oneshot";
+      };
+      script = ''
+        mkdir -p /var/lib/spamassassin
+        chown spamd:spamd /var/lib/spamassassin -R
+        if [ "$(ls -A /var/lib/spamassassin)" = "" ]; then
+          echo "'/var/lib/spamassassin' is empty, running sa-update..."
+          set +e
+          ${pkgs.su}/bin/su -s "${pkgs.bash}/bin/bash" -c "${pkgs.spamassassin}/bin/sa-update --gpghomedir=/var/lib/spamassassin/sa-update-keys/" spamd
+          v=$?
+          set -e
+          # 0 and 1 no error, exitcode > 1 means error:
+          # https://spamassassin.apache.org/full/3.1.x/doc/sa-update.html#exit_codes
+          if [ $v -gt 1 ]; then
+            echo "sa-update execution error"
+            exit $v
+          fi
+          echo "sa-update run successfully."
+        fi
+      '';
+    };
+
     systemd.services.spamd = {
-      description = "Spam Assassin Server";
+      description = "SpamAssassin Server";
 
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
+      wants = [ "spamd-init.service" ];
+      after = [
+        "network.target"
+        "spamd-init.service"
+      ];
 
       serviceConfig = {
         ExecStart = "${pkgs.spamassassin}/bin/spamd ${optionalString cfg.debug "-D"} --username=spamd --groupname=spamd --virtual-config-dir=/var/lib/spamassassin/user-%u --allow-tell --pidfile=/run/spamd.pid";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       };
-
-      # 0 and 1 no error, exitcode > 1 means error:
-      # https://spamassassin.apache.org/full/3.1.x/doc/sa-update.html#exit_codes
-      preStart = ''
-        echo "Recreating '/var/lib/spamasassin' with creating '3.004001' (or similar) and 'sa-update-keys'"
-        mkdir -p /var/lib/spamassassin
-        chown spamd:spamd /var/lib/spamassassin -R
-        set +e
-        ${pkgs.su}/bin/su -s "${pkgs.bash}/bin/bash" -c "${pkgs.spamassassin}/bin/sa-update --gpghomedir=/var/lib/spamassassin/sa-update-keys/" spamd
-        v=$?
-        set -e
-        if [ $v -gt 1 ]; then
-          echo "sa-update execution error"
-          exit $v
-        fi
-        chown spamd:spamd /var/lib/spamassassin -R
-      '';
     };
   };
 }

--- a/pkgs/servers/mail/spamassassin/default.nix
+++ b/pkgs/servers/mail/spamassassin/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, perlPackages, makeWrapper, gnupg }:
+{ lib, fetchurl, perlPackages, makeWrapper, gnupg, re2c, gcc, gnumake }:
 
 perlPackages.buildPerlPackage rec {
   pname = "SpamAssassin";
@@ -28,7 +28,7 @@ perlPackages.buildPerlPackage rec {
     mv "rules/"* $out/share/spamassassin/
 
     for n in "$out/bin/"*; do
-      wrapProgram "$n" --prefix PERL5LIB : "$PERL5LIB" --prefix PATH : "${gnupg}/bin"
+      wrapProgram "$n" --prefix PERL5LIB : "$PERL5LIB" --prefix PATH : ${lib.makeBinPath [ gnupg re2c gcc gnumake ]}
     done
   '';
 


### PR DESCRIPTION
###### Motivation for this change

sa-update currently runs as part of the pre-start script of spamd. The network is not guaranteed to be online at that point and even if we were to depend on that, it makes the bootup brittle, as there is a reliance on SpamAssassin's update server as a startup dependency on boot.

Refactor the setup to move the pre-start script into its own oneshot unit (`spamd-init.service`). This allows to perform the setup task only once. Continuous updates are already done by `sa-update.service` triggered by `sa-update.timer`. Only run `sa-update` in case `/var/lib/spamassassin` is empty.

While we are on it, let sa-update.service depend on the network being online.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - None, because it's a change to a module.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
