### PR TITLE
gping: 1.1 -> 0.1.6

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -128,6 +128,7 @@
   ./programs/gnome-documents.nix
   ./programs/gnome-terminal.nix
   ./programs/gpaste.nix
+  ./programs/gping.nix
   ./programs/gnupg.nix
   ./programs/gphoto2.nix
   ./programs/hamster.nix

--- a/nixos/modules/programs/gping.nix
+++ b/nixos/modules/programs/gping.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+
+  ###### interface
+  options = {
+    programs.gping = {
+      enable = mkEnableOption "gping utility";
+    };
+  };
+
+  ###### implementation
+  config = mkIf config.programs.gping.enable {
+    security.wrappers = {
+      ping = {
+        source = "${pkgs.gping.out}/bin/gping";
+        owner = "nobody";
+        group = "nogroup";
+        capabilities = "cap_net_raw+ep";
+      };
+    };
+  };
+}

--- a/pkgs/tools/networking/gping/default.nix
+++ b/pkgs/tools/networking/gping/default.nix
@@ -1,32 +1,25 @@
 { lib
-, iputils
-, python3
-, python3Packages
+, fetchFromGitHub
+, rustPlatform
 }:
 
-python3Packages.buildPythonApplication rec {
+rustPlatform.buildRustPackage rec {
   pname = "gping";
-  version = "1.1";
+  version = "0.1.6";
 
-  propagatedBuildInputs = with python3Packages; [ colorama ];
-
-  src = python3Packages.fetchPypi {
-    inherit version;
-    pname  = "pinggraph";
-    sha256 = "0q5ma98457zb6vxsnhmrr3p38j1vg0gl155y0adzfg67wlniac92";
+  src = fetchFromGitHub {
+    owner  = "orf";
+    repo = "gping";
+    rev = "v${version}";
+    sha256 = "Qqtx+a5H/rAQu2A3oUXPiw7qJbH3mXOyT86BIXPmnOk=";
   };
 
-  # Make path to ping explicit
-  postFixup = ''
-    substituteInPlace $out/${python3.sitePackages}/gping/pinger.py \
-      --replace 'subprocess.getoutput("ping ' 'subprocess.getoutput("${iputils}/bin/ping ' \
-      --replace 'args = ["ping"]' 'args = ["${iputils}/bin/ping"]'
-  '';
+  cargoSha256 = "E9WmfpJU/aPxRF/h6tv5wXZQ5JGDXEN/tYlKxQrNTrc=";
 
   meta = with lib; {
     description = "Ping, but with a graph";
     homepage = "https://github.com/orf/gping";
-    license = licenses.gpl2;
+    license = licenses.mit;
     maintainers = with maintainers; [ andrew-d ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The software received an update which is a complete rewrite in rust, they went back
to 0.x branch but it is still new

If you want to test this PR, you must use the module in order to add the security wrapper

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
