### PR TITLE
nice-dcv-client: init at 2020.2.1737-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7403,6 +7403,12 @@
     githubId = 13752145;
     name = "Richard Lupton";
   };
+  rmcgibbo = {
+    email = "rmcgibbo@gmail.com";
+    github = "rmcgibbo";
+    githubId = 641278;
+    name = "Robert T. McGibbon";
+  };
   rnhmjoj = {
     email = "rnhmjoj@inventati.org";
     github = "rnhmjoj";

--- a/pkgs/applications/networking/remote/nice-dcv-client/default.nix
+++ b/pkgs/applications/networking/remote/nice-dcv-client/default.nix
@@ -1,0 +1,87 @@
+{ stdenv
+, fetchurl
+, glib
+, libX11
+, gst_all_1
+, sqlite
+, epoxy
+, pango
+, cairo
+, gdk-pixbuf
+, e2fsprogs
+, libkrb5
+, libva
+, openssl
+, pcsclite
+, gtk3
+, libselinux
+, libxml2
+, python3Packages
+, cpio
+, autoPatchelfHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nice-dcv-client";
+  version = "2020.2.1737-1";
+
+  src =
+    fetchurl {
+      url = "https://d1uj6qtbmh3dt5.cloudfront.net/2020.2/Clients/nice-dcv-viewer-${version}.el8.x86_64.rpm";
+      sha256 = "sha256-SUpfHd/Btc07cfjc3zx5I5BiNatr/c4E2/mfJuU4R1E=";
+    };
+
+  nativeBuildInputs = [ autoPatchelfHook python3Packages.rpm ];
+  unpackPhase = ''
+    rpm2cpio $src | ${cpio}/bin/cpio -idm
+  '';
+
+  buildInputs = [
+    libselinux
+    libkrb5
+    libxml2
+    libva
+    e2fsprogs
+    libX11
+    openssl
+    pcsclite
+    gtk3
+    cairo
+    epoxy
+    pango
+    gdk-pixbuf
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    mkdir -p $out/lib64/
+
+    mv usr/bin/dcvviewer $out/bin/dcvviewer
+    mv usr/lib64/* $out/lib64/
+
+    mkdir -p $out/libexec/dcvviewer
+    mv usr/libexec/dcvviewer/dcvviewer $out/libexec/dcvviewer/dcvviewer
+    patchelf \
+      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/libexec/dcvviewer/dcvviewer
+
+    # Fix the wrapper script to have the right basedir.
+    sed -i "s#basedir=/usr#basedir=$out#" $out/bin/dcvviewer
+
+    mv usr/share $out/
+    ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+
+    # broken symlink, seems to give a warning message if i don't delete it
+    rm $out/lib64/dcvviewer/gio/modules/libdconfsettings.so
+  '';
+
+  meta = with stdenv.lib; {
+    description = "High-performance remote display protocol";
+    homepage = "https://aws.amazon.com/hpc/dcv/";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ rmcgibbo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22580,6 +22580,8 @@ julia_15 = callPackage ../development/compilers/julia/1.5.nix {
     geoip = geoipWithDatabase;
   };
 
+  nice-dcv-client = callPackage ../applications/networking/remote/nice-dcv-client { };
+
   nixos-shell = callPackage ../tools/virtualization/nixos-shell {};
 
   noaa-apt = callPackage ../applications/radio/noaa-apt { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a client for a remote desktop protocol. I've been using this package on my NixOS machine for a few weeks, and thought it would be better to submit it here. I'm not sure that I've done the expression in the best way or with the best style, so any feedback would be appreciated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
