### PR TITLE
pkgs-lib: allow paths in TOML, YAML and JSON

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -30,6 +30,7 @@ rec {
         int
         float
         str
+        path
         (attrsOf valueType)
         (listOf valueType)
       ]) // {
@@ -112,6 +113,7 @@ rec {
         int
         float
         str
+        path
         (attrsOf valueType)
         (listOf valueType)
       ] // {

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -38,6 +38,7 @@ in runBuildTests {
       str = "foo";
       attrs.foo = null;
       list = [ null null ];
+      path = ./formats.nix;
     };
     expected = ''
       {
@@ -52,6 +53,7 @@ in runBuildTests {
           null
         ],
         "null": null,
+        "path": "${./formats.nix}",
         "str": "foo",
         "true": true
       }
@@ -67,6 +69,7 @@ in runBuildTests {
       str = "foo";
       attrs.foo = null;
       list = [ null null ];
+      path = ./formats.nix;
     };
     expected = ''
       {
@@ -80,6 +83,7 @@ in runBuildTests {
           null
         ],
         "null": null,
+        "path": "${./formats.nix}",
         "str": "foo",
         "true": true
       }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Without this PR, https://github.com/NixOS/nixpkgs/pull/98025 broke my config because I include a certificate as a path.

Paths to get automatically added to the store, as if they were interpolated. The INI generator currently chokes on paths, so it is not supported for now.

cc @Infinisil 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
