### PR TITLE
maintainers: mwilsoninsight -> maxwilson

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6149,10 +6149,10 @@
     githubId = 6455574;
     name = "Matt Votava";
   };
-  mwilsoninsight = {
-    email = "max.wilson@insight.com";
-    github = "mwilsoninsight";
-    githubId = 47782621;
+  maxwilson = {
+    email = "nixpkgs@maxwilson.dev";
+    github = "mwilsoncoding";
+    githubId = 43796009;
     name = "Max Wilson";
   };
   myrl = {

--- a/pkgs/development/python-modules/azure-applicationinsights/default.nix
+++ b/pkgs/development/python-modules/azure-applicationinsights/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Application Insights Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-batch/default.nix
+++ b/pkgs/development/python-modules/azure-batch/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Batch Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-common/default.nix
+++ b/pkgs/development/python-modules/azure-common/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure common code";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ olcai mwilsoninsight ];
+    maintainers = with maintainers; [ olcai maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-cosmosdb-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-cosmosdb-nspkg/default.nix
@@ -24,6 +24,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure CosmosDB namespace package";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-cosmosdb-table/default.nix
+++ b/pkgs/development/python-modules/azure-cosmosdb-table/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Log Analytics Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-datalake-store/default.nix
+++ b/pkgs/development/python-modules/azure-datalake-store/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     description = "This project is the Python filesystem library for Azure Data Lake Store";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-eventgrid/default.nix
+++ b/pkgs/development/python-modules/azure-eventgrid/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "A fully-managed intelligent event routing service that allows for uniform event consumption using a publish-subscribe model";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-graphrbac/default.nix
+++ b/pkgs/development/python-modules/azure-graphrbac/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Graph RBAC Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-loganalytics/default.nix
+++ b/pkgs/development/python-modules/azure-loganalytics/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Log Analytics Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight jonringer ];
+    maintainers = with maintainers; [ maxwilson jonringer ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-advisor/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-advisor/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Advisor Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-applicationinsights/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-applicationinsights/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Application Insights Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-authorization/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-authorization/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Authorization Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-batch/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-batch/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Batch Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-batchai/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-batchai/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Batch AI Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-billing/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-billing/default.nix
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Billing Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-cdn/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-cdn/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure CDN Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-cognitiveservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-cognitiveservices/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Cognitive Services Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-commerce/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-commerce/default.nix
@@ -41,6 +41,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Commerce Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight jonringer ];
+    maintainers = with maintainers; [ maxwilson jonringer ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-common/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-common/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Resource Management common code";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ olcai mwilsoninsight ];
+    maintainers = with maintainers; [ olcai maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-compute/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-compute/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Compute Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ olcai mwilsoninsight ];
+    maintainers = with maintainers; [ olcai maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-consumption/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-consumption/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Consumption Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-containerinstance/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-containerinstance/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Container Instance Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-containerservice/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-containerservice/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Container Service Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-cosmosdb/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-cosmosdb/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Cosmos DB Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-datafactory/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datafactory/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Data Factory Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-datalake-analytics/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-analytics/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Data Lake Analytics Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-datalake-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-nspkg/default.nix
@@ -25,6 +25,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Data Lake Management namespace package";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-datalake-store/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-store/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Data Lake Store Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-datamigration/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datamigration/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Data Migration Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-devspaces/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-devspaces/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Dev Spaces Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-devtestlabs/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-devtestlabs/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure DevTestLabs Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-dns/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-dns/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure DNS Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-eventgrid/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-eventgrid/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure EventGrid Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-eventhub/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-eventhub/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure EventHub Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-hanaonazure/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-hanaonazure/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure SAP Hana on Azure Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-iotcentral/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-iotcentral/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure IoTCentral Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-iothub/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-iothub/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure IoTHub Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-iothubprovisioningservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-iothubprovisioningservices/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure IoTHub Provisioning Services Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-keyvault/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Key Vault Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-loganalytics/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-loganalytics/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Log Analytics Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-logic/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-logic/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Logic Apps Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-machinelearningcompute/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-machinelearningcompute/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Machine Learning Compute Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-managementgroups/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-managementgroups/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Management Groups Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-managementpartner/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-managementpartner/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure ManagementPartner Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-maps/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-maps/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Maps Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-marketplaceordering/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-marketplaceordering/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Market Place Ordering Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-media/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-media/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Media Services Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-monitor/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-monitor/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Monitor Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-msi/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-msi/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure MSI Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-network/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-network/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     description = "Microsoft Azure SDK for Python";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ olcai mwilsoninsight jonringer ];
+    maintainers = with maintainers; [ olcai maxwilson jonringer ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-notificationhubs/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-notificationhubs/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Notification Hubs Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-nspkg/default.nix
@@ -24,6 +24,6 @@ buildPythonPackage rec {
     description = "Microsoft Azure SDK for Python";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ olcai mwilsoninsight ];
+    maintainers = with maintainers; [ olcai maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-policyinsights/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-policyinsights/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Policy Insights Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-powerbiembedded/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-powerbiembedded/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Power BI Embedded Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-rdbms/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-rdbms/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure RDBMS Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-recoveryservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-recoveryservices/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Recovery Services Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-recoveryservicesbackup/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-recoveryservicesbackup/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Recovery Services Backup Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-redis/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-redis/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Redis Cache Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-relay/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-relay/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Relay Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-reservations/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-reservations/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Reservations Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-resource/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-resource/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     description = "Microsoft Azure SDK for Python";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ olcai mwilsoninsight jonringer ];
+    maintainers = with maintainers; [ olcai maxwilson jonringer ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-scheduler/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-scheduler/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Scheduler Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-search/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-search/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Search Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-servicebus/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-servicebus/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Service Bus Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-servicefabric/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-servicefabric/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Service Fabric Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-signalr/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-signalr/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure SignalR Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-sql/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-sql/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure SQL Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-storage/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-storage/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Storage Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ jonringer olcai mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer olcai maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-subscription/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-subscription/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Subscription Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-trafficmanager/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-trafficmanager/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Traffic Manager Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-web/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-web/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Web Apps Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-nspkg/default.nix
@@ -21,6 +21,6 @@ buildPythonPackage rec {
     description = "Microsoft Azure SDK for Python";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ olcai mwilsoninsight ];
+    maintainers = with maintainers; [ olcai maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-servicebus/default.nix
+++ b/pkgs/development/python-modules/azure-servicebus/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Service Bus Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-servicefabric/default.nix
+++ b/pkgs/development/python-modules/azure-servicefabric/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     description = "This project provides a client library in Python that makes it easy to consume Microsoft Azure Storage services";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-servicemanagement-legacy/default.nix
+++ b/pkgs/development/python-modules/azure-servicemanagement-legacy/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Service Management Legacy Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ olcai mwilsoninsight ];
+    maintainers = with maintainers; [ olcai maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/azure-storage-blob/default.nix
+++ b/pkgs/development/python-modules/azure-storage-blob/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "Client library for Microsoft Azure Storage services containing the blob service APIs";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ cmcdragonkai mwilsoninsight ];
+    maintainers = with maintainers; [ cmcdragonkai maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -48,6 +48,6 @@ buildPythonPackage rec {
     description = "The runtime library 'msrest' for AutoRest generated Python clients.";
     homepage = "https://github.com/Azure/msrest-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ bendlas jonringer mwilsoninsight ];
+    maintainers = with maintainers; [ bendlas jonringer maxwilson ];
   };
 }

--- a/pkgs/development/python-modules/uamqp/default.nix
+++ b/pkgs/development/python-modules/uamqp/default.nix
@@ -41,6 +41,6 @@ buildPythonPackage rec {
     description = "An AMQP 1.0 client library for Python";
     homepage = "https://github.com/Azure/azure-uamqp-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ maxwilson ];
   };
 }

--- a/pkgs/misc/drivers/utsushi/default.nix
+++ b/pkgs/misc/drivers/utsushi/default.nix
@@ -146,7 +146,7 @@ in stdenv.mkDerivation rec {
     '';
     homepage = "https://gitlab.com/utsushi/imagescan";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ wucke13 ];
+    maintainers = with maintainers; [ wucke13 maxwilson ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/http/showoff/default.nix
+++ b/pkgs/servers/http/showoff/default.nix
@@ -13,6 +13,6 @@ bundlerApp {
     homepage = "https://puppetlabs.github.io/showoff/";
     license = with licenses; mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ mwilsoninsight nicknovitski ];
+    maintainers = with maintainers; [ maxwilson nicknovitski ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I contributed my first package under a GitHub account that was bespoke to my employer at the time.

This contact information is more persistent.

I also recently did the debugging necessary to change the `utsushi` driver from using `gitlab/utsushi/imagescan` to `gitlab/utsushi/utsushi`. [Details](https://gitlab.com/utsushi/utsushi/-/issues/98)

###### Things done

- [x] Changed contact info in `maintainers/maintainer-list.nix`
  - `vim maintainers/maintainer-list.nix`
- [x] Changed all mentions of `mwilsoninsight` in nixpkgs to `maxwilson`
  - `for f in $(grep -r 'mwilsoninsight' . | cut -d ':' -f1); do sed -i 's/mwilsoninsight/maxwilson/g' $f; done`
- [x] Added self to maintainer list for `utsushi`