### PR TITLE
transgui: patch to circumvent v3 rpc issue

### DIFF
--- a/pkgs/applications/networking/p2p/transgui/default.nix
+++ b/pkgs/applications/networking/p2p/transgui/default.nix
@@ -1,30 +1,38 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, makeDesktopItem, unzip, fpc, lazarus,
-libX11, glib, gtk2, gdk-pixbuf, pango, atk, cairo, openssl }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, makeDesktopItem, fetchpatch, unzip
+, fpc, lazarus, libX11, glib, gtk2, gdk-pixbuf, pango, atk, cairo, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "transgui";
-  version = "5.18.0";
+  version = "unstable-2022-02-02";
 
   src = fetchFromGitHub {
     owner = "transmission-remote-gui";
     repo = "transgui";
-    rev = "v${version}";
-    sha256 = "1dyx778756zhvz5sxgdvy49p2c0x44w4nmcfd90wqrmgfknncnf5";
+    rev = "0e2c2a07c1b21b1704c0a4945a111a8aa1050a1a";
+    sha256 = "1x9wzii3q9zanpik4xc99jqsfrqch8vjmlx12jrvczxcfy51b1ba";
   };
+
+  patches = [
+    # TDDO: remove when transgui updates for transmission-daemon v3 rpc protocol
+    (fetchpatch {
+      url = "https://github.com/transmission-remote-gui/transgui/commit/9275c3fb877dd753a1940d1b900630cdc09a0cc2.patch";
+      sha256 = "0w2x7gcxp5kqczdz7ckfqhdz9hhkm62k8gcws54d6km7x9vc1023";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config unzip ];
   buildInputs = [
-    fpc lazarus stdenv.cc
-    libX11 glib gtk2 gdk-pixbuf pango atk cairo openssl
+    fpc lazarus stdenv.cc libX11 glib gtk2 gdk-pixbuf
+    pango atk cairo openssl
   ];
 
-  NIX_LDFLAGS = "
-    -L${stdenv.cc.cc.lib}/lib
-    -lX11 -lglib-2.0 -lgtk-x11-2.0 -lgdk-x11-2.0
-    -lgdk_pixbuf-2.0 -lpango-1.0 -latk-1.0 -lcairo -lc -lcrypto
-  ";
+  NIX_LDFLAGS = ''
+    -L${stdenv.cc.cc.lib}/lib -lX11 -lglib-2.0 -lgtk-x11-2.0
+    -lgdk-x11-2.0 -lgdk_pixbuf-2.0 -lpango-1.0 -latk-1.0 -lcairo
+    -lc -lcrypto
+  '';
 
-  prePatch = ''
+  postPatch = ''
     substituteInPlace restranslator.pas --replace /usr/ $out/
   '';
 
@@ -33,23 +41,19 @@ stdenv.mkDerivation rec {
     lazbuild -B transgui.lpr --lazarusdir=${lazarus}/share/lazarus
   '';
 
-  makeFlags = [
-    "FPC=fpc"
-    "PP=fpc"
-    "INSTALL_PREFIX=$(out)"
-  ];
+  makeFlags = [ "FPC=fpc" "PP=fpc" "INSTALL_PREFIX=$(out)" ];
 
   LCL_PLATFORM = "gtk2";
 
-  desktopItem = makeDesktopItem rec {
-    name = "transgui";
-    exec = name + " %U";
-    icon = name;
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = "${pname} %U";
+    icon = pname;
     type = "Application";
     comment = meta.description;
     desktopName = "Transmission Remote GUI";
     genericName = "BitTorrent Client";
-    categories = [ "Application" "Network" "FileTransfer" "P2P" "GTK" ];
+    categories = [ "Network" "FileTransfer" "P2P" "GTK" ];
     startupNotify = true;
     mimeTypes = [ "application/x-bittorrent" "x-scheme-handler/magnet" ];
   };
@@ -64,10 +68,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "A cross platform front-end for the Transmission Bit-Torrent client";
+    description = "A cross platform front-end for the Transmission BitTorrent client";
     homepage = "https://sourceforge.net/p/transgui";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ ramkromberg ];
-    platforms = lib.platforms.linux;
+    mainProgram = "transgui";
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/97430

###### Things done

reviewed the source and read up on the rpc; added the patch; built and executed on nixos 20.09; tried out adding, removing and moving torrents to verify nothing gets accidentally deleted...

I'm still not too happy about what essentially comes down to circumventing rpc changes between versions instead of properly updating the sources to the new specs but I haven't noticed anything that can lead to data loss and upstream hasn't reviewed much other than translations for months AND this project has a long history of going out of maintenance and forking...
